### PR TITLE
Power sign and analyze fix

### DIFF
--- a/libraries/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/libraries/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -289,6 +289,7 @@ static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);
 static constexpr uint8_t PSF_CH2_CONT  = (1u << 1);
 static constexpr uint8_t PSF_CH1_FIRED = (1u << 2);
 static constexpr uint8_t PSF_CH2_FIRED = (1u << 3);
+static constexpr uint8_t PSF_REBOOT_RECOVERY = (1u << 4);  // mid-flight reboot recovery occurred
 
 typedef struct
 {

--- a/tests/analyze_bench.py
+++ b/tests/analyze_bench.py
@@ -438,42 +438,80 @@ def parse_serial(path: str) -> SerialStats:
 # ============================================================================
 
 def compute_rate_stats(ts_list: list, max_gap_us: int = 1_000_000) -> dict:
-    """Compute rate statistics from a list of uint32 microsecond timestamps.
+    """Compute rate statistics from a list of microsecond timestamps.
 
-    Gaps larger than max_gap_us are excluded from interval statistics
-    (they indicate logging dropouts, not sensor pauses).
+    Primary rate is computed as (count - 1) / span_s, where span is the
+    elapsed time from the first to the last timestamp.  This matches what
+    analyze_rates.py reports and is the only metric that's meaningful when
+    the log contains non-chronological data (e.g., ring-buffer dumps).
+
+    Interval statistics (median, P95, P99, gap counts) are computed from
+    forward-going intervals only.  Negative intervals (timestamps going
+    backwards) and intervals larger than max_gap_us are excluded from
+    interval stats but counted separately — a non-zero non_monotonic count
+    flags the log as out of order so the caller can warn the user.
     """
-    if len(ts_list) < 2:
-        return {'count': len(ts_list), 'rate_hz': 0, 'span_s': 0}
-
-    diffs = []
-    for i in range(1, len(ts_list)):
-        d = (ts_list[i] - ts_list[i - 1]) & 0xFFFFFFFF  # handle uint32 wrap
-        if 0 < d < max_gap_us:
-            diffs.append(d)
-
-    if not diffs:
-        return {'count': len(ts_list), 'rate_hz': 0, 'span_s': 0}
-
-    diffs_sorted = sorted(diffs)
-    n = len(diffs_sorted)
-    avg_us = sum(diffs) / n
-    span_s = (ts_list[-1] - ts_list[0]) / 1e6
-
-    return {
+    empty = {
         'count': len(ts_list),
-        'rate_hz': 1e6 / avg_us if avg_us > 0 else 0,
+        'rate_hz': 0,
+        'span_s': 0,
+        'non_monotonic': 0,
+        'valid_intervals': 0,
+    }
+    if len(ts_list) < 2:
+        return empty
+
+    # Classify every raw interval (signed, not uint32-masked).
+    forward_diffs = []          # 0 < d <= max_gap_us
+    large_forward = 0           # d > max_gap_us (dropouts, not stalls)
+    non_monotonic = 0           # d <= 0 (duplicates or time going backwards)
+    for i in range(1, len(ts_list)):
+        d = ts_list[i] - ts_list[i - 1]
+        if d <= 0:
+            non_monotonic += 1
+        elif d > max_gap_us:
+            large_forward += 1
+        else:
+            forward_diffs.append(d)
+
+    # Span: first-to-last timestamp.  If non-positive (e.g., the log ends
+    # earlier than it started — ring-buffer wrap), fall back to the sum of
+    # forward-going intervals as a best-effort "real elapsed time".
+    raw_span_us = ts_list[-1] - ts_list[0]
+    if raw_span_us > 0:
+        span_us = raw_span_us
+    else:
+        span_us = sum(forward_diffs)  # may still be 0 if nothing is sane
+
+    span_s = span_us / 1e6
+    # Primary rate: observed throughput over the span the data actually covers.
+    rate_hz = (len(ts_list) - 1) / span_s if span_s > 0 else 0
+
+    result = {
+        'count': len(ts_list),
+        'rate_hz': rate_hz,
         'span_s': span_s,
-        'avg_us': avg_us,
+        'non_monotonic': non_monotonic,
+        'large_forward': large_forward,
+        'valid_intervals': len(forward_diffs),
+    }
+
+    if not forward_diffs:
+        return result
+
+    diffs_sorted = sorted(forward_diffs)
+    n = len(diffs_sorted)
+    result.update({
+        'avg_us': sum(forward_diffs) / n,
         'median_us': diffs_sorted[n // 2],
         'min_us': diffs_sorted[0],
         'max_us': diffs_sorted[-1],
         'p95_us': diffs_sorted[int(0.95 * n)],
         'p99_us': diffs_sorted[int(0.99 * n)] if n >= 100 else diffs_sorted[-1],
-        'gaps_gt_2ms': sum(1 for d in diffs if d > 2000),
-        'gaps_gt_10ms': sum(1 for d in diffs if d > 10000),
-        'valid_intervals': n,
-    }
+        'gaps_gt_2ms': sum(1 for d in forward_diffs if d > 2000),
+        'gaps_gt_10ms': sum(1 for d in forward_diffs if d > 10000),
+    })
+    return result
 
 
 # ============================================================================
@@ -530,19 +568,33 @@ def report_binary(bs: BinaryStats):
     print(f"  {'Sensor':<14s} {'Rate':>8s} {'Target':>8s} {'Status':>6s}  {'Median':>8s} {'P99':>8s} {'Msgs':>8s} {'Span':>6s}")
     print(f"  {'-'*14} {'-'*8} {'-'*8} {'-'*6}  {'-'*8} {'-'*8} {'-'*8} {'-'*6}")
 
+    any_non_monotonic = False
     for name in ["ISM6", "BMP", "MMC", "GNSS", "NonSensor", "Power"]:
         ts = bs.timestamps.get(name, [])
         target = TARGET_RATES.get(name, -1)
         rs = compute_rate_stats(ts)
 
+        if rs.get('non_monotonic', 0) > 0:
+            any_non_monotonic = True
+
         if rs['rate_hz'] > 0:
             target_str = f"{target}" if target > 0 else "—"
             status = _status_icon(rs['rate_hz'], target) if target > 0 else " "
+            median = rs.get('median_us', 0)
+            p99    = rs.get('p99_us', 0)
+            flag = " *" if rs.get('non_monotonic', 0) > 0 else ""
             print(f"  {name:<14s} {rs['rate_hz']:>7.1f}  {target_str:>7s}   {status}   "
-                  f"{rs['median_us']:>7.0f}  {rs.get('p99_us', 0):>7.0f}  {rs['count']:>7,}  {rs['span_s']:>5.1f}s")
+                  f"{median:>7.0f}  {p99:>7.0f}  {rs['count']:>7,}  {rs['span_s']:>5.1f}s{flag}")
         elif len(ts) > 0:
             print(f"  {name:<14s}     —       —        —    (only {len(ts)} msgs)")
         # Skip if no messages at all
+
+    if any_non_monotonic:
+        print()
+        print("  * Non-monotonic timestamps detected — log is not chronological.")
+        print("    This is typical of a ring-buffer / recovery dump, not a live")
+        print("    flight log.  Rate is computed as (count-1)/span and is reliable;")
+        print("    individual gap stats reflect forward intervals only.")
 
     # ── Gap analysis for key sensors ──
     for sensor_name in ["ISM6", "BMP", "MMC", "NonSensor"]:
@@ -553,6 +605,11 @@ def report_binary(bs: BinaryStats):
 
         print_header(f"{sensor_name} GAP ANALYSIS")
         print(f"  Intervals:  {rs['valid_intervals']:,}")
+        skipped_nm = rs.get('non_monotonic', 0)
+        skipped_lg = rs.get('large_forward', 0)
+        if skipped_nm or skipped_lg:
+            print(f"  Excluded:   {skipped_nm:,} non-monotonic, "
+                  f"{skipped_lg:,} >1s (dropouts)")
         print(f"  Min gap:    {rs['min_us']:,.0f} µs  ({rs['min_us']/1000:.1f} ms)")
         print(f"  Median gap: {rs['median_us']:,.0f} µs  ({rs['median_us']/1000:.1f} ms)")
         print(f"  P95 gap:    {rs['p95_us']:,.0f} µs  ({rs['p95_us']/1000:.1f} ms)")
@@ -619,14 +676,20 @@ def report_binary(bs: BinaryStats):
         if 3 in states_seen:
             anomalies.append("Rocket entered INFLIGHT on bench!")
 
-    # Sensor rate anomalies
+    # Sensor rate anomalies + non-chronological log detection
+    log_non_chrono = False
     for name, target in TARGET_RATES.items():
         if target <= 0:
             continue
         ts = bs.timestamps.get(name, [])
         rs = compute_rate_stats(ts)
+        if rs.get('non_monotonic', 0) > 0:
+            log_non_chrono = True
         if rs['rate_hz'] > 0 and rs['rate_hz'] < target * 0.5:
             anomalies.append(f"{name} rate {rs['rate_hz']:.0f} Hz is <50% of target {target} Hz")
+    if log_non_chrono:
+        anomalies.append("Log contains non-monotonic timestamps — "
+                         "likely a ring-buffer / recovery dump, not a live flight log")
 
     # IMU saturation
     imu_frames = [(n, p) for n, p in bs.parsed_frames if n == "ISM6"]

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -57,6 +57,18 @@ struct EkfBaroData {
 };
 
 
+// Bulk snapshot of all EKF internal state for persistence across reboots.
+struct EkfStateSnapshot {
+    double pos_rrm[3];        // LLA position (rad, rad, m)
+    float  vel_ned_mps[3];    // NED velocity (m/s)
+    float  quat[4];           // body-to-NED quaternion (scalar-first)
+    float  accel_bias[3];     // accelerometer bias (m/s²)
+    float  gyro_bias[3];      // gyroscope bias (rad/s)
+    float  P[15][15];         // error covariance matrix
+    uint32_t t_prev_us;       // last time-update timestamp (µs)
+    float  euler[3];          // cached Euler angles (rad)
+};
+
 class GpsInsEKF {
 public:
     GpsInsEKF();
@@ -120,6 +132,36 @@ public:
     void getCovOrient(float (&r)[3]) const { r[0]=P_[6][6]; r[1]=P_[7][7]; r[2]=P_[8][8]; }
     void getCovAccelBias(float (&r)[3]) const { r[0]=P_[9][9]; r[1]=P_[10][10]; r[2]=P_[11][11]; }
     void getCovRotRateBias(float (&r)[3]) const { r[0]=P_[12][12]; r[1]=P_[13][13]; r[2]=P_[14][14]; }
+
+    // ─── Bulk state save/restore (reboot recovery) ─────────────────
+    void getState(EkfStateSnapshot& s) const {
+        std::memcpy(s.pos_rrm,     pEst_D_rrm_,   sizeof(s.pos_rrm));
+        std::memcpy(s.vel_ned_mps, vEst_NED_mps_,  sizeof(s.vel_ned_mps));
+        std::memcpy(s.quat,        quat_BL_,       sizeof(s.quat));
+        std::memcpy(s.accel_bias,  aBias_mps2_,    sizeof(s.accel_bias));
+        std::memcpy(s.gyro_bias,   wBias_rps_,     sizeof(s.gyro_bias));
+        std::memcpy(s.P,           P_,             sizeof(s.P));
+        s.t_prev_us = tPrev_us_;
+        std::memcpy(s.euler,       euler_BL_rad_,  sizeof(s.euler));
+    }
+
+    void setState(const EkfStateSnapshot& s) {
+        std::memcpy(pEst_D_rrm_,   s.pos_rrm,     sizeof(pEst_D_rrm_));
+        std::memcpy(vEst_NED_mps_,  s.vel_ned_mps, sizeof(vEst_NED_mps_));
+        std::memcpy(quat_BL_,       s.quat,        sizeof(quat_BL_));
+        std::memcpy(aBias_mps2_,    s.accel_bias,  sizeof(aBias_mps2_));
+        std::memcpy(wBias_rps_,     s.gyro_bias,   sizeof(wBias_rps_));
+        std::memcpy(P_,             s.P,           sizeof(P_));
+        tPrev_us_ = s.t_prev_us;
+        std::memcpy(euler_BL_rad_,  s.euler,       sizeof(euler_BL_rad_));
+        // Rebuild DCM from restored quaternion
+        Quat2DCM(T_B2NED, quat_BL_);
+    }
+
+    /// Add offset to covariance diagonal (inflate uncertainty after reboot)
+    void inflateCovDiag(int idx, float delta) {
+        if (idx >= 0 && idx < 15) P_[idx][idx] += delta;
+    }
 
 private:
     void timeUpdate();

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -289,6 +289,7 @@ static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);
 static constexpr uint8_t PSF_CH2_CONT  = (1u << 1);
 static constexpr uint8_t PSF_CH1_FIRED = (1u << 2);
 static constexpr uint8_t PSF_CH2_FIRED = (1u << 3);
+static constexpr uint8_t PSF_REBOOT_RECOVERY = (1u << 4);  // mid-flight reboot recovery occurred
 
 typedef struct
 {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -28,6 +28,8 @@
 #include <nvs_flash.h>
 #include <esp_log.h>
 #include <esp_task_wdt.h>
+#include <esp_system.h>
+#include <CRC32.h>
 static const char* TAG = "FC";
 
 // EKF timeUpdate()/measUpdate() allocate ~7.5 KB of temporary 15x15 matrices
@@ -227,6 +229,128 @@ static bool pyro2_fired = false;
 static uint32_t pyro2_fire_start_ms = 0;
 static bool pyro_apogee_detected = false;
 static uint32_t pyro_apogee_time_ms = 0;
+// --- Inflight reboot recovery ---
+// Snapshot of critical flight state, persisted to NVS at 10 Hz during INFLIGHT.
+// On unexpected reboot (brownout, watchdog), this allows resuming flight ops
+// with correct pyro state, EKF navigation, and flight phase.
+struct FlightSnapshot {
+    static constexpr uint32_t MAGIC   = 0xF1A7C0DE;
+    static constexpr uint8_t  VERSION = 1;
+
+    uint32_t magic;
+    uint8_t  version;
+    uint8_t  rocket_state;
+    uint8_t  pad[2];
+
+    // Timestamps stored as durations relative to launch (millis epoch changes on reboot)
+    uint32_t flight_elapsed_ms;   // now_ms - launch_time_millis
+    uint32_t apogee_elapsed_ms;   // pyro_apogee_time_ms - launch_time_millis (0 if no apogee)
+    uint32_t burnout_elapsed_ms;  // burnout_time_ms - launch_time_millis (0 if no burnout)
+
+    // Pyro state (safety-critical)
+    bool     pyro_apogee_detected;
+    bool     pyro1_armed;
+    bool     pyro1_fired;
+    bool     pyro2_armed;
+    bool     pyro2_fired;
+
+    // Flight references
+    float    ground_pressure_pa;
+    double   ref_lat_rad, ref_lon_rad, ref_alt_m;
+
+    // Control state
+    bool     ekf_initialized;
+    bool     guidance_enabled;
+    bool     burnout_detected;
+    bool     servo_enabled;
+
+    // EKF full state
+    EkfStateSnapshot ekf_state;
+
+    // Integrity check (CRC32 over all preceding bytes)
+    uint32_t crc32;
+};
+
+static bool     reboot_recovery = false;      // true during servo settle period after recovery
+static bool     reboot_recovery_telem = false; // true for rest of flight (telemetry flag)
+static uint32_t servo_settle_end_ms = 0;      // hold servos neutral until this time
+static uint32_t last_snapshot_ms = 0;         // rate-limit NVS writes to 10 Hz
+
+static uint32_t computeSnapshotCRC(const FlightSnapshot& snap)
+{
+    CRC32 crc;
+    crc.add(reinterpret_cast<const uint8_t*>(&snap),
+            offsetof(FlightSnapshot, crc32));
+    return crc.calc();
+}
+
+static void saveFlightSnapshot(uint32_t now_ms)
+{
+    FlightSnapshot snap = {};
+    snap.magic   = FlightSnapshot::MAGIC;
+    snap.version = FlightSnapshot::VERSION;
+    snap.rocket_state = (uint8_t)rocket_state;
+
+    snap.flight_elapsed_ms  = now_ms - launch_time_millis;
+    snap.apogee_elapsed_ms  = pyro_apogee_detected
+                            ? (pyro_apogee_time_ms - launch_time_millis) : 0;
+    snap.burnout_elapsed_ms = burnout_detected
+                            ? (burnout_time_ms - launch_time_millis) : 0;
+
+    portENTER_CRITICAL(&pyro_spinlock);
+    snap.pyro_apogee_detected = pyro_apogee_detected;
+    snap.pyro1_armed = pyro1_armed;
+    snap.pyro1_fired = pyro1_fired;
+    snap.pyro2_armed = pyro2_armed;
+    snap.pyro2_fired = pyro2_fired;
+    portEXIT_CRITICAL(&pyro_spinlock);
+
+    snap.ground_pressure_pa = ground_pressure_pa;
+    snap.ref_lat_rad = ref_lat_rad;
+    snap.ref_lon_rad = ref_lon_rad;
+    snap.ref_alt_m   = ref_alt_m;
+
+    snap.ekf_initialized  = ekf_initialized;
+    snap.guidance_enabled  = guidance_enabled;
+    snap.burnout_detected  = burnout_detected;
+    snap.servo_enabled     = servo_enabled;
+
+    if (ekf_initialized) {
+        ekf.getState(snap.ekf_state);
+    }
+
+    snap.crc32 = computeSnapshotCRC(snap);
+
+    Preferences snap_prefs;
+    if (snap_prefs.begin("fsnap", false)) {
+        snap_prefs.putBytes("s", &snap, sizeof(snap));
+        snap_prefs.end();
+    }
+}
+
+static void clearFlightSnapshot()
+{
+    Preferences snap_prefs;
+    if (snap_prefs.begin("fsnap", false)) {
+        snap_prefs.remove("s");
+        snap_prefs.end();
+    }
+}
+
+static const char* resetReasonStr(esp_reset_reason_t r)
+{
+    switch (r) {
+        case ESP_RST_BROWNOUT:  return "BROWNOUT";
+        case ESP_RST_PANIC:     return "PANIC";
+        case ESP_RST_INT_WDT:   return "INT_WDT";
+        case ESP_RST_TASK_WDT:  return "TASK_WDT";
+        case ESP_RST_WDT:       return "WDT";
+        case ESP_RST_POWERON:   return "POWERON";
+        case ESP_RST_SW:        return "SW";
+        default:                return "OTHER";
+    }
+}
+
 enum class BootChirpPhase : uint8_t { Idle, GapAfterBeep1, WaitingBeep2End };
 static BootChirpPhase boot_chirp_phase = BootChirpPhase::Idle;
 static uint32_t boot_chirp_next_ms = 0;
@@ -1310,6 +1434,135 @@ static void setup_fc()
     {
         servo_enabled = false;
         ESP_LOGW(TAG, "Servo control disabled (set SERVO_PIN_* in config.h)");
+    }
+
+    // ── Inflight reboot recovery ────────────────────────────────────────────
+    // If the reset was unexpected (brownout, watchdog, panic), check for a
+    // valid flight snapshot in NVS and restore state to resume INFLIGHT ops.
+    {
+        esp_reset_reason_t rst = esp_reset_reason();
+        ESP_LOGI(TAG, "Reset reason: %s (%d)", resetReasonStr(rst), (int)rst);
+
+        bool unexpected_reset = (rst == ESP_RST_BROWNOUT ||
+                                 rst == ESP_RST_PANIC    ||
+                                 rst == ESP_RST_INT_WDT  ||
+                                 rst == ESP_RST_TASK_WDT ||
+                                 rst == ESP_RST_WDT);
+
+        if (unexpected_reset) {
+            Preferences snap_prefs;
+            FlightSnapshot snap = {};
+            bool valid = false;
+
+            if (snap_prefs.begin("fsnap", true)) {
+                size_t len = snap_prefs.getBytesLength("s");
+                if (len == sizeof(FlightSnapshot)) {
+                    snap_prefs.getBytes("s", &snap, sizeof(snap));
+                    if (snap.magic == FlightSnapshot::MAGIC &&
+                        snap.version == FlightSnapshot::VERSION &&
+                        snap.rocket_state == (uint8_t)INFLIGHT &&
+                        snap.crc32 == computeSnapshotCRC(snap)) {
+                        valid = true;
+                    } else {
+                        ESP_LOGW(TAG, "[RECOVERY] Snapshot invalid (magic=0x%08lX state=%u crc=%s)",
+                                 (unsigned long)snap.magic, snap.rocket_state,
+                                 (snap.crc32 == computeSnapshotCRC(snap)) ? "OK" : "FAIL");
+                    }
+                }
+                snap_prefs.end();
+            }
+
+            if (valid) {
+                ESP_LOGW(TAG, "========================================");
+                ESP_LOGW(TAG, "[RECOVERY] INFLIGHT REBOOT RECOVERY from %s", resetReasonStr(rst));
+                ESP_LOGW(TAG, "[RECOVERY] Flight elapsed: %lu ms", (unsigned long)snap.flight_elapsed_ms);
+                ESP_LOGW(TAG, "========================================");
+
+                const uint32_t now_ms = millis();
+
+                // Restore flight state
+                rocket_state = INFLIGHT;
+
+                // Rebase timestamps to new millis() epoch
+                launch_time_millis = now_ms - snap.flight_elapsed_ms;
+                if (snap.pyro_apogee_detected) {
+                    pyro_apogee_detected = true;
+                    pyro_apogee_time_ms = launch_time_millis + snap.apogee_elapsed_ms;
+                }
+                if (snap.burnout_detected) {
+                    burnout_detected = true;
+                    burnout_time_ms = launch_time_millis + snap.burnout_elapsed_ms;
+                }
+
+                // Restore pyro state (safety-critical: no double-fire, no missed fire)
+                portENTER_CRITICAL(&pyro_spinlock);
+                pyro1_fired = snap.pyro1_fired;
+                pyro2_fired = snap.pyro2_fired;
+                pyro1_fire_start_ms = 0;
+                pyro2_fire_start_ms = 0;
+                portEXIT_CRITICAL(&pyro_spinlock);
+
+                // Re-arm unfired pyro channels (GPIO ARM pins reset on reboot)
+                if (snap.pyro1_armed && !snap.pyro1_fired && pyro_config.ch1_enabled) {
+                    portENTER_CRITICAL(&pyro_spinlock);
+                    gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 1);
+                    pyro1_armed = true;
+                    portEXIT_CRITICAL(&pyro_spinlock);
+                    ESP_LOGW(TAG, "[RECOVERY] CH1 re-armed");
+                }
+                if (snap.pyro2_armed && !snap.pyro2_fired && pyro_config.ch2_enabled) {
+                    portENTER_CRITICAL(&pyro_spinlock);
+                    gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 1);
+                    pyro2_armed = true;
+                    portEXIT_CRITICAL(&pyro_spinlock);
+                    ESP_LOGW(TAG, "[RECOVERY] CH2 re-armed");
+                }
+
+                ESP_LOGW(TAG, "[RECOVERY] Pyro: apogee=%d ch1_armed=%d ch1_fired=%d ch2_armed=%d ch2_fired=%d",
+                         pyro_apogee_detected, pyro1_armed, pyro1_fired, pyro2_armed, pyro2_fired);
+
+                // Restore flight references
+                ground_pressure_pa = snap.ground_pressure_pa;
+                ref_lat_rad = snap.ref_lat_rad;
+                ref_lon_rad = snap.ref_lon_rad;
+                ref_alt_m   = snap.ref_alt_m;
+                have_ref_pos = true;
+                ref_pos_frozen = true;
+                ground_pressure_found = true;
+
+                // Restore control state
+                ekf_initialized  = snap.ekf_initialized;
+                guidance_enabled = snap.guidance_enabled;
+                servo_enabled    = snap.servo_enabled;
+                landed_actions_done = false;
+                end_flight_sent = false;
+
+                // Restore EKF state and inflate covariance for reboot uncertainty
+                if (snap.ekf_initialized) {
+                    ekf.setState(snap.ekf_state);
+                    // Inflate position covariance (5m sigma → 25 m²)
+                    for (int i = 0; i < 3; i++) ekf.inflateCovDiag(i, 25.0f);
+                    // Inflate velocity covariance (5 m/s sigma → 25 m²/s²)
+                    for (int i = 3; i < 6; i++) ekf.inflateCovDiag(i, 25.0f);
+                    // Inflate attitude covariance (~10° sigma → 0.03 rad²)
+                    for (int i = 6; i < 9; i++) ekf.inflateCovDiag(i, 0.03f);
+                    ESP_LOGW(TAG, "[RECOVERY] EKF state restored (covariance inflated)");
+                }
+
+                // Hold servos neutral for 500ms while EKF settles
+                reboot_recovery = true;
+                reboot_recovery_telem = true;
+                servo_settle_end_ms = now_ms + 500;
+
+                // Mark launch flag so kinematic checks don't re-trigger launch detection
+                kinematics.launch_flag = true;
+            }
+        }
+
+        // Clear stale snapshot on normal boot (prevents recovery on next power cycle)
+        if (!reboot_recovery) {
+            clearFlightSnapshot();
+        }
     }
 
     ESP_LOGI(TAG, "Setup complete");
@@ -2582,13 +2835,25 @@ static void loop_fc()
                 // Service pyro channels (check triggers, manage fire pulses)
                 servicePyroChannels(now_ms);
 
+                // Save flight snapshot at 10 Hz for reboot recovery
+                if (now_ms - last_snapshot_ms >= 100U) {
+                    last_snapshot_ms = now_ms;
+                    saveFlightSnapshot(now_ms);
+                }
+
+                // Servo settling after reboot recovery — hold neutral until EKF stabilizes
+                if (reboot_recovery && now_ms >= servo_settle_end_ms) {
+                    reboot_recovery = false;  // keep PSF_REBOOT_RECOVERY flag in telemetry
+                    ESP_LOGI(TAG, "[RECOVERY] Servo settle complete, control resumed");
+                }
+
                 if (servo_enabled)
                 {
                     // Delay roll control activation after launch if configured
                     const uint32_t t_since_launch_ms = now_ms - launch_time_millis;
-                    if (t_since_launch_ms < roll_delay_ms)
+                    if (reboot_recovery || t_since_launch_ms < roll_delay_ms)
                     {
-                        // Hold fins neutral until delay elapses
+                        // Hold fins neutral until delay/settle elapses
                         servo_control.control(0.0f);
                     }
                     else if (have_ism6_si)
@@ -2779,6 +3044,7 @@ static void loop_fc()
                 {
                     landed_actions_done = true;
                     pyroSafeAll();
+                    clearFlightSnapshot();  // prevent stale recovery on next boot
                     if (servo_enabled)
                     {
                         servo_control.stowControl();
@@ -2788,6 +3054,8 @@ static void loop_fc()
                     control_mixer.reset();
                     roll_rate_pid_standalone.reset();
                     guidance_active = false;
+                    reboot_recovery = false;
+                    reboot_recovery_telem = false;
                     cameraStop(now_ms);
                     if (!end_flight_sent)
                     {
@@ -2840,6 +3108,9 @@ static void loop_fc()
                 burnout_detected = false;
                 burnout_time_ms = 0;
                 guidance_active = false;
+                reboot_recovery = false;
+                reboot_recovery_telem = false;
+                clearFlightSnapshot();
                 ESP_LOGI(TAG, "[STATE] Sim complete -> READY");
             }
             prev_sim_active = curr_sim_active;
@@ -2923,6 +3194,7 @@ static void loop_fc()
             // Update fired bits
             if (p1_fired) ps |= PSF_CH1_FIRED;
             if (p2_fired) ps |= PSF_CH2_FIRED;
+            if (reboot_recovery_telem) ps |= PSF_REBOOT_RECOVERY;
             non_sensor_data.pyro_status = ps;
         }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -269,7 +269,10 @@ static void readINA230Power()
                   ? latest_non_sensor.time_us
                   : (uint32_t)micros();
     psi.voltage = bus_v;
-    psi.current = current_a * 1000.0f;
+    // Sign convention: negative = discharging (power consumed), positive = charging.
+    // The INA230 shunt is wired such that load current reads positive, so invert
+    // here to match the base-station battery convention.
+    psi.current = -current_a * 1000.0f;
     psi.soc     = soc_pct;
 
     sensor_converter.packPowerData(psi, latest_power_raw);
@@ -2455,7 +2458,8 @@ static void loop_oc()
                         POWERDataSI psi = {};
                         psi.time_us = (uint32_t)micros();
                         psi.voltage = bus_v;
-                        psi.current = current_a * 1000.0f;
+                        // Invert so negative = discharging, matching base-station convention.
+                        psi.current = -current_a * 1000.0f;
                         // SOC lookup (same as readINA230Power)
                         static constexpr float SOC_V[] = { 6.60f, 7.00f, 7.40f, 7.60f, 7.80f, 8.40f };
                         static constexpr float SOC_P[] = { 0.0f,  10.0f, 25.0f, 50.0f, 75.0f, 100.0f };


### PR DESCRIPTION
## Summary
- Flip `out_computer` INA230 current sign so rocket-side telemetry reports
  negative for power consumed, matching the base-station MAX17205G convention
- Fix `analyze_bench.py` rate calculation to use `(count-1) / span` (matches
  `analyze_rates.py`) so ring-buffer / recovery dumps are not reported as
  60–70% of target rate when actual throughput is healthy
- Flag non-chronological logs with a `*` marker and a new anomaly so they
  can't be mistaken for real rate degradations

## Test plan
- [ ] Rerun `analyze_bench.py` on a clean chronological bench log — verify
      no `*` markers and rates match `analyze_rates.py`
- [ ] Verify rocket-side current in BLE/LoRa telemetry matches base station
      sign during a bench power draw