### PR TITLE
sensors: complete IIS2MDC integration — converter + EKF mag input

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -9,6 +9,7 @@ SensorConverter::SensorConverter()
                                 ISM6GyroFullScale::DPS_4000);
     configureISM6HG256RotationZ(0.0f);
     configureMMC5983MARotationZ(0.0f);
+    configureIIS2MDCRotationZ(0.0f);
 }
 
 void SensorConverter::configureISM6HG256FullScale(
@@ -51,6 +52,11 @@ void SensorConverter::configureISM6HG256RotationZ(float rotation_z_deg)
 void SensorConverter::configureMMC5983MARotationZ(float rotation_z_deg)
 {
     mmc_rot_z_rad = rotation_z_deg * (PI / 180.0f);
+}
+
+void SensorConverter::configureIIS2MDCRotationZ(float rotation_z_deg)
+{
+    iis2mdc_rot_z_rad = rotation_z_deg * (PI / 180.0f);
 }
 
 void SensorConverter::setHighGBias(float bx, float by, float bz)
@@ -218,6 +224,29 @@ void SensorConverter::convertMMC5983MAData(const MMC5983MAData& in, MMC5983MADat
   out.mag_x_uT = (mx * c) - (my * s);
   out.mag_y_uT = (mx * s) + (my * c);
   out.mag_z_uT = mz;
+}
+
+// --- IIS2MDC (new-PCB magnetometer) ---
+// Sensitivity per datasheet 9.13: 1.5 mgauss/LSB = 0.15 uT/LSB. Raw is
+// already signed int16 centered at 0 (no offset register subtract here —
+// see TR_IIS2MDC's softReset path which zeroes OFFSET_X/Y/Z).
+void SensorConverter::convertIIS2MDCData(const IIS2MDCData& in, IIS2MDCDataSI& out)
+{
+    out.time_us = in.time_us;
+
+    static constexpr double UT_PER_LSB = 0.15;
+
+    const double mx = (double)in.mag_x * UT_PER_LSB;
+    const double my = (double)in.mag_y * UT_PER_LSB;
+    const double mz = (double)in.mag_z * UT_PER_LSB;
+
+    const double c = (double)cosf(iis2mdc_rot_z_rad);
+    const double s = (double)sinf(iis2mdc_rot_z_rad);
+
+    // Sensor frame -> board frame, rotation about +Z.
+    out.mag_x_uT = (mx * c) - (my * s);
+    out.mag_y_uT = (mx * s) + (my * c);
+    out.mag_z_uT = mz;
 }
 
 // --- NonSensor ---

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
@@ -43,6 +43,7 @@ public:
                                      ISM6GyroFullScale gyro_fs);
     void configureISM6HG256RotationZ(float rotation_z_deg);
     void configureMMC5983MARotationZ(float rotation_z_deg);
+    void configureIIS2MDCRotationZ(float rotation_z_deg);
 
     // Set high-g accelerometer bias (m/s², in body frame).
     // Subtracted from ISM6HG256 high-g output during conversion.
@@ -58,8 +59,10 @@ public:
                            BMP585DataSI& out);
     void convertISM6HG256Data(const ISM6HG256Data& in, 
                               ISM6HG256DataSI& out);
-    void convertMMC5983MAData(const MMC5983MAData& in, 
+    void convertMMC5983MAData(const MMC5983MAData& in,
                               MMC5983MADataSI& out);
+    void convertIIS2MDCData(const IIS2MDCData& in,
+                            IIS2MDCDataSI& out);
     void convertNonSensorData(const NonSensorData& in, 
                               NonSensorDataSI& out);
     
@@ -83,6 +86,7 @@ private:
     float gyro_dps_per_lsb     = 0.0f;
     float ism6_rot_z_rad       = 0.0f;
     float mmc_rot_z_rad        = 0.0f;
+    float iis2mdc_rot_z_rad    = 0.0f;
 
     // High-g accelerometer bias (m/s², body frame)
     float hg_bias_x_ = 0.0f, hg_bias_y_ = 0.0f, hg_bias_z_ = 0.0f;

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -76,6 +76,11 @@ struct config
     // MMC5983MA -> board frame (deg), CCW positive about +Z.
     // Note: board frame: +X forward, +Y left, +Z up.
     static constexpr float MMC5983MA_ROT_Z_DEG = 180.0f;
+    // IIS2MDC -> board frame (deg). Default 0 deg (no rotation) until
+    // bench characterization confirms the chip's mounting on the new PCB
+    // rev. Adjust here when the EKF heading shows a fixed offset relative
+    // to the IMU's Z axis.
+    static constexpr float IIS2MDC_ROT_Z_DEG = 0.0f;
 
     // TODO Auto dection of orientation and rotation of aribtrary board position
     // to body frame

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -81,6 +81,8 @@ static MMC5983MAData mmc5983ma_data;
 static uint8_t mmc5983ma_data_buffer[SIZE_OF_MMC5983MA_DATA];
 static IIS2MDCData iis2mdc_data;
 static uint8_t iis2mdc_data_buffer[SIZE_OF_IIS2MDC_DATA];
+static IIS2MDCDataSI iis2mdc_latest_si = {};
+static bool have_iis2mdc_si = false;
 static GNSSData gnss_data;
 static uint8_t gnss_data_buffer[SIZE_OF_GNSS_DATA];
 static NonSensorData non_sensor_data;
@@ -1345,6 +1347,7 @@ static void setup_fc()
         static_cast<ISM6GyroFullScale>(config::ISM6_GYRO_FS_DPS));
     sensor_converter.configureISM6HG256RotationZ(config::ISM6HG256_ROT_Z_DEG);
     sensor_converter.configureMMC5983MARotationZ(config::MMC5983MA_ROT_Z_DEG);
