### PR TITLE
Report battery voltage with 0.01 V resolution (fixes #10)

### DIFF
--- a/libraries/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/libraries/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -963,7 +963,7 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     // Battery
     addFloat("soc", data.soc, 1);
     addFloat("cur", data.current, 1);
-    addFloat("vol", data.voltage, 1);
+    addFloat("vol", data.voltage, 2);
 
     // GPS
     addDouble("lat", data.latitude, 7);
@@ -1027,7 +1027,7 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
 
     // Base station
     addFloat("bsoc", data.bs_soc, 1);
-    addFloat("bvol", data.bs_voltage, 1);
+    addFloat("bvol", data.bs_voltage, 2);
     addFloat("bcur", data.bs_current, 0);
     addBool("bslog", data.bs_logging_active);
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -963,7 +963,7 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     // Battery
     addFloat("soc", data.soc, 1);
     addFloat("cur", data.current, 1);
-    addFloat("vol", data.voltage, 1);
+    addFloat("vol", data.voltage, 2);
 
     // GPS
     addDouble("lat", data.latitude, 7);
@@ -1027,7 +1027,7 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
 
     // Base station
     addFloat("bsoc", data.bs_soc, 1);
-    addFloat("bvol", data.bs_voltage, 1);
+    addFloat("bvol", data.bs_voltage, 2);
     addFloat("bcur", data.bs_current, 0);
     addBool("bslog", data.bs_logging_active);
 


### PR DESCRIPTION
## Summary
- Bump BLE telemetry `vol` and `bvol` JSON fields from 1 to 2 decimal places so the iOS dashboard's `%.2f V` formatter actually sees hundredths instead of a trailing zero.
- Touches both copies (`libraries/` and `tinkerrocket-idf/components/`) per the standing sync rule.

Fixes #10.

## Test plan
- [ ] Flash flight computer, connect iOS app, confirm dashboard voltage updates in hundredths (e.g. 7.83 V → 7.84 V) during normal use.
- [ ] Confirm BLE telemetry still updates at the normal rate — watch for any "Telemetry JSON X bytes > MTU limit" warnings in the ESP32 logs (existing guard at `TR_BLE_To_APP.cpp:732-741`).
- [ ] Check base-station relay path also shows `bvol` in hundredths.

## Notes
- LoRa `voltage_u8` (2–10 V in 8 bits, ~0.031 V LSB) is unchanged — it physically can't deliver true hundredths without a width change, and is left for a possible follow-up as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)