### PR TITLE
sim: source component libs from tinkerrocket-idf/components

### DIFF
--- a/tinkerrocket-sim/cpp/ekf/ekf_bindings.cpp
+++ b/tinkerrocket-sim/cpp/ekf/ekf_bindings.cpp
@@ -128,7 +128,8 @@ PYBIND11_MODULE(_ekf, m) {
         .def("get_cov_rot_rate_bias", [](const GpsInsEKF& self) {
             float r[3]; self.getCovRotRateBias(r);
             return py::make_tuple(r[0], r[1], r[2]);
-        })
-        .def("get_baro_offset", &GpsInsEKF::getBaroOffset)
-        .def("get_cov_baro_offset", &GpsInsEKF::getCovBaroOffset);
+        });
+    // NB: get_baro_offset / get_cov_baro_offset bindings removed — the
+    // component EKF is now 15-state (baro folded into position altitude).
+    // Altitude and its covariance can be read via get_pos_est()/get_cov_pos().
 }

--- a/tinkerrocket-sim/setup.py
+++ b/tinkerrocket-sim/setup.py
@@ -1,11 +1,33 @@
-"""Build script for C++ pybind11 extensions (PID controller and EKF)."""
+"""Build script for C++ pybind11 extensions (PID controller, EKF, GuidancePN, ControlMixer).
+
+Shared component sources live under ``tinkerrocket-idf/components/`` — the
+canonical ESP-IDF component tree that is also flashed to the rocket. The
+host build of the migrated components unconditionally includes <compat.h>,
+so the pybind11 extensions add ``tests_cpp/host_shim`` (a small Arduino/
+compat shim shared with the cpp unit tests) to their include path.
+
+TR_GuidancePN is the lone exception: it is a separate git submodule whose
+sources still live under libraries/TR_GuidancePN/ and still use
+``#ifdef ARDUINO`` guards, so it builds on host without any shim. It will
+migrate to tinkerrocket-idf/components/TR_GuidancePN once the submodule is
+properly registered there — tracked alongside the libraries/ deletion PR.
+"""
 import os
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
-# Path to shared Arduino libraries (one level up from TinkerRocket-Sim)
 _HERE = os.path.dirname(os.path.abspath(__file__))
-SHARED_LIB_DIR = os.path.relpath(os.path.join(_HERE, "..", "libraries"), _HERE)
+
+# Canonical ESP-IDF component sources (used for TR_GpsInsEKF, TR_ControlMixer, TR_PID).
+SHARED_LIB_DIR = os.path.relpath(
+    os.path.join(_HERE, "..", "tinkerrocket-idf", "components"), _HERE
+)
+# Legacy Arduino library tree (only TR_GuidancePN still sourced from here).
+LEGACY_LIB_DIR = os.path.relpath(os.path.join(_HERE, "..", "libraries"), _HERE)
+# Host-side shim providing Arduino.h/compat.h for components that #include <compat.h>.
+SHIM_DIR = os.path.relpath(
+    os.path.join(_HERE, "..", "tests_cpp", "host_shim"), _HERE
+)
 
 ext_modules = [
     Pybind11Extension(
@@ -26,13 +48,14 @@ if os.path.exists("cpp/ekf/ekf_bindings.cpp") and os.path.exists(ekf_lib_dir):
                 os.path.join(ekf_lib_dir, "TR_GpsInsEKF.cpp"),
                 "cpp/ekf/ekf_bindings.cpp",
             ],
-            include_dirs=[ekf_lib_dir, "cpp/ekf", "cpp/common"],
+            include_dirs=[SHIM_DIR, ekf_lib_dir, "cpp/ekf", "cpp/common"],
             cxx_std=17,
         ),
     )
 
