### PR TITLE
Defer prepareFlight to flush task on Core 0 (#77)

### DIFF
--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -773,6 +773,150 @@ TEST(TRFlightLogPrepare, PersistsBitmapOnSuccess) {
 }
 
 // ================================================================
+// Deferred prepareFlight — issue #77
+// requestPrepareFlight() sets a flag; servicePendingPrepareFlight() does
+// the work. Lets the ~770 ms 256-block erase loop run on the flush task's
+// core (Core 0) instead of blocking sensor ingest on Core 1.
+// ================================================================
+
+TEST(TRFlightLogDeferredPrepare, RequestDoesNotEraseUntilServiced) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    const uint64_t erases_before = nand.eraseCount();
+    fl.requestPrepareFlight();
+
+    // Pure flag-set: no NAND I/O, no flight active.
+    EXPECT_EQ(nand.eraseCount(), erases_before);
+    EXPECT_FALSE(fl.isFlightActive());
+    EXPECT_TRUE(fl.isPrepareFlightPending());
+}
+
+TEST(TRFlightLogDeferredPrepare, ServiceRunsPrepareWhenPending) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    TR_FlightLog::Config cfg;
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    fl.requestPrepareFlight();
+
+    uint32_t id = 0;
+    Status st = Status::Error;
+    EXPECT_TRUE(fl.servicePendingPrepareFlight(id, st));
+    EXPECT_EQ(st, Status::Ok);
+    EXPECT_EQ(id, 1u);
+    EXPECT_TRUE(fl.isFlightActive());
+    EXPECT_FALSE(fl.isPrepareFlightPending());
+
+    // Bitmap was updated and the chosen range was actually erased — i.e.
+    // the deferred path produced the same end state as a direct
+    // prepareFlight() call.
+    EXPECT_EQ(fl.activeBlockCount(), cfg.prealloc_blocks);
+    for (uint32_t b = fl.activeStartBlock();
+         b < fl.activeStartBlock() + fl.activeBlockCount(); ++b) {
+        EXPECT_EQ(fl.bitmap().get(b), BLOCK_ALLOCATED) << "block " << b;
+    }
+    EXPECT_TRUE(rangeIsErased(nand, fl.activeStartBlock(), fl.activeBlockCount()));
+}
+
+TEST(TRFlightLogDeferredPrepare, ServiceWithoutRequestIsNoOp) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    const uint64_t erases_before = nand.eraseCount();
+    uint32_t id = 0;
+    Status st = Status::Error;
+    EXPECT_FALSE(fl.servicePendingPrepareFlight(id, st));
+    EXPECT_EQ(nand.eraseCount(), erases_before);
+    EXPECT_FALSE(fl.isFlightActive());
+}
+
+TEST(TRFlightLogDeferredPrepare, RequestIsIdempotent) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    // Multiple requests collapse into one pending flag → at most one
+    // prepareFlight runs per service call.
+    fl.requestPrepareFlight();
+    fl.requestPrepareFlight();
+    fl.requestPrepareFlight();
+
+    uint32_t id = 0;
+    Status st = Status::Error;
+    EXPECT_TRUE(fl.servicePendingPrepareFlight(id, st));
+    EXPECT_EQ(st, Status::Ok);
+    EXPECT_TRUE(fl.isFlightActive());
+
+    // A second service call after the flight is active does nothing.
+    uint32_t id2 = 99;
+    Status st2 = Status::Ok;
+    EXPECT_FALSE(fl.servicePendingPrepareFlight(id2, st2));
+    EXPECT_EQ(id2, 99u);  // untouched
+}
+
+TEST(TRFlightLogDeferredPrepare, RequestIgnoredWhileFlightActive) {
+    // Once a flight is active, requestPrepareFlight() must not arm a
+    // pending request — otherwise a stale flag could fire on the next
+    // service call after finalizeFlight, claiming a fresh range without
+    // the caller asking for it.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    ASSERT_TRUE(fl.isFlightActive());
+
+    fl.requestPrepareFlight();
+    EXPECT_FALSE(fl.isPrepareFlightPending());
+
+    uint32_t id2 = 0;
+    Status st2 = Status::Error;
+    EXPECT_FALSE(fl.servicePendingPrepareFlight(id2, st2));
+}
+
+TEST(TRFlightLogDeferredPrepare, ServiceClearsRequestEvenIfFlightActive) {
+    // Race condition guard: if some other path activates a flight between
+    // the request being set and service running, the flag must still be
+    // cleared so it can't fire after the flight finalizes.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    // Direct-prepare to simulate an alternate code path landing first,
+    // then forcibly arm the deferred flag (white-box scenario for what
+    // would otherwise require multi-task scheduling).
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    // requestPrepareFlight bails when active, so reach in via a fresh
+    // request that lands before activation: simulate by using a separate
+    // instance and forcing flag through the public API in a non-active
+    // window first.
+    // (Easiest concrete way: finalize + then request + activate-by-direct.)
+    ASSERT_EQ(fl.finalizeFlight("flight_001.bin", 0), Status::Ok);
+    fl.requestPrepareFlight();
+    ASSERT_TRUE(fl.isPrepareFlightPending());
+    // Now activate via direct call before service runs — service must still
+    // clear the stale flag.
+    uint32_t direct_id = 0;
+    ASSERT_EQ(fl.prepareFlight(direct_id), Status::Ok);
+
+    uint32_t serviced_id = 0;
+    Status st = Status::Error;
+    EXPECT_FALSE(fl.servicePendingPrepareFlight(serviced_id, st));
+    EXPECT_FALSE(fl.isPrepareFlightPending());
+}
+
+// ================================================================
 // writePage — hot path, bad-block skip, overflow extend
 // ================================================================
 

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -230,6 +230,26 @@ void TR_FlightLog::persistBitmap() {
     bitmap_store_->save(buf, sizeof(buf));
 }
 
