### PR TITLE
lora: scan-derived rendezvous + skip-mask (#40 / #41 phase 3)

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -84,6 +84,143 @@ TEST(RocketComputerTypes, LoRaFlagEncoding) {
 }
 
 // ============================================================================
+// Issues #40 / #41 phase 3: channel-set selection from scan
+// ============================================================================
+
+TEST(LoraNextActiveChannel, BasicWraparoundNoMask) {
+    // Empty mask → just (idx + 1) mod n.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    EXPECT_EQ(loraNextActiveChannelIdx(0,  mask, 10), 1);
+    EXPECT_EQ(loraNextActiveChannelIdx(9,  mask, 10), 0);  // wrap
+    EXPECT_EQ(loraNextActiveChannelIdx(5,  mask, 10), 6);
+}
+
+TEST(LoraNextActiveChannel, SkipsMaskedChannels) {
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    // Skip channels 1, 2, 3 — from idx 0 we should jump to idx 4.
+    loraSkipMaskSet(mask, 1);
+    loraSkipMaskSet(mask, 2);
+    loraSkipMaskSet(mask, 3);
+    EXPECT_EQ(loraNextActiveChannelIdx(0, mask, 10), 4);
+    // From the last unmasked we should wrap past masked back to 0.
+    EXPECT_EQ(loraNextActiveChannelIdx(9, mask, 10), 0);
+}
+
+TEST(LoraNextActiveChannel, SkipsAcrossWrap) {
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    // Skip 9 (last) — from 8, wrap should go to 0, not 9.
+    loraSkipMaskSet(mask, 9);
+    EXPECT_EQ(loraNextActiveChannelIdx(8, mask, 10), 0);
+}
+
+TEST(LoraNextActiveChannel, AllMaskedDegenerateSafe) {
+    // Defensive — should never happen in practice (FCC floor prevents
+    // it), but loraNextActiveChannelIdx must still make progress.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES];
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) mask[i] = 0xFF;
+    const uint8_t next = loraNextActiveChannelIdx(0, mask, 10);
+    EXPECT_LT(next, 10);  // Some valid index in range; just don't crash.
+}
+
+TEST(LoraSelectChannelSet, NoScanResultsFallbacks) {
+    // No scan input: rendezvous = fallback, mask all-zero.
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(nullptr, nullptr, 0, /*bw_khz=*/250.0f,
+                          /*fallback=*/915.0f, &out);
+    EXPECT_FLOAT_EQ(out.rendezvous_mhz, 915.0f);
+    EXPECT_EQ(out.n_channels, loraChannelCount(250.0f));
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++)
+        EXPECT_EQ(out.skip_mask[i], 0u) << "byte " << i;
+}
+
+TEST(LoraSelectChannelSet, RendezvousIsScanMinimum) {
+    // Three scan points; pick the lowest-RSSI one as rendezvous.
+    const float   freqs[] = { 910.0f, 915.0f, 920.0f };
+    const int8_t  rssi[]  = {  -75,    -95,    -80 };  // 915 quietest
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(freqs, rssi, 3, 250.0f, 915.0f, &out);
+    EXPECT_FLOAT_EQ(out.rendezvous_mhz, 915.0f);
+}
+
+TEST(LoraSelectChannelSet, NoiseAboveThresholdGetsSkipped) {
+    // Build a synthetic scan that covers the BW=125 hop table (139
+    // channels, FCC floor 50).  Every grid point quiet at -110 dBm
+    // except a couple loud spikes well above median + 15.  Loud
+    // channels should be skipped while the floor stays satisfied.
+    const uint8_t n_chan = loraChannelCount(125.0f);
+    const size_t  N      = n_chan;
+    float  freqs[160];   // > LORA_SKIP_MASK_MAX_BYTES * 8 for safety
+    int8_t rssi[160];
+    for (size_t i = 0; i < N; i++) {
+        freqs[i] = loraChannelMHz(125.0f, (uint8_t)i);
+        rssi[i]  = -110;
+    }
+    rssi[10] = -60;   // very loud
+    rssi[55] = -50;   // very loud
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(freqs, rssi, N, 125.0f, 915.0f, &out);
+
+    EXPECT_EQ(out.n_channels, n_chan);
+    EXPECT_TRUE (loraSkipMaskTest(out.skip_mask, 10));
+    EXPECT_TRUE (loraSkipMaskTest(out.skip_mask, 55));
+    EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, 11));
+    EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, 0));
+
+    // Rendezvous picks one of the quiet -110 channels (any is fine).
+    EXPECT_NE(out.rendezvous_mhz, freqs[10]);
+    EXPECT_NE(out.rendezvous_mhz, freqs[55]);
+}
+
+TEST(LoraSelectChannelSet, FccFloorEnforced_BW250) {
+    // BW=250 → fhss_min=50.  If the relative threshold would skip more
+    // than (n - 50), enforce the floor by keeping the K quietest active.
+    const uint8_t n = loraChannelCount(250.0f);
+    ASSERT_GE(n, 50u);
+
+    constexpr size_t M = 70;  // assume n ≥ 50; build at-channel-rate scan
+    ASSERT_GE(n, M / 2);
+    float  freqs[M];
+    int8_t rssi[M];
+    for (size_t i = 0; i < M; i++) {
+        freqs[i] = 902.125f + (float)i * 0.375f;
+        // Make almost every channel "loud" — this would naively skip
+        // them all.  A handful are quiet.
+        rssi[i] = (i % 5 == 0) ? -100 : -50;
+    }
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(freqs, rssi, M, 250.0f, 915.0f, &out);
+
+    // Count active (non-skipped).  Must be ≥ fhss_min = 50.
+    uint8_t active = 0;
+    for (uint8_t i = 0; i < out.n_channels; i++)
+        if (!loraSkipMaskTest(out.skip_mask, i)) active++;
+    EXPECT_GE(active, loraFhssMinChannels(250.0f));
+}
+
+TEST(LoraSelectChannelSet, AllQuietSkipsNothing) {
+    // If every scan point is roughly the same RSSI, no channel exceeds
+    // median+15 and the mask stays empty.
+    constexpr size_t N = 53;
+    float  freqs[N];
+    int8_t rssi[N];
+    for (size_t i = 0; i < N; i++) {
+        freqs[i] = 902.0f + (float)i * 0.5f;
+        rssi[i]  = -105 + (int8_t)(i % 3);  // tiny variation
+    }
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(freqs, rssi, N, 250.0f, 915.0f, &out);
+
+    for (uint8_t i = 0; i < out.n_channels; i++)
+        EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, i)) << "channel " << (int)i;
+}
+
+TEST(LoraFhssMinChannels, BoundaryValues) {
+    EXPECT_EQ(loraFhssMinChannels(125.0f), 50u);  // narrow → strict
+    EXPECT_EQ(loraFhssMinChannels(250.0f), 50u);  // exactly 250 — at boundary
+    EXPECT_EQ(loraFhssMinChannels(500.0f), 25u);  // wide → relaxed
+}
+
+// ============================================================================
 // Issues #40 / #41: per-packet channel hopping — state gate
 // ============================================================================
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -165,6 +165,181 @@ static inline float loraChannelMHz(float bw_khz, uint8_t idx)
     return min_f + spacing * (float)idx;
 }
 
