### PR TITLE
lora: per-packet channel hopping in PRELAUNCH/INFLIGHT (#40 / #41 phase 2a)

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -84,7 +84,33 @@ TEST(RocketComputerTypes, LoRaFlagEncoding) {
 }
 
 // ============================================================================
-// Issues #40 / #41: per-packet channel hopping channel-set helpers
+// Issues #40 / #41: per-packet channel hopping — state gate
+// ============================================================================
+
+TEST(ShouldHopInState, OnlyPrelaunchAndInflight) {
+    // Hopping is intentionally gated to the two states where the rocket
+    // is committed to its modulation config and isn't in a recovery /
+    // pre-handshake situation.  Ground states (READY/LANDED/INIT) stay
+    // on the static channel so config and recovery work as before.
+    EXPECT_FALSE(shouldHopInState(INITIALIZATION));
+    EXPECT_FALSE(shouldHopInState(READY));
+    EXPECT_TRUE (shouldHopInState(PRELAUNCH));
+    EXPECT_TRUE (shouldHopInState(INFLIGHT));
+    EXPECT_FALSE(shouldHopInState(LANDED));
+}
+
+TEST(ShouldHopInState, Uint8OverloadMatchesEnum) {
+    // The BS receives state numerically from the LoRa downlink, so the
+    // uint8_t overload must agree bit-for-bit with the enum overload.
+    for (uint8_t s = 0; s <= 4; s++)
+    {
+        EXPECT_EQ(shouldHopInState(s),
+                  shouldHopInState((RocketState)s)) << "state=" << (int)s;
+    }
+}
+
+// ============================================================================
+// Issues #40 / #41: channel-set helpers
 // ============================================================================
 
 TEST(LoRaChannelSet, FastPreset_BW500) {

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -1,5 +1,6 @@
 #include "TR_LoRa_Comms.h"
 #include <esp_log.h>
+#include <cmath>
 
 static const char* TAG = "LORA";
 
@@ -403,6 +404,42 @@ rollback:
     if (steps_done >= 2) (void)radio_->setSpreadingFactor(old_sf);
     if (steps_done >= 1) (void)radio_->setBandwidth(old_bw);
     return false;
+}
+
+// ============================================================================
+// Lightweight frequency-only retune for per-packet hopping (#40 / #41)
+// ============================================================================
+
+bool TR_LoRa_Comms::hopToFrequencyMHz(float freq_mhz)
+{
+    if (!enabled_ || radio_ == nullptr)         return false;
+    if (tx_ongoing_)                            return false;  // can't retune mid-TX
+    if (scan_state_ != ScanState::Idle &&
+        scan_state_ != ScanState::Done)         return false;  // can't retune mid-scan
+
+    // No-op fast path: already on the requested frequency (within
+    // floating-point slop).  Avoids unnecessary radio churn when the
+    // hop state machine asks for the channel we're already on.
+    if (fabsf(freq_mhz - cfg_freq_mhz_) < 0.0005f) return true;
+
+    int16_t st = radio_->setFrequency(freq_mhz);
+    if (st != RADIOLIB_ERR_NONE)
+    {
+        stats_.last_error = st;
+        if (debug_) ESP_LOGE(TAG, "LoRa hopToFrequency failed: %d", st);
+        return false;
+    }
+    cfg_freq_mhz_ = freq_mhz;
+
+    // Re-enter RX so a packet on the new frequency lands without an
+    // explicit caller-side startReceive().  Mirrors what reconfigure()
+    // does after a successful parameter change.
+    if (rx_mode_)
+    {
+        rx_done_ = false;
+        radio_->startReceive();
+    }
+    return true;
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -422,23 +422,38 @@ bool TR_LoRa_Comms::hopToFrequencyMHz(float freq_mhz)
     // hop state machine asks for the channel we're already on.
     if (fabsf(freq_mhz - cfg_freq_mhz_) < 0.0005f) return true;
 
+    // Mirror the established pattern from reconfigure() / startScan():
+    // mark RX as exited *before* issuing any SPI to the radio.  Two
+    // reasons:
+    //   1. RadioLib's setFrequency on SX126x is multi-step (standby →
+    //      calibrateImage → setRfFreq → setOutputPower).  Field testing
+    //      crashed inside ESP-IDF's spi_bus_lock_bg_exit (NULL deref on
+    //      lock->acquiring_dev — a TOCTOU race in the driver's
+    //      ISR-completion path) when these bursts overlapped with
+    //      DIO1-ISR-triggered rx_done_ handling.
+    //   2. Without this, our own DIO1 ISR (gated on rx_mode_) would
+    //      latch rx_done_ on any spurious DIO1 edge during the retune,
+    //      causing the main loop to fire off a readPacket() SPI burst
+    //      on top of the in-flight ones.
+    const bool was_rx = rx_mode_;
+    rx_mode_ = false;
+    rx_done_ = false;
+
     int16_t st = radio_->setFrequency(freq_mhz);
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
         if (debug_) ESP_LOGE(TAG, "LoRa hopToFrequency failed: %d", st);
+        // Best-effort: if we were in RX, try to get back so a single
+        // failed retune doesn't strand the radio in standby.
+        if (was_rx) (void)startReceive();
         return false;
     }
     cfg_freq_mhz_ = freq_mhz;
 
-    // Re-enter RX so a packet on the new frequency lands without an
-    // explicit caller-side startReceive().  Mirrors what reconfigure()
-    // does after a successful parameter change.
-    if (rx_mode_)
-    {
-        rx_done_ = false;
-        radio_->startReceive();
-    }
+    // Re-enter RX via the canonical wrapper so internal flag state
+    // matches what the rest of the codebase expects after a fresh RX.
+    if (was_rx) (void)startReceive();
     return true;
 }
 

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -66,6 +66,22 @@ public:
     // Runtime reconfiguration (LLCC68: must set BW before SF)
     bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power);
 
