### PR TITLE
lora: BS-coordinated hop pause for in-flight scan (#90)

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -446,3 +446,42 @@ TEST(LoraCmdHopPause, WireFormatRoundtrip) {
         EXPECT_EQ(decoded, dur);
     }
 }
+
+TEST(RocketLikelyHopping, HopActiveAlwaysWins) {
+    // hop_active=true short-circuits — recency / state irrelevant.
+    EXPECT_TRUE(rocketLikelyHopping(/*hop_active=*/true,
+                                     /*last_packet_ms=*/0,
+                                     /*now_ms=*/100000,
+                                     /*last_rocket_state=*/READY,
+                                     /*recent_threshold_ms=*/10000));
+}
+
+TEST(RocketLikelyHopping, NeverRxFalse) {
+    // Fresh boot, never received a packet → not presumed hopping.
+    EXPECT_FALSE(rocketLikelyHopping(false, /*last_packet_ms=*/0,
+                                      100000, PRELAUNCH, 10000));
+}
+
+TEST(RocketLikelyHopping, RecentHopStateTrue) {
+    // The #90 case: hop_active false (e.g., last packet had NO_HOP), but
+    // we caught it 5 s ago in PRELAUNCH.  Treat as hopping for cmd 60.
+    EXPECT_TRUE (rocketLikelyHopping(false, /*last_packet_ms=*/95000,
+                                      100000, PRELAUNCH, 10000));
+    EXPECT_TRUE (rocketLikelyHopping(false,  95000, 100000, INFLIGHT, 10000));
+}
+
+TEST(RocketLikelyHopping, RecentNonHopStateFalse) {
+    // Recent RX but in READY/INIT/LANDED — direct scan path is correct.
+    EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, READY,         10000));
+    EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, INITIALIZATION,10000));
+    EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, LANDED,        10000));
+}
+
+TEST(RocketLikelyHopping, StaleRxFalseEvenInHopState) {
+    // Same recency window: ON the boundary should still pass; one ms
+    // past it should fail.  Keeps the threshold intent unambiguous.
+    EXPECT_TRUE (rocketLikelyHopping(false, /*last_packet_ms=*/90000,
+                                      100000, PRELAUNCH, 10000));   // exactly 10 s — inclusive
+    EXPECT_FALSE(rocketLikelyHopping(false, /*last_packet_ms=*/89999,
+                                      100000, PRELAUNCH, 10000));   // 10001 ms ago — too stale
+}

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cstring>
 #include "RocketComputerTypes.h"
 
 // Verify packed struct sizes match the SIZE_OF_* constants.
@@ -409,4 +410,39 @@ TEST(ShouldBeaconInState, AllowsAllExceptInflight) {
     EXPECT_TRUE(shouldBeaconInState(PRELAUNCH));
     EXPECT_FALSE(shouldBeaconInState(INFLIGHT));
     EXPECT_TRUE(shouldBeaconInState(LANDED));
+}
+
+// ============================================================================
+// Issue #90: coordinated hop pause (cmd 16)
+// ============================================================================
+
+TEST(LoraCmdHopPause, IdAndCapAreStable) {
+    // Wire constants pinned by the BS-rocket protocol.  Bumping either
+    // requires a coordinated firmware update on both sides + iOS app.
+    EXPECT_EQ(LORA_CMD_HOP_PAUSE, 16u);
+    EXPECT_GT(LORA_HOP_PAUSE_MAX_MS, 0u);
+    EXPECT_LE(LORA_HOP_PAUSE_MAX_MS, 65535u);  // must fit u16 wire field
+    // Cmd-15 and cmd-16 must not collide.
+    EXPECT_NE(LORA_CMD_CHANNEL_SET, LORA_CMD_HOP_PAUSE);
+}
+
+TEST(LoraCmdHopPause, WireFormatRoundtrip) {
+    // BS-side encode (mirrors startCoordinatedScan in base_station/main.cpp):
+    //   payload[0..1] = duration_ms little-endian.
+    // Rocket-side decode (mirrors processUplinkCommand cmd 16 arm):
+    //   memcpy(&dur, payload, 2).
+    for (uint16_t dur : {(uint16_t)1, (uint16_t)100, (uint16_t)12000,
+                         (uint16_t)LORA_HOP_PAUSE_MAX_MS, (uint16_t)65535})
+    {
+        uint8_t payload[2];
+        std::memcpy(payload, &dur, 2);
+        // Independently verify little-endian byte order so a host with
+        // a hypothetical big-endian compiler would catch a regression.
+        EXPECT_EQ(payload[0], (uint8_t)(dur & 0xFF));
+        EXPECT_EQ(payload[1], (uint8_t)((dur >> 8) & 0xFF));
+
+        uint16_t decoded;
+        std::memcpy(&decoded, payload, 2);
+        EXPECT_EQ(decoded, dur);
+    }
 }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -192,6 +192,35 @@ static constexpr uint8_t LORA_CMD_CHANNEL_SET     = 15;   // uplink cmd: rendezv
 static constexpr uint8_t LORA_CMD_HOP_PAUSE       = 16;   // uplink cmd: park on lora_freq_mhz for N ms (#90)
 static constexpr uint16_t LORA_HOP_PAUSE_MAX_MS   = 60000; // server-side cap on cmd 16 duration
 
