### PR TITLE
Stage 2c-2: shrink LFS to 4 MB, wipe legacy flight logs on first boot (#50)

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -151,7 +151,10 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
     lfs_cfg->read_size = NAND_PAGE_SIZE;      // 2048
     lfs_cfg->prog_size = NAND_PAGE_SIZE;      // 2048
     lfs_cfg->block_size = NAND_BLOCK_SIZE;    // 128KB
-    lfs_cfg->block_count = NAND_BLOCK_COUNT;  // 1024
+    // Default to the full chip; caller may shrink (issue #50 Stage 2c) so the
+    // trailing blocks can be owned by TR_FlightLog.
+    lfs_cfg->block_count = (cfg.lfs_block_count > 0) ? cfg.lfs_block_count
+                                                     : NAND_BLOCK_COUNT;
     lfs_cfg->cache_size = NAND_PAGE_SIZE;     // 2048
     lfs_cfg->lookahead_size = 128;            // 128 bytes = 1024 bits
     lfs_cfg->block_cycles = 500;              // Wear leveling

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -17,6 +17,12 @@ struct TR_LogToFlashConfig
     bool debug = false;
     bool force_format = false;  // Erase entire NAND before mount (recovery from corruption)
 
+    // LittleFS block-count. Defaults to the full chip for backward compat.
+    // When sharing the NAND with TR_FlightLog (issue #50 Stage 2c) the caller
+    // shrinks this to just the blocks LFS owns (e.g. 32 for a 4 MB LFS
+    // partition) so the flight-log allocator can safely use the remainder.
+    uint32_t lfs_block_count = 0;  // 0 = full chip (NAND_BLOCK_COUNT)
+
     // MRAM ring buffer (optional — set mram_cs >= 0 to enable).
     // When enabled the ring buffer lives in SPI MRAM instead of ESP32 RAM,
     // providing larger capacity (128 KB) and power-loss survivability.

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2200,10 +2200,49 @@ void initPeripherals()
     log_cfg.spi_hz_mram = config::SPI_HZ_MRAM;
     log_cfg.spi_mode_mram = config::SPI_MODE_MRAM;
     log_cfg.mram_size = config::MRAM_SIZE;
+
+    // --- LFS partition shrink (issue #50 Stage 2c-2) ------------------------
+    // When TR_FlightLog is active we restrict LFS to the first 32 blocks
+    // (4 MB) so the flight-log allocator can own the remaining 988 blocks
+    // plus the metadata blocks. First boot under the shrunk layout force-
+    // formats (wipes any legacy flight_*.bin files) — that's the accepted
+    // upgrade cost. Subsequent boots read the NVS marker and skip the wipe.
+    bool lfs_wipe_pending = false;
+    if (config::ENABLE_FLIGHTLOG_SHADOW)
+    {
+        log_cfg.lfs_block_count = 32;
+
+        Preferences fl_prefs;
+        bool already_shrunk = false;
+        if (fl_prefs.begin("flightlog", /*readOnly=*/true))
+        {
+            already_shrunk = fl_prefs.getBool("lfs_shrunk", false);
+            fl_prefs.end();
+        }
+        if (!already_shrunk)
+        {
+            log_cfg.force_format = true;
+            lfs_wipe_pending = true;
+            ESP_LOGW("FLIGHTLOG", "First boot of shrunk-LFS firmware — will wipe legacy flight files");
+        }
+    }
+
     if (!logger.begin(SPI, log_cfg))
     {
         ESP_LOGE("PWR", "TR_LogToFlash begin failed");
         return;
+    }
+
+    // Record the shrunk-layout marker so subsequent boots skip the force_format.
+    if (lfs_wipe_pending)
+    {
+        Preferences fl_prefs;
+        if (fl_prefs.begin("flightlog", /*readOnly=*/false))
+        {
+            fl_prefs.putBool("lfs_shrunk", true);
+            fl_prefs.end();
+            ESP_LOGI("FLIGHTLOG", "Recorded shrunk-LFS marker in NVS");
+        }
     }
 
     // --- TR_FlightLog shadow (issue #50 Stage 2b) ---------------------------
@@ -2211,7 +2250,7 @@ void initPeripherals()
     // At this point the SPI bus + bad-block bitmap are initialized by
     // logger.begin(); the shadow just reads state (no NAND writes) and logs
     // its view so bench tests can verify it loads cleanly. Hot-path writes
-    // still go through LFS until Stage 2c.
+    // still go through LFS until Stage 2c-3.
     if (config::ENABLE_FLIGHTLOG_SHADOW)
     {
         flightlog_backend = tr_flightlog::TR_NandBackend_esp(&logger);


### PR DESCRIPTION
## Summary

Second of three Stage 2c PRs. Shrinks LittleFS from the full 128 MB chip down to just **blocks 0–31 (4 MB)** so the remaining blocks can be owned by `TR_FlightLog` without collision. On the first boot of this firmware, force-formats LFS to the new geometry — wiping any pre-existing `flight_*.bin` files. That's the accepted upgrade cost per the [#50 design decision (Q4)](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/50#issuecomment-4299300538) ("wipe on first boot").

### What this does

- `TR_LogToFlash`: new `uint32_t lfs_block_count` field on `TR_LogToFlashConfig`. Default `0` keeps existing full-chip behaviour (backward-compat for base_station and any other caller). Non-zero overrides `lfs_cfg->block_count`.
- `out_computer/main.cpp`: when `ENABLE_FLIGHTLOG_SHADOW` is on:
  1. Set `log_cfg.lfs_block_count = 32`
  2. Check NVS namespace `"flightlog"` key `"lfs_shrunk"` — if missing, set `force_format = true` and log `First boot of shrunk-LFS firmware — will wipe legacy flight files`
  3. After `logger.begin()` succeeds, write the marker so subsequent boots skip the wipe
- The existing Stage 2b shadow `begin()` continues to run after the LFS wipe.

### What this does NOT do

- Lifecycle hooks (`prepareFlight` on PRELAUNCH, `finalizeFlight` on stop) — **Stage 2c-3**
- Flush-task write-sink to `TR_FlightLog::writeFrame` — **Stage 2c-3**
- Wire `NvsBitmapStore` into `flightlog.begin()` — **Stage 2c-3**, at the same time as the lifecycle hooks (otherwise the bitmap state would be misleading — no prepareFlight = nothing to persist)

### Bench validation plan

1. Boot with `ENABLE_FLIGHTLOG_SHADOW = true` and observe:
   - `W ... FLIGHTLOG: First boot of shrunk-LFS firmware — will wipe legacy flight files`
   - `LFS format` (via the existing mount-fail-then-format fallback *or* the explicit `force_format`)
   - `LittleFS mounted successfully`
   - `I ... FLIGHTLOG: Recorded shrunk-LFS marker in NVS`
   - `FLIGHTLOG: shadow up: 0 flight(s) in index, 0 bad blocks`
2. Reboot. Observe that **no wipe** happens this time:
   - No "First boot" warning
   - No "Recorded shrunk-LFS marker"
   - Directly to `FLIGHTLOG: shadow up: ...`
3. BLE cmd 2 (file list) returns `[]` (the legacy files were wiped). Confirms the shrink.

### Caveat

If someone builds with `ENABLE_FLIGHTLOG_SHADOW = false` **after** the marker has been set, LFS would try to mount with `block_count=1024` against an on-disk 32-block filesystem. The existing mount-fail-then-format fallback would then reformat to full-chip, destroying any `TR_FlightLog` state in the upper blocks. Real-world usage won't toggle the flag like this, so no mitigation in this PR.

## Test plan

- [x] 191 host tests still pass locally — change doesn't touch any code the host tests exercise
- [ ] `build (out_computer)` + `build (base_station)` CI green
- [ ] Bench validation (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