+// ============================================================================
+// Channel-set selection from pre-launch scan (#40 / #41 phase 3)
+// ============================================================================
+// After the pre-launch frequency scan (#6), the BS analyzes the result to
+// pick (a) a rendezvous channel — the quietest frequency in the scanned
+// range — and (b) a per-preset skip-mask of channels too noisy to use for
+// hopping.  Both are then pushed to the rocket via LORA_CMD_CHANNEL_SET
+// so the per-packet hop sequence skips noisy channels and the
+// slow-rendezvous fallback uses the quietest meeting point.
+//
+// Skip-mask packing: bit i of byte (i / 8) represents channel i, LSB
+// first.  A 1 means "skip this channel."  The mask is sized for the
+// largest hop table we generate (139 channels at Max Range / BW=125,
+// rounded up to 18 bytes = 144 bits).
+//
+// Threshold rule: a channel is marked as skip if its peak RSSI exceeds
+// median(all channel peaks) + LORA_NOISE_THRESHOLD_DB.  An FCC floor
+// (loraFhssMinChannels) is applied last — if the relative rule would
+// take the active count below the floor, we instead keep the K quietest
+// channels and skip the rest, regardless of absolute level.
+
+static constexpr size_t  LORA_SKIP_MASK_MAX_BYTES = 18;   // 18*8 = 144 bits ≥ 139 channels
+static constexpr uint8_t LORA_NOISE_THRESHOLD_DB  = 15;   // skip if peak > median + this
+static constexpr uint8_t LORA_CMD_CHANNEL_SET     = 15;   // uplink cmd: rendezvous + mask
+
+// FCC Part 15.247 minimum channel count for FHSS classification.  We
+// operate as digital modulation (DTS) so this isn't strictly binding,
+// but keeping ≥ this many channels active also preserves the diversity
+// that motivates hopping in the first place.
+static inline uint8_t loraFhssMinChannels(float bw_khz)
+{
+    return (bw_khz <= 250.0f) ? 50 : 25;
+}
+
+// Skip-mask bit accessors (LSB-first within each byte).
+static inline bool loraSkipMaskTest(const uint8_t* mask, uint8_t idx)
+{
+    return (mask[idx >> 3] >> (idx & 7)) & 1u;
+}
+
+static inline void loraSkipMaskSet(uint8_t* mask, uint8_t idx)
+{
+    mask[idx >> 3] |= (uint8_t)(1u << (idx & 7));
+}
+
+// Given the current channel index and a skip-mask, returns the next
+// active (non-skipped) channel index, wrapping at n_channels.  Used by
+// both sides when computing next_channel_idx for the hop header.  If
+// every channel were masked (defensive — the FCC floor prevents this),
+// returns (current + 1) % n_channels so we still make progress.
+static inline uint8_t loraNextActiveChannelIdx(
+    uint8_t current_idx, const uint8_t* mask, uint8_t n_channels)
+{
+    if (n_channels == 0) return 0;
+    for (uint8_t step = 1; step <= n_channels; step++)
+    {
+        const uint8_t cand = (uint8_t)((current_idx + step) % n_channels);
+        if (!loraSkipMaskTest(mask, cand)) return cand;
+    }
+    return (uint8_t)((current_idx + 1) % n_channels);
+}
+
+typedef struct
+{
+    float   rendezvous_mhz;                     // best-quietest scan freq, or fallback
+    uint8_t n_channels;                         // hop table size for the given BW
+    uint8_t skip_mask[LORA_SKIP_MASK_MAX_BYTES]; // 1 = skip, LSB-first
+} LoRaChannelSetSelection;
+
+// Find the scan grid point with frequency closest to center_mhz; return
+// its RSSI.  Returns INT8_MIN if scan_count is zero.
+static inline int8_t loraScanRssiAtMHz(
+    const float* scan_freqs, const int8_t* scan_rssi,
+    size_t scan_count, float center_mhz)
+{
+    if (scan_count == 0) return INT8_MIN;
+    size_t best = 0;
+    float best_dist = scan_freqs[0] - center_mhz;
+    if (best_dist < 0) best_dist = -best_dist;
+    for (size_t i = 1; i < scan_count; i++)
+    {
+        float d = scan_freqs[i] - center_mhz;
+        if (d < 0) d = -d;
+        if (d < best_dist) { best = i; best_dist = d; }
+    }
+    return scan_rssi[best];
+}
+
+// Insertion-sort + median.  In-place.  n ≤ 130 in practice, so O(n²)
+// is fine (~17k ops, microseconds on ESP32).
+static inline int8_t loraI8MedianInPlace(int8_t* arr, size_t n)
+{
+    if (n == 0) return INT8_MIN;
+    for (size_t i = 1; i < n; i++)
+    {
+        const int8_t key = arr[i];
+        size_t j = i;
+        while (j > 0 && arr[j - 1] > key) { arr[j] = arr[j - 1]; j--; }
+        arr[j] = key;
+    }
+    return arr[n / 2];
+}
+
+// Pure orchestrator.  Computes rendezvous freq + skip-mask for the
+// current operating BW from a (freq, rssi) scan grid.  See the comment
+// block above for the threshold rule and FCC-floor handling.
+//
+// fallback_rendezvous_mhz is used when scan_count == 0 (e.g., scan
+// never run yet, or skipped).  In that case skip_mask is left all-zero
+// (no skips) and n_channels reflects the BW table.
+static inline void loraSelectChannelSet(
+    const float* scan_freqs, const int8_t* scan_rssi, size_t scan_count,
+    float bw_khz, float fallback_rendezvous_mhz,
+    LoRaChannelSetSelection* out)
+{
+    out->n_channels = loraChannelCount(bw_khz);
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) out->skip_mask[i] = 0;
+
+    if (scan_count == 0 || out->n_channels == 0)
+    {
+        out->rendezvous_mhz = fallback_rendezvous_mhz;
+        return;
+    }
+
+    // (1) Rendezvous = lowest-RSSI scan point.
+    {
+        size_t best = 0;
+        for (size_t i = 1; i < scan_count; i++)
+        {
+            if (scan_rssi[i] < scan_rssi[best]) best = i;
+        }
+        out->rendezvous_mhz = scan_freqs[best];
+    }
+
+    // (2) Per-channel peak RSSI from the nearest scan grid point.
+    int8_t peak[LORA_SKIP_MASK_MAX_BYTES * 8];
+    for (uint8_t i = 0; i < out->n_channels; i++)
+    {
+        const float c = loraChannelMHz(bw_khz, i);
+        peak[i] = loraScanRssiAtMHz(scan_freqs, scan_rssi, scan_count, c);
+    }
+
+    // (3) Median + threshold.
+    int8_t sorted[LORA_SKIP_MASK_MAX_BYTES * 8];
+    for (uint8_t i = 0; i < out->n_channels; i++) sorted[i] = peak[i];
+    const int8_t median    = loraI8MedianInPlace(sorted, out->n_channels);
+    const int    threshold = (int)median + (int)LORA_NOISE_THRESHOLD_DB;
+
+    // (4) Initial mask: channels above threshold.
+    uint8_t skip_count = 0;
+    for (uint8_t i = 0; i < out->n_channels; i++)
+    {
+        if ((int)peak[i] > threshold)
+        {
+            loraSkipMaskSet(out->skip_mask, i);
+            skip_count++;
+        }
+    }
+
+    // (5) FCC floor: keep at least fhss_min channels active.  If the
+    // relative rule wants more than that skipped, fall back to "keep
+    // the quietest fhss_min" by re-deriving from the sorted peaks.
+    const uint8_t fhss_min = loraFhssMinChannels(bw_khz);
+    const uint8_t active   = (uint8_t)(out->n_channels - skip_count);
+    if (active < fhss_min && fhss_min <= out->n_channels)
+    {
+        const int8_t cutoff = sorted[fhss_min - 1];
+        for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) out->skip_mask[i] = 0;
+        for (uint8_t i = 0; i < out->n_channels; i++)
+        {
+            if (peak[i] > cutoff) loraSkipMaskSet(out->skip_mask, i);
+        }
+    }
+}
+
 // Payload sent with OUT_STATUS_QUERY so the OUT processor can configure
 // its SensorConverter consistently with the FlightComputer.
 typedef struct __attribute__((packed))

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -157,6 +157,7 @@ static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
 // boot-time NVS load) need them earlier in the file.
 static void loadChannelSetFromNvs();
 static void invalidateSkipMaskForBwChange();