+    // Lightweight frequency-only retune for per-packet hopping (#40 / #41).
+    // Unlike reconfigure(), this does not touch BW/SF/CR/power — those
+    // remain locked across hops within a session.  Returns false if the
+    // radio is mid-TX, mid-scan, or the underlying setFrequency call fails;
+    // in those cases the caller should keep its current channel state and
+    // try again on the next packet boundary.  If the radio was in RX mode,
+    // it re-enters RX after the retune so the next packet is received on
+    // the new frequency without an extra startReceive() call from the
+    // caller.
+    bool hopToFrequencyMHz(float freq_mhz);
+
+    // Reports the radio's currently-tuned frequency in MHz (the last value
+    // accepted by reconfigure() or hopToFrequencyMHz()).  Useful for the
+    // hop state machine to detect whether a retune is actually required.
+    float currentFrequencyMHz() const { return cfg_freq_mhz_; }
+
     // ---- Spectrum scan (pre-launch collision avoidance) ------------------
     // Non-blocking channel-hopping RSSI scan. Step through a frequency range,
     // dwell in RX mode for `dwell_ms` per channel, then read instantaneous

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -85,6 +85,30 @@ static inline bool shouldBeaconInState(RocketState s)
     return s != INFLIGHT;
 }
 
+// Whether per-packet channel hopping should be active in this state.
+// PRELAUNCH and INFLIGHT only — ground states (READY/LANDED/INITIALIZATION)
+// stay on the static configured channel so configuration, recovery, and
+// initial handshake stay simple and predictable.
+//
+// Hopping starts at PRELAUNCH (rather than INFLIGHT) so the behaviour gets
+// real ground-test airtime before the rocket leaves the pad — that's the
+// window where defects are cheap to find.
+//
+// Edge case: a post-flight LANDED → PRELAUNCH transition (rocket regains
+// GPS without a power cycle) would also activate hopping, which is
+// suboptimal for recovery.  The existing rendezvous fallback recovers
+// from this gracefully if it ever happens; revisit with a sticky
+// "post-flight" gate if it bites.
+static inline bool shouldHopInState(RocketState s)
+{
+    return s == PRELAUNCH || s == INFLIGHT;
+}
+
+static inline bool shouldHopInState(uint8_t s)
+{
+    return shouldHopInState((RocketState)s);
+}
+
 // ============================================================================
 // Channel-set generator for per-packet frequency hopping (issues #40 / #41)
 // ============================================================================

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -121,6 +121,31 @@ static inline void updateFreqLockFromRocketState(uint8_t s)
     freq_locked_for_flight = computeFreqLockForFlight(freq_locked_for_flight, s);
 }
 
