### PR TITLE
bs: read VFSOC to bypass CSP/CSN swap on fuel gauge (#49)

### DIFF
--- a/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
@@ -232,8 +232,11 @@ esp_err_t TR_MAX17205G::update()
     if (readReg(Reg::VCELL, raw))
         _data.voltage = (float)raw * 0.078125e-3f * (float)_cfg.num_cells;
 
-    // RepSOC: 1/256 % per LSB
-    if (readReg(Reg::REP_SOC, raw))
+    // VFSOC (1/256 % per LSB) -- voltage-driven SoC. We read VFSOC instead
+    // of RepSOC because on boards where CSP/CSN are swapped (current_invert),
+    // the chip's internal m5 algorithm integrates current with the wrong
+    // sign and RepSOC walks down during charge. VFSOC is largely immune.
+    if (readReg(Reg::VFSOC, raw))
         _data.soc = (float)raw / 256.0f;
 
     // Current: signed, 1.5625 µV per LSB / Rsense. Result in mA.
@@ -280,6 +283,20 @@ void TR_MAX17205G::logDiagnostics(const char* log_tag)
     if (readReg(Reg::FULL_CAP_NOM, raw)) ESP_LOGI(log_tag, "[FG-DIAG] FullCapNom (0x23) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
     if (readReg(Reg::DESIGN_CAP,   raw)) ESP_LOGI(log_tag, "[FG-DIAG] DesignCap  (0x18) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
     if (readReg(Reg::PACK_CFG,     raw)) ESP_LOGI(log_tag, "[FG-DIAG] PackCfg    (0xBD) = 0x%04X", raw);
+    if (readReg(Reg::CURRENT,      raw)) {
+        const int16_t signed_raw = (int16_t)raw;
+        const float ma = (float)signed_raw * 1.5625e-3f / (_cfg.rsense_mohm * 1e-3f);
+        ESP_LOGI(log_tag, "[FG-DIAG] Current    (0x0A) = %d (raw signed) -> %.0f mA chip-frame, %.0f mA app-frame (invert=%d)",
+                 signed_raw, (double)ma,
+                 _cfg.current_invert ? -(double)ma : (double)ma,
+                 _cfg.current_invert);
+    }
+    if (readReg(Reg::AVG_CUR,      raw)) {
+        const int16_t signed_raw = (int16_t)raw;
+        const float ma = (float)signed_raw * 1.5625e-3f / (_cfg.rsense_mohm * 1e-3f);
+        ESP_LOGI(log_tag, "[FG-DIAG] AvgCurrent (0x0B) = %d (raw signed) -> %.0f mA chip-frame", signed_raw, (double)ma);
+    }
+    if (readReg(Reg::VCELL,        raw)) ESP_LOGI(log_tag, "[FG-DIAG] VCell      (0x09) = %.1f mV (raw=0x%04X)", (double)((float)raw * 0.078125f), raw);
     ESP_LOGI(log_tag, "[FG-DIAG] Pack: %u cells series, design %u mAh, Rsense %.1f mΩ",
              (unsigned)_cfg.num_cells, (unsigned)_cfg.design_mah, (double)_cfg.rsense_mohm);
     ESP_LOGI(log_tag, "[FG-DIAG] --------------------------------");

--- a/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.h
+++ b/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.h
@@ -53,8 +53,16 @@ struct TR_MAX17205G_Config
 {
     uint16_t design_mah     = 2800;   // Pack design capacity in mAh (series = per-cell)
     float    rsense_mohm    = 10.0f;  // Sense resistor value
-    bool     current_invert = true;   // Flip sign (use true if R_SENSE polarity reversed
-                                      //   vs datasheet, so charge reads positive)
+    bool     current_invert = true;   // Flip the *displayed* current sign. Set true on
+                                      //   boards where CSP/CSN are swapped vs. the
+                                      //   MAX17205 typical app circuit (which expects
+                                      //   CSP→BATT-, CSN→GND for charge to read positive).
+                                      //   NOTE: this only affects the value returned by
+                                      //   current(); the chip's internal m5 algorithm uses
+                                      //   the raw register and cannot be told about the
+                                      //   swap, so RepSOC integrates current the wrong way.
+                                      //   Driver reads VFSOC (voltage-based) for soc() to
+                                      //   sidestep this.
     uint8_t  num_cells      = 2;      // Series cell count (for pack-voltage scaling
                                       //   off the VCell register)
 };

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1497,7 +1497,11 @@ static void setup_bs()
             TR_MAX17205G_Config fg_cfg;
             fg_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
             fg_cfg.rsense_mohm    = config::RSENSE_MOHM;
-            fg_cfg.current_invert = true;   // R_SENSE reversed on this board
+            fg_cfg.current_invert = true;   // CSP/CSN swapped on schematic (U7) vs.
+                                            //   datasheet typical app circuit; flips
+                                            //   displayed current so charge reads
+                                            //   positive. Driver uses VFSOC for SoC
+                                            //   because the chip's m5 can't be told.
             fg_cfg.num_cells      = config::NUM_BATTERY_CELLS;
 
             if (fuel_gauge.begin(i2c_bus, fg_cfg, config::I2C_FREQ_HZ) == ESP_OK)
@@ -1508,6 +1512,7 @@ static void setup_bs()
                 updateBattery();
                 ESP_LOGI(TAG, "Battery: %.2f V, %.1f%% SoC, %.0f mA",
                          (double)bs_voltage, (double)bs_soc, (double)bs_current);
+                fuel_gauge.logDiagnostics(TAG);
             }
             else
             {


### PR DESCRIPTION
## Summary

- Read VFSOC (0xFF) instead of RepSOC (0x06) for base station SoC reporting, to sidestep the CSP/CSN swap on the current PCB.
- Add raw signed CURRENT register, AvgCurrent, and VCell to `logDiagnostics()`; call it once at BS boot so the swap is visible in the boot log.
- Update `current_invert` doc comment to spell out that it only flips the *displayed* value -- the chip's m5 algorithm uses the raw register and cannot be told about the swap.

## Why

Issue #49: base station SoC drops while charging. Diagnosis traced it to U7's CSP (pin 2) and CSN (pin 4) being swapped relative to the MAX17205 datasheet typical app circuit. The chip's CURRENT register reads negative during charge, m5 integrates phantom discharge, and RepSOC walks down. VFSOC is voltage-driven and largely immune to the sign error.

## Verification

Boot log on real hardware while plugged in (charging at ~860 mA):

```
I (1065) BS: Battery: 8.31 V, 77.4% SoC, 845 mA
I (1067) BS: [FG-DIAG] RepSOC     (0x06) = 68.36 %      <- old read, drifting
I (1069) BS: [FG-DIAG] VFSOC      (0xFF) = 77.36 %      <- new read, matches VCell
I (1074) BS: [FG-DIAG] Current    (0x0A) = -5502 (raw signed) -> -860 mA chip-frame
I (1076) BS: [FG-DIAG] VCell      (0x09) = 4153.1 mV    <- ~77% on NCR18650B
```

`Current = -5502` while pack is actually charging at +860 mA confirms the polarity issue directly. After the fix, `bsoc` in the BLE JSON went from 75.8% (RepSOC, drifting) to 77.7% (VFSOC, stable matching voltage).

## Follow-up

A separate hardware issue should be filed for the next PCB rev to swap the CSP/CSN net assignments at U7, which would let us go back to RepSOC for slightly better dynamic accuracy.

## Test plan

- [x] Builds cleanly under ESP-IDF
- [x] Boot log on real BS hardware shows VFSOC tracking voltage during charge
- [x] Raw signed CURRENT register confirmed negative during charge (the smoking gun)
- [ ] Run a full charge cycle and confirm VFSOC reaches >95% near top-of-charge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
