### PR TITLE
sensors: stage 1 — emit IIS2MDC frames into the binary log

### DIFF
--- a/tests/INSTRUCTIONS.txt
+++ b/tests/INSTRUCTIONS.txt
@@ -24,6 +24,21 @@ After a bench test, you typically have:
   - A binary flight log:  ~/Downloads/flight_YYYYMMDD_HHMMSS.bin
   - Serial monitor output: copy-pasted or saved from Arduino Serial Monitor
 
+Optional board-variant sidecar:
+  Drop a <binfile>.meta.json next to the .bin to declare which PCB rev
+  produced the capture.  The integration tests and analyze_bench.py use
+  it to apply the right invariants (e.g. expect zero MMC5983MA frames
+  on the new IIS2MDC board, where the MMC poll path is gated off).
+
+  Schema:
+      {"board": "old"}     # MMC5983MA SPI mag (legacy PCB)
+      {"board": "new"}     # IIS2MDC I2C mag (current PCB rev)
+
+  Missing/invalid sidecar -> defaults to "old" so legacy logs assert
+  unchanged.  The companion <binfile>.json (no .meta) is the iOS
+  flight-summary file written by TinkerRocketApp; do not put board
+  metadata there -- it is on a different schema and may get overwritten.
+
 Run the unified analyzer:
 
     python3 tests/analyze_bench.py <binary.bin>