+static void analyzeAndPushFromCachedScan();
 
 // If we're following a hopping rocket and packets dry up for this long,
 // give up and fall back to lora_freq_mhz so the existing silence /
@@ -1134,6 +1135,15 @@ static void serviceLoRaTransaction()
                     invalidateSkipMaskForBwChange();
                 }
 
+                // Re-push the channel-set if we have a recent scan
+                // (#40 / #41 phase 3).  The original post-scan cmd-15
+                // would have been displaced from the uplink queue by
+                // this very cmd-10 transaction; re-pushing here is the
+                // simplest way to guarantee delivery, and it also
+                // re-sizes the skip-mask if BW just changed.  Inert if
+                // no scan has happened this session.
+                analyzeAndPushFromCachedScan();
+
                 ESP_LOGI(TAG, "[TXN] COMMIT: heard rocket on NEW %.2f MHz, saved",
                          (double)lora_freq_mhz);
                 lora_txn_state = LoRaTxnState::IDLE;
@@ -1489,6 +1499,11 @@ static size_t   scan_peak_count_ = 0;
 static float    scan_peak_start_mhz_ = 0.0f;
 static float    scan_peak_step_khz_  = 0.0f;
 static uint8_t  scan_passes_remaining_ = 0;
+// Set true after a multi-pass scan completes; used by the cmd-10
+// commit path to re-push the channel-set selection (the original
+// post-scan push gets clobbered when the iOS app's auto-channel-select
+// queues cmd 10 immediately after seeing scan results).
+static bool     scan_results_valid_ = false;
 
 // Held across passes so subsequent calls re-use the same parameters.
 static float    scan_param_start_mhz_ = 0.0f;
@@ -1610,6 +1625,7 @@ static bool startNoiseScan(float start_mhz, float stop_mhz,
     scan_param_step_khz_   = step_khz;
     scan_param_dwell_ms_   = dwell_ms;
     scan_peak_count_       = 0;  // signals "first pass, copy not max"
+    scan_results_valid_    = false;  // becomes true on finalize
     for (size_t i = 0; i < TR_LoRa_Comms::SCAN_MAX_SAMPLES; i++)
         scan_peak_rssi_[i] = INT8_MIN;
 
@@ -1651,26 +1667,36 @@ static bool absorbScanPass()
     return (--scan_passes_remaining_) > 0;
 }
 
-// All passes done.  Ship results to BLE (preserving the existing
-// single-result protocol so the iOS app doesn't need to change),
-// run the channel-set analyzer, push the result to the rocket.
-static void finalizeNoiseScan()
+// Re-run the channel-set analyzer over the most recent scan grid using
+// `lora_bw_khz` (whatever it is right now), then push to the rocket.
+// Used by both finalizeNoiseScan() and the cmd-10 commit path — the
+// latter to re-push after the auto-select cmd-10 race clobbered the
+// initial cmd-15 in the uplink queue.
+static void analyzeAndPushFromCachedScan()
 {
-    ble_app.sendScanResults(scan_peak_start_mhz_, scan_peak_step_khz_,
-                            scan_peak_rssi_, (uint8_t)scan_peak_count_);
+    if (!scan_results_valid_ || scan_peak_count_ == 0) return;
 
-    // Build the parallel scan_freqs[] from start/step
     float scan_freqs[TR_LoRa_Comms::SCAN_MAX_SAMPLES];
     for (size_t i = 0; i < scan_peak_count_; i++)
     {
         scan_freqs[i] = scan_peak_start_mhz_
                         + (scan_peak_step_khz_ * (float)i) / 1000.0f;
     }
-
     LoRaChannelSetSelection sel{};
     loraSelectChannelSet(scan_freqs, scan_peak_rssi_, scan_peak_count_,
                           lora_bw_khz, config::LORA_RENDEZVOUS_MHZ, &sel);
     applyAndPushChannelSet(sel, lora_bw_khz);
+}
+
+// All passes done.  Ship results to BLE (preserving the existing
+// single-result protocol so the iOS app doesn't need to change), then
+// run the analyzer + push to the rocket.
+static void finalizeNoiseScan()
+{
+    ble_app.sendScanResults(scan_peak_start_mhz_, scan_peak_step_khz_,
+                            scan_peak_rssi_, (uint8_t)scan_peak_count_);
+    scan_results_valid_ = true;
+    analyzeAndPushFromCachedScan();
 }
 
 static void setup_bs()

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -77,7 +77,7 @@ static char    unit_name[24]  = "TinkerBaseStation"; // default until NVS loads
 static uint8_t network_id     = config::DEFAULT_NETWORK_ID;
 
 // LoRa uplink state (BaseStation → OutComputer)
-static uint8_t  uplink_buf[32];   // 6-byte header + up to ~26 bytes payload (PID config = 20)
+static uint8_t  uplink_buf[40];   // 6-byte header + up to ~33 bytes payload (cmd 15 channel-set push needs 27 at BW=125)
 static size_t   uplink_len = 0;
 static uint8_t  uplink_retries_left = 0;
 static uint32_t uplink_last_tx_ms = 0;
@@ -138,6 +138,25 @@ static bool     hop_active_       = false;
 static uint8_t  hop_idx_          = 0;
 static bool     hop_needs_retune_ = false;
 static uint32_t hop_last_rx_ms_   = 0;
