### PR TITLE
lora: SF-aware SNR floor on RX to drop noise-floor false positives

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -485,3 +485,45 @@ TEST(RocketLikelyHopping, StaleRxFalseEvenInHopState) {
     EXPECT_FALSE(rocketLikelyHopping(false, /*last_packet_ms=*/89999,
                                       100000, PRELAUNCH, 10000));   // 10001 ms ago — too stale
 }
+
+// ============================================================================
+// LoRa RX SNR floor (#90 follow-up)
+// ============================================================================
+
+TEST(LoraMinValidSnrDb, MatchesPerSfTheoreticalFloor) {
+    // Per-SF demod-floor − 2 dB margin.  Pinned so a typo in the formula
+    // is caught immediately.
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(6),   -7.0f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(7),   -9.5f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(8),  -12.0f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(9),  -14.5f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(10), -17.0f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(11), -19.5f);
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(12), -22.0f);
+}
+
+TEST(LoraMinValidSnrDb, ClampsOutOfRange) {
+    // Defensive: a stale SF reading (e.g., uninitialised radio) shouldn't
+    // produce a NaN threshold or wrap into a positive number.
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(0),   loraMinValidSnrDb(6));
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(5),   loraMinValidSnrDb(6));
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(13),  loraMinValidSnrDb(12));
+    EXPECT_FLOAT_EQ(loraMinValidSnrDb(255), loraMinValidSnrDb(12));
+}
+
+TEST(LoraMinValidSnrDb, RejectsFieldLogFalsePositive) {
+    // The motivating case: 2026-04-29 field log saw a CRC-passing
+    // decode at SNR=-12.8 dB on SF8 that was clearly garbage (zeroed
+    // payload, RSSI=-110 dBm).  Threshold for SF8 must reject it.
+    constexpr float field_log_snr = -12.8f;
+    EXPECT_LT(field_log_snr, loraMinValidSnrDb(8));
+}
+
+TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
+    // Conversely, a genuine packet at the SF8 sensitivity floor (-10 dB)
+    // must pass, plus a small margin for noise on the SNR estimate.
+    EXPECT_GE(-10.0f, loraMinValidSnrDb(8));   // sensitivity floor passes
+    EXPECT_GE(-11.0f, loraMinValidSnrDb(8));   // 1 dB below sensitivity still passes
+    // SF12 at sensitivity (-20 dB) must also pass.
+    EXPECT_GE(-20.0f, loraMinValidSnrDb(12));
+}

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -82,6 +82,12 @@ public:
     // hop state machine to detect whether a retune is actually required.
     float currentFrequencyMHz() const { return cfg_freq_mhz_; }
 
+    // Reports the radio's currently-configured spreading factor.  The
+    // application uses this to compute an SF-aware SNR floor for RX
+    // (#90 follow-up): rendezvous mode and operating mode can run at
+    // different SFs, so the threshold needs to follow the radio.
+    uint8_t currentSpreadingFactor() const { return cfg_sf_; }
+
     // ---- Spectrum scan (pre-launch collision avoidance) ------------------
     // Non-blocking channel-hopping RSSI scan. Step through a frequency range,
     // dwell in RX mode for `dwell_ms` per channel, then read instantaneous

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -192,6 +192,33 @@ static constexpr uint8_t LORA_CMD_CHANNEL_SET     = 15;   // uplink cmd: rendezv
 static constexpr uint8_t LORA_CMD_HOP_PAUSE       = 16;   // uplink cmd: park on lora_freq_mhz for N ms (#90)
 static constexpr uint16_t LORA_HOP_PAUSE_MAX_MS   = 60000; // server-side cap on cmd 16 duration
 
+// Minimum SNR (dB) for an RX packet to be considered trustworthy at the
+// given spreading factor.  Bench-confirmed in #90 follow-up: a CRC-
+// passing decode at -12.8 dB SNR on SF8 (sensitivity -10 dB) was a
+// noise-floor false positive that confused recovery + hop tracking for
+// 50+ s.  Any decode below this threshold is treated as garbage and
+// dropped before it touches application state.
+//
+// LoRa modulation theory gives demod sensitivity per SF (SNR floor at
+// PER ~10%):
+//   SF6:  -5    SF7:  -7.5   SF8:  -10    SF9:  -12.5
+//   SF10: -15   SF11: -17.5  SF12: -20    (in dB)
+//
+// We keep a 2 dB margin BELOW that floor so the cutoff doesn't reject
+// borderline-but-real packets that the radio happens to demod a touch
+// below the theoretical limit.  Floor − 2 dB lands at:
+//   SF6:  -7    SF7:  -9.5   SF8:  -12    SF9:  -14.5
+//   SF10: -17   SF11: -19.5  SF12: -22
+// — enough to drop the field-log -12.8 dB SF8 false positive while
+// preserving every genuine decode within the demod's working range.
+static inline float loraMinValidSnrDb(uint8_t sf)
+{
+    if (sf < 6)  sf = 6;
+    if (sf > 12) sf = 12;
+    const float sensitivity = -2.5f * (float)(sf - 6) - 5.0f;
+    return sensitivity - 2.0f;
+}
+
 // "Is the rocket presumed to be hopping right now, from the BS's
 // perspective?" — used to decide whether a BLE cmd 60 should take the
 // direct-scan or coordinated-pause path (#90).

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -48,6 +48,12 @@ static int8_t  lora_tx_power   = config::LORA_TX_POWER_DBM;
 static uint32_t last_stats_ms = 0;
 static uint32_t last_rx_count = 0;
 static uint32_t last_packet_ms = 0;