--- a/tests/analyze_bench.py
+++ b/tests/analyze_bench.py
@@ -37,6 +37,7 @@ TARGET_RATES = {
     "ISM6":       960,   # ISM6HG256_UPDATE_RATE
     "BMP":        500,   # BMP585_UPDATE_RATE (OSR x1/x1 ≈ 460 Hz actual)
     "MMC":        200,   # MMC5983MA_UPDATE_RATE (hw step: 200 Hz)
+    "IIS2MDC":    100,   # IIS2MDC default ODR (new PCB mag)
     "GNSS":        10,   # Realistic ceiling with 4 constellations (config asks 18)
     "NonSensor":  500,   # NON_SENSOR_UPDATE_RATE
     "Power":       -1,   # No fixed rate target
@@ -56,6 +57,7 @@ MSG_INFO = {
     0xA6: ("Power",        10),
     0xA7: ("StartLog",      0),
     0xA8: ("EndFlight",     0),
+    0xD1: ("IIS2MDC",      10),
     0xF1: ("LoRa",         57),
 }
 
@@ -100,6 +102,9 @@ class BinaryStats:
     counts: dict = field(default_factory=dict)          # name -> count
     timestamps: dict = field(default_factory=dict)       # name -> [uint32 us, ...]
     parsed_frames: list = field(default_factory=list)    # [(name, parsed_dict), ...]
+    # Board variant ("old" = MMC5983MA SPI mag, "new" = IIS2MDC I2C mag).
+    # Sourced from <binfile>.meta.json sidecar; defaults to "old".
+    board_variant: str = "old"
 
 
 @dataclass
@@ -166,10 +171,33 @@ class SerialStats:
 # Binary log parser
 # ============================================================================
 
+def _load_board_variant(binfile: Path) -> str:
+    """Read the <binfile>.meta.json sidecar and return its declared board.
+
+    Schema: {"board": "old" | "new"}. Missing/invalid → "old" (legacy).
+    """
+    sidecar = binfile.with_suffix(".meta.json")
+    if not sidecar.exists():
+        return "old"
+    try:
+        import json
+        meta = json.loads(sidecar.read_text())
+        declared = meta.get("board")
+        if declared in ("old", "new"):
+            return declared
+    except (json.JSONDecodeError, OSError):
+        pass
+    return "old"
+
+
 def parse_binary(path: str) -> BinaryStats:
     """Parse a TinkerRocket binary flight log file."""
     data = Path(path).read_bytes()
-    stats = BinaryStats(file_path=path, file_size=len(data))
+    stats = BinaryStats(
+        file_path=path,
+        file_size=len(data),
+        board_variant=_load_board_variant(Path(path)),
+    )
 
     counts = defaultdict(int)
     timestamps = defaultdict(list)
@@ -553,6 +581,11 @@ def report_binary(bs: BinaryStats):
     print(f"  File size:    {bs.file_size:,} bytes")
     print(f"  Valid frames: {bs.valid_frames:,}")
     print(f"  CRC errors:   {bs.crc_errors:,}")
+    variant_note = {
+        "old": "MMC5983MA SPI mag",
+        "new": "IIS2MDC I2C mag (MMC poll-gate active)",
+    }.get(bs.board_variant, bs.board_variant)
+    print(f"  Board variant: {bs.board_variant}  ({variant_note})")
 
     # ── Message counts ──
     print_header("MESSAGE COUNTS")
@@ -569,7 +602,7 @@ def report_binary(bs: BinaryStats):
     print(f"  {'-'*14} {'-'*8} {'-'*8} {'-'*6}  {'-'*8} {'-'*8} {'-'*8} {'-'*6}")
 
     any_non_monotonic = False
-    for name in ["ISM6", "BMP", "MMC", "GNSS", "NonSensor", "Power"]:
+    for name in ["ISM6", "BMP", "MMC", "IIS2MDC", "GNSS", "NonSensor", "Power"]:
         ts = bs.timestamps.get(name, [])
         target = TARGET_RATES.get(name, -1)
         rs = compute_rate_stats(ts)
@@ -597,7 +630,7 @@ def report_binary(bs: BinaryStats):
         print("    individual gap stats reflect forward intervals only.")
 
     # ── Gap analysis for key sensors ──
-    for sensor_name in ["ISM6", "BMP", "MMC", "NonSensor"]:
+    for sensor_name in ["ISM6", "BMP", "MMC", "IIS2MDC", "NonSensor"]:
         ts = bs.timestamps.get(sensor_name, [])
         rs = compute_rate_stats(ts)
         if rs.get('valid_intervals', 0) < 10:
@@ -676,10 +709,16 @@ def report_binary(bs: BinaryStats):
         if 3 in states_seen:
             anomalies.append("Rocket entered INFLIGHT on bench!")
 
-    # Sensor rate anomalies + non-chronological log detection
+    # Sensor rate anomalies + non-chronological log detection.
+    # Mag stream depends on board variant: old uses MMC, new uses IIS2MDC.
+    # Skip the low-rate anomaly for the inactive stream on each variant.
     log_non_chrono = False
     for name, target in TARGET_RATES.items():
         if target <= 0:
+            continue
+        if bs.board_variant == "new" and name == "MMC":
+            continue
+        if bs.board_variant == "old" and name == "IIS2MDC":
             continue
         ts = bs.timestamps.get(name, [])
         rs = compute_rate_stats(ts)
@@ -687,6 +726,29 @@ def report_binary(bs: BinaryStats):
             log_non_chrono = True
         if rs['rate_hz'] > 0 and rs['rate_hz'] < target * 0.5:
             anomalies.append(f"{name} rate {rs['rate_hz']:.0f} Hz is <50% of target {target} Hz")
+
+    # Board-variant invariants.
+    mmc_count = bs.counts.get("MMC", 0)
+    iis2mdc_count = bs.counts.get("IIS2MDC", 0)
+    if bs.board_variant == "new":
+        if mmc_count > 0:
+            anomalies.append(
+                f"new-board log contains {mmc_count} MMC5983MA frames — MMC "
+                f"poll gate broken (regression of #98)"
+            )
+        if iis2mdc_count == 0 and bs.valid_frames > 1000:
+            anomalies.append(
+                "new-board log has zero IIS2MDC frames — I2C mag stream dead "
+                "(check SensorCollector::pollIMUdata IIS2MDC branch)"
+            )
+    elif bs.board_variant == "old":
+        if iis2mdc_count > 0:
+            anomalies.append(
+                f"old-board log contains {iis2mdc_count} IIS2MDC frames — "
+                f"shouldn't happen, the chip isn't populated on this rev"
+            )
+        if mmc_count == 0 and bs.valid_frames > 1000:
+            anomalies.append("old-board log has zero MMC5983MA frames — SPI mag dead?")
     if log_non_chrono:
         anomalies.append("Log contains non-monotonic timestamps — "
                          "likely a ring-buffer / recovery dump, not a live flight log")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,16 @@ To add test data:
     git lfs track "tests/test_data/*.bin"
     cp /path/to/bench_log.bin tests/test_data/bench_static_60s.bin
     git add tests/test_data/bench_static_60s.bin
+
+Board variant metadata (optional):
+    Each <binfile>.bin may have a companion <binfile>.meta.json with the
+    schema {"board": "old" | "new"}. Captures from the legacy MMC5983MA
+    PCB are "old"; captures from the IIS2MDC PCB rev are "new". When the
+    sidecar is absent the variant defaults to "old" so legacy logs keep
+    their existing assertions. The companion <binfile>.json (no .meta)
+    is the iOS app's flight summary and is unrelated.
 """
+import json
 import pytest
 import struct
 from pathlib import Path
@@ -24,6 +33,7 @@ MSG_TYPES = {
     0xA4: "MMC5983MA",
     0xA5: "NON_SENSOR",
     0xA6: "POWER",
+    0xD1: "IIS2MDC",
     0xF1: "LORA",
 }
 
@@ -90,6 +100,53 @@ def parse_bin_file(path: Path) -> list:
 
 
 TEST_DATA_DIR = Path(__file__).parent.parent / "test_data"
+
+
+# Board variants for sensor-suite differences:
+#   "old" — MMC5983MA over SPI (pin 13 CS).  Mag frames type 0xA4 are emitted.
+#   "new" — IIS2MDC over I2C  (pins 13 SDA, 20 SCL).  MMC poll path is
+#            gated off via SensorCollector::iis2mdc_active, so the new board
+#            emits zero 0xA4 frames.  IIS2MDC polling integration is a
+#            follow-up; once it lands a new MSG type will be added here.
+BOARD_OLD = "old"
+BOARD_NEW = "new"
+BOARD_DEFAULT = BOARD_OLD
+KNOWN_BOARDS = (BOARD_OLD, BOARD_NEW)
+
+
+def sidecar_path(binfile: Path) -> Path:
+    """Return the expected sidecar metadata path for a given binfile."""
+    return binfile.with_suffix(".meta.json")
+
+
+def load_sidecar(binfile: Path) -> dict:
+    """Load <binfile>.meta.json, or return {} if missing/unreadable.
+
+    The companion <binfile>.json (no .meta) is the iOS flight-summary
+    file written by TinkerRocketApp and intentionally not consulted here.
+    """
+    path = sidecar_path(binfile)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def board_variant(binfile: Path) -> str:
+    """Return the declared board variant for a binfile.
+
+    Reads the sidecar metadata if present, falling back to BOARD_DEFAULT
+    so legacy logs (no sidecar) keep their pre-existing assertions. An
+    unknown value in the sidecar is treated as missing — log a warning
+    via pytest if/when we ever care, for now silently fall through.
+    """
+    meta = load_sidecar(binfile)
+    declared = meta.get("board")
+    if declared in KNOWN_BOARDS:
+        return declared
+    return BOARD_DEFAULT
 
 
 @pytest.fixture

--- a/tests/integration/test_bin_replay.py
+++ b/tests/integration/test_bin_replay.py
@@ -9,7 +9,14 @@ To add test data:
 """
 import pytest
 from collections import defaultdict
-from conftest import parse_bin_file, get_bin_files, MSG_TYPES
+from conftest import (
+    parse_bin_file,
+    get_bin_files,
+    MSG_TYPES,
+    board_variant,
+    BOARD_OLD,
+    BOARD_NEW,
+)
 
 
 bin_files = get_bin_files()
@@ -143,3 +150,48 @@ class TestBinReplay:
             f"{len(large_gaps)} IMU gaps > 10ms (max 2 allowed): "
             f"{[f'{g:.1f}ms' for g in large_gaps]}"
         )
