### PR TITLE
CI: install pytest before running bench-integration tests

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -52,5 +52,8 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
       - name: Run integration tests (skip if no test data)
         run: python -m pytest tests/integration/ -v --tb=short


### PR DESCRIPTION
## Summary

- The `bench-integration` job in [cpp-tests.yml](.github/workflows/cpp-tests.yml) has been failing on **every** main commit since it was introduced (at least 5+ commits back).
- Root cause: `actions/setup-python` does not install pytest by default, and there is no `requirements.txt` in `tests/integration/` for it to pick up. `python -m pytest …` fails with `No module named pytest` before the test runner ever starts.
- Fix: add an explicit `pip install pytest` step before the test runner.

The test suite itself already skips cleanly when no `.bin` test data is present ([conftest.py](tests/integration/conftest.py)), so no fixtures need to land with this change — the job will go from red (import error) to green (tests skipped).

## Test plan

- [x] Workflow file parses (YAML valid)
- [ ] `bench-integration` CI reports green after this lands
- [ ] No effect on the `cpp-tests` job (separate job in the same workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