+// "Is the rocket presumed to be hopping right now, from the BS's
+// perspective?" — used to decide whether a BLE cmd 60 should take the
+// direct-scan or coordinated-pause path (#90).
+//
+// Returns true when:
+//   • we're actively following the hop sequence (hop_active = true), OR
+//   • we caught a recent packet (within recent_threshold_ms) showing the
+//     rocket in PRELAUNCH/INFLIGHT, even if its next_channel_idx was
+//     LORA_NEXT_CH_NO_HOP.  The latter case covers a rocket that is
+//     bootstrapping (hop_first_pkt_ true but the BS missed it), visiting
+//     rendezvous as a hop-silence fallback (#41 phase 2b), or already
+//     paused for an earlier coordinated scan.  In all of those, a direct
+//     scan would still drop the link — the rocket is conceptually
+//     hopping, just momentarily off the regular schedule.
+//
+// Pure helper so we can unit-test the predicate without spinning up the
+// BS module-statics that real code reads from.
+static inline bool rocketLikelyHopping(bool hop_active,
+                                        uint32_t last_packet_ms,
+                                        uint32_t now_ms,
+                                        uint8_t last_rocket_state,
+                                        uint32_t recent_threshold_ms)
+{
+    if (hop_active) return true;
+    if (last_packet_ms == 0) return false;
+    if ((now_ms - last_packet_ms) > recent_threshold_ms) return false;
+    return shouldHopInState(last_rocket_state);
+}
+
 // FCC Part 15.247 minimum channel count for FHSS classification.  We
 // operate as digital modulation (DTS) so this isn't strictly binding,
 // but keeping ≥ this many channels active also preserves the diversity

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -189,6 +189,8 @@ static inline float loraChannelMHz(float bw_khz, uint8_t idx)
 static constexpr size_t  LORA_SKIP_MASK_MAX_BYTES = 18;   // 18*8 = 144 bits ≥ 139 channels
 static constexpr uint8_t LORA_NOISE_THRESHOLD_DB  = 15;   // skip if peak > median + this
 static constexpr uint8_t LORA_CMD_CHANNEL_SET     = 15;   // uplink cmd: rendezvous + mask
+static constexpr uint8_t LORA_CMD_HOP_PAUSE       = 16;   // uplink cmd: park on lora_freq_mhz for N ms (#90)
+static constexpr uint16_t LORA_HOP_PAUSE_MAX_MS   = 60000; // server-side cap on cmd 16 duration
 
 // FCC Part 15.247 minimum channel count for FHSS classification.  We
 // operate as digital modulation (DTS) so this isn't strictly binding,

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1511,6 +1511,48 @@ static float    scan_param_stop_mhz_  = 0.0f;
 static uint16_t scan_param_step_khz_  = 0;
 static uint16_t scan_param_dwell_ms_  = 0;
 
