### PR TITLE
flight_computer: relabel EKF diag roll values (#45)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3397,13 +3397,19 @@ static void loop_fc()
         {
             last_ekf_diag_ms = now_ms_for_sound;
 
-            // Quaternion-based roll (gimbal-lock-free): azimuth of body-Z in NED
+            // Horizontal azimuth of the rocket's body-Z axis in NED. This is *not*
+            // a roll in the Euler sense -- it's only a useful roll proxy when the
+            // rocket is near vertical (body-Z ≈ world-Z, so its horizontal
+            // projection rotates with vehicle roll about the vertical axis).
+            // At low pitch this is dominated by yaw and will diverge from
+            // euler_roll arbitrarily; that divergence is itself a useful informal
+            // indicator of how close euler_roll is to gimbal lock.
             float quat[4];
             ekf.getQuaternion(quat);
             float qw = quat[0], qx = quat[1], qy = quat[2], qz = quat[3];
             float z_n = 2.0f * (qx * qz + qw * qy);
             float z_e = 2.0f * (qy * qz - qw * qx);
-            float quat_roll_deg = -atan2f(z_e, z_n) * (180.0f / (float)M_PI);
+            float bodyZ_az_deg = -atan2f(z_e, z_n) * (180.0f / (float)M_PI);
 
             // Euler angles (erratic near pitch=90° due to gimbal lock)
             float rpy[3];
@@ -3431,9 +3437,9 @@ static void loop_fc()
             float gb[3];
             ekf.getRotRateBias(gb);
 
-            ESP_LOGI(TAG, "[EKF DIAG] quat_roll=%.1f euler_roll=%.1f pitch=%.1f yaw=%.1f cos2p=%.4f",
-                          (double)quat_roll_deg,
+            ESP_LOGI(TAG, "[EKF DIAG] roll(euler)=%.1f roll(bodyZ_az)=%.1f pitch=%.1f yaw=%.1f cos2p=%.4f",
                           (double)euler_roll_deg,
+                          (double)bodyZ_az_deg,
                           (double)pitch_deg,
                           (double)yaw_deg,
                           (double)cos2p);


### PR DESCRIPTION
## Summary

Relabel the `[EKF DIAG]` line so the two "roll" values aren't presented as if they should agree.

Before:
```
[EKF DIAG] quat_roll=-96.9 euler_roll=-30.8 pitch=-4.8 yaw=-1.0 cos2p=0.9931
```

After:
```
[EKF DIAG] roll(euler)=-30.8 roll(bodyZ_az)=-96.9 pitch=-4.8 yaw=-1.0 cos2p=0.9931
```

Also rename the local variable `quat_roll_deg` → `bodyZ_az_deg` and expand the comment to spell out when each value is meaningful and why their divergence is itself a useful informal gimbal-lock indicator.

No functional change.

## Why

Issue #45: the previous labels imply the two numbers measure the same quantity. They don't — `quat_roll` is the horizontal azimuth of body-Z in NED (only meaningful near vertical), while `euler_roll` is the standard Euler roll (only meaningful at low pitch).

## Test plan

- [x] flight_computer ESP-IDF build passes locally
- [x] No runtime change beyond the log line text and one local variable name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
