### PR TITLE
landing: relax gyro threshold and add impact-detected fast path

### DIFF
--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -195,3 +195,96 @@ TEST_F(KinematicChecksTest, Reset_ClearsAll) {
     EXPECT_FLOAT_EQ(kc.max_altitude, 0.0f);
     EXPECT_FLOAT_EQ(kc.max_speed, 0.0f);
 }
+
+// ── Tests for issue #113: relaxed gyro threshold + impact fast path ──
+
+TEST_F(KinematicChecksTest, Landing_RollRate15dps_StillPasses) {
+    // The relaxed 20 dps threshold accepts steady 15 dps wobble (e.g. wind
+    // on a landed rocket). Old 2 dps threshold would fail this case.
+    for (int i = 0; i < 80; i++) {
+        setMockMillis(i * 2);
+        callFlight(float(i), 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    ASSERT_GT(kc.max_altitude, 15.0f);
+
+    for (int second = 0; second < 7; second++) {
+        uint32_t base = 1000 + second * 1000;
+        for (int i = 0; i < 50; i++) {
+            setMockMillis(base + i * 2);
+            callFlight(5.0f, 9.81f, 0.0f, 15.0f);
+        }
+    }
+    EXPECT_TRUE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_RollRate25dps_DoesNotTrigger) {
+    // 25 dps exceeds the 20 dps threshold -- still rejected by slow path.
+    for (int i = 0; i < 80; i++) {
+        setMockMillis(i * 2);
+        callFlight(float(i), 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+
+    for (int second = 0; second < 7; second++) {
+        uint32_t base = 1000 + second * 1000;
+        for (int i = 0; i < 50; i++) {
+            setMockMillis(base + i * 2);
+            callFlight(5.0f, 9.81f, 0.0f, 25.0f);
+        }
+    }
+    EXPECT_FALSE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_FastPath_ImpactTriggers) {
+    // apogee + low altitude + >15g for 5 consecutive samples -> landed
+    kc.apogee_flag = true;
+    for (int i = 0; i < 10; i++) {
+        setMockMillis(1000 + i);
+        callFlight(5.0f, 200.0f, -10.0f, 0.0f);  // ~20g, 5m alt
+    }
+    EXPECT_TRUE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_FastPath_GatedOnApogee) {
+    // Same impact-magnitude accel pre-apogee -> NO trigger (e.g. boost spike)
+    for (int i = 0; i < 50; i++) {
+        setMockMillis(1000 + i);
+        callFlight(5.0f, 200.0f, 10.0f, 0.0f);
+    }
+    EXPECT_FALSE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_FastPath_GatedOnAltitude) {
+    // Apogee + impact-magnitude accel at altitude (e.g. ejection at apogee)
+    // -> NO trigger because pressure_altitude > 20m
+    kc.apogee_flag = true;
+    for (int i = 0; i < 50; i++) {
+        setMockMillis(1000 + i);
+        callFlight(100.0f, 200.0f, -10.0f, 0.0f);
+    }
+    EXPECT_FALSE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_FastPath_BelowG_NoTrigger) {
+    // Apogee + low altitude but accel below 15 g threshold -> NO trigger
+    kc.apogee_flag = true;
+    for (int i = 0; i < 50; i++) {
+        setMockMillis(1000 + i);
+        callFlight(5.0f, 100.0f, -10.0f, 0.0f);  // ~10g, below threshold
+    }
+    EXPECT_FALSE(kc.alt_landed_flag);
+}
+
+TEST_F(KinematicChecksTest, Landing_FastPath_BriefSpike_CounterResets) {
+    // Single high-g sample then back to quiet -> count resets, no trigger.
+    // Verifies the noise-rejection behavior of the consecutive-sample gate.
+    kc.apogee_flag = true;
+    setMockMillis(1000);
+    callFlight(5.0f, 200.0f, -10.0f, 0.0f);  // 1 sample at impact magnitude
+    for (int i = 0; i < 100; i++) {
+        setMockMillis(1001 + i);
+        callFlight(5.0f, 9.81f, 0.0f, 0.0f);  // back to gravity floor
+    }
+    EXPECT_FALSE(kc.alt_landed_flag);
+}

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -1,6 +1,18 @@
 #include <TR_KinematicChecks.h>
 #include <algorithm>
 
+namespace {
+// Impact-detected landing fast path (see issue #113).
+// Descent tumbling never exceeds ~12 g; impact on RolyPoly 5/3/26 peaked at
+// 218 g. 15 g cleanly separates them with no false positives in descent.
+// Gated on apogee + low altitude so launch (~7 g) and ejection (~22 g at
+// apogee) cannot trigger.
+constexpr float    LANDING_IMPACT_G       = 15.0f;
+constexpr float    LANDING_IMPACT_ALT_M   = 20.0f;
+constexpr uint16_t LANDING_IMPACT_COUNT   = 5;       // ~5 ms at 1 kHz
+constexpr float    G_MS2                  = 9.80665f;
+}
+
 TR_KinematicChecks::TR_KinematicChecks()
 {
     launch_flag = false;
@@ -18,6 +30,7 @@ TR_KinematicChecks::TR_KinematicChecks()
     landing_check_dt = 1000;
     apogee_count = 0;
     landing_checks = 0;
+    impact_seen_count = 0;
     max_gps_altitude_ = 0.0f;
     gps_apogee_count_ = 0;
     gps_available_ = false;
@@ -58,6 +71,7 @@ void TR_KinematicChecks::reset()
     landing_look_back_alt = 0.0;
     apogee_count = 0;
     landing_checks = 0;
+    impact_seen_count = 0;
     max_gps_altitude_ = 0.0f;
     gps_apogee_count_ = 0;
     gps_available_ = false;
@@ -126,11 +140,14 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         landing_look_back_alt = pressure_altitude;
         landing_check_time = millis();
 
-        // Checking landing declaration criteria
+        // Checking landing declaration criteria.
+        // roll_rate threshold: 20 dps tolerates wind-induced body roll on a
+        // landed rocket (RolyPoly 5/3/26 saw 5-22 dps wobbles post-touchdown);
+        // anything below 50 dps is clearly not in flight.
         if (pressure_altitude < 50.0      // Low current altitude
          && landing_altitude_change < 2.0 // Less than 2 m change
          && max_altitude > 15.0           // Max altitude was more than 15 m
-         && fabs(roll_rate) < 2.0)        // Gyro is stable
+         && fabs(roll_rate) < 20.0)       // Gyro is stable (no longer in flight)
         {
             landing_checks++;
         }
@@ -144,6 +161,27 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         {
             alt_landed_flag = true;
         }
+    }
+
+    // ### Impact-detected fast path ###
+    // High-energy ground impact is unambiguous: descent tumbling tops out
+    // around 12 g, and a hard landing is several hundred g for ~100 ms.
+    // This runs every call (gyro rate, ~1 kHz) so we don't have to wait
+    // 5 s for the slow path to accumulate when impact already gave us a
+    // definitive ground signal. See issue #113.
+    if (apogee_flag
+     && pressure_altitude < LANDING_IMPACT_ALT_M
+     && acc_mag > LANDING_IMPACT_G * G_MS2)
+    {
+        impact_seen_count++;
+        if (impact_seen_count >= LANDING_IMPACT_COUNT)
+        {
+            alt_landed_flag = true;
+        }
+    }
+    else
+    {
+        impact_seen_count = 0;
     }
 
     // ### GPS altitude tracking ###

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -45,6 +45,7 @@ private:
     uint32_t landing_check_dt;
     uint8_t apogee_count;
     uint16_t landing_checks;
+    uint16_t impact_seen_count;
 
     // GPS apogee test state
     float max_gps_altitude_;


### PR DESCRIPTION
Closes #113. Diagnosed from RolyPoly 5/3/26 (`flight_recovered_4`) — see #109 for the original symptom.

## Summary
- **Slow path**: relax `|roll_rate|` threshold from `2.0` → `20.0` dps in `TR_KinematicChecks.cpp:147`. Wind-induced body roll on a landed rocket easily produces 5–22 dps wobbles; the 2 dps threshold was unrealistic and reset the 1-Hz counter repeatedly post-touchdown on this flight.
- **Fast path**: new per-call check that sets `alt_landed_flag` immediately when `apogee_flag && pressure_altitude < 20 m && acc_mag > 15 g` holds for ~5 ms (5 consecutive samples at 1 kHz).

The downstream `INFLIGHT → LANDED` gate in `main.cpp:3110` (`alt_landed_flag && |roll_rate| < 30 dps` + 2 s debounce) is unchanged. Both paths set the same flag — whichever fires first wins.

## Why the thresholds
| phase | window | mean | max |
|---|---|---|---|
| Descent (tumbling) | T+10..27 (17 s) | 11.6 m/s² (1.2 g) | **11.7 g** |
| Impact | T+28.6..28.7 (100 ms) | ~197 m/s² (20 g) | **218 g** |
| Post-touchdown floor | T+30..36 (6 s) | 9.6 m/s² (0.98 g) | 1.0 g |

15 g cleanly separates impact from any descent dynamics with zero false positives in the analyzed flight. The `apogee_flag` and `pressure_altitude < 20 m` gates prevent launch (~7 g) and ejection (~22 g at apogee) from triggering the fast path.

## What didn't change
- Slow-path structure (5 consecutive 1-second checks, 4 conditions, look-back altitude)
- The `INFLIGHT → LANDED` debounce / gate in `main.cpp`
- `kinematicChecks()` signature — `acc_mag` and `apogee_flag` were already available

## Test plan
- [ ] `idf.py build` succeeds (verified locally — clean build, only pre-existing `r00/r10/r20` unused-variable warnings in `main.cpp`)
- [ ] Bench test: spin up + stop → confirm slow path still fires when conditions are quiet
- [ ] Bench test: simulate impact (sharp tap on board ≥15 g while `apogee_flag` is forced high) → fast path fires within ~5 ms
- [ ] Next field flight: confirm LANDED transitions on touchdown, log finalizes (also gated on #108)

## Files
- `tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h` — +1 private member `impact_seen_count`
- `tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp` — file-local constants, init in ctor + reset, threshold change, fast-path block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
