### PR TITLE
log: make endLogging idempotent so cmd=23 stop-toggle can recover

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -291,6 +291,14 @@ void TR_LogToFlash::prepareLogFile()
 
 void TR_LogToFlash::endLogging()
 {
+    // Idempotent when nothing is logging. The flush-task drain block clears
+    // end_flight_requested only when (end_flight_requested && logging_active
+    // && file_open) all hold, so latching it here while logging_active is
+    // already false leaves it stuck true forever — and isLoggingActive()
+    // (returns logging_active || end_flight_requested) then never goes
+    // false. That made the BLE cmd=23 toggle handler stuck on "stop" after
+    // a normal LANDED-triggered drain.
+    if (!logging_active && !file_open) return;
     end_flight_requested = true;
 }
 


### PR DESCRIPTION
Stacked on #116 (depends on the SPI-fix branch only because it's where I caught the symptom; the change itself is independent and applies cleanly to main once #116 lands).

## The bug

After a LANDED-triggered drain finishes, `logging_active` and `file_open` are both false. If `endLogging()` is then called (BLE cmd=23 manual stop, LoRa uplink stop, etc.), the old implementation unconditionally set `end_flight_requested = true`:

```cpp
void TR_LogToFlash::endLogging() {
    end_flight_requested = true;
}
```

The flush-task drain block at `TR_LogToFlash.cpp:2048` only clears `end_flight_requested` when **all three** of `end_flight_requested && logging_active && file_open` hold. So once we set the flag in this state, the drain block never fires and the flag latches true forever.

That fed back into `isLoggingActive()`:

```cpp
bool TR_LogToFlash::isLoggingActive() const {
    return logging_active || end_flight_requested;
}
```

…which then returned true forever, even though nothing was actually being written. The BLE cmd=23 handler at `main.cpp:3886` is a pure toggle on `isLoggingActive()`, so every press hit the "stop" branch:

```
I (269874) OC_CMD: BLE cmd=23
I (269874) OC_CMD: Logging STOPPED (manual)
I (270141) OC_CMD: BLE cmd=23
I (270142) OC_CMD: Logging STOPPED (manual)   <- should have been STARTED
I (270231) OC_CMD: BLE cmd=23
I (270232) OC_CMD: Logging STOPPED (manual)
...
```

User-visible effect: after a successful sim flight, the GUI couldn't take the system back into a state where file list / download worked, because `isLoggingActive()` was permanently stuck.

## The fix

Make `endLogging()` short-circuit when nothing is actually logging:

```cpp
void TR_LogToFlash::endLogging() {
    if (!logging_active && !file_open) return;
    end_flight_requested = true;
}
```

Two consequences:
- `endLogging()` is now idempotent when called repeatedly after a drain has already finalized the file (matches the convention of most begin/end pairs).
- `end_flight_requested` can no longer be latched stale, so `isLoggingActive()` reflects reality.

The cmd=23 toggle then behaves correctly: first press after a flight → "STARTED" (begins a new session), then "STOPPED" → "STARTED" → … in a clean alternating pattern.

## Test plan
- [x] OC builds clean
- [x] Full cpp test suite (245 tests) green
- [ ] Manual: after a sim flight ends and the LANDED drain completes, the BLE Stop button alternates STOPPED↔STARTED on consecutive presses (was: stuck on STOPPED)
- [ ] Manual: file list / download via GUI works after a sim flight (was: blocked because logging "still active")

## Files
- `tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp` — 7-line guard + comment

## Related
- Caught while bench-verifying #116 (the OC SPI polling fix). Independent code path, but the user couldn't pull the post-fix bin file off OC because of this bug, so we paused to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
