### PR TITLE
Remove Finder/iCloud duplicate files and dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ __pycache__/
 .DS_Store
 ._*
 
+# Finder / iCloud duplicates (files and dirs ending in " 2", " 3", etc.)
+* 2.*
+* 3.*
+* 2/
+* 3/
+
 # IDE
 .vscode/
 *.swp

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP 2.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BLE_To_APP/TR_BLE_To_APP.cpp

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP 2.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BLE_To_APP/TR_BLE_To_APP.h

--- a/tinkerrocket-idf/components/TR_BMP585/TR_BMP585 2.cpp
+++ b/tinkerrocket-idf/components/TR_BMP585/TR_BMP585 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BMP585/TR_BMP585.cpp

--- a/tinkerrocket-idf/components/TR_BMP585/TR_BMP585 2.h
+++ b/tinkerrocket-idf/components/TR_BMP585/TR_BMP585 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BMP585/TR_BMP585.h

--- a/tinkerrocket-idf/components/TR_BMP585/bmp5 2.c
+++ b/tinkerrocket-idf/components/TR_BMP585/bmp5 2.c
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BMP585/bmp5.c

--- a/tinkerrocket-idf/components/TR_BMP585/bmp5 2.h
+++ b/tinkerrocket-idf/components/TR_BMP585/bmp5 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BMP585/bmp5.h

--- a/tinkerrocket-idf/components/TR_BMP585/bmp5_defs 2.h
+++ b/tinkerrocket-idf/components/TR_BMP585/bmp5_defs 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_BMP585/bmp5_defs.h

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer 2.cpp
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ControlMixer/TR_ControlMixer.cpp

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer 2.h
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ControlMixer/TR_ControlMixer.h

--- a/tinkerrocket-idf/components/TR_Coordinates/TR_Coordinates 2.cpp
+++ b/tinkerrocket-idf/components/TR_Coordinates/TR_Coordinates 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Coordinates/TR_Coordinates.cpp

--- a/tinkerrocket-idf/components/TR_Coordinates/TR_Coordinates 2.h
+++ b/tinkerrocket-idf/components/TR_Coordinates/TR_Coordinates 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Coordinates/TR_Coordinates.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial 2.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_SparkFun_u-blox_GNSS_v3 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_SparkFun_u-blox_GNSS_v3 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/TR_SparkFun_u-blox_GNSS_v3.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/sfe_bus 2.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/sfe_bus 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/sfe_bus.cpp

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/sfe_bus 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/sfe_bus 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/sfe_bus.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_Class_and_ID 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_Class_and_ID 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_Class_and_ID.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS 2.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS.cpp

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_GNSS.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_config_keys 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_config_keys 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_config_keys.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_external_typedefs 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_external_typedefs 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_external_typedefs.h

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_structs 2.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/u-blox_structs 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GNSSReceiverUBlox_Serial/u-blox_structs.h

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF 2.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GpsInsEKF/TR_GpsInsEKF.cpp

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF 2.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_GpsInsEKF/TR_GpsInsEKF.h

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface 2.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_I2C_Interface/TR_I2C_Interface.cpp

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface 2.h
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_I2C_Interface/TR_I2C_Interface.h

--- a/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream 2.cpp
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_I2S_Stream/TR_I2S_Stream.cpp

--- a/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream 2.h
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_I2S_Stream/TR_I2S_Stream.h

--- a/tinkerrocket-idf/components/TR_IMU_Int_V2/TR_IMU_Int_V2 2.cpp
+++ b/tinkerrocket-idf/components/TR_IMU_Int_V2/TR_IMU_Int_V2 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_IMU_Int_V2/TR_IMU_Int_V2.cpp

--- a/tinkerrocket-idf/components/TR_IMU_Int_V2/TR_IMU_Int_V2 2.h
+++ b/tinkerrocket-idf/components/TR_IMU_Int_V2/TR_IMU_Int_V2 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_IMU_Int_V2/TR_IMU_Int_V2.h

--- a/tinkerrocket-idf/components/TR_INA230/TR_INA230 2.cpp
+++ b/tinkerrocket-idf/components/TR_INA230/TR_INA230 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_INA230/TR_INA230.cpp

--- a/tinkerrocket-idf/components/TR_INA230/TR_INA230 2.h
+++ b/tinkerrocket-idf/components/TR_INA230/TR_INA230 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_INA230/TR_INA230.h

--- a/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256 2.cpp
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ISM6HG256/TR_ISM6HG256.cpp

--- a/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256 2.h
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ISM6HG256/TR_ISM6HG256.h

--- a/tinkerrocket-idf/components/TR_ISM6HG256/ism6hg256x_reg 2.c
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/ism6hg256x_reg 2.c
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ISM6HG256/ism6hg256x_reg.c

