### PR TITLE
Make TR_GuidancePN private submodule optional (stub + CI auth)

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -12,6 +12,14 @@ on:
       - 'tests_cpp/**'
       - 'tests/integration/**'
 
+# TR_GuidancePN is a private submodule. When the repo secret
+# TR_GUIDANCEPN_TOKEN is set (this org, trusted branches), we recurse
+# submodules and include guidance coverage. For forks / PRs without the
+# secret, we skip the submodule and rely on the stub — guidance tests are
+# simply not discovered (tests_cpp/CMakeLists.txt handles that gracefully).
+env:
+  HAS_GUIDANCE_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' }}
+
 jobs:
   cpp-tests:
     runs-on: ubuntu-latest
@@ -19,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
+          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
 
       - name: Configure
         run: cmake -S tests_cpp -B tests_cpp/build -DCMAKE_BUILD_TYPE=Debug
@@ -36,7 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
+          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -26,7 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # TR_GuidancePN is a private submodule. Recurse only when the
+          # TR_GUIDANCEPN_TOKEN repo secret is present. Without it, the
+          # submodule is skipped and flight_computer's CMakeLists picks
+          # up the TR_GuidancePN_Stub component instead (no-op API).
+          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
+          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
 
       - name: Build ${{ matrix.project }}
         working-directory: tinkerrocket-idf/projects/${{ matrix.project }}

--- a/.github/workflows/sim-tests.yml
+++ b/.github/workflows/sim-tests.yml
@@ -23,7 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # TR_GuidancePN is a private submodule. Recurse only when the
+          # TR_GUIDANCEPN_TOKEN repo secret is present (trusted branches).
+          # Forks / PRs without the secret skip the submodule; the
+          # _guidance pybind11 extension is skipped in setup.py and the
+          # test file uses pytest.importorskip to skip at test time.
+          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
+          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
 
       - uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ TinkerRocket/
 - Python 3.10+ for simulation
 - CMake 3.16+ for host-side tests
 