+void TR_FlightLog::requestPrepareFlight() {
+    // Idempotent: extra calls collapse into one pending flag.
+    // Skip when a flight is already active so the consumer doesn't see a
+    // request that would immediately be rejected anyway.
+    if (flight_active_) return;
+    prepare_request_pending_ = true;
+}
+
+bool TR_FlightLog::servicePendingPrepareFlight(uint32_t& id_out, Status& status_out) {
+    if (!prepare_request_pending_) return false;
+    // Always clear the flag — even when we won't run prepareFlight — so a
+    // stale request can't fire on a later iteration after the flight has
+    // started through another path (e.g. a host-test direct call).
+    prepare_request_pending_ = false;
+    if (flight_active_) return false;
+
+    status_out = prepareFlight(id_out);
+    return true;
+}
+
 Status TR_FlightLog::prepareFlight(uint32_t& flight_id_out) {
     if (!initialized_) return Status::NotInitialized;
     if (flight_active_)  return Status::Error;  // already flying

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -54,7 +54,34 @@ public:
 
     // Pre-launch: pick + erase a free contiguous range. May stall ~770 ms.
     // Writes the assigned flight_id to `flight_id_out` on success.
+    //
+    // This is the synchronous form. On hardware, prefer
+    // requestPrepareFlight() + servicePendingPrepareFlight() so the 256-block
+    // erase loop runs on the flush task's core (Core 0) instead of blocking
+    // sensor ingest on the calling core (issue #77).
     Status prepareFlight(uint32_t& flight_id_out);
+
+    // Defer a prepareFlight call. Sets a flag and returns immediately; the
+    // ~770 ms erase loop is performed by a later servicePendingPrepareFlight()
+    // call (typically from the flush task on Core 0). Idempotent — calling
+    // multiple times before service queues at most one prepare. No-op if a
+    // flight is already active.
+    void requestPrepareFlight();
+
+    // True iff requestPrepareFlight() has been called and the request has not
+    // yet been picked up by servicePendingPrepareFlight().
+    bool isPrepareFlightPending() const { return prepare_request_pending_; }
+
+    // If a request is pending and no flight is currently active, runs
+    // prepareFlight() inline and reports its outcome via id_out / status_out.
+    // Returns true when work was done; false when there was nothing to do
+    // (no request pending, or a flight is already active). The pending flag
+    // is cleared in either case so a stale request can't fire after the
+    // flight has been started by some other path.
+    //
+    // Intended call site: once per flush-task iteration on the same core that
+    // owns expensive NAND I/O.
+    bool servicePendingPrepareFlight(uint32_t& id_out, Status& status_out);
 
     // Hot path: deterministic page write. Called by flush task.
     // `page` must be exactly NAND_PAGE_SIZE bytes. No allocation, no metadata.
@@ -97,6 +124,12 @@ private:
     uint32_t active_next_page_    = 0;  // absolute page index within the flight range
     uint32_t extension_count_     = 0;
     bool     flight_active_       = false;
+
+    // Single-producer (any task) / single-consumer (flush task) request flag
+    // for the deferred prepareFlight path. `volatile` is sufficient because
+    // the consumer is idempotent: a missed clear at worst causes one extra
+    // service call that no-ops via the flight_active_ check.
+    volatile bool prepare_request_pending_ = false;
 
     void persistBitmap();
     void seedBitmapFromBackend();  // initial bad-block scan into the fresh bitmap

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -1977,6 +1977,16 @@ void TR_LogToFlash::flushTaskLoop()
             prepare_file_requested_ = false;
         }
 