+
+// ----------------------------------------------------------------------------
+// Channel-set state (#40 / #41 phase 3)
+// ----------------------------------------------------------------------------
+// Selected by `loraSelectChannelSet()` after the pre-launch scan finishes,
+// persisted to NVS, and pushed to the rocket via LORA_CMD_CHANNEL_SET.
+// `channel_set_bw_khz_` is the BW the mask was generated against — used
+// to detect when a cmd-10 BW change invalidates the mask (we revert to
+// "no skips" until the user re-runs the scan on the new BW).
+static float   rendezvous_mhz_     = config::LORA_RENDEZVOUS_MHZ;
+static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
+static uint8_t skip_mask_n_        = 0;        // 0 = no mask yet
+static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
+
+// Forward declarations — definitions live further down with the other
+// channel-set machinery, but a couple of call sites (cmd-10 commit,
+// boot-time NVS load) need them earlier in the file.
+static void loadChannelSetFromNvs();
+static void invalidateSkipMaskForBwChange();
 
 // If we're following a hopping rocket and packets dry up for this long,
 // give up and fall back to lora_freq_mhz so the existing silence /
@@ -889,7 +908,7 @@ static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payloa
                  uplink_buf[4], cmd);
     }
 
-    if (payload_len > 25) payload_len = 25;  // 32-byte buf − 6-byte header − 1 byte slack
+    if (payload_len > 33) payload_len = 33;  // 40-byte buf − 6-byte header − 1 byte slack
     // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
     uplink_buf[0] = config::UPLINK_SYNC_BYTE;  // 0xCA
     uplink_buf[1] = network_id;
@@ -1093,6 +1112,7 @@ static void serviceLoRaTransaction()
                 // COMMIT: radio already on NEW; persist to NVS + update
                 // runtime vars so the rest of the firmware sees the new
                 // config in readbacks.
+                const float old_bw = lora_bw_khz;
                 lora_freq_mhz = txn_new_freq;
                 lora_bw_khz   = txn_new_bw;
                 lora_sf       = txn_new_sf;
@@ -1106,6 +1126,13 @@ static void serviceLoRaTransaction()
                 prefs.putUChar("cr",    lora_cr);
                 prefs.putChar("txpwr",  lora_tx_power);
                 prefs.end();
+
+                // BW change invalidates the skip-mask (it's sized for
+                // the old hop table).  Rendezvous freq survives.
+                if (old_bw != lora_bw_khz)
+                {
+                    invalidateSkipMaskForBwChange();
+                }
 
                 ESP_LOGI(TAG, "[TXN] COMMIT: heard rocket on NEW %.2f MHz, saved",
                          (double)lora_freq_mhz);