+// ----------------------------------------------------------------------------
+// Per-packet channel-hop state (issues #40 / #41, phase 2a — BS side)
+// ----------------------------------------------------------------------------
+// The BS is purely reactive: the rocket owns the hop sequence, and the BS
+// retunes after each successful RX based on the packet's next_channel_idx.
+// hop_active_ tracks whether we're currently following a hopping rocket;
+// hop_idx_ is the channel we're (about to be) tuned to for the next RX.
+//
+// Multi-rocket caveat (deliberately punted to a follow-up): if the BS is
+// tracking more than one rocket, only one of them can drive the hop
+// sequence at a time.  v2a follows whichever rocket's packet arrived
+// most recently, which works fine when there's just one rocket on the
+// link — the dominant case for our setup.
+static bool     hop_active_       = false;
+static uint8_t  hop_idx_          = 0;
+static bool     hop_needs_retune_ = false;
+static uint32_t hop_last_rx_ms_   = 0;
+
+// If we're following a hopping rocket and packets dry up for this long,
+// give up and fall back to lora_freq_mhz so the existing silence /
+// recovery machinery can take over.  Sized to swallow a handful of
+// missed hop windows even at the slowest preset (Long Range = ~2 Hz),
+// without holding the radio hostage if the rocket really has vanished.
+static constexpr uint32_t HOP_SILENCE_FALLBACK_MS = 3000;
+
 // Per-rocket tracker (replaces single last_decoded for multi-rocket support)
 static constexpr int MAX_TRACKED_ROCKETS = 4;
 struct TrackedRocket {
@@ -975,9 +1000,11 @@ static constexpr uint32_t TXN_MAX_RELAY_MS     = 3000;  // Upper bound on relay 
 static bool startLoRaTransaction(float new_freq, float new_bw,
                                  uint8_t new_sf, uint8_t new_cr, int8_t new_pwr)
 {
-    if (freq_locked_for_flight)
+    if (freq_locked_for_flight || hop_active_)
     {
-        ESP_LOGW(TAG, "[TXN] Refused: frequency locked for flight");
+        ESP_LOGW(TAG, "[TXN] Refused: %s",
+                 freq_locked_for_flight ? "frequency locked for flight"
+                                        : "channel hopping active");
         sendCurrentConfig();
         return false;
     }
@@ -1255,10 +1282,14 @@ static void recoveryPushRocketHome()
 
 static void serviceRecovery()
 {
-    // While locked for flight, accept silence — no hopping, no alarms.
-    if (freq_locked_for_flight)
+    // While locked for flight, or while actively hopping with the rocket,
+    // accept silence — neither is a recovery scenario.  In flight, momentary
+    // SNR dips look like silence; while hopping (#40 / #41), the recovery
+    // hop scan and the hop sequence would fight each other for the radio.
+    if (freq_locked_for_flight || hop_active_)
     {
-        if (recovery_state != RecoveryState::IDLE) recoveryEnd("flight locked");
+        if (recovery_state != RecoveryState::IDLE)
+            recoveryEnd(freq_locked_for_flight ? "flight locked" : "hopping active");
         return;
     }
     // Transactional reconfigure takes priority.  A BLE Cmd 10 arriving
@@ -1671,6 +1702,37 @@ static void loop_bs()
     lora_comms.service();
     lora_comms.pollDio1();  // Fallback if DIO1 interrupt doesn't fire
 
+    // Hop-silence fallback: if we've been following a hopping rocket but
+    // haven't heard from it in HOP_SILENCE_FALLBACK_MS, drop back to the
+    // static channel so the standard silence / recovery machinery can
+    // take over.  Without this, hop_active_ would pin the BS to a hop
+    // channel forever after a lost rocket — recovery itself is
+    // suppressed while hop_active_ for the opposite reason (don't
+    // recover during normal hop misses).
+    if (hop_active_ && hop_last_rx_ms_ != 0 &&
+        (millis() - hop_last_rx_ms_) > HOP_SILENCE_FALLBACK_MS)
+    {
+        ESP_LOGW(TAG, "[HOP] Silence > %u ms — falling back to static channel",
+                 (unsigned)HOP_SILENCE_FALLBACK_MS);
+        hop_active_       = false;
+        hop_needs_retune_ = true;
+    }
+
+    // Honour any pending hop retune — the RX path defers the actual
+    // setFrequency call to here so the radio finishes any in-flight
+    // operation first (#40 / #41 phase 2a).
+    if (hop_needs_retune_ && lora_comms.canSend())
+    {
+        const float target = hop_active_
+            ? loraChannelMHz(lora_bw_khz, hop_idx_)
+            : lora_freq_mhz;
+        if (target > 0.0f)
+        {
+            (void)lora_comms.hopToFrequencyMHz(target);
+        }
+        hop_needs_retune_ = false;
+    }
+
     // Check for received packet
     uint8_t rx_buf[256];
     size_t rx_len = 0;
@@ -1764,6 +1826,35 @@ static void loop_bs()
 
                 last_rocket_state = decoded.rocket_state;
                 updateFreqLockFromRocketState(decoded.rocket_state);
+
+                // Hop state follow (#40 / #41 phase 2a).  The rocket owns
+                // the schedule; we just retune to wherever its packet says
+                // we should be next.  Honoured as soon as the radio is
+                // idle (top of serviceLoRa) — we don't retune in the RX
+                // callback path because the radio still has work to do.
+                if (shouldHopInState(decoded.rocket_state))
+                {
+                    if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
+                    {
+                        const uint8_t n = loraChannelCount(lora_bw_khz);
+                        if (n > 0 && decoded.next_channel_idx < n)
+                        {
+                            hop_idx_           = decoded.next_channel_idx;
+                            hop_active_        = true;
+                            hop_needs_retune_  = true;
+                            hop_last_rx_ms_    = millis();
+                        }
+                    }
+                }
+                else if (hop_active_)
+                {
+                    // Rocket is no longer in a hop state — return to the
+                    // static configured channel so recovery / ground
+                    // comms resume on a known frequency.
+                    hop_active_       = false;
+                    hop_needs_retune_ = true;
+                }
+
                 last_known_camera_recording = decoded.camera_recording;
 
                 // Update per-rocket tracker

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1402,6 +1402,14 @@ static uint32_t last_heartbeat_tx_ms = 0;
 static void serviceHeartbeat()
 {
     if (freq_locked_for_flight)                return;  // No heartbeats in flight
+    // Suppress while channel hopping is active (#40 / #41 phase 2a).
+    // Heartbeats only exist to reset the rocket's slow-rendezvous timer
+    // (#71), and that timer is already suppressed during hopping — so a
+    // heartbeat here is pure airtime noise.  Worse, the 2-retry pattern
+    // (~200 ms total TX window) is large enough to collide with the
+    // rocket's ~500 ms-spaced TX slot, and a collision desyncs the hop
+    // state until the 3 s silence fallback fires.  Bench-confirmed.
+    if (hop_active_)                           return;
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (uplink_pending)                        return;  // Don't clobber a real cmd
@@ -1839,10 +1847,19 @@ static void loop_bs()
                         const uint8_t n = loraChannelCount(lora_bw_khz);
                         if (n > 0 && decoded.next_channel_idx < n)
                         {
+                            const bool was_active = hop_active_;
                             hop_idx_           = decoded.next_channel_idx;
                             hop_active_        = true;
                             hop_needs_retune_  = true;
                             hop_last_rx_ms_    = millis();
+                            if (!was_active)
+                            {
+                                ESP_LOGI(TAG, "[HOP] Active: %u channels at BW=%.0f kHz, "
+                                              "first hop -> idx=%u (%.3f MHz)",
+                                         (unsigned)n, (double)lora_bw_khz,
+                                         (unsigned)hop_idx_,
+                                         (double)loraChannelMHz(lora_bw_khz, hop_idx_));
+                            }
                         }
                     }
                 }
@@ -1853,6 +1870,8 @@ static void loop_bs()
                     // comms resume on a known frequency.
                     hop_active_       = false;
                     hop_needs_retune_ = true;
+                    ESP_LOGI(TAG, "[HOP] Inactive (rocket state changed): "
+                                  "returning to %.2f MHz", (double)lora_freq_mhz);
                 }
 
                 last_known_camera_recording = decoded.camera_recording;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1399,20 +1399,34 @@ static constexpr uint32_t HEARTBEAT_RX_FRESH_MS = 5000;   // rocket "alive"
 static constexpr uint8_t  HEARTBEAT_RETRIES     = 2;
 static uint32_t last_heartbeat_tx_ms = 0;
 
+// Safe-window guard for BS uplinks while the rocket is hopping
+// (#40 / #41 phase 2b).  The rocket TXes telemetry at a fixed rate
+// (typ. 2 Hz = 500 ms cycle); after we RX a packet, we know the
+// rocket is in RX mode for the rest of its slot.  TXing within
+// ~150 ms of that RX guarantees we finish well before the rocket's
+// next TX, avoiding the desync collision pattern that broke the
+// link in phase 2a bench testing.
+static constexpr uint32_t HOP_BS_TX_SAFE_WINDOW_MS = 150;
+
+static inline bool inHopSafeWindow()
+{
+    if (!hop_active_) return true;             // not hopping → always safe
+    if (last_packet_ms == 0) return false;     // never RX'd → no anchor
+    return (millis() - last_packet_ms) <= HOP_BS_TX_SAFE_WINDOW_MS;
+}
+
 static void serviceHeartbeat()
 {
     if (freq_locked_for_flight)                return;  // No heartbeats in flight
-    // Suppress while channel hopping is active (#40 / #41 phase 2a).
-    // Heartbeats only exist to reset the rocket's slow-rendezvous timer
-    // (#71), and that timer is already suppressed during hopping — so a
-    // heartbeat here is pure airtime noise.  Worse, the 2-retry pattern
-    // (~200 ms total TX window) is large enough to collide with the
-    // rocket's ~500 ms-spaced TX slot, and a collision desyncs the hop
-    // state until the 3 s silence fallback fires.  Bench-confirmed.
-    if (hop_active_)                           return;
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (uplink_pending)                        return;  // Don't clobber a real cmd
+    // While hopping, only TX in the safe window right after a fresh
+    // rocket RX — see HOP_BS_TX_SAFE_WINDOW_MS comment.  Without this,
+    // the heartbeat's 2-retry burst (~200 ms) collides with the
+    // rocket's ~500 ms-spaced TX, desyncs the hop sequence, and the
+    // link drops until the 3 s hop-silence fallback fires.
+    if (!inHopSafeWindow())                    return;
 
     const uint32_t now = millis();
     // Only heartbeat when we've recently heard the rocket.  If rocket has

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -378,6 +378,10 @@ static inline void updateHopFromState(RocketState s)
         hop_first_pkt_    = true;
         hop_idx_          = 0;
         hop_needs_retune_ = true;  // ensure we're on lora_freq_mhz before TXing
+        ESP_LOGI("OC", "[HOP] Active: bootstrap on %.2f MHz, then idx=0 "
+                       "(%u channels at BW=%.0f kHz)",
+                 (double)lora_freq_mhz, (unsigned)loraChannelCount(lora_bw_khz),
+                 (double)lora_bw_khz);
     }
     else if (!want_active && hop_active_)
     {
@@ -387,6 +391,7 @@ static inline void updateHopFromState(RocketState s)
         hop_active_       = false;
         hop_first_pkt_    = false;
         hop_needs_retune_ = true;
+        ESP_LOGI("OC", "[HOP] Inactive: returning to %.2f MHz", (double)lora_freq_mhz);
     }
 }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -338,6 +338,72 @@ static inline void updateFreqLockFromState(RocketState s)
     freq_locked_for_flight = computeFreqLockForFlight(freq_locked_for_flight, s);
 }
 