+
+    def test_mag_frames_match_board_variant(self, binfile):
+        """Magnetometer frame counts must match the declared board variant.
+
+        Old board: MMC5983MA over SPI at 200 Hz. Expect MMC frames present,
+        zero IIS2MDC frames (the IIS2MDC chip isn't populated).
+
+        New board: IIS2MDC over I2C at 100 Hz. Expect IIS2MDC frames present,
+        zero MMC frames (poll path gated on !iis2mdc_active).
+
+        Either-direction non-zero count on the wrong stream is a regression
+        of #98's auto-detect / poll-gate.
+        """
+        frames = sensor_frames(parse_bin_file(binfile))
+        mmc_count = sum(1 for f in frames if f.msg_type == 0xA4)
+        iis2mdc_count = sum(1 for f in frames if f.msg_type == 0xD1)
+        variant = board_variant(binfile)
+
+        if variant == BOARD_NEW:
+            assert mmc_count == 0, (
+                f"new-board log contains {mmc_count} MMC5983MA frames "
+                f"(0xA4); MMC poll path should be gated off when "
+                f"iis2mdc_active is true. Likely regression of #98."
+            )
+            if len(frames) < 1000:
+                pytest.skip("Capture too short to assert IIS2MDC presence")
+            assert iis2mdc_count > 100, (
+                f"new-board log has only {iis2mdc_count} IIS2MDC frames "
+                f"(0xD1); the I2C mag stream looks dead. Check that "
+                f"SensorCollector::pollIMUdata is firing iis2mdc.readRawXYZ."
+            )
+        elif variant == BOARD_OLD:
+            assert iis2mdc_count == 0, (
+                f"old-board log contains {iis2mdc_count} IIS2MDC frames "
+                f"(0xD1); the IIS2MDC chip isn't populated on this PCB rev."
+            )
+            # Sanity gate: a stationary 20+ s capture at 200 Hz target
+            # should yield thousands of MMC frames. Use a low floor
+            # (100) so a brief stall-truncated capture still passes.
+            if len(frames) < 1000:
+                pytest.skip("Capture too short to assert MMC presence")
+            assert mmc_count > 100, (
+                f"old-board log has only {mmc_count} MMC5983MA frames "
+                f"(0xA4); the SPI mag stream looks dead."
+            )

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -562,13 +562,35 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(MMC5983MAData) == 16, 
               "MMC5983MAData must be 16 bytes");
 