+        // Periodic hook for deferred Core-0 work. Used by main.cpp to run
+        // TR_FlightLog::servicePendingPrepareFlight on Core 0 (issue #77),
+        // moving the ~770 ms 256-block erase loop off the requesting task.
+        // file_open is already set above, so frames keep flowing into the
+        // ring on Core 1 while this hook runs.
+        if (cfg.flush_task_hook != nullptr)
+        {
+            cfg.flush_task_hook(cfg.flush_task_hook_ctx);
+        }
+
         // Handle deferred start-logging request (launch detected)
         if (start_logging_requested && !logging_active)
         {

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -34,6 +34,16 @@ struct TR_LogToFlashConfig
     bool (*write_sink)(void* ctx, const uint8_t* payload, size_t payload_len) = nullptr;
     void* write_sink_ctx = nullptr;
 
+    // Optional periodic hook called once per flushTaskLoop iteration on the
+    // flush task's core. Used to drive deferred work that needs to run on
+    // Core 0 instead of the original requesting task — specifically, the
+    // TR_FlightLog deferred prepareFlight (issue #77). The hook fires after
+    // the prepareLogFile request is processed and before the startLogging
+    // request is processed, so a deferred prepareFlight completes between
+    // file_open=true and logging_active=true.
+    void (*flush_task_hook)(void* ctx) = nullptr;
+    void* flush_task_hook_ctx = nullptr;
+
     // MRAM ring buffer (optional — set mram_cs >= 0 to enable).
     // When enabled the ring buffer lives in SPI MRAM instead of ESP32 RAM,
     // providing larger capacity (128 KB) and power-loss survivability.

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -164,12 +164,29 @@ static void flightlogBeginFlight()
         ESP_LOGW("FLIGHTLOG", "prepareFlight: already active, skipping");
         return;
     }
