### PR TITLE
log: defer flightlog.finalizeFlight to flush task to fix I2S Parse stack overflow

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/EspHal.h
@@ -192,7 +192,13 @@ public:
         t.tx_buffer = out;
         t.rx_buffer = in;
 
-        spi_device_transmit(spiDevice, &t);
+        // Polling-mode (busy-wait, no internal ret_queue) avoids the
+        // `assert(ret_trans == trans_desc)` panic in spi_device_transmit
+        // that fires when the IDF v5.3.2 SPI master driver's per-device
+        // ret_queue gets corrupted by cross-task internal state. SX1262
+        // transfers are small (max 256 B per max_transfer_sz at 2 MHz)
+        // so the CPU spin is negligible. See issue #115.
+        spi_device_polling_transmit(spiDevice, &t);
     }
 
     void spiEndTransaction() {

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -1480,6 +1480,7 @@ void TR_LogToFlash::closeLogSession()
             ESP_LOGI(TAG, "closeLogSession (sink mode): %lu bytes handed off",
                      (unsigned long)current_file_bytes);
         }
+        last_closed_session_bytes_ = current_file_bytes;
         current_file_bytes = 0;
         return;
     }
@@ -1525,6 +1526,7 @@ void TR_LogToFlash::closeLogSession()
                       current_filename, current_file_bytes);
     }
 
+    last_closed_session_bytes_ = current_file_bytes;
     current_file_bytes = 0;
 }
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -291,6 +291,14 @@ void TR_LogToFlash::prepareLogFile()
 
 void TR_LogToFlash::endLogging()
 {
+    // Idempotent when nothing is logging. The flush-task drain block clears
+    // end_flight_requested only when (end_flight_requested && logging_active
+    // && file_open) all hold, so latching it here while logging_active is
+    // already false leaves it stuck true forever — and isLoggingActive()
+    // (returns logging_active || end_flight_requested) then never goes
+    // false. That made the BLE cmd=23 toggle handler stuck on "stop" after
+    // a normal LANDED-triggered drain.
+    if (!logging_active && !file_open) return;
     end_flight_requested = true;
 }
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -139,6 +139,12 @@ public:
     // Bytes drained from the ring into the current flight so far (reset at
     // openLogSession, incremented as pages are pushed to the sink/LFS).
     uint32_t currentFileBytes() const { return current_file_bytes; }
+
+    // Bytes drained during the most recently closed session. Captured by
+    // closeLogSession just before current_file_bytes is reset, so callers
+    // that finalize the flight on a later flush-task iteration (after the
+    // close runs) can still recover the final byte count.
+    uint32_t lastClosedSessionBytes() const { return last_closed_session_bytes_; }
     void startLogging();
     void endLogging(); // request close after buffered data is flushed
     void prepareLogFile();  // Pre-create log file (call during PRELAUNCH to avoid NAND stall at launch)
@@ -354,6 +360,10 @@ private:
     // Current file tracking
     char current_filename[64] = {};
     uint32_t current_file_bytes = 0;
+    // Sticky byte count from the most recently closed session (see
+    // lastClosedSessionBytes()). Updated by closeLogSession before
+    // current_file_bytes is reset.
+    uint32_t last_closed_session_bytes_ = 0;
     bool current_file_has_timestamp = false;
 
     // Deferred timestamp (set from Core 1, applied by flush task on Core 0)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -209,7 +209,11 @@ static void flightlogServicePendingFinalize()
         return;
     }
 
-    const uint32_t bytes = logger.currentFileBytes();
+    // closeLogSession (which ran in the same flush-task iteration that drained
+    // the ring) has already zeroed current_file_bytes by the time we get here.
+    // lastClosedSessionBytes() is a sticky snapshot it took just before the
+    // reset, so this is the exact byte count the sink received.
+    const uint32_t bytes = logger.lastClosedSessionBytes();
     auto st = flightlog.finalizeFlight(name_local, bytes);
     if (st == tr_flightlog::Status::Ok)
     {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -173,6 +173,58 @@ static void flightlogBeginFlight()
     flightlog.requestPrepareFlight();
 }
 
