### PR TITLE
lora: plumb next_channel_idx for #40/#41 channel hopping (phase 1)

### DIFF
--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -85,6 +85,62 @@ static inline bool shouldBeaconInState(RocketState s)
     return s != INFLIGHT;
 }
 
+// ============================================================================
+// Channel-set generator for per-packet frequency hopping (issues #40 / #41)
+// ============================================================================
+// The rocket and base station derive an identical channel table from the
+// active LoRa bandwidth.  Both sides hold the same NVS preset (set via cmd
+// 10), so neither side has to push the table over the wire — the agreement
+// falls out of the existing modulation-config sync.
+//
+// Layout: channel centers are spaced at 1.5 × BW so each channel keeps a
+// half-BW guard from its neighbours.  Channel 0 sits half a BW above the
+// low band edge; the last channel sits half a BW below the high edge.  The
+// US 902-928 MHz ISM band fits 35/69/130 channels at the Fast/250kHz/Max
+// Range presets respectively.  All three counts comfortably exceed the
+// FCC Part 15.247 FHSS thresholds (25 channels for BW > 250 kHz, 50 for
+// BW ≤ 250 kHz) — though we operate as digital modulation (DTS), not
+// FHSS, so those thresholds are headroom rather than a binding constraint.
+//
+// next_channel_idx in the LoRa header is 1 byte (0..N-1).  The sentinel
+// LORA_NEXT_CH_NO_HOP means "stay on the current channel for one more
+// window".  Phase 1 wires the byte through but always sends the sentinel;
+// Phase 2 will start emitting real indices.
+static constexpr float   LORA_BAND_LO_MHZ        = 902.0f;  // US ISM band low edge
+static constexpr float   LORA_BAND_HI_MHZ        = 928.0f;  // US ISM band high edge
+static constexpr float   LORA_CHANNEL_SPACING_X  = 1.5f;    // spacing as multiple of BW
+static constexpr uint8_t LORA_NEXT_CH_NO_HOP     = 0xFF;    // sentinel: don't hop
+
+// Number of channels available for a given LoRa bandwidth.  Returns 0 if
+// the BW would not fit a single channel inside the band.
+static inline uint8_t loraChannelCount(float bw_khz)
+{
+    if (bw_khz <= 0.0f) return 0;
+    const float bw_mhz   = bw_khz / 1000.0f;
+    const float spacing  = bw_mhz * LORA_CHANNEL_SPACING_X;
+    const float min_f    = LORA_BAND_LO_MHZ + bw_mhz * 0.5f;
+    const float max_f    = LORA_BAND_HI_MHZ - bw_mhz * 0.5f;
+    if (max_f <= min_f) return 0;
+    const float span     = max_f - min_f;
+    const int   n        = (int)(span / spacing) + 1;
+    if (n < 1)   return 0;
+    if (n > 255) return 255;  // cap so idx fits in the 1-byte header field
+    return (uint8_t)n;
+}
+
+// Center frequency of channel `idx` for the given bandwidth.  Returns 0.0
+// if idx is out of range — callers should treat that as "fall back to
+// rendezvous".
+static inline float loraChannelMHz(float bw_khz, uint8_t idx)
+{
+    const uint8_t n = loraChannelCount(bw_khz);
+    if (idx >= n) return 0.0f;
+    const float bw_mhz  = bw_khz / 1000.0f;
+    const float spacing = bw_mhz * LORA_CHANNEL_SPACING_X;
+    const float min_f   = LORA_BAND_LO_MHZ + bw_mhz * 0.5f;
+    return min_f + spacing * (float)idx;
+}
+
 // Payload sent with OUT_STATUS_QUERY so the OUT processor can configure
 // its SensorConverter consistently with the FlightComputer.
 typedef struct __attribute__((packed))
@@ -399,9 +455,10 @@ static constexpr uint8_t LORA_CMD_HEARTBEAT = 0xFE;
 // LoRa data to send from rocket to ground station
 typedef struct __attribute__((packed))
 {
-    // --- Routing header (added in proto v1) ---
+    // --- Routing header (proto v2: hop byte added for #40/#41) ---
     uint8_t network_id;      // LoRa network namespace (0..255)
     uint8_t rocket_id;       // Source rocket ID within network (1..254, 0=unset, 255=broadcast)
+    uint8_t next_channel_idx;// 0..N-1 = hop to that channel after this RX; 0xFF = stay
 
     // --- Telemetry payload (unchanged from proto v0) ---
     uint8_t num_sats;        // 0..255
@@ -452,8 +509,8 @@ typedef struct __attribute__((packed))
 
 } LoRaData;
 
