### PR TITLE
lora: switch EspHal to polling-mode SPI to dodge IDF v5.3.2 ret_queue race

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h
@@ -192,7 +192,13 @@ public:
         t.tx_buffer = out;
         t.rx_buffer = in;
 
-        spi_device_transmit(spiDevice, &t);
+        // Polling-mode (busy-wait, no internal ret_queue) avoids the
+        // `assert(ret_trans == trans_desc)` panic in spi_device_transmit
+        // that fires when the IDF v5.3.2 SPI master driver's per-device
+        // ret_queue gets corrupted by cross-task internal state. SX1262
+        // transfers are small (max 256 B per max_transfer_sz at 2 MHz)
+        // so the CPU spin is negligible. See issue #115.
+        spi_device_polling_transmit(spiDevice, &t);
     }
 
     void spiEndTransaction() {


### PR DESCRIPTION
Closes #115. Diagnosed in the issue: OC reboots on the LANDED transition with `assert failed: spi_device_transmit spi_master.c:1273 (ret_trans == trans_desc)`.

## Change

One line in `tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h:155`:

```diff
-spi_device_transmit(spiDevice, &t);
+spi_device_polling_transmit(spiDevice, &t);
```

(plus a comment block explaining the rationale.)

## Why polling

The application-side audit in #115 confirms only `loop_oc` ever queues into the LoRa device's `ret_queue` (DIO1 ISR is flag-only, no timers, no other tasks touch LoRa). The race is internal to the IDF v5.3.2 SPI master driver — upstream IDF even carries a `// ToDo: check if any spi transfers in flight` comment right at the offending call.

Polling-mode bypasses `ret_queue` entirely: no `xQueueReceive`, no `ret_trans == trans_desc` assert, no internal-queue race surface. Same `spi_transaction_t` struct, mechanical swap.

## Cost analysis

| factor | impact |
|---|---|
| CPU spin during transfer | ~1 ms per LoRa packet at 2 MHz (max 256 B `max_transfer_sz`) |
| Compared to NAND drain | NAND drain on Core 0 already runs 100s of ms of polling SPI per landing event — LoRa's added 1 ms is in the noise |
| Compared to BLE/I2C activity on Core 1 | Same order of magnitude as a single BLE notify, fires far less often |
| Backpressure on hop scheduler | None — a hop reconfigure already takes 50–100 ms in `LORA_STALL_INSTR` measurements; +1 ms is irrelevant |

NAND on OC already uses `spi_device_polling_transmit` via the `compat.h` SPIClass shim, so this change also **unifies OC's SPI access pattern** — both users now polling, eliminating the queued/polled mixed-mode entirely.

## Test plan

- [x] OC builds (esp32s3): clean
- [x] base_station builds (esp32s3): clean
- [x] cpp test suite: 245/245 pass
- [ ] Bench-repro: trigger END_FLIGHT on OC during active LoRa hopping → confirm no panic (needs hardware)
- [ ] Sim flight: compare LoRa RX/TX rates and FC↔OC I2C gaps before/after to confirm no regression in data throughput

## Files
- `tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h` — 1 line + comment

## Notes
- TR_LoRa_Comms is also used by `base_station` — change applies there too. base_station has no NAND drain to race against, but polling-mode is fine for the ground side as well (and removes any future regression risk).
- Does **not** revert or affect the local IDF TOCTOU patch on `spi_bus_lock.c` (#18527). Different bug, different code path; that patch stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
