### PR TITLE
trace_divergence.py: parse current 43-byte NON_SENSOR schema (fixes #32)

### DIFF
--- a/tests/trace_divergence.py
+++ b/tests/trace_divergence.py
@@ -57,8 +57,12 @@ def main():
 
     first_time = None
     for msg_type, msg_len, payload in frames:
-        if msg_type == 0xA5 and msg_len == 42:  # NON_SENSOR
-            fields = struct.unpack('<I hhhh h iii iii BB h', payload)
+        if msg_type == 0xA5 and msg_len in (42, 43):  # NON_SENSOR (43=current, 42=legacy)
+            # Current: uint32 time + i16*4 quat + i16 roll_cmd + i32*3 pos + i32*3 vel
+            #          + u8 flags + u8 rocket_state + i16 baro_alt_rate_dmps + u8 pyro_status
+            # Legacy (42 bytes) is the same minus the trailing pyro_status byte.
+            fmt = '<I hhhh h iii iii BB h B' if msg_len == 43 else '<I hhhh h iii iii BB h'
+            fields = struct.unpack(fmt, payload)
             t = fields[0]
             if first_time is None: first_time = t
             speed = math.sqrt((fields[9]/100.0)**2 + (fields[10]/100.0)**2 + (fields[11]/100.0)**2)


### PR DESCRIPTION
One-line schema fix. Accepts both 42-byte (legacy) and 43-byte (current) NON_SENSOR frames and picks the matching struct format.

Verified on `tests/test_data/flight_20260418_120835.bin`:
```
before: Parsed: 0 EKF, 838 GNSS, 42759 IMU, 22454 BARO
after:  Parsed: 21964 EKF, 838 GNSS, 42759 IMU, 22454 BARO
```

Divergence timeline, interleaved event list, and state-transition report all now populate correctly.

Fixes #32.