+// CRC-passing decodes whose SNR was below loraMinValidSnrDb(current_sf)
+// — almost certainly noise-floor false positives.  Counted but otherwise
+// dropped so they don't update last_packet_ms / hop / recovery state.
+// (#90 follow-up; the field-confirmed t=79 -12.8 dB SF8 catch is the
+// motivating example.)
+static uint32_t lora_low_snr_drops = 0;
 
 // Base station battery (MAX17205G fuel gauge via I2C)
 static float bs_voltage = NAN;
@@ -796,10 +802,11 @@ static void printStats()
         snprintf(last_pkt_str, sizeof(last_pkt_str), "never");
     }
 
-    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | ISR: %lu | rx_mode: %d | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
+    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | low-SNR drop: %lu | ISR: %lu | rx_mode: %d | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
              (unsigned long)ls.rx_count,
              (double)rx_hz,
              (unsigned long)ls.rx_crc_fail,
+             (unsigned long)lora_low_snr_drops,
              (unsigned long)ls.isr_count,
              (int)ls.rx_mode,
              (double)ls.last_rssi,
@@ -2241,7 +2248,35 @@ static void loop_bs()
     uint8_t rx_buf[256];
     size_t rx_len = 0;
 
+    bool rx_packet_accepted = false;
     if (lora_comms.readPacket(rx_buf, sizeof(rx_buf), rx_len))
