### PR TITLE
dedup: split ts-eq vs ts-lt + stamp DMA cb per frame (#74)

### DIFF
--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -921,8 +921,11 @@ TEST(TRFlightLogWrite, OverflowExtendFailsWhenAdjacentAllocated) {
 }
 
 TEST(TRFlightLogPrepare, PicksNextRangeAfterFirstAllocation) {
-    // Prepare+finalize a first flight, then prepare again — second range
-    // should start right after the first.
+    // Prepare+finalize a first flight, then prepare again — the second
+    // range should start right after the first flight's TRIMMED extent.
+    // finalizeFlight releases unused tail blocks (#74), so a tiny first
+    // flight (1000 B = 1 page = 1 block) only keeps 1 block, freeing
+    // blocks 1..255 for the next prepareFlight to pick from.
     FakeNandBackend nand;
     MemoryBitmapStore store;
     TR_FlightLog fl;
@@ -936,7 +939,7 @@ TEST(TRFlightLogPrepare, PicksNextRangeAfterFirstAllocation) {
     uint32_t second_id = 0;
     ASSERT_EQ(fl.prepareFlight(second_id), Status::Ok);
     EXPECT_EQ(fl.activeStartBlock(),
-              cfg.flight_region_start + cfg.prealloc_blocks);
+              cfg.flight_region_start + 1u);
 }
 
 // ================================================================
@@ -970,7 +973,10 @@ TEST(TRFlightLogFinalize, AppendsEntryAndClearsActiveState) {
     auto* e = fl.index().findByFilename("flight_001.bin");
     ASSERT_NE(e, nullptr);
     EXPECT_EQ(e->flight_id, id);
-    EXPECT_EQ(e->n_blocks, 256u);
+    // n_blocks reflects the trimmed extent (#74). final_bytes=5*2048=10240
+    // payload bytes / 2032 B per page = 6 logical pages, /64 pages per
+    // block = 1 block. The remaining 255 prealloc blocks are released.
+    EXPECT_EQ(e->n_blocks, 1u);
     EXPECT_EQ(e->final_bytes, 5u * NAND_PAGE_SIZE);
 }
 

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -354,21 +354,50 @@ Status TR_FlightLog::finalizeFlight(const char* filename, uint32_t final_bytes) 
     if (!flight_active_)  return Status::Error;
     if (filename == nullptr) return Status::OutOfRange;
 
+    // Trim unused tail blocks from the preallocated range. prepareFlight
+    // reserves 32 MB of headroom for long flights, but most flights are far
+    // shorter — without trimming, the bitmap caps out at floor(region / 32MB)
+    // simultaneous flights regardless of their actual size. Round up to cover
+    // any partial trailing page.
+    constexpr uint32_t PAYLOAD_PER_PAGE = NAND_PAGE_SIZE - sizeof(PageHeader);
+    const uint32_t used_pages = (final_bytes == 0) ? 0
+        : (final_bytes + PAYLOAD_PER_PAGE - 1) / PAYLOAD_PER_PAGE;
+    uint32_t used_blocks = (used_pages + NAND_PAGES_PER_BLK - 1) / NAND_PAGES_PER_BLK;
+    if (used_blocks > active_n_blocks_) used_blocks = active_n_blocks_;
+
     FlightIndexEntry entry{};
     entry.magic       = FLGT_MAGIC;
     entry.flight_id   = active_flight_id_;
     std::strncpy(entry.filename, filename, sizeof(entry.filename) - 1);
     entry.start_block = static_cast<uint16_t>(active_start_block_);
-    entry.n_blocks    = static_cast<uint16_t>(active_n_blocks_);
+    entry.n_blocks    = static_cast<uint16_t>(used_blocks);
     entry.final_bytes = final_bytes;
 
+    // Release the tail in the in-memory bitmap before the index save so the
+    // two stay consistent; roll back if the save fails.
+    const uint32_t free_start = active_start_block_ + used_blocks;
+    const uint32_t free_count = active_n_blocks_ - used_blocks;
+    if (free_count > 0) {
+        bitmap_.markFreeRange(free_start, free_count);
+    }
+
     Status st = index_.append(entry);
-    if (st != Status::Ok) return st;
+    if (st != Status::Ok) {
+        if (free_count > 0) bitmap_.markAllocatedRange(free_start, free_count);
+        return st;
+    }
     st = index_.save(*nand_, cfg_.metadata_blocks[0], cfg_.metadata_blocks[1]);
     if (st != Status::Ok) {
         index_.removeByFilename(entry.filename);  // roll back the in-memory add
+        if (free_count > 0) bitmap_.markAllocatedRange(free_start, free_count);
         return st;
     }
+
+    // Both RAM structures are committed; persist the bitmap change to NAND.
+    // If this fails the on-disk bitmap just keeps the tail marked allocated;
+    // startup recovery handles orphan-allocated blocks by detecting them as
+    // not-in-index and releasing them on the next boot.
+    if (free_count > 0) persistBitmap();
 
     flight_active_    = false;
     active_flight_id_ = 0;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -78,6 +78,17 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
     }
     ring_prelaunch_cap_ = ring_size_ / 2;
 