-typedef struct 
+typedef struct
 {
     uint32_t time_us;
     double mag_x_uT; // Micro Tesla
     double mag_y_uT;
     double mag_z_uT;
 } MMC5983MADataSI;
+
+// --- IIS2MDC Magnetometer Data (new PCB rev) ---
+// Raw int16 per axis at 0.15 µT/LSB (datasheet 9.13). Scaling and frame
+// rotation handled by TR_Sensor_Data_Converter (Stage 2 follow-up).
+typedef struct __attribute__((packed))
+{
+    uint32_t time_us;   // micros()
+    int16_t  mag_x;     // Raw counts (signed 16-bit)
+    int16_t  mag_y;
+    int16_t  mag_z;
+} IIS2MDCData;
+
+static_assert(sizeof(IIS2MDCData) == 10,
+              "IIS2MDCData must be 10 bytes");
+
+typedef struct
+{
+    uint32_t time_us;
+    double mag_x_uT;
+    double mag_y_uT;
+    double mag_z_uT;
+} IIS2MDCDataSI;
 
 // --- Non sensor data ---
 typedef struct __attribute__((packed))
@@ -884,6 +906,7 @@ static constexpr uint8_t PYRO_CONFIG_PENDING      = 0xCD;
 static constexpr uint8_t PYRO_CONFIG_MSG          = 0xCE;
 static constexpr uint8_t PYRO_CONT_TEST           = 0xCF;  // momentary arm → read continuity → disarm
 static constexpr uint8_t PYRO_FIRE_TEST            = 0xD0;  // test-fire a pyro channel from app
+static constexpr uint8_t IIS2MDC_MSG          = 0xD1;  // new-PCB IIS2MDC magnetometer raw frame
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
 // Camera types
@@ -1005,6 +1028,7 @@ static constexpr size_t SIZE_OF_GNSS_DATA = sizeof(GNSSData);
 static constexpr size_t SIZE_OF_BMP585_DATA     = sizeof(BMP585Data);
 static constexpr size_t SIZE_OF_ISM6HG256_DATA  = sizeof(ISM6HG256Data);
 static constexpr size_t SIZE_OF_MMC5983MA_DATA  = sizeof(MMC5983MAData);
+static constexpr size_t SIZE_OF_IIS2MDC_DATA    = sizeof(IIS2MDCData);
 static constexpr size_t SIZE_OF_POWER_DATA      = sizeof(POWERData);
 static constexpr size_t SIZE_OF_NON_SENSOR_DATA = sizeof(NonSensorData);
 static constexpr size_t SIZE_OF_LORA_DATA       = sizeof(LoRaData);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -76,7 +76,9 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     ism6hg256_data_ready = false;
     bmp585_data_ready = false;
     mmc5983ma_data_ready = false;
+    iis2mdc_data_ready = false;
     gnss_data_ready = false;
+    iis2mdc_last_sample_us = 0;
     bmp585_irq_pending_count = 0;
     mmc5983ma_irq_pending_count = 0;
     ism6_isr_fired = false;
@@ -153,6 +155,14 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         while (1) delay(1000);
     }
     xSemaphoreGive(mmc5983maDataSemaphore);
+
+    iis2mdcDataSemaphore = xSemaphoreCreateBinary();
+    if (iis2mdcDataSemaphore == NULL)
+    {
+        ESP_LOGE(SC_TAG, "Failed to create IIS2MDC data semaphore!");
+        while (1) delay(1000);
+    }
+    xSemaphoreGive(iis2mdcDataSemaphore);
 
     gnssDataSemaphore = xSemaphoreCreateBinary();
     if (gnssDataSemaphore == NULL)