+// ----------------------------------------------------------------------------
+// Coordinated hop pause for in-flight scan (#90)
+// ----------------------------------------------------------------------------
+// When a BLE cmd 60 arrives while we're already following a hopping rocket
+// (hop_active_ == true), running the scan directly would silence the link
+// for ~9 s and trip the rocket's hop fallback.  Instead, we ask the rocket
+// to park on lora_freq_mhz for a known window via cmd 16, then run the
+// scan + push cmd 15 inside that window, then both sides re-bootstrap hop.
+//
+// State flow:
+//   IDLE          → AWAITING_PAUSE  (cmd 16 queued; wait for retries done)
+//   AWAITING_PAUSE → SCANNING       (reconfigure to lora_freq_mhz, kick scan)
+//   SCANNING       → PUSHING_CHSET  (scan finalized, cmd 15 queued)
+//   PUSHING_CHSET  → RESUMING       (cmd 15 retries done)
+//   RESUMING       → IDLE           (rocket bootstrap RX, or timeout)
+enum class CoordScanState : uint8_t {
+    IDLE,
+    AWAITING_PAUSE,
+    SCANNING,
+    PUSHING_CHSET,
+    RESUMING,
+};
+
+static CoordScanState coord_scan_state_       = CoordScanState::IDLE;
+static uint32_t       coord_scan_phase_ms_    = 0;
+static uint32_t       coord_scan_resume_anchor_ms_ = 0;  // hop_last_rx_ms_ snapshot at RESUMING entry
+// Stored scan params so we can re-issue startNoiseScan() after the pause is acked.
+static float    coord_scan_start_mhz_ = 0.0f;
+static float    coord_scan_stop_mhz_  = 0.0f;
+static uint16_t coord_scan_step_khz_  = 0;
+static uint16_t coord_scan_dwell_ms_  = 0;
+
+// After cmd 16 retries finish, give the rocket a moment to actually swap
+// to lora_freq_mhz before we reconfigure the BS radio.
+static constexpr uint32_t COORD_SCAN_PAUSE_GRACE_MS  = 500;
+// If the rocket never resumes hopping after we push cmd 15, give up so
+// the normal silence/recovery machinery can take over.
+static constexpr uint32_t COORD_SCAN_RESUMING_MAX_MS = 5000;
+// Slack on top of the computed scan + cmd 15 retry budget so the rocket's
+// pause comfortably outlasts our work window.
+static constexpr uint32_t COORD_SCAN_PAUSE_SLACK_MS  = 2000;
+
 // Persist channel-set selection to NVS.  Skip-mask is keyed off the BW
 // it was generated for so a later cmd-10 BW change invalidates it
 // cleanly (loadChannelSetFromNvs detects mismatch and clears).
@@ -1697,6 +1739,154 @@ static void finalizeNoiseScan()
                             scan_peak_rssi_, (uint8_t)scan_peak_count_);
     scan_results_valid_ = true;
     analyzeAndPushFromCachedScan();
