### PR TITLE
base_station: frequency scan for pre-launch collision avoidance (#6)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -47,6 +47,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var connectedRSSI: Int?
     @Published var rocketConfig: RocketConfig?
 
+    // Frequency scan state (base-station pre-launch collision avoidance)
+    @Published var scanSamples: [FrequencyScanSample] = []
+    @Published var isScanning: Bool = false
+
     // MARK: - Device identity (populated from config_identity readback)
 
     @Published var unitID: String = ""      // e.g. "a1b2c3d4" (immutable hardware ID)
@@ -185,6 +189,24 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         data.append(payload)
         peripheral.writeValue(data, for: characteristic, type: .withResponse)
         print("Sent command \(command) with \(payload.count) bytes payload")
+    }
+
+    /// Kick off a base-station frequency scan.  Clears any previous results
+    /// and flips `isScanning` true; the result arrives asynchronously on the
+    /// FILE_OPS characteristic and resets `isScanning` when parsed.
+    func startFrequencyScan(startMHz: Float, stopMHz: Float, stepKHz: UInt16, dwellMs: UInt16) {
+        var payload = Data()
+        var start = startMHz
+        var stop  = stopMHz
+        var step  = stepKHz
+        var dwell = dwellMs
+        payload.append(Data(bytes: &start, count: 4))
+        payload.append(Data(bytes: &stop,  count: 4))
+        payload.append(Data(bytes: &step,  count: 2))
+        payload.append(Data(bytes: &dwell, count: 2))
+        scanSamples = []
+        isScanning = true
+        sendRawCommand(60, payload: payload)
     }
 
     func sendLoRaConfig(freqMHz: Float, bwKHz: Float, sf: UInt8, cr: UInt8, txPower: Int8) {
@@ -733,7 +755,15 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         if characteristic.uuid == telemetryCharUUID {
             parseTelemetryData(characteristic.value)
         } else if characteristic.uuid == fileOpsCharUUID {
-            if let data = characteristic.value { parseFileList(data) }
+            if let data = characteristic.value {
+                // Scan results use a 0xAA binary prefix; JSON responses start
+                // with '{' or '[' so the first byte is enough to disambiguate.
+                if data.first == 0xAA {
+                    parseScanResult(data)
+                } else {
+                    parseFileList(data)
+                }
+            }
         } else if characteristic.uuid == fileTransferCharUUID {
             if let data = characteristic.value { handleFileChunk(data) }
         }
@@ -859,6 +889,45 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         if let i = value as? Int { return Float(i) }
         if let s = value as? String { return Float(s) }
         return nil
+    }
+
+    /// Parse the base-station scan-result binary blob.
+    /// Format: [0xAA][start_mhz f32][step_khz f32][n u8][rssi i8 × n]
+    /// Floats live at unaligned offsets (1 and 5), so we use `loadUnaligned`
+    /// — plain `load` there is undefined behaviour and was silently failing.
+    /// We copy into a `[UInt8]` first so indexing is always zero-based, which
+    /// avoids the `Data` slice-startIndex footgun if CoreBluetooth ever hands
+    /// us a sliced buffer.
+    private func parseScanResult(_ data: Data) {
+        print("[SCAN] parseScanResult: \(data.count) bytes, first=\(data.first.map { String(format: "0x%02X", $0) } ?? "nil")")
+        let bytes = [UInt8](data)
+        guard bytes.count >= 10, bytes[0] == 0xAA else {
+            print("[SCAN] Malformed scan result (len=\(bytes.count))")
+            isScanning = false
+            return
+        }
+        let start: Float = bytes.withUnsafeBufferPointer {
+            UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: 1, as: Float.self)
+        }
+        let stepKHz: Float = bytes.withUnsafeBufferPointer {
+            UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: 5, as: Float.self)
+        }
+        let n = Int(bytes[9])
+        guard bytes.count >= 10 + n else {
+            print("[SCAN] Truncated scan result: need \(10 + n) bytes, got \(bytes.count)")
+            isScanning = false
+            return
+        }
+        var samples: [FrequencyScanSample] = []
+        samples.reserveCapacity(n)
+        for i in 0..<n {
+            let rssi = Int8(bitPattern: bytes[10 + i])
+            let freq = start + (stepKHz * Float(i)) / 1000.0
+            samples.append(FrequencyScanSample(freqMHz: freq, rssiDbm: Int(rssi)))
+        }
+        scanSamples = samples
+        isScanning = false
+        print("[SCAN] Parsed \(n) samples, start=\(start) MHz step=\(stepKHz) kHz")
     }
 
     private func parseFileList(_ data: Data?) {

--- a/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift
@@ -1,0 +1,15 @@
+//
+//  FrequencyScanSample.swift
+//  TinkerRocketApp
+//
+//  One sample of a base-station frequency scan: the channel centre frequency
+//  and the instantaneous RSSI reported by the LoRa front end.
+//
+
+import Foundation
+
+struct FrequencyScanSample: Identifiable, Equatable {
+    let id = UUID()
+    let freqMHz: Float
+    let rssiDbm: Int
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -21,6 +21,7 @@ enum DashboardSheet: Identifiable {
     case settings
     case servoTest
     case driftCast
+    case frequencyScan
 
     var id: Int { hashValue }
 }
@@ -185,6 +186,8 @@ struct DashboardView: View {
                     ServoTestView(device: device)
                 case .driftCast:
                     DriftCastView(device: device)
+                case .frequencyScan:
+                    NavigationView { FrequencyScanView(device: device) }
                 }
             }
         }