+    // Mutex to serialize ringPush callers and to block clearRing from
+    // running concurrently with an in-flight push (#74). Unconditionally
+    // created — parser + oc_loop can race on Core 1 regardless of ring
+    // backing, so RAM and MRAM paths both need it.
+    push_mutex_ = xSemaphoreCreateMutex();
+    if (!push_mutex_)
+    {
+        if (cfg.debug) ESP_LOGE(TAG, "Failed to create push mutex");
+        return false;
+    }
+
     rb_head = rb_tail = rb_count = 0;
     rb_overruns = rb_highwater = 0;
     rb_drop_oldest_bytes = 0;
@@ -663,6 +674,12 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
         return false;
     }
 
+    // Serialize against concurrent pushes (parser and oc_loop can preempt
+    // each other on Core 1) and against clearRing (Core 0 flush task). This
+    // closes the #74 race where a push snapshotted rb_head before clearRing
+    // ran and then wrote a stale rb_head value, clobbering the reset.
+    if (push_mutex_) xSemaphoreTake(push_mutex_, portMAX_DELAY);
+
     // Read current count under spinlock
     portENTER_CRITICAL(&ring_mux_);
     const uint32_t count_now = rb_count;
@@ -675,6 +692,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
         if (ring_prelaunch_cap_ - count_now < len)
         {
             rb_overruns++;
+            if (push_mutex_) xSemaphoreGive(push_mutex_);
             return false;
         }
     }
@@ -689,7 +707,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
             if (local_count < 6)
             {
                 rb_drop_oldest_bytes += local_count;
-                clearRing();
+                clearRingLocked();
                 local_count = 0;
                 break;
             }
@@ -704,7 +722,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
                     ESP_LOGW(TAG, "ringPush: bad SOF at tail, clearing ring");
                 }
                 rb_drop_oldest_bytes += local_count;
-                clearRing();
+                clearRingLocked();
                 local_count = 0;
                 break;
             }
@@ -720,7 +738,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
                                   (unsigned long)frame_size, (unsigned long)local_count);
                 }
                 rb_drop_oldest_bytes += local_count;
-                clearRing();
+                clearRingLocked();
                 local_count = 0;
                 break;
             }
@@ -782,6 +800,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
     {
         rb_highwater = new_count;
     }
+    if (push_mutex_) xSemaphoreGive(push_mutex_);
     return true;
 }
 
@@ -1513,6 +1532,18 @@ bool TR_LogToFlash::checkDirtyOnStartup()
 }
 
 void TR_LogToFlash::clearRing()