+    // Defer the 256-block erase loop (~770 ms) to the flush task on Core 0
+    // (issue #77). Running it inline here used to block whatever Core 1
+    // task was on the call stack — loop_oc, the BLE/LoRa cmd 23 handler,
+    // or the I2S/I2C parse path — which starved the parser task and
+    // produced multi-hundred-ms gaps in the recorded sensor stream. The
+    // actual prepareFlight runs from flightlogFlushTaskHook below.
+    flightlog.requestPrepareFlight();
+}
+
+// Drives the deferred Core-0 work for TR_FlightLog. Wired into
+// TR_LogToFlash::flushTaskLoop via cfg.flush_task_hook so it executes on the
+// flush task's core (Core 0). Logs the prepareFlight outcome here because
+// TR_FlightLog itself stays free of ESP_LOG dependencies (host-testable).
+static void flightlogFlushTaskHook(void* /*ctx*/)
+{
     uint32_t id = 0;
-    auto st = flightlog.prepareFlight(id);
+    tr_flightlog::Status st = tr_flightlog::Status::Ok;
+    if (!flightlog.servicePendingPrepareFlight(id, st)) return;
+
     if (st == tr_flightlog::Status::Ok)
     {
         ESP_LOGI("FLIGHTLOG",
-                 "prepareFlight OK: id=%u, range=[%u..%u), pages=%u",
+                 "prepareFlight OK (deferred): id=%u, range=[%u..%u), pages=%u",
                  (unsigned)id,
                  (unsigned)flightlog.activeStartBlock(),
                  (unsigned)(flightlog.activeStartBlock() + flightlog.activeBlockCount()),
@@ -177,7 +194,7 @@ static void flightlogBeginFlight()
     }
     else
     {
-        ESP_LOGW("FLIGHTLOG", "prepareFlight: %s",
+        ESP_LOGW("FLIGHTLOG", "prepareFlight (deferred): %s",
                  tr_flightlog::to_string(st));
     }
 }
@@ -2669,6 +2686,7 @@ void initPeripherals()
     log_cfg.lfs_block_count = 32;
     log_cfg.write_sink = flightlogWriteSink;
     log_cfg.write_sink_ctx = &flightlog;
+    log_cfg.flush_task_hook = flightlogFlushTaskHook;
 
     bool lfs_wipe_pending = false;
     {
@@ -3136,6 +3154,13 @@ static void loop_oc()
                                    nsFlagSet(latest_non_sensor.flags, NSF_LAUNCH);
             if (ns_launch && !prev_ns_launch)
             {
+                // Mirror the cmd 23 lifecycle so a launch detected without a
+                // prior PRELAUNCH transition still gets a flightlog flight
+                // and an opened sink session. Each call is a no-op when the
+                // matching state has already been set, so the normal
+                // PRELAUNCH→LAUNCH path is unaffected.
+                logger.prepareLogFile();
+                flightlogBeginFlight();
                 logger.startLogging();
                 ESP_LOGI("OC", "Launch detected - logging started");
             }


### PR DESCRIPTION
Closes #77.

## Summary

- `flightlogBeginFlight()` now requests a deferred prepareFlight instead of running the 256-block erase loop (~770 ms) inline on Core 1.
- The actual `prepareFlight()` runs on Core 0 inside `TR_LogToFlash::flushTaskLoop` via a new `flush_task_hook` config callback.
- Fixes the NSF_LAUNCH-detected logging path so it calls `prepareLogFile` + `flightlogBeginFlight` before `startLogging`, matching the cmd 23 path.

## Why

Issue #77 logged a system-wide 744 ms gap in sensor data during a PRELAUNCH bench capture. Investigation traced it to `flightlog.prepareFlight()` running synchronously in `flightlogBeginFlight()` from whichever Core 1 task triggered it — `loop_oc`, the cmd 23 handler, or the PRELAUNCH state-transition path. While Core 1 is stuck in the 256 × ~3 ms erase loop, the priority-1 I2S parser task is preempted and `parseCmdRing` (driven by `loop_oc` itself) doesn't run either, so sensor frames pile up faster than DMA / rx_ring can absorb.

A new bench serial capture (firmware 1790a52) confirmed it directly:

```
I (24757) BLE: Received command: 23
I (24762) LOG: openLogSession (sink mode, LFS skipped)
I (25485) FLIGHTLOG: prepareFlight OK: id=4, range=[82..338), pages=256   <- +723 ms
I (25485) OC_CMD: Logging STARTED (manual)
I (25486) LOG TIMING: ... erases=256 ring_peak=50135 ...
W (25714) LOG: STALL: flushTaskLoop iteration took 227995 us
```

723 ms inline on Core 1 between `openLogSession` and `prepareFlight OK`, with the ring backed up to 50 KB.

Stage 2 of #50 already established the deferred-request pattern for `prepareLogFile` and `startLogging`. The lifecycle hook `flightlogBeginFlight()` was missed during that migration. This PR extends the same pattern to `prepareFlight`.

## How

| Component | Change |
|---|---|
| `TR_FlightLog` | New `requestPrepareFlight()` (sets a flag), `isPrepareFlightPending()` accessor, and `servicePendingPrepareFlight(id_out, status_out)` (runs the work if pending). Existing synchronous `prepareFlight()` is unchanged. |
| `TR_LogToFlash::Config` | New `flush_task_hook` / `flush_task_hook_ctx` callback fires once per `flushTaskLoop` iteration, after the `prepareLogFile` request is processed and before `startLogging`. |
| `main.cpp` | `flightlogBeginFlight()` now calls `requestPrepareFlight()`. New `flightlogFlushTaskHook()` runs `servicePendingPrepareFlight()` on Core 0 and logs the result. Hook is registered via `log_cfg.flush_task_hook = flightlogFlushTaskHook`. The NSF_LAUNCH path now mirrors cmd 23's full lifecycle. |

The hook fires *after* `prepareLogFile`'s `openLogSession` — so `file_open=true` is set before the 770 ms erase begins. Core 1's `enqueueFrame` accepts frames into the ring throughout the stall; once `prepareFlight` completes and `activateLogging` flips `logging_active`, the flush task drains the ring with timestamps preserved. Net effect: no Core-1 starvation, no recorded data gap.

## Tests

Added six host tests in `TRFlightLogDeferredPrepare`:

- `RequestDoesNotEraseUntilServiced` — flag is pure flag-set, no NAND I/O
- `ServiceRunsPrepareWhenPending` — deferred path produces same end state as direct call (bitmap allocated + range erased)
- `ServiceWithoutRequestIsNoOp` — service is cheap when nothing is pending
- `RequestIsIdempotent` — multiple requests collapse, second service after active is no-op
- `RequestIgnoredWhileFlightActive` — flag never armed when a flight is in progress
- `ServiceClearsRequestEvenIfFlightActive` — stale-flag-clear race guard so a leftover request can't fire after finalize

`ctest --test-dir tests_cpp/build -j4` reports 210/210 passing. `test_tr_flightlog_core`: 96/96 (90 existing + 6 new). Wire-format suite: 10/10.

## Test plan

- [x] All host tests pass (`ctest -j4` -> 210/210)
- [x] Bench test on hardware: BLE cmd 23 in READY, confirm `prepareFlight OK (deferred):` log line appears from the flush task
- [x] Confirm `LOG TIMING` line shows the 998 ms iteration on Core 0 instead of blocking Core 1
- [x] Sensor data file shows no prepareFlight-sized gap

## Bench result

`flight_20260426_100157.bin` (1.87 MB, 26.1 s, 59 349 frames). Cmd 23 in READY:

```
I (36896) BLE: Received command: 23
I (36897) OC_CMD: Logging STARTED (manual)         <- Core 1 returned in <1 ms
I (36899) LOG: openLogSession (sink mode, LFS skipped)
I (37674) FLIGHTLOG: prepareFlight OK (deferred): id=5, range=[95..351), pages=256
W (37896) LOG: STALL: flushTaskLoop iteration took 998003 us  <- Core 0
```

Gap analysis (max inter-record delta per sensor):

| Sensor | Before (#77) | After |
|---|---|---|
| ISM6 | 744 ms | 59.5 ms |
| BMP | 744 ms | 58.4 ms |
| MMC | 744 ms | 62.6 ms |
| NonSensor | 744 ms | 60.4 ms |

The 770 ms prepareFlight stall is no longer visible in the recorded data. Core 1 stayed responsive throughout the 775 ms erase window — `I2C_RX` traffic continued at the normal 250–500 ms cadence and the ring filled to ~49 KB before activate, then drained cleanly.

A residual ~60 ms gap shared across all sensors aligns with `LORA: LoRa reconfigured ...` at wall-time T+50061 (the rendezvous-silence frequency hop). Same Core-1 / priority-5 starvation pattern as prepareFlight had, just much smaller blast radius. Out of scope for #77 — worth a separate issue.

Generated with [Claude Code](https://claude.com/claude-code)