@@ -1529,6 +1532,24 @@ struct TestingControlsView: View {
                     .cornerRadius(10)
                 }
                 .disabled(!canStartGroundTest)
+
+                // Frequency Scan (base station radio only)
+                if device.isBaseStation {
+                    Button {
+                        activeSheet = .frequencyScan
+                    } label: {
+                        HStack {
+                            Image(systemName: "waveform.badge.magnifyingglass")
+                            Text("Frequency Scan")
+                        }
+                        .font(.system(.body, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .foregroundColor(.white)
+                        .background(Color.purple)
+                        .cornerRadius(10)
+                    }
+                }
             }
         }
         .padding()

--- a/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
@@ -1,0 +1,214 @@
+//
+//  FrequencyScanView.swift
+//  TinkerRocketApp
+//
+//  Pre-launch RF collision-avoidance tool.  Tells the base station to sweep
+//  the ISM band, reads the RSSI-per-channel result back over BLE, and plots
+//  it as a bar chart so the user can pick a quiet channel.
+//
+
+import SwiftUI
+import Charts
+
+struct FrequencyScanView: View {
+    @ObservedObject var device: BLEDevice
+    @Environment(\.dismiss) var dismiss
+
+    // Scan parameters, persisted so the user gets the same range next time.
+    @AppStorage("scanStartMHz")  private var startMHz: Double = 902.0
+    @AppStorage("scanStopMHz")   private var stopMHz:  Double = 928.0
+    @AppStorage("scanStepKHz")   private var stepKHz:  Double = 500.0
+    @AppStorage("scanDwellMs")   private var dwellMs:  Double = 30.0
+
+    // Reference ceiling used to convert dBm into a positive "noise margin"
+    // that grows with channel quietness: margin = referenceDbm − rssi.
+    // −40 dBm is stronger than any real traffic we'll ever see in free air,
+    // so margin stays ≥ 0 in practice.
+    private let referenceDbm: Int = -40
+
+    // Bars at or above this margin are highlighted green ("comfortable").
+    // 70 dB margin corresponds to rssi ≤ −110 dBm.
+    private let quietMarginDb: Int = 70
+
+    private func marginDb(_ rssi: Int) -> Int { referenceDbm - rssi }
+
+    var body: some View {
+        Form {
+            Section("Scan Range") {
+                HStack {
+                    Text("Start")
+                    Spacer()
+                    TextField("902.0", value: $startMHz, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                    Text("MHz").foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Stop")
+                    Spacer()
+                    TextField("928.0", value: $stopMHz, format: .number.precision(.fractionLength(1)))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                    Text("MHz").foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Step")
+                    Spacer()
+                    TextField("500", value: $stepKHz, format: .number.precision(.fractionLength(0)))
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                    Text("kHz").foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Dwell")
+                    Spacer()
+                    TextField("30", value: $dwellMs, format: .number.precision(.fractionLength(0)))
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                    Text("ms").foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Channels")
+                    Spacer()
+                    Text("\(estimatedChannels)")
+                        .foregroundColor(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
+                HStack {
+                    Text("Est. Duration")
+                    Spacer()
+                    Text(estimatedDurationLabel)
+                        .foregroundColor(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
+            }
+
+            Section {
+                Button {
+                    device.startFrequencyScan(
+                        startMHz: Float(startMHz),
+                        stopMHz:  Float(stopMHz),
+                        stepKHz:  UInt16(clamping: Int(stepKHz)),
+                        dwellMs:  UInt16(clamping: Int(dwellMs))
+                    )
+                } label: {
+                    HStack {
+                        Spacer()
+                        if device.isScanning {
+                            ProgressView().padding(.trailing, 6)
+                            Text("Scanning…")
+                        } else {
+                            Image(systemName: "waveform.badge.magnifyingglass")
+                            Text("Start Scan")
+                        }
+                        Spacer()
+                    }
+                }
+                .disabled(device.isScanning || !paramsValid)
+            }
+
+            if !device.scanSamples.isEmpty {
+                Section("Result") {
+                    chart
+                        .frame(height: 240)
+                        .padding(.vertical, 4)
+                    summary
+                }
+            }
+        }
+        .navigationTitle("Frequency Scan")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+
+    // MARK: - Derived values
+
+    private var paramsValid: Bool {
+        stopMHz > startMHz && stepKHz > 0 && dwellMs > 0 && estimatedChannels <= 128
+    }
+
+    private var estimatedChannels: Int {
+        guard stepKHz > 0, stopMHz > startMHz else { return 0 }
+        let span = (stopMHz - startMHz) * 1000.0
+        return Int(span / stepKHz) + 1
+    }
+
+    private var estimatedDurationLabel: String {
+        let totalMs = Double(estimatedChannels) * (dwellMs + 2.0)   // ~2 ms overhead per step
+        if totalMs < 1000 {
+            return String(format: "%.0f ms", totalMs)
+        }
+        return String(format: "%.1f s", totalMs / 1000.0)
+    }
+
+    private var quietestSample: FrequencyScanSample? {
+        device.scanSamples.min(by: { $0.rssiDbm < $1.rssiDbm })
+    }
+
+    @ViewBuilder private var summary: some View {
+        if let quiet = quietestSample {
+            HStack {
+                Text("Quietest channel")
+                Spacer()
+                Text(String(format: "%.2f MHz  \u{00B7}  %d dB",
+                            quiet.freqMHz, marginDb(quiet.rssiDbm)))
+                    .foregroundColor(.green)
+                    .font(.system(.body, design: .monospaced))
+            }
+            let noisy = device.scanSamples.filter { marginDb($0.rssiDbm) < quietMarginDb }
+            HStack {
+                Text("Below \(quietMarginDb) dB margin")
+                Spacer()
+                Text("\(noisy.count) of \(device.scanSamples.count)")
+                    .foregroundColor(noisy.isEmpty ? .green : .orange)
+                    .font(.system(.body, design: .monospaced))
+            }
+        }
+    }
+
+    private var chartDomain: ClosedRange<Double> {
+        // Prefer the actual scanned range; fall back to the form values so
+        // Swift Charts never auto-extends to zero and crushes the bars into
+        // a sliver at the right edge.
+        if let first = device.scanSamples.first, let last = device.scanSamples.last {
+            let lo = Double(min(first.freqMHz, last.freqMHz))
+            let hi = Double(max(first.freqMHz, last.freqMHz))
+            // Pad half a step either side so the first/last bars aren't clipped.
+            let padMHz = Double(last.freqMHz - first.freqMHz) / Double(max(device.scanSamples.count - 1, 1)) * 0.5
+            return (lo - padMHz)...(hi + padMHz)
+        }
+        return startMHz...stopMHz
+    }
+
+    @ViewBuilder private var chart: some View {
+        Chart(device.scanSamples) { s in
+            BarMark(
+                x: .value("Freq", Double(s.freqMHz)),
+                y: .value("Margin", marginDb(s.rssiDbm)),
+                width: .fixed(6)
+            )
+            .foregroundStyle(marginDb(s.rssiDbm) >= quietMarginDb ? Color.green : Color.orange)
+        }
+        .chartXScale(domain: chartDomain)
+        .chartYScale(domain: 0...100)
+        .chartYAxisLabel("Noise Margin (dB)")
+        .chartXAxisLabel("Frequency (MHz)")
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 5)) { value in
+                AxisGridLine()
+                AxisTick()
+                if let mhz = value.as(Double.self) {
+                    AxisValueLabel { Text(String(format: "%.0f", mhz)) }
+                }
+            }
+        }
+    }
+}

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -836,6 +836,32 @@ void TR_BLE_To_APP::sendFileList(const String& files_json)
              (unsigned)file_list_json_.length(), (unsigned long)file_list_send_count);
 }
 
+void TR_BLE_To_APP::sendScanResults(float start_mhz, float step_khz,
+                                     const int8_t* rssi, uint8_t n)
+{
+    if (!device_connected_ || rssi == nullptr) return;
+
+    uint8_t buf[10 + 128];
+    buf[0] = 0xAA;
+    memcpy(&buf[1], &start_mhz, 4);
+    memcpy(&buf[5], &step_khz,  4);
+    buf[9] = n;
+    for (uint8_t i = 0; i < n; ++i)
+    {
+        buf[10 + i] = (uint8_t)rssi[i];
+    }
+    const size_t total = 10u + (size_t)n;
+
+    int rc = notify_data(conn_handle_, file_ops_val_handle_, buf, total);
+    if (rc != 0)
+    {
+        ESP_LOGW(BLE_TAG, "Scan result notify failed, rc=%d", rc);
+        return;
+    }
+    ESP_LOGI(BLE_TAG, "Sent scan results (%u bytes, %u samples)",
+             (unsigned)total, (unsigned)n);
+}
+
 void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
                                    size_t len, bool eof)
 {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -135,6 +135,15 @@ public:
     // files: JSON string like [{"name":"file1.bin","size":1234},...]
     void sendFileList(const String& files_json);
 
+    // Send frequency-scan result as a compact binary blob on the file-ops
+    // characteristic.  Format (little-endian):
+    //   [0][0xAA marker] [1..4][start_mhz f32] [5..8][step_khz f32]
+    //   [9][n u8] [10..10+n-1][rssi i8 dBm]
+    // The 0xAA leading byte disambiguates this from the JSON responses
+    // (file list, config) that also use this characteristic.
+    void sendScanResults(float start_mhz, float step_khz,
+                         const int8_t* rssi, uint8_t n);
+
     // Get pending download filename (empty if none)
     // Clears the filename after reading
     String getDownloadFilename();

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -406,6 +406,119 @@ rollback:
 }
 
 // ============================================================================
