### PR TITLE
Stage 2c-3a: wire NvsBitmapStore into flightlog.begin() (#50)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -54,6 +54,7 @@ static inline std::string itos(int v)
 #include <TR_INA230.h>
 #include <TR_FlightLog.h>
 #include <TR_NandBackend_esp.h>
+#include <NvsBitmapStore.h>
 // FlightSimulator.h removed — sim now runs on FlightComputer via TR_Sensor_Collector_Sim
 
 static TR_I2C_Interface i2c_interface(config::I2C_ADDRESS);
@@ -67,6 +68,9 @@ static TR_LogToFlash logger;
 // copy index. Nothing on the flight hot path touches it yet.
 static tr_flightlog::TR_NandBackend_esp flightlog_backend;
 static tr_flightlog::TR_FlightLog flightlog;
+// Stage 2c-3a: persistent bitmap store wired into begin() so bad-block state
+// and (future) allocated-block state survive reboots.
+static tr_flightlog::NvsBitmapStore flightlog_bitmap_store;
 static TR_BLE_To_APP ble_app("TinkerRocket");
 static TR_LoRa_Comms lora_comms;
 static SensorConverter sensor_converter;
@@ -2256,7 +2260,7 @@ void initPeripherals()
         flightlog_backend = tr_flightlog::TR_NandBackend_esp(&logger);
         auto st = flightlog.begin(flightlog_backend,
                                   tr_flightlog::TR_FlightLog::Config{},
-                                  /*bitmap_store=*/nullptr);
+                                  &flightlog_bitmap_store);
         if (st == tr_flightlog::Status::Ok)
         {
             ESP_LOGI("FLIGHTLOG", "shadow up: %zu flight(s) in index, %zu bad blocks",


### PR DESCRIPTION
## Summary

5-line follow-up to [#58](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/58). Passes the `NvsBitmapStore` that already exists in the binary to `flightlog.begin()` in `out_computer` — so the 3-state block bitmap actually persists across reboots instead of being seeded fresh every boot.

### Why this matters

Before: `flightlog.begin(backend, cfg, /*bitmap_store=*/nullptr)` — runtime-discovered bad blocks and (future) allocated-block state are lost on every power cycle.

After: `flightlog.begin(backend, cfg, &flightlog_bitmap_store)` — state round-trips through NVS namespace `"flightlog"` key `"bitmap"`.

### Scope

- One new include
- One new file-scope static (`NvsBitmapStore`)
- One `nullptr` → `&flightlog_bitmap_store` swap at the begin() call site

No hot-path change; TR_FlightLog is still shadow-only until Stage 2c-3c lands.

## Test plan

- [ ] `build (out_computer)` CI green
- [ ] Bench: first boot logs `shadow up: 0 flight(s), 0 bad`. Subsequent boots log the same numbers (proves the NVS round-trip is live; if the store were silently skipping, you'd see the bad-block count drift if the rescan found new ones — this PR makes the seed-once-then-persist contract real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
