### PR TITLE
out_computer: undef nimble max/min macros after BLE include

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -14,6 +14,16 @@
 #include "freertos/queue.h"
 #include "host/ble_gap.h"       // ble_gap_update_params
 
+// Nimble's os.h (pulled in by host/ble_gap.h) defines `max` and `min` as
+// function-style macros, which collide with std::max / std::min. Undo them
+// here so subsequent <algorithm> calls compile cleanly.
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
 // std::string is used as "String" in non-Arduino builds (same typedef as TR_BLE_To_APP.h)
 using String = std::string;
 


### PR DESCRIPTION
## Summary

- `host/ble_gap.h` transitively includes nimble's `os.h`, which defines `max` and `min` as function-style macros:
  ```c
  #define max(a, b) ((a)>(b)?(a):(b))
  #define min(a, b) ((a)<(b)?(a):(b))
  ```
- These poison later `std::max(…)` / `std::min(…)` calls in [out_computer/main/main.cpp](tinkerrocket-idf/projects/out_computer/main/main.cpp) (lines 422, 452, etc.), producing `error: expected unqualified-id before '(' token`.
- `build (out_computer)` has been **failing on every main commit** for this reason — same story as the pytest and EKF-NaN issues we just fixed.
- Fix: `#undef max` / `#undef min` right after the nimble include, before any `<algorithm>` user downstream encounters them. Scoped to the single file that actually clashes.

`power_test` also includes `host/ble_gap.h` but uses neither `std::max` nor `std::min`, so no fix needed there.

## Test plan

- [ ] `build (out_computer)` CI goes green after this lands (primary signal — this is the bug the fix targets)
- [x] `build (base_station)` unaffected (different code, doesn't use BLE host headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