+### Guidance (optional)
+
+The proportional-navigation guidance law lives in a separate private submodule at [`tinkerrocket-idf/components/TR_GuidancePN`](https://github.com/Tinkerbug-Robotics/TR_GuidancePN). Everything else — roll control, EKF, sensor collection, telemetry, logging, LoRa, BLE, iOS integration, ground-test modes — builds and runs **without** it. Public contributors can clone, build, flash, and contribute to any non-guidance feature with a standard, non-recursive clone.
+
+When the submodule is not initialized:
+- Firmware compiles against a header-only no-op stub (`TR_GuidancePN_Stub`). At boot the flight computer logs `PN Guidance: NOT COMPILED IN (stub active)`. All `guidance.*` call sites still exist, but each method returns zero / false.
+- `tests_cpp`: the `test_guidance_pn` target is skipped at CMake configure time.
+- `tinkerrocket-sim`: the `_guidance` pybind11 extension is skipped at `pip install -e` time; `tests/test_guidance_pn.py` is skipped via `pytest.importorskip`.
+
+Contributors with access can opt in:
+```bash
+git submodule update --init tinkerrocket-idf/components/TR_GuidancePN
+```
+
 ### Firmware (ESP-IDF)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ TinkerRocket/
 │   ├── cpp/                    # pybind11 bindings for EKF, PID, mixer, guidance
 │   └── tests/                  # Pytest regression suite
 │
-├── tests_cpp/                  # GoogleTest host-side unit tests
 ├── tests/integration/          # Binary log replay integration tests
 ├── preflight/                  # Pre-flight go/no-go checklist
 │

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -109,15 +109,23 @@ target_link_libraries(test_control_mixer GTest::gtest_main)
 gtest_discover_tests(test_control_mixer)
 
 # ---------- test_guidance_pn ----------
-add_executable(test_guidance_pn test_guidance_pn.cpp
-    ${LIB_DIR}/TR_GuidancePN/TR_GuidancePN.cpp
-)
-target_include_directories(test_guidance_pn PRIVATE
-    ${SHIM_DIR}
-    ${LIB_DIR}/TR_GuidancePN
-)
-target_link_libraries(test_guidance_pn GTest::gtest_main)
-gtest_discover_tests(test_guidance_pn)
+# TR_GuidancePN is a private submodule (optional). Only build the test if
+# the submodule is initialized. Contributors without access to the private
+# upstream can work on every other feature; guidance tests are skipped.
+if(EXISTS "${LIB_DIR}/TR_GuidancePN/TR_GuidancePN.cpp")
+    add_executable(test_guidance_pn test_guidance_pn.cpp
+        ${LIB_DIR}/TR_GuidancePN/TR_GuidancePN.cpp
+    )
+    target_include_directories(test_guidance_pn PRIVATE
+        ${SHIM_DIR}
+        ${LIB_DIR}/TR_GuidancePN
+    )
+    target_link_libraries(test_guidance_pn GTest::gtest_main)
+    gtest_discover_tests(test_guidance_pn)
+else()
+    message(STATUS "TR_GuidancePN submodule not initialized — skipping test_guidance_pn")
+    message(STATUS "  (to enable: git submodule update --init tinkerrocket-idf/components/TR_GuidancePN)")
+endif()
 
 # ============================================================
 # Phase 3: Data Path Tests (Coordinates, Sensor Converter, LoRa)

--- a/tinkerrocket-idf/components/TR_GuidancePN_Stub/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_GuidancePN_Stub/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Header-only no-op stand-in for the private TR_GuidancePN submodule.
+# See TR_GuidancePN.h in this directory for rationale.
+#
+# This component exposes the same include path (`#include <TR_GuidancePN.h>`)
+# as the real TR_GuidancePN submodule, so consumer code compiles unchanged.
+# The flight_computer project's CMakeLists.txt picks one or the other via
+# EXCLUDE_COMPONENTS at configure time.
+idf_component_register(INCLUDE_DIRS ".")

--- a/tinkerrocket-idf/components/TR_GuidancePN_Stub/TR_GuidancePN.h
+++ b/tinkerrocket-idf/components/TR_GuidancePN_Stub/TR_GuidancePN.h
@@ -1,0 +1,56 @@
+// TR_GuidancePN.h (stub)
+//
+// No-op stand-in for the real TR_GuidancePN submodule. Built ONLY when
+// the real submodule at tinkerrocket-idf/components/TR_GuidancePN is not
+// initialized (e.g. clones without access to the private upstream
+// repository). Provides exactly the same public API as the real class;
+// every method is a no-op that returns zero / false.
+//
+// This lets flight_computer/main.cpp compile and run every non-guidance
+// feature (roll control, EKF, sensors, telemetry, logging, LoRa, BLE)
+// without a single `#ifdef` sprinkled across 15+ call sites. A runtime
+// `guidance_enabled` bool gates most of the public calls anyway, so the
+// stubs rarely execute at all on a public build — and when they do they
+// silently no-op.
+//
+// flight_computer/CMakeLists.txt picks between the real component and
+// this stub at configure time based on whether the submodule is populated
+// (see TR_GUIDANCE_AVAILABLE compile definition). When the real component
+// is present, this stub is excluded from the build via EXCLUDE_COMPONENTS.
+
+#ifndef TR_GUIDANCE_PN_H
+#define TR_GUIDANCE_PN_H
+
+#include <cstdint>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+class TR_GuidancePN {
+public:
+    TR_GuidancePN() = default;
+
+    void configure(float /*nav_gain*/,
+                   float /*max_accel_mps2*/,
+                   float /*target_alt_m*/) {}
+
+    bool update(const float /*pos_enu*/[3],
+                const float /*vel_ned*/[3],
+                float /*dt*/) { return false; }
+
+    float getAccelEastCmd()    const { return 0.0f; }
+    float getAccelNorthCmd()   const { return 0.0f; }
+    float getAccelUpCmd()      const { return 0.0f; }
+    float getLosAngleDeg()     const { return 0.0f; }
+    float getClosingVelocity() const { return 0.0f; }
+    float getRange()           const { return 0.0f; }
+    float getLateralOffset()   const { return 0.0f; }
+    bool  isActive()           const { return false; }
+    bool  isCpaReached()       const { return false; }
+
+    void reset() {}
+};
+
+#endif // TR_GUIDANCE_PN_H

--- a/tinkerrocket-idf/projects/base_station/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
+# base_station doesn't use guidance — exclude both the real submodule and
+# the stub so neither ends up in the component list.
+set(EXCLUDE_COMPONENTS "TR_GuidancePN TR_GuidancePN_Stub")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(base_station)