+{
+    // Public entry point: acquire push_mutex_ so any in-flight ringPush on
+    // Core 1 finishes before we start, and no new push can start until we
+    // return. Without this guard, a push that already snapshotted rb_head
+    // would clobber our reset back to a prelaunch value on its trailing
+    // rb_head assignment (the #74 race).
+    if (push_mutex_) xSemaphoreTake(push_mutex_, portMAX_DELAY);
+    clearRingLocked();
+    if (push_mutex_) xSemaphoreGive(push_mutex_);
+}
+
+void TR_LogToFlash::clearRingLocked()
 {
     LFS_TIMING_START();
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -261,8 +261,9 @@ bool TR_LogToFlash::enqueueFrame(const uint8_t* frame, size_t len)
     // Accept frames when logging is active OR when the log file has been
     // pre-created (PRELAUNCH).  Pre-launch frames buffer in the ring
     // (capped at 50%) and are flushed once activateLogging() fires.
-    // Stale MRAM data is no longer a concern: clearRing() now zeros
-    // the MRAM, and processFrame() has a timestamp monotonicity filter.
+    // Cross-session stale MRAM is handled by runStartupRecovery() at boot;
+    // within a session, processFrame() has a timestamp monotonicity filter
+    // that catches anything that would look like a replay from the ring.
     if (!logging_active && !file_open)
     {
         return false;
@@ -1391,14 +1392,13 @@ void TR_LogToFlash::activateLogging()
              (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
              (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
 
-    // Clear stale pre-launch data from the ring buffer so only
-    // fresh data from this moment forward gets logged.
-    clearRing();
-
-    ESP_LOGW(TAG, "ACT1 post-clear h=%lu t=%lu c=%lu push=%llu pop=%llu",
-             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
-             (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
-
+    // Preserve the prelaunch ring contents. The next flushRingToNand drains
+    // from rb_tail forward, so the flight file starts with ~500 ms of
+    // pre-command sensor data (the drop-oldest cap bounds the window).
+    // clearRing is intentionally NOT called here — it was the source of the
+    // clobber race in #74, and the monotonic dedup filter in processFrame
+    // already rejects any stale MRAM frames that cross session boundaries.
+    // Cross-boot stale MRAM is handled by runStartupRecovery at begin().
     logging_active = true;
     ring_prelaunch_cap_ = ring_size_;
     end_flight_requested = false;
@@ -1408,7 +1408,7 @@ void TR_LogToFlash::activateLogging()
     ESP_LOGW(TAG, "ACT2 exit      h=%lu t=%lu c=%lu (logging_active=1)",
              (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count);
 
-    if (cfg.debug) ESP_LOGI(TAG, "Logging activated (ring cleared + cap raised)");
+    if (cfg.debug) ESP_LOGI(TAG, "Logging activated (prelaunch buffer preserved)");
 
     LFS_TIMING_END(activate_max_us_, "activateLogging");
 }

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -776,6 +776,8 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
     const uint32_t new_count = rb_count;
     portEXIT_CRITICAL(&ring_mux_);
 
+    ringpush_bytes_ += len;
+
     if (new_count > rb_highwater)
     {
         rb_highwater = new_count;
@@ -826,6 +828,8 @@ uint32_t TR_LogToFlash::ringPop(uint8_t* out, uint32_t len)
     portENTER_CRITICAL(&ring_mux_);
     rb_count -= len;
     portEXIT_CRITICAL(&ring_mux_);
+
+    ringpop_bytes_ += len;
 
     return len;
 }
@@ -1363,13 +1367,28 @@ void TR_LogToFlash::activateLogging()
 {
     LFS_TIMING_START();
 
+    // Issue #74 diagnostic: log pointer state at entry (end of prelaunch).
+    ESP_LOGW(TAG, "ACT0 entry     h=%lu t=%lu c=%lu push=%llu pop=%llu",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
+             (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
+
     // Clear stale pre-launch data from the ring buffer so only
     // fresh data from this moment forward gets logged.
     clearRing();
 
+    ESP_LOGW(TAG, "ACT1 post-clear h=%lu t=%lu c=%lu push=%llu pop=%llu",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
+             (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
+
     logging_active = true;
     ring_prelaunch_cap_ = ring_size_;
     end_flight_requested = false;
+    // Arm per-drain diagnostic logs for the first 20 flushRingToNand drains.
+    flush_log_remaining_ = 20;
+
+    ESP_LOGW(TAG, "ACT2 exit      h=%lu t=%lu c=%lu (logging_active=1)",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count);
+
     if (cfg.debug) ESP_LOGI(TAG, "Logging activated (ring cleared + cap raised)");
 
     LFS_TIMING_END(activate_max_us_, "activateLogging");
@@ -1497,11 +1516,20 @@ void TR_LogToFlash::clearRing()
 {
     LFS_TIMING_START();
 
+    // Issue #74 diagnostic: log pointer state going in so we can see what
+    // the prelaunch ring looked like before the reset.
+    ESP_LOGW(TAG, "CR0 pre-reset  h=%lu t=%lu c=%lu push=%llu pop=%llu",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
+             (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
+
     portENTER_CRITICAL(&ring_mux_);
     rb_head = 0;
     rb_tail = 0;
     rb_count = 0;
     portEXIT_CRITICAL(&ring_mux_);
+
+    ESP_LOGW(TAG, "CR1 post-reset h=%lu t=%lu c=%lu (MRAM zero-sweep next)",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count);
 
     // When using MRAM, zero-fill the entire ring to prevent stale data from
     // a previous session from leaking into the log file.  MRAM is non-volatile,
@@ -1529,6 +1557,12 @@ void TR_LogToFlash::clearRing()
             mramWriteBytes(addr, zeros, len);
         }
     }
+
+    // Issue #74 diagnostic: log pointer state after the 33 ms zero-sweep
+    // to detect if ringPush races clobbered the reset.
+    ESP_LOGW(TAG, "CR2 post-sweep h=%lu t=%lu c=%lu push=%llu pop=%llu",
+             (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count,
+             (unsigned long long)ringpush_bytes_, (unsigned long long)ringpop_bytes_);
 
     LFS_TIMING_END(clear_ring_max_us_, "clearRing");
 }
@@ -1780,6 +1814,25 @@ void TR_LogToFlash::flushRingToNand()
         if (chunk == 0)
         {
             break;
+        }
+
+        // Issue #74 diagnostic: for the first 20 drains after activateLogging,
+        // peek the first 8 bytes at rb_tail and log with pointer state.
+        // `AA 55 AA 55 <type> <len>` = real frame; all-zero = post-clearRing
+        // zeroed MRAM; anything else = stale prelaunch data being re-exposed.
+        if (flush_log_remaining_ > 0)
+        {
+            uint8_t peek[8] = {0};
+            if (chunk >= 8) ringPeekAt(rb_tail, peek, 8);
+            ESP_LOGW(TAG, "FL%02lu h=%lu t=%lu c=%lu len=%lu peek=%02X%02X%02X%02X%02X%02X%02X%02X push=%llu pop=%llu",
+                     (unsigned long)(20 - flush_log_remaining_),
+                     (unsigned long)rb_head, (unsigned long)rb_tail,
+                     (unsigned long)rb_count, (unsigned long)chunk,
+                     peek[0], peek[1], peek[2], peek[3],
+                     peek[4], peek[5], peek[6], peek[7],
+                     (unsigned long long)ringpush_bytes_,
+                     (unsigned long long)ringpop_bytes_);
+            flush_log_remaining_--;
         }
 
         const uint32_t popped = ringPop(page_buf + page_buf_idx, chunk);

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -211,6 +211,15 @@ private:
     // Remaining per-drain diagnostic prints allowed after the most recent
     // activateLogging(). Set to 20 on activate, decremented per drain.
     uint32_t flush_log_remaining_ = 0;
+
+    // Serializes ringPush against itself (parser and oc_loop can both push
+    // from Core 1 and preempt each other on priority boundaries) and against
+    // clearRing (Core 0 flush task). Without this, rb_head read-write pairs
+    // race with the pointer reset in clearRing — the snapshot of rb_head
+    // taken before mramWriteBytes gets written back AFTER clearRing has
+    // reset it to 0, clobbering the reset with a prelaunch value.
+    // See #74 bench trace (CR1 h=0 → CR2 h=50771 despite zero-sweep).
+    SemaphoreHandle_t push_mutex_ = nullptr;
     // Before logging starts, cap the ring at 50% so the initial flush at
     // launch detection doesn't stall the main loop.  Raised to full size
     // once logging is active (see openLogSession / closeLogSession).
@@ -403,6 +412,10 @@ private:
     void clearDirty();          // Remove LittleFS marker file on log close
     bool checkDirtyOnStartup(); // Check if previous session was dirty
     void clearRing();
+    // Internal variant: caller holds push_mutex_. Used by ringPush()'s
+    // drop-oldest fallback so it doesn't re-acquire the mutex it already
+    // holds (regular FreeRTOS mutexes are not recursive).
+    void clearRingLocked();
     void runStartupRecovery();
 };
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -201,6 +201,16 @@ private:
     uint32_t rb_overruns = 0;
     uint32_t rb_drop_oldest_bytes = 0;
     uint32_t rb_highwater = 0;
+
+    // Issue #74 diagnostic: compare total bytes pushed vs popped. A healthy
+    // ring has pop <= push at all times (residual frames left unflushed at
+    // end of flight). pop > push proves the same MRAM region is being drained
+    // twice — i.e. a ring-pointer race is re-exposing stale prelaunch data.
+    uint64_t ringpush_bytes_ = 0;
+    uint64_t ringpop_bytes_ = 0;
+    // Remaining per-drain diagnostic prints allowed after the most recent
+    // activateLogging(). Set to 20 on activate, decremented per drain.
+    uint32_t flush_log_remaining_ = 0;
     // Before logging starts, cap the ring at 50% so the initial flush at
     // launch detection doesn't stall the main loop.  Raised to full size
     // once logging is active (see openLogSession / closeLogSession).

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1207,6 +1207,15 @@ static void handleReceivedFrame(const uint8_t* frame, size_t frame_len,
 static void parseRxStream()
 {
     uint8_t payload[MAX_PAYLOAD];
+    // Issue #74 follow-up: when the prelaunch ring is at cap, every ringPush
+    // triggers drop-oldest which does an MRAM peek (~150 us SPI) on top of the
+    // normal MRAM write. Under sustained 72 KB/s ingest that pushes per-frame
+    // work above 400 us / 2400 fps = 416 us budget. rx_ring fills faster than
+    // this loop drains, the while condition never goes false, Core 1 stays
+    // 100% busy in this task, IDLE1 never runs, task_wdt trips. Yield a tick
+    // every N frames so IDLE can pet the watchdog even under that load.
+    static constexpr size_t YIELD_EVERY_N_FRAMES = 64;
+    size_t frames_this_call = 0;
     while (rxLen() >= (4 + 1 + 1 + 2))
     {
         if (!(rxPeek(0) == 0xAA &&
@@ -1259,6 +1268,12 @@ static void parseRxStream()
             (void)rxPop();
         }
         handleReceivedFrame(frame, frame_len, type, payload, out_payload_len);
+
+        if (++frames_this_call >= YIELD_EVERY_N_FRAMES)
+        {
+            frames_this_call = 0;
+            vTaskDelay(1);
+        }
     }
 }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -703,7 +703,8 @@ static uint64_t parser_len_drops = 0;
 
 static uint32_t frames_bad_crc = 0;
 static volatile uint32_t dma_cb_count = 0;      // DMA callback invocations
-static uint32_t dedup_drops = 0;                 // timestamp dedup rejects
+static uint32_t dedup_drops_lt = 0;              // ts strictly less than prev (replay / reorder)
+static uint32_t dedup_drops_eq = 0;              // ts exactly equal to prev (byte-duplicate)
 static uint32_t stale_drops = 0;                 // stale timestamp rejects
 static uint32_t raw_i2c_reads = 0;
 static uint64_t raw_i2c_bytes = 0;
@@ -992,18 +993,27 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                          prev_time_mmc = 0, prev_time_gnss = 0,
                          prev_time_ns = 0, prev_time_pwr = 0,
                          prev_time_guid = 0;
+        // dma_cb_count snapshot taken when each prev_time_* was last updated.
+        // Used to diagnose issue #74: when a duplicate frame arrives, compare
+        // its current dma_cb_count to the prev_cb value to tell whether the
+        // duplicate came from the same DMA delivery or a different one.
+        static uint32_t prev_cb_ism6 = 0, prev_cb_bmp = 0,
+                         prev_cb_mmc = 0, prev_cb_gnss = 0,
+                         prev_cb_ns = 0, prev_cb_pwr = 0,
+                         prev_cb_guid = 0;
         static uint32_t max_time_us = 0;  // Monotonic high-water mark across all types
         uint32_t time_us;
         memcpy(&time_us, payload, sizeof(time_us));
         uint32_t* prev = nullptr;
+        uint32_t* prev_cb = nullptr;
         switch (type) {
-            case ISM6HG256_MSG:       prev = &prev_time_ism6; break;
-            case BMP585_MSG:          prev = &prev_time_bmp;  break;
-            case MMC5983MA_MSG:       prev = &prev_time_mmc;  break;
-            case GNSS_MSG:            prev = &prev_time_gnss; break;
-            case NON_SENSOR_MSG:      prev = &prev_time_ns;   break;
-            case POWER_MSG:           prev = &prev_time_pwr;  break;
-            case GUIDANCE_TELEM_MSG:  prev = &prev_time_guid; break;
+            case ISM6HG256_MSG:       prev = &prev_time_ism6; prev_cb = &prev_cb_ism6; break;
+            case BMP585_MSG:          prev = &prev_time_bmp;  prev_cb = &prev_cb_bmp;  break;
+            case MMC5983MA_MSG:       prev = &prev_time_mmc;  prev_cb = &prev_cb_mmc;  break;
+            case GNSS_MSG:            prev = &prev_time_gnss; prev_cb = &prev_cb_gnss; break;
+            case NON_SENSOR_MSG:      prev = &prev_time_ns;   prev_cb = &prev_cb_ns;   break;
+            case POWER_MSG:           prev = &prev_time_pwr;  prev_cb = &prev_cb_pwr;  break;
+            case GUIDANCE_TELEM_MSG:  prev = &prev_time_guid; prev_cb = &prev_cb_guid; break;
             default: break;
         }
         if (prev != nullptr)
@@ -1013,7 +1023,28 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             // (which finds *prev == 0) still passes.
             if (time_us != 0 && time_us <= *prev)
             {
-                dedup_drops++;
+                const uint32_t cur_cb = dma_cb_count;
+                const bool is_eq = (time_us == *prev);
+                if (is_eq) dedup_drops_eq++;
+                else       dedup_drops_lt++;
+
+                // Log the first N drops of this boot with prev/cur cb values
+                // so we can tell whether the duplicate came from the same DMA
+                // callback (cur_cb == prev_cb) or a later one. Rate-limited
+                // to avoid flooding the console during a stall-triggered burst.
+                static uint32_t logged_count = 0;
+                if (logged_count < 50)
+                {
+                    ESP_LOGW("DEDUP", "drop type=%u %s prev_ts=%lu cur_ts=%lu prev_cb=%lu cur_cb=%lu (dcb=%lu)",
+                             (unsigned)type,
+                             is_eq ? "==" : "<",
+                             (unsigned long)*prev,
+                             (unsigned long)time_us,
+                             (unsigned long)*prev_cb,
+                             (unsigned long)cur_cb,
+                             (unsigned long)(cur_cb - *prev_cb));
+                    logged_count++;
+                }
                 return;
             }
 
@@ -1029,6 +1060,7 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             }
 
             *prev = time_us;
+            *prev_cb = dma_cb_count;
             if (time_us > max_time_us)
                 max_time_us = time_us;
         }
@@ -2154,13 +2186,16 @@ static void printStats()
     }
     // I2S pipeline stats
     {
-        static uint32_t prev_dma_cb = 0, prev_ring_ovf = 0, prev_dedup = 0, prev_stale = 0, prev_parsed = 0;
+        static uint32_t prev_dma_cb = 0, prev_ring_ovf = 0,
+                         prev_dedup_eq = 0, prev_dedup_lt = 0,
+                         prev_stale = 0, prev_parsed = 0;
         static uint64_t prev_dma_bytes = 0;
         uint32_t d_cb = dma_cb_count - prev_dma_cb;
         uint64_t d_bytes = raw_i2c_bytes - prev_dma_bytes;
         uint32_t d_ovf = rx_ring_overflow_drops - prev_ring_ovf;
         uint32_t d_stale = stale_drops - prev_stale;
-        uint32_t d_dedup = dedup_drops - prev_dedup;
+        uint32_t d_dedup_eq = dedup_drops_eq - prev_dedup_eq;
+        uint32_t d_dedup_lt = dedup_drops_lt - prev_dedup_lt;
         uint32_t d_parsed = msg_count_ism6 + msg_count_bmp + msg_count_mmc + msg_count_non_sensor + msg_count_gnss;
         static uint32_t prev_total_parsed = 0;
         uint32_t d_p = d_parsed - prev_total_parsed;
@@ -2171,12 +2206,13 @@ static void printStats()
         uint32_t d_tot = dma_total_bytes - prev_tot;
         float nz_pct = (d_tot > 0) ? (d_nz * 100.0f / d_tot) : 0;
 
-        ESP_LOGI("I2S", "dma_cb=%lu KB=%.1f nz=%.1f%% ovf=%lu dedup=%lu stale=%lu parsed=%lu frx=%lu fdr=%lu",
+        ESP_LOGI("I2S", "dma_cb=%lu KB=%.1f nz=%.1f%% ovf=%lu dedup_eq=%lu dedup_lt=%lu stale=%lu parsed=%lu frx=%lu fdr=%lu",
                  (unsigned long)d_cb,
                  (double)(d_bytes / 1024.0),
                  (double)nz_pct,
                  (unsigned long)d_ovf,
-                 (unsigned long)d_dedup,
+                 (unsigned long)d_dedup_eq,
+                 (unsigned long)d_dedup_lt,
                  (unsigned long)d_stale,
                  (unsigned long)d_p,
                  (unsigned long)s.frames_received,
@@ -2213,7 +2249,8 @@ static void printStats()
         prev_dma_cb = dma_cb_count;
         prev_dma_bytes = raw_i2c_bytes;
         prev_ring_ovf = rx_ring_overflow_drops;
-        prev_dedup = dedup_drops;
+        prev_dedup_eq = dedup_drops_eq;
+        prev_dedup_lt = dedup_drops_lt;
         prev_stale = stale_drops;
         prev_total_parsed = d_parsed;
         prev_nz = dma_nonzero_bytes;


### PR DESCRIPTION
## Summary

Instrumentation for #74, landing **before** a second fix attempt. PR #75 removed `clearRing()` from `activateLogging()` to preserve the prelaunch ring, but exposed a deeper bug: 1953 byte-identical duplicate frames reached `ringPush` via a path that bypassed `processFrame`'s dedup filter. We don't yet know which path.

This PR adds two diagnostic signals, zero behavior change, so the next bench flight characterizes what's slipping through.

- **Split `dedup_drops`** into `dedup_drops_eq` (`ts == prev`) and `dedup_drops_lt` (`ts < prev`). The existing I2S stats line now prints `dedup_eq=N dedup_lt=M` separately, matching the breakdown the issue comment asked for.
- **Per-type `prev_cb_*` snapshot** of `dma_cb_count`, captured whenever `prev_time_*` is updated. On a dedup drop, the first 50 events per boot emit `ESP_LOGW("DEDUP", ...)` with `prev_ts`, `cur_ts`, `prev_cb`, `cur_cb`, and `dcb = cur_cb - prev_cb`.

`dcb` is the money signal:
- `dcb=0` → duplicate arrived in the same DMA callback as the original (same-buffer replay).
- `dcb>>0` → duplicate came from a much later callback (parser reprocessing a stale rx_ring region, or session-crossing leak).

The 50-log cap per boot keeps the console quiet during normal operation while still capturing the whole startup duplicate cluster observed in flight_20260424_093652.bin (~800 duplicate groups concentrated in the first 900 ms).

## What changes for the user

- One additional WARN log line per dedup drop (up to 50 per boot).
- I2S stats line adds one field (`dedup_lt`) and renames `dedup` → `dedup_eq`. Any downstream parser of that line needs to update.
- No change to the flight-log file format or the dedup behavior itself — same frames dropped as before.

## Test plan

- [ ] Flash out_computer on bench. Local build already verified clean.
- [ ] Run a normal prelaunch → activate → flight sequence.
- [ ] Capture serial log. Verify the I2S stats line prints `dedup_eq` and `dedup_lt`, and that up to 50 `DEDUP drop` WARN lines fire in the first ~1 s after activate with `dcb` present.
- [ ] Pull the flight file; confirm byte-identical duplicate pairs are still there (this PR doesn't fix, just instruments.
- [ ] Post the first ~20 DEDUP drop lines + final dedup_eq / dedup_lt counts to issue #74 so we can decide the fix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)