### PR TITLE
out_computer: stall instrumentation for loop_oc + LoRa SPI

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -1,8 +1,28 @@
 #include "TR_LoRa_Comms.h"
 #include <esp_log.h>
+#include <esp_timer.h>
 #include <cmath>
 
 static const char* TAG = "LORA";
+
+// SPI-bus / RadioLib stall instrumentation (#90 follow-up).  Bench logs
+// showed every-15 s, ~745 ms blocking on Core 1 with all six rocket sensor
+// streams freezing together — the resume sync points to a single Core-1
+// blocker.  reconfigure() is the prime suspect (its TX-wait loop has a 2 s
+// deadline; individual SPI calls can stack behind a slow NAND op via the
+// shared bus mutex).  Anything inside this file that takes longer than
+// LORA_STALL_THRESHOLD_US is logged with its step name so the next bench
+// run names the offending op.
+static constexpr int64_t LORA_STALL_THRESHOLD_US = 50'000;  // 50 ms
+
+#define LORA_STALL_INSTR(name, expr) do {                                      \
+    const int64_t _stall_t0_ = esp_timer_get_time();                           \
+    expr;                                                                      \
+    const int64_t _stall_dt_ = esp_timer_get_time() - _stall_t0_;              \
+    if (_stall_dt_ > LORA_STALL_THRESHOLD_US) {                                \
+        ESP_LOGW(TAG, "STALL: %s took %lld us", (name), (long long)_stall_dt_); \
+    }                                                                          \
+} while (0)
 
 TR_LoRa_Comms* TR_LoRa_Comms::instance_ = nullptr;
 
@@ -111,7 +131,8 @@ void TR_LoRa_Comms::service()
     }
 
     tx_done_ = false;
-    const int16_t st = radio_->finishTransmit();
+    int16_t st;
+    LORA_STALL_INSTR("service finishTransmit", st = radio_->finishTransmit());
     stats_.last_error = st;
     if (st == RADIOLIB_ERR_NONE)
     {
@@ -147,7 +168,8 @@ bool TR_LoRa_Comms::send(const uint8_t* payload, size_t len)
     rx_mode_ = false;
     rx_done_ = false;
 
-    const int16_t st = radio_->startTransmit(payload, len);
+    int16_t st;
+    LORA_STALL_INSTR("send startTransmit", st = radio_->startTransmit(payload, len));
     stats_.last_error = st;
     if (st != RADIOLIB_ERR_NONE)
     {
@@ -192,7 +214,8 @@ bool TR_LoRa_Comms::startReceive()
     rx_done_ = false;
     tx_ongoing_ = false;
 
-    const int16_t st = radio_->startReceive();
+    int16_t st;
+    LORA_STALL_INSTR("startReceive radio_->startReceive", st = radio_->startReceive());
     stats_.last_error = st;
     if (st != RADIOLIB_ERR_NONE)
     {
@@ -231,7 +254,8 @@ bool TR_LoRa_Comms::readPacket(uint8_t* buf, size_t maxLen, size_t& len)
     }
 
     // Read the packet data
-    const int16_t st = radio_->readData(buf, pkt_len);
+    int16_t st;
+    LORA_STALL_INSTR("readPacket readData", st = radio_->readData(buf, pkt_len));
     stats_.last_error = st;
 
     if (st == RADIOLIB_ERR_NONE)
@@ -309,17 +333,29 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
         return false;
     }
 
+    // Whole-call timing — gives an easy upper-bound number for the bench
+    // logs even before any per-step warning fires.
+    const int64_t _reconf_t0 = esp_timer_get_time();
+
     // Wait for any in-progress TX to complete (up to 2 s).
     // Without this, reconfigure silently fails ~18% of the time when
     // the radio happens to be mid-transmit, and NVS never gets updated.
     if (tx_ongoing_)
     {
+        const int64_t _wait_t0 = esp_timer_get_time();
         const uint32_t deadline = millis() + 2000;
         while (tx_ongoing_ && millis() < deadline)
         {
             pollDio1();
             if (tx_done_) { service(); }
             vTaskDelay(1);
+        }
+        const int64_t _wait_dt = esp_timer_get_time() - _wait_t0;
+        if (_wait_dt > LORA_STALL_THRESHOLD_US) {
+            ESP_LOGW(TAG, "STALL: reconfigure wait-for-TX took %lld us "
+                          "(tx_ongoing=%d, hit_deadline=%d)",
+                     (long long)_wait_dt, tx_ongoing_ ? 1 : 0,
+                     tx_ongoing_ ? 1 : 0);
         }
         if (tx_ongoing_) { return false; }  // TX stuck -- give up
     }
@@ -337,7 +373,8 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     int steps_done = 0;
 
     // LLCC68 validates SF against the current BW, so set BW first
-    int16_t st = radio_->setBandwidth(bw_khz);
+    int16_t st;
+    LORA_STALL_INSTR("reconfigure setBandwidth", st = radio_->setBandwidth(bw_khz));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
@@ -346,7 +383,7 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     }
     steps_done = 1;
 
