### PR TITLE
tests_cpp: source component libs from tinkerrocket-idf/components

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -17,14 +17,22 @@ include(GoogleTest)
 enable_testing()
 
 # ---------- Path shortcuts ----------
-set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libraries")
+# Component sources now live under the ESP-IDF tree. The libraries/
+# mirror is being removed in a follow-up; all paths below point at
+# the canonical components/ tree.
+set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/components")
 set(SHIM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/host_shim")
+
+# Every target needs ${SHIM_DIR} on its include path because the
+# component headers now #include <compat.h> (previously <Arduino.h>).
+# The shim resolves both to the host-side Arduino.h stub.
 
 # ---------- test_pid ----------
 add_executable(test_pid test_pid.cpp
     ${LIB_DIR}/TR_PID/TR_PID.cpp
 )
 target_include_directories(test_pid PRIVATE
+    ${SHIM_DIR}
     ${LIB_DIR}/TR_PID
 )
 target_link_libraries(test_pid GTest::gtest_main)
@@ -33,27 +41,30 @@ gtest_discover_tests(test_pid)
 # ---------- test_rocket_computer_types ----------
 add_executable(test_rocket_computer_types test_rocket_computer_types.cpp)
 target_include_directories(test_rocket_computer_types PRIVATE
+    ${SHIM_DIR}
     ${LIB_DIR}/TR_RocketComputerTypes
 )
 target_link_libraries(test_rocket_computer_types GTest::gtest_main)
 gtest_discover_tests(test_rocket_computer_types)
 
 # ---------- test_crc16_compat ----------
-# CRC library needs Arduino.h shim (via CrcDefines.h)
+# CRC library needs Arduino.h shim (via CrcDefines.h).
+# Note: the IDF components/CRC/ layout is flat — sources live directly
+# under CRC/, not CRC/src/ like the old Arduino libraries/ layout.
 add_executable(test_crc16_compat test_crc16_compat.cpp
-    ${LIB_DIR}/CRC/src/CRC16.cpp
-    ${LIB_DIR}/CRC/src/CRC.cpp
-    ${LIB_DIR}/CRC/src/CrcFastReverse.cpp
+    ${LIB_DIR}/CRC/CRC16.cpp
+    ${LIB_DIR}/CRC/CRC.cpp
+    ${LIB_DIR}/CRC/CrcFastReverse.cpp
     # Need CRC8/12/32/64 because CRC.h pulls them all in
-    ${LIB_DIR}/CRC/src/CRC8.cpp
-    ${LIB_DIR}/CRC/src/CRC12.cpp
-    ${LIB_DIR}/CRC/src/CRC32.cpp
-    ${LIB_DIR}/CRC/src/CRC64.cpp
-    ${LIB_DIR}/CRC/src/FastCRC32.cpp
+    ${LIB_DIR}/CRC/CRC8.cpp
+    ${LIB_DIR}/CRC/CRC12.cpp
+    ${LIB_DIR}/CRC/CRC32.cpp
+    ${LIB_DIR}/CRC/CRC64.cpp
+    ${LIB_DIR}/CRC/FastCRC32.cpp
 )
 target_include_directories(test_crc16_compat PRIVATE
     ${SHIM_DIR}   # Must come first so Arduino.h resolves to our shim
-    ${LIB_DIR}/CRC/src
+    ${LIB_DIR}/CRC
 )
 target_link_libraries(test_crc16_compat GTest::gtest_main)
 gtest_discover_tests(test_crc16_compat)
@@ -67,6 +78,7 @@ add_executable(test_ekf test_ekf.cpp
     ${LIB_DIR}/TR_GpsInsEKF/TR_GpsInsEKF.cpp
 )
 target_include_directories(test_ekf PRIVATE
+    ${SHIM_DIR}
     ${LIB_DIR}/TR_GpsInsEKF
 )
 target_link_libraries(test_ekf GTest::gtest_main)
@@ -89,6 +101,7 @@ add_executable(test_control_mixer test_control_mixer.cpp
     ${LIB_DIR}/TR_PID/TR_PID.cpp
 )
 target_include_directories(test_control_mixer PRIVATE
+    ${SHIM_DIR}
     ${LIB_DIR}/TR_ControlMixer
     ${LIB_DIR}/TR_PID
 )
@@ -96,11 +109,18 @@ target_link_libraries(test_control_mixer GTest::gtest_main)
 gtest_discover_tests(test_control_mixer)
 
 # ---------- test_guidance_pn ----------
+# TRANSITIONAL: TR_GuidancePN still sourced from the legacy libraries/
+# tree because tinkerrocket-idf/components/TR_GuidancePN is not yet
+# properly registered in git (loose files only; .gitmodules entry is
+# a stub). Will switch to components/ once the submodule is set up
+# correctly — tracked alongside the libraries/ deletion PR.
+set(LEGACY_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../libraries")
 add_executable(test_guidance_pn test_guidance_pn.cpp
-    ${LIB_DIR}/TR_GuidancePN/TR_GuidancePN.cpp
+    ${LEGACY_LIB_DIR}/TR_GuidancePN/TR_GuidancePN.cpp
 )
 target_include_directories(test_guidance_pn PRIVATE
-    ${LIB_DIR}/TR_GuidancePN
+    ${SHIM_DIR}
+    ${LEGACY_LIB_DIR}/TR_GuidancePN
 )
 target_link_libraries(test_guidance_pn GTest::gtest_main)
 gtest_discover_tests(test_guidance_pn)

--- a/tests_cpp/host_shim/compat.h
+++ b/tests_cpp/host_shim/compat.h
@@ -1,0 +1,31 @@
+/**
+ * compat.h — Host-side forwarder for TinkerRocket component headers
+ *            that include <compat.h> when building against the real
+ *            ESP-IDF TR_Compat component.
+ *
+ * On the host the real compat.h cannot be used (it pulls in
+ * esp_timer.h, FreeRTOS, driver/gpio.h, etc. — all ESP-only).
+ * We forward to the existing host_shim/Arduino.h, which provides the
+ * subset of the Arduino API our tests exercise — BUT we then #undef
+ * the preprocessor macros that conflict with std:: names (`max`,
+ * `min`, `abs`, `constrain`). Post-migration component code uses
+ * `std::max` etc. instead of the Arduino macros.
+ */
+#pragma once
+
+#include "Arduino.h"
+
+// Mirror the real TR_Compat compat.h on the device, which defines
+// `constrain` as a macro but does NOT poison `min`/`max`/`abs`.
+// Post-migration component code (e.g. TR_KinematicChecks) uses
+// std::max; leaving those as macros breaks those calls at parse time.
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+#ifdef abs
+#undef abs
+#endif
+// NB: `constrain` intentionally kept — TR_PID and others rely on it.

--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -186,15 +186,20 @@ TEST_F(EKFTest, BaroUpdateReducesAltCovariance) {
         ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
     }
 
-    float cov_before = ekf.getCovBaroOffset();
+    // EKF is 15-state (baro offset was dropped); baro directly updates the
+    // altitude (down) component of position. Read cov[2] before/after.
+    float cov_pos[3];
+    ekf.getCovPos(cov_pos);
+    float cov_alt_before = cov_pos[2];
 
     EkfBaroData baro;
     baro.time_us = t;
     baro.altitude_m = ALT_M;
     ekf.baroMeasUpdate(baro);
 
-    float cov_after = ekf.getCovBaroOffset();
-    EXPECT_LE(cov_after, cov_before);
+    ekf.getCovPos(cov_pos);
+    float cov_alt_after = cov_pos[2];
+    EXPECT_LE(cov_alt_after, cov_alt_before);
 }
 
 TEST_F(EKFTest, InvertMatrix6x6_Identity) {


### PR DESCRIPTION
## Summary
Redirects `tests_cpp/CMakeLists.txt` to source component libraries from `tinkerrocket-idf/components/` instead of the legacy `libraries/` mirror, so host tests run against the same sources the firmware flashes.

## Changes
- **`tests_cpp/CMakeLists.txt`** — `LIB_DIR` now points at `../tinkerrocket-idf/components`. `SHIM_DIR` added to every target (previously only some) because migrated headers now `#include <compat.h>` instead of `<Arduino.h>`. CRC paths updated for the flattened `components/CRC/` layout.
- **`tests_cpp/host_shim/compat.h`** (new) — forwarder that includes `Arduino.h` and then `#undef`s `min`/`max`/`abs`. This mirrors the real `tinkerrocket-idf/components/TR_Compat/include/compat.h`, which defines `constrain` but does **not** poison the std names — post-migration components (e.g. `TR_KinematicChecks.cpp`) use `std::max`, which the old Arduino macro would break at parse time.
- **`tests_cpp/test_ekf.cpp`** — `BaroUpdateReducesAltCovariance` rewritten. The components/ EKF was refactored from 16 states (15 nav + 1 baro offset) to 15 states (baro update now writes directly into altitude). The test now asserts `cov_pos[2]` (altitude covariance) decreases after a baro update, instead of reading the dropped `getCovBaroOffset()`.

## Out of scope
`test_guidance_pn` is intentionally still sourced from `libraries/TR_GuidancePN/` (the working submodule). The `components/TR_GuidancePN` entry in `.gitmodules` is a stub — no `git submodule add` was completed, and the files on disk are uncommitted. A follow-up PR will properly register it as a submodule before `libraries/` is removed.

## Test plan
Local:
```
rm -rf tests_cpp/build
cmake -S tests_cpp -B tests_cpp/build
cmake --build tests_cpp/build
(cd tests_cpp/build && ctest --output-on-failure)
```
Result: **94/94 tests pass.**

CI: will still be red on the pre-existing failures tracked in #13 (submodule checkout + NimBLE header error). This PR does not regress those.

## Context
PR 2 of 7 in the Arduino → ESP-IDF restructure. PR 1 (Finder duplicates cleanup) is #12. #11 handles issue #10 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
