### PR TITLE
dedup: drop non-monotonic frames per type (#69)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -976,13 +976,16 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
     if (!isKnownMessageType(type))
         return;
 
-    // ── Duplicate & stale frame detection for I2S DMA ──
-    // 1. Skip exact-duplicate frames (same type, same time_us) caused by
-    //    DMA buffer replay.
-    // 2. Skip stale frames whose timestamp is more than 5 seconds behind
-    //    the latest seen timestamp.  These can appear when MRAM ring buffer
-    //    data from a previous logging session leaks into the current one
-    //    (clearRing resets pointers but doesn't zero MRAM contents).
+    // ── Duplicate, replay & stale frame detection for I2S DMA ──
+    // Within a boot session, each FC-side time_us (= micros() on the FC) is
+    // strictly monotonically increasing for a given sensor type. So for each
+    // type, any incoming frame whose time_us is <= the last-seen value for
+    // that type is either an exact duplicate (== prev) or an older replay
+    // (< prev). Both cases are safe to drop. This catches I2S DMA buffer
+    // replays observed at boot — issue #69 documented ~170 replayed frames
+    // covering the first ~70 ms of every flight log (first 65 IMU frames
+    // byte-identical to frames 70-134). The cross-type 5-second stale filter
+    // remains as a second line of defence against large cross-session leaks.
     if (payload_len >= 4)
     {
         static uint32_t prev_time_ism6 = 0, prev_time_bmp = 0,
@@ -1005,21 +1008,24 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         }
         if (prev != nullptr)
         {
-            if (time_us == *prev && time_us != 0)
+            // Non-monotonic or exact-duplicate frame for this type — drop.
+            // time_us == 0 is excluded so the very first frame of each type
+            // (which finds *prev == 0) still passes.
+            if (time_us != 0 && time_us <= *prev)
             {
                 dedup_drops++;
-                return;  // duplicate — skip
+                return;
             }
 
-            // Reject stale frames: if we've seen timestamps > 5s ahead of this
-            // frame, it's from a previous session.  The 5s threshold avoids
-            // false positives from minor jitter or sensor startup delays.
+            // Cross-type stale filter: ts more than 5 s behind the global
+            // high-water mark is almost certainly from a prior session.
+            // Avoids false positives on minor jitter between sensor streams.
             static constexpr uint32_t STALE_THRESHOLD_US = 5'000'000;
             if (time_us != 0 && max_time_us > STALE_THRESHOLD_US &&
                 time_us < (max_time_us - STALE_THRESHOLD_US))
             {
                 stale_drops++;
-                return;  // stale — skip
+                return;
             }
 
             *prev = time_us;


### PR DESCRIPTION
## Summary

- Closes #69. Every flight log has started with ~5 KB of byte-identical duplicate sensor data across the first ~377 ms — 726 replayed frames on `flight_20260423_204822.bin`, concentrated entirely in the first 1000 frames of the file.
- Root cause is I2S DMA buffer replay at OC boot. The existing dedup filter in `processFrame` (OC main) only caught exact per-type timestamp matches (`ts == prev_time_T`); the replay's first frame arrives at ts 346 ms *before* the last-seen-for-type, which was neither an exact match nor >5 s stale, so every replay frame slipped through.
- Fix: for each sensor type, drop any incoming frame with `ts <= prev_time_T`. Within a boot session the FC's `micros()` is strictly monotonic per sensor type, so a non-greater timestamp is by definition a replay.

## Verification (Python simulation against the actual bench log)

| metric | before fix | after fix |
|---|---|---|
| frames kept | 52028 | 51303 |
| per-type monotonicity violations | 726 | 0 |
| drop scope | — | first 377 ms, first 1000 frames |
| ISM6 steady-state rate | 921 Hz | 906 Hz |
| ISM6 max gap | 86.8 ms (in replayed segment, noise) | 86.8 ms (real early-boot scheduler hiccup, unchanged) |

Per-type drop breakdown: ISM6 354 / BMP 167 / NS 112 / MMC 77 / POWER 15 / GNSS 1. All concentrated in the first 377 ms of the file.

## Test plan

- [x] Python simulation of old-vs-new filter against `tests/test_data/flight_20260423_204822.bin` — confirms 726 replays caught, all 6 streams strictly monotonic post-filter, no over-drop.
- [ ] Reflash out_computer with this change, run a fresh bench, confirm `flight_YYYYMMDD_HHMMSS.bin` no longer has the duplicate startup window. Stats line should show `dedup=~700` during the first second and near 0 thereafter.
- [ ] Spot-check that steady-state rates stay at ~920 Hz ISM6, ~480 Hz BMP/NS, ~220 Hz MMC — confirming we're not over-filtering in live flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