@@ -1199,7 +1226,9 @@ static constexpr float    RECOVERY_PHASE_B_SPAN_MHZ = 2.0f;  // ±2 MHz around N
 // fallback, regardless of what the user set in NVS.
 static void recoveryHopToRendezvousMode()
 {
-    if (lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+    // rendezvous_mhz_ is scan-selected (#40 / #41 phase 3) and falls
+    // back to config::LORA_RENDEZVOUS_MHZ when no scan has been run.
+    if (lora_comms.reconfigure(rendezvous_mhz_,
                                 config::LORA_RENDEZVOUS_SF,
                                 config::LORA_RENDEZVOUS_BW_KHZ,
                                 config::LORA_RENDEZVOUS_CR,
@@ -1236,7 +1265,7 @@ static void recoveryEnterPhaseA()
     recovery_phase_start_ms     = millis();
     recovery_state              = RecoveryState::PHASE_A_RENDEZVOUS;
     ESP_LOGW(TAG, "[RECOVER] Silent — Phase A rendezvous mode (%.2f MHz SF%u BW%.0f) for %u ms",
-             (double)config::LORA_RENDEZVOUS_MHZ,
+             (double)rendezvous_mhz_,
              (unsigned)config::LORA_RENDEZVOUS_SF,
              (double)config::LORA_RENDEZVOUS_BW_KHZ,
              (unsigned)RECOVERY_PHASE_A_DWELL_MS);
@@ -1442,6 +1471,208 @@ static void serviceHeartbeat()
     last_heartbeat_tx_ms = now;
 }
 
+// ============================================================================
+// Channel-set: multi-pass scan + auto-analyze + push to rocket (#40/#41 phase 3)
+// ============================================================================
+// On BLE cmd 60 we run a 5-pass noise scan (max-RSSI accumulation per
+// channel) instead of a single sweep, so an intermittent jammer that
+// only fires every couple of seconds is more likely to be captured.
+// When all passes complete, we ship the accumulated grid to the iOS app
+// (preserving the existing single-result protocol), run the channel-set
+// analyzer locally, persist the result to NVS, and push it to the
+// rocket via LORA_CMD_CHANNEL_SET.
+
+static constexpr uint8_t LORA_NOISE_SCAN_PASSES = 5;
+
+static int8_t   scan_peak_rssi_[TR_LoRa_Comms::SCAN_MAX_SAMPLES] = {0};
+static size_t   scan_peak_count_ = 0;
+static float    scan_peak_start_mhz_ = 0.0f;
+static float    scan_peak_step_khz_  = 0.0f;
+static uint8_t  scan_passes_remaining_ = 0;
+
+// Held across passes so subsequent calls re-use the same parameters.
+static float    scan_param_start_mhz_ = 0.0f;
+static float    scan_param_stop_mhz_  = 0.0f;
+static uint16_t scan_param_step_khz_  = 0;
+static uint16_t scan_param_dwell_ms_  = 0;
+
+// Persist channel-set selection to NVS.  Skip-mask is keyed off the BW
+// it was generated for so a later cmd-10 BW change invalidates it
+// cleanly (loadChannelSetFromNvs detects mismatch and clears).
+static void saveChannelSetToNvs(const LoRaChannelSetSelection& sel,
+                                float bw_khz)
+{
+    Preferences p;
+    if (!p.begin("lora", false)) return;
+    p.putFloat("rdv_mhz", sel.rendezvous_mhz);
+    p.putUChar("chset_n", sel.n_channels);
+    p.putFloat("chset_bw", bw_khz);
+    const size_t bytes_used = (sel.n_channels + 7) / 8;
+    p.putBytes("chset_mask", sel.skip_mask, bytes_used);
+    p.end();
+}
+
+// Restore channel-set selection from NVS.  If the stored BW doesn't
+// match the active operating BW, the skip-mask is treated as stale and
+// the runtime state is reset to "no skips".  Rendezvous freq survives
+// a BW change (it isn't tied to the operating channel table).
+static void loadChannelSetFromNvs()
+{
+    Preferences p;
+    if (!p.begin("lora", true)) return;
+    rendezvous_mhz_ = p.getFloat("rdv_mhz", config::LORA_RENDEZVOUS_MHZ);
+    const uint8_t n_stored  = p.getUChar("chset_n", 0);
+    const float   bw_stored = p.getFloat("chset_bw", 0.0f);
+    if (n_stored > 0 && bw_stored > 0.0f && bw_stored == lora_bw_khz)
+    {
+        const size_t bytes_used = (n_stored + 7) / 8;
+        size_t got = p.getBytes("chset_mask", skip_mask_, bytes_used);
+        if (got == bytes_used)
+        {
+            skip_mask_n_        = n_stored;
+            channel_set_bw_khz_ = bw_stored;
+        }
+    }
+    else
+    {
+        skip_mask_n_        = 0;
+        channel_set_bw_khz_ = 0.0f;
+        for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+    }
+    p.end();
+}
+
+// Clear stored skip-mask (rendezvous_mhz_ unchanged) — called on cmd-10
+// BW change so the rocket doesn't follow a stale skip-mask sized for
+// the previous BW.
+static void invalidateSkipMaskForBwChange()
+{
+    skip_mask_n_        = 0;
+    channel_set_bw_khz_ = 0.0f;
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+    Preferences p;
+    if (p.begin("lora", false))
+    {
+        p.remove("chset_n");
+        p.remove("chset_bw");
+        p.remove("chset_mask");
+        p.end();
+    }
+    ESP_LOGI(TAG, "[CHSET] BW changed — skip-mask invalidated");
+}
+
+// Apply a freshly computed selection to runtime state and queue a push
+// to the rocket so the rocket's NVS + runtime mirrors ours.
+static void applyAndPushChannelSet(const LoRaChannelSetSelection& sel,
+                                    float bw_khz)
+{
+    // Adopt locally
+    rendezvous_mhz_     = sel.rendezvous_mhz;
+    skip_mask_n_        = sel.n_channels;
+    channel_set_bw_khz_ = bw_khz;
+    const size_t bytes_used = (sel.n_channels + 7) / 8;
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+    for (size_t i = 0; i < bytes_used; i++) skip_mask_[i] = sel.skip_mask[i];
+
+    saveChannelSetToNvs(sel, bw_khz);
+
+    // Wire format: [rdv:f4][bw:f4][n:u1][mask: ceil(n/8)]
+    uint8_t payload[40] = {0};
+    size_t  off = 0;
+    memcpy(payload + off, &sel.rendezvous_mhz, 4); off += 4;
+    memcpy(payload + off, &bw_khz,             4); off += 4;
+    payload[off++] = sel.n_channels;
+    for (size_t i = 0; i < bytes_used; i++) payload[off++] = sel.skip_mask[i];
+
+    // Count active for the log so user sees how many channels survived
+    uint8_t active = 0;
+    for (uint8_t i = 0; i < sel.n_channels; i++)
+        if (!loraSkipMaskTest(sel.skip_mask, i)) active++;
+    ESP_LOGI(TAG, "[CHSET] rendezvous=%.2f MHz, %u/%u channels active at BW=%.0f kHz "
+                  "(min FCC floor %u) — pushing to rocket",
+             (double)sel.rendezvous_mhz, (unsigned)active,
+             (unsigned)sel.n_channels, (double)bw_khz,
+             (unsigned)loraFhssMinChannels(bw_khz));
+
+    buildUplinkPacket(LORA_CMD_CHANNEL_SET, payload, off, /*target_rid=*/0xFF,
+                      /*retries=*/config::UPLINK_RETRIES);
+}
+
+// Called on a fresh BLE cmd-60 to start the multi-pass scan sequence.
+// Returns true if the first pass started successfully.
+static bool startNoiseScan(float start_mhz, float stop_mhz,
+                            uint16_t step_khz, uint16_t dwell_ms)
+{
+    if (scan_passes_remaining_ != 0) return false;  // already scanning
+
+    scan_param_start_mhz_  = start_mhz;
+    scan_param_stop_mhz_   = stop_mhz;
+    scan_param_step_khz_   = step_khz;
+    scan_param_dwell_ms_   = dwell_ms;
+    scan_peak_count_       = 0;  // signals "first pass, copy not max"
+    for (size_t i = 0; i < TR_LoRa_Comms::SCAN_MAX_SAMPLES; i++)
+        scan_peak_rssi_[i] = INT8_MIN;
+
+    if (!lora_comms.startScan(start_mhz, stop_mhz, step_khz, dwell_ms))
+        return false;
+
+    scan_passes_remaining_ = LORA_NOISE_SCAN_PASSES;
+    ESP_LOGI(TAG, "[CHSET] Noise scan started: %u passes × %u ms dwell, %.1f..%.1f MHz",
+             (unsigned)LORA_NOISE_SCAN_PASSES, (unsigned)dwell_ms,
+             (double)start_mhz, (double)stop_mhz);
+    return true;
+}
+
+// Merge the just-completed pass's samples into scan_peak_rssi_[] (max).
+// On the first pass we also capture the geometry (start_mhz, step_khz)
+// for the analyzer.  Returns true if more passes are needed.
+static bool absorbScanPass()
+{
+    const auto* samples = lora_comms.getScanSamples();
+    const size_t n = lora_comms.getScanSampleCount();
+
+    if (scan_peak_count_ == 0)
+    {
+        scan_peak_start_mhz_ = lora_comms.getScanStartMHz();
+        scan_peak_step_khz_  = lora_comms.getScanStepKHz();
+        scan_peak_count_     = (n > TR_LoRa_Comms::SCAN_MAX_SAMPLES)
+                                ? TR_LoRa_Comms::SCAN_MAX_SAMPLES : n;
+        for (size_t i = 0; i < scan_peak_count_; i++)
+            scan_peak_rssi_[i] = samples[i].rssi_dbm;
+    }
+    else
+    {
+        const size_t cap = (n < scan_peak_count_) ? n : scan_peak_count_;
+        for (size_t i = 0; i < cap; i++)
+            if (samples[i].rssi_dbm > scan_peak_rssi_[i])
+                scan_peak_rssi_[i] = samples[i].rssi_dbm;
+    }
+    lora_comms.consumeScanDone();
+    return (--scan_passes_remaining_) > 0;
+}
+
+// All passes done.  Ship results to BLE (preserving the existing
+// single-result protocol so the iOS app doesn't need to change),
+// run the channel-set analyzer, push the result to the rocket.
+static void finalizeNoiseScan()
+{
+    ble_app.sendScanResults(scan_peak_start_mhz_, scan_peak_step_khz_,
+                            scan_peak_rssi_, (uint8_t)scan_peak_count_);
+
+    // Build the parallel scan_freqs[] from start/step
+    float scan_freqs[TR_LoRa_Comms::SCAN_MAX_SAMPLES];
+    for (size_t i = 0; i < scan_peak_count_; i++)
+    {
+        scan_freqs[i] = scan_peak_start_mhz_
+                        + (scan_peak_step_khz_ * (float)i) / 1000.0f;
+    }
+
+    LoRaChannelSetSelection sel{};
+    loraSelectChannelSet(scan_freqs, scan_peak_rssi_, scan_peak_count_,
+                          lora_bw_khz, config::LORA_RENDEZVOUS_MHZ, &sel);
+    applyAndPushChannelSet(sel, lora_bw_khz);
+}
+
 static void setup_bs()
 {
     delay(500);
@@ -1611,6 +1842,25 @@ static void setup_bs()
     ESP_LOGI(TAG, "[CFG] LoRa NVS: %.1f MHz SF%u BW%.0f CR%u %d dBm",
              (double)lora_freq_mhz, (unsigned)lora_sf,
              (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
+
+    // Channel-set: rendezvous freq + skip-mask from the most recent
+    // pre-launch scan (#40 / #41 phase 3).  Falls back to defaults if
+    // never scanned, or if the stored mask was generated for a
+    // different BW.
+    loadChannelSetFromNvs();
+    if (skip_mask_n_ > 0)
+    {
+        uint8_t active = 0;
+        for (uint8_t i = 0; i < skip_mask_n_; i++)
+            if (!loraSkipMaskTest(skip_mask_, i)) active++;
+        ESP_LOGI(TAG, "[CHSET] NVS: rendezvous=%.2f MHz, %u/%u channels active",
+                 (double)rendezvous_mhz_, (unsigned)active, (unsigned)skip_mask_n_);
+    }
+    else
+    {
+        ESP_LOGI(TAG, "[CHSET] NVS: rendezvous=%.2f MHz (default), no skip-mask",
+                 (double)rendezvous_mhz_);
+    }
 
     // Load cached servo config from NVS
     prefs.begin("servo", true);
@@ -2242,11 +2492,12 @@ static void loop_bs()
             memcpy(&step_khz,  payload + 8, 2);
             memcpy(&dwell_ms,  payload + 10, 2);
 
-            if (lora_comms.startScan(start_mhz, stop_mhz, step_khz, dwell_ms))
+            if (startNoiseScan(start_mhz, stop_mhz, step_khz, dwell_ms))
             {
-                ESP_LOGI(TAG, "[BLE] Scan started: %.1f..%.1f MHz, %u kHz, %u ms",
+                ESP_LOGI(TAG, "[BLE] Scan started: %.1f..%.1f MHz, %u kHz, %u ms (×%u passes)",
                          (double)start_mhz, (double)stop_mhz,
-                         (unsigned)step_khz, (unsigned)dwell_ms);
+                         (unsigned)step_khz, (unsigned)dwell_ms,
+                         (unsigned)LORA_NOISE_SCAN_PASSES);
             }
             else
             {
@@ -2256,20 +2507,37 @@ static void loop_bs()
     }
 
     // Service scan state machine (no-op when idle).  Must come before
-    // serviceUplink so a TX retry doesn't fire while we're mid-scan — the
-    // scan temporarily owns the radio's frequency.
+    // serviceUplink so a TX retry doesn't fire while we're mid-scan —
+    // the scan temporarily owns the radio's frequency.
     lora_comms.serviceScan();
     if (lora_comms.isScanDone())
     {
-        const auto* samples = lora_comms.getScanSamples();
-        const size_t n = lora_comms.getScanSampleCount();
-        int8_t rssi[TR_LoRa_Comms::SCAN_MAX_SAMPLES];
-        const size_t n_send = (n > TR_LoRa_Comms::SCAN_MAX_SAMPLES) ? TR_LoRa_Comms::SCAN_MAX_SAMPLES : n;
-        for (size_t i = 0; i < n_send; ++i) rssi[i] = samples[i].rssi_dbm;
-        ble_app.sendScanResults(lora_comms.getScanStartMHz(),
-                                lora_comms.getScanStepKHz(),
-                                rssi, (uint8_t)n_send);
-        lora_comms.consumeScanDone();
+        if (scan_passes_remaining_ > 0)
+        {
+            // Multi-pass mode (#40 / #41 phase 3): merge this pass's
+            // samples into the running max-RSSI accumulator, then
+            // either kick off the next pass or finalize.
+            const bool more = absorbScanPass();
+            if (more)
+            {
+                (void)lora_comms.startScan(scan_param_start_mhz_,
+                                           scan_param_stop_mhz_,
+                                           scan_param_step_khz_,
+                                           scan_param_dwell_ms_);
+            }
+            else
+            {
+                finalizeNoiseScan();
+            }
+        }
+        else
+        {
+            // Defensive: a scan finished but we have no pass count
+            // (shouldn't happen — startNoiseScan is the only path that
+            // starts a scan).  Drain to keep the radio sane.
+            (void)lora_comms.getScanSampleCount();
+            lora_comms.consumeScanDone();
+        }
     }
 
     // Service LoRa uplink retries (TX commands, then resume RX)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -378,6 +378,16 @@ static uint32_t         hop_fallback_phase_start_ms = 0;
 static uint32_t         hop_active_entered_ms       = 0;
 static uint32_t         hop_session_uplink_count    = 0;  // resets each hop session
 
+// Channel-set state pushed by the BS via LORA_CMD_CHANNEL_SET (#40 / #41
+// phase 3).  rendezvous_mhz_ replaces the hardcoded LORA_RENDEZVOUS_MHZ
+// constant for both slow_rendezvous and hop-silence visits.  skip_mask_
+// is consulted in the per-packet next_channel_idx advance so the hop
+// sequence skips noisy channels.
+static float   rendezvous_mhz_     = config::LORA_RENDEZVOUS_MHZ;
+static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
+static uint8_t skip_mask_n_        = 0;        // 0 = no mask (all active)
+static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
+
 // Tracks whether the radio is currently in RX mode.  Forward-declared
 // here so updateHopFromState() (just below) can reset it cleanly when
 // we exit a rendezvous visit.  Initialized at file scope further down
@@ -1583,14 +1593,30 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
         {
             // Bootstrap: this packet still goes out on lora_freq_mhz.
             // Tell the BS to follow us to channel 0 for the next one.
+            // (Channel 0 is intentionally always considered active even
+            // if the skip-mask covers it, since it's the bootstrap
+            // anchor — the next non-bootstrap packet will skip-advance.)
             lora.next_channel_idx = 0;
         }
         else
         {
             const uint8_t n = loraChannelCount(lora_bw_khz);
-            lora.next_channel_idx = (n > 0)
-                ? (uint8_t)((hop_idx_ + 1) % n)
-                : LORA_NEXT_CH_NO_HOP;
+            if (n == 0)
+            {
+                lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;
+            }
+            else
+            {
+                // Skip-mask aware advance (#40 / #41 phase 3).  When no
+                // valid mask is loaded (n_chan == 0 or BW mismatch), the
+                // skip_mask_ is all-zeros so loraNextActiveChannelIdx
+                // degenerates to (idx + 1) % n.
+                const bool mask_valid = (skip_mask_n_ == n &&
+                                          channel_set_bw_khz_ == lora_bw_khz);
+                static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+                const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                lora.next_channel_idx = loraNextActiveChannelIdx(hop_idx_, mask, n);
+            }
         }
     }
     else
@@ -1735,8 +1761,19 @@ static void serviceLoRa()
             }
             else
             {
+                // Skip-mask aware advance — must match the value we
+                // just wrote into the packet's next_channel_idx field
+                // in buildLoRaPayload, otherwise rocket and BS land on
+                // different channels.
                 const uint8_t n = loraChannelCount(lora_bw_khz);
-                if (n > 0) hop_idx_ = (uint8_t)((hop_idx_ + 1) % n);
+                if (n > 0)
+                {
+                    const bool mask_valid = (skip_mask_n_ == n &&
+                                              channel_set_bw_khz_ == lora_bw_khz);
+                    static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+                    const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                    hop_idx_ = loraNextActiveChannelIdx(hop_idx_, mask, n);
+                }
             }
             hop_needs_retune_ = true;
         }
@@ -2039,6 +2076,7 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
 
         if (lora_comms.reconfigure(new_freq, new_sf, new_bw, new_cr, new_pwr))
         {
+            const float old_bw = lora_bw_khz;
             lora_freq_mhz = new_freq;
             lora_bw_khz   = new_bw;
             lora_sf        = new_sf;
@@ -2051,6 +2089,19 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
             prefs.putUChar("sf",    lora_sf);
             prefs.putUChar("cr",    lora_cr);
             prefs.putChar("txpwr",  lora_tx_power);
+            // BW change invalidates the channel-set skip-mask (#40/#41
+            // phase 3): the mask is sized for the OLD hop table.  The
+            // BS will re-push after its own state settles + a new scan.
+            if (old_bw != lora_bw_khz)
+            {
+                skip_mask_n_        = 0;
+                channel_set_bw_khz_ = 0.0f;
+                for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+                prefs.remove("chset_n");
+                prefs.remove("chset_bw");
+                prefs.remove("chset_mask");
+                ESP_LOGI("LORA", "UPLINK [CHSET] BW changed — skip-mask invalidated");
+            }
             prefs.end();
 
             ESP_LOGI("LORA", "UPLINK LoRa reconfigured + saved: %.1f MHz SF%u BW%.0f CR%u %d dBm",
@@ -2115,6 +2166,57 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         cfg_guidance_en = enabled;
         setPendingCommand(enabled ? GUIDANCE_ENABLE : GUIDANCE_DISABLE);
         ESP_LOGI("LORA", "UPLINK Guidance: %s", enabled ? "ENABLE" : "DISABLE");
+    }
+    else if (cmd == LORA_CMD_CHANNEL_SET && payload_len >= 9)
+    {
+        // Channel-set push from BS (#40 / #41 phase 3).  Wire format:
+        //   [rdv:f4][bw:f4][n_channels:u1][skip_mask: ceil(n/8) bytes]
+        float new_rdv, new_bw;
+        memcpy(&new_rdv, payload + 0, 4);
+        memcpy(&new_bw,  payload + 4, 4);
+        const uint8_t new_n = payload[8];
+        const size_t  mask_bytes = (size_t)(new_n + 7) / 8;
+        if (payload_len < 9 + mask_bytes || mask_bytes > LORA_SKIP_MASK_MAX_BYTES)
+        {
+            ESP_LOGW("LORA", "UPLINK Cmd 15 ignored: payload truncated (len=%u, need %u)",
+                     (unsigned)payload_len, (unsigned)(9 + mask_bytes));
+            return;
+        }
+        // Reject if BW doesn't match — the BS sent a mask sized for a
+        // different hop table.  Either the user just changed BW and
+        // we're racing the cmd-10 transaction, or the BS NVS is stale.
+        // Either way, drop this push; the BS will re-push after its
+        // own state settles.
+        if (new_bw != lora_bw_khz)
+        {
+            ESP_LOGW("LORA", "UPLINK Cmd 15 ignored: BW mismatch "
+                              "(payload=%.0f kHz, ours=%.0f kHz)",
+                     (double)new_bw, (double)lora_bw_khz);
+            return;
+        }
+        rendezvous_mhz_     = new_rdv;
+        skip_mask_n_        = new_n;
+        channel_set_bw_khz_ = new_bw;
+        for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+        for (size_t i = 0; i < mask_bytes;          i++) skip_mask_[i] = payload[9 + i];
+
+        // Persist
+        Preferences p;
+        if (p.begin("lora", false))
+        {
+            p.putFloat("rdv_mhz", rendezvous_mhz_);
+            p.putUChar("chset_n", skip_mask_n_);
+            p.putFloat("chset_bw", channel_set_bw_khz_);
+            p.putBytes("chset_mask", skip_mask_, mask_bytes);
+            p.end();
+        }
+
+        uint8_t active = 0;
+        for (uint8_t i = 0; i < skip_mask_n_; i++)
+            if (!loraSkipMaskTest(skip_mask_, i)) active++;
+        ESP_LOGI("LORA", "UPLINK Cmd 15: rendezvous=%.2f MHz, %u/%u active at BW=%.0f kHz",
+                 (double)rendezvous_mhz_, (unsigned)active,
+                 (unsigned)skip_mask_n_, (double)channel_set_bw_khz_);
     }
     else if (cmd == LORA_CMD_HEARTBEAT)
     {
@@ -2242,7 +2344,10 @@ static constexpr uint32_t RENDEZVOUS_SAVED_MS           = 20000;  // back on sav
 // fallback.
 static void rendezvousHopToRendezvousMode()
 {
-    if (lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+    // rendezvous_mhz_ is scan-selected (#40 / #41 phase 3) and falls
+    // back to config::LORA_RENDEZVOUS_MHZ when no scan-pushed value is
+    // in NVS.
+    if (lora_comms.reconfigure(rendezvous_mhz_,
                                 config::LORA_RENDEZVOUS_SF,
                                 config::LORA_RENDEZVOUS_BW_KHZ,
                                 config::LORA_RENDEZVOUS_CR,
@@ -2334,7 +2439,7 @@ static void serviceRocketRendezvous()
                 rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
                 ESP_LOGW("OC", "[RENDEZVOUS] Silent %u s; hop to rendezvous mode %.2f MHz SF%u BW%.0f",
                          (unsigned)(silent_for / 1000),
-                         (double)config::LORA_RENDEZVOUS_MHZ,
+                         (double)rendezvous_mhz_,
                          (unsigned)config::LORA_RENDEZVOUS_SF,
                          (double)config::LORA_RENDEZVOUS_BW_KHZ);
             }
@@ -2418,7 +2523,7 @@ static void serviceHopFallback()
             // BW/SF/CR/freq atomically (with rollback on failure) —
             // same machinery as slow_rendezvous so the radio handling
             // is identical and well-tested.
-            if (!lora_comms.reconfigure(config::LORA_RENDEZVOUS_MHZ,
+            if (!lora_comms.reconfigure(rendezvous_mhz_,
                                          config::LORA_RENDEZVOUS_SF,
                                          config::LORA_RENDEZVOUS_BW_KHZ,
                                          config::LORA_RENDEZVOUS_CR,
@@ -2433,7 +2538,7 @@ static void serviceHopFallback()
             hop_fallback_state = HopFallbackState::VISITING_RENDEZVOUS;
             ESP_LOGW("OC", "[HOP] Silence %u s — visiting rendezvous %.2f MHz for %u s",
                      (unsigned)((now - ref) / 1000),
-                     (double)config::LORA_RENDEZVOUS_MHZ,
+                     (double)rendezvous_mhz_,
                      (unsigned)(HOP_FALLBACK_VISIT_MS / 1000));
             break;
         }
@@ -3095,10 +3200,43 @@ void initPeripherals()
         lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
         lora_cr        = prefs.getUChar("cr",   config::LORA_CR);
         lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
+
+        // Channel-set restore (#40 / #41 phase 3): rendezvous freq +
+        // skip-mask pushed by the BS via cmd 15.  Skip-mask is keyed
+        // off the BW it was generated for; if NVS BW != active BW,
+        // discard the mask (the BS will re-push after the user re-runs
+        // the scan).
+        rendezvous_mhz_ = prefs.getFloat("rdv_mhz", config::LORA_RENDEZVOUS_MHZ);
+        const uint8_t chset_n  = prefs.getUChar("chset_n", 0);
+        const float   chset_bw = prefs.getFloat("chset_bw", 0.0f);
+        if (chset_n > 0 && chset_bw == lora_bw_khz)
+        {
+            const size_t mask_bytes = (size_t)(chset_n + 7) / 8;
+            size_t got = prefs.getBytes("chset_mask", skip_mask_, mask_bytes);
+            if (got == mask_bytes)
+            {
+                skip_mask_n_        = chset_n;
+                channel_set_bw_khz_ = chset_bw;
+            }
+        }
         prefs.end();
         ESP_LOGI("CFG", "LoRa NVS: %.1f MHz SF%u BW%.0f CR%u %d dBm",
                       (double)lora_freq_mhz, (unsigned)lora_sf,
                       (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
+        if (skip_mask_n_ > 0)
+        {
+            uint8_t active = 0;
+            for (uint8_t i = 0; i < skip_mask_n_; i++)
+                if (!loraSkipMaskTest(skip_mask_, i)) active++;
+            ESP_LOGI("CFG", "[CHSET] NVS: rendezvous=%.2f MHz, %u/%u channels active",
+                     (double)rendezvous_mhz_, (unsigned)active,
+                     (unsigned)skip_mask_n_);
+        }
+        else
+        {
+            ESP_LOGI("CFG", "[CHSET] NVS: rendezvous=%.2f MHz (default), no skip-mask",
+                     (double)rendezvous_mhz_);
+        }
 
         // Load cached servo config from NVS
         prefs.begin("servo", false);  // read-write (creates namespace on first boot)
@@ -3996,6 +4134,7 @@ static void loop_oc()
                 // Always update runtime vars and persist to NVS, even if the
                 // radio isn't initialized yet (e.g. config sent before power-on).
                 // The saved values will be loaded by initPeripherals() on next boot.
+                const float old_bw = lora_bw_khz;
                 lora_freq_mhz = new_freq;
                 lora_bw_khz   = new_bw;
                 lora_sf        = new_sf;
@@ -4008,6 +4147,18 @@ static void loop_oc()
                 prefs.putUChar("sf",    lora_sf);
                 prefs.putUChar("cr",    lora_cr);
                 prefs.putChar("txpwr",  lora_tx_power);
+                // BW change invalidates the channel-set skip-mask (#40 / #41
+                // phase 3): the mask is sized for the OLD hop table.
+                if (old_bw != lora_bw_khz)
+                {
+                    skip_mask_n_        = 0;
+                    channel_set_bw_khz_ = 0.0f;
+                    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
+                    prefs.remove("chset_n");
+                    prefs.remove("chset_bw");
+                    prefs.remove("chset_mask");
+                    ESP_LOGI("BLE", "[CHSET] BW changed — skip-mask invalidated");
+                }
                 prefs.end();
 
                 // Verify NVS write by reading back


### PR DESCRIPTION
## Summary

Phase 3 of #40/#41 — uses the pre-launch scan (#6) to (a) pick a quiet rendezvous channel and (b) build a per-preset skip-mask of noisy channels that the hop sequence avoids. Both are pushed to the rocket via a new uplink command (`LORA_CMD_CHANNEL_SET`, cmd 15), persisted in NVS on both sides, and applied automatically on next hop session.

## What changed

**Scan now multi-pass.** Cmd 60 runs a 5-pass noise scan (~5–8 s total, max-RSSI accumulation per channel) instead of a single sweep, so an intermittent jammer that fires once a second is more likely to get caught. The accumulated grid is shipped to the iOS app exactly the same way the single-sweep result was — `FrequencyScanView` doesn't need any changes.

**Selection (pure, host-tested).** New `loraSelectChannelSet()`:

1. Rendezvous = scan freq with lowest peak RSSI.
2. Per-channel peak RSSI from the nearest scan grid point.
3. Skip channels with peak > median(peaks) + 15 dB.
4. Enforce FCC FHSS floor (50 for BW ≤ 250, 25 otherwise) by preserving the K quietest if the relative rule would drop the active count below the floor.

**Wire format for cmd 15:** `[rdv_mhz: f4][bw_khz: f4][n_channels: u1][mask: ⌈n/8⌉ bytes]` — max 27 bytes payload at BW=125 (139 channels → 18-byte mask). `uplink_buf` bumped to 40 bytes to fit.

**Persistence.** New NVS keys `rdv_mhz`, `chset_n`, `chset_bw`, `chset_mask` in the existing `lora` namespace, on both BS and rocket. A cmd-10 reconfigure that changes BW invalidates the mask on both sides (it's sized for the old hop table); rendezvous freq survives.

**Skip-mask aware advance.** Both `buildLoRaPayload` (advertising next idx) and the post-TX `hop_idx_` advance now use the new shared `loraNextActiveChannelIdx(idx, mask, n)` helper, which walks forward over masked channels. Bootstrap packet (first PRELAUNCH TX, idx=0) is exempt — it's the anchor.

## Tests

9 new GoogleTest cases (`test_rocket_computer_types.cpp`) covering:
- `loraNextActiveChannelIdx`: basic wrap, skip across mask, all-masked safety
- `loraSelectChannelSet`: no-scan fallback, rendezvous picking, threshold behaviour, FCC floor at BW=250, all-quiet edge case
- `loraFhssMinChannels` boundary values

Full host suite stays at 227/227.

## Test plan

- [x] Both ESP-IDF projects build clean
- [x] Host tests 227/227
- [ ] Bench: boot both, observe `[CHSET] Noise scan started: 5 passes …` on BS, then `[CHSET] rendezvous=… M/N channels active … pushing to rocket`, then `UPLINK Cmd 15: rendezvous=… M/N active …` on rocket
- [ ] Bench: force PRELAUNCH; verify per-packet next_channel_idx walks the table skipping masked indices (idx jumps by >1 across skipped ranges)
- [ ] Bench: trigger silence fallback; verify the rendezvous visit lands on the scan-picked freq (not 915 MHz hardcoded)
- [ ] Bench: change BW via cmd 10; both sides log `[CHSET] BW changed — skip-mask invalidated`; hopping resumes against the full new table until a fresh scan re-pushes a mask

## Phase 4 / follow-ups (deferred)

- iOS app UI changes: explicit display of chosen rendezvous + count of skipped channels (currently the user only sees the scan grid; the BS-side selection is logged but not surfaced).
- Configurable noise threshold / skip rule from app.
- BLE-provisioned overrides (Phase 4) for multi-team deconfliction.