-static_assert(sizeof(LoRaData) == 59,
-              "LoRaData must be 59 bytes (2-byte header + 57-byte payload)");
+static_assert(sizeof(LoRaData) == 60,
+              "LoRaData must be 60 bytes (3-byte header + 57-byte payload)");
 
 static constexpr uint8_t LORA_LAUNCH      = (1u << 0);  // bit 0
 static constexpr uint8_t LORA_VEL_APOGEE  = (1u << 1);  // bit 1
@@ -470,6 +527,7 @@ typedef struct
 {                                   // Precision    : Range
     uint8_t network_id;             // Routing header: network namespace
     uint8_t rocket_id;              // Routing header: source rocket ID
+    uint8_t next_channel_idx;       // Routing header: 0..N-1 hop target, 0xFF = stay
     uint8_t num_sats;               // int          : 0 to 255
     float   pdop;                   // meter        : 0 to 100
     double  ecef_x, ecef_y, ecef_z; // meter        : +/- 7,000,000

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -282,8 +282,9 @@ void SensorConverter::convertNonSensorData(const NonSensorData& in, NonSensorDat
 void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
 {
     // Routing header
-    out.network_id = in.network_id;
-    out.rocket_id  = in.rocket_id;
+    out.network_id       = in.network_id;
+    out.rocket_id        = in.rocket_id;
+    out.next_channel_idx = in.next_channel_idx;
 
     // num_sats (bits 0-6) + logging_active (bit 7)
     out.num_sats = (uint8_t)lroundi32(clampf((float)in.num_sats, 0.f, 127.f));
@@ -410,8 +411,9 @@ void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
 void SensorConverter::unpackLoRa(const LoRaData& in, LoRaDataSI& out)
 {
     // Routing header
-    out.network_id = in.network_id;
-    out.rocket_id  = in.rocket_id;
+    out.network_id       = in.network_id;
+    out.rocket_id        = in.rocket_id;
+    out.next_channel_idx = in.next_channel_idx;
 
     out.num_sats = in.num_sats & 0x7F;  // bits 0-6
     out.logging_active = (in.num_sats & LORA_LOGGING_BIT) != 0;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -77,7 +77,7 @@ static char    unit_name[24]  = "TinkerBaseStation"; // default until NVS loads
 static uint8_t network_id     = config::DEFAULT_NETWORK_ID;
 
 // LoRa uplink state (BaseStation → OutComputer)
-static uint8_t  uplink_buf[24];   // 3-byte header + up to 20 bytes payload (PID config needs 20)
+static uint8_t  uplink_buf[32];   // 6-byte header + up to ~26 bytes payload (PID config = 20)
 static size_t   uplink_len = 0;
 static uint8_t  uplink_retries_left = 0;
 static uint32_t uplink_last_tx_ms = 0;
@@ -693,7 +693,17 @@ static void printTelemetry(const LoRaDataSI& data, float rssi, float snr,
     last_telem_print_ms = now;
     last_printed_state  = data.rocket_state;
 
-    ESP_LOGI(TAG, "[RX] %s | alt=%.0fm spd=%.1fm/s | %.0fdBm SNR=%.1f | sats=%u | %.2fV %.0f%%",
+    // next_channel_idx is logged so we can verify the framing byte is
+    // crossing the wire correctly before phase 2 starts using it.  0xFF
+    // ("--") is the phase-1 sentinel meaning "no hop"; anything else is
+    // already a hop intent.
+    char hop_str[8];
+    if (data.next_channel_idx == LORA_NEXT_CH_NO_HOP)
+        snprintf(hop_str, sizeof(hop_str), "--");
+    else
+        snprintf(hop_str, sizeof(hop_str), "%u", (unsigned)data.next_channel_idx);
+
+    ESP_LOGI(TAG, "[RX] %s | alt=%.0fm spd=%.1fm/s | %.0fdBm SNR=%.1f | sats=%u | %.2fV %.0f%% | nextCh=%s",
              rocketStateToString(data.rocket_state),
              (double)data.pressure_alt,
              (double)data.max_speed,
@@ -701,7 +711,8 @@ static void printTelemetry(const LoRaDataSI& data, float rssi, float snr,
              (double)snr,
              (unsigned)data.num_sats,
              (double)data.voltage,
-             (double)data.soc);
+             (double)data.soc,
+             hop_str);
 }
 
 static void printStats()
@@ -850,21 +861,22 @@ static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payloa
     if (uplink_pending)
     {
         ESP_LOGW(TAG, "[UPLINK] Discarding pending cmd=%u, replacing with cmd=%u",
-                 uplink_buf[3], cmd);
+                 uplink_buf[4], cmd);
     }
 
-    if (payload_len > 18) payload_len = 18;  // max 18 bytes payload (was 20, now 2 bytes for routing)
-    // Uplink format v1: [0xCA][network_id][target_rocket_id][cmd][len][payload...]
+    if (payload_len > 25) payload_len = 25;  // 32-byte buf − 6-byte header − 1 byte slack
+    // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
     uplink_buf[0] = config::UPLINK_SYNC_BYTE;  // 0xCA
     uplink_buf[1] = network_id;
     uplink_buf[2] = target_rid;
-    uplink_buf[3] = cmd;
-    uplink_buf[4] = (uint8_t)payload_len;
+    uplink_buf[3] = LORA_NEXT_CH_NO_HOP;       // phase 1: hop logic deferred
+    uplink_buf[4] = cmd;
+    uplink_buf[5] = (uint8_t)payload_len;
     if (payload_len > 0 && payload != nullptr)
     {
-        memcpy(&uplink_buf[5], payload, payload_len);
+        memcpy(&uplink_buf[6], payload, payload_len);
     }
-    uplink_len = 5 + payload_len;
+    uplink_len = 6 + payload_len;
     uplink_retries_left = retries;
     uplink_pending = true;
     uplink_last_tx_ms = 0;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1465,8 +1465,9 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
 
     LoRaDataSI lora = {};
     // Routing header
-    lora.network_id = network_id;
-    lora.rocket_id  = rocket_id;
+    lora.network_id       = network_id;
+    lora.rocket_id        = rocket_id;
+    lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;  // phase 1: hop logic deferred
 
     if (latest_gnss_valid)
     {
@@ -2001,8 +2002,8 @@ static void serviceLoRaUplink()
 
     if (lora_comms.readPacket(rx_buf, sizeof(rx_buf), rx_len))
     {
-        // Uplink format v1: [0xCA][network_id][target_rocket_id][cmd][len][payload...]
-        if (rx_len >= 5 && rx_buf[0] == config::UPLINK_SYNC_BYTE)
+        // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
+        if (rx_len >= 6 && rx_buf[0] == config::UPLINK_SYNC_BYTE)
         {
             uint8_t pkt_nid = rx_buf[1];
             uint8_t pkt_rid = rx_buf[2];
@@ -2010,11 +2011,13 @@ static void serviceLoRaUplink()
             if (pkt_nid == network_id &&
                 (pkt_rid == rocket_id || pkt_rid == 0xFF))
             {
-                uint8_t cmd = rx_buf[3];
-                uint8_t payload_len = rx_buf[4];
-                if (rx_len >= (size_t)(5 + payload_len))
+                // rx_buf[3] = next_channel_idx — phase 1 ignores it (sentinel only).
+                // Phase 2 will hop to loraChannelMHz(bw, idx) here unless == 0xFF.
+                uint8_t cmd = rx_buf[4];
+                uint8_t payload_len = rx_buf[5];
+                if (rx_len >= (size_t)(6 + payload_len))
                 {
-                    processUplinkCommand(cmd, &rx_buf[5], payload_len);
+                    processUplinkCommand(cmd, &rx_buf[6], payload_len);
                     lora_uplink_rx_count++;
                     last_uplink_rx_ms = millis();
                 }


### PR DESCRIPTION
## Summary
- Phase 1 of #40/#41: plumb a 1-byte `next_channel_idx` through both downlink (LoRaData) and uplink LoRa headers without yet emitting hop targets. Both sides send the `LORA_NEXT_CH_NO_HOP` sentinel (`0xFF`) and ignore it on RX, so the wire-format change is isolated from any behavioral change.
- Adds shared helpers `loraChannelCount(bw_khz)` / `loraChannelMHz(bw_khz, idx)` that derive the channel table from the active bandwidth across the 902-928 MHz US ISM band: 35/69/130 channels at the Fast / 250-kHz / Max Range presets, all comfortably above FCC Part 15.247 FHSS thresholds (though we operate as digital modulation, not FHSS).
- Base-station `[RX]` log now prints `nextCh=--` so the byte's transit can be eyeballed.
- `uplink_buf` grew from 24 → 32 bytes to fit the new 6-byte header. As a side effect, 20-byte PID-config payloads no longer get silently truncated to 18 — though in practice PID config is sent via direct rocket BLE rather than this path.

Phase 2 (hop on RX) and phase 3 (rendezvous selection from pre-launch scan #6) will land in follow-up PRs.

## Test plan
- [x] Both firmware projects build clean (`./tools/build.sh out_computer build`, `./tools/build.sh base_station build`).
- [x] Bench-verified: rocket ↔ base-station link still functions after flashing both sides.
- [ ] (Optional) Confirm `nextCh=--` appears in base-station serial log alongside telemetry.
