### PR TITLE
ci: checkout submodules and trigger on components/ tree

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -3,11 +3,13 @@ name: C++ Unit Tests
 on:
   push:
     paths:
-      - 'libraries/**'
+      - 'tinkerrocket-idf/components/**'
+      - 'libraries/**'        # transitional: test_guidance_pn still sources from here
       - 'tests_cpp/**'
       - 'tests/integration/**'
   pull_request:
     paths:
+      - 'tinkerrocket-idf/components/**'
       - 'libraries/**'
       - 'tests_cpp/**'
       - 'tests/integration/**'
@@ -18,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Configure
         run: cmake -S tests_cpp -B tests_cpp/build -DCMAKE_BUILD_TYPE=Debug
@@ -33,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -4,11 +4,9 @@ on:
   push:
     paths:
       - 'tinkerrocket-idf/**'
-      - 'libraries/**'
   pull_request:
     paths:
       - 'tinkerrocket-idf/**'
-      - 'libraries/**'
 
 jobs:
   build:
@@ -27,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build ${{ matrix.project }}
         working-directory: tinkerrocket-idf/projects/${{ matrix.project }}

--- a/.github/workflows/sim-tests.yml
+++ b/.github/workflows/sim-tests.yml
@@ -4,15 +4,18 @@ on:
   push:
     paths:
       - 'tinkerrocket-sim/**'
-      - 'libraries/TR_GpsInsEKF/**'
-      - 'libraries/TR_PID/**'
-      - 'libraries/TR_ControlMixer/**'
-      - 'libraries/TR_GuidancePN/**'
+      - 'tinkerrocket-idf/components/TR_GpsInsEKF/**'
+      - 'tinkerrocket-idf/components/TR_PID/**'
+      - 'tinkerrocket-idf/components/TR_ControlMixer/**'
+      - 'libraries/TR_GuidancePN/**'   # transitional: sim _guidance still sources from here
+      - 'tests_cpp/host_shim/**'       # sim reuses the host_shim compat headers
       - 'tests/integration/**'
   pull_request:
     paths:
       - 'tinkerrocket-sim/**'
+      - 'tinkerrocket-idf/components/**'
       - 'libraries/**'
+      - 'tests_cpp/host_shim/**'
 
 jobs:
   test:
@@ -20,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
Fixes three of the four pre-existing CI failures on `main` tracked in #13. Two independent fixes in the same PR because they both touch the same workflow files:

1. **`submodules: recursive`** added to every `actions/checkout` step. `libraries/TR_GuidancePN` (and soon `tinkerrocket-idf/components/TR_GuidancePN`) are submodules; checkout was pulling only the top-level repo, leading to `fatal error: ../libraries/TR_GuidancePN/TR_GuidancePN.cpp: No such file or directory` in `cpp-tests`, `sim-tests` (install step), and `bench-integration`.
2. **Path triggers updated** to point at `tinkerrocket-idf/components/**` where appropriate, after PR #14 (tests_cpp) and PR #15 (sim) redirected their sources off `libraries/`. `libraries/**` triggers kept transitionally for the TR_GuidancePN code path that hasn't moved yet.

## What each workflow got
- **`cpp-tests.yml`** — both jobs get `submodules: recursive`. Path triggers include `tinkerrocket-idf/components/**`; `libraries/**` kept transitionally.
- **`sim-tests.yml`** — `submodules: recursive`. TR_* triggers swapped from `libraries/` to `tinkerrocket-idf/components/` for TR_GpsInsEKF / TR_PID / TR_ControlMixer. TR_GuidancePN trigger still points at `libraries/` until PR 5 properly registers the `components/` copy as a submodule. Also added `tests_cpp/host_shim/**` since the sim now reuses that compat shim.
- **`firmware-build.yml`** — dropped the stale `libraries/**` trigger (firmware never sourced from `libraries/`). Added `submodules: recursive`.
- **`ios-tests.yml`** — untouched (iOS tests are independent of the component tree).

## Not in scope
The `out_computer` NimBLE header error (`os.h:38:19: error: expected unqualified-id before '(' token`) is a real code/include-order bug, unrelated to the restructure. It remains tracked in #13 and will need its own fix.

## Test plan
- [ ] CI on this PR shows `cpp-tests`, `bench-integration`, and `test` (sim install) green after merge of PRs #14 + #15. (Merge order matters: #14 → #15 → this PR for all green to appear.)
- [ ] `build (out_computer)` still fails on the NimBLE bug — documented known issue.
- [ ] `build (base_station)` continues to pass.
- [ ] `iOS Tests (XCTest)` continues to pass.

## Stack & context
PR 4 of 7 in the Arduino → ESP-IDF restructure. Depends on PR #14 and PR #15 being merged first for CI to go fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