+// Spectrum scan
+// ============================================================================
+
+bool TR_LoRa_Comms::startScan(float start_mhz, float stop_mhz, uint16_t step_khz, uint16_t dwell_ms)
+{
+    if (!enabled_ || radio_ == nullptr) return false;
+    if (scan_state_ != ScanState::Idle) return false;  // already scanning or result pending
+    if (step_khz == 0 || stop_mhz <= start_mhz) return false;
+
+    // Clamp dwell to a reasonable range.  Below ~5 ms the receiver front end
+    // hasn't fully settled after setFrequency, so RSSI readings drift high.
+    if (dwell_ms < 5)   dwell_ms = 5;
+    if (dwell_ms > 500) dwell_ms = 500;
+
+    const float span_khz = (stop_mhz - start_mhz) * 1000.0f;
+    uint32_t n = (uint32_t)(span_khz / (float)step_khz) + 1;
+    if (n > SCAN_MAX_SAMPLES) n = SCAN_MAX_SAMPLES;
+
+    // Refuse to scan while TX is still in flight — setFrequency mid-transmit
+    // corrupts the packet and can leave the radio in an undefined state.
+    if (tx_ongoing_) return false;
+
+    rx_mode_ = false;
+    rx_done_ = false;
+
+    scan_start_mhz_ = start_mhz;
+    scan_step_khz_  = (float)step_khz;
+    scan_n_steps_   = (uint16_t)n;
+    scan_idx_       = 0;
+    scan_dwell_ms_  = dwell_ms;
+    scan_count_     = 0;
+    scan_state_     = ScanState::SetFreq;
+
+    if (debug_)
+    {
+        ESP_LOGI(TAG, "Scan start: %.1f → %.1f MHz, %u kHz step, %u ms dwell, %u steps",
+                 (double)start_mhz, (double)stop_mhz,
+                 (unsigned)step_khz, (unsigned)dwell_ms, (unsigned)n);
+    }
+    return true;
+}
+
+void TR_LoRa_Comms::serviceScan()
+{
+    if (!enabled_ || radio_ == nullptr) return;
+    if (scan_state_ == ScanState::Idle || scan_state_ == ScanState::Done) return;
+
+    switch (scan_state_)
+    {
+        case ScanState::SetFreq:
+        {
+            const float f = scan_start_mhz_ + (scan_step_khz_ * (float)scan_idx_) / 1000.0f;
+            int16_t st = radio_->setFrequency(f);
+            if (st != RADIOLIB_ERR_NONE)
+            {
+                stats_.last_error = st;
+                // Record a sentinel and skip to next channel.
+                if (scan_count_ < SCAN_MAX_SAMPLES)
+                {
+                    scan_samples_[scan_count_++] = { f, -128 };
+                }
+                scan_idx_++;
+            }
+            else
+            {
+                // Enter RX so the front end is active and RSSI is meaningful.
+                (void)radio_->startReceive();
+                scan_dwell_start_ms_ = millis();
+                scan_state_ = ScanState::Dwell;
+            }
+            break;
+        }
+        case ScanState::Dwell:
+        {
+            if ((millis() - scan_dwell_start_ms_) >= scan_dwell_ms_)
+            {
+                const float rssi = radio_->getRSSI(false);  // instantaneous, not packet
+                int rssi_i = (int)rssi;
+                if (rssi_i < -128) rssi_i = -128;
+                if (rssi_i >  127) rssi_i =  127;
+                const float f = scan_start_mhz_ + (scan_step_khz_ * (float)scan_idx_) / 1000.0f;
+                if (scan_count_ < SCAN_MAX_SAMPLES)
+                {
+                    scan_samples_[scan_count_++] = { f, (int8_t)rssi_i };
+                }
+                scan_idx_++;
+                if (scan_idx_ >= scan_n_steps_)
+                {
+                    // Restore the operating frequency and return to RX so
+                    // normal comms with the OutComputer resume.
+                    (void)radio_->setFrequency(cfg_freq_mhz_);
+                    (void)radio_->startReceive();
+                    rx_mode_ = true;
+                    scan_state_ = ScanState::Done;
+                    if (debug_)
+                    {
+                        ESP_LOGI(TAG, "Scan done: %u samples, restored %.1f MHz",
+                                 (unsigned)scan_count_, (double)cfg_freq_mhz_);
+                    }
+                }
+                else
+                {
+                    scan_state_ = ScanState::SetFreq;
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+// ============================================================================
 // ISR
 // ============================================================================
 

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -66,6 +66,29 @@ public:
     // Runtime reconfiguration (LLCC68: must set BW before SF)
     bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power);
 
+    // ---- Spectrum scan (pre-launch collision avoidance) ------------------
+    // Non-blocking channel-hopping RSSI scan. Step through a frequency range,
+    // dwell in RX mode for `dwell_ms` per channel, then read instantaneous
+    // RSSI.  Call serviceScan() from the main loop each iteration until
+    // isScanDone() returns true.  While active, normal RX is suspended; the
+    // previous frequency is restored on completion.
+    static constexpr size_t SCAN_MAX_SAMPLES = 128;
+    struct ScanSample
+    {
+        float  freq_mhz;
+        int8_t rssi_dbm;   // clamped to int8 (−128..0 dBm is well outside useful range)
+    };
+
+    bool startScan(float start_mhz, float stop_mhz, uint16_t step_khz, uint16_t dwell_ms);
+    void serviceScan();
+    bool isScanActive() const { return scan_state_ != ScanState::Idle && scan_state_ != ScanState::Done; }
+    bool isScanDone() const   { return scan_state_ == ScanState::Done; }
+    void consumeScanDone()    { scan_state_ = ScanState::Idle; }
+    size_t getScanSampleCount() const { return scan_count_; }
+    const ScanSample* getScanSamples() const { return scan_samples_; }
+    float getScanStartMHz() const { return scan_start_mhz_; }
+    float getScanStepKHz()  const { return scan_step_khz_; }
+
 private:
     static void IRAM_ATTR onDio1ISR();
 
@@ -91,4 +114,16 @@ private:
     Module* module_ = nullptr;
     LLCC68* radio_ = nullptr;
     Stats stats_ = {};
+
+    // ---- Scan state ------------------------------------------------------
+    enum class ScanState : uint8_t { Idle, SetFreq, Dwell, Done };
+    ScanState scan_state_    = ScanState::Idle;
+    uint16_t  scan_idx_      = 0;
+    uint16_t  scan_n_steps_  = 0;
+    uint16_t  scan_dwell_ms_ = 30;
+    uint32_t  scan_dwell_start_ms_ = 0;
+    float     scan_start_mhz_ = 0.0f;
+    float     scan_step_khz_  = 0.0f;
+    size_t    scan_count_    = 0;
+    ScanSample scan_samples_[SCAN_MAX_SAMPLES] = {};
 };

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1617,6 +1617,52 @@ static void loop_bs()
                      inner_cmd, target_rid, (unsigned)inner_len);
         }
     }