+    {
+        // SNR floor (#90 follow-up).  Defends against noise-floor
+        // false-positive decodes that confuse recovery + hop tracking.
+        // The threshold tracks the radio's currently-configured SF
+        // because Phase A rendezvous can run at a different SF than
+        // operating mode.
+        TR_LoRa_Comms::Stats ls_pre = {};
+        lora_comms.getStats(ls_pre);
+        const float min_snr = loraMinValidSnrDb(lora_comms.currentSpreadingFactor());
+        if (ls_pre.last_snr < min_snr)
+        {
+            lora_low_snr_drops++;
+            ESP_LOGW(TAG, "[RX] Drop: SNR %.1f dB < %.1f dB floor "
+                          "(SF%u) — likely noise-floor false positive",
+                     (double)ls_pre.last_snr, (double)min_snr,
+                     (unsigned)lora_comms.currentSpreadingFactor());
+            // Fall through; the `if (rx_packet_accepted)` guard below
+            // skips state updates while letting the rest of loop_bs
+            // (serviceUplink etc.) keep running on schedule.
+        }
+        else
+        {
+            rx_packet_accepted = true;
+        }
+    }
+
+    if (rx_packet_accepted)
     {
         last_packet_ms = millis();
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -522,6 +522,11 @@ static uint32_t lora_tx_fail = 0;
 static uint32_t last_lora_tx_ms = 0;
 // lora_in_rx_mode forward-declared up with the hop state.
 static uint32_t lora_uplink_rx_count = 0;
+// CRC-passing decodes whose SNR was below loraMinValidSnrDb(current_sf)
+// — almost certainly noise-floor false positives.  Counted but otherwise
+// dropped so they can't act on a fake uplink command (cmd 10 reconfigure
+// on garbage payload would be especially bad).  #90 follow-up.
+static uint32_t lora_low_snr_drops = 0;
 
 // Slow-rendezvous trackers (issue #71).  last_uplink_rx_ms bumps on every
 // successfully-parsed uplink packet; ready_entry_ms latches on each
@@ -2328,6 +2333,24 @@ static void serviceLoRaUplink()
 
     if (lora_comms.readPacket(rx_buf, sizeof(rx_buf), rx_len))
     {
+        // SNR floor (#90 follow-up).  Drop noise-floor false positives
+        // before they can fire processUplinkCommand — a fake cmd 10 on
+        // garbage payload could put the radio on a bad channel that
+        // breaks the link entirely.  Threshold tracks the current SF
+        // (rendezvous + operating use different presets).
+        TR_LoRa_Comms::Stats ls = {};
+        lora_comms.getStats(ls);
+        const float min_snr = loraMinValidSnrDb(lora_comms.currentSpreadingFactor());
+        if (ls.last_snr < min_snr)
+        {
+            lora_low_snr_drops++;
+            ESP_LOGW("LORA", "RX drop: SNR %.1f dB < %.1f dB floor (SF%u) "
+                              "— likely noise-floor false positive",
+                     (double)ls.last_snr, (double)min_snr,
+                     (unsigned)lora_comms.currentSpreadingFactor());
+            return;  // skip uplink processing for this iteration
+        }
+
         // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
         if (rx_len >= 6 && rx_buf[0] == config::UPLINK_SYNC_BYTE)
         {
@@ -2968,11 +2991,12 @@ static void printStats()
         {
             TR_LoRa_Comms::Stats ls = {};
             lora_comms.getStats(ls);
-            ESP_LOGI("LORA", "LoRa tx=%lu/%lu rx=%lu crc_fail=%lu isr=%lu uplink_rx=%lu rxmode=%c",
+            ESP_LOGI("LORA", "LoRa tx=%lu/%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu rxmode=%c",
                           (unsigned long)ls.tx_ok,
                           (unsigned long)ls.tx_fail,
                           (unsigned long)ls.rx_count,
                           (unsigned long)ls.rx_crc_fail,
+                          (unsigned long)lora_low_snr_drops,
                           (unsigned long)ls.isr_count,
                           (unsigned long)lora_uplink_rx_count,
                           ls.rx_mode ? 'Y' : 'N');


### PR DESCRIPTION
## Summary

Field test for #90 surfaced a separate-but-related bug: a CRC-passing decode at **SNR = -12.8 dB on SF8** (with sensitivity floor at -10 dB) was treated as a real catch. The packet had all-zero data fields and `next_channel_idx = LORA_NEXT_CH_NO_HOP` — clearly a noise-floor false positive. Once accepted it cascaded: recovery declared itself done, the iOS auto-cmd-60 took the direct-scan path, the iOS auto-cmd-10 raced cmd 15, and 50+ s of churn followed before the link re-established.

This PR adds an SF-aware SNR floor to both RX paths so that kind of decode never enters application state.

## Threshold formula

`loraMinValidSnrDb(sf) = sensitivity_floor(sf) - 2 dB`

Where `sensitivity_floor(sf)` is the LoRa demod theoretical minimum at PER ~10%:

| SF | Sensitivity | Threshold (− 2 dB) |
|----|-------------|---------------------|
| 6  | -5    | -7    |
| 7  | -7.5  | -9.5  |
| 8  | -10   | **-12** |
| 9  | -12.5 | -14.5 |
| 10 | -15   | -17   |
| 11 | -17.5 | -19.5 |
| 12 | -20   | -22   |

The -12.8 dB SF8 field-log false positive is rejected; SF8 packets at sensitivity (-10 dB) still pass with 2 dB of headroom for SNR-estimate noise.

## Where it goes

- **BS RX path** (`base_station/main.cpp`, around the `readPacket` call): pre-fetches stats, drops on low SNR, sets `rx_packet_accepted = false` so the rest of `loop_bs` (uplink retries, recovery service, etc.) keeps running on schedule.
- **Rocket RX path** (`out_computer/main.cpp` `serviceLoRaUplink`): same check; `return` early on drop, since only the uplink-parsing tail of that single function is skipped.
- **TR_LoRa_Comms**: new `currentSpreadingFactor()` getter so the threshold follows the radio's actual SF (rendezvous mode runs at a different SF than operating mode).
- **`loraMinValidSnrDb()`** helper lives in `RocketComputerTypes.h` so it's pure and shared.
- A `lora_low_snr_drops` counter is added to both stats printouts.

## Test plan

- [x] 4 new host tests (`LoraMinValidSnrDb.*`) pin the formula, clamp behavior, field-log rejection, and genuine-borderline acceptance.
- [x] Full host suite passes: 238/238.
- [x] `out_computer` and `base_station` IDF builds clean.
- [ ] Field-test the same "rocket first / BS second" scenario from #91 and verify recovery doesn't end on a -110 dBm catch anymore. Should see `[RX] Drop: SNR -12.8 dB < -12.0 dB floor` in the BS log instead of a bogus `[RX] PRELAUNCH | -110 dBm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