+}
+
+// Compute the cmd 16 pause duration (ms) for a coordinated scan.  Sized
+// to comfortably cover scan + cmd 15 retries + slack, and capped to the
+// rocket-side max so a too-large value doesn't silently get truncated
+// to a different value than we accounted for.
+static uint16_t computeCoordPauseMs(float start_mhz, float stop_mhz,
+                                     uint16_t step_khz, uint16_t dwell_ms)
+{
+    if (step_khz == 0 || stop_mhz <= start_mhz) return LORA_HOP_PAUSE_MAX_MS;
+    const uint32_t span_khz   = (uint32_t)((stop_mhz - start_mhz) * 1000.0f);
+    const uint32_t channels   = span_khz / step_khz + 1;
+    const uint32_t scan_ms    = (uint32_t)LORA_NOISE_SCAN_PASSES * channels
+                                * (uint32_t)dwell_ms;
+    const uint32_t cmd15_ms   = (uint32_t)config::UPLINK_RETRIES
+                                * (uint32_t)config::UPLINK_RETRY_INTERVAL_MS;
+    uint32_t total = scan_ms + cmd15_ms + COORD_SCAN_PAUSE_GRACE_MS
+                     + COORD_SCAN_PAUSE_SLACK_MS;
+    if (total > LORA_HOP_PAUSE_MAX_MS) total = LORA_HOP_PAUSE_MAX_MS;
+    return (uint16_t)total;
+}
+
+// Kick off a coordinated scan: queue cmd 16 to the rocket and stash the
+// scan params for use once retries finish.  Caller has already verified
+// hop_active_ and that no coordinated scan is in progress.
+static void startCoordinatedScan(float start_mhz, float stop_mhz,
+                                  uint16_t step_khz, uint16_t dwell_ms)
+{
+    coord_scan_start_mhz_ = start_mhz;
+    coord_scan_stop_mhz_  = stop_mhz;
+    coord_scan_step_khz_  = step_khz;
+    coord_scan_dwell_ms_  = dwell_ms;
+
+    const uint16_t pause_ms = computeCoordPauseMs(start_mhz, stop_mhz,
+                                                   step_khz, dwell_ms);
+    uint8_t payload[2];
+    memcpy(payload, &pause_ms, 2);
+    buildUplinkPacket(LORA_CMD_HOP_PAUSE, payload, 2,
+                      /*target_rid=*/0xFF, config::UPLINK_RETRIES);
+    coord_scan_state_    = CoordScanState::AWAITING_PAUSE;
+    coord_scan_phase_ms_ = millis();
+    ESP_LOGI(TAG, "[CHSET] Coordinated scan start: pausing rocket for %u ms "
+                  "(scan range %.1f..%.1f MHz, %u kHz, %u ms dwell)",
+             (unsigned)pause_ms, (double)start_mhz, (double)stop_mhz,
+             (unsigned)step_khz, (unsigned)dwell_ms);
+}
+
+// Drive the coordinated-scan state machine.  Called every loop iteration
+// before the scan-done detection so that AWAITING_PAUSE → SCANNING can
+// kick off a fresh scan in the same iteration where it transitions.
+static void serviceCoordinatedScan()
+{
+    if (coord_scan_state_ == CoordScanState::IDLE) return;
+
+    const uint32_t now = millis();
+    switch (coord_scan_state_)
+    {
+        case CoordScanState::IDLE: return;
+        case CoordScanState::AWAITING_PAUSE:
+        {
+            // Cmd 16 retries still going — push out the grace anchor so
+            // we wait COORD_SCAN_PAUSE_GRACE_MS after the *last* retry,
+            // not after we queued the command.
+            if (uplink_pending)
+            {
+                coord_scan_phase_ms_ = now;
+                return;
+            }
+            if ((now - coord_scan_phase_ms_) < COORD_SCAN_PAUSE_GRACE_MS) return;
+
+            // Cmd 16 has been pushed (8 retries / ~800 ms).  We don't
+            // get an explicit ack — the rocket pause is fire-and-forget.
+            // Reconfigure the BS radio to lora_freq_mhz so we (a) can
+            // verify the rocket is actually parked there, and (b) the
+            // scan starts from a known frequency.
+            if (!lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
+                                         lora_cr, lora_tx_power))
+            {
+                ESP_LOGE(TAG, "[CHSET] Coord scan: reconfigure to %.2f MHz failed — abandoning",
+                         (double)lora_freq_mhz);
+                coord_scan_state_ = CoordScanState::IDLE;
+                return;
+            }
+            (void)lora_comms.startReceive();
+            // Drop hop tracking flags so the post-scan packet from the
+            // rocket re-enters hop following cleanly (matching a fresh
+            // bootstrap, not a continuation).
+            hop_active_       = false;
+            hop_needs_retune_ = false;
+
+            if (!startNoiseScan(coord_scan_start_mhz_, coord_scan_stop_mhz_,
+                                 coord_scan_step_khz_, coord_scan_dwell_ms_))
+            {
+                ESP_LOGE(TAG, "[CHSET] Coord scan: startNoiseScan failed — abandoning");
+                coord_scan_state_ = CoordScanState::IDLE;
+                return;
+            }
+            coord_scan_state_    = CoordScanState::SCANNING;
+            coord_scan_phase_ms_ = now;
+            ESP_LOGI(TAG, "[CHSET] Coord scan: rocket should be parked, scan started");
+            break;
+        }
+        case CoordScanState::SCANNING:
+        {
+            // finalizeNoiseScan() runs from the existing scan-done path
+            // and (a) sets scan_results_valid_ = true, (b) queues cmd 15
+            // via applyAndPushChannelSet().  Either signal works as a
+            // transition trigger; combining them is most precise.
+            if (scan_results_valid_ && uplink_pending)
+            {
+                coord_scan_state_    = CoordScanState::PUSHING_CHSET;
+                coord_scan_phase_ms_ = now;
+            }
+            break;
+        }
+        case CoordScanState::PUSHING_CHSET:
+        {
+            if (uplink_pending) return;  // cmd 15 retries still going
+            // Cmd 15 has been delivered (or all retries exhausted).
+            // Rocket should resume hopping when its pause deadline hits.
+            // Snapshot hop_last_rx_ms_ so we can detect a fresh RX.
+            coord_scan_resume_anchor_ms_ = hop_last_rx_ms_;
+            coord_scan_state_            = CoordScanState::RESUMING;
+            coord_scan_phase_ms_         = now;
+            ESP_LOGI(TAG, "[CHSET] Coord scan: cmd 15 pushed, awaiting rocket hop resume");
+            break;
+        }
+        case CoordScanState::RESUMING:
+        {
+            // The rocket-side pause expires and a bootstrap packet hits
+            // us on lora_freq_mhz.  The existing RX path adopts the new
+            // hop_idx_ and sets hop_active_ + hop_last_rx_ms_.  Detect
+            // either: a fresh RX (anchor changed) or a timeout.
+            if (hop_last_rx_ms_ != coord_scan_resume_anchor_ms_)
+            {
+                ESP_LOGI(TAG, "[CHSET] Coord scan complete — hop resumed");
+                coord_scan_state_ = CoordScanState::IDLE;
+            }
+            else if ((now - coord_scan_phase_ms_) > COORD_SCAN_RESUMING_MAX_MS)
+            {
+                ESP_LOGW(TAG, "[CHSET] Coord scan: rocket did not resume hop within %u ms — "
+                              "letting normal recovery take over",
+                         (unsigned)COORD_SCAN_RESUMING_MAX_MS);
+                coord_scan_state_ = CoordScanState::IDLE;
+            }
+            break;
+        }
+    }
 }
 
 static void setup_bs()