+    sensor_converter.configureIIS2MDCRotationZ(config::IIS2MDC_ROT_Z_DEG);
     sensor_collector.configureSimRotation(config::ISM6HG256_ROT_Z_DEG);
 
     out_status_query_data.ism6_low_g_fs_g = config::ISM6_LOW_G_FS_G;
@@ -1657,8 +1660,9 @@ static void loop_fc()
 
     if (sensor_collector.getIIS2MDCData(iis2mdc_data))
     {
-        // Stage 1: raw frames flow through I2S/log only.
-        // Converter + EKF integration arrive in Stages 2 and 3.
+        sensor_converter.convertIIS2MDCData(iis2mdc_data, iis2mdc_latest_si);
+        have_iis2mdc_si = true;
+
         memcpy(iis2mdc_data_buffer,
                &iis2mdc_data,
                SIZE_OF_IIS2MDC_DATA);
@@ -1763,12 +1767,20 @@ static void loop_fc()
             ekf_imu.gyro_z = -(double)ism6_latest_si.gyro_z;
 
             // ── Build EKF input: Magnetometer in FRD body frame ──
+            // Prefer IIS2MDC (new PCB) when its samples are flowing, fall
+            // back to MMC5983MA on legacy boards. Only one is populated on
+            // any given board, so this picks "whichever mag is alive".
             EkfMagData ekf_mag = {};
-            ekf_mag.time_us = have_mmc_si ? mmc_latest_si.time_us : 0;
-            if (have_mmc_si) {
+            if (have_iis2mdc_si) {
+                ekf_mag.time_us = iis2mdc_latest_si.time_us;
+                ekf_mag.mag_x =  iis2mdc_latest_si.mag_x_uT;
+                ekf_mag.mag_y = -iis2mdc_latest_si.mag_y_uT;   // FLU→FRD
+                ekf_mag.mag_z = -iis2mdc_latest_si.mag_z_uT;   // FLU→FRD
+            } else if (have_mmc_si) {
+                ekf_mag.time_us = mmc_latest_si.time_us;
                 ekf_mag.mag_x =  mmc_latest_si.mag_x_uT;
-                ekf_mag.mag_y = -mmc_latest_si.mag_y_uT;   // FLU→FRD
-                ekf_mag.mag_z = -mmc_latest_si.mag_z_uT;   // FLU→FRD
+                ekf_mag.mag_y = -mmc_latest_si.mag_y_uT;       // FLU→FRD
+                ekf_mag.mag_z = -mmc_latest_si.mag_z_uT;       // FLU→FRD
             }
 
             // ── Build EKF input: GNSS in LLA + NED ──

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -504,8 +504,8 @@ static MMC5983MADataSI latest_mmc_si = {};
 static bool latest_mmc_valid = false;
 
 static IIS2MDCData latest_iis2mdc_raw = {};
+static IIS2MDCDataSI latest_iis2mdc_si = {};
 static bool latest_iis2mdc_valid = false;
-// IIS2MDCDataSI populated in Stage 2 (converter integration).
 
 static bool latest_ism6_valid = false;
 static bool latest_bmp_valid = false;
@@ -1309,11 +1309,8 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         if (payload_len >= sizeof(IIS2MDCData))
         {
             memcpy(&latest_iis2mdc_raw, payload, sizeof(IIS2MDCData));
+            sensor_converter.convertIIS2MDCData(latest_iis2mdc_raw, latest_iis2mdc_si);
             latest_iis2mdc_valid = true;
-            // Conversion to SI is deferred to Stage 2.
-            // Frame is already enqueued for the binary log via the
-            // logger.enqueueFrame above; downstream consumers (BLE telemetry,
-            // EKF) get wired in Stage 2/3.
         }
     }
     else if (type == GNSS_MSG)


### PR DESCRIPTION
## Summary

Stage 2 + 3 of the IIS2MDC work, follow-up to [#99](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/99) (raw frames). Pipes IIS2MDC samples through the existing converter + EKF mag-update path so the new-PCB rocket actually uses the magnetometer for heading instead of leaving it dark.

The EKF already accepts mag data via `EkfMagData`; this PR just adds raw → µT scaling (`0.15 µT/LSB` per the IIS2MDC datasheet) and routes the new mag's SI struct into that same input — preferring IIS2MDC when active, falling back to MMC on legacy boards.

## Changes

**Converter** ([TR_Sensor_Data_Converter](tinkerrocket-idf/components/TR_Sensor_Data_Converter/))

- `convertIIS2MDCData(raw, si)` — scales `0.15 µT/LSB` and applies the same +Z rotation pattern as `convertMMC5983MAData`.
- `configureIIS2MDCRotationZ(deg)` — mirrors `configureMMC5983MARotationZ`.
- Constructor defaults rotation to `0°`.

**Flight computer** ([flight_computer/main/](tinkerrocket-idf/projects/flight_computer/main/))

- New `IIS2MDC_ROT_Z_DEG = 0.0f` in `config.h`. User-tunable once bench characterization tells us the chip's mounting on the new PCB rev.
- `setup()` calls `configureIIS2MDCRotationZ(IIS2MDC_ROT_Z_DEG)` at boot.
- `loop_fc` consume block calls `convertIIS2MDCData` and sets `have_iis2mdc_si = true`.
- EKF mag input prefers IIS2MDC when `have_iis2mdc_si`, falls back to MMC otherwise. Only one mag is populated on any board so this picks "whichever is alive". FLU→FRD axis fix is the same on both paths (negate Y and Z).

**Out computer** ([out_computer/main/](tinkerrocket-idf/projects/out_computer/main/main.cpp))

- Stores `latest_iis2mdc_si` and calls `convertIIS2MDCData` on every IIS2MDC frame ingested over I2S. Same shape as the MMC ingress today. Used by future BLE telemetry / log consumers; the conversion is computed now so downstream wiring is just plumbing later.

## Out of scope (deferred)

- `OutStatusQueryData` wire-format change to push `iis2mdc_rot_z_cdeg` from FC to OC. Both ends default to `0°` and stay in sync until bench data tells us we need a non-zero rotation.
- iOS app surfacing IIS2MDC mag values in the BLE telemetry JSON. The OC's `latest_iis2mdc_si` is computed but not yet emitted in the JSON — matches the MMC's current OC-side situation.

## Test plan

- [x] `flight_computer` (esp32p4) and `out_computer` (esp32s3) both compile clean.
- [x] Host-side tests: EKF sparse-vs-dense passes (numerical layer untouched). Pytest 5/6 pass on prior new-board capture; the 6th failure is the pre-existing #94/#77 `prepareFlight` stall, unrelated.
- [ ] Bench test on new board: capture during PRELAUNCH/READY, confirm `[EKF DIAG]` shows `mag=XX.X uT(OK)` (real reading, not `mag=0.0uT(NONE)`) and yaw stops drifting once mag updates fire.
- [ ] Spot-check `|B|` magnitude in the converted µT — should land ≈ Earth's field at arm's length (~50 µT) once #96 calibration is done; for now the residual hard-iron offset (~1700 µT) is expected per the bench measurements.
- [ ] Confirm IIS2MDC frame rate stays at ~100 Hz after the converter call is added (extra work per frame is small but worth confirming).

## Related

- [#98](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/98) — IIS2MDC driver + auto-detect (boot probe).
- [#99](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/99) — Stage 1: raw frames into the binary log.
- [#96](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/96) — hard-iron calibration follow-up. Until that lands, expect the EKF to see a constant ≈1.7 mT bias in the mag readings (won't crash anything; it'll just bias the heading reference until calibration zeros it out).
- [#94](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/94) / [#77](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/77) — `prepareFlight` PRELAUNCH stall, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