-    st = radio_->setSpreadingFactor(sf);
+    LORA_STALL_INSTR("reconfigure setSpreadingFactor", st = radio_->setSpreadingFactor(sf));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
@@ -355,7 +392,7 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     }
     steps_done = 2;
 
-    st = radio_->setFrequency(freq_mhz);
+    LORA_STALL_INSTR("reconfigure setFrequency", st = radio_->setFrequency(freq_mhz));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
@@ -364,7 +401,7 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     }
     steps_done = 3;
 
-    st = radio_->setCodingRate(cr);
+    LORA_STALL_INSTR("reconfigure setCodingRate", st = radio_->setCodingRate(cr));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
@@ -373,7 +410,7 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     }
     steps_done = 4;
 
-    st = radio_->setOutputPower(tx_power);
+    LORA_STALL_INSTR("reconfigure setOutputPower", st = radio_->setOutputPower(tx_power));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;
@@ -394,6 +431,15 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
                       (double)freq_mhz, (unsigned)sf, (double)bw_khz, (unsigned)cr, (int)tx_power);
     }
 
+    {
+        const int64_t _reconf_dt = esp_timer_get_time() - _reconf_t0;
+        if (_reconf_dt > LORA_STALL_THRESHOLD_US) {
+            ESP_LOGW(TAG, "STALL: reconfigure(total) took %lld us "
+                          "(target %.2f MHz SF%u BW%.0f)",
+                     (long long)_reconf_dt,
+                     (double)freq_mhz, (unsigned)sf, (double)bw_khz);
+        }
+    }
     return true;
 
 rollback:
@@ -439,7 +485,8 @@ bool TR_LoRa_Comms::hopToFrequencyMHz(float freq_mhz)
     rx_mode_ = false;
     rx_done_ = false;
 
-    int16_t st = radio_->setFrequency(freq_mhz);
+    int16_t st;
+    LORA_STALL_INSTR("hopToFrequency setFrequency", st = radio_->setFrequency(freq_mhz));
     if (st != RADIOLIB_ERR_NONE)
     {
         stats_.last_error = st;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3629,10 +3629,32 @@ static void setup_oc()
     ESP_LOGI("OC", "OutComputer ready (PWR_PIN OFF, waiting for power-on command).");
 }
 