--- a/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
+
+# TR_GuidancePN is a private submodule. Detect whether it's initialized
+# (working tree populated) and either include it + the stub is excluded,
+# or exclude it + the stub fills in so consumer code compiles unchanged.
+set(_guidance_real_src "${CMAKE_CURRENT_LIST_DIR}/../../components/TR_GuidancePN/TR_GuidancePN.cpp")
+if(EXISTS "${_guidance_real_src}")
+    message(STATUS "TR_GuidancePN submodule found — guidance compiled in")
+    list(APPEND EXCLUDE_COMPONENTS TR_GuidancePN_Stub)
+    add_compile_definitions(TR_GUIDANCE_AVAILABLE=1)
+else()
+    message(STATUS "TR_GuidancePN submodule not initialized — building with no-op stub")
+    list(APPEND EXCLUDE_COMPONENTS TR_GuidancePN)
+    add_compile_definitions(TR_GUIDANCE_AVAILABLE=0)
+endif()
+
 # Exclude BLE and LoRa components not used by FlightComputer
-set(EXCLUDE_COMPONENTS "TR_BLE_To_APP TR_LoRa_Comms TR_INA230")
+list(APPEND EXCLUDE_COMPONENTS TR_BLE_To_APP TR_LoRa_Comms TR_INA230)
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(flight_computer)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1231,7 +1231,11 @@ static void setup_fc()
     ESP_LOGI(TAG, "Gain scheduling: %s", gain_sched_enabled ? "ON" : "OFF");
     ESP_LOGI(TAG, "Angle control: %s  Roll delay: %u ms",
                   use_angle_control ? "ON" : "OFF", (unsigned)roll_delay_ms);
-    ESP_LOGI(TAG, "PN Guidance: %s", guidance_enabled ? "ON" : "OFF");
+#if TR_GUIDANCE_AVAILABLE
+    ESP_LOGI(TAG, "PN Guidance: %s (compiled in)", guidance_enabled ? "ON" : "OFF");
+#else
+    ESP_LOGW(TAG, "PN Guidance: NOT COMPILED IN (TR_GuidancePN submodule not initialized — stub active)");
+#endif
 
     // Configure guidance and control mixer
     guidance.configure(config::PN_NAV_GAIN,

--- a/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
+# out_computer doesn't use guidance — exclude both the real submodule and
+# the stub so neither ends up in the component list.
+set(EXCLUDE_COMPONENTS "TR_GuidancePN TR_GuidancePN_Stub")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(out_computer)

--- a/tinkerrocket-sim/setup.py
+++ b/tinkerrocket-sim/setup.py
@@ -49,10 +49,13 @@ if os.path.exists("cpp/ekf/ekf_bindings.cpp") and os.path.exists(ekf_lib_dir):
         ),
     )
 
