### PR TITLE
iOS: catch NonSensor parser up to the 43-byte wire format (#43)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -486,6 +486,14 @@ nonisolated class CSVGenerator {
         columns.append("Velocity Apogee Flag")
         columns.append("Launch Flag")
 
+        // Pyro status bits (appended in #34 wire format; legacy files emit 0s)
+        columns.append("Pyro 1 Continuity")
+        columns.append("Pyro 2 Continuity")
+        columns.append("Pyro 1 Fired")
+        columns.append("Pyro 2 Fired")
+        columns.append("Reboot Recovery")
+        columns.append("FC Guidance Enabled")
+
         return columns.joined(separator: ",") + "\n"
     }
 
@@ -568,6 +576,14 @@ nonisolated class CSVGenerator {
         values.append(nonSensor.map { $0.alt_apogee_flag ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.vel_u_apogee_flag ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.launch_flag ? "1" : "0" } ?? "")
+
+        // Pyro status bits
+        values.append(nonSensor.map { $0.pyro1_continuity ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro2_continuity ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro1_fired ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro2_fired ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.reboot_recovery ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.guidance_enabled ? "1" : "0" } ?? "")
 
         return values.joined(separator: ",") + "\n"
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -345,7 +345,14 @@ nonisolated class SensorConverter {
             alt_apogee_flag: raw.alt_apogee_flag,
             vel_u_apogee_flag: raw.vel_u_apogee_flag,
             launch_flag: raw.launch_flag,
-            rocket_state: rocket_state
+            rocket_state: rocket_state,
+            // Legacy wire format never carried pyro_status — leave unset.
+            pyro1_continuity: false,
+            pyro2_continuity: false,
+            pyro1_fired: false,
+            pyro2_fired: false,
+            reboot_recovery: false,
+            guidance_enabled: false
         )
     }
 
@@ -388,6 +395,14 @@ nonisolated class SensorConverter {
         // dm/s -> m/s
         let altitude_rate = Double(raw.baro_alt_rate_dmps) * 0.1
 
+        // Pyro status byte — mirror the C++ PSF_ masks in RocketComputerTypes.h
+        let PSF_CH1_CONT: UInt8         = (1 << 0)
+        let PSF_CH2_CONT: UInt8         = (1 << 1)
+        let PSF_CH1_FIRED: UInt8        = (1 << 2)
+        let PSF_CH2_FIRED: UInt8        = (1 << 3)
+        let PSF_REBOOT_RECOVERY: UInt8  = (1 << 4)
+        let PSF_GUIDANCE_ENABLED: UInt8 = (1 << 5)
+
         return NonSensorDataSI(
             time_us: raw.time_us,
             roll: roll,
@@ -405,7 +420,13 @@ nonisolated class SensorConverter {
             alt_apogee_flag: alt_apogee_flag,
             vel_u_apogee_flag: vel_u_apogee_flag,
             launch_flag: launch_flag,
-            rocket_state: rocket_state
+            rocket_state: rocket_state,
+            pyro1_continuity: (raw.pyro_status & PSF_CH1_CONT) != 0,
+            pyro2_continuity: (raw.pyro_status & PSF_CH2_CONT) != 0,
+            pyro1_fired:      (raw.pyro_status & PSF_CH1_FIRED) != 0,
+            pyro2_fired:      (raw.pyro_status & PSF_CH2_FIRED) != 0,
+            reboot_recovery:  (raw.pyro_status & PSF_REBOOT_RECOVERY) != 0,
+            guidance_enabled: (raw.pyro_status & PSF_GUIDANCE_ENABLED) != 0
         )
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -234,7 +234,9 @@ nonisolated struct MMC5983MAData {
     }
 }
 
-// Non-Sensor Data (38 bytes)
+// Non-Sensor Data (43 bytes)
+// Wire layout mirrors C++ NonSensorData in RocketComputerTypes.h — bump the
+// size guard + add the matching field here whenever a byte is appended.
 nonisolated struct NonSensorData {
     let time_us: UInt32
 
@@ -262,9 +264,18 @@ nonisolated struct NonSensorData {
     // KF-filtered barometric altitude rate (dm/s = 0.1 m/s)
     let baro_alt_rate_dmps: Int16
 
+    // Pyro channel status bitfield (appended in #34):
+    //   bit 0 PSF_CH1_CONT  — ch1 continuity
+    //   bit 1 PSF_CH2_CONT
+    //   bit 2 PSF_CH1_FIRED
+    //   bit 3 PSF_CH2_FIRED
+    //   bit 4 PSF_REBOOT_RECOVERY  — mid-flight reboot recovery occurred
+    //   bit 5 PSF_GUIDANCE_ENABLED — FC's live guidance_enabled config
+    let pyro_status: UInt8
+
     init(from data: Data) throws {
-        guard data.count >= 42 else {
-            throw ParseError.invalidSize(expected: 42, got: data.count)
+        guard data.count >= 43 else {
+            throw ParseError.invalidSize(expected: 43, got: data.count)
         }
 
         var offset = 0
@@ -289,6 +300,8 @@ nonisolated struct NonSensorData {
         rocket_state = data.readUInt8(at: &offset)
 
         baro_alt_rate_dmps = data.readInt16LE(at: &offset)
+
+        pyro_status = data.readUInt8(at: &offset)
     }
 }
 
@@ -535,6 +548,15 @@ nonisolated struct NonSensorDataSI {
     let launch_flag: Bool
 
     let rocket_state: RocketState
+
+    // Derived from NonSensorData.pyro_status (raw byte is kept here so
+    // downstream consumers can inspect individual bits as needed).
+    let pyro1_continuity: Bool
+    let pyro2_continuity: Bool
+    let pyro1_fired: Bool
+    let pyro2_fired: Bool
+    let reboot_recovery: Bool
+    let guidance_enabled: Bool
 }
 
 // MARK: - Parsing Errors

--- a/TinkerRocketApp/TinkerRocketAppTests/SensorTypesTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/SensorTypesTests.swift
@@ -35,10 +35,7 @@ final class SensorTypesTests: XCTestCase {
         assertSize(10) { try POWERData(from: $0) }
     }
 
-    // Swift parser currently reads 42 bytes.  The C++ wire format grew to
-    // 43 bytes in commit 7d214f8 (#34) but the iOS side has not been
-    // updated — tracked separately as an iOS/firmware sync bug.
-    func testNonSensorData_Size42() {
-        assertSize(42) { try NonSensorData(from: $0) }
+    func testNonSensorData_Size43() {
+        assertSize(43) { try NonSensorData(from: $0) }
     }
 }


### PR DESCRIPTION
## Summary

- Closes #43. The Swift `NonSensorData` parser was one byte behind the C++ wire format since #34 — every `pyro_status` byte has been silently dropped on iOS.
- Adds `pyro_status: UInt8` to the raw struct + six derived Bool fields to `NonSensorDataSI` (pyro1/2 continuity/fired, reboot_recovery, guidance_enabled).
- CSV export grows 6 columns at the end of the NonSensor block; legacy flights emit 0s, current flights get real bits.
- Renames `testNonSensorData_Size42` back to `Size43` — short-term sticking-plaster retired.

## Test plan

- [x] `xcodebuild test` on iPhone 17 simulator — `SensorTypesTests` full suite green, including `testNonSensorData_Size43`
- [x] Grep confirmed live BLE JSON telemetry path (`TelemetryData.swift`) is a separate channel and stays untouched
- [x] Python side (`tests/parse_flight.py`) already on 43 bytes — Swift + Python are now in sync
- [ ] Spot-check: open a current flight log in the app, export CSV, confirm the 6 new pyro columns populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)