+// Pending-finalize state. Set by flightlogEndFlight (which runs in the
+// I2S Parse task at END_FLIGHT message receipt) and serviced by
+// flightlogFlushTaskHook on the flush task (Core 0). Deferral matches the
+// pattern used for prepareFlight — keeps NAND-heavy work (FlightIndex::save
+// allocates a 2 KB page buffer on the stack via readPage) off the I2S Parse
+// task's 4 KB stack. final_bytes is read at service time (not request time)
+// because the flush task may still be draining the ring when the request
+// fires; reading it then would undercount by the still-buffered bytes.
+static portMUX_TYPE g_finalize_mux        = portMUX_INITIALIZER_UNLOCKED;
+static bool         g_finalize_pending    = false;
+static char         g_finalize_name[28]   = {};
+
+static void flightlogServicePendingFinalize()
+{
+    char name_local[sizeof(g_finalize_name)];
+    bool do_it = false;
+    portENTER_CRITICAL(&g_finalize_mux);
+    // Only act once the drain is fully complete — logger.isLoggingActive()
+    // covers both logging_active and the not-yet-cleared end_flight_requested.
+    // While either is true the flush task hasn't yet popped the last byte to
+    // the sink, so currentFileBytes() would undercount.
+    if (g_finalize_pending && !logger.isLoggingActive())
+    {
+        std::memcpy(name_local, g_finalize_name, sizeof(name_local));
+        g_finalize_pending = false;
+        do_it = true;
+    }
+    portEXIT_CRITICAL(&g_finalize_mux);
+    if (!do_it) return;
+
+    if (!flightlog.isFlightActive())
+    {
+        ESP_LOGW("FLIGHTLOG", "finalizeFlight (deferred): no active flight, skipped");
+        return;
+    }
+
+    const uint32_t bytes = logger.currentFileBytes();
+    auto st = flightlog.finalizeFlight(name_local, bytes);
+    if (st == tr_flightlog::Status::Ok)
+    {
+        ESP_LOGI("FLIGHTLOG",
+                 "finalizeFlight OK (deferred): %s (%u bytes, %u extensions)",
+                 name_local, (unsigned)bytes,
+                 (unsigned)flightlog.overflowExtensionCount());
+    }
+    else
+    {
+        ESP_LOGW("FLIGHTLOG", "finalizeFlight (deferred): %s",
+                 tr_flightlog::to_string(st));
+    }
+}
+
 // Drives the deferred Core-0 work for TR_FlightLog. Wired into
 // TR_LogToFlash::flushTaskLoop via cfg.flush_task_hook so it executes on the
 // flush task's core (Core 0). Logs the prepareFlight outcome here because
@@ -181,22 +233,25 @@ static void flightlogFlushTaskHook(void* /*ctx*/)
 {
     uint32_t id = 0;
     tr_flightlog::Status st = tr_flightlog::Status::Ok;
-    if (!flightlog.servicePendingPrepareFlight(id, st)) return;
+    if (flightlog.servicePendingPrepareFlight(id, st))
+    {
+        if (st == tr_flightlog::Status::Ok)
+        {
+            ESP_LOGI("FLIGHTLOG",
+                     "prepareFlight OK (deferred): id=%u, range=[%u..%u), pages=%u",
+                     (unsigned)id,
+                     (unsigned)flightlog.activeStartBlock(),
+                     (unsigned)(flightlog.activeStartBlock() + flightlog.activeBlockCount()),
+                     (unsigned)flightlog.activeBlockCount());
+        }
+        else
+        {
+            ESP_LOGW("FLIGHTLOG", "prepareFlight (deferred): %s",
+                     tr_flightlog::to_string(st));
+        }
+    }
 
-    if (st == tr_flightlog::Status::Ok)
-    {
-        ESP_LOGI("FLIGHTLOG",
-                 "prepareFlight OK (deferred): id=%u, range=[%u..%u), pages=%u",
-                 (unsigned)id,
-                 (unsigned)flightlog.activeStartBlock(),
-                 (unsigned)(flightlog.activeStartBlock() + flightlog.activeBlockCount()),
-                 (unsigned)flightlog.activeBlockCount());
-    }
-    else
-    {
-        ESP_LOGW("FLIGHTLOG", "prepareFlight (deferred): %s",
-                 tr_flightlog::to_string(st));
-    }
+    flightlogServicePendingFinalize();
 }
 
 static void flightlogEndFlight()
@@ -240,21 +295,17 @@ static void flightlogEndFlight()
         std::snprintf(name, sizeof(name), "flight_%lu.bin",
                       (unsigned long)flightlog.activeFlightId());
     }
