### PR TITLE
TR_LogToFlash: add rb_bad_sof_clears counter for #46 verification

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -92,6 +92,7 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
     rb_head = rb_tail = rb_count = 0;
     rb_overruns = rb_highwater = 0;
     rb_drop_oldest_bytes = 0;
+    rb_bad_sof_clears = 0;
     nand_page = nand_block = 0;
     nand_bytes_written = 0;
     nand_prog_fail = nand_erase_fail = 0;
@@ -322,6 +323,7 @@ void TR_LogToFlash::getStats(TR_LogToFlashStats& out) const
     out.ring_highwater = rb_highwater;
     out.ring_overruns = rb_overruns;
     out.ring_drop_oldest_bytes = rb_drop_oldest_bytes;
+    out.ring_bad_sof_clears = rb_bad_sof_clears;
     out.bytes_received = bytes_received;
     out.frames_received = frames_received;
     out.frames_dropped = frames_dropped;
@@ -723,6 +725,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
                     ESP_LOGW(TAG, "ringPush: bad SOF at tail, clearing ring");
                 }
                 rb_drop_oldest_bytes += local_count;
+                rb_bad_sof_clears++;
                 clearRingLocked();
                 local_count = 0;
                 break;
@@ -739,6 +742,7 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
                                   (unsigned long)frame_size, (unsigned long)local_count);
                 }
                 rb_drop_oldest_bytes += local_count;
+                rb_bad_sof_clears++;
                 clearRingLocked();
                 local_count = 0;
                 break;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -59,6 +59,10 @@ struct TR_LogToFlashStats
     uint32_t ring_highwater = 0;
     uint32_t ring_overruns = 0;
     uint32_t ring_drop_oldest_bytes = 0;
+    uint32_t ring_bad_sof_clears = 0;   // Issue #46: count of clearRing fires from
+                                        //   the drop-oldest path due to a corrupt
+                                        //   tail (bad SOF or truncated frame).
+                                        //   Distinct from happy-path drop-oldest.
     uint64_t bytes_received = 0;
     uint32_t frames_received = 0;
     uint32_t frames_dropped = 0;
@@ -211,6 +215,7 @@ private:
     uint32_t rb_overruns = 0;
     uint32_t rb_drop_oldest_bytes = 0;
     uint32_t rb_highwater = 0;
+    uint32_t rb_bad_sof_clears = 0;
 
     // Issue #74 diagnostic: compare total bytes pushed vs popped. A healthy
     // ring has pop <= push at all times (residual frames left unflushed at

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -775,6 +775,7 @@ static uint64_t prev_bytes_nand = 0;
 static uint64_t prev_raw_i2c_bytes = 0;
 static uint32_t prev_ring_overruns = 0;
 static uint32_t prev_ring_drop_oldest_bytes = 0;
+static uint32_t prev_ring_bad_sof_clears = 0;
 static uint32_t interval_ring_fill_peak = 0;
 
 static inline size_t rxLen()
@@ -2341,11 +2342,13 @@ static void printStats()
     const uint64_t raw_i2c_delta = raw_i2c_bytes - prev_raw_i2c_bytes;
     const uint32_t ring_overrun_delta = s.ring_overruns - prev_ring_overruns;
     const uint32_t ring_drop_oldest_delta = s.ring_drop_oldest_bytes - prev_ring_drop_oldest_bytes;
+    const uint32_t ring_bad_sof_delta = s.ring_bad_sof_clears - prev_ring_bad_sof_clears;
     prev_bytes_rx = s.bytes_received;
     prev_bytes_nand = s.bytes_written_nand;
     prev_raw_i2c_bytes = raw_i2c_bytes;
     prev_ring_overruns = s.ring_overruns;
     prev_ring_drop_oldest_bytes = s.ring_drop_oldest_bytes;
+    prev_ring_bad_sof_clears = s.ring_bad_sof_clears;
 
     const float rx_kbs = (dt > 0) ? ((float)rx_delta / (float)dt) : 0.0f;
     const float wr_kbs = (dt > 0) ? ((float)nand_delta / (float)dt) : 0.0f;
@@ -2393,10 +2396,12 @@ static void printStats()
                   (unsigned long)s.ring_fill,
                   (unsigned long)config::RAM_RING_SIZE,
                   (unsigned long)s.ring_highwater);
-    ESP_LOGI("OC", "RING interval peak/overrun/drop_oldest_bytes=%lu/%lu/%lu",
+    ESP_LOGI("OC", "RING interval peak/overrun/drop_oldest_bytes/bad_sof=%lu/%lu/%lu/%lu (bad_sof_total=%lu)",
                   (unsigned long)interval_ring_fill_peak,
                   (unsigned long)ring_overrun_delta,
-                  (unsigned long)ring_drop_oldest_delta);
+                  (unsigned long)ring_drop_oldest_delta,
+                  (unsigned long)ring_bad_sof_delta,
+                  (unsigned long)s.ring_bad_sof_clears);
     ESP_LOGI("OC", "i2c raw reads/bytes=%lu/%llu",
                   (unsigned long)raw_i2c_reads,
                   (unsigned long long)raw_i2c_bytes);


### PR DESCRIPTION
## Summary

Add a dedicated `rb_bad_sof_clears` counter so the safety-net path in `ringPush()`'s drop-oldest loop is distinguishable from happy-path drop-oldest activity in the stats line.

## Why

Per [#46](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/46) — the `bad SOF at tail, clearing ring` warning was wiping ~32 KB of pre-launch data when it fired, but the only accounting was `rb_drop_oldest_bytes`, shared with normal drop-oldest. Hard to tell from stats whether the safety net was tripping or just normal cap behaviour.

The `push_mutex_` work in the [#74](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/74) series should have closed the underlying race. This counter gives an unambiguous signal on the next bench capture: `bad_sof_total=0` confirms the fix held.

## What changed

- `TR_LogToFlash::rb_bad_sof_clears` — new private counter, init'd in `begin()`, incremented in both error branches of the drop-oldest loop (corrupt SOF and partial frame).
- `TR_LogToFlashStats::ring_bad_sof_clears` — exposed through `getStats()`.
- `out_computer` stats line now prints interval delta + lifetime total:

  ```
  RING interval peak/overrun/drop_oldest_bytes/bad_sof=N/N/N/N (bad_sof_total=N)
  ```

No change to ring-buffer logic itself.

## Test plan

- [x] `out_computer` and `base_station` ESP-IDF builds pass locally
- [ ] Bench PRELAUNCH capture — confirm `bad_sof_total=0` throughout the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