@@ -695,6 +705,34 @@ void SensorCollector::pollIMUdata(void* parameter)
             }
         }
 
+        // === IIS2MDC — time-gated I2C poll at ODR (default 100 Hz) ===
+        // No DRDY pin yet; we throttle reads to IIS2MDC_PERIOD_US so we don't
+        // spam the I2C bus from the ~1 kHz polling task. BDU is on, so a
+        // partial read across an internal sample boundary returns the prior
+        // complete sample instead of tearing.
+        if (self->iis2mdc_active)
+        {
+            const uint32_t iis2_now_us = micros();
+            if ((int32_t)(iis2_now_us - self->iis2mdc_last_sample_us) >=
+                (int32_t)IIS2MDC_PERIOD_US)
+            {
+                IIS2MDC_RawData iis2_raw = {};
+                if (self->iis2mdc.readRawXYZ(&iis2_raw) == TR_IIS2MDC_OK)
+                {
+                    if (xSemaphoreTake(self->iis2mdcDataSemaphore, 0) == pdTRUE)
+                    {
+                        self->iis2mdc_data.time_us = iis2_now_us;
+                        self->iis2mdc_data.mag_x = iis2_raw.x;
+                        self->iis2mdc_data.mag_y = iis2_raw.y;
+                        self->iis2mdc_data.mag_z = iis2_raw.z;
+                        self->iis2mdc_data_ready = true;
+                        xSemaphoreGive(self->iis2mdcDataSemaphore);
+                    }
+                    self->iis2mdc_last_sample_us = iis2_now_us;
+                }
+            }
+        }
+
         // Track total iteration time (excluding the notification wait)
         const uint32_t iter_elapsed = micros() - iter_start_us;
         if (iter_elapsed > self->pt_iter_max_us)
@@ -783,6 +821,18 @@ bool SensorCollector::getMMC5983MAData(MMC5983MAData& mmc5983ma_out)
         mmc5983ma_out = mmc5983ma_data;
         xSemaphoreGive(mmc5983maDataSemaphore);
         mmc5983ma_data_ready = false;
+        return true;
+    }
+    return false;
+}
+
+bool SensorCollector::getIIS2MDCData(IIS2MDCData& iis2mdc_out)
+{
+    if (iis2mdc_data_ready && xSemaphoreTake(iis2mdcDataSemaphore, 0) == pdTRUE)
+    {
+        iis2mdc_out = iis2mdc_data;
+        xSemaphoreGive(iis2mdcDataSemaphore);
+        iis2mdc_data_ready = false;
         return true;
     }
     return false;

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -97,11 +97,13 @@ public:
     volatile bool ism6hg256_data_ready;
     volatile bool bmp585_data_ready;
     volatile bool mmc5983ma_data_ready;
+    volatile bool iis2mdc_data_ready;
     volatile bool gnss_data_ready;
 
     bool getISM6HG256Data(ISM6HG256Data &data_out);
     bool getBMP585Data(BMP585Data &data_out);
     bool getMMC5983MAData(MMC5983MAData &data_out);
+    bool getIIS2MDCData(IIS2MDCData &data_out);
     bool getGNSSData(GNSSData &data_out);
     void getISM6HG256DebugSnapshot(ISM6HG256DebugSnapshot &snapshot_out) const;
     void getMMC5983MADebugSnapshot(MMC5983MADebugSnapshot &snapshot_out) const;
@@ -166,12 +168,18 @@ private:
     ISM6HG256Data ism6hg256_data;
     BMP585Data bmp585_data;
     MMC5983MAData mmc5983ma_data;
+    IIS2MDCData iis2mdc_data;
     GNSSData gnss_data;
 
     SemaphoreHandle_t ism6hg256DataSemaphore;
     SemaphoreHandle_t bmp585DataSemaphore;
     SemaphoreHandle_t mmc5983maDataSemaphore;
+    SemaphoreHandle_t iis2mdcDataSemaphore;
     SemaphoreHandle_t gnssDataSemaphore;
+
+    // Time-gated polling state for IIS2MDC (no DRDY pin yet).
+    uint32_t iis2mdc_last_sample_us = 0;
+    static constexpr uint32_t IIS2MDC_PERIOD_US = 10000;  // 100 Hz, matches default ODR
     TaskHandle_t pollIMUTaskHandle;
     TaskHandle_t pollGNSSTaskHandle = nullptr;
 

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -178,6 +178,14 @@ bool SensorCollectorSim::getMMC5983MAData(MMC5983MAData& data_out)
     return true;
 }
 