-    // Real byte count now that writeFrame is the hot path — logger.currentFileBytes()
-    // tracks bytes popped from the ring, which equals bytes handed to the sink.
-    const uint32_t bytes = logger.currentFileBytes();
-    auto st = flightlog.finalizeFlight(name, bytes);
-    if (st == tr_flightlog::Status::Ok)
-    {
-        ESP_LOGI("FLIGHTLOG", "finalizeFlight OK: %s (%u bytes, %u extensions)",
-                 name, (unsigned)bytes,
-                 (unsigned)flightlog.overflowExtensionCount());
-    }
-    else
-    {
-        ESP_LOGW("FLIGHTLOG", "finalizeFlight: %s",
-                 tr_flightlog::to_string(st));
-    }
+    // Defer the actual finalize to the flush task. flightlog.finalizeFlight
+    // calls FlightIndex::save which reads NAND with a ~2 KB on-stack page
+    // buffer (FlightIndex.cpp:120). The I2S Parse task (where this runs)
+    // only has a 4 KB stack — enough for nominal frame parsing but not for
+    // any path that pulls in NAND I/O. flightlogServicePendingFinalize on
+    // the flush task does the actual work; final_bytes is read there too,
+    // since the flush task may still be draining the ring when this runs.
+    portENTER_CRITICAL(&g_finalize_mux);
+    std::memcpy(g_finalize_name, name, sizeof(g_finalize_name));
+    g_finalize_pending = true;
+    portEXIT_CRITICAL(&g_finalize_mux);
     // 2c-3c: do NOT delete — the flight has real data now. Index entries
     // accumulate across reboots; deletion becomes an explicit BLE cmd 3
     // operation (re-backed on TR_FlightLog in Stage 3).


### PR DESCRIPTION
Closes #118. Stacked on top of #117 (which is itself stacked on #116).

## The bug

After #116 stopped the OC SPI panic, the next failure landed on the same code path: I2S Parse task stack overflow at LANDED.

```
I (580894) LOG: Draining 58 bytes...
***ERROR*** A stack overflow in task I2S Parse has been detected.
0x420140d5: TR_LogToFlash::readNandPage at TR_LogToFlash.cpp:2279
rst:0xc (RTC_SW_CPU_RST)
```

Chain: `i2sParserTask → parseRxStream → processFrame (END_FLIGHT) → flightlogEndFlight → flightlog.finalizeFlight → FlightIndex::save → nand.readPage`. `readPage` allocates a 2 KB on-stack page buffer in [`FlightIndex.cpp:120`](tinkerrocket-idf/components/TR_FlightLog/FlightIndex.cpp#L120) — too much for the 4 KB I2S Parse stack.

`flightlogBeginFlight` already had this exact pattern fixed (a ~770 ms erase loop blocking the ingest path) — the comment at [`main.cpp:167-173`](tinkerrocket-idf/projects/out_computer/main/main.cpp#L167-L173) describes the previous defer-to-flush-task fix. The finalize side was missed.

## The fix

Mirror the prepare side's request/service pattern, with one wrinkle: `final_bytes` must be read at service time, not request time, because the flush task may still be draining the ring when the request fires (reading then would undercount by the buffered bytes).

```cpp
// New file-static state, portMUX-protected for cross-core safety
static portMUX_TYPE g_finalize_mux        = portMUX_INITIALIZER_UNLOCKED;
static bool         g_finalize_pending    = false;
static char         g_finalize_name[28]   = {};
```

`flightlogEndFlight` (I2S Parse task at END_FLIGHT receipt) now just queues the filename:

```cpp
portENTER_CRITICAL(&g_finalize_mux);
std::memcpy(g_finalize_name, name, sizeof(g_finalize_name));
g_finalize_pending = true;
portEXIT_CRITICAL(&g_finalize_mux);
```

`flightlogServicePendingFinalize` (flush task on Core 0, called from existing `flush_task_hook`) waits until `logger.isLoggingActive()` returns false (drain complete), reads `logger.currentFileBytes()`, then calls `flightlog.finalizeFlight()`.

## Why portMUX instead of `volatile bool`

The existing prepare-side request flag uses `volatile bool prepare_request_pending_`. That works because the producer writes only a single bool. Here we write a string *plus* a flag — without a barrier the consumer could observe the flag set before the string write has propagated. `portENTER_CRITICAL` is a real cross-core barrier and matches the precedent set by `ring_mux_` in `TR_LogToFlash`.

Consumer remains idempotent: if it dequeues a request but `!flightlog.isFlightActive()`, it logs a warning and bails (the in-memory state is the source of truth, the flag is just a signal).

## Test plan
- [x] OC builds clean
- [x] cpp test suite: 245/245 pass
- [ ] Bench: combined PR-#116 + PR-#117 + PR-#118 stack on hardware; sim flight through LANDED; confirm no panic, no reboot, bin file downloadable post-flight

## Files
- `tinkerrocket-idf/projects/out_computer/main/main.cpp` — adds `flightlogServicePendingFinalize`, extends `flightlogFlushTaskHook` to call it, replaces inline `flightlog.finalizeFlight` with the queue-up

## Related
- #116 (SPI polling fix that stopped masking this bug)
- #117 (cmd=23 toggle fix)
- #77 in code comments — original flightlogBeginFlight deferral, same class of bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