-# GuidancePN: build from shared TR_GuidancePN library
-guidance_lib_dir = os.path.join(SHARED_LIB_DIR, "TR_GuidancePN")
+# GuidancePN: TRANSITIONAL — still sourced from legacy libraries/ tree until
+# tinkerrocket-idf/components/TR_GuidancePN is set up as a proper submodule.
+guidance_lib_dir = os.path.join(LEGACY_LIB_DIR, "TR_GuidancePN")
 if os.path.exists("cpp/guidance/guidance_bindings.cpp") and os.path.exists(guidance_lib_dir):
     ext_modules.append(
         Pybind11Extension(
@@ -59,7 +82,7 @@ if (os.path.exists("cpp/mixer/mixer_bindings.cpp") and
                 os.path.join(pid_lib_dir, "TR_PID.cpp"),
                 "cpp/mixer/mixer_bindings.cpp",
             ],
-            include_dirs=[mixer_lib_dir, pid_lib_dir, "cpp/common"],
+            include_dirs=[SHIM_DIR, mixer_lib_dir, pid_lib_dir, "cpp/common"],
             cxx_std=17,
         ),
     )

--- a/tinkerrocket-sim/tests/test_ekf_sim.py
+++ b/tinkerrocket-sim/tests/test_ekf_sim.py
@@ -124,6 +124,8 @@ class TestEKFStationary:
             assert abs(v) < 0.5  # < 0.5 m/s
 
     def test_baro_reduces_alt_covariance(self):
+        # EKF is 15-state (baro offset dropped); baro updates now write
+        # directly into the altitude (down) component of position.
         t = 0
         for _ in range(100):
             t += 2000
@@ -131,9 +133,9 @@ class TestEKFStationary:
                                 make_stationary_imu(t),
                                 make_stationary_gnss_lla(t),
                                 make_stationary_mag(t))
-        cov_before = self.ekf.get_cov_baro_offset()
+        cov_before = self.ekf.get_cov_pos()[2]  # altitude covariance
         self.ekf.baro_meas_update(make_baro(t, ALT_M))
-        cov_after = self.ekf.get_cov_baro_offset()
+        cov_after = self.ekf.get_cov_pos()[2]
         assert cov_after <= cov_before
 
     def test_no_nan_after_60s(self):


### PR DESCRIPTION
## Summary
Redirects the sim's pybind11 extensions (`_ekf`, `_mixer`) to build from `tinkerrocket-idf/components/` instead of `libraries/`. Mirrors PR #14's `tests_cpp` redirect so the sim exercises the same sources the firmware flashes.

## Changes
- **`tinkerrocket-sim/setup.py`** — `SHARED_LIB_DIR` points at `../tinkerrocket-idf/components`. A new `LEGACY_LIB_DIR` (pointing at `../libraries`) is kept only for `_guidance` (see below). Reuses `tests_cpp/host_shim` via a new `SHIM_DIR` so the sim and host tests share one compat layer.
- **`tinkerrocket-sim/cpp/ekf/ekf_bindings.cpp`** — drops the `get_baro_offset` / `get_cov_baro_offset` bindings. The components EKF is now 15-state (baro folded into altitude). An inline comment points callers at `get_pos_est()` / `get_cov_pos()` for altitude.
- **`tinkerrocket-sim/tests/test_ekf_sim.py`** — `test_baro_reduces_alt_covariance` reads `get_cov_pos()[2]` instead of the dropped `get_cov_baro_offset()`. Same rewrite as the equivalent C++ test in PR #14.

Repo-wide grep confirmed **no python code** anywhere in the tree calls `get_baro_offset` or `get_cov_baro_offset`, so removing those bindings is safe.

## Out of scope
`_guidance` continues to source `TR_GuidancePN` from `libraries/` because `tinkerrocket-idf/components/TR_GuidancePN` is not yet set up as a proper submodule (same deferral as PR #14). This will be resolved in PR 5 (the `libraries/` deletion).

## Test plan
Local:
```
cd tinkerrocket-sim
rm -rf build src/tinkerrocket_sim.egg-info
pip install -e .
python3 -m pytest tests/ -q
```
Result: **48/48 tests pass.**

## Stack & context
PR 3 of 7 in the Arduino → ESP-IDF restructure. Stacks on **PR #14** (PR 2 — tests_cpp host_shim/compat.h). Order for merge:
1. #11 voltage fix (#10) — independent
2. #12 Finder-duplicate cleanup (PR 1)
3. #14 tests_cpp → components/ (PR 2)
4. **This PR** (PR 3)
5. PR 4 — CI workflow fixes
6. PR 5 — delete `libraries/` + properly register `components/TR_GuidancePN` submodule
7. PR 6 — docs
8. (Optional) PR 7 — port remaining `<Arduino.h>` stragglers

Pre-existing CI failures tracked in #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