+bool SensorCollectorSim::getIIS2MDCData(IIS2MDCData& data_out)
+{
+    // No sim model for IIS2MDC yet — pass through real data only.
+    // When sim is active, IIS2MDC frames are simply not produced (sim flights
+    // populate MMC instead via encodeMMC5983MA above).
+    return real_.getIIS2MDCData(data_out);
+}
+
 bool SensorCollectorSim::getGNSSData(GNSSData& data_out)
 {
     bool have_data = real_.getGNSSData(data_out);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
@@ -33,6 +33,7 @@ public:
     bool getISM6HG256Data(ISM6HG256Data& data_out);
     bool getBMP585Data(BMP585Data& data_out);
     bool getMMC5983MAData(MMC5983MAData& data_out);
+    bool getIIS2MDCData(IIS2MDCData& data_out);
     bool getGNSSData(GNSSData& data_out);
 
     // Debug passthrough

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -79,6 +79,8 @@ static BMP585Data bmp585_data;
 static uint8_t bmp585_data_buffer[SIZE_OF_BMP585_DATA];
 static MMC5983MAData mmc5983ma_data;
 static uint8_t mmc5983ma_data_buffer[SIZE_OF_MMC5983MA_DATA];
+static IIS2MDCData iis2mdc_data;
+static uint8_t iis2mdc_data_buffer[SIZE_OF_IIS2MDC_DATA];
 static GNSSData gnss_data;
 static uint8_t gnss_data_buffer[SIZE_OF_GNSS_DATA];
 static NonSensorData non_sensor_data;
@@ -119,6 +121,8 @@ uint32_t i2s_tx_bmp_ok = 0;
 uint32_t i2s_tx_bmp_fail = 0;
 uint32_t i2s_tx_mmc_ok = 0;
 uint32_t i2s_tx_mmc_fail = 0;
+uint32_t i2s_tx_iis2mdc_ok = 0;
+uint32_t i2s_tx_iis2mdc_fail = 0;
 uint32_t i2s_tx_gnss_ok = 0;
 uint32_t i2s_tx_gnss_fail = 0;
 uint32_t i2s_tx_ns_ok = 0;
@@ -729,6 +733,7 @@ static inline void i2sSendWithStats(uint8_t type, const uint8_t *payload, size_t
             case ISM6HG256_MSG: i2s_tx_ism6_ok++; break;
             case BMP585_MSG: i2s_tx_bmp_ok++; break;
             case MMC5983MA_MSG: i2s_tx_mmc_ok++; break;
+            case IIS2MDC_MSG: i2s_tx_iis2mdc_ok++; break;
             case GNSS_MSG: i2s_tx_gnss_ok++; break;
             case NON_SENSOR_MSG: i2s_tx_ns_ok++; break;
             default: break;
@@ -743,6 +748,7 @@ static inline void i2sSendWithStats(uint8_t type, const uint8_t *payload, size_t
             case ISM6HG256_MSG: i2s_tx_ism6_fail++; break;
             case BMP585_MSG: i2s_tx_bmp_fail++; break;
             case MMC5983MA_MSG: i2s_tx_mmc_fail++; break;
+            case IIS2MDC_MSG: i2s_tx_iis2mdc_fail++; break;
             case GNSS_MSG: i2s_tx_gnss_fail++; break;
             case NON_SENSOR_MSG: i2s_tx_ns_fail++; break;
             default: break;
@@ -1647,6 +1653,19 @@ static void loop_fc()
         (void)enqueueI2STx(MMC5983MA_MSG,
                            mmc5983ma_data_buffer,
                            SIZE_OF_MMC5983MA_DATA);
+    }
+
+    if (sensor_collector.getIIS2MDCData(iis2mdc_data))
+    {
+        // Stage 1: raw frames flow through I2S/log only.
+        // Converter + EKF integration arrive in Stages 2 and 3.
+        memcpy(iis2mdc_data_buffer,
+               &iis2mdc_data,
+               SIZE_OF_IIS2MDC_DATA);
+
+        (void)enqueueI2STx(IIS2MDC_MSG,
+                           iis2mdc_data_buffer,
+                           SIZE_OF_IIS2MDC_DATA);
     }
 
     if (sensor_collector.getGNSSData(gnss_data))

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -503,6 +503,10 @@ static MMC5983MAData latest_mmc_raw = {};
 static MMC5983MADataSI latest_mmc_si = {};
 static bool latest_mmc_valid = false;
 
+static IIS2MDCData latest_iis2mdc_raw = {};
+static bool latest_iis2mdc_valid = false;
+// IIS2MDCDataSI populated in Stage 2 (converter integration).
+
 static bool latest_ism6_valid = false;
 static bool latest_bmp_valid = false;
 static GNSSDataSI latest_gnss_si = {};
@@ -882,6 +886,7 @@ static uint32_t msg_count_query = 0;
 static uint32_t msg_count_ism6 = 0;
 static uint32_t msg_count_bmp = 0;
 static uint32_t msg_count_mmc = 0;
+static uint32_t msg_count_iis2mdc = 0;
 static uint32_t msg_count_gnss = 0;
 static uint32_t msg_count_non_sensor = 0;
 static uint32_t msg_count_power = 0;
@@ -893,6 +898,7 @@ static uint32_t prev_msg_count_query = 0;
 static uint32_t prev_msg_count_ism6 = 0;
 static uint32_t prev_msg_count_bmp = 0;
 static uint32_t prev_msg_count_mmc = 0;
+static uint32_t prev_msg_count_iis2mdc = 0;
 static uint32_t prev_msg_count_gnss = 0;
 static uint32_t prev_msg_count_non_sensor = 0;
 static uint32_t prev_msg_count_power = 0;
@@ -1102,6 +1108,7 @@ static bool isKnownMessageType(uint8_t type)
         case ISM6HG256_MSG:
         case BMP585_MSG:
         case MMC5983MA_MSG:
+        case IIS2MDC_MSG:
         case NON_SENSOR_MSG:
         case POWER_MSG:
         case START_LOGGING:
@@ -1161,7 +1168,8 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
     if (payload_len >= 4)
     {
         static uint32_t prev_time_ism6 = 0, prev_time_bmp = 0,
-                         prev_time_mmc = 0, prev_time_gnss = 0,
+                         prev_time_mmc = 0, prev_time_iis2mdc = 0,
+                         prev_time_gnss = 0,
                          prev_time_ns = 0, prev_time_pwr = 0,
                          prev_time_guid = 0;
         // dma_cb_count snapshot taken when each prev_time_* was last updated.
@@ -1169,7 +1177,8 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         // its current dma_cb_count to the prev_cb value to tell whether the
         // duplicate came from the same DMA delivery or a different one.
         static uint32_t prev_cb_ism6 = 0, prev_cb_bmp = 0,
-                         prev_cb_mmc = 0, prev_cb_gnss = 0,
+                         prev_cb_mmc = 0, prev_cb_iis2mdc = 0,
+                         prev_cb_gnss = 0,
                          prev_cb_ns = 0, prev_cb_pwr = 0,
                          prev_cb_guid = 0;
         static uint32_t max_time_us = 0;  // Monotonic high-water mark across all types
@@ -1181,6 +1190,7 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             case ISM6HG256_MSG:       prev = &prev_time_ism6; prev_cb = &prev_cb_ism6; break;
             case BMP585_MSG:          prev = &prev_time_bmp;  prev_cb = &prev_cb_bmp;  break;
             case MMC5983MA_MSG:       prev = &prev_time_mmc;  prev_cb = &prev_cb_mmc;  break;
+            case IIS2MDC_MSG:         prev = &prev_time_iis2mdc; prev_cb = &prev_cb_iis2mdc; break;
             case GNSS_MSG:            prev = &prev_time_gnss; prev_cb = &prev_cb_gnss; break;
             case NON_SENSOR_MSG:      prev = &prev_time_ns;   prev_cb = &prev_cb_ns;   break;
             case POWER_MSG:           prev = &prev_time_pwr;  prev_cb = &prev_cb_pwr;  break;
@@ -1291,6 +1301,19 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             memcpy(&latest_mmc_raw, payload, sizeof(MMC5983MAData));
             sensor_converter.convertMMC5983MAData(latest_mmc_raw, latest_mmc_si);
             latest_mmc_valid = true;
+        }
+    }
+    else if (type == IIS2MDC_MSG)
+    {
+        msg_count_iis2mdc++;
+        if (payload_len >= sizeof(IIS2MDCData))
+        {
+            memcpy(&latest_iis2mdc_raw, payload, sizeof(IIS2MDCData));
+            latest_iis2mdc_valid = true;
+            // Conversion to SI is deferred to Stage 2.
+            // Frame is already enqueued for the binary log via the
+            // logger.enqueueFrame above; downstream consumers (BLE telemetry,
+            // EKF) get wired in Stage 2/3.
         }
     }
     else if (type == GNSS_MSG)


### PR DESCRIPTION
## Summary

Stage 1 of the IIS2MDC integration: wires the magnetometer (added in [#98](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/98) for boot-time detect only) through the polling loop, I2S TX path, OC ingress, and binary log so fresh new-PCB captures produce a magnetometer stream for the first time.

Subsequent **complete-integration branch** will add the converter (raw → µT + rotation) and the EKF `magMeasUpdate` hookup; deliberately deferred so this PR can land + bench-validate the data path in isolation.

## Changes

**Data type & wire format**

- New `IIS2MDC_MSG = 0xD1` and packed `IIS2MDCData` struct (10 bytes: `uint32_t time_us + 3 × int16_t` raw counts) in [TR_RocketComputerTypes](tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h).

**Polling**

- [SensorCollector::pollIMUdata](tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp) gains a time-gated branch (`IIS2MDC_PERIOD_US = 10 000 µs = 100 Hz`, matching the default ODR set in [#98](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/98)) that issues `iis2mdc.readRawXYZ()` and populates `iis2mdc_data` when `iis2mdc_active` is true.
- New `iis2mdcDataSemaphore` + `iis2mdc_data_ready` flag mirror the existing MMC pattern.
- New `getIIS2MDCData()` consumer + `SensorCollectorSim` passthrough (no synthetic IIS2MDC model yet — sim flights still populate MMC).

**Telemetry plumbing**

- [flight_computer/main/main.cpp](tinkerrocket-idf/projects/flight_computer/main/main.cpp) consumes `getIIS2MDCData()` → `enqueueI2STx(IIS2MDC_MSG, ...)` right after the MMC enqueue. New `i2s_tx_iis2mdc_ok/fail` stats. **Converter call intentionally absent** — coming in the next branch.
- [out_computer/main/main.cpp](tinkerrocket-idf/projects/out_computer/main/main.cpp): `IIS2MDC_MSG` accepted by `isKnownMessageType`, added to the dedup tracking table (`prev_time_iis2mdc` / `prev_cb_iis2mdc`), and a Stage-1 ingress handler that `memcpy`s into `latest_iis2mdc_raw`. Frame is logged via `logger.enqueueFrame` like every other sensor stream.

**Test infrastructure**

- Sidecar `<binfile>.meta.json` schema documented in [tests/INSTRUCTIONS.txt](tests/INSTRUCTIONS.txt). Optional; defaults to `{"board": "old"}` so legacy logs assert unchanged.
- [conftest.py](tests/integration/conftest.py): `0xD1 → "IIS2MDC"` in `MSG_TYPES`.
- [test_mag_frames_match_board_variant](tests/integration/test_bin_replay.py) now asserts the *correct stream* is alive on each variant: new boards must emit IIS2MDC frames + zero MMC frames; old boards must emit MMC frames + zero IIS2MDC frames.
- [analyze_bench.py](tests/analyze_bench.py): IIS2MDC picked up in the rate table, gap analysis, and anomaly check. Zero-IIS2MDC on a new board is flagged; the inactive stream's low-rate warning is suppressed per variant.

## Test plan

- [x] Both `flight_computer` and `out_computer` build clean.
- [x] All pre-existing pytest tests still pass on legacy data (5/6 — the one failure is the *new* assertion correctly catching pre-Stage-1 captures with zero IIS2MDC frames).
- [ ] Bench test on new board: confirm IIS2MDC frames flow at ~100 Hz, `mmc=0`, `[GAP DIAG]` clean, no #94 stalls.
- [ ] `analyze_bench` shows IIS2MDC row in the rate table at ~100 Hz with `✅` status.
- [ ] `test_mag_frames_match_board_variant` passes on the fresh capture with `{"board": "new"}` sidecar.
- [ ] Old-board sanity: confirm MMC stream still healthy and IIS2MDC count is 0 (no regression of the legacy path).

## Notes for the bench run

A Stage-1 firmware capture is required to validate the new test path. Pre-Stage-1 captures from new boards (e.g. `flight_20260501_191713.bin` already in `tests/test_data/`) **will fail** the new IIS2MDC-presence assertion — that's expected; remove or re-capture them. After flashing this build, drop the new `.bin` + `.meta.json` (`{"board": "new"}`) into `tests/test_data/` and run `./tests/run_bench_tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