+// ============================================================================
+// loop_oc stall instrumentation (#90 follow-up — periodic 745 ms Core-1 stall)
+// ============================================================================
+// Bench analysis showed all six sensor streams freezing for ~745 ms every
+// ~15 s with the Core-1 sensor pipeline resuming within 5 ms across streams
+// — a single Core-1 blocker preempting the I2S parser long enough to
+// overflow the DMA ring.  These macros log any blocking call inside loop_oc
+// (or the LoRa internals) that exceeds LOOP_STALL_THRESHOLD_US so the next
+// bench run names the offending op directly.  Modeled on the existing
+// LFS_TIMING / STALL_THRESHOLD_US instrumentation in TR_LogToFlash.cpp.
+static constexpr int64_t LOOP_STALL_THRESHOLD_US = 100'000;  // 100 ms
+
+#define LOOP_STALL_INSTR(name, expr) do {                                       \
+    const int64_t _stall_t0_ = esp_timer_get_time();                            \
+    expr;                                                                       \
+    const int64_t _stall_dt_ = esp_timer_get_time() - _stall_t0_;               \
+    if (_stall_dt_ > LOOP_STALL_THRESHOLD_US) {                                 \
+        ESP_LOGW("LOOP_STALL", "%s took %lld us", (name), (long long)_stall_dt_); \
+    }                                                                           \
+} while (0)
+
 static void loop_oc()
 {
     // Serial debug console removed (was Arduino Serial.available/read).
     // Use ESP-IDF console component or BLE commands for debug interaction.
+    const int64_t _loop_oc_t0 = esp_timer_get_time();
 
     // --- Active mode: FlightComputer + sensors powered on ---
     if (pwr_pin_on)
@@ -3648,7 +3670,7 @@ static void loop_oc()
         // Skip during blocking flash ops (file list/delete/download) to avoid
         // stalling the I2C slave response and causing FC timeout storms.
         if (i2c_slave_initialized && !flash_op_active)
-            serviceI2CIngress();
+            LOOP_STALL_INSTR("serviceI2CIngress", serviceI2CIngress());
 
         // Launch-triggered logging: start when NSF_LAUNCH appears in NonSensorData
         {
@@ -3669,7 +3691,7 @@ static void loop_oc()
             }
             prev_ns_launch = ns_launch;
         }
-        logger.service();
+        LOOP_STALL_INSTR("logger.service", logger.service());
 
         // Read power data at ~100 Hz (always, so BLE telemetry has fresh data
         // even before launch).  Only log to flash when logging is active.
@@ -3678,7 +3700,7 @@ static void loop_oc()
             uint32_t now_ms = millis();
             if ((now_ms - last_pwr_log_ms) >= 10) {
                 last_pwr_log_ms = now_ms;
-                readINA230Power();
+                LOOP_STALL_INSTR("readINA230Power", readINA230Power());
                 if (latest_power_valid && logger.isLoggingActive()) {
                     uint8_t pwr_frame[MAX_FRAME];
                     size_t  pwr_frame_len = 0;
@@ -3687,29 +3709,30 @@ static void loop_oc()
                                                        sizeof(POWERData),
                                                        pwr_frame, sizeof(pwr_frame),
                                                        pwr_frame_len)) {
-                        logger.enqueueFrame(pwr_frame, pwr_frame_len);
+                        LOOP_STALL_INSTR("logger.enqueueFrame(pwr)",
+                                         logger.enqueueFrame(pwr_frame, pwr_frame_len));
                     }
                 }
             }
         }
 
-        serviceLoRa();
+        LOOP_STALL_INSTR("serviceLoRa", serviceLoRa());
 
         // Check for LoRa uplink commands between TX cycles
-        serviceLoRaUplink();
+        LOOP_STALL_INSTR("serviceLoRaUplink", serviceLoRaUplink());
 
         // Slow-rendezvous cycle: brief visits to LORA_RENDEZVOUS_MHZ when
         // the rocket has been silent in READY for a long time, so the base
         // station's Phase-A recovery has a meeting point (issue #71).
-        serviceRocketRendezvous();
+        LOOP_STALL_INSTR("serviceRocketRendezvous", serviceRocketRendezvous());
 
         // Hop-silence rendezvous: same idea but gated for the hopping
         // case (#40 / #41 phase 2b).  Active only while hop_active_ and
         // suppressed when slow_rendezvous owns the radio.
-        serviceHopFallback();
+        LOOP_STALL_INSTR("serviceHopFallback", serviceHopFallback());
 
         // Send name beacon so base station can identify us
-        sendLoRaBeacon();
+        LOOP_STALL_INSTR("sendLoRaBeacon", sendLoRaBeacon());
     }
     else
     {
@@ -4568,7 +4591,17 @@ static void loop_oc()
         }
     }
 
