### PR TITLE
Fix LoRa channel desync between rocket and base station (#71)

### DIFF
--- a/Data_Analysis/analyze_gaps.py
+++ b/Data_Analysis/analyze_gaps.py
@@ -577,9 +577,44 @@ def plot_gap_analysis(result):
 # ── Main ───────────────────────────────────────────────────────────────────────
 
 def main():
+    # Allow the FLIGHTS list to be overridden from the command line.  A
+    # bare `python3 analyze_gaps.py` runs the hard-coded analyses (useful
+    # for the curated reference flights); passing a path runs the same
+    # analysis pipeline on a one-off binary, with output written next to
+    # it under <stem>_analysis/.  Keeps the canonical FLIGHTS list intact
+    # so reproducing a published analysis is still a no-arg invocation.
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Gap analysis for TinkerRocket binary flight logs.")
+    parser.add_argument("binary", nargs="?",
+                        help="Optional path to a single .bin to analyze. "
+                             "If omitted, runs the FLIGHTS list at the top of "
+                             "this file.")
+    parser.add_argument("--name", default=None,
+                        help="Display name (defaults to the file basename).")
+    parser.add_argument("--out", default=None,
+                        help="Output directory for plots (defaults to "
+                             "<binary_stem>_analysis/ next to the input).")
+    parser.add_argument("--no-show", action="store_true",
+                        help="Skip plt.show() — useful for headless runs / CI.")
+    args = parser.parse_args()
+
+    if args.binary:
+        bin_path = os.path.abspath(args.binary)
+        stem = os.path.splitext(os.path.basename(bin_path))[0]
+        out_dir = args.out or os.path.join(os.path.dirname(bin_path),
+                                            f"{stem}_analysis")
+        flights = [{
+            "name": args.name or stem,
+            "bin_path": bin_path,
+            "output_dir": out_dir,
+        }]
+    else:
+        flights = FLIGHTS
+
     all_plot_paths = []
 
-    for flight in FLIGHTS:
+    for flight in flights:
         result = analyze_one_flight(flight)
         if result is not None:
             paths = plot_gap_analysis(result)
@@ -593,8 +628,8 @@ def main():
     print("  (See individual flight sections above for detailed gap tables)")
     print()
 
-    # Show all plots
-    plt.show()
+    if not args.no_show:
+        plt.show()
 
     return all_plot_paths
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -239,12 +239,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// existing LoRa link; if the rocket has not yet been heard, the BS has
     /// no way to tell it about the new channel and would strand it.
     func triggerAutoChannelSelectIfNeeded() {
-        guard isBaseStation,
-              !hasAutoSelectedChannel,
-              rocketConfig?.loraFreqMHz != nil,
-              !remoteRockets.isEmpty,
+        // Same gating as manual apply — no point scanning if we couldn't
+        // apply the result anyway.
+        guard !hasAutoSelectedChannel,
               !isScanning,
-              !pendingAutoApply else { return }
+              !pendingAutoApply,
+              autoApplyRefusalReason() == nil else { return }
 
         hasAutoSelectedChannel = true
         pendingAutoApply = true
@@ -262,55 +262,90 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
+    /// Reasons an auto-apply can be refused, surfaced to the UI so the user
+    /// gets a concrete next step instead of a silent no-op.
+    enum AutoApplyRefusal: String {
+        case notBaseStation       = "Connect to the base station first."
+        case notConnected         = "Base station is not connected over BLE."
+        case configMissing        = "Waiting for base-station config readback."
+        case noRocketPresent      = "No rocket has beaconed recently — power it on and wait for it to show up."
+    }
+
+    /// Maximum age of the most-recent rocket beacon for auto-apply to be
+    /// allowed.  The whole point of the gating is to prevent the app from
+    /// pushing a new frequency to a base station while the rocket is off or
+    /// out of range — doing so strands the rocket on the old channel.
+    /// 10 s comfortably covers the ~2 Hz beacon cadence.
+    static let autoApplyMaxBeaconAgeSeconds: TimeInterval = 10.0
+
+    /// Pure decision logic for whether auto-apply should proceed.  Lives
+    /// here as a static so it can be unit-tested without standing up a
+    /// CoreBluetooth peripheral, and so the rules stay in one place
+    /// rather than getting duplicated between this method and the view.
+    static func autoApplyRefusalReason(
+        isBaseStation: Bool,
+        isConnected: Bool,
+        config: RocketConfig?,
+        rocketLastSeenTimes: [Date],
+        now: Date = Date()
+    ) -> AutoApplyRefusal? {
+        if !isBaseStation { return .notBaseStation }
+        if !isConnected   { return .notConnected }
+        guard let cfg = config,
+              cfg.loraBwKHz != nil, cfg.loraSF != nil,
+              cfg.loraCR != nil, cfg.loraTxPower != nil else {
+            return .configMissing
+        }
+        // At least one tracked rocket beaconed within the freshness window.
+        // Beacons fire at ~0.5 Hz in READY/PRELAUNCH/INIT, so "silent > 10 s"
+        // is a strong signal the rocket isn't on-air.
+        let cutoff = now.addingTimeInterval(-autoApplyMaxBeaconAgeSeconds)
+        let haveFreshRocket = rocketLastSeenTimes.contains { $0 >= cutoff }
+        if !haveFreshRocket { return .noRocketPresent }
+        return nil
+    }
+
+    /// Returns `.none` if auto-apply is currently allowed, otherwise the
+    /// specific reason it's being refused.  Called by the Frequency Scan
+    /// view to decide whether to enable the Apply button and what message
+    /// to surface if it's disabled.
+    func autoApplyRefusalReason() -> AutoApplyRefusal? {
+        return Self.autoApplyRefusalReason(
+            isBaseStation: isBaseStation,
+            isConnected:   isConnected,
+            config:        rocketConfig,
+            rocketLastSeenTimes: remoteRockets.map { $0.lastSeen }
+        )
+    }
+
     /// Relay a LoRa reconfig to every tracked rocket, then apply the same
     /// config to this base station after the uplink retries have had time
     /// to land.  Keeps SF/BW/CR/power from the current base-station config
     /// — only the frequency changes.
     ///
-    /// Returns false if no base-station config has been read back yet; we
-    /// need it to pick SF/BW/CR that the rocket will also accept.
+    /// Refuses unless `autoApplyRefusalReason()` returns nil.  The base
+    /// station's transactional Cmd 10 handler (issue #71) will commit the
+    /// new frequency only after verifying the rocket joined the new
+    /// channel, so a missed relay rolls back instead of stranding.
     @discardableResult
     func autoApplyFrequency(_ freqMHz: Float) -> Bool {
-        guard isBaseStation,
-              let cfg = rocketConfig,
+        if let refusal = autoApplyRefusalReason() {
+            print("[FREQ] Auto-apply refused: \(refusal.rawValue)")
+            return false
+        }
+        guard let cfg = rocketConfig,
               let bw = cfg.loraBwKHz,
               let sf = cfg.loraSF,
               let cr = cfg.loraCR,
-              let pwr = cfg.loraTxPower else {
-            print("[FREQ] Auto-apply refused: no base-station LoRa config yet")
-            return false
-        }
+              let pwr = cfg.loraTxPower else { return false }
 
-        // cmd-10 payload (same layout as sendLoRaConfig)
-        var loraPayload = Data()
-        var f = freqMHz
-        var b = bw
-        loraPayload.append(Data(bytes: &f, count: 4))
-        loraPayload.append(Data(bytes: &b, count: 4))
-        loraPayload.append(sf)
-        loraPayload.append(cr)
-        loraPayload.append(UInt8(bitPattern: pwr))
-
-        // Relay to each tracked rocket.  The BS retries each uplink packet
-        // up to 8 times over ~800 ms; a missed relay is rare but possible,
-        // in which case the rocket stays on the old channel and must be
-        // reconfigured manually over BLE.
-        for rocket in remoteRockets {
-            var relay = Data()
-            relay.append(rocket.rocketID)
-            relay.append(10)          // inner cmd = LoRa config
-            relay.append(loraPayload)
-            sendRawCommand(50, payload: relay)
-        }
-
-        // Switch the base station last.  Wait long enough for the uplink
-        // retries (8 × 100 ms + TX time ≈ 1.5 s) to complete first so the
-        // rocket has already hopped before we leave the old channel.
-        let delay = remoteRockets.isEmpty ? 0.0 : 2.5
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self = self else { return }
-            self.sendLoRaConfig(freqMHz: freqMHz, bwKHz: bw, sf: sf, cr: cr, txPower: pwr)
-        }
+        // Send a single Cmd 10 to the base station carrying the new config.
+        // The base station (firmware) now owns the relay + verify handshake:
+        // it issues Cmd 50 → inner Cmd 10 uplink to every tracked rocket,
+        // switches to the new frequency, listens for a beacon on the new
+        // channel, and either commits or rolls back atomically.  The app
+        // no longer has to coordinate the 2-step dance.
+        sendLoRaConfig(freqMHz: freqMHz, bwKHz: bw, sf: sf, cr: cr, txPower: pwr)
         return true
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
@@ -145,21 +145,16 @@ struct FrequencyScanView: View {
                                 Spacer()
                             }
                         }
-                        .disabled(!canApply || applyStatus != nil)
+                        .disabled(applyRefusal != nil || applyStatus != nil)
 
                         if let s = applyStatus {
                             Text(s).font(.caption).foregroundColor(.secondary)
-                        } else if !canApply {
-                            Text("Waiting for base-station config readback…")
-                                .font(.caption).foregroundColor(.secondary)
-                        } else {
-                            Text("Relays the new frequency to every tracked rocket, then switches the base station. Keeps current SF/BW/CR/power.")
-                                .font(.caption).foregroundColor(.secondary)
-                        }
-
-                        if device.remoteRockets.isEmpty {
-                            Text("No rockets online — only the base station will be switched.")
+                        } else if let refusal = applyRefusal {
+                            Text(refusal.rawValue)
                                 .font(.caption).foregroundColor(.orange)
+                        } else {
+                            Text("The base station relays the new frequency to every tracked rocket, verifies they hopped, and only then commits. A failed verification rolls both sides back to the current channel.")
+                                .font(.caption).foregroundColor(.secondary)
                         }
                     }
                 }
@@ -177,13 +172,15 @@ struct FrequencyScanView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             if let q = quietestSample {
-                Text("The rocket and base station will both switch to \(String(format: "%.2f", q.freqMHz)) MHz. If the rocket misses the relay packet it will be stranded on the old channel.")
+                Text("The rocket and base station will both switch to \(String(format: "%.2f", q.freqMHz)) MHz. The base station verifies the rocket joined the new channel before committing — if verification fails, both sides roll back to the current channel.")
             }
         }
     }
 
