### PR TITLE
base_station: SPIFFS fallback, MAX17205G driver, iOS logging fix

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1397,13 +1397,16 @@ struct ControlsView: View {
             Button(action: {
                 device.sendCommand(23)
             }) {
+                // Cmd 23 starts/stops logging on BOTH rocket and base station, so
+                // reflect "logging in progress" if either side reports active.
+                let isLogging = device.telemetry.logging_active || device.telemetry.bs_logging_active
                 HStack {
-                    Image(systemName: device.telemetry.logging_active ? "stop.circle.fill" : "record.circle")
-                    Text(device.telemetry.logging_active ? "Stop Logging" : "Start Logging")
+                    Image(systemName: isLogging ? "stop.circle.fill" : "record.circle")
+                    Text(isLogging ? "Stop Logging" : "Start Logging")
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(device.telemetry.logging_active ? Color.red : Color.orange)
+                .background(isLogging ? Color.red : Color.orange)
                 .foregroundColor(.white)
                 .cornerRadius(10)
             }

--- a/tinkerrocket-idf/components/TR_MAX17205G/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MAX17205G/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "TR_MAX17205G.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat PRIV_REQUIRES driver)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
@@ -1,0 +1,286 @@
+#include <TR_MAX17205G.h>
+
+#include <math.h>
+
+static constexpr uint32_t I2C_TIMEOUT_MS = 100;
+
+namespace Reg = MAX17205_Reg;
+
+TR_MAX17205G::TR_MAX17205G(uint8_t addr)
+    : _dev(nullptr),
+      _addr(addr),
+      _cfg(),
+      _data()
+{
+    _data.voltage       = NAN;
+    _data.current       = NAN;
+    _data.soc           = NAN;
+    _data.temperature   = NAN;
+    _data.capacity      = NAN;
+    _data.full_capacity = NAN;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level I2C
+// ---------------------------------------------------------------------------
+bool TR_MAX17205G::readReg(uint8_t reg, uint16_t& value)
+{
+    if (_dev == nullptr) return false;
+    uint8_t buf[2] = {};
+    esp_err_t err = i2c_master_transmit_receive(_dev, &reg, 1, buf, 2,
+                                                pdMS_TO_TICKS(I2C_TIMEOUT_MS));
+    if (err != ESP_OK) return false;
+    value = ((uint16_t)buf[1] << 8) | buf[0];  // Little-endian on the wire
+    return true;
+}
+
+bool TR_MAX17205G::writeReg(uint8_t reg, uint16_t value)
+{
+    if (_dev == nullptr) return false;
+    uint8_t buf[3] = { reg,
+                       (uint8_t)(value & 0xFF),
+                       (uint8_t)((value >> 8) & 0xFF) };
+    return i2c_master_transmit(_dev, buf, 3, pdMS_TO_TICKS(I2C_TIMEOUT_MS)) == ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// begin
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17205G::begin(i2c_master_bus_handle_t bus,
+                              const TR_MAX17205G_Config& cfg,
+                              uint32_t clock_hz)
+{
+    _cfg = cfg;
+
+    i2c_device_config_t dev_cfg = {};
+    dev_cfg.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+    dev_cfg.device_address  = _addr;
+    dev_cfg.scl_speed_hz    = clock_hz;
+
+    esp_err_t err = i2c_master_bus_add_device(bus, &dev_cfg, &_dev);
+    if (err != ESP_OK) return err;
+
+    // Probe: most registers are always readable, pick Status (0x00).
+    uint16_t probe = 0;
+    if (!readReg(Reg::STATUS, probe))
+    {
+        i2c_master_bus_rm_device(_dev);
+        _dev = nullptr;
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// DesignCap scaling
+// ---------------------------------------------------------------------------
+// Capacity registers use 1 LSB = 5 µVh / Rsense.
+// For Rsense = 10 mΩ: 1 LSB = 0.5 mAh, so raw = mAh * 2.
+// For generic Rsense: raw = mAh * 2 * (10 / rsense_mohm).
+uint16_t TR_MAX17205G::designCapRaw() const
+{
+    float raw = (float)_cfg.design_mah * 2.0f * (10.0f / _cfg.rsense_mohm);
+    if (raw < 0.0f)       raw = 0.0f;
+    if (raw > 65535.0f)   raw = 65535.0f;
+    return (uint16_t)raw;
+}
+
+// ---------------------------------------------------------------------------
+// initIfNeeded
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17205G::initIfNeeded()
+{
+    if (_dev == nullptr) return ESP_FAIL;
+
+    uint16_t status = 0;
+    if (!readReg(Reg::STATUS, status))
+    {
+        ESP_LOGE("MAX17205", "Status read failed during init check");
+        return ESP_FAIL;
+    }
+
+    bool por = (status & 0x0002);
+
+    // Sanity check: if FullCapNom is more than 20% off from our configured
+    // DesignCap, assume the chip is stuck on a stale NV value and re-init.
+    bool cap_stale = false;
+    uint16_t expected = designCapRaw();
+    uint16_t fcn = 0;
+    if (readReg(Reg::FULL_CAP_NOM, fcn))
+    {
+        uint32_t diff = (fcn > expected) ? (fcn - expected) : (expected - fcn);
+        if (diff > (uint32_t)(expected / 5)) cap_stale = true;
+    }
+
+    if (!por && !cap_stale) return ESP_OK;  // Quiet no-op path
+    return runEzInit();
+}
+
+esp_err_t TR_MAX17205G::forceReinit()
+{
+    if (_dev == nullptr) return ESP_FAIL;
+    return runEzInit();
+}
+
+// ---------------------------------------------------------------------------
+// runEzInit — ModelGauge m5 "EZ" configuration + capacity override
+//
+// The datasheet's recommended init writes DesignCap and triggers a ModelCfg
+// refresh. By itself, that isn't enough when the chip has a stale nFullCapNom
+// in its nonvolatile backup (which our parts do — they restore FullCapNom to
+// ~655 mAh on every POR regardless of DesignCap). After the refresh we also
+// directly write FullCap / FullCapRep / FullCapNom / RepCap in volatile RAM
+// so RepSOC computes against the correct pack capacity from the very first
+// sample. Volatile writes repeat on each cold boot — no NV write budget spent.
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17205G::runEzInit()
+{
+    const uint16_t design_raw = designCapRaw();
+
+    // 1. Wait for FStat.DNR to clear — up to ~2 s after POR
+    for (int i = 0; i < 200; ++i)
+    {
+        uint16_t fstat = 0;
+        if (readReg(Reg::FSTAT, fstat) && !(fstat & 0x0001)) break;
+        delay(10);
+    }
+
+    // 2. Save HibCfg, pull chip out of hibernate so writes take effect
+    uint16_t orig_hibcfg = 0;
+    readReg(Reg::HIB_CFG, orig_hibcfg);
+    writeReg(Reg::SOFT_WAKEUP, 0x0090);
+    writeReg(Reg::HIB_CFG, 0x0000);
+    writeReg(Reg::SOFT_WAKEUP, 0x0000);
+    delay(10);
+
+    // 3. Seed model inputs
+    writeReg(Reg::DESIGN_CAP, design_raw);
+    writeReg(Reg::ICHG_TERM,  0x0640);   // ~250 mA at 10 mΩ — default is fine
+    writeReg(Reg::V_EMPTY,    0x9661);   // VE=3000 mV, VR=3880 mV (standard Li-ion)
+
+    // 4. Trigger ModelCfg.Refresh with default 4.2 V Li-ion chemistry
+    writeReg(Reg::MODEL_CFG, 0x8000);
+    bool refresh_ok = false;
+    for (int i = 0; i < 200; ++i)
+    {
+        uint16_t mcfg = 0;
+        if (readReg(Reg::MODEL_CFG, mcfg) && !(mcfg & 0x8000))
+        {
+            refresh_ok = true;
+            break;
+        }
+        delay(10);
+    }
+
+    // 5. Override stuck capacity registers (volatile — bypasses bad NV state)
+    writeReg(Reg::FULL_CAP,     design_raw);
+    writeReg(Reg::FULL_CAP_REP, design_raw);
+    writeReg(Reg::FULL_CAP_NOM, design_raw);
+
+    // 6. Seed RepCap from VFSOC × FullCap so RepSOC starts sensible.
+    //    VFSOC is in 1/256 %, so the full-scale raw is 25600 (not 65536).
+    //    RepCap_raw = FullCap_raw × VFSOC_raw / 25600.
+    uint16_t vfsoc = 0;
+    if (readReg(Reg::VFSOC, vfsoc))
+    {
+        uint32_t rep_cap = ((uint32_t)design_raw * (uint32_t)vfsoc) / 25600U;
+        if (rep_cap > design_raw) rep_cap = design_raw;
+        writeReg(Reg::REP_CAP, (uint16_t)rep_cap);
+    }
+
+    // 7. Restore HibCfg
+    writeReg(Reg::HIB_CFG, orig_hibcfg);
+
+    // 8. Clear Status.POR (bit 1), Br (bit 15), Bi (bit 11) so we don't re-run
+    //    init on every MCU reboot while the chip stays battery-powered
+    uint16_t status_after = 0;
+    if (readReg(Reg::STATUS, status_after))
+    {
+        writeReg(Reg::STATUS, status_after & ~((uint16_t)0x8802));
+    }
+
+    // Verify writes landed; warn loudly only if they didn't.
+    uint16_t dc_back = 0;
+    readReg(Reg::DESIGN_CAP, dc_back);
+    if (dc_back != design_raw || !refresh_ok)
+    {
+        ESP_LOGW("MAX17205",
+                 "EZ init incomplete: DesignCap readback 0x%04X vs wrote 0x%04X, refresh=%s",
+                 dc_back, design_raw, refresh_ok ? "OK" : "TIMEOUT");
+    }
+    else
+    {
+        ESP_LOGI("MAX17205", "Configured for %u mAh pack (%u cells, Rsense %.1f mΩ)",
+                 (unsigned)_cfg.design_mah,
+                 (unsigned)_cfg.num_cells,
+                 (double)_cfg.rsense_mohm);
+    }
+
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17205G::update()
+{
+    if (_dev == nullptr) return ESP_FAIL;
+
+    uint16_t raw = 0;
+
+    // Pack voltage: VCell is per-cell voltage (0.078125 mV/LSB).
+    if (readReg(Reg::VCELL, raw))
+        _data.voltage = (float)raw * 0.078125e-3f * (float)_cfg.num_cells;
+
+    // RepSOC: 1/256 % per LSB
+    if (readReg(Reg::REP_SOC, raw))
+        _data.soc = (float)raw / 256.0f;
+
+    // Current: signed, 1.5625 µV per LSB / Rsense. Result in mA.
+    if (readReg(Reg::CURRENT, raw))
+    {
+        float cur_ma = (float)(int16_t)raw * 1.5625e-3f / (_cfg.rsense_mohm * 1e-3f);
+        _data.current = _cfg.current_invert ? -cur_ma : cur_ma;
+    }
+
+    // Temperature: signed, 1/256 °C per LSB
+    if (readReg(Reg::TEMP, raw))
+        _data.temperature = (float)(int16_t)raw / 256.0f;
+
+    // Remaining capacity: 0.5 mAh/LSB at 10 mΩ, scales with rsense
+    if (readReg(Reg::REP_CAP, raw))
+        _data.capacity = (float)raw * 0.5f * (10.0f / _cfg.rsense_mohm);
+
+    // Full capacity (learned)
+    if (readReg(Reg::FULL_CAP_REP, raw))
+        _data.full_capacity = (float)raw * 0.5f * (10.0f / _cfg.rsense_mohm);
+
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// logDiagnostics — one-shot register dump for troubleshooting
+// ---------------------------------------------------------------------------
+void TR_MAX17205G::logDiagnostics(const char* log_tag)
+{
+    if (_dev == nullptr) return;
+    uint16_t raw = 0;
+    auto pct = [](uint16_t r) { return (float)r / 256.0f; };
+    const float cap_lsb_mah = 0.5f * (10.0f / _cfg.rsense_mohm);
+
+    ESP_LOGI(log_tag, "[FG-DIAG] --- MAX17205 register dump ---");
+    if (readReg(Reg::STATUS,       raw)) ESP_LOGI(log_tag, "[FG-DIAG] Status     (0x00) = 0x%04X", raw);
+    if (readReg(Reg::REP_SOC,      raw)) ESP_LOGI(log_tag, "[FG-DIAG] RepSOC     (0x06) = %.2f %% (raw=0x%04X)", pct(raw), raw);
+    if (readReg(Reg::MIX_SOC,      raw)) ESP_LOGI(log_tag, "[FG-DIAG] MixSOC     (0x0D) = %.2f %% (raw=0x%04X)", pct(raw), raw);
+    if (readReg(Reg::AV_SOC,       raw)) ESP_LOGI(log_tag, "[FG-DIAG] AvSOC      (0x0E) = %.2f %% (raw=0x%04X)", pct(raw), raw);
+    if (readReg(Reg::VFSOC,        raw)) ESP_LOGI(log_tag, "[FG-DIAG] VFSOC      (0xFF) = %.2f %% (raw=0x%04X)", pct(raw), raw);
+    if (readReg(Reg::REP_CAP,      raw)) ESP_LOGI(log_tag, "[FG-DIAG] RepCap     (0x05) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::FULL_CAP,     raw)) ESP_LOGI(log_tag, "[FG-DIAG] FullCap    (0x10) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::FULL_CAP_REP, raw)) ESP_LOGI(log_tag, "[FG-DIAG] FullCapRep (0x35) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::FULL_CAP_NOM, raw)) ESP_LOGI(log_tag, "[FG-DIAG] FullCapNom (0x23) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::DESIGN_CAP,   raw)) ESP_LOGI(log_tag, "[FG-DIAG] DesignCap  (0x18) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::PACK_CFG,     raw)) ESP_LOGI(log_tag, "[FG-DIAG] PackCfg    (0xBD) = 0x%04X", raw);
+    ESP_LOGI(log_tag, "[FG-DIAG] Pack: %u cells series, design %u mAh, Rsense %.1f mΩ",
+             (unsigned)_cfg.num_cells, (unsigned)_cfg.design_mah, (double)_cfg.rsense_mohm);
+    ESP_LOGI(log_tag, "[FG-DIAG] --------------------------------");
+}

--- a/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.h
+++ b/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.h
@@ -1,0 +1,111 @@
+#ifndef TR_MAX17205G_H
+#define TR_MAX17205G_H
+
+#include <compat.h>
+#include <driver/i2c_master.h>
+
+// MAX17201/MAX17205 ModelGauge m5 fuel gauge driver.
+// Supports 1S/2S/3S Li-ion packs. Uses the primary I2C address (0x36) for
+// volatile registers 0x00-0xFF. Nonvolatile registers at 0x100-0x1FF (accessed
+// via secondary address 0x0B) are intentionally NOT written — the chip has a
+// limited NV write budget (~7) and all needed config can be re-seeded on each
+// cold boot into volatile shadow RAM.
+
+namespace MAX17205_Reg {
+    // Output / status
+    static constexpr uint8_t STATUS     = 0x00;  // POR bit 1, Br bit 15, Bi bit 11
+    static constexpr uint8_t REP_CAP    = 0x05;  // Reported remaining capacity
+    static constexpr uint8_t REP_SOC    = 0x06;  // Reported SOC (1/256 %)
+    static constexpr uint8_t TEMP       = 0x08;  // Die temp (signed, 1/256 °C)
+    static constexpr uint8_t VCELL      = 0x09;  // Per-cell voltage (0.078125 mV/LSB)
+    static constexpr uint8_t CURRENT    = 0x0A;  // Signed (1.5625 µV / Rsense)
+    static constexpr uint8_t AVG_CUR    = 0x0B;
+    static constexpr uint8_t MIX_SOC    = 0x0D;
+    static constexpr uint8_t AV_SOC     = 0x0E;
+    static constexpr uint8_t FULL_CAP   = 0x10;
+    static constexpr uint8_t AVG_VCELL  = 0x19;
+    static constexpr uint8_t FULL_CAP_NOM = 0x23;
+    static constexpr uint8_t FULL_CAP_REP = 0x35;
+    static constexpr uint8_t VFSOC      = 0xFF;
+    static constexpr uint8_t FSTAT      = 0x3D;  // DNR bit 0
+
+    // Config / command
+    static constexpr uint8_t DESIGN_CAP = 0x18;
+    static constexpr uint8_t ICHG_TERM  = 0x1E;
+    static constexpr uint8_t V_EMPTY    = 0x3A;
+    static constexpr uint8_t SOFT_WAKEUP = 0x60;
+    static constexpr uint8_t HIB_CFG    = 0xBA;
+    static constexpr uint8_t PACK_CFG   = 0xBD;
+    static constexpr uint8_t MODEL_CFG  = 0xDB;  // Bit 15 = Refresh (self-clearing)
+}
+
+struct TR_MAX17205G_Data
+{
+    float voltage;        // Pack voltage, V
+    float current;        // mA (positive = charging after optional invert)
+    float soc;            // State-of-charge, %
+    float temperature;    // °C
+    float capacity;       // Remaining capacity, mAh
+    float full_capacity;  // Full capacity (learned), mAh
+};
+
+struct TR_MAX17205G_Config
+{
+    uint16_t design_mah     = 2800;   // Pack design capacity in mAh (series = per-cell)
+    float    rsense_mohm    = 10.0f;  // Sense resistor value
+    bool     current_invert = true;   // Flip sign (use true if R_SENSE polarity reversed
+                                      //   vs datasheet, so charge reads positive)
+    uint8_t  num_cells      = 2;      // Series cell count (for pack-voltage scaling
+                                      //   off the VCell register)
+};
+
+class TR_MAX17205G
+{
+public:
+    explicit TR_MAX17205G(uint8_t addr = 0x36);
+
+    // Add device to an existing I2C master bus and probe it.
+    esp_err_t begin(i2c_master_bus_handle_t bus,
+                    const TR_MAX17205G_Config& cfg,
+                    uint32_t clock_hz = 400000);
+
+    // Runs the ModelGauge m5 EZ init (DesignCap + ModelCfg.Refresh + override of
+    // FullCap/FullCapRep/FullCapNom/RepCap). Decides whether to run based on
+    // Status.POR and a sanity check that FullCapNom roughly matches DesignCap.
+    // Always safe to call at boot.
+    esp_err_t initIfNeeded();
+
+    // Force the full init regardless of chip state. Use from diagnostics.
+    esp_err_t forceReinit();
+
+    // Re-read voltage/current/soc/temperature/capacity. Populates data().
+    esp_err_t update();
+
+    const TR_MAX17205G_Data& data() const { return _data; }
+    float voltage() const     { return _data.voltage; }
+    float current() const     { return _data.current; }
+    float soc() const         { return _data.soc; }
+    float temperature() const { return _data.temperature; }
+
+    // Low-level helpers (exposed for diagnostics).
+    bool readReg(uint8_t reg, uint16_t& value);
+    bool writeReg(uint8_t reg, uint16_t value);
+
+    // One-shot diagnostic dump: Status, candidate SoC registers, capacity
+    // registers, and pack voltage. Uses ESP_LOGI under the given log tag.
+    void logDiagnostics(const char* log_tag);
+
+    // Compute the DesignCap raw value for the configured pack. Exposed for
+    // tests and the staleness check.
+    uint16_t designCapRaw() const;
+
+private:
+    esp_err_t runEzInit();
+
+    i2c_master_dev_handle_t _dev;
+    uint8_t                 _addr;
+    TR_MAX17205G_Config     _cfg;
+    TR_MAX17205G_Data       _data;
+};
+
+#endif

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -9,10 +9,12 @@ idf_component_register(
         TR_Coordinates
         TR_BLE_To_APP
         TR_LoRa_Comms
+        TR_MAX17205G
         driver
         esp_timer
         fatfs
         sdmmc
+        spiffs
         vfs
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -63,4 +63,8 @@ namespace config
     static constexpr int      NUM_BATTERY_CELLS  = 2;        // 2S NCR18650B
     static constexpr float    RSENSE_MOHM        = 10.0f;    // Sense resistor (mΩ)
     static constexpr uint32_t PWR_UPDATE_PERIOD_MS = 2000;   // Battery read interval
+    // Pack design capacity in mAh. Two 2800 mAh 18650 cells in 2S = 2800 mAh
+    // (series doubles voltage, capacity stays per-cell). Written to MAX17205
+    // DesignCap at boot to seed the ModelGauge m5 algorithm.
+    static constexpr uint16_t BATTERY_DESIGN_MAH = 2800;
 }

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -5,6 +5,7 @@
 #include <esp_log.h>
 #include <esp_mac.h>              // esp_efuse_mac_get_default for unit_id
 #include <esp_vfs_fat.h>
+#include <esp_spiffs.h>
 #include <sdmmc_cmd.h>
 #include <driver/sdmmc_host.h>
 #include <driver/i2c_master.h>
@@ -22,6 +23,7 @@
 #include <TR_Sensor_Data_Converter.h>
 #include <TR_Coordinates.h>
 #include <TR_BLE_To_APP.h>
+#include <TR_MAX17205G.h>
 #include <RocketComputerTypes.h>
 
 static const char* TAG = "BS";
@@ -54,7 +56,8 @@ static float bs_current = NAN;
 static float bs_temperature = NAN;
 static uint32_t last_battery_ms = 0;
 static i2c_master_bus_handle_t i2c_bus = nullptr;
-static i2c_master_dev_handle_t max17205_dev = nullptr;
+static TR_MAX17205G fuel_gauge(config::MAX17205_ADDR);
+static bool fuel_gauge_present = false;
 
 // Servo/PID config cache (for BLE readback — mirrors what was sent to rocket)
 static int16_t cfg_servo_bias1 = 0;
@@ -80,9 +83,14 @@ static uint8_t  uplink_retries_left = 0;
 static uint32_t uplink_last_tx_ms = 0;
 static bool     uplink_pending = false;
 
-// SDMMC mount state
+// Storage mount state. Preferred backend is SD over SDMMC; if that fails at boot
+// we fall back to SPIFFS on internal flash (partitions.csv: "spiffs", ~5 MB).
+// The pointer is reassigned to /flash on fallback so all downstream paths
+// (logger, BLE file list/delete/download) keep working via VFS unchanged.
 static const char* SD_MOUNT_POINT = "/sdcard";
 static sdmmc_card_t* sd_card = nullptr;
+static bool using_internal_flash = false;
+static const char* SPIFFS_PARTITION_LABEL = "spiffs";
 
 // CSV logging state
 static FILE* log_file = nullptr;
@@ -154,38 +162,17 @@ static uint8_t  sync_month = 0, sync_day = 0;
 static uint8_t  sync_hour = 0, sync_minute = 0, sync_second = 0;
 
 // ── MAX17205G fuel gauge helpers ──
-
-static bool max17205_readReg16(uint8_t reg, uint16_t& value)
-{
-    if (max17205_dev == nullptr) return false;
-    uint8_t buf[2] = {};
-    esp_err_t err = i2c_master_transmit_receive(max17205_dev, &reg, 1, buf, 2, pdMS_TO_TICKS(100));
-    if (err != ESP_OK) return false;
-    value = ((uint16_t)buf[1] << 8) | buf[0];
-    return true;
-}
-
+// The chip is read/configured through the TR_MAX17205G component.
+// updateBattery() fans the latest readings into the global fields used by
+// the BLE telemetry builder.
 static void updateBattery()
 {
-    if (max17205_dev == nullptr) return;
-
-    uint16_t raw;
-
-    // Pack voltage from VCell register (lowest cell × nCells)
-    if (max17205_readReg16(0x09, raw))
-        bs_voltage = (float)raw * 0.078125f * config::NUM_BATTERY_CELLS / 1000.0f;
-
-    // State of charge (%)
-    if (max17205_readReg16(0x06, raw))
-        bs_soc = (float)raw / 256.0f;
-
-    // Current (mA) — signed
-    if (max17205_readReg16(0x0A, raw))
-        bs_current = (float)(int16_t)raw * 1.5625e-3f / (config::RSENSE_MOHM * 1e-3f);
-
-    // Temperature (°C) — signed
-    if (max17205_readReg16(0x08, raw))
-        bs_temperature = (float)(int16_t)raw / 256.0f;
+    if (!fuel_gauge_present) return;
+    fuel_gauge.update();
+    bs_voltage     = fuel_gauge.voltage();
+    bs_soc         = fuel_gauge.soc();
+    bs_current     = fuel_gauge.current();
+    bs_temperature = fuel_gauge.temperature();
 }
 
 // ============================================================================
@@ -340,22 +327,36 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
 {
     if (!logging_active) return;
 
-    // Periodic flash usage check (every 100 writes)
+    // Periodic storage usage check (every 100 writes)
     if (++log_write_count % 100 == 0)
     {
-        FATFS* fs;
-        DWORD free_clust;
-        if (f_getfree("0:", &free_clust, &fs) == FR_OK)
+        uint64_t total = 0, used = 0;
+        if (using_internal_flash)
         {
-            uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
-            uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
-            uint64_t used = total - free_bytes;
-            if (total > 0 && used > (total * 9 / 10))
+            size_t t = 0, u = 0;
+            if (esp_spiffs_info(SPIFFS_PARTITION_LABEL, &t, &u) == ESP_OK)
             {
-                ESP_LOGW(TAG, "[LOG] SD card nearly full! %llu/%llu bytes (%.0f%%)",
-                         (unsigned long long)used, (unsigned long long)total,
-                         (double)used * 100.0 / (double)total);
+                total = t;
+                used  = u;
             }
+        }
+        else
+        {
+            FATFS* fs;
+            DWORD free_clust;
+            if (f_getfree("0:", &free_clust, &fs) == FR_OK)
+            {
+                total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
+                uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
+                used = total - free_bytes;
+            }
+        }
+        if (total > 0 && used > (total * 9 / 10))
+        {
+            ESP_LOGW(TAG, "[LOG] %s nearly full! %llu/%llu bytes (%.0f%%)",
+                     using_internal_flash ? "Internal flash" : "SD card",
+                     (unsigned long long)used, (unsigned long long)total,
+                     (double)used * 100.0 / (double)total);
         }
     }
 
@@ -886,13 +887,13 @@ static void setup_bs()
     ESP_LOGI(TAG, "  TinkerRocket Base Station");
     ESP_LOGI(TAG, "======================================");
 
-    // Initialize SD card (SDMMC 4-bit mode) via ESP-IDF VFS
+    // Initialize storage: prefer SD (SDMMC 4-bit), fall back to SPIFFS on internal flash.
     {
         sdmmc_host_t host = SDMMC_HOST_DEFAULT();
         host.max_freq_khz = SDMMC_FREQ_DEFAULT;
 
         sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
-        slot.width = 4;  // 4-bit mode
+        slot.width = 4;
         slot.clk = (gpio_num_t)config::SD_CLK;
         slot.cmd = (gpio_num_t)config::SD_CMD;
         slot.d0  = (gpio_num_t)config::SD_D0;
@@ -908,13 +909,7 @@ static void setup_bs()
 
         esp_err_t ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot,
                                                  &mount_cfg, &sd_card);
-        if (ret != ESP_OK)
-        {
-            ESP_LOGE(TAG, "SD card mount FAILED (0x%x)! Check card is inserted and FAT32 formatted.",
-                     (int)ret);
-            sd_card = nullptr;
-        }
-        else
+        if (ret == ESP_OK)
         {
             sdmmc_card_print_info(stdout, sd_card);
 
@@ -930,8 +925,45 @@ static void setup_bs()
                          (unsigned long long)(used / (1024 * 1024)),
                          (unsigned long long)(free_bytes / (1024 * 1024)));
             }
+        }
+        else
+        {
+            ESP_LOGW(TAG, "SD card mount failed (0x%x) — falling back to internal flash (SPIFFS)",
+                     (int)ret);
+            sd_card = nullptr;
 
-            // Verify SD card is writable
+            esp_vfs_spiffs_conf_t spiffs_conf = {};
+            spiffs_conf.base_path              = "/flash";
+            spiffs_conf.partition_label        = SPIFFS_PARTITION_LABEL;
+            spiffs_conf.max_files              = 5;
+            spiffs_conf.format_if_mount_failed = true;
+
+            esp_err_t sret = esp_vfs_spiffs_register(&spiffs_conf);
+            if (sret != ESP_OK)
+            {
+                ESP_LOGE(TAG, "SPIFFS fallback mount FAILED (0x%x) — no logging available",
+                         (int)sret);
+            }
+            else
+            {
+                SD_MOUNT_POINT = "/flash";
+                using_internal_flash = true;
+
+                size_t total = 0, used = 0;
+                if (esp_spiffs_info(SPIFFS_PARTITION_LABEL, &total, &used) == ESP_OK)
+                {
+                    ESP_LOGI(TAG, "SPIFFS mounted at %s: %u KB total, %u KB used, %u KB free",
+                             SD_MOUNT_POINT,
+                             (unsigned)(total / 1024),
+                             (unsigned)(used / 1024),
+                             (unsigned)((total - used) / 1024));
+                }
+            }
+        }
+
+        // Write test covers both backends
+        if (sd_card || using_internal_flash)
+        {
             char test_path[48];
             snprintf(test_path, sizeof(test_path), "%s/.write_test", SD_MOUNT_POINT);
             FILE* test = fopen(test_path, "w");
@@ -940,11 +972,12 @@ static void setup_bs()
                 fprintf(test, "ok\n");
                 fclose(test);
                 remove(test_path);
-                ESP_LOGI(TAG, "SD card write test: OK");
+                ESP_LOGI(TAG, "Storage write test: OK (%s)",
+                         using_internal_flash ? "internal flash" : "SD card");
             }
             else
             {
-                ESP_LOGE(TAG, "SD card write test FAILED! errno=%d (%s) — card may be write-protected",
+                ESP_LOGE(TAG, "Storage write test FAILED! errno=%d (%s)",
                          errno, strerror(errno));
             }
         }
@@ -961,24 +994,32 @@ static void setup_bs()
         bus_cfg.flags.enable_internal_pullup = false;
 
         esp_err_t err = i2c_new_master_bus(&bus_cfg, &i2c_bus);
-        if (err == ESP_OK)
+        if (err == ESP_OK &&
+            i2c_master_probe(i2c_bus, config::MAX17205_ADDR, pdMS_TO_TICKS(50)) == ESP_OK)
         {
-            i2c_device_config_t dev_cfg = {};
-            dev_cfg.dev_addr_length = I2C_ADDR_BIT_LEN_7;
-            dev_cfg.device_address  = config::MAX17205_ADDR;
-            dev_cfg.scl_speed_hz    = config::I2C_FREQ_HZ;
-            err = i2c_master_bus_add_device(i2c_bus, &dev_cfg, &max17205_dev);
-        }
+            TR_MAX17205G_Config fg_cfg;
+            fg_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
+            fg_cfg.rsense_mohm    = config::RSENSE_MOHM;
+            fg_cfg.current_invert = true;   // R_SENSE reversed on this board
+            fg_cfg.num_cells      = config::NUM_BATTERY_CELLS;
 
-        if (err == ESP_OK && i2c_master_probe(i2c_bus, config::MAX17205_ADDR, pdMS_TO_TICKS(50)) == ESP_OK)
-        {
-            ESP_LOGI(TAG, "MAX17205G fuel gauge found on I2C (0x%02X)", config::MAX17205_ADDR);
-            updateBattery();
+            if (fuel_gauge.begin(i2c_bus, fg_cfg, config::I2C_FREQ_HZ) == ESP_OK)
+            {
+                fuel_gauge_present = true;
+                ESP_LOGI(TAG, "MAX17205G fuel gauge found on I2C (0x%02X)", config::MAX17205_ADDR);
+                fuel_gauge.initIfNeeded();
+                updateBattery();
+                ESP_LOGI(TAG, "Battery: %.2f V, %.1f%% SoC, %.0f mA",
+                         (double)bs_voltage, (double)bs_soc, (double)bs_current);
+            }
+            else
+            {
+                ESP_LOGW(TAG, "MAX17205G probe succeeded but begin() failed");
+            }
         }
         else
         {
             ESP_LOGW(TAG, "MAX17205G not found — battery readings unavailable");
-            max17205_dev = nullptr;
         }
     }
 
@@ -1272,17 +1313,25 @@ static void loop_bs()
         // Re-send last-known rocket telemetry so battery/RSSI stay up to date.
         if (ble_app.isConnected())
         {
+            TR_BLE_To_APP::TelemetryData ble_telem = {};
             auto& tr = tracked_rockets[active_rocket_idx];
             if (tr.active)
             {
-                TR_BLE_To_APP::TelemetryData ble_telem = {};
                 buildBLETelemetry(tr.last_data, tr.last_rssi, tr.last_snr,
                                   tr.last_lat_deg, tr.last_lon_deg, tr.last_alt_m, ble_telem);
                 if (tr.unit_name[0]) {
                     ble_telem.source_unit_name = tr.unit_name;
                 }
-                ble_app.sendTelemetry(ble_telem);
             }
+            else
+            {
+                // No rocket tracked — publish base-station-only fields so the
+                // app still sees BS battery/logging state. Rocket-side fields
+                // stay NaN/zero.
+                LoRaDataSI empty = {};
+                buildBLETelemetry(empty, NAN, NAN, NAN, NAN, NAN, ble_telem);
+            }
+            ble_app.sendTelemetry(ble_telem);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes that came out of bringing up a freshly-assembled base station board:

- **SD fallback to SPIFFS** — this board's SD mount fails at 0x107 on DAT0; now falls through to the existing 5 MB `spiffs` partition at `/flash` so logging keeps working. Short-term workaround; PCB swap to onboard NAND tracked in #36.
- **Base-station telemetry without a rocket** — the periodic BLE update previously gated on `tr.active`, so the iOS app never saw `bs_voltage` / `bs_soc` / `bs_current` with no rocket connected. Now sends a zeroed rocket frame with only BS-local fields populated.
- **MAX17205G driver component** — new `TR_MAX17205G` in `components/`, replacing the inline helpers in `main.cpp`. Implements the datasheet EZ init and also overrides the stuck nonvolatile `FullCapNom` in volatile RAM so `RepSOC` tracks reality (was reading ~1% on an 8.4 V pack). Seeds `RepCap` from `VFSOC` so the first reading is correct.
- **Current sign inversion** — R_SENSE on this board is wired opposite to the datasheet; handled via the driver's `current_invert` config flag.
- **iOS logging button fix** — button now ORs `logging_active` with `bs_logging_active` so it flips correctly when BS-only logging is active (no rocket connected).

## Commits

1. `Add TR_MAX17205G component for fuel gauge reads + init`
2. `base_station: SPIFFS fallback + MAX17205G wiring + misc BLE/power fixes`
3. `ios: logging button tracks base-station logging too`

## Test plan

- [x] Base station boots and mounts `/flash` (SPIFFS) when SD fails; CSV logging + file list + BLE download all work against that path.
- [x] iOS app receives BS telemetry (`bsoc` / `bvol` / `bcur`) with no rocket connected.
- [x] MAX17205 reports correct SoC (86.5% at 8.37 V, 2S 2800 mAh pack) from first boot.
- [x] Current sign: charging shows positive mA.
- [x] iOS Start/Stop Logging button flips correctly on BS-only logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