+// ----------------------------------------------------------------------------
+// Per-packet channel-hop state (issues #40 / #41, phase 2a)
+// ----------------------------------------------------------------------------
+// hop_active_       = true once we've started hopping (PRELAUNCH/INFLIGHT).
+// hop_idx_          = index into the channel table for the channel we're
+//                     currently tuned to (or, equivalently, the channel of
+//                     the packet most recently transmitted).  Meaningless
+//                     while inactive.
+// hop_first_pkt_    = true on the very first TX after activating: that
+//                     packet still goes out on the static lora_freq_mhz
+//                     channel with next_channel_idx = 0, so the BS sees
+//                     the transition and follows without needing time
+//                     sync.  Cleared after the packet is queued.
+// hop_needs_retune_ = a retune is owed (e.g. just transitioned, or just
+//                     finished a TX and need to step to the next channel).
+//                     Honoured at the top of serviceLoRa as soon as the
+//                     radio is idle (canSend()).
+//
+// The hop sequence in v2a is intentionally simple: linear (idx, idx+1, …)
+// mod the channel-set count from the active BW.  Replacing this with a
+// PRNG seeded by network_id is a follow-up; the wire format does not
+// change so it can drop in without coordination.
+static bool    hop_active_        = false;
+static uint8_t hop_idx_           = 0;
+static bool    hop_first_pkt_     = false;
+static bool    hop_needs_retune_  = false;
+
+static inline void updateHopFromState(RocketState s)
+{
+    const bool want_active = shouldHopInState(s);
+    if (want_active && !hop_active_)
+    {
+        // OFF → ON.  Bootstrap: the next TX still goes out on
+        // lora_freq_mhz with next_channel_idx = 0 so the BS sees the
+        // transition; we retune to channel 0 only after that packet is
+        // in the air.
+        hop_active_       = true;
+        hop_first_pkt_    = true;
+        hop_idx_          = 0;
+        hop_needs_retune_ = true;  // ensure we're on lora_freq_mhz before TXing
+    }
+    else if (!want_active && hop_active_)
+    {
+        // ON → OFF (e.g. INFLIGHT → LANDED): leave the table and return
+        // to the static configured channel so recovery / ground comms
+        // resume on a known frequency.
+        hop_active_       = false;
+        hop_first_pkt_    = false;
+        hop_needs_retune_ = true;
+    }
+}
+
+// Frequency the radio should currently be tuned to, given the hop state.
+// First-packet bootstrap and inactive both stay on lora_freq_mhz; the
+// active steady state uses the channel table for the current BW.
+static inline float hopTargetFreqMHz()
+{
+    if (hop_active_ && !hop_first_pkt_)
+    {
+        const float f = loraChannelMHz(lora_bw_khz, hop_idx_);
+        if (f > 0.0f) return f;
+        // Channel table empty (BW invalid) — fall through to static.
+    }
+    return lora_freq_mhz;
+}
+
 // Servo/PID config cache (mirrored from FlightComputer for BLE readback)
 static int16_t cfg_servo_bias1 = 0;
 static int16_t cfg_servo_hz    = 50;
