### PR TITLE
TR_FlightLog Stage 2c-1: NvsBitmapStore for persistent bitmap (#50)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -182,6 +182,7 @@ add_executable(test_tr_flightlog_core
     ${LIB_DIR}/TR_FlightLog/BlockStateBitmap.cpp
     ${LIB_DIR}/TR_FlightLog/FlightIndex.cpp
     ${LIB_DIR}/TR_FlightLog/TR_NandBackend_esp.cpp
+    ${LIB_DIR}/TR_FlightLog/NvsBitmapStore.cpp
     ${LIB_DIR}/CRC/CRC.cpp
     ${LIB_DIR}/CRC/CRC8.cpp
     ${LIB_DIR}/CRC/CRC12.cpp

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -2,6 +2,7 @@
 
 #include "BlockStateBitmap.h"
 #include "FlightIndex.h"
+#include "NvsBitmapStore.h"
 #include "TR_FlightLog.h"
 #include "TR_NandBackend_esp.h"
 #include "fakes/fake_nand_backend.h"
@@ -1376,6 +1377,33 @@ TEST(TRNandBackendEsp, StubInstantiatesAndReturnsFailures) {
     EXPECT_FALSE(backend.eraseBlock(0));
     EXPECT_FALSE(backend.markBlockBad(0));
     EXPECT_TRUE(backend.isBlockBad(0));  // conservative — all blocks "bad"
+}
+
+// ================================================================
+// NvsBitmapStore — real implementation only exists on ESP-IDF; host
+// compiles to a stub so TR_FlightLog::begin() falls back to a fresh
+// chip + seed-from-backend. These tests guard that contract so the
+// host build behaves the same as a first-boot-on-new-firmware path.
+// ================================================================
+
+TEST(NvsBitmapStore, HostStubReturnsFalseForBothOps) {
+    tr_flightlog::NvsBitmapStore store;
+    uint8_t buf[tr_flightlog::BlockStateBitmap::SERIALIZED_SIZE] = {};
+    EXPECT_FALSE(store.load(buf, sizeof(buf)));
+    EXPECT_FALSE(store.save(buf, sizeof(buf)));
+}
+
+TEST(NvsBitmapStore, TRFlightLogAcceptsNvsStoreOnHostWithFreshSeed) {
+    // Using an NvsBitmapStore on host should behave identically to passing
+    // nullptr — begin() sees load() fail, seeds from backend, (tries to)
+    // persist via save() which also fails silently. No crash.
+    FakeNandBackend nand;
+    nand.injectFactoryBadBlock(77);
+    tr_flightlog::NvsBitmapStore store;
+
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    EXPECT_EQ(fl.bitmap().get(77), BLOCK_BAD);
 }
 
 TEST(TRFlightLogBrownout, FinalizedFlightsAreNotRecovered) {

--- a/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
-    SRCS "TR_FlightLog.cpp" "BlockStateBitmap.cpp" "FlightIndex.cpp" "WireFormat.cpp" "TR_NandBackend_esp.cpp"
+    SRCS "TR_FlightLog.cpp" "BlockStateBitmap.cpp" "FlightIndex.cpp" "WireFormat.cpp" "TR_NandBackend_esp.cpp" "NvsBitmapStore.cpp"
     INCLUDE_DIRS "include"
-    REQUIRES TR_Compat CRC TR_LogToFlash
+    REQUIRES TR_Compat CRC TR_LogToFlash TR_NVS
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_FlightLog/NvsBitmapStore.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/NvsBitmapStore.cpp
@@ -1,0 +1,38 @@
+#include "NvsBitmapStore.h"
+
+#ifdef ESP_PLATFORM
+#include <TR_NVS.h>  // Arduino-compatible Preferences shim over ESP-IDF nvs_flash
+#endif
+
+namespace tr_flightlog {
+
+bool NvsBitmapStore::load(uint8_t* buf, size_t len) {
+#ifdef ESP_PLATFORM
+    Preferences prefs;
+    // Read-only open; fails cleanly when the namespace doesn't exist yet
+    // (fresh chip / first boot of new firmware) — caller then seeds from
+    // the NAND backend's bad-block oracle.
+    if (!prefs.begin(ns_, /*readOnly=*/true)) return false;
+    const size_t got = prefs.getBytes(key_, buf, len);
+    prefs.end();
+    return got == len;
+#else
+    (void)buf; (void)len;
+    return false;
+#endif
+}
+
+bool NvsBitmapStore::save(const uint8_t* buf, size_t len) {
+#ifdef ESP_PLATFORM
+    Preferences prefs;
+    if (!prefs.begin(ns_, /*readOnly=*/false)) return false;
+    prefs.putBytes(key_, buf, len);
+    prefs.end();
+    return true;
+#else
+    (void)buf; (void)len;
+    return false;
+#endif
+}
+
+}  // namespace tr_flightlog

--- a/tinkerrocket-idf/components/TR_FlightLog/include/NvsBitmapStore.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/NvsBitmapStore.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "TR_BitmapStore.h"
+
+namespace tr_flightlog {
+
+// Concrete TR_BitmapStore backed by ESP-IDF NVS (Arduino Preferences wrapper).
+// Persists the TR_FlightLog 3-state block bitmap across reboots.
+//
+// Uses a distinct NVS namespace from TR_LogToFlash's own bad-block map
+// ("bblk"/"map"). The layouts are not compatible: TR_LogToFlash stores a
+// 128-byte 1-bit-per-block map, TR_FlightLog stores a 256-byte 2-bit map.
+// Sharing the namespace would cause silent corruption on upgrade.
+//
+// On host / in tests the implementation compiles to stubs that always return
+// false — callers (TR_FlightLog::begin) treat that as "fresh chip" and seed
+// from the backend's bad-block oracle, which is the correct behaviour for
+// host tests using FakeNandBackend.
+class NvsBitmapStore : public TR_BitmapStore {
+public:
+    explicit NvsBitmapStore(const char* namespace_name = "flightlog",
+                            const char* key = "bitmap")
+        : ns_(namespace_name), key_(key) {}
+
+    bool load(uint8_t* buf, size_t len) override;
+    bool save(const uint8_t* buf, size_t len) override;
+
+private:
+    const char* ns_;
+    const char* key_;
+};
+
+}  // namespace tr_flightlog


### PR DESCRIPTION
## Summary

First of three Stage 2c PRs. Adds `NvsBitmapStore` — the concrete `TR_BitmapStore` implementation backed by ESP-IDF NVS — so the `TR_FlightLog` 3-state block bitmap can survive reboots.

Required by Stage 2c-3 (hot-path cut): without persistent bitmap state, every reboot would cold-scan the chip to rebuild the bad-block picture and forget which blocks belong to in-progress flights, breaking the brownout-recovery contract.

### Why a new NVS namespace

Uses `"flightlog"/"bitmap"` — distinct from the `"bblk"/"map"` namespace `TR_LogToFlash` owns. The formats are incompatible:

| Owner | Size | Encoding |
|---|---|---|
| `TR_LogToFlash` | 128 B | 1-bit-per-block (good/bad) |
| `TR_FlightLog` | 256 B | 2-bit-per-block (free/allocated/bad) |

Sharing would silently corrupt the map on upgrade.

### Integration

- Compiles on ESP-IDF via `<TR_NVS.h>` (the Arduino `Preferences` shim already used by `TR_LogToFlash`)
- On host: `load`/`save` compile to stubs that return `false`, which `TR_FlightLog::begin` already treats as "fresh chip, seed from backend" — so the host test suite stays valid without NVS
- Adds `TR_NVS` to `TR_FlightLog`'s `REQUIRES`

### Not in this PR

Nothing calls `NvsBitmapStore` at runtime yet. Stage 2c-2 wires it up alongside the `prepareFlight`/`finalizeFlight` lifecycle hooks. Stage 2c-3 is the hot-path cut.

## Test plan

- [x] 193 host tests pass locally — 2 new `NvsBitmapStore.*` tests verify the host stub behaviour and that `TR_FlightLog::begin` degrades gracefully when `load` fails
- [ ] `build (out_computer)` / `build (base_station)` CI green — verifies the `TR_NVS` dep resolves cleanly in the ESP-IDF component graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