@@ -2000,14 +2190,22 @@ static void loop_bs()
     lora_comms.service();
     lora_comms.pollDio1();  // Fallback if DIO1 interrupt doesn't fire
 
+    // Drive the coordinated-scan state machine first so AWAITING_PAUSE
+    // → SCANNING transitions can kick off a scan in the same iteration
+    // serviceUplink finishes the cmd 16 retries (#90).
+    serviceCoordinatedScan();
+
     // Hop-silence fallback: if we've been following a hopping rocket but
     // haven't heard from it in HOP_SILENCE_FALLBACK_MS, drop back to the
     // static channel so the standard silence / recovery machinery can
     // take over.  Without this, hop_active_ would pin the BS to a hop
     // channel forever after a lost rocket — recovery itself is
     // suppressed while hop_active_ for the opposite reason (don't
-    // recover during normal hop misses).
-    if (hop_active_ && hop_last_rx_ms_ != 0 &&
+    // recover during normal hop misses).  Suppressed during a
+    // coordinated scan (#90): the BS sweeps off the hop channel and the
+    // rocket is parked on lora_freq_mhz, so silence is expected.
+    if (hop_active_ && coord_scan_state_ == CoordScanState::IDLE &&
+        hop_last_rx_ms_ != 0 &&
         (millis() - hop_last_rx_ms_) > HOP_SILENCE_FALLBACK_MS)
     {
         ESP_LOGW(TAG, "[HOP] Silence > %u ms — falling back to static channel",
@@ -2505,8 +2703,14 @@ static void loop_bs()
     {
         // Frequency scan (base-station radio, pre-launch collision avoidance).
         // Payload: [start_mhz f32][stop_mhz f32][step_khz u16][dwell_ms u16]
-        // All fields are little-endian.  A scan blocks normal LoRa RX for
-        // the scan duration — explicitly user-initiated and short (~1-3 s).
+        // All fields are little-endian.
+        //
+        // Two paths (#90):
+        //   • Direct: rocket is in a non-hop state (READY/INIT/LANDED) so we
+        //     can scan immediately without dropping the link.
+        //   • Coordinated: rocket is hopping → tell it to park on
+        //     lora_freq_mhz via cmd 16, *then* scan + push cmd 15, *then*
+        //     let both sides re-bootstrap hop.
         const uint8_t* payload = ble_app.getCommandPayload();
         const size_t plen = ble_app.getCommandPayloadLength();
         if (plen >= 12)
@@ -2518,16 +2722,31 @@ static void loop_bs()
             memcpy(&step_khz,  payload + 8, 2);
             memcpy(&dwell_ms,  payload + 10, 2);
 
-            if (startNoiseScan(start_mhz, stop_mhz, step_khz, dwell_ms))
+            if (!hop_active_)
             {
-                ESP_LOGI(TAG, "[BLE] Scan started: %.1f..%.1f MHz, %u kHz, %u ms (×%u passes)",
-                         (double)start_mhz, (double)stop_mhz,
-                         (unsigned)step_khz, (unsigned)dwell_ms,
-                         (unsigned)LORA_NOISE_SCAN_PASSES);
+                if (startNoiseScan(start_mhz, stop_mhz, step_khz, dwell_ms))
+                {
+                    ESP_LOGI(TAG, "[BLE] Scan started: %.1f..%.1f MHz, %u kHz, %u ms (×%u passes)",
+                             (double)start_mhz, (double)stop_mhz,
+                             (unsigned)step_khz, (unsigned)dwell_ms,
+                             (unsigned)LORA_NOISE_SCAN_PASSES);
+                }
+                else
+                {
+                    ESP_LOGW(TAG, "[BLE] Scan start rejected (busy or invalid range)");
+                }
+            }
+            else if (coord_scan_state_ != CoordScanState::IDLE)
+            {
+                ESP_LOGW(TAG, "[BLE] Scan rejected: coordinated scan already in progress");
+            }
+            else if (uplink_pending)
+            {
+                ESP_LOGW(TAG, "[BLE] Scan rejected: uplink busy — retry shortly");
             }
             else
             {
-                ESP_LOGW(TAG, "[BLE] Scan start rejected (busy or invalid range)");
+                startCoordinatedScan(start_mhz, stop_mhz, step_khz, dwell_ms);
             }
         }
     }

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1552,6 +1552,14 @@ static constexpr uint32_t COORD_SCAN_RESUMING_MAX_MS = 5000;
 // Slack on top of the computed scan + cmd 15 retry budget so the rocket's
 // pause comfortably outlasts our work window.
 static constexpr uint32_t COORD_SCAN_PAUSE_SLACK_MS  = 2000;
+// "Recent enough" window for treating a non-hop_active_ rocket as still
+// in a hop state (#90).  A packet within this window showing PRELAUNCH
+// or INFLIGHT means the rocket is conceptually hopping (possibly
+// bootstrapping or visiting rendezvous) and a direct scan would still
+// drop the link — so route through the coordinated-pause path.  Sized
+// to match RECOVERY_SILENCE_MS (10 s): beyond that the recovery layer
+// has already taken over and we don't presume anything.
+static constexpr uint32_t COORD_HOP_RECENT_MS        = 10000;
 
 // Persist channel-set selection to NVS.  Skip-mask is keyed off the BW
 // it was generated for so a later cmd-10 BW change invalidates it
@@ -2706,11 +2714,16 @@ static void loop_bs()
         // All fields are little-endian.
         //
         // Two paths (#90):
-        //   • Direct: rocket is in a non-hop state (READY/INIT/LANDED) so we
-        //     can scan immediately without dropping the link.
-        //   • Coordinated: rocket is hopping → tell it to park on
-        //     lora_freq_mhz via cmd 16, *then* scan + push cmd 15, *then*
-        //     let both sides re-bootstrap hop.
+        //   • Direct: rocket isn't presumed to be hopping (no recent RX, or
+        //     last seen in READY/INIT/LANDED) — scan immediately.
+        //   • Coordinated: rocket is presumed hopping → cmd 16 to park it
+        //     on lora_freq_mhz, scan, push cmd 15, then re-bootstrap hop.
+        //
+        // The coordinated trigger uses rocketLikelyHopping() so it also
+        // fires when the BS recently caught the rocket in a hop state but
+        // the packet's next_channel_idx was NO_HOP (bootstrap, visiting
+        // rendezvous, or paused).  In all those cases a direct scan would
+        // still drop the link, even though hop_active_ is currently false.
         const uint8_t* payload = ble_app.getCommandPayload();
         const size_t plen = ble_app.getCommandPayloadLength();
         if (plen >= 12)
@@ -2722,7 +2735,11 @@ static void loop_bs()
             memcpy(&step_khz,  payload + 8, 2);
             memcpy(&dwell_ms,  payload + 10, 2);
 
-            if (!hop_active_)
+            const bool need_coord = rocketLikelyHopping(
+                hop_active_, last_packet_ms, millis(),
+                last_rocket_state, COORD_HOP_RECENT_MS);
+
+            if (!need_coord)
             {
                 if (startNoiseScan(start_mhz, stop_mhz, step_khz, dwell_ms))
                 {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -371,12 +371,14 @@ static bool    hop_needs_retune_  = false;
 enum class HopFallbackState : uint8_t {
     NORMAL,
     VISITING_RENDEZVOUS,
+    PAUSED_FOR_SCAN,        // BS-coordinated cmd 16 pause (#90)
 };
 
 static HopFallbackState hop_fallback_state          = HopFallbackState::NORMAL;
 static uint32_t         hop_fallback_phase_start_ms = 0;
 static uint32_t         hop_active_entered_ms       = 0;
 static uint32_t         hop_session_uplink_count    = 0;  // resets each hop session
+static uint32_t         hop_pause_until_ms          = 0;  // wall-clock deadline for PAUSED_FOR_SCAN
 
 // Channel-set state pushed by the BS via LORA_CMD_CHANNEL_SET (#40 / #41
 // phase 3).  rendezvous_mhz_ replaces the hardcoded LORA_RENDEZVOUS_MHZ
@@ -430,6 +432,14 @@ static inline void updateHopFromState(RocketState s)
             lora_in_rx_mode = true;
             hop_fallback_state = HopFallbackState::NORMAL;
         }
+        else if (hop_fallback_state == HopFallbackState::PAUSED_FOR_SCAN)
+        {
+            // We're already on lora_freq_mhz with the operating preset
+            // (cmd 16 reconfigured us there).  No radio-side cleanup
+            // needed — just clear the pause state.
+            hop_fallback_state = HopFallbackState::NORMAL;
+            hop_pause_until_ms = 0;
+        }
         hop_active_       = false;
         hop_first_pkt_    = false;
         hop_needs_retune_ = true;
@@ -438,11 +448,13 @@ static inline void updateHopFromState(RocketState s)
 }
 
 // Frequency the radio should currently be tuned to, given the hop state.
-// First-packet bootstrap and inactive both stay on lora_freq_mhz; the
-// active steady state uses the channel table for the current BW.
+// First-packet bootstrap, PAUSED_FOR_SCAN (#90), and inactive all stay on
+// lora_freq_mhz; the active steady state uses the channel table for the
+// current BW.
 static inline float hopTargetFreqMHz()
 {
-    if (hop_active_ && !hop_first_pkt_)
+    if (hop_active_ && !hop_first_pkt_ &&
+        hop_fallback_state == HopFallbackState::NORMAL)
     {
         const float f = loraChannelMHz(lora_bw_khz, hop_idx_);
         if (f > 0.0f) return f;
@@ -2218,6 +2230,53 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
                  (double)rendezvous_mhz_, (unsigned)active,
                  (unsigned)skip_mask_n_, (double)channel_set_bw_khz_);
     }
+    else if (cmd == LORA_CMD_HOP_PAUSE && payload_len >= 2)
+    {
+        // Coordinated hop pause from BS (#90).  The BS asks us to park
+        // on lora_freq_mhz with our operating preset for N ms, so it can
+        // run a noise scan + push cmd 15 without the link dropping.
+        // Wire format: [duration_ms:u2 little-endian].
+        uint16_t dur_ms;
+        memcpy(&dur_ms, payload + 0, 2);
+        if (dur_ms == 0)
+        {
+            ESP_LOGW("LORA", "UPLINK Cmd 16 ignored: zero duration");
+            return;
+        }
+        if (dur_ms > LORA_HOP_PAUSE_MAX_MS) dur_ms = LORA_HOP_PAUSE_MAX_MS;
+        // Only meaningful while we're hopping.  In non-hop states the
+        // BS uses the existing direct-scan path and never sends cmd 16.
+        // Slow-rendezvous (#71) doesn't need to be checked here: while
+        // it's parking the radio on rendezvous_mhz_, the BS is on a
+        // hop channel and physically can't deliver cmd 16 to us.
+        if (!hop_active_)
+        {
+            ESP_LOGI("LORA", "UPLINK Cmd 16 ignored: not hopping");
+            return;
+        }
+        // Idempotent if we're already paused — extend the deadline.
+        if (hop_fallback_state == HopFallbackState::PAUSED_FOR_SCAN)
+        {
+            hop_pause_until_ms = millis() + dur_ms;
+            ESP_LOGI("OC", "[HOP] Pause extended: +%u ms", (unsigned)dur_ms);
+            return;
+        }
+        // From any other fallback state (NORMAL or mid VISITING_RENDEZVOUS)
+        // we move to PAUSED_FOR_SCAN.  Reconfigure with the operating
+        // preset on lora_freq_mhz; this is *not* a rendezvous visit.
+        if (!lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
+                                     lora_cr, lora_tx_power))
+        {
+            ESP_LOGE("LORA", "UPLINK Cmd 16: reconfigure to lora_freq_mhz failed");
+            return;
+        }
+        (void)lora_comms.startReceive();
+        lora_in_rx_mode = true;
+        hop_pause_until_ms = millis() + dur_ms;
+        hop_fallback_state = HopFallbackState::PAUSED_FOR_SCAN;
+        ESP_LOGW("OC", "[HOP] Paused for scan: %.2f MHz for %u ms",
+                 (double)lora_freq_mhz, (unsigned)dur_ms);
+    }
     else if (cmd == LORA_CMD_HEARTBEAT)
     {
         // Heartbeat from BS (issue #71).  No action — last_uplink_rx_ms
@@ -2570,6 +2629,26 @@ static void serviceHopFallback()
             hop_active_entered_ms = now;
             hop_session_uplink_count = 0;
             ESP_LOGI("OC", "[HOP] Visit done — resuming hop with fresh bootstrap");
+            break;
+        }
+        case HopFallbackState::PAUSED_FOR_SCAN:
+        {
+            // Coordinated pause for BS scan (#90).  We're parked on
+            // lora_freq_mhz with the operating preset; the BS is
+            // sweeping for noise + pushing cmd 15.  When the deadline
+            // hits, re-bootstrap hopping identical to a fresh
+            // PRELAUNCH entry — including the channel(0) anchor — so
+            // both sides re-enter the table cleanly.  Use signed delta
+            // to handle millis() wrap.
+            if ((int32_t)(now - hop_pause_until_ms) < 0) return;
+            hop_first_pkt_           = true;
+            hop_idx_                 = 0;
+            hop_needs_retune_        = false;  // already on lora_freq_mhz
+            hop_active_entered_ms    = now;
+            hop_session_uplink_count = 0;
+            hop_fallback_state       = HopFallbackState::NORMAL;
+            hop_pause_until_ms       = 0;
+            ESP_LOGI("OC", "[HOP] Pause done — resuming hop with fresh bootstrap");
             break;
         }
     }


