### PR TITLE
LoRa uplink cmd 23: prepare log + begin flightlog before startLogging (#72)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1663,6 +1663,14 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
                                           : !logger.isLoggingActive();
         if (want_on && !logger.isLoggingActive())
         {
+            // Mirror the BLE cmd 23 start path: prepareLogFile opens the sink
+            // session (file_open=true so enqueueFrame accepts frames) and
+            // flightlogBeginFlight allocates the TR_FlightLog block range.
+            // startLogging alone would flip logging_active without either, so
+            // every incoming frame would be rejected at enqueue and the flight
+            // would never land on NAND (#72).
+            logger.prepareLogFile();
+            flightlogBeginFlight();
             logger.startLogging();
             ESP_LOGI("LORA", "UPLINK Logging started");
         }


### PR DESCRIPTION
## Summary

- Closes #72. Base-station-initiated logging (iOS Log toggle on the base station card → LoRa uplink cmd 23 to rocket) entered "logging active" state but produced no flight on the rocket.
- Root cause: uplink cmd 23 handler called only `logger.startLogging()` without `prepareLogFile()` (opens the sink session so `enqueueFrame` accepts frames) or `flightlogBeginFlight()` (allocates the TR_FlightLog block range).
- Fix: mirror the local BLE cmd 23 path — prepare + begin + start, in that order. Stop path unchanged (already correct).

## Test plan

- [x] Diff reviewed against local BLE cmd 23 path at `out_computer/main/main.cpp:3042-3049` — now symmetric.
- [ ] Flash this branch on out_computer, start logging from the base station card in the iOS app, confirm a `flight_YYYYMMDD_HHMMSS.bin` appears in the rocket file list after stop.
- [ ] Confirm base station SD log also records the same window (existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