-# GuidancePN: submodule under components/. No compat shim needed — the
-# library is framework-neutral.
-guidance_lib_dir = os.path.join(SHARED_LIB_DIR, "TR_GuidancePN")
-if os.path.exists("cpp/guidance/guidance_bindings.cpp") and os.path.exists(guidance_lib_dir):
+# GuidancePN: private submodule under components/. Optional — if the
+# submodule is not initialized, skip the _guidance pybind11 extension and
+# the sim still builds + tests run for everything else (PID, EKF, mixer).
+# No compat shim needed — the library is framework-neutral.
+guidance_src = os.path.join(SHARED_LIB_DIR, "TR_GuidancePN", "TR_GuidancePN.cpp")
+if os.path.exists("cpp/guidance/guidance_bindings.cpp") and os.path.exists(guidance_src):
+    guidance_lib_dir = os.path.join(SHARED_LIB_DIR, "TR_GuidancePN")
     ext_modules.append(
         Pybind11Extension(
             "tinkerrocket_sim._guidance",
@@ -63,6 +66,12 @@ if os.path.exists("cpp/guidance/guidance_bindings.cpp") and os.path.exists(guida
             include_dirs=[guidance_lib_dir, "cpp/common"],
             cxx_std=17,
         ),
+    )
+else:
+    print(
+        "NOTE: TR_GuidancePN submodule not initialized — skipping the _guidance "
+        "pybind11 extension. (To enable: "
+        "git submodule update --init tinkerrocket-idf/components/TR_GuidancePN)"
     )
 
 # ControlMixer: build from shared TR_ControlMixer + TR_PID libraries

--- a/tinkerrocket-sim/tests/test_guidance_pn.py
+++ b/tinkerrocket-sim/tests/test_guidance_pn.py
@@ -1,11 +1,20 @@
 """
 Pybind11 GuidancePN tests.
 Mirrors C++ test_guidance_pn.cpp to ensure sim matches flight code.
+
+Skipped entirely when the private TR_GuidancePN submodule is not
+initialized (i.e. the _guidance pybind11 extension wasn't built).
 """
 import pytest
 import math
 
-from tinkerrocket_sim._guidance import GuidancePN
+_guidance = pytest.importorskip(
+    "tinkerrocket_sim._guidance",
+    reason="TR_GuidancePN submodule not initialized — _guidance extension "
+           "not built. To enable: git submodule update --init "
+           "tinkerrocket-idf/components/TR_GuidancePN",
+)
+GuidancePN = _guidance.GuidancePN
 
 
 TARGET_ALT = 600.0


### PR DESCRIPTION
## Summary
Make the private `TR_GuidancePN` submodule **optional**. Everything else — roll control, EKF, sensors, telemetry, logging, LoRa, BLE, iOS integration — builds and runs without it. Contributors with access to the private upstream opt in with `git submodule update --init`; everyone else gets a stub that no-ops the guidance API.

## Design — stub sibling component
Instead of sprinkling `#if TR_GUIDANCE_AVAILABLE` across ~15 call sites in `flight_computer/main.cpp`, a sibling public component `TR_GuidancePN_Stub` provides the **same public API** (`#include <TR_GuidancePN.h>`) but every method is a no-op returning zero / false. `flight_computer/CMakeLists.txt` detects at configure time whether the real submodule is populated and excludes either the real or the stub — so only one resolves `TR_GuidancePN.h` at a time.

Exactly one `#if` in all of `main.cpp`: the startup log line reports `PN Guidance: compiled in` vs `PN Guidance: NOT COMPILED IN (stub active)` for unambiguous field debug.

## What changed

| File | Change |
|---|---|
| `tinkerrocket-idf/components/TR_GuidancePN_Stub/TR_GuidancePN.h` | **New** — no-op class, public API matches upstream |
| `tinkerrocket-idf/components/TR_GuidancePN_Stub/CMakeLists.txt` | **New** — header-only component registration |
| `tinkerrocket-idf/projects/flight_computer/CMakeLists.txt` | Pick real-or-stub via `if(EXISTS)`, define `TR_GUIDANCE_AVAILABLE={0,1}` |
| `tinkerrocket-idf/projects/flight_computer/main/main.cpp` | 1 line: startup log is `#if` gated |
| `tests_cpp/CMakeLists.txt` | `if(EXISTS …)` wrap on `test_guidance_pn`; prints opt-in hint when skipped |
| `tinkerrocket-sim/setup.py` | Friendlier `NOTE:` print when `_guidance` extension is skipped |
| `tinkerrocket-sim/tests/test_guidance_pn.py` | `pytest.importorskip` with opt-in hint |
| `.github/workflows/cpp-tests.yml` | Secret-conditional `submodules:` + `token:` |
| `.github/workflows/sim-tests.yml` | Same |
| `.github/workflows/firmware-build.yml` | Same |
| `README.md` | New "Guidance (optional)" subsection |

## Verification — both paths locally
| State | `tests_cpp` | `tinkerrocket-sim` |
|---|---|---|
| Real submodule initialized | **94/94** pass | **48/48** pass |
| Submodule `deinit`'d (stub active) | **85/85** pass (9 guidance tests skipped) | **39 passed, 1 skipped** (_guidance extension absent) |

## CI pattern
```yaml
- uses: actions/checkout@v4
  with:
    submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
    token:      ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
```

- **Trusted branches of this repo (secret set)** — clone submodule, guidance paths exercised.
- **Forks / PRs (no secret)** — skip submodule, stub takes over, guidance tests auto-skip.

## Required follow-up from you
Before CI flips to private mode, you need to:
1. Create a fine-grained PAT with **Contents: Read** on `Tinkerbug-Robotics/TR_GuidancePN` (90d or 1y expiry).
2. Add it as a repo secret on `Tinkerbug-Robotics/TinkerRocket` named `TR_GUIDANCEPN_TOKEN`.

Until that happens, CI runs in public mode (which now works cleanly — no more "repo not found" failures). Once added, the next push flips automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