-    private var canApply: Bool {
-        device.isBaseStation && device.rocketConfig?.loraFreqMHz != nil
+    /// Re-evaluated on every view update so the button enables as soon as
+    /// the rocket beacons in and disables again if it goes silent.
+    private var applyRefusal: BLEDevice.AutoApplyRefusal? {
+        device.autoApplyRefusalReason()
     }
 
     private func applyQuietest() {
@@ -191,11 +188,14 @@ struct FrequencyScanView: View {
         applyStatus = "Applying \(String(format: "%.2f", q.freqMHz)) MHz…"
         let ok = device.autoApplyFrequency(q.freqMHz)
         if !ok {
-            applyStatus = "Failed: base-station config unavailable"
+            applyStatus = applyRefusal.map { "Failed: \($0.rawValue)" } ?? "Failed"
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) { applyStatus = nil }
             return
         }
-        // Retry window (uplink retries) + BS switch delay + a little slack.
+        // Base station's transactional handler takes ~3 s (relay retries +
+        // beacon verify window).  Give it a little slack before we clear
+        // the banner; the real commit/rollback status shows up in the next
+        // config readback.
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
             applyStatus = "Done"
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { applyStatus = nil }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -10,13 +10,14 @@
 import SwiftUI
 import Combine
 
-// MARK: - Channel & Preset Definitions
-
-struct LoRaChannel: Identifiable {
-    let id: Int
-    let label: String
-    let freqMHz: Float
-}
+// MARK: - Preset Definitions
+//
+// Manual frequency selection was removed in issue #71 — letting the user
+// type any frequency is the #1 way the base station and rocket end up on
+// different channels.  The only path to change frequency now is the
+// Frequency Scan view, which picks the quietest channel and uses the
+// transactional apply flow.  SF/BW/CR/power presets remain user-editable
+// because they change rarely and are relayed atomically.
 
 struct LoRaPreset: Identifiable {
     let id: Int
@@ -27,18 +28,6 @@ struct LoRaPreset: Identifiable {
     let maxTxHz: String        // Max TX rate
     let approxRange: String    // Approximate LOS range
 }
-
-private let loraChannels: [LoRaChannel] = [
-    LoRaChannel(id: 0, label: "Ch 1 \u{00B7} 903.0 MHz", freqMHz: 903.0),
-    LoRaChannel(id: 1, label: "Ch 2 \u{00B7} 904.6 MHz", freqMHz: 904.6),
-    LoRaChannel(id: 2, label: "Ch 3 \u{00B7} 906.2 MHz", freqMHz: 906.2),
-    LoRaChannel(id: 3, label: "Ch 4 \u{00B7} 907.8 MHz", freqMHz: 907.8),
-    LoRaChannel(id: 4, label: "Ch 5 \u{00B7} 909.4 MHz", freqMHz: 909.4),
-    LoRaChannel(id: 5, label: "Ch 6 \u{00B7} 911.0 MHz", freqMHz: 911.0),
-    LoRaChannel(id: 6, label: "Ch 7 \u{00B7} 912.6 MHz", freqMHz: 912.6),
-    LoRaChannel(id: 7, label: "Ch 8 \u{00B7} 914.2 MHz", freqMHz: 914.2),
-    LoRaChannel(id: 8, label: "Ch 9 \u{00B7} 915.0 MHz", freqMHz: 915.0),
-]
 
 private let loraPresets: [LoRaPreset] = [
     LoRaPreset(id: 0, name: "Fast",       sf: 7,  bwKHz: 500.0, approxToA: "25 ms",  maxTxHz: "25 Hz", approxRange: "~3 km"),
@@ -54,8 +43,7 @@ struct SettingsView: View {
     @ObservedObject var device: BLEDevice
     @Environment(\.dismiss) var dismiss
 
-    // Persisted selections — LoRa
-    @AppStorage("loraChannelId")        private var channelId: Int = 8          // Default: Ch 9 (915.0 MHz)
+    // Persisted selections — LoRa (frequency no longer user-settable; see note above)
     @AppStorage("loraPresetId")         private var presetId: Int = 1           // Default: Standard
     @AppStorage("loraTxPower")          private var txPower: Double = 12.0      // Default: 12 dBm
 
@@ -110,12 +98,15 @@ struct SettingsView: View {
     @State private var servoApplied = false
     @State private var pidApplied = false
 
-    private var selectedChannel: LoRaChannel {
-        loraChannels.first(where: { $0.id == channelId }) ?? loraChannels[8]
-    }
-
     private var selectedPreset: LoRaPreset {
         loraPresets.first(where: { $0.id == presetId }) ?? loraPresets[1]
+    }
+
+    /// Current active frequency for the connected device, read from the most
+    /// recent config readback.  Falls back to the factory default so the
+    /// Summary section has something to show before the first readback lands.
+    private var currentFreqMHz: Float {
+        device.rocketConfig?.loraFreqMHz ?? 915.0
     }
 
     /// True when the connected rocket is still initializing (sensors/GPS starting up).
@@ -177,71 +168,110 @@ struct SettingsView: View {
 
                 // --- LoRa Settings ---
 
-                // Channel picker (default Form style = navigation link, avoids
-                // UIContextMenuInteraction issues that .menu causes in sheets)
-                Section("LoRa Channel") {
-                    Picker("Frequency", selection: $channelId) {
-                        ForEach(loraChannels) { ch in
-                            Text(ch.label).tag(ch.id)
-                        }
+                // Frequency is read-only here — it changes only via the
+                // Frequency Scan view (issue #71).  Show the currently active
+                // value so the user can confirm both devices match.
+                Section(header: Text("LoRa Frequency"),
+                        footer: Text(device.isBaseStation
+                            ? "To change frequency, run a Frequency Scan on the base station. The scan picks the quietest channel and applies it transactionally to both devices."
+                            : "Frequency is managed from the base station. Connect to the base station to change it.")) {
+                    HStack {
+                        Text("Current")
+                        Spacer()
+                        Text(String(format: "%.2f MHz", currentFreqMHz))
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
                     }
                 }
 
-                // Preset picker
-                Section("LoRa Range / Rate Preset") {
-                    Picker("Preset", selection: $presetId) {
-                        ForEach(loraPresets) { preset in
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(preset.name)
-                                Text("\(preset.approxRange) \u{00B7} \(preset.maxTxHz) \u{00B7} \(preset.approxToA)")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                // LoRa modulation (preset + TX power) is editable ONLY on the
+                // base station.  The base station relays its config to every
+                // tracked rocket via the transactional Cmd 10 path, keeping
+                // both ends in lockstep.  On a direct rocket connection we
+                // show the loaded values read-only so the user can verify
+                // they match — but never edit, eliminating the "I changed
+                // it on the rocket but not the BS" footgun.
+                if device.isBaseStation {
+                    // Preset picker
+                    Section("LoRa Range / Rate Preset") {
+                        Picker("Preset", selection: $presetId) {
+                            ForEach(loraPresets) { preset in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(preset.name)
+                                    Text("\(preset.approxRange) \u{00B7} \(preset.maxTxHz) \u{00B7} \(preset.approxToA)")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                .tag(preset.id)
                             }
-                            .tag(preset.id)
+                        }
+                        .pickerStyle(.inline)
+                        .labelsHidden()
+                    }
+
+                    // TX Power slider
+                    Section("LoRa TX Power") {
+                        VStack {
+                            HStack {
+                                Text("Power")
+                                Spacer()
+                                Text("\(Int(txPower)) dBm")
+                                    .foregroundColor(.secondary)
+                                    .font(.system(.body, design: .monospaced))
+                            }
+                            Slider(value: $txPower, in: 2...22, step: 1)
                         }
                     }
-                    .pickerStyle(.inline)
-                    .labelsHidden()
                 }
 
-                // TX Power slider
-                Section("LoRa TX Power") {
-                    VStack {
-                        HStack {
-                            Text("Power")
-                            Spacer()
-                            Text("\(Int(txPower)) dBm")
-                                .foregroundColor(.secondary)
-                                .font(.system(.body, design: .monospaced))
-                        }
-                        Slider(value: $txPower, in: 2...22, step: 1)
-                    }
-                }
-
-                // Summary
+                // Summary — what the user is about to apply (BS) vs. what
+                // the rocket has loaded right now (rocket-direct).
                 Section("LoRa Summary") {
-                    infoRow(label: "Frequency", value: String(format: "%.1f MHz", selectedChannel.freqMHz))
-                    infoRow(label: "Spreading Factor", value: "SF\(selectedPreset.sf)")
-                    infoRow(label: "Bandwidth", value: String(format: "%.0f kHz", selectedPreset.bwKHz))
-                    infoRow(label: "Coding Rate", value: "4/5")
-                    infoRow(label: "TX Power", value: "\(Int(txPower)) dBm")
-                    infoRow(label: "Time on Air", value: selectedPreset.approxToA)
-                    infoRow(label: "Est. Range (LOS)", value: selectedPreset.approxRange)
+                    infoRow(label: "Frequency", value: String(format: "%.2f MHz", currentFreqMHz))
+                    if device.isBaseStation {
+                        infoRow(label: "Spreading Factor", value: "SF\(selectedPreset.sf)")
+                        infoRow(label: "Bandwidth", value: String(format: "%.0f kHz", selectedPreset.bwKHz))
+                        infoRow(label: "Coding Rate", value: "4/5")
+                        infoRow(label: "TX Power", value: "\(Int(txPower)) dBm")
+                        infoRow(label: "Time on Air", value: selectedPreset.approxToA)
+                        infoRow(label: "Est. Range (LOS)", value: selectedPreset.approxRange)
+                    } else if let cfg = device.rocketConfig {
+                        // Read-only view of whatever the rocket actually has.
+                        if let sf = cfg.loraSF {
+                            infoRow(label: "Spreading Factor", value: "SF\(sf)")
+                        }
+                        if let bw = cfg.loraBwKHz {
+                            infoRow(label: "Bandwidth", value: String(format: "%.0f kHz", bw))
+                        }
+                        if let cr = cfg.loraCR {
+                            infoRow(label: "Coding Rate", value: "4/\(cr)")
+                        }
+                        if let pwr = cfg.loraTxPower {
+                            infoRow(label: "TX Power", value: "\(pwr) dBm")
+                        }
+                    } else {
+                        Text("Waiting for rocket config readback…")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
                 }
 
-                // Apply LoRa button
-                Section {
-                    applyButton(
-                        icon: "antenna.radiowaves.left.and.right",
-                        label: "Apply LoRa Config to \(device.isBaseStation ? "Base Station" : "Rocket")",
-                        applied: loraApplied
-                    ) {
-                        applyLoRaConfig()
-                    }
+                // Apply button — base station only.  Rocket gets its config
+                // via the BS's transactional Cmd 10 relay; there's no
+                // direct-apply path on a rocket connection.
+                if device.isBaseStation {
+                    Section {
+                        applyButton(
+                            icon: "antenna.radiowaves.left.and.right",
+                            label: "Apply LoRa Config",
+                            applied: loraApplied
+                        ) {
+                            applyLoRaConfig()
+                        }
 
-                    Text("Both devices must use matching LoRa settings. Connect to each device separately and apply the same config.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                        Text("Applies to the base station and relays to every tracked rocket. Frequency is preserved — change it via Frequency Scan.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 // --- Servo & PID Settings (rocket only) ---
@@ -493,12 +523,9 @@ struct SettingsView: View {
                 rollDelayMs = Double(cfg.rollDelayMs)
                 guidanceEnabled = cfg.guidanceEnabled
                 cameraType = Int(cfg.cameraType)
-                // Sync LoRa settings from device (reverse-map raw values to channel/preset IDs)
-                if let freq = cfg.loraFreqMHz {
-                    if let ch = loraChannels.first(where: { abs($0.freqMHz - freq) < 0.1 }) {
-                        channelId = ch.id
-                    }
-                }
+                // Sync LoRa preset + TX power from device.  Frequency is
+                // displayed read-only via `currentFreqMHz` and doesn't need
+                // reverse-mapping to any picker.
                 if let sf = cfg.loraSF, let bw = cfg.loraBwKHz {
                     if let preset = loraPresets.first(where: { $0.sf == sf && abs($0.bwKHz - bw) < 1.0 }) {
                         presetId = preset.id
@@ -590,12 +617,15 @@ struct SettingsView: View {
     // MARK: - Apply actions
 
     private func applyLoRaConfig() {
-        let channel = selectedChannel
+        // Keep the currently active frequency — only preset + power change
+        // here.  Frequency is managed exclusively by the Frequency Scan view
+        // so that every frequency change goes through the transactional
+        // apply path (issue #71).
         let preset = selectedPreset
         let cr: UInt8 = 5  // All presets use CR 4/5
 
         device.sendLoRaConfig(
-            freqMHz: channel.freqMHz,
+            freqMHz: currentFreqMHz,
             bwKHz: preset.bwKHz,
             sf: preset.sf,
             cr: cr,

--- a/TinkerRocketApp/TinkerRocketAppTests/AutoApplyRefusalTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/AutoApplyRefusalTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import TinkerRocketApp
+
+// Tests for BLEDevice.autoApplyRefusalReason — the gating that decides
+// whether the Frequency Scan view's "Apply" button should be enabled.
+// Issue #71: pushing a new frequency to the base station without a live
+// rocket strands the rocket on the old channel, so we refuse unless all
+// preconditions are met.  Logic was extracted to a pure static so it can
+// be exercised without standing up a CoreBluetooth peripheral.
+
+final class AutoApplyRefusalTests: XCTestCase {
+
+    // Reference time pinned across tests so beacon-age math is deterministic.
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    /// Build a "valid" RocketConfig — every LoRa field populated so config
+    /// gating doesn't trip.  Tests that want to break this property only
+    /// override the field they care about.
+    private func validConfig() -> RocketConfig {
+        var cfg = RocketConfig()
+        cfg.loraFreqMHz  = 915.0
+        cfg.loraSF       = 8
+        cfg.loraBwKHz    = 250.0
+        cfg.loraCR       = 5
+        cfg.loraTxPower  = 12
+        return cfg
+    }
+
+    // ------------------------------------------------------------------
+    // Refusal cases
+    // ------------------------------------------------------------------
+
+    func test_refuses_when_not_base_station() {
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: false,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [now],
+            now: now
+        )
+        XCTAssertEqual(r, .notBaseStation)
+    }
+
+    func test_refuses_when_not_connected() {
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: false,
+            config: validConfig(),
+            rocketLastSeenTimes: [now],
+            now: now
+        )
+        XCTAssertEqual(r, .notConnected)
+    }
+
+    func test_refuses_when_config_missing_entirely() {
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: nil,
+            rocketLastSeenTimes: [now],
+            now: now
+        )
+        XCTAssertEqual(r, .configMissing)
+    }
+
+    func test_refuses_when_config_missing_a_lora_field() {
+        // Missing any one of loraSF/BW/CR/TxPower is treated as "config not
+        // ready yet" — partial configs land here while the readback streams.
+        var cfg = validConfig()
+        cfg.loraSF = nil
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: cfg,
+            rocketLastSeenTimes: [now],
+            now: now
+        )
+        XCTAssertEqual(r, .configMissing)
+    }
+
+    func test_refuses_when_no_tracked_rockets() {
+        // Empty list — base station hasn't heard from any rocket since
+        // booting, no point pushing a frequency change into the void.
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [],
+            now: now
+        )
+        XCTAssertEqual(r, .noRocketPresent)
+    }
+
+    func test_refuses_when_only_stale_rocket_beacons() {
+        // Last beacon was older than the freshness window; rocket has
+        // probably gone off-air or out of range.
+        let stale = now.addingTimeInterval(-(BLEDevice.autoApplyMaxBeaconAgeSeconds + 1))
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [stale],
+            now: now
+        )
+        XCTAssertEqual(r, .noRocketPresent)
+    }
+
+    // ------------------------------------------------------------------
+    // Allowance cases
+    // ------------------------------------------------------------------
+
+    func test_allows_when_rocket_just_beaconed() {
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [now],
+            now: now
+        )
+        XCTAssertNil(r)
+    }
+
+    func test_allows_when_at_least_one_rocket_is_fresh() {
+        // Mix of stale and fresh — any one fresh beacon is enough.
+        let stale = now.addingTimeInterval(-100)
+        let fresh = now.addingTimeInterval(-3)
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [stale, fresh],
+            now: now
+        )
+        XCTAssertNil(r)
+    }
+
+    func test_freshness_boundary_is_inclusive_at_window_edge() {
+        // Beacon exactly at the freshness cutoff should count as fresh
+        // (>= cutoff, not strict >), so the gating doesn't briefly flap
+        // off→on→off as the cutoff sweeps past a single beacon timestamp.
+        let edge = now.addingTimeInterval(-BLEDevice.autoApplyMaxBeaconAgeSeconds)
+        let r = BLEDevice.autoApplyRefusalReason(
+            isBaseStation: true,
+            isConnected: true,
+            config: validConfig(),
+            rocketLastSeenTimes: [edge],
+            now: now
+        )
+        XCTAssertNil(r)
+    }
+
+    // ------------------------------------------------------------------
+    // Refusal-message wording — these strings appear verbatim in the
+    // Frequency Scan view to surface the failure reason; pin them so a
+    // typo doesn't silently change user-facing copy.
+    // ------------------------------------------------------------------
+
+    func test_refusal_messages_are_user_friendly() {
+        XCTAssertEqual(BLEDevice.AutoApplyRefusal.notBaseStation.rawValue,
+                       "Connect to the base station first.")
+        XCTAssertEqual(BLEDevice.AutoApplyRefusal.notConnected.rawValue,
+                       "Base station is not connected over BLE.")
+        XCTAssertEqual(BLEDevice.AutoApplyRefusal.configMissing.rawValue,
+                       "Waiting for base-station config readback.")
+        XCTAssertEqual(BLEDevice.AutoApplyRefusal.noRocketPresent.rawValue,
+                       "No rocket has beaconed recently — power it on and wait for it to show up.")
+    }
+}

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -82,3 +82,117 @@ TEST(RocketComputerTypes, LoRaFlagEncoding) {
         EXPECT_EQ(decoded, s);
     }
 }
+
+// ============================================================================
+// Issue #71: rendezvous protocol & lock-for-flight helpers
+// ============================================================================
+
+TEST(RocketComputerTypes, RocketState_NumericValues) {
+    // The wire protocol depends on these exact values — both ends must
+    // agree, and the host-side BS firmware decodes uint8_t state directly.
+    // If the enum order changes, the BS's freq-lock logic + everything
+    // downstream breaks silently.
+    EXPECT_EQ(static_cast<uint8_t>(INITIALIZATION), 0u);
+    EXPECT_EQ(static_cast<uint8_t>(READY),          1u);
+    EXPECT_EQ(static_cast<uint8_t>(PRELAUNCH),      2u);
+    EXPECT_EQ(static_cast<uint8_t>(INFLIGHT),       3u);
+    EXPECT_EQ(static_cast<uint8_t>(LANDED),         4u);
+}
+
+TEST(RocketComputerTypes, LoRaCmdHeartbeat_DoesNotCollide) {
+    // The heartbeat cmd must not collide with any of the existing command
+    // bytes the rocket / base station already use.  Existing commands
+    // span 1..60 today; 0xFE was chosen as deliberately out-of-band so
+    // we have headroom for new low-numbered commands.
+    EXPECT_EQ(LORA_CMD_HEARTBEAT, 0xFE);
+    EXPECT_NE(LORA_CMD_HEARTBEAT, LORA_BEACON_SYNC);
+    // Above the highest currently-used command byte (60 = freq scan)
+    EXPECT_GT(LORA_CMD_HEARTBEAT, 60);
+}
+
+TEST(FreqLockForFlight, InflightLatchesOn) {
+    // Any state transition into INFLIGHT must set the lock, regardless
+    // of the previous value.
+    EXPECT_TRUE(computeFreqLockForFlight(false, INFLIGHT));
+    EXPECT_TRUE(computeFreqLockForFlight(true,  INFLIGHT));
+}
+
+TEST(FreqLockForFlight, ReadyClearsLock) {
+    // Returning to READY (e.g. user reset between flights) clears the
+    // lock so recovery / config changes are allowed again.
+    EXPECT_FALSE(computeFreqLockForFlight(true,  READY));
+    EXPECT_FALSE(computeFreqLockForFlight(false, READY));
+}
+
+TEST(FreqLockForFlight, LandedClearsLock) {
+    // Critical post-flight transition: rocket lands, state goes
+    // INFLIGHT → LANDED.  The lock must clear so silence recovery is
+    // available again to relocate a rocket that drifted to a field 800m
+    // away.  Symmetrical with READY for clearing.
+    EXPECT_FALSE(computeFreqLockForFlight(true,  LANDED));
+    EXPECT_FALSE(computeFreqLockForFlight(false, LANDED));
+}
+
+TEST(FreqLockForFlight, PrelaunchPreservesLock) {
+    // PRELAUNCH must NOT clear the lock.  The "rocket regains GPS lock
+    // on the ground after a flight" path goes LANDED → PRELAUNCH on
+    // the FlightComputer; if PRELAUNCH cleared the lock we'd have
+    // already cleared it on LANDED, but this guarantees the same
+    // input-output if e.g. the FC briefly oscillates LANDED↔PRELAUNCH
+    // around the boundary.
+    EXPECT_TRUE(computeFreqLockForFlight(true,  PRELAUNCH));
+    EXPECT_FALSE(computeFreqLockForFlight(false, PRELAUNCH));
+}
+
+TEST(FreqLockForFlight, InitializationPreservesLock) {
+    // INITIALIZATION shouldn't toggle the lock either way — the rocket
+    // is just booting and we don't have enough info to make a call.
+    EXPECT_TRUE(computeFreqLockForFlight(true,  INITIALIZATION));
+    EXPECT_FALSE(computeFreqLockForFlight(false, INITIALIZATION));
+}
+
+TEST(FreqLockForFlight, FullFlightSequence) {
+    // Walk a typical flight start-to-finish and verify the lock is on
+    // exactly during INFLIGHT (and stays on through any LANDED→PRELAUNCH
+    // glitch — though here we go straight LANDED → READY for the next
+    // flight prep, which clears it).
+    bool locked = false;
+
+    locked = computeFreqLockForFlight(locked, INITIALIZATION);
+    EXPECT_FALSE(locked);
+    locked = computeFreqLockForFlight(locked, READY);
+    EXPECT_FALSE(locked);
+    locked = computeFreqLockForFlight(locked, PRELAUNCH);
+    EXPECT_FALSE(locked);  // unchanged from previous unlocked state
+    locked = computeFreqLockForFlight(locked, INFLIGHT);
+    EXPECT_TRUE(locked);   // latch on
+    locked = computeFreqLockForFlight(locked, LANDED);
+    EXPECT_FALSE(locked);  // post-flight clear
+    locked = computeFreqLockForFlight(locked, PRELAUNCH);
+    EXPECT_FALSE(locked);  // next flight: prelaunch keeps unlocked
+    locked = computeFreqLockForFlight(locked, INFLIGHT);
+    EXPECT_TRUE(locked);   // and re-locks for the next flight
+}
+
+TEST(FreqLockForFlight, Uint8Overload_MatchesEnumOverload) {
+    // The base station receives state numerically over LoRa.  The two
+    // overloads must produce identical output for every valid state.
+    for (uint8_t s = 0; s <= 4; ++s) {
+        for (bool prev : {false, true}) {
+            EXPECT_EQ(computeFreqLockForFlight(prev, s),
+                      computeFreqLockForFlight(prev, static_cast<RocketState>(s)))
+                << "state=" << (int)s << " prev=" << prev;
+        }
+    }
+}
+
+TEST(ShouldBeaconInState, AllowsAllExceptInflight) {
+    // Beaconing during INITIALIZATION is the key fix that lets the BS
+    // find a rocket whose FC hasn't booted yet.  Suppressed only in
+    // INFLIGHT to give telemetry every available slot.
+    EXPECT_TRUE(shouldBeaconInState(INITIALIZATION));
+    EXPECT_TRUE(shouldBeaconInState(READY));
+    EXPECT_TRUE(shouldBeaconInState(PRELAUNCH));
+    EXPECT_FALSE(shouldBeaconInState(INFLIGHT));
+    EXPECT_TRUE(shouldBeaconInState(LANDED));
+}

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -47,6 +47,44 @@ enum RocketState : uint8_t
     LANDED
 };
 
+// ============================================================================
+// Shared LoRa-recovery helpers (issue #71)
+// ============================================================================
+// Pure functions used by both the rocket and base station firmware so the
+// behaviour stays bit-for-bit identical and is unit-testable from the host
+// side without dragging in the radio/state machinery.
+
+// Sticky frequency-lock-for-flight transition.  Given the previous lock
+// state and the latest rocket state, returns the new lock state:
+//   • INFLIGHT       → true  (latch on)
+//   • READY/LANDED   → false (clear: back on the ground)
+//   • everything else (INITIALIZATION/PRELAUNCH) → unchanged
+// PRELAUNCH explicitly does NOT clear, so a post-flight LANDED→PRELAUNCH
+// transition (rocket regains GPS while still on the ground) doesn't drop
+// the lock prematurely.  Overload taking uint8_t exists because the base
+// station receives state numerically from the LoRa downlink.
+static inline bool computeFreqLockForFlight(bool prev_locked, RocketState s)
+{
+    if (s == INFLIGHT)                  return true;
+    if (s == LANDED || s == READY)      return false;
+    return prev_locked;
+}
+
+static inline bool computeFreqLockForFlight(bool prev_locked, uint8_t s)
+{
+    return computeFreqLockForFlight(prev_locked, (RocketState)s);
+}
+
+// Whether the rocket should be transmitting LoRa name beacons in this
+// state.  Suppress only in INFLIGHT — telemetry needs that airtime, and
+// the BS already knows where we are.  All other states (including
+// INITIALIZATION) beacon: this lets the BS find the rocket even before
+// the FlightComputer has finished booting and reported READY.
+static inline bool shouldBeaconInState(RocketState s)
+{
+    return s != INFLIGHT;
+}
+
 // Payload sent with OUT_STATUS_QUERY so the OUT processor can configure
 // its SensorConverter consistently with the FlightComputer.
 typedef struct __attribute__((packed))
@@ -347,6 +385,16 @@ static constexpr uint8_t LORA_PROTO_VERSION = 1;
 
 // LoRa name beacon sync byte (distinguishes from telemetry by size + prefix)
 static constexpr uint8_t LORA_BEACON_SYNC = 0xBE;
+
+// Heartbeat uplink command (issue #71).  Sent by the base station roughly
+// every 30 s while it's actively hearing rocket telemetry, so the rocket
+// has positive proof of comms in the absence of any user-initiated
+// uplink.  Without this, the rocket's slow-rendezvous timer would expire
+// during a passive monitoring session and waste airtime visiting the
+// rendezvous frequency.  The handler is a no-op — last_uplink_rx_ms
+// updates unconditionally on any successfully decoded uplink, which is
+// all the rocket needs to keep the timer reset.
+static constexpr uint8_t LORA_CMD_HEARTBEAT = 0xFE;
 
 // LoRa data to send from rocket to ground station
 typedef struct __attribute__((packed))

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -28,6 +28,23 @@ namespace config
     static constexpr bool    LORA_RX_BOOSTED_GAIN = true;
     static constexpr bool    LORA_SYNCWORD_PRIVATE = true;
 
+    // Known-good rendezvous mode (issue #71).  When the rocket and base
+    // station drift apart, both fall back to this complete LoRa config
+    // — frequency AND modulation parameters.  Frequency alone isn't
+    // enough: the user can configure SF/BW/CR/TX power via the iOS app
+    // ("Fast" / "Standard" / "Long Range" presets), and a divergence on
+    // those is just as fatal as a frequency mismatch.  All five values
+    // must be identical on both firmware builds; the constants below are
+    // the "Standard" preset, which is also the NVS factory default — so
+    // a fresh-NVS device is already in rendezvous mode at boot.  Never
+    // persisted to NVS; NVS holds the working config and this is always
+    // the same compile-time fallback.
+    static constexpr float   LORA_RENDEZVOUS_MHZ          = 915.0f;
+    static constexpr uint8_t LORA_RENDEZVOUS_SF           = 8;
+    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = 250.0f;
+    static constexpr uint8_t LORA_RENDEZVOUS_CR           = 5;
+    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = 12;
+
     // --- LoRa Uplink (BaseStation → OutComputer) ---
     static constexpr uint8_t  UPLINK_SYNC_BYTE        = 0xCA;
     static constexpr uint8_t  UPLINK_RETRIES           = 8;     // TX attempts per command

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -103,6 +103,24 @@ static uint8_t  last_rocket_state = 0;  // Track state transitions
 static bool     last_known_camera_recording = false;  // Track rocket camera state for idempotent uplink
 static bool     last_known_rocket_logging = false;    // Actual rocket logging state from LoRa downlink
 
+// Frequency lock for flight (issue #71).  Set when any tracked rocket
+// reports INFLIGHT; cleared on LANDED or READY (matches the rocket-side
+// sticky flag).  PRELAUNCH does NOT clear, since a post-flight
+// LANDED → PRELAUNCH transition (rocket regains GPS on the ground) would
+// otherwise leave the lock stuck on indefinitely.  While set:
+//   • Silence recovery is suppressed (we don't hop/scan during flight).
+//   • Silence tolerance is extended so momentary SNR dips don't alarm.
+//   • Transactional Cmd 10 handler still refuses on the rocket side, but
+//     we refuse on the base station side too as belt-and-braces.
+// The transition logic is shared with the rocket side via
+// computeFreqLockForFlight() in RocketComputerTypes.h.
+static bool freq_locked_for_flight = false;
+
+static inline void updateFreqLockFromRocketState(uint8_t s)
+{
+    freq_locked_for_flight = computeFreqLockForFlight(freq_locked_for_flight, s);
+}
+
 // Per-rocket tracker (replaces single last_decoded for multi-rocket support)
 static constexpr int MAX_TRACKED_ROCKETS = 4;
 struct TrackedRocket {
@@ -708,9 +726,21 @@ static void printStats()
     const float rx_hz = (dt > 0) ? ((float)rx_delta * 1000.0f / (float)dt) : 0.0f;
     last_rx_count = ls.rx_count;
 
-    const uint32_t since_last = (last_packet_ms > 0) ? (now - last_packet_ms) : 0;
+    // "Last pkt N ms ago" was misleading when N == 0 (looked like "just
+    // received" but actually meant "never received").  Print "never" in
+    // that case so a fresh-BS-no-rocket scenario is unambiguous in logs.
+    char last_pkt_str[24];
+    if (last_packet_ms > 0)
+    {
+        snprintf(last_pkt_str, sizeof(last_pkt_str), "%lu ms ago",
+                 (unsigned long)(now - last_packet_ms));
+    }
+    else
+    {
+        snprintf(last_pkt_str, sizeof(last_pkt_str), "never");
+    }
 
-    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | ISR: %lu | rx_mode: %d | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %lu ms ago",
+    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | ISR: %lu | rx_mode: %d | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
              (unsigned long)ls.rx_count,
              (double)rx_hz,
              (unsigned long)ls.rx_crc_fail,
@@ -718,7 +748,7 @@ static void printStats()
              (int)ls.rx_mode,
              (double)ls.last_rssi,
              (double)ls.last_snr,
-             (unsigned long)since_last);
+             last_pkt_str);
 }
 
 // ============================================================================
@@ -810,8 +840,12 @@ static void cachePIDConfig(const uint8_t* payload, size_t len)
 
 /// Build an uplink packet with routing header.
 /// target_rid: destination rocket_id (0xFF = broadcast to all rockets in network)
+/// retries: number of TX attempts.  Defaults to config::UPLINK_RETRIES (8) for
+///   reliability on important commands; heartbeat-style traffic can pass a
+///   smaller value to keep airtime low.
 static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payload_len,
-                              uint8_t target_rid = 0xFF)
+                              uint8_t target_rid = 0xFF,
+                              uint8_t retries = config::UPLINK_RETRIES)
 {
     if (uplink_pending)
     {
@@ -831,11 +865,11 @@ static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payloa
         memcpy(&uplink_buf[5], payload, payload_len);
     }
     uplink_len = 5 + payload_len;
-    uplink_retries_left = config::UPLINK_RETRIES;
+    uplink_retries_left = retries;
     uplink_pending = true;
     uplink_last_tx_ms = 0;
     ESP_LOGI(TAG, "[UPLINK] Queued cmd=%u -> rid=%u payload=%u bytes, %u retries",
-             cmd, target_rid, (unsigned)payload_len, config::UPLINK_RETRIES);
+             cmd, target_rid, (unsigned)payload_len, (unsigned)retries);
 }
 
 static void serviceUplink()
@@ -878,6 +912,469 @@ static void serviceUplink()
     {
         ESP_LOGW(TAG, "[UPLINK] send() failed, will retry");
     }
+}
+
+// ============================================================================
+// LoRa Config Transaction (issue #71)
+// ============================================================================
+// Transactional commit of a new LoRa config (freq / bw / sf / cr / pwr).
+// Sequence:
+//   1. On BLE Cmd 10 the base station takes a rollback snapshot, then queues
+//      a broadcast uplink of inner Cmd 10 to every rocket on the OLD channel.
+//   2. Once the uplink retries finish (or the upper-bound timer fires), the
+//      base station switches its radio to the NEW channel and listens for
+//      proof of life (any rocket beacon or telemetry packet bumps
+//      last_packet_ms).
+//   3. On proof → commit to NVS + send BLE readback.
+//      On timeout → reconfigure back to OLD, send BLE readback with OLD
+//      values, and leave NVS untouched.  The silence-recovery layer is
+//      then responsible for healing any residual divergence.
+// The handler is a non-blocking state machine serviced from loop_bs();
+// the whole transaction takes ~3 s under normal conditions.
+
+enum class LoRaTxnState : uint8_t {
+    IDLE,
+    RELAYING,       // Uplink retries in flight on OLD channel
+    VERIFYING,      // Listening for rocket beacon/telem on NEW channel
+    ROLLING_BACK,   // Restoring OLD channel after verify timed out
+};
+
+static LoRaTxnState lora_txn_state = LoRaTxnState::IDLE;
+
+// Target config
+static float   txn_new_freq = 0.0f, txn_new_bw = 0.0f;
+static uint8_t txn_new_sf = 0, txn_new_cr = 0;
+static int8_t  txn_new_pwr = 0;
+// Rollback snapshot
+static float   txn_old_freq = 0.0f, txn_old_bw = 0.0f;
+static uint8_t txn_old_sf = 0, txn_old_cr = 0;
+static int8_t  txn_old_pwr = 0;
+
+static uint32_t txn_phase_start_ms = 0;
+// last_packet_ms value at the moment we switched to NEW.  Any increase
+// during the verify window proves the rocket joined us on NEW.
+static uint32_t txn_verify_baseline_packet_ms = 0;
+
+static constexpr uint32_t TXN_VERIFY_WINDOW_MS = 5000;  // Listen 5 s on NEW
+static constexpr uint32_t TXN_MAX_RELAY_MS     = 3000;  // Upper bound on relay phase
+
+/// Begin a transactional LoRa reconfigure.  Returns false (and leaves the
+/// BS config unchanged, BLE readback sent) if the preconditions fail.
+static bool startLoRaTransaction(float new_freq, float new_bw,
+                                 uint8_t new_sf, uint8_t new_cr, int8_t new_pwr)
+{
+    if (freq_locked_for_flight)
+    {
+        ESP_LOGW(TAG, "[TXN] Refused: frequency locked for flight");
+        sendCurrentConfig();
+        return false;
+    }
+    if (lora_txn_state != LoRaTxnState::IDLE)
+    {
+        ESP_LOGW(TAG, "[TXN] Refused: transaction already in progress");
+        sendCurrentConfig();
+        return false;
+    }
+
+    // Take rollback snapshot BEFORE queuing the uplink, so we can always
+    // restore whatever was active when the transaction started.
+    txn_old_freq = lora_freq_mhz;
+    txn_old_bw   = lora_bw_khz;
+    txn_old_sf   = lora_sf;
+    txn_old_cr   = lora_cr;
+    txn_old_pwr  = lora_tx_power;
+
+    txn_new_freq = new_freq;
+    txn_new_bw   = new_bw;
+    txn_new_sf   = new_sf;
+    txn_new_cr   = new_cr;
+    txn_new_pwr  = new_pwr;
+
+    // Broadcast uplink to every rocket in the network on the OLD channel.
+    // buildUplinkPacket queues + runs 8 retries on its own (~800 ms total).
+    uint8_t loraPayload[11];
+    memcpy(loraPayload + 0, &new_freq, 4);
+    memcpy(loraPayload + 4, &new_bw,   4);
+    loraPayload[8]  = new_sf;
+    loraPayload[9]  = new_cr;
+    loraPayload[10] = (uint8_t)new_pwr;
+    buildUplinkPacket(10, loraPayload, 11, /* target_rid = broadcast */ 0xFF);
+
+    lora_txn_state = LoRaTxnState::RELAYING;
+    txn_phase_start_ms = millis();
+    ESP_LOGI(TAG, "[TXN] Start: relay %.2f MHz SF%u BW%.0f on OLD, then verify on NEW",
+             (double)new_freq, (unsigned)new_sf, (double)new_bw);
+    return true;
+}
+
+/// Run the transaction state machine — call from loop_bs() every iteration.
+static void serviceLoRaTransaction()
+{
+    switch (lora_txn_state)
+    {
+        case LoRaTxnState::IDLE:
+            return;
+
+        case LoRaTxnState::RELAYING:
+        {
+            const uint32_t now = millis();
+            // serviceUplink() clears uplink_pending once the last retry has
+            // fired; at that point the rocket has either joined NEW or not.
+            // TXN_MAX_RELAY_MS is a safety net in case uplink state is stuck.
+            const bool relay_done   = !uplink_pending;
+            const bool relay_timeout = (now - txn_phase_start_ms) > TXN_MAX_RELAY_MS;
+            if (!relay_done && !relay_timeout) return;
+
+            if (!lora_comms.reconfigure(txn_new_freq, txn_new_sf, txn_new_bw,
+                                        txn_new_cr, txn_new_pwr))
+            {
+                ESP_LOGE(TAG, "[TXN] reconfigure(NEW) failed — rolling back");
+                lora_txn_state = LoRaTxnState::ROLLING_BACK;
+                txn_phase_start_ms = now;
+                return;
+            }
+            lora_comms.startReceive();  // listen on NEW freq
+
+            txn_verify_baseline_packet_ms = last_packet_ms;
+            lora_txn_state = LoRaTxnState::VERIFYING;
+            txn_phase_start_ms = now;
+            ESP_LOGI(TAG, "[TXN] On NEW %.2f MHz; verifying for %u ms",
+                     (double)txn_new_freq, (unsigned)TXN_VERIFY_WINDOW_MS);
+            break;
+        }
+
+        case LoRaTxnState::VERIFYING:
+        {
+            const uint32_t now = millis();
+            // Any packet (beacon or telem) received after we switched proves
+            // the rocket joined us on NEW.  The RX path unconditionally
+            // bumps last_packet_ms on every successful receive.
+            if (last_packet_ms > txn_verify_baseline_packet_ms)
+            {
+                // COMMIT: radio already on NEW; persist to NVS + update
+                // runtime vars so the rest of the firmware sees the new
+                // config in readbacks.
+                lora_freq_mhz = txn_new_freq;
+                lora_bw_khz   = txn_new_bw;
+                lora_sf       = txn_new_sf;
+                lora_cr       = txn_new_cr;
+                lora_tx_power = txn_new_pwr;
+
+                prefs.begin("lora", false);
+                prefs.putFloat("freq",  lora_freq_mhz);
+                prefs.putFloat("bw",    lora_bw_khz);
+                prefs.putUChar("sf",    lora_sf);
+                prefs.putUChar("cr",    lora_cr);
+                prefs.putChar("txpwr",  lora_tx_power);
+                prefs.end();
+
+                ESP_LOGI(TAG, "[TXN] COMMIT: heard rocket on NEW %.2f MHz, saved",
+                         (double)lora_freq_mhz);
+                lora_txn_state = LoRaTxnState::IDLE;
+                sendCurrentConfig();
+                return;
+            }
+            if ((now - txn_phase_start_ms) >= TXN_VERIFY_WINDOW_MS)
+            {
+                ESP_LOGW(TAG, "[TXN] TIMEOUT: no rocket on NEW %.2f MHz, rolling back",
+                         (double)txn_new_freq);
+                lora_txn_state = LoRaTxnState::ROLLING_BACK;
+                txn_phase_start_ms = now;
+            }
+            break;
+        }
+
+        case LoRaTxnState::ROLLING_BACK:
+        {
+            // Restore the OLD config.  If this fails the radio may be stuck;
+            // log loudly and return to IDLE — silence recovery is the last
+            // line of defence.
+            if (lora_comms.reconfigure(txn_old_freq, txn_old_sf, txn_old_bw,
+                                       txn_old_cr, txn_old_pwr))
+            {
+                lora_freq_mhz = txn_old_freq;
+                lora_bw_khz   = txn_old_bw;
+                lora_sf       = txn_old_sf;
+                lora_cr       = txn_old_cr;
+                lora_tx_power = txn_old_pwr;
+                lora_comms.startReceive();
+                ESP_LOGI(TAG, "[TXN] ROLLED BACK to %.2f MHz", (double)txn_old_freq);
+            }
+            else
+            {
+                ESP_LOGE(TAG, "[TXN] Rollback reconfigure FAILED — radio may be stuck");
+            }
+            lora_txn_state = LoRaTxnState::IDLE;
+            sendCurrentConfig();
+            break;
+        }
+    }
+}
+
+// ============================================================================
+// LoRa Silence Recovery (issue #71)
+// ============================================================================
+// If the base station hears nothing from any rocket for RECOVERY_SILENCE_MS
+// while on the ground (not freq_locked_for_flight), hop through known-good
+// frequencies looking for the rocket:
+//   Phase A (rendezvous): tune to LORA_RENDEZVOUS_MHZ and listen 3 s.  If a
+//     beacon / telem arrives, relay Cmd 10 with the saved NVS config to
+//     push the rocket back, then return to the saved NVS freq.
+//   Phase B (grid scan): if Phase A was silent, scan the saved NVS freq ±
+//     2 MHz in 200 kHz steps (21 channels), dwelling one beacon cycle per
+//     step.  On hit, relay Cmd 10 on that channel and return to NVS.
+//     If the grid completes with nothing heard, give up this cycle and
+//     wait for the next silence trip.
+// While in flight (freq_locked_for_flight) recovery is fully disabled —
+// momentary silence during flight is expected (SNR dips) and hopping would
+// guarantee we lose the rest of the telemetry stream.
+
+enum class RecoveryState : uint8_t {
+    IDLE,
+    PHASE_A_RENDEZVOUS,
+    PHASE_B_SCAN,
+    COMPLETE,               // Relay in flight; hop home once it drains
+};
+
+static RecoveryState recovery_state = RecoveryState::IDLE;
+static uint32_t recovery_phase_start_ms     = 0;
+static uint32_t recovery_baseline_packet_ms = 0;
+static int      recovery_scan_index         = 0;
+static float    recovery_scan_current_mhz   = 0.0f;
+
+static constexpr uint32_t RECOVERY_SILENCE_MS       = 10000; // idle trigger
+// Phase A dwells on the rendezvous frequency long enough to (a) catch
+// many beacons from a rocket sitting permanently on rendezvous (factory
+// default case, ~15 beacons in 30 s) and (b) deterministically overlap
+// the rocket's 5 s slow-rendezvous window when the two NVS freqs differ.
+// Anything shorter than ~10 s is statistical and was the root of the
+// "BS comes up, never sees rocket" symptom from the field test.
+static constexpr uint32_t RECOVERY_PHASE_A_DWELL_MS = 30000;
+static constexpr uint32_t RECOVERY_PHASE_B_DWELL_MS = 2500;  // one beacon cycle + slack
+static constexpr int      RECOVERY_PHASE_B_CHANNELS = 21;    // ±10 steps of 200 kHz
+static constexpr float    RECOVERY_PHASE_B_STEP_MHZ = 0.200f;
+static constexpr float    RECOVERY_PHASE_B_SPAN_MHZ = 2.0f;  // ±2 MHz around NVS
+
+// Hop to the full rendezvous mode (freq + SF/BW/CR/power).  Used for
+// Phase A — both ends agree on this exact config as a known-good
+// fallback, regardless of what the user set in NVS.
+static void recoveryHopToRendezvousMode()
+{
+    if (lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+                                config::LORA_RENDEZVOUS_SF,
+                                config::LORA_RENDEZVOUS_BW_KHZ,
+                                config::LORA_RENDEZVOUS_CR,
+                                config::LORA_RENDEZVOUS_TX_POWER_DBM))
+    {
+        lora_comms.startReceive();
+    }
+    else
+    {
+        ESP_LOGE(TAG, "[RECOVER] reconfigure to rendezvous mode failed");
+    }
+}
+
+// Hop to a target frequency keeping the user-configured NVS modulation
+// (SF/BW/CR/power).  Used for Phase B local scan and the post-recovery
+// return to the saved channel.  This catches the common case of "rocket
+// is on a slightly off frequency but same SF/BW as the BS".
+static void recoveryHopToFreq(float freq_mhz)
+{
+    if (lora_comms.reconfigure(freq_mhz, lora_sf, lora_bw_khz, lora_cr, lora_tx_power))
+    {
+        lora_comms.startReceive();
+    }
+    else
+    {
+        ESP_LOGE(TAG, "[RECOVER] reconfigure to %.2f MHz failed", (double)freq_mhz);
+    }
+}
+
+static void recoveryEnterPhaseA()
+{
+    recoveryHopToRendezvousMode();
+    recovery_baseline_packet_ms = last_packet_ms;
+    recovery_phase_start_ms     = millis();
+    recovery_state              = RecoveryState::PHASE_A_RENDEZVOUS;
+    ESP_LOGW(TAG, "[RECOVER] Silent — Phase A rendezvous mode (%.2f MHz SF%u BW%.0f) for %u ms",
+             (double)config::LORA_RENDEZVOUS_MHZ,
+             (unsigned)config::LORA_RENDEZVOUS_SF,
+             (double)config::LORA_RENDEZVOUS_BW_KHZ,
+             (unsigned)RECOVERY_PHASE_A_DWELL_MS);
+}
+
+static void recoveryEnterPhaseB()
+{
+    recovery_scan_index       = 0;
+    recovery_scan_current_mhz = lora_freq_mhz - RECOVERY_PHASE_B_SPAN_MHZ;
+    recoveryHopToFreq(recovery_scan_current_mhz);
+    recovery_baseline_packet_ms = last_packet_ms;
+    recovery_phase_start_ms     = millis();
+    recovery_state              = RecoveryState::PHASE_B_SCAN;
+    ESP_LOGW(TAG, "[RECOVER] Phase B scan: %d channels around %.2f MHz",
+             RECOVERY_PHASE_B_CHANNELS, (double)lora_freq_mhz);
+}
+
+static void recoveryEnd(const char* why)
+{
+    // Always come back to the saved NVS frequency so we're either settled
+    // on the committed channel or poised to hear the rocket once it
+    // returns there.
+    recoveryHopToFreq(lora_freq_mhz);
+    recovery_state = RecoveryState::IDLE;
+    ESP_LOGI(TAG, "[RECOVER] Done (%s). Back on %.2f MHz",
+             why, (double)lora_freq_mhz);
+}
+
+/// Relay Cmd 10 on the current channel to push the rocket back to the
+/// saved NVS config.  Used when we re-locate the rocket during recovery.
+static void recoveryPushRocketHome()
+{
+    uint8_t payload[11];
+    memcpy(payload + 0, &lora_freq_mhz, 4);
+    memcpy(payload + 4, &lora_bw_khz,   4);
+    payload[8]  = lora_sf;
+    payload[9]  = lora_cr;
+    payload[10] = (uint8_t)lora_tx_power;
+    buildUplinkPacket(10, payload, 11, /* target_rid = broadcast */ 0xFF);
+    ESP_LOGI(TAG, "[RECOVER] Relay Cmd 10 -> %.2f MHz (saved NVS)",
+             (double)lora_freq_mhz);
+}
+
+static void serviceRecovery()
+{
+    // While locked for flight, accept silence — no hopping, no alarms.
+    if (freq_locked_for_flight)
+    {
+        if (recovery_state != RecoveryState::IDLE) recoveryEnd("flight locked");
+        return;
+    }
+    // Transactional reconfigure takes priority.  A BLE Cmd 10 arriving
+    // mid-recovery aborts the recovery cycle; the transaction then
+    // self-rolls-back-or-commits, and any residual divergence is healed
+    // by the next recovery pass.
+    if (lora_txn_state != LoRaTxnState::IDLE)
+    {
+        if (recovery_state != RecoveryState::IDLE) recoveryEnd("transaction");
+        return;
+    }
+
+    const uint32_t now = millis();
+
+    switch (recovery_state)
+    {
+        case RecoveryState::IDLE:
+        {
+            // Avoid firing during the first RECOVERY_SILENCE_MS after boot
+            // — it's normal to be silent while the rocket is still booting.
+            if (last_packet_ms == 0 && now < RECOVERY_SILENCE_MS) return;
+            const uint32_t silent_for = (last_packet_ms > 0)
+                ? (now - last_packet_ms)
+                : now;
+            if (silent_for >= RECOVERY_SILENCE_MS) recoveryEnterPhaseA();
+            break;
+        }
+
+        case RecoveryState::PHASE_A_RENDEZVOUS:
+        {
+            if (last_packet_ms > recovery_baseline_packet_ms)
+            {
+                recoveryPushRocketHome();
+                recovery_phase_start_ms = now;
+                recovery_state = RecoveryState::COMPLETE;
+                break;
+            }
+            if ((now - recovery_phase_start_ms) >= RECOVERY_PHASE_A_DWELL_MS)
+            {
+                recoveryEnterPhaseB();
+            }
+            break;
+        }
+
+        case RecoveryState::PHASE_B_SCAN:
+        {
+            if (last_packet_ms > recovery_baseline_packet_ms)
+            {
+                recoveryPushRocketHome();
+                recovery_phase_start_ms = now;
+                recovery_state = RecoveryState::COMPLETE;
+                break;
+            }
+            if ((now - recovery_phase_start_ms) >= RECOVERY_PHASE_B_DWELL_MS)
+            {
+                recovery_scan_index++;
+                if (recovery_scan_index >= RECOVERY_PHASE_B_CHANNELS)
+                {
+                    // Exhausted grid with no hits — give up this cycle.
+                    // Silence will trip us again after RECOVERY_SILENCE_MS.
+                    recoveryEnd("scan exhausted");
+                    return;
+                }
+                recovery_scan_current_mhz += RECOVERY_PHASE_B_STEP_MHZ;
+                recoveryHopToFreq(recovery_scan_current_mhz);
+                recovery_baseline_packet_ms = last_packet_ms;
+                recovery_phase_start_ms = now;
+            }
+            break;
+        }
+
+        case RecoveryState::COMPLETE:
+        {
+            // Give uplink retries time to land on the current channel
+            // before we hop back to NVS — otherwise the rocket might miss
+            // the push command and we'd just rediscover it next cycle.
+            if (!uplink_pending ||
+                (now - recovery_phase_start_ms) > TXN_MAX_RELAY_MS)
+            {
+                recoveryEnd("pushed rocket home");
+            }
+            break;
+        }
+    }
+}
+
+// ============================================================================
+// Heartbeat (issue #71)
+// ============================================================================
+// Periodic uplink that gives the rocket positive proof of comms.  Without
+// this, a rocket happily streaming telemetry to a base station that's
+// receiving fine would still fall into its slow-rendezvous cycle every
+// time the user goes a couple of minutes without sending a command —
+// because beacons go one way and the rocket has no signal that anyone is
+// listening.
+//
+// Only sent while we ARE hearing the rocket (last_packet_ms recent).  If
+// rocket goes silent, the recovery state machine takes over and we stop
+// heartbeating until comms are restored.  Uses 2 retries instead of 8 to
+// keep airtime negligible (<0.1%) — losing one heartbeat is fine, the
+// next one comes 30 s later, well inside the rocket's tolerance.
+// (Defined here, after the LoRa transaction & recovery sections, so the
+// state-machine enums it depends on are in scope.)
+
+static constexpr uint32_t HEARTBEAT_INTERVAL_MS = 30000;  // every 30 s
+static constexpr uint32_t HEARTBEAT_RX_FRESH_MS = 5000;   // rocket "alive"
+static constexpr uint8_t  HEARTBEAT_RETRIES     = 2;
+static uint32_t last_heartbeat_tx_ms = 0;
+
+static void serviceHeartbeat()
+{
+    if (freq_locked_for_flight)                return;  // No heartbeats in flight
+    if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
+    if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
+    if (uplink_pending)                        return;  // Don't clobber a real cmd
+
+    const uint32_t now = millis();
+    // Only heartbeat when we've recently heard the rocket.  If rocket has
+    // gone silent, recovery will engage and ramp through rendezvous/scan;
+    // beating into the void during that is just wasted airtime.
+    if (last_packet_ms == 0)                                  return;
+    if ((now - last_packet_ms) > HEARTBEAT_RX_FRESH_MS)       return;
+    if ((now - last_heartbeat_tx_ms) < HEARTBEAT_INTERVAL_MS) return;
+
+    buildUplinkPacket(LORA_CMD_HEARTBEAT, nullptr, 0,
+                      /* target_rid = broadcast */ 0xFF,
+                      /* retries */ HEARTBEAT_RETRIES);
+    last_heartbeat_tx_ms = now;
 }
 
 static void setup_bs()
@@ -1249,6 +1746,7 @@ static void loop_bs()
                 }
 
                 last_rocket_state = decoded.rocket_state;
+                updateFreqLockFromRocketState(decoded.rocket_state);
                 last_known_camera_recording = decoded.camera_recording;
 
                 // Update per-rocket tracker
@@ -1471,8 +1969,11 @@ static void loop_bs()
     }
     else if (ble_cmd == 10)
     {
-        // LoRa reconfiguration (BaseStation only — NOT relayed over uplink)
-        // Changing BS frequency over LoRa would break the link to OutComputer.
+        // LoRa reconfiguration — transactional (issue #71).  The base
+        // station relays the new config to every rocket on the OLD channel,
+        // then switches to NEW and verifies the rocket joined before
+        // committing to NVS.  On timeout, both sides stay on OLD and the
+        // silence-recovery layer heals any residual divergence.
         const uint8_t* payload = ble_app.getCommandPayload();
         size_t payload_len = ble_app.getCommandPayloadLength();
         if (payload_len >= 11)
@@ -1483,41 +1984,7 @@ static void loop_bs()
             uint8_t new_sf   = payload[8];
             uint8_t new_cr   = payload[9];
             int8_t  new_pwr  = (int8_t)payload[10];
-
-            if (lora_comms.reconfigure(new_freq, new_sf, new_bw, new_cr, new_pwr))
-            {
-                // Update runtime vars
-                lora_freq_mhz = new_freq;
-                lora_bw_khz   = new_bw;
-                lora_sf        = new_sf;
-                lora_cr        = new_cr;
-                lora_tx_power  = new_pwr;
-
-                // Persist to NVS
-                prefs.begin("lora", false);  // read-write
-                prefs.putFloat("freq",  lora_freq_mhz);
-                prefs.putFloat("bw",    lora_bw_khz);
-                prefs.putUChar("sf",    lora_sf);
-                prefs.putUChar("cr",    lora_cr);
-                prefs.putChar("txpwr",  lora_tx_power);
-                prefs.end();
-
-                // Re-enter RX mode after reconfiguration
-                lora_comms.startReceive();
-
-                ESP_LOGI(TAG, "[BLE] LoRa reconfigured + saved: %.1f MHz SF%u BW%.0f CR%u %d dBm",
-                         (double)lora_freq_mhz, (unsigned)lora_sf,
-                         (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
-
-                // Send config readback so app can confirm the actual values applied
-                sendCurrentConfig();
-            }
-            else
-            {
-                ESP_LOGE(TAG, "[BLE] LoRa reconfigure FAILED");
-                // Send readback with OLD config so app reverts its display
-                sendCurrentConfig();
-            }
+            startLoRaTransaction(new_freq, new_bw, new_sf, new_cr, new_pwr);
         }
     }
     else if (ble_cmd == 12)
@@ -1666,6 +2133,20 @@ static void loop_bs()
 
     // Service LoRa uplink retries (TX commands, then resume RX)
     serviceUplink();
+
+    // Advance the transactional reconfigure state machine (issue #71).
+    // Must run after serviceUplink so we observe uplink_pending transitions
+    // to false in the same loop iteration they happen.
+    serviceLoRaTransaction();
+
+    // Silence recovery runs after the transaction service so a freshly
+    // started transaction always wins over any pending recovery cycle.
+    serviceRecovery();
+
+    // Heartbeat — quietly tells the rocket "we're hearing you" so its
+    // slow-rendezvous timer doesn't expire during normal idle operation.
+    // Gates itself on recovery/transaction state internally.
+    serviceHeartbeat();
 
     printStats();
 

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -86,6 +86,23 @@ struct config
     static constexpr bool LORA_SYNCWORD_PRIVATE = true;
     static constexpr uint16_t LORA_TX_RATE_HZ = 2;
 
+    // Known-good rendezvous mode (issue #71).  When the rocket and base
+    // station drift apart, both fall back to this complete LoRa config
+    // — frequency AND modulation parameters.  Frequency alone isn't
+    // enough: the user can configure SF/BW/CR/TX power via the iOS app
+    // ("Fast" / "Standard" / "Long Range" presets), and a divergence on
+    // those is just as fatal as a frequency mismatch.  All five values
+    // must be identical on both firmware builds; the constants below are
+    // the "Standard" preset, which is also the NVS factory default — so
+    // a fresh-NVS device is already in rendezvous mode at boot.  Never
+    // persisted to NVS; NVS holds the working config and this is always
+    // the same compile-time fallback.
+    static constexpr float   LORA_RENDEZVOUS_MHZ          = 915.0f;
+    static constexpr uint8_t LORA_RENDEZVOUS_SF           = 8;
+    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = 250.0f;
+    static constexpr uint8_t LORA_RENDEZVOUS_CR           = 5;
+    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = 12;
+
     // --- LoRa Uplink RX (commands from BaseStation) ---
     static constexpr uint8_t UPLINK_SYNC_BYTE = 0xCA;
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -305,6 +305,22 @@ static RocketState latest_rocket_state = INITIALIZATION;
 static bool pwr_pin_on = false;              // Power rail state — starts OFF
 static bool peripherals_initialized = false; // Deferred init for peripherals behind PWR_PIN
 
+// Frequency is locked once the rocket enters flight (issue #71).  Any
+// Cmd 10 uplink received in flight is ignored, and the slow-rendezvous
+// recovery cycle is suppressed — we cannot afford to leave the operating
+// frequency mid-flight, and momentary silence during flight is usually
+// an SNR dip, not real divergence.
+//
+// The transition logic itself is pure and lives in the shared header
+// (computeFreqLockForFlight) so both the rocket and base station follow
+// identical, unit-tested rules.
+static bool freq_locked_for_flight = false;
+
+static inline void updateFreqLockFromState(RocketState s)
+{
+    freq_locked_for_flight = computeFreqLockForFlight(freq_locked_for_flight, s);
+}
+
 // Servo/PID config cache (mirrored from FlightComputer for BLE readback)
 static int16_t cfg_servo_bias1 = 0;
 static int16_t cfg_servo_hz    = 50;
@@ -364,6 +380,13 @@ static uint32_t lora_tx_fail = 0;
 static uint32_t last_lora_tx_ms = 0;
 static bool     lora_in_rx_mode = false;
 static uint32_t lora_uplink_rx_count = 0;
+
+// Slow-rendezvous trackers (issue #71).  last_uplink_rx_ms bumps on every
+// successfully-parsed uplink packet; ready_entry_ms latches on each
+// INITIALIZATION→READY transition so we don't fire rendezvous just
+// because the rocket briefly sat silent before READY.
+static uint32_t last_uplink_rx_ms = 0;
+static uint32_t ready_entry_ms    = 0;
 
 static OutStatusQueryData last_query_cfg = {};
 
@@ -1141,6 +1164,18 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             memcpy(&latest_non_sensor, payload, sizeof(NonSensorData));
             latest_non_sensor_valid = true;
             latest_rocket_state = (RocketState)latest_non_sensor.rocket_state;
+            // Update the flight-freeze sticky flag whenever the state
+            // changes (issue #71).  Safe to call on every frame — the
+            // function only flips the bool on INFLIGHT / READY edges.
+            updateFreqLockFromState(latest_rocket_state);
+
+            // Latch the moment we entered READY so the slow-rendezvous
+            // silence timer has a fair starting point.  Boot-time READY
+            // (first frame from FC) also triggers this.
+            if (latest_rocket_state == READY && prev_state != READY)
+            {
+                ready_entry_ms = millis();
+            }
             if (latest_rocket_state != prev_state && latest_rocket_state == PRELAUNCH)
             {
                 max_alt_m = 0.0f;
@@ -1537,8 +1572,16 @@ static void sendLoRaBeacon()
 {
     if (!config::USE_LORA_RADIO) return;
 
-    // Only beacon in idle states
-    if (latest_rocket_state != READY && latest_rocket_state != PRELAUNCH) return;
+    // Beacon in any state EXCEPT INFLIGHT.  We used to gate on
+    // READY/PRELAUNCH only, but that meant a rocket whose FlightComputer
+    // was slow to report state (or never did, e.g. I2C hiccup) would
+    // never advertise itself — leaving the base station's recovery
+    // scanning forever (issue #71 field test).  INITIALIZATION beaconing
+    // costs ~25 ms TOA every 2 s = < 2% duty, so the trade is trivial.
+    // INFLIGHT is still suppressed: telemetry needs the airtime, and
+    // we don't change channel mid-flight anyway.  Logic shared with
+    // tests via shouldBeaconInState() in RocketComputerTypes.h.
+    if (!shouldBeaconInState(latest_rocket_state)) return;
 
     const uint32_t now_ms = millis();
     if ((now_ms - last_beacon_ms) < 2000) return;
@@ -1790,6 +1833,19 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
     else if (cmd == 10 && payload_len >= 11)
     {
         // LoRa reconfiguration via uplink: [freq:4f][bw:4f][sf:1][cr:1][txpwr:1]
+
+        // Inflight freeze (issue #71): refuse to change frequency once we
+        // are in flight.  Momentary silence in flight is almost always an
+        // SNR dip, not divergence, and hopping channels mid-flight would
+        // guarantee we lose the rest of the telemetry stream.  The base
+        // station is also expected to suppress its own recovery while
+        // rocket is in flight, so this branch is defence-in-depth.
+        if (freq_locked_for_flight)
+        {
+            ESP_LOGW("LORA", "UPLINK Cmd 10 ignored: frequency locked for flight");
+            return;
+        }
+
         float new_freq, new_bw;
         memcpy(&new_freq, payload + 0, 4);
         memcpy(&new_bw,   payload + 4, 4);
@@ -1876,6 +1932,14 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         setPendingCommand(enabled ? GUIDANCE_ENABLE : GUIDANCE_DISABLE);
         ESP_LOGI("LORA", "UPLINK Guidance: %s", enabled ? "ENABLE" : "DISABLE");
     }
+    else if (cmd == LORA_CMD_HEARTBEAT)
+    {
+        // Heartbeat from BS (issue #71).  No action — last_uplink_rx_ms
+        // is already updated in the caller, which is all this command
+        // exists to do.  Verbose-level log only, since these fire every
+        // 30 s during normal operation.
+        ESP_LOGV("LORA", "UPLINK heartbeat");
+    }
     else
     {
         ESP_LOGW("LORA", "UPLINK Unknown cmd %u", cmd);
@@ -1934,10 +1998,176 @@ static void serviceLoRaUplink()
                 {
                     processUplinkCommand(cmd, &rx_buf[5], payload_len);
                     lora_uplink_rx_count++;
+                    last_uplink_rx_ms = millis();
                 }
             }
         }
         // readPacket() internally re-enters RX mode after reading
+    }
+}
+
+// ============================================================================
+// Slow Rendezvous Cycle (issue #71)
+// ============================================================================
+// If the rocket has been silent (no uplink received) for long enough, hop
+// briefly to LORA_RENDEZVOUS_MHZ on a duty cycle so the base station's
+// Phase-A recovery has a guaranteed meeting point even when the two NVS
+// freqs disagree by more than the BS's ±2 MHz scan range (e.g. the rocket
+// kept a previously-scanned channel like 921.5 MHz while the BS rebooted
+// to a fresh 915 MHz default).
+//
+// Trigger is adaptive:
+//   • If we've never received an uplink (last_uplink_rx_ms == 0), fire
+//     after just RENDEZVOUS_TRIGGER_INITIAL_MS — the BS may genuinely be
+//     lost and we want to find it quickly.
+//   • Once we've seen at least one uplink, fall back to the longer
+//     RENDEZVOUS_TRIGGER_QUIET_MS — the BS is alive, it's just being
+//     idle; no need to thrash the channel.
+//
+// Cycle (30 s period) is sized so a 30 s BS Phase A on the rendezvous
+// freq always overlaps at least one full rocket window:
+//   10 s on rendezvous → 20 s back on NVS → repeat.
+//
+// Suppressed while freq_locked_for_flight (set on INFLIGHT, cleared on
+// LANDED/READY).  Allowed from any other state — including INITIALIZATION,
+// so a rocket whose FlightComputer hasn't booted yet can still surface
+// itself on the rendezvous channel.
+
+enum class RocketRendezvousState : uint8_t {
+    IDLE,
+    ON_RENDEZVOUS,    // RENDEZVOUS_WINDOW_MS on LORA_RENDEZVOUS_MHZ
+    ON_SAVED,         // RENDEZVOUS_SAVED_MS back on lora_freq_mhz (NVS)
+};
+
+static RocketRendezvousState rendezvous_state = RocketRendezvousState::IDLE;
+static uint32_t rendezvous_phase_start_ms = 0;
+
+static constexpr uint32_t RENDEZVOUS_TRIGGER_INITIAL_MS = 30000;  // never heard BS yet
+static constexpr uint32_t RENDEZVOUS_TRIGGER_QUIET_MS   = 120000; // BS seen, just idle
+static constexpr uint32_t RENDEZVOUS_WINDOW_MS          = 10000;  // on rendezvous freq
+static constexpr uint32_t RENDEZVOUS_SAVED_MS           = 20000;  // back on saved freq
+
+// Hop the radio to the full rendezvous mode (freq + SF/BW/CR/power).
+// Uses ALL the rendezvous constants — frequency alone isn't enough if
+// the user has configured a non-Standard preset (e.g. Long Range = SF10/
+// BW125).  Both sides need to agree on every modulation parameter to
+// decode each other; the rendezvous mode is the shared known-good
+// fallback.
+static void rendezvousHopToRendezvousMode()
+{
+    if (lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+                                config::LORA_RENDEZVOUS_SF,
+                                config::LORA_RENDEZVOUS_BW_KHZ,
+                                config::LORA_RENDEZVOUS_CR,
+                                config::LORA_RENDEZVOUS_TX_POWER_DBM))
+    {
+        lora_comms.startReceive();
+        lora_in_rx_mode = true;
+    }
+    else
+    {
+        ESP_LOGE("OC", "[RENDEZVOUS] reconfigure to rendezvous mode failed");
+    }
+}
+
+// Hop the radio back to whatever NVS says — i.e. the working config the
+// user picked (or factory defaults if NVS empty).  Called when exiting
+// rendezvous and at the end of each ON_RENDEZVOUS window.
+static void rendezvousHopToSavedMode()
+{
+    if (lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
+                                lora_cr, lora_tx_power))
+    {
+        lora_comms.startReceive();
+        lora_in_rx_mode = true;
+    }
+    else
+    {
+        ESP_LOGE("OC", "[RENDEZVOUS] reconfigure to saved mode failed");
+    }
+}
+
+static void rendezvousExit(const char* why)
+{
+    if (rendezvous_state == RocketRendezvousState::IDLE) return;
+    rendezvousHopToSavedMode();
+    rendezvous_state = RocketRendezvousState::IDLE;
+    ESP_LOGI("OC", "[RENDEZVOUS] Exit (%s); back on saved mode %.2f MHz SF%u",
+             why, (double)lora_freq_mhz, (unsigned)lora_sf);
+}
+
+static void serviceRocketRendezvous()
+{
+    if (!config::USE_LORA_RADIO)  return;
+    if (!peripherals_initialized) return;
+    // Suppress only in flight — INITIALIZATION/READY/PRELAUNCH/LANDED are
+    // all valid times to hunt for the BS via rendezvous.  Allowing
+    // INITIALIZATION matters: if the rocket booted before its FC came up
+    // (or the FC is unhappy), we'd otherwise never visit the rendezvous
+    // mode and the BS would never find us.
+    if (freq_locked_for_flight)
+    {
+        rendezvousExit("flight locked");
+        return;
+    }
+
+    const uint32_t now = millis();
+
+    // Adaptive trigger: short window if we've never received an uplink
+    // (BS may genuinely be lost), longer otherwise (BS exists, just idle).
+    const uint32_t trigger_ms = (last_uplink_rx_ms == 0)
+        ? RENDEZVOUS_TRIGGER_INITIAL_MS
+        : RENDEZVOUS_TRIGGER_QUIET_MS;
+
+    // Silence reference: most-recent uplink receipt or, failing that,
+    // most-recent READY entry.  If neither has happened (fresh boot,
+    // never reached READY), measure from boot itself.
+    const uint32_t last_activity_ms = (last_uplink_rx_ms > ready_entry_ms)
+        ? last_uplink_rx_ms : ready_entry_ms;
+    const uint32_t silent_for = (last_activity_ms > 0)
+        ? (now - last_activity_ms) : now;
+
+    // Any fresh uplink breaks silence and returns us to the saved mode.
+    if (rendezvous_state != RocketRendezvousState::IDLE &&
+        silent_for < trigger_ms)
+    {
+        rendezvousExit("silence broke");
+        return;
+    }
+
+    switch (rendezvous_state)
+    {
+        case RocketRendezvousState::IDLE:
+            if (silent_for >= trigger_ms)
+            {
+                rendezvousHopToRendezvousMode();
+                rendezvous_phase_start_ms = now;
+                rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
+                ESP_LOGW("OC", "[RENDEZVOUS] Silent %u s; hop to rendezvous mode %.2f MHz SF%u BW%.0f",
+                         (unsigned)(silent_for / 1000),
+                         (double)config::LORA_RENDEZVOUS_MHZ,
+                         (unsigned)config::LORA_RENDEZVOUS_SF,
+                         (double)config::LORA_RENDEZVOUS_BW_KHZ);
+            }
+            break;
+
+        case RocketRendezvousState::ON_RENDEZVOUS:
+            if ((now - rendezvous_phase_start_ms) >= RENDEZVOUS_WINDOW_MS)
+            {
+                rendezvousHopToSavedMode();
+                rendezvous_phase_start_ms = now;
+                rendezvous_state = RocketRendezvousState::ON_SAVED;
+            }
+            break;
+
+        case RocketRendezvousState::ON_SAVED:
+            if ((now - rendezvous_phase_start_ms) >= RENDEZVOUS_SAVED_MS)
+            {
+                rendezvousHopToRendezvousMode();
+                rendezvous_phase_start_ms = now;
+                rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
+            }
+            break;
     }
 }
 
@@ -2940,6 +3170,11 @@ static void loop_oc()
         // Check for LoRa uplink commands between TX cycles
         serviceLoRaUplink();
 
+        // Slow-rendezvous cycle: brief visits to LORA_RENDEZVOUS_MHZ when
+        // the rocket has been silent in READY for a long time, so the base
+        // station's Phase-A recovery has a meeting point (issue #71).
+        serviceRocketRendezvous();
+
         // Send name beacon so base station can identify us
         sendLoRaBeacon();
     }
@@ -3391,7 +3626,16 @@ static void loop_oc()
             // LoRa reconfiguration: [freq:4f][bw:4f][sf:1][cr:1][txpwr:1]
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
-            if (plen >= 11)
+            // Inflight freeze (issue #71): refuse direct BLE reconfig in
+            // flight.  The iOS app already hides the apply button, but
+            // belt-and-braces in case of version skew.  We still send a
+            // readback so the app's UI reverts to the actual values.
+            if (plen >= 11 && freq_locked_for_flight)
+            {
+                ESP_LOGW("BLE", "Cmd 10 ignored: frequency locked for flight");
+                sendCurrentConfig();
+            }
+            else if (plen >= 11)
             {
                 float new_freq, new_bw;
                 memcpy(&new_freq, payload + 0, 4);


### PR DESCRIPTION
Closes #71.

## Summary
- Transactional Cmd 10 on the base station (stage → relay → verify → commit-or-rollback) so frequency changes never leave the two ends out of sync.
- Self-healing recovery: BS scan + shared "rendezvous mode" (full freq + SF/BW/CR/power, factory default) that both sides fall back to after silence. BS finds the rocket and pushes it back to the saved config.
- Heartbeat from the BS so the rocket's slow-rendezvous timer doesn't fire during normal idle monitoring.
- iOS: removed the manual frequency picker; LoRa preset / power are base-station-only edits now; rocket-direct view is read-only. Eliminates the "I changed it on the rocket but not the BS" footgun.
- Sticky inflight freeze (cleared on LANDED or READY, preserved through PRELAUNCH).

## Tests
- 204/204 C++ host tests pass (+10 new for `computeFreqLockForFlight`, `shouldBeaconInState`, `LORA_CMD_HEARTBEAT`, and `RocketState` numeric values).
- 32/32 iOS tests pass (+10 new in `AutoApplyRefusalTests.swift` covering every refusal/allowance branch and the freshness-window edge).
- Both firmware targets (`base_station`, `out_computer`) build clean.
- iOS app builds clean.

## Field-tested
Confirmed sync against a previously-divergent rocket (NVS = 921.5 MHz vs BS = 915 MHz) — BS recovery loop dwelled on rendezvous, caught the rocket's beacon at -36 dBm SNR 11 dB, relayed Cmd 10 with the saved NVS config, and returned to steady-state telemetry within ~130 s. Heartbeat suppression of the rocket's rendezvous cycle during idle was verified afterward.

## Out of scope (filed separately)
- #77 — 744 ms sensor-logging stall during PRELAUNCH, hypothesized as NAND / LittleFS block erase. Surfaced while investigating gap data; confirmed unrelated to the LoRa work in this PR (different cores, no shared mutex, LoRa SPI is on a separate bus from NAND).

## Test plan
- [ ] Flash both firmwares and the iOS app.
- [ ] Verify `Apply` is disabled in the Frequency Scan view until a rocket beacon arrives within the last 10 s.
- [ ] Run a quietest-channel scan + apply; confirm both sides commit to the new freq, or both roll back together if the rocket is unplugged mid-handshake.
- [ ] Power-cycle one side with non-default NVS on the other; confirm sync within ~90–150 s without manual reconfigure.
- [ ] Idle for 5+ min while the BS receives telemetry; confirm rocket logs do **not** show `[RENDEZVOUS] Hop` lines (heartbeat is keeping the silence timer reset).
- [ ] Trigger PRELAUNCH → INFLIGHT and verify Cmd 10 is refused on both sides while INFLIGHT.
- [ ] Verify the lock clears on LANDED (recovery becomes available again to relocate the rocket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