+    else if (ble_cmd == 60)
+    {
+        // Frequency scan (base-station radio, pre-launch collision avoidance).
+        // Payload: [start_mhz f32][stop_mhz f32][step_khz u16][dwell_ms u16]
+        // All fields are little-endian.  A scan blocks normal LoRa RX for
+        // the scan duration — explicitly user-initiated and short (~1-3 s).
+        const uint8_t* payload = ble_app.getCommandPayload();
+        const size_t plen = ble_app.getCommandPayloadLength();
+        if (plen >= 12)
+        {
+            float start_mhz, stop_mhz;
+            uint16_t step_khz, dwell_ms;
+            memcpy(&start_mhz, payload + 0, 4);
+            memcpy(&stop_mhz,  payload + 4, 4);
+            memcpy(&step_khz,  payload + 8, 2);
+            memcpy(&dwell_ms,  payload + 10, 2);
+
+            if (lora_comms.startScan(start_mhz, stop_mhz, step_khz, dwell_ms))
+            {
+                ESP_LOGI(TAG, "[BLE] Scan started: %.1f..%.1f MHz, %u kHz, %u ms",
+                         (double)start_mhz, (double)stop_mhz,
+                         (unsigned)step_khz, (unsigned)dwell_ms);
+            }
+            else
+            {
+                ESP_LOGW(TAG, "[BLE] Scan start rejected (busy or invalid range)");
+            }
+        }
+    }
+
+    // Service scan state machine (no-op when idle).  Must come before
+    // serviceUplink so a TX retry doesn't fire while we're mid-scan — the
+    // scan temporarily owns the radio's frequency.
+    lora_comms.serviceScan();
+    if (lora_comms.isScanDone())
+    {
+        const auto* samples = lora_comms.getScanSamples();
+        const size_t n = lora_comms.getScanSampleCount();
+        int8_t rssi[TR_LoRa_Comms::SCAN_MAX_SAMPLES];
+        const size_t n_send = (n > TR_LoRa_Comms::SCAN_MAX_SAMPLES) ? TR_LoRa_Comms::SCAN_MAX_SAMPLES : n;
+        for (size_t i = 0; i < n_send; ++i) rssi[i] = samples[i].rssi_dbm;
+        ble_app.sendScanResults(lora_comms.getScanStartMHz(),
+                                lora_comms.getScanStepKHz(),
+                                rssi, (uint8_t)n_send);
+        lora_comms.consumeScanDone();
+    }
 
     // Service LoRa uplink retries (TX commands, then resume RX)
     serviceUplink();


### PR DESCRIPTION
## Summary
- Channel-hopping RSSI scan on the base-station radio with a non-blocking state machine in TR_LoRa_Comms that restores the operating frequency when done
- iOS FrequencyScanView plots results as noise margin (dB) on a Swift Charts bar plot, so higher bars mean quieter channels
- Entry point lives under the dashboard Testing section for base-station devices; compact 0xAA-prefixed binary blob on the existing file-ops characteristic keeps the transport one-MTU

Closes #6.

## Test plan
- [x] Firmware build: idf.py build in tinkerrocket-idf/projects/base_station — clean
- [x] iOS build: xcodebuild for iOS Simulator — clean
- [x] Hardware smoke test: issued cmd 60, firmware logged Scan done: 53 samples, restored 915.0 MHz and iOS plot populates
- [ ] Double-check RX resumes after scan (no dropped rocket packets once the sweep finishes)
- [ ] Try narrow-range scan (e.g. 914-916 MHz, 100 kHz step) to confirm resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)