--- a/tinkerrocket-idf/components/TR_ISM6HG256/ism6hg256x_reg 2.h
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/ism6hg256x_reg 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ISM6HG256/ism6hg256x_reg.h

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks 2.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_KinematicChecks/TR_KinematicChecks.cpp

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks 2.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_KinematicChecks/TR_KinematicChecks.h

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms 2.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LoRa_Comms/TR_LoRa_Comms.cpp

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms 2.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LoRa_Comms/TR_LoRa_Comms.h

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash 2.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/TR_LogToFlash.cpp

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash 2.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/TR_LogToFlash.h

--- a/tinkerrocket-idf/components/TR_LogToFlash/lfs 2.c
+++ b/tinkerrocket-idf/components/TR_LogToFlash/lfs 2.c
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/lfs.c

--- a/tinkerrocket-idf/components/TR_LogToFlash/lfs 2.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/lfs 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/lfs.h

--- a/tinkerrocket-idf/components/TR_LogToFlash/lfs_util 2.c
+++ b/tinkerrocket-idf/components/TR_LogToFlash/lfs_util 2.c
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/lfs_util.c

--- a/tinkerrocket-idf/components/TR_LogToFlash/lfs_util 2.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/lfs_util 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_LogToFlash/lfs_util.h

--- a/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA 2.cpp
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_MMC5983MA/TR_MMC5983MA.cpp

--- a/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA 2.h
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_MMC5983MA/TR_MMC5983MA.h

--- a/tinkerrocket-idf/components/TR_OUT_Page/TR_OUT_Page 2.cpp
+++ b/tinkerrocket-idf/components/TR_OUT_Page/TR_OUT_Page 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_OUT_Page/TR_OUT_Page.cpp

--- a/tinkerrocket-idf/components/TR_OUT_Page/TR_OUT_Page 2.h
+++ b/tinkerrocket-idf/components/TR_OUT_Page/TR_OUT_Page 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_OUT_Page/TR_OUT_Page.h

--- a/tinkerrocket-idf/components/TR_PID/TR_PID 2.cpp
+++ b/tinkerrocket-idf/components/TR_PID/TR_PID 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_PID/TR_PID.cpp

--- a/tinkerrocket-idf/components/TR_PID/TR_PID 2.h
+++ b/tinkerrocket-idf/components/TR_PID/TR_PID 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_PID/TR_PID.h

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes 2.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_RocketComputerTypes/RocketComputerTypes.h

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector 2.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Collector/TR_Sensor_Collector.cpp

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector 2.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Collector/TR_Sensor_Collector.h

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim 2.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim 2.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter 2.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter 2.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult 2.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult 2.cpp
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult 2.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult 2.h
@@ -1,1 +1,0 @@
-/Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/libraries/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h


### PR DESCRIPTION
## Summary
Deletes 139 accidentally-duplicated paths with " 2" / " 3" suffixes (Finder/iCloud artifacts):

- **61 tracked entries** in tinkerrocket-idf/components/TR_*/ — all turned out to be symlinks (mode 120000), one per file in the canonical source. Nothing was referencing them.
- **RadioLib** ({src 2, examples 2, extras 3}) and **CRC** ({src 2, examples 2}) untracked directory copies in both libraries/ and tinkerrocket-idf/components/.
- **~50 managed_components/ duplicate trees** under tinkerrocket-idf/projects/{i2s_rx_test,i2s_tx_test}/ — untracked, IDF will regenerate on next reconfigure.
- A stray tinkerrocket-idf/.git 2/ directory.

Also adds .gitignore patterns ("* 2.\*", "* 3.\*", "* 2/", "* 3/") so these cannot come back silently.

## Why this is safe
- No CMakeLists.txt uses file(GLOB) — every component lists sources explicitly, so the " 2" copies were never reachable by any build.
- Literal " 2" grep across all CMakeLists is empty — no explicit references either.
- The tracked items were all symlinks, not duplicate content, so no source history is lost.

## Test plan
- [ ] idf.py build for each project under tinkerrocket-idf/projects/ still succeeds (managed_components repopulate on reconfigure).
- [ ] cpp-tests host build still passes.
- [ ] tinkerrocket-sim pytest still passes.
- [ ] `find . -name "* 2.*" -o -name "* 3.*"` returns empty.

## Context
First of 7 PRs to finish the Arduino → ESP-IDF restructure. PR #11 handles a separate voltage-resolution bug (#10).

Note: existing CI on main is currently red from unrelated issues (TR_GuidancePN submodule not checked out by CI + NimBLE header error in out_computer build). Those will be addressed by later PRs in the restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