-    printStats();
+    LOOP_STALL_INSTR("printStats", printStats());
+
+    // Catch-all: any iteration whose total wall time exceeds the threshold
+    // gets logged even if no individual wrapped callsite tripped.  This
+    // surfaces blocking work outside the named LOOP_STALL_INSTR sites.
+    const int64_t _loop_oc_dt = esp_timer_get_time() - _loop_oc_t0;
+    if (_loop_oc_dt > LOOP_STALL_THRESHOLD_US) {
+        ESP_LOGW("LOOP_STALL", "loop_oc iteration took %lld us (catch-all)",
+                 (long long)_loop_oc_dt);
+    }
+
     vTaskDelay(1);  // yield to FreeRTOS scheduler
 }
 


### PR DESCRIPTION
## Summary

Bench analysis of `flight_20260430_005157.bin` (39.94 s recording, PRELAUNCH state) showed all six rocket sensor streams freezing **simultaneously** for ~745 ms every ~15 s, with resume sync points across streams within ~5 ms:

| Sensor | Median gap | Max gap |
|---|---|---|
| ISM6 | 1.0 ms | **744.9 ms** |
| BMP | 2.0 ms | **745.1 ms** |
| MMC | 4.5 ms | **750.8 ms** |
| NonSensor (EKF) | 2.0 ms | **745.5 ms** |
| GNSS | 55.0 ms | **824.6 ms** |
| Power | 10.1 ms | **751.3 ms** |

The cross-stream synchronization on resume points to **a single Core-1 blocker** preempting the I2S parser long enough for the DMA ring to overflow. Steady-state sensor rates are healthy; the issue is purely the periodic stalls.

This PR adds timing instrumentation in two layers so the next bench run names the offending op directly. No behavior change — these only fire `ESP_LOGW` when a wrapped call exceeds its threshold.

## Layer 1 — `loop_oc` (≥ 100 ms threshold)

Wraps every blocking call inside `loop_oc`:

- `serviceI2CIngress`, `logger.service`, `readINA230Power`, `logger.enqueueFrame(pwr)`
- `serviceLoRa`, `serviceLoRaUplink`, `serviceRocketRendezvous`, `serviceHopFallback`, `sendLoRaBeacon`
- `printStats`
- **Catch-all**: total iteration wall time, so anything outside the named sites still surfaces

Format: `LOOP_STALL: <name> took N us`

## Layer 2 — `TR_LoRa_Comms.cpp` internals (≥ 50 ms threshold)

The prime suspect is `lora_comms.reconfigure()` (called from the hop-silence fallback every ~30 s) blocking on the SPI bus mutex while the flush task is mid-NAND-erase. Added per-step timing inside:

- `reconfigure`: wait-for-TX loop, `setBandwidth`, `setSpreadingFactor`, `setFrequency`, `setCodingRate`, `setOutputPower`, plus whole-call total
- `hopToFrequencyMHz`: `setFrequency`
- `service`: `finishTransmit`
- `send`: `startTransmit`
- `startReceive`: `radio_->startReceive`
- `readPacket`: `readData`

Format: `STALL: <step name> took N us`

## How to read the next bench log

After the next run, grep for `LOOP_STALL` and `STALL`. We should see ~3 such lines per 40 s window (matching the 3 observed stalls). The combination of layer-1 (which `loop_oc` call) and layer-2 (which SPI step inside it) tells us exactly which op blocks.

If `serviceHopFallback` is at the top with `reconfigure(total)` underneath, the fix is moving the hop-fallback `reconfigure()` calls to the flush task on Core 0 (same pattern as `prepareFlight` deferral in #77). If something else shows up, we go from there.

## Test plan

- [x] `out_computer` IDF build clean
- [x] Host test suite still passes (no app-side changes touch host-tested code)
- [ ] Bench run with serial output captured. Expected output near each stall:
  ```
  W LOOP_STALL: <call_name> took ~745000 us
  W LORA: STALL: <inner step> took ~Nus  (if LoRa-related)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