@@ -1186,6 +1252,9 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             // changes (issue #71).  Safe to call on every frame — the
             // function only flips the bool on INFLIGHT / READY edges.
             updateFreqLockFromState(latest_rocket_state);
+            // Drive the per-packet hop state machine off the same edge
+            // (issues #40 / #41).  Pure function; idempotent per state.
+            updateHopFromState(latest_rocket_state);
 
             // Latch the moment we entered READY so the slow-rendezvous
             // silence timer has a fair starting point.  Boot-time READY
@@ -1465,9 +1534,30 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
 
     LoRaDataSI lora = {};
     // Routing header
-    lora.network_id       = network_id;
-    lora.rocket_id        = rocket_id;
-    lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;  // phase 1: hop logic deferred
+    lora.network_id = network_id;
+    lora.rocket_id  = rocket_id;
+    // Hop byte (#40 / #41 phase 2a).  Either tell the BS where we'll be
+    // for the next packet, or send the no-hop sentinel if hopping is off.
+    if (hop_active_)
+    {
+        if (hop_first_pkt_)
+        {
+            // Bootstrap: this packet still goes out on lora_freq_mhz.
+            // Tell the BS to follow us to channel 0 for the next one.
+            lora.next_channel_idx = 0;
+        }
+        else
+        {
+            const uint8_t n = loraChannelCount(lora_bw_khz);
+            lora.next_channel_idx = (n > 0)
+                ? (uint8_t)((hop_idx_ + 1) % n)
+                : LORA_NEXT_CH_NO_HOP;
+        }
+    }
+    else
+    {
+        lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;
+    }
 
     if (latest_gnss_valid)
     {
@@ -1553,6 +1643,16 @@ static void serviceLoRa()
 
     lora_comms.service();
 
+    // Honour any pending hop retune as soon as the radio is idle.  The
+    // post-TX path below sets hop_needs_retune_ when the previous TX
+    // completed, since send() returns when the TX *starts*, not when it
+    // finishes — canSend() going true is our "TX done" signal.
+    if (hop_needs_retune_ && lora_comms.canSend())
+    {
+        (void)lora_comms.hopToFrequencyMHz(hopTargetFreqMHz());
+        hop_needs_retune_ = false;
+    }
+
     const uint32_t now_ms = millis();
     const uint32_t period_ms = (config::LORA_TX_RATE_HZ > 0)
         ? (1000U / config::LORA_TX_RATE_HZ)
@@ -1576,6 +1676,26 @@ static void serviceLoRa()
     if (lora_comms.send(payload, sizeof(payload)))
     {
         lora_tx_ok++;
+
+        // Advance hop state and schedule the post-TX retune.  We can't
+        // retune here directly (TX is still in progress); the top of
+        // the next serviceLoRa iteration will catch it.
+        if (hop_active_)
+        {
+            if (hop_first_pkt_)
+            {
+                // Bootstrap packet just went out on lora_freq_mhz.
+                // hop_idx_ is already 0; clear the first-packet flag so
+                // the upcoming retune lands us on channel 0.
+                hop_first_pkt_ = false;
+            }
+            else
+            {
+                const uint8_t n = loraChannelCount(lora_bw_khz);
+                if (n > 0) hop_idx_ = (uint8_t)((hop_idx_ + 1) % n);
+            }
+            hop_needs_retune_ = true;
+        }
     }
     else
     {
@@ -1853,15 +1973,16 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
     {
         // LoRa reconfiguration via uplink: [freq:4f][bw:4f][sf:1][cr:1][txpwr:1]
 
-        // Inflight freeze (issue #71): refuse to change frequency once we
-        // are in flight.  Momentary silence in flight is almost always an
-        // SNR dip, not divergence, and hopping channels mid-flight would
-        // guarantee we lose the rest of the telemetry stream.  The base
-        // station is also expected to suppress its own recovery while
-        // rocket is in flight, so this branch is defence-in-depth.
-        if (freq_locked_for_flight)
+        // Reject reconfigures while the link is "committed" — either
+        // freq-locked for flight (issue #71) or actively hopping
+        // (#40 / #41).  Either case, changing modulation underneath the
+        // hop state machine would desynchronise the channel set on the
+        // two sides; the user must drop back to READY first.
+        if (freq_locked_for_flight || hop_active_)
         {
-            ESP_LOGW("LORA", "UPLINK Cmd 10 ignored: frequency locked for flight");
+            ESP_LOGW("LORA", "UPLINK Cmd 10 ignored: %s",
+                     freq_locked_for_flight ? "frequency locked for flight"
+                                            : "channel hopping active");
             return;
         }
 
@@ -2121,14 +2242,16 @@ static void serviceRocketRendezvous()
 {
     if (!config::USE_LORA_RADIO)  return;
     if (!peripherals_initialized) return;
-    // Suppress only in flight — INITIALIZATION/READY/PRELAUNCH/LANDED are
-    // all valid times to hunt for the BS via rendezvous.  Allowing
-    // INITIALIZATION matters: if the rocket booted before its FC came up
-    // (or the FC is unhappy), we'd otherwise never visit the rendezvous
-    // mode and the BS would never find us.
-    if (freq_locked_for_flight)
+    // Suppress while in flight (#71) or actively hopping (#40 / #41).
+    // The hop state machine and the slow-rendezvous cycle both want to
+    // own the radio frequency; running them concurrently would have the
+    // rocket disappear from the hop sequence every 30 s to visit the
+    // rendezvous freq, which defeats the point.
+    // INITIALIZATION/READY/LANDED stay eligible — those are recovery /
+    // pre-handshake situations where rendezvous is the right behaviour.
+    if (freq_locked_for_flight || hop_active_)
     {
-        rendezvousExit("flight locked");
+        rendezvousExit(freq_locked_for_flight ? "flight locked" : "hopping active");
         return;
     }
 
@@ -3689,13 +3812,16 @@ static void loop_oc()
             // LoRa reconfiguration: [freq:4f][bw:4f][sf:1][cr:1][txpwr:1]
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
-            // Inflight freeze (issue #71): refuse direct BLE reconfig in
-            // flight.  The iOS app already hides the apply button, but
-            // belt-and-braces in case of version skew.  We still send a
-            // readback so the app's UI reverts to the actual values.
-            if (plen >= 11 && freq_locked_for_flight)
+            // Refuse direct BLE reconfig while either (a) freq-locked
+            // for flight (#71) or (b) channel hopping is active
+            // (#40 / #41).  iOS app should already hide the apply button
+            // in both cases, but we belt-and-brace for version skew.
+            // Either way we send a readback so the app's UI reverts.
+            if (plen >= 11 && (freq_locked_for_flight || hop_active_))
             {
-                ESP_LOGW("BLE", "Cmd 10 ignored: frequency locked for flight");
+                ESP_LOGW("BLE", "Cmd 10 ignored: %s",
+                         freq_locked_for_flight ? "frequency locked for flight"
+                                                : "channel hopping active");
                 sendCurrentConfig();
             }
             else if (plen >= 11)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -365,6 +365,25 @@ static uint8_t hop_idx_           = 0;
 static bool    hop_first_pkt_     = false;
 static bool    hop_needs_retune_  = false;
 
+// Hop-silence rendezvous fallback state (#40 / #41 phase 2b).
+// Definitions of HOP_FALLBACK_*_MS constants and the serviceHopFallback()
+// function live further down with the other rendezvous machinery.
+enum class HopFallbackState : uint8_t {
+    NORMAL,
+    VISITING_RENDEZVOUS,
+};
+
+static HopFallbackState hop_fallback_state          = HopFallbackState::NORMAL;
+static uint32_t         hop_fallback_phase_start_ms = 0;
+static uint32_t         hop_active_entered_ms       = 0;
+static uint32_t         hop_session_uplink_count    = 0;  // resets each hop session
+
+// Tracks whether the radio is currently in RX mode.  Forward-declared
+// here so updateHopFromState() (just below) can reset it cleanly when
+// we exit a rendezvous visit.  Initialized at file scope further down
+// alongside the other LoRa-stats vars.
+static bool lora_in_rx_mode = false;
+
 static inline void updateHopFromState(RocketState s)
 {
     const bool want_active = shouldHopInState(s);
@@ -374,10 +393,13 @@ static inline void updateHopFromState(RocketState s)
         // lora_freq_mhz with next_channel_idx = 0 so the BS sees the
         // transition; we retune to channel 0 only after that packet is
         // in the air.
-        hop_active_       = true;
-        hop_first_pkt_    = true;
-        hop_idx_          = 0;
-        hop_needs_retune_ = true;  // ensure we're on lora_freq_mhz before TXing
+        hop_active_              = true;
+        hop_first_pkt_           = true;
+        hop_idx_                 = 0;
+        hop_needs_retune_        = true;  // ensure we're on lora_freq_mhz before TXing
+        hop_active_entered_ms    = millis();
+        hop_session_uplink_count = 0;
+        hop_fallback_state       = HopFallbackState::NORMAL;
         ESP_LOGI("OC", "[HOP] Active: bootstrap on %.2f MHz, then idx=0 "
                        "(%u channels at BW=%.0f kHz)",
                  (double)lora_freq_mhz, (unsigned)loraChannelCount(lora_bw_khz),
@@ -387,7 +409,17 @@ static inline void updateHopFromState(RocketState s)
     {
         // ON → OFF (e.g. INFLIGHT → LANDED): leave the table and return
         // to the static configured channel so recovery / ground comms
-        // resume on a known frequency.
+        // resume on a known frequency.  If we were mid-rendezvous-visit,
+        // come out of that first so the radio ends up with the saved
+        // modulation, not the rendezvous one.
+        if (hop_fallback_state == HopFallbackState::VISITING_RENDEZVOUS)
+        {
+            (void)lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
+                                          lora_cr, lora_tx_power);
+            (void)lora_comms.startReceive();
+            lora_in_rx_mode = true;
+            hop_fallback_state = HopFallbackState::NORMAL;
+        }
         hop_active_       = false;
         hop_first_pkt_    = false;
         hop_needs_retune_ = true;
@@ -466,7 +498,7 @@ static float max_speed_mps = 0.0f;
 static uint32_t lora_tx_ok = 0;
 static uint32_t lora_tx_fail = 0;
 static uint32_t last_lora_tx_ms = 0;
-static bool     lora_in_rx_mode = false;
+// lora_in_rx_mode forward-declared up with the hop state.
 static uint32_t lora_uplink_rx_count = 0;
 
 // Slow-rendezvous trackers (issue #71).  last_uplink_rx_ms bumps on every
@@ -1541,9 +1573,11 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
     // Routing header
     lora.network_id = network_id;
     lora.rocket_id  = rocket_id;
-    // Hop byte (#40 / #41 phase 2a).  Either tell the BS where we'll be
-    // for the next packet, or send the no-hop sentinel if hopping is off.
-    if (hop_active_)
+    // Hop byte (#40 / #41).  Either tell the BS where we'll be for the
+    // next packet, or send the no-hop sentinel.  During a rendezvous
+    // visit (phase 2b) we explicitly send the sentinel — we're parked
+    // on rendezvous, not following the hop schedule.
+    if (hop_active_ && hop_fallback_state == HopFallbackState::NORMAL)
     {
         if (hop_first_pkt_)
         {
@@ -1651,8 +1685,11 @@ static void serviceLoRa()
     // Honour any pending hop retune as soon as the radio is idle.  The
     // post-TX path below sets hop_needs_retune_ when the previous TX
     // completed, since send() returns when the TX *starts*, not when it
-    // finishes — canSend() going true is our "TX done" signal.
-    if (hop_needs_retune_ && lora_comms.canSend())
+    // finishes — canSend() going true is our "TX done" signal.  Skip
+    // during a rendezvous visit; the radio is being managed by
+    // serviceHopFallback() in that case.
+    if (hop_needs_retune_ && lora_comms.canSend() &&
+        hop_fallback_state == HopFallbackState::NORMAL)
     {
         (void)lora_comms.hopToFrequencyMHz(hopTargetFreqMHz());
         hop_needs_retune_ = false;
@@ -1684,8 +1721,10 @@ static void serviceLoRa()
 
         // Advance hop state and schedule the post-TX retune.  We can't
         // retune here directly (TX is still in progress); the top of
-        // the next serviceLoRa iteration will catch it.
-        if (hop_active_)
+        // the next serviceLoRa iteration will catch it.  Skip during a
+        // rendezvous visit — the radio is on rendezvous mode, not in
+        // the hop sequence.
+        if (hop_active_ && hop_fallback_state == HopFallbackState::NORMAL)
         {
             if (hop_first_pkt_)
             {
@@ -2146,6 +2185,7 @@ static void serviceLoRaUplink()
                     processUplinkCommand(cmd, &rx_buf[6], payload_len);
                     lora_uplink_rx_count++;
                     last_uplink_rx_ms = millis();
+                    if (hop_active_) hop_session_uplink_count++;
                 }
             }
         }
@@ -2317,6 +2357,116 @@ static void serviceRocketRendezvous()
                 rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
             }
             break;
+    }
+}
+
+// ============================================================================
+// Hop-silence rendezvous fallback (#40 / #41 phase 2b)
+// ============================================================================
+// While hop_active_, periodically check whether we've heard *anything*
+// from the base station recently.  If we haven't, briefly park on the
+// rendezvous channel/preset so a desynced BS — one whose 3 s
+// hop-silence fallback (loop_bs) fired and dropped to its static
+// channel — can find us via its existing recovery scan, which sweeps
+// to the rendezvous frequency in Phase A.
+//
+// This mirrors slow_rendezvous (#71) but with hop-aware triggers:
+//   • Reference time is the most recent LoRa uplink during the
+//     current hop session (or hop entry, if no uplink heard yet).
+//     Heartbeats from the BS — newly safe-window-scheduled in this
+//     phase — bump last_uplink_rx_ms every 30 s in nominal operation,
+//     so this trigger fires only when comms have actually broken.
+//   • Visit is a single short window (no on/off oscillation), then we
+//     re-bootstrap hopping with a fresh transition packet on
+//     lora_freq_mhz so the BS sees a clean re-entry.
+//
+// Suppressed when slow_rendezvous is busy (it owns the radio in that
+// case) and when not actually hopping.  HopFallbackState and its module
+// variables live up with the other hop_* state; constants live here
+// alongside the service function that uses them.
+
+static constexpr uint32_t HOP_FALLBACK_TRIGGER_INITIAL_MS = 30000;  // never heard BS yet
+static constexpr uint32_t HOP_FALLBACK_TRIGGER_QUIET_MS   = 60000;  // BS seen, then silent
+static constexpr uint32_t HOP_FALLBACK_VISIT_MS           = 3000;   // park 3 s on rendezvous
+
+static void serviceHopFallback()
+{
+    if (!hop_active_) return;
+    if (rendezvous_state != RocketRendezvousState::IDLE) return;  // slow_rendezvous owns the radio
+
+    const uint32_t now = millis();
+
+    switch (hop_fallback_state)
+    {
+        case HopFallbackState::NORMAL:
+        {
+            uint32_t ref;
+            uint32_t trigger;
+            if (hop_session_uplink_count == 0)
+            {
+                ref     = hop_active_entered_ms;
+                trigger = HOP_FALLBACK_TRIGGER_INITIAL_MS;
+            }
+            else
+            {
+                ref     = last_uplink_rx_ms;
+                trigger = HOP_FALLBACK_TRIGGER_QUIET_MS;
+            }
+            if ((now - ref) < trigger) return;
+
+            // Trigger: visit rendezvous.  reconfigure() switches
+            // BW/SF/CR/freq atomically (with rollback on failure) —
+            // same machinery as slow_rendezvous so the radio handling
+            // is identical and well-tested.
+            if (!lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+                                         config::LORA_RENDEZVOUS_SF,
+                                         config::LORA_RENDEZVOUS_BW_KHZ,
+                                         config::LORA_RENDEZVOUS_CR,
+                                         config::LORA_RENDEZVOUS_TX_POWER_DBM))
+            {
+                ESP_LOGE("OC", "[HOP] Visit failed: reconfigure to rendezvous mode");
+                return;
+            }
+            (void)lora_comms.startReceive();
+            lora_in_rx_mode = true;
+            hop_fallback_phase_start_ms = now;
+            hop_fallback_state = HopFallbackState::VISITING_RENDEZVOUS;
+            ESP_LOGW("OC", "[HOP] Silence %u s — visiting rendezvous %.2f MHz for %u s",
+                     (unsigned)((now - ref) / 1000),
+                     (double)config::LORA_RENDEZVOUS_MHZ,
+                     (unsigned)(HOP_FALLBACK_VISIT_MS / 1000));
+            break;
+        }
+        case HopFallbackState::VISITING_RENDEZVOUS:
+        {
+            if ((now - hop_fallback_phase_start_ms) < HOP_FALLBACK_VISIT_MS) return;
+
+            // Visit done.  Reconfigure back to the saved params and
+            // restart hopping with a fresh bootstrap so the BS sees a
+            // clean transition packet on lora_freq_mhz with
+            // next_channel_idx = 0.
+            if (!lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
+                                         lora_cr, lora_tx_power))
+            {
+                ESP_LOGE("OC", "[HOP] Visit failed: reconfigure back to saved params");
+                // Stay in VISITING_RENDEZVOUS; will retry on next call.
+                return;
+            }
+            (void)lora_comms.startReceive();
+            lora_in_rx_mode = true;
+
+            hop_first_pkt_    = true;
+            hop_idx_          = 0;
+            hop_needs_retune_ = false;  // already on lora_freq_mhz from reconfigure
+            hop_fallback_state = HopFallbackState::NORMAL;
+            // Restart trigger reference so the next visit fires only
+            // after a fresh QUIET window (or INITIAL if nothing
+            // arrives during this pass either).
+            hop_active_entered_ms = now;
+            hop_session_uplink_count = 0;
+            ESP_LOGI("OC", "[HOP] Visit done — resuming hop with fresh bootstrap");
+            break;
+        }
     }
 }
 
@@ -3335,6 +3485,11 @@ static void loop_oc()
         // the rocket has been silent in READY for a long time, so the base
         // station's Phase-A recovery has a meeting point (issue #71).
         serviceRocketRendezvous();
+
+        // Hop-silence rendezvous: same idea but gated for the hopping
+        // case (#40 / #41 phase 2b).  Active only while hop_active_ and
+        // suppressed when slow_rendezvous owns the radio.
+        serviceHopFallback();
 
         // Send name beacon so base station can identify us
         sendLoRaBeacon();


### PR DESCRIPTION
## Summary

Phase 2a of #40/#41 — activates the per-packet channel hopping wired in #85. Hopping starts on the **PRELAUNCH transition** (per [discussion](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/85)) and continues through INFLIGHT, giving real ground-test airtime to flush out defects before launch.

## How it works

- **Rocket owns the schedule.** Each rocket TX advertises `next_channel_idx` in the LoRa header and retunes after TX completes. The very first PRELAUNCH packet still goes out on `lora_freq_mhz` with `next_idx = 0`, so the BS sees the transition and follows without time sync.
- **Linear sequence** (i, i+1, …) mod N for v2a — covers 35 / 69 / 130 channels at the Fast / 250-kHz / Max Range presets across the 902-928 MHz ISM band. Swapping in a PRNG seeded by `network_id` is a follow-up that doesn't change the wire format.
- **BS is purely reactive** — retunes after each successful RX based on the packet's `next_channel_idx`.
- **Hop-silence fallback (3 s)** — if a hopping rocket goes silent, the BS drops back to `lora_freq_mhz` so the existing silence / recovery machinery (#71) can take over. Without this, `hop_active_` would pin the radio forever after a lost rocket. While normal hopping is active, recovery is suppressed so the recovery scan and the hop sequence don't fight for the radio.
- **Reconfigure interlock**: cmd-10 reconfigure (LoRa uplink + direct BLE on rocket, transactional path on BS) is now blocked when *either* `freq_locked_for_flight` (#71) or `hop_active_`. Changing modulation underneath the hop state machine would desynchronise the channel set on the two sides — drop to READY first.

## New code surface

- `shouldHopInState(RocketState)` / `shouldHopInState(uint8_t)` — pure helper, lives next to `computeFreqLockForFlight`. Independent so the well-tested freq-lock semantics for cmd 10 are unchanged.
- `TR_LoRa_Comms::hopToFrequencyMHz(float)` — lightweight retune that doesn't touch BW/SF/CR/power; refuses mid-TX or mid-scan.
- `TR_LoRa_Comms::currentFrequencyMHz()` — read-back accessor.

## Edge case (intentionally punted)

Post-flight `LANDED → PRELAUNCH` (rocket regains GPS without a power cycle) would also reactivate hopping, which is suboptimal for recovery. The hop-silence fallback recovers from this within 3 s; we'll add a sticky "post-flight" gate if it ever bites in practice. Documented in the `shouldHopInState` block comment.

## Test plan

- [x] Both ESP-IDF projects build clean (`./tools/build.sh out_computer build`, `./tools/build.sh base_station build`).
- [x] Full host-side suite passes (217/217), including new `ShouldHopInState.OnlyPrelaunchAndInflight` and `ShouldHopInState.Uint8OverloadMatchesEnum`.
- [ ] **Bench test**: rocket + BS together, force PRELAUNCH (e.g. simulate readiness), verify `nextCh=` in BS log walks the table monotonically, telemetry continues across hops.
- [ ] Bench test: force LANDED transition, verify both sides return to `lora_freq_mhz` and BS logs read `nextCh=--` again.
- [ ] Bench test: power-cycle rocket mid-hop, verify BS hits `[HOP] Silence > 3000 ms — falling back to static channel`, then recovery / re-acquisition behaves as before.
- [ ] Bench test: try cmd-10 from iOS app while hop is active → expect rejection with logged reason.

## Phase 3 / 4 follow-ups (separate PRs)

- Use #6 pre-launch scan results to pick rendezvous (and optionally exclude noisy channels).
- BLE-provisioned channel-set / rendezvous push.
- PRNG-seeded sequence to replace the linear one.