### PR DESCRIPTION
## Summary

- Adds `LORA_CMD_HOP_PAUSE` (cmd 16) so the BS can tell the rocket to park on `lora_freq_mhz` for N ms while it runs a noise scan + pushes cmd 15. Closes the link-drop pattern from #90 where an iOS auto-cmd-60 fired on a fresh BLE connection while the rocket was already hopping cost ~100 s of re-acquisition.
- Rocket-side `HopFallbackState::PAUSED_FOR_SCAN` with a deadline-driven re-bootstrap that's bit-for-bit identical to a fresh PRELAUNCH entry — channel(0) anchor, `hop_first_pkt_=true`, etc.
- BS-side 5-state `CoordScanState` machine: `AWAITING_PAUSE` → `SCANNING` → `PUSHING_CHSET` → `RESUMING` → `IDLE`. Cmd-60 BLE handler now dispatches direct vs. coordinated path based on `hop_active_`. The `[HOP] Silence > 3000 ms` fallback is gated on `coord_scan_state == IDLE` so the intentional quiet window doesn't trip it.

## Acceptance criteria (from #90)

- [x] Coordinated path runs when `hop_active_`; logs `[CHSET] Coordinated scan start: pausing rocket for N ms` on the BS and `[HOP] Paused for scan: <freq> for N ms` on the rocket.
- [x] No `[HOP] Silence > 3000 ms` fallback during the coordinated window (gated on `coord_scan_state == IDLE`).
- [x] Direct scan path unchanged when not hopping.
- [x] Cmd-16 retry exhaustion / rocket out of range: BS times out in `RESUMING` (5 s) and lets normal recovery take over.
- [x] Cmd-10 BW change during pause: cmd-10 is already rejected while `hop_active_`; `updateHopFromState` clears `PAUSED_FOR_SCAN` cleanly if the user drops to READY first.
- [ ] Field-flow test (power rocket → wait for PRELAUNCH → power BS → let recovery catch the rocket → verify auto-cmd-60 triggers the coordinated flow). Bench/field follow-up — not runnable from CI.

## Wire format

```
cmd 16 LORA_CMD_HOP_PAUSE
  payload: [duration_ms: u2 little-endian]   // 2 bytes; rocket caps to 60 s
```

## Test plan

- [x] `tests_cpp/test_rocket_computer_types.cpp` adds two tests:
  - `LoraCmdHopPause.IdAndCapAreStable` pins cmd-16 = 16, cap fits u16, cmd-15 ≠ cmd-16.
  - `LoraCmdHopPause.WireFormatRoundtrip` verifies LE byte order for a range of durations including 1, 100, 12000, the cap, and 65535.
- [x] Full host suite (229/229) passes.
- [x] `out_computer` and `base_station` IDF builds are clean.
- [ ] Bench: power rocket → PRELAUNCH (rocket hopping) → power BS → recovery catches → fire iOS auto-cmd-60 → verify both `[CHSET] Coordinated scan start` (BS) and `[HOP] Paused for scan` (rocket) logs, no `[HOP] Silence` fallback during the window, both sides resume hop with new rendezvous + skip-mask in effect.
- [ ] Bench: drop rocket out of range mid cmd-16 retries → verify BS abandons in `RESUMING` after 5 s and recovery picks up the rocket.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)