### PR TITLE
TR_FlightLog Stage 2a: real ESP NAND backend via TR_LogToFlash bridge (#50)

### DIFF
--- a/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "TR_FlightLog.cpp" "BlockStateBitmap.cpp" "FlightIndex.cpp" "WireFormat.cpp" "TR_NandBackend_esp.cpp"
     INCLUDE_DIRS "include"
-    REQUIRES TR_Compat CRC
+    REQUIRES TR_Compat CRC TR_LogToFlash
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_NandBackend_esp.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_NandBackend_esp.cpp
@@ -1,32 +1,62 @@
 #include "TR_NandBackend_esp.h"
 
+#ifdef ESP_PLATFORM
+#include "TR_LogToFlash.h"
+#endif
+
 namespace tr_flightlog {
 
-// Stage 1: every operation fails. This is intentional — the class exists so
-// the TR_FlightLog component compiles under ESP-IDF; Stage 2 wires the
-// methods to the real SPI NAND driver before anything on the flight side
-// switches over.
+// Host build (no ESP_PLATFORM): every method returns a safe "no" so the same
+// stub surface the host tests see is preserved.
+// ESP-IDF build: delegate to the logger's public NAND forwarders when a
+// logger is attached; return "no" when it is not (handy during early boot
+// before the logger's begin() has run).
 
-bool TR_NandBackend_esp::readPage(uint32_t /*block*/, uint32_t /*page_in_block*/,
-                                  uint8_t* /*out*/) {
+bool TR_NandBackend_esp::readPage(uint32_t block, uint32_t page_in_block, uint8_t* out) {
+#ifdef ESP_PLATFORM
+    return logger_ && logger_->readNandPage(block, page_in_block, out);
+#else
+    (void)block; (void)page_in_block; (void)out;
     return false;
+#endif
 }
 
-bool TR_NandBackend_esp::programPage(uint32_t /*block*/, uint32_t /*page_in_block*/,
-                                      const uint8_t* /*data*/) {
+bool TR_NandBackend_esp::programPage(uint32_t block, uint32_t page_in_block, const uint8_t* data) {
+#ifdef ESP_PLATFORM
+    return logger_ && logger_->programNandPage(block, page_in_block, data);
+#else
+    (void)block; (void)page_in_block; (void)data;
     return false;
+#endif
 }
 
-bool TR_NandBackend_esp::eraseBlock(uint32_t /*block*/) {
+bool TR_NandBackend_esp::eraseBlock(uint32_t block) {
+#ifdef ESP_PLATFORM
+    return logger_ && logger_->eraseNandBlock(block);
+#else
+    (void)block;
     return false;
+#endif
 }
 
-bool TR_NandBackend_esp::isBlockBad(uint32_t /*block*/) {
-    return true;  // conservative default — never allocate from this backend yet
+bool TR_NandBackend_esp::isBlockBad(uint32_t block) {
+#ifdef ESP_PLATFORM
+    // Conservative default when no logger is attached: treat as bad so the
+    // allocator will not pick the block. Matches the host stub behaviour.
+    return !logger_ || logger_->isNandBlockBad(block);
+#else
+    (void)block;
+    return true;
+#endif
 }
 
-bool TR_NandBackend_esp::markBlockBad(uint32_t /*block*/) {
+bool TR_NandBackend_esp::markBlockBad(uint32_t block) {
+#ifdef ESP_PLATFORM
+    return logger_ && logger_->markNandBlockBad(block);
+#else
+    (void)block;
     return false;
+#endif
 }
 
 }  // namespace tr_flightlog

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_NandBackend_esp.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_NandBackend_esp.h
@@ -4,31 +4,39 @@
 
 #include <stdint.h>
 
+// Forward declaration — the full header drags in lfs.h + FreeRTOS so it is
+// only included in TR_NandBackend_esp.cpp under an ESP_PLATFORM guard.
+class TR_LogToFlash;
+
 namespace tr_flightlog {
 
-// ESP-IDF implementation of TR_NandBackend, backed by the SPI NAND driver
-// that currently lives in TR_LogToFlash.
+// ESP-IDF implementation of TR_NandBackend, bridged to the SPI NAND driver
+// currently owned by TR_LogToFlash.
 //
-// Stage 1 (this file): scaffold only — every operation returns false so the
-// component compiles under ESP-IDF without pulling in an actual SPI stack.
-// Stage 2 wiring will either:
-//   * extract the nandRead/Program/EraseBlock helpers from TR_LogToFlash into
-//     a shared low-level component (preferred), or
-//   * add a narrow accessor interface on TR_LogToFlash that this class
-//     delegates to.
+// During Stage 2 the legacy LFS logger and TR_FlightLog coexist: they share
+// the NAND, the SPI bus, and the NVS bad-block bitmap. This adapter forwards
+// each primitive into TR_LogToFlash's public *NandPage / *NandBlock /
+// *NandBlockBad surface so both layers stay consistent without duplication.
 //
-// The choice is deferred because Stage 2 is where the flight_computer main.cpp
-// flips between the legacy LFS path and the new TR_FlightLog path — we want
-// the refactor boundary to fall along that flip.
+// Stage 3 removes LFS from the hot path; Stage 4 may retire TR_LogToFlash
+// entirely, at which point the SPI driver moves into TR_FlightLog and this
+// adapter becomes the owner rather than a bridge.
+//
+// Pass `nullptr` (or use the default ctor) on host / in tests — every
+// operation returns a safe "no" without touching real hardware.
 class TR_NandBackend_esp : public TR_NandBackend {
 public:
     TR_NandBackend_esp() = default;
+    explicit TR_NandBackend_esp(TR_LogToFlash* logger) : logger_(logger) {}
 
     bool readPage(uint32_t block, uint32_t page_in_block, uint8_t* out) override;
     bool programPage(uint32_t block, uint32_t page_in_block, const uint8_t* data) override;
     bool eraseBlock(uint32_t block) override;
     bool isBlockBad(uint32_t block) override;
     bool markBlockBad(uint32_t block) override;
+
+private:
+    TR_LogToFlash* logger_ = nullptr;
 };
 
 }  // namespace tr_flightlog

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -2039,3 +2039,39 @@ void TR_LogToFlash::applyPendingTimestamp_impl(const char* filename, uint16_t ye
         }
     }
 }
+
+// ─── Raw NAND bridge (TR_FlightLog, issue #50 Stage 2) ───────────────────
+// Forwarders that convert (block, page_in_block) -> rowPageAddr and always
+// operate on a full NAND_PAGE_SIZE page. See TR_LogToFlash.h for rationale.
+
+bool TR_LogToFlash::readNandPage(uint32_t block, uint32_t page_in_block, uint8_t* out)
+{
+    if (block >= NAND_BLOCK_COUNT || page_in_block >= NAND_PAGES_PER_BLK) return false;
+    uint32_t rowPageAddr = block * NAND_PAGES_PER_BLK + page_in_block;
+    return nandReadPage(rowPageAddr, out, NAND_PAGE_SIZE);
+}
+
+bool TR_LogToFlash::programNandPage(uint32_t block, uint32_t page_in_block, const uint8_t* data)
+{
+    if (block >= NAND_BLOCK_COUNT || page_in_block >= NAND_PAGES_PER_BLK) return false;
+    uint32_t rowPageAddr = block * NAND_PAGES_PER_BLK + page_in_block;
+    return nandProgramPage(rowPageAddr, data, NAND_PAGE_SIZE);
+}
+
+bool TR_LogToFlash::eraseNandBlock(uint32_t block)
+{
+    if (block >= NAND_BLOCK_COUNT) return false;
+    return nandEraseBlock(block);
+}
+
+bool TR_LogToFlash::isNandBlockBad(uint32_t block) const
+{
+    return isBlockBad(block);
+}
+
+bool TR_LogToFlash::markNandBlockBad(uint32_t block)
+{
+    if (block >= NAND_BLOCK_COUNT) return false;
+    markBlockBad(block);
+    return true;
+}

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -92,6 +92,18 @@ public:
 
     bool begin(SPIClass& spi, const TR_LogToFlashConfig& cfg);
     bool enqueueFrame(const uint8_t* frame, size_t len);
+
+    // --- Raw NAND access (bridge for TR_FlightLog, issue #50 Stage 2) --------
+    // These expose the private nand* primitives as full-page (2 KB) ops keyed
+    // by (block, page_in_block). They share the same SPI bus + bad-block
+    // bitmap as the LFS-backed flush path, so both layers stay consistent.
+    // Intended only for the TR_NandBackend_esp adapter; internal callers keep
+    // using the rowPageAddr variants.
+    bool readNandPage(uint32_t block, uint32_t page_in_block, uint8_t* out);
+    bool programNandPage(uint32_t block, uint32_t page_in_block, const uint8_t* data);
+    bool eraseNandBlock(uint32_t block);
+    bool isNandBlockBad(uint32_t block) const;
+    bool markNandBlockBad(uint32_t block);
     void startLogging();
     void endLogging(); // request close after buffered data is flushed
     void prepareLogFile();  // Pre-create log file (call during PRELAUNCH to avoid NAND stall at launch)


### PR DESCRIPTION
## Summary

First PR in the Stage 2 series (see [plan](docs/plans/50-custom-nand-flight-log.md)). Makes `TR_FlightLog` instantiable on real hardware by wiring `TR_NandBackend_esp` to the SPI NAND driver that already lives in `TR_LogToFlash` — no duplication, no new SPI component, no flight-path behaviour change.

### What changes

- **[TR_LogToFlash](tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h)** gains 5 public forwarders: `readNandPage`, `programNandPage`, `eraseNandBlock`, `isNandBlockBad`, `markNandBlockBad`. Each converts `(block, page_in_block)` → `rowPageAddr` and calls the existing private primitive. Full 2 KB pages only; internal callers unchanged.
- **[TR_NandBackend_esp](tinkerrocket-idf/components/TR_FlightLog/include/TR_NandBackend_esp.h)** forward-declares `TR_LogToFlash`, holds a `TR_LogToFlash*`, and delegates each override. Header stays host-portable; the full `TR_LogToFlash.h` is only included inside the `.cpp` under `#ifdef ESP_PLATFORM`.
- **Host / test path** unchanged: default constructor keeps `logger_ = nullptr`, methods return the existing "safe no" stub values, and the 191-test suite stays green.

Both layers share the same NVS bad-block bitmap via the forwarder, so a block marked bad by either one stays bad for the other — no drift.

### What does **not** change

Nothing on the flight path yet — no caller constructs `TR_FlightLog` at runtime. Stage 2b adds the feature flag + lifecycle hooks; Stage 2c flips the hot path; Stage 4 bench-validates.

## Test plan

- [x] 191 host tests pass locally (`test_tr_flightlog_core` + `test_tr_flightlog_wire_format`)
- [ ] `build (out_computer)` + `build (base_station)` CI green — verifies the new `REQUIRES TR_LogToFlash` doesn't break the ESP-IDF component graph
- [x] Existing cpp-tests unaffected — no change touches `TR_LogToFlash`'s observable behaviour from its existing callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
