### PR TITLE
lora: BS-only LoRa params + operator-toggleable hop disable (#106)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -373,6 +373,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendRawCommand(11, payload: Data([enabled ? 0x01 : 0x00]))
     }
 
+    /// Disable / re-enable LoRa frequency hopping (#106).  Only meaningful
+    /// when sent to the base station — the BS persists the new value, hands
+    /// off to the rocket via the corresponding uplink cmd, and restores
+    /// fixed-frequency operation on lora_freq_mhz.  Sending this directly
+    /// to a rocket is rejected by the rocket-side firmware.
+    func sendLoRaHopDisabled(_ disabled: Bool) {
+        sendRawCommand(17, payload: Data([disabled ? 0x01 : 0x00]))
+        if var cfg = rocketConfig {
+            cfg.loraHopDisabled = disabled
+            rocketConfig = cfg
+        }
+    }
+
     func sendServoConfig(biases: [Int16], hz: Int16, minUs: Int16, maxUs: Int16) {
         var payload = Data()
         for i in 0..<4 {
@@ -938,6 +951,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             cfg.loraBwKHz = parseFloat(dict["lbw"])
             cfg.loraCR = (dict["lcr"] as? Int).map { UInt8($0) }
             cfg.loraTxPower = (dict["lpw"] as? Int).map { Int8($0) }
+            cfg.loraHopDisabled = dict["lhd"] as? Bool   // #106 (nil if device doesn't report it)
             if let existing = self.rocketConfig {
                 cfg.pyro1Enabled = existing.pyro1Enabled
                 cfg.pyro1TriggerMode = existing.pyro1TriggerMode

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -105,6 +105,7 @@ struct RocketConfig {
     var loraBwKHz: Float? = nil
     var loraCR: UInt8? = nil
     var loraTxPower: Int8? = nil
+    var loraHopDisabled: Bool? = nil   // #106 fixed-frequency override (BS-controlled)
     var pyro1Enabled: Bool = false
     var pyro1TriggerMode: UInt8 = 0
     var pyro1TriggerValue: Float = 1.0

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -98,6 +98,11 @@ struct SettingsView: View {
     @State private var servoApplied = false
     @State private var pidApplied = false
 
+    // Hop disable (#106) — local mirror of base-station's lora_hop_disabled flag.
+    // We keep a State so the toggle is responsive; the truth lives on the BS
+    // and is restored whenever a config readback arrives.
+    @State private var loraHopDisabled = false
+
     private var selectedPreset: LoRaPreset {
         loraPresets.first(where: { $0.id == presetId }) ?? loraPresets[1]
     }
@@ -221,6 +226,25 @@ struct SettingsView: View {
                             }
                             Slider(value: $txPower, in: 2...22, step: 1)
                         }
+                    }
+
+                    // Frequency-hopping override (#106).  Diagnostic / link-debug
+                    // mode — disables the per-packet channel hopping that runs in
+                    // PRELAUNCH/INFLIGHT and pins both BS and rocket to a fixed
+                    // frequency.  Useful for isolating link issues from hop
+                    // coordination bugs.  Sends cmd 17 to the BS, which persists
+                    // and uplinks the same byte to every tracked rocket.
+                    Section(header: Text("LoRa Frequency Hopping"),
+                            footer: Text(loraHopDisabled
+                                ? "DISABLED — both ends stay on the configured frequency. Not FHSS-compliant; use for diagnostics only."
+                                : "Enabled (default). Channels hop during PRELAUNCH and INFLIGHT.")) {
+                        Toggle("Disable hopping (fixed frequency)", isOn: Binding(
+                            get: { loraHopDisabled },
+                            set: { newValue in
+                                loraHopDisabled = newValue
+                                device.sendLoRaHopDisabled(newValue)
+                            }
+                        ))
                     }
                 }
 
@@ -533,6 +557,12 @@ struct SettingsView: View {
                 }
                 if let pwr = cfg.loraTxPower {
                     txPower = Double(pwr)
+                }
+                // #106 — sync hop-disable from device.  Older firmware doesn't
+                // emit "lhd"; in that case we leave the toggle showing its
+                // last value (defaults to false on first load).
+                if let hopDis = cfg.loraHopDisabled {
+                    loraHopDisabled = hopDis
                 }
                 loadStringsFromStorage()
             }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -191,6 +191,7 @@ static constexpr uint8_t LORA_NOISE_THRESHOLD_DB  = 15;   // skip if peak > medi
 static constexpr uint8_t LORA_CMD_CHANNEL_SET     = 15;   // uplink cmd: rendezvous + mask
 static constexpr uint8_t LORA_CMD_HOP_PAUSE       = 16;   // uplink cmd: park on lora_freq_mhz for N ms (#90)
 static constexpr uint16_t LORA_HOP_PAUSE_MAX_MS   = 60000; // server-side cap on cmd 16 duration
+static constexpr uint8_t LORA_CMD_SET_HOP_DISABLED = 17;  // uplink cmd: 1 byte payload, 0=hopping enabled (default), 1=disabled (fixed-frequency mode for diagnostics, #106)
 
 // Minimum SNR (dB) for an RX packet to be considered trustworthy at the
 // given spreading factor.  Bench-confirmed in #90 follow-up: a CRC-

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -162,6 +162,14 @@ static uint8_t  hop_idx_          = 0;
 static bool     hop_needs_retune_ = false;
 static uint32_t hop_last_rx_ms_   = 0;
 
+// Operator override (#106): suppress hopping in PRELAUNCH/INFLIGHT and stay
+// on lora_freq_mhz instead.  BS is the authority; the BLE handler for
+// cmd 17 updates this flag, persists to NVS, and uplinks the same byte to
+// the rocket via LORA_CMD_SET_HOP_DISABLED so both sides stay aligned.
+// Diagnostic / link-debugging mode only — fixed-frequency in flight is
+// not FHSS-compliant.
+static bool     lora_hop_disabled = false;
+
 // ----------------------------------------------------------------------------
 // Channel-set state (#40 / #41 phase 3)
 // ----------------------------------------------------------------------------
@@ -880,14 +888,16 @@ static void sendCurrentConfig()
              ",\"kp\":%.4f,\"ki\":%.4f,\"kd\":%.4f"
              ",\"pmn\":%.1f,\"pmx\":%.1f"
              ",\"sen\":%s"
-             ",\"lf\":%.1f,\"lsf\":%u,\"lbw\":%.0f,\"lcr\":%u,\"lpw\":%d}",
+             ",\"lf\":%.1f,\"lsf\":%u,\"lbw\":%.0f,\"lcr\":%u,\"lpw\":%d"
+             ",\"lhd\":%s}",
              (int)cfg_servo_bias1, (int)cfg_servo_hz,
              (int)cfg_servo_min, (int)cfg_servo_max,
              (double)cfg_pid_kp, (double)cfg_pid_ki, (double)cfg_pid_kd,
              (double)cfg_pid_min, (double)cfg_pid_max,
              cfg_servo_enabled ? "true" : "false",
              (double)lora_freq_mhz, (unsigned)lora_sf,
-             (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
+             (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
+             lora_hop_disabled ? "true" : "false");
     if (n < 0 || (size_t)n >= sizeof(buf)) {
         ESP_LOGW(TAG, "[CFG] Config JSON truncated! (%d bytes, buf=%u)", n, (unsigned)sizeof(buf));
     }
@@ -2122,10 +2132,12 @@ static void setup_bs()
     lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
     lora_cr        = prefs.getUChar("cr",   config::LORA_CR);
     lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
+    lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106 fixed-frequency override
     prefs.end();
-    ESP_LOGI(TAG, "[CFG] LoRa NVS: %.1f MHz SF%u BW%.0f CR%u %d dBm",
+    ESP_LOGI(TAG, "[CFG] LoRa NVS: %.1f MHz SF%u BW%.0f CR%u %d dBm hop_disabled=%d",
              (double)lora_freq_mhz, (unsigned)lora_sf,
-             (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
+             (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
+             (int)lora_hop_disabled);
 
     // Channel-set: rendezvous freq + skip-mask from the most recent
     // pre-launch scan (#40 / #41 phase 3).  Falls back to defaults if
@@ -2464,7 +2476,13 @@ static void loop_bs()
                 // we should be next.  Honoured as soon as the radio is
                 // idle (top of serviceLoRa) — we don't retune in the RX
                 // callback path because the radio still has work to do.
-                if (shouldHopInState(decoded.rocket_state))
+                // #106: when the operator has disabled hopping, ignore the
+                // rocket's next_channel_idx and stay on lora_freq_mhz.  The
+                // rocket-side LORA_CMD_SET_HOP_DISABLED handler also clears
+                // its own hop_active_ so it stops emitting non-NO_HOP indices,
+                // but we belt-and-brace here in case the rocket missed the
+                // uplink and is still hopping.
+                if (!lora_hop_disabled && shouldHopInState(decoded.rocket_state))
                 {
                     if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
                     {
@@ -2795,6 +2813,36 @@ static void loop_bs()
             buildUplinkPacket(14, payload, 1);
             ESP_LOGI(TAG, "[BLE->UPLINK] Servo control: %s",
                      cfg_servo_enabled ? "ENABLE" : "DISABLE");
+        }
+    }
+    else if (ble_cmd == LORA_CMD_SET_HOP_DISABLED)
+    {
+        // BS-controlled hop enable/disable (#106).  Persist locally,
+        // re-tune to lora_freq_mhz immediately if we were tracking a hop,
+        // and uplink the same byte to the rocket so both sides agree.
+        const uint8_t* payload = ble_app.getCommandPayload();
+        size_t payload_len = ble_app.getCommandPayloadLength();
+        if (payload_len >= 1)
+        {
+            const bool new_disabled = (payload[0] != 0);
+            if (new_disabled != lora_hop_disabled)
+            {
+                lora_hop_disabled = new_disabled;
+                prefs.begin("lora", false);
+                prefs.putUChar("hopdis", lora_hop_disabled ? 1 : 0);
+                prefs.end();
+                if (lora_hop_disabled && hop_active_)
+                {
+                    // Drop hop tracking so the next radio service tick
+                    // returns us to lora_freq_mhz.
+                    hop_active_       = false;
+                    hop_needs_retune_ = true;
+                }
+            }
+            buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, payload, 1);
+            ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: %s",
+                     lora_hop_disabled ? "DISABLED (fixed freq)" : "ENABLED");
+            sendCurrentConfig();
         }
     }
     else if (ble_cmd == 20)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -419,6 +419,13 @@ static bool    hop_active_        = false;
 static uint8_t hop_idx_           = 0;
 static bool    hop_first_pkt_     = false;
 static bool    hop_needs_retune_  = false;
+// Operator override: when true, hopping is suppressed even in PRELAUNCH /
+// INFLIGHT and we stay on lora_freq_mhz for the whole flight (#106).  Set
+// by the BS via LORA_CMD_SET_HOP_DISABLED (cmd 17).  NVS-backed so the
+// setting survives reboot.  Both sides must agree; the BS keeps its own
+// copy and pushes changes here.  Diagnostic / link-debugging mode only —
+// using a fixed frequency in flight is not FHSS-compliant.
+static bool    lora_hop_disabled  = false;
 
 // Hop-silence rendezvous fallback state (#40 / #41 phase 2b).
 // Definitions of HOP_FALLBACK_*_MS constants and the serviceHopFallback()
@@ -453,7 +460,10 @@ static bool lora_in_rx_mode = false;
 
 static inline void updateHopFromState(RocketState s)
 {
-    const bool want_active = shouldHopInState(s);
+    // Operator override: in fixed-frequency mode (#106) we stay on
+    // lora_freq_mhz for every state.  Otherwise fall back to the
+    // shared per-state policy.
+    const bool want_active = !lora_hop_disabled && shouldHopInState(s);
     if (want_active && !hop_active_)
     {
         // OFF → ON.  Bootstrap: the next TX still goes out on
@@ -1943,6 +1953,7 @@ static void sendCurrentConfig()
     j += ",\"lbw\":"; j += fmtf(lora_bw_khz, 0);
     j += ",\"lcr\":"; j += itos(lora_cr);
     j += ",\"lpw\":"; j += itos(lora_tx_power);
+    j += ",\"lhd\":"; j += lora_hop_disabled ? "true" : "false";  // #106
     j += "}";
     ble_app.sendConfigJSON(j);
     ESP_LOGI("CFG", "Sent config readback (%u bytes)", (unsigned)j.length());
@@ -2203,6 +2214,31 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         else
         {
             ESP_LOGE("LORA", "UPLINK LoRa reconfigure FAILED");
+        }
+    }
+    else if (cmd == LORA_CMD_SET_HOP_DISABLED && payload_len >= 1)
+    {
+        // BS-controlled hop enable/disable (#106).  Payload byte 0 = 1 to
+        // disable hopping (fixed-frequency mode), 0 to re-enable.  We
+        // honour the change immediately by re-evaluating the hop state
+        // against the rocket's last known state — this gracefully turns
+        // hopping off mid-PRELAUNCH or back on once the operator clears
+        // the override.  Persist to NVS so the setting survives reboot.
+        const bool new_disabled = (payload[0] != 0);
+        if (new_disabled != lora_hop_disabled)
+        {
+            lora_hop_disabled = new_disabled;
+            prefs.begin("lora", false);
+            prefs.putUChar("hopdis", lora_hop_disabled ? 1 : 0);
+            prefs.end();
+            ESP_LOGI("LORA", "UPLINK Hop disable: %s — re-evaluating hop state",
+                     lora_hop_disabled ? "DISABLED (fixed freq)" : "ENABLED");
+            updateHopFromState(latest_rocket_state);
+        }
+        else
+        {
+            ESP_LOGI("LORA", "UPLINK Hop disable: already %s",
+                     lora_hop_disabled ? "DISABLED" : "ENABLED");
         }
     }
     else if (cmd == 12 && payload_len >= 14)
@@ -3378,6 +3414,7 @@ void initPeripherals()
         lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
         lora_cr        = prefs.getUChar("cr",   config::LORA_CR);
         lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
+        lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106 fixed-frequency override
 
         // Channel-set restore (#40 / #41 phase 3): rendezvous freq +
         // skip-mask pushed by the BS via cmd 15.  Skip-mask is keyed
@@ -3619,9 +3656,11 @@ static void setup_oc()
             lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
             lora_cr        = prefs.getUChar("cr",    config::LORA_CR);
             lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
-            ESP_LOGI("CFG", "NVS LoRa early load: %.1f MHz SF%u BW%.0f CR%u %d dBm",
+            lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106
+            ESP_LOGI("CFG", "NVS LoRa early load: %.1f MHz SF%u BW%.0f CR%u %d dBm hop_disabled=%d",
                           (double)lora_freq_mhz, (unsigned)lora_sf,
-                          (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
+                          (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
+                          (int)lora_hop_disabled);
         }
         prefs.end();
 
@@ -4308,83 +4347,18 @@ static void loop_oc()
         }
         else if (ble_cmd == 10)
         {
-            // LoRa reconfiguration: [freq:4f][bw:4f][sf:1][cr:1][txpwr:1]
-            const uint8_t* payload = ble_app.getCommandPayload();
-            const size_t plen = ble_app.getCommandPayloadLength();
-            // Refuse direct BLE reconfig while either (a) freq-locked
-            // for flight (#71) or (b) channel hopping is active
-            // (#40 / #41).  iOS app should already hide the apply button
-            // in both cases, but we belt-and-brace for version skew.
-            // Either way we send a readback so the app's UI reverts.
-            if (plen >= 11 && (freq_locked_for_flight || hop_active_))
-            {
-                ESP_LOGW("BLE", "Cmd 10 ignored: %s",
-                         freq_locked_for_flight ? "frequency locked for flight"
-                                                : "channel hopping active");
-                sendCurrentConfig();
-            }
-            else if (plen >= 11)
-            {
-                float new_freq, new_bw;
-                memcpy(&new_freq, payload + 0, 4);
-                memcpy(&new_bw,   payload + 4, 4);
-                uint8_t new_sf   = payload[8];
-                uint8_t new_cr   = payload[9];
-                int8_t  new_pwr  = (int8_t)payload[10];
-
-                // Always update runtime vars and persist to NVS, even if the
-                // radio isn't initialized yet (e.g. config sent before power-on).
-                // The saved values will be loaded by initPeripherals() on next boot.
-                const float old_bw = lora_bw_khz;
-                lora_freq_mhz = new_freq;
-                lora_bw_khz   = new_bw;
-                lora_sf        = new_sf;
-                lora_cr        = new_cr;
-                lora_tx_power  = new_pwr;
-
-                prefs.begin("lora", false);
-                prefs.putFloat("freq",  lora_freq_mhz);
-                prefs.putFloat("bw",    lora_bw_khz);
-                prefs.putUChar("sf",    lora_sf);
-                prefs.putUChar("cr",    lora_cr);
-                prefs.putChar("txpwr",  lora_tx_power);
-                // BW change invalidates the channel-set skip-mask (#40 / #41
-                // phase 3): the mask is sized for the OLD hop table.
-                if (old_bw != lora_bw_khz)
-                {
-                    skip_mask_n_        = 0;
-                    channel_set_bw_khz_ = 0.0f;
-                    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
-                    prefs.remove("chset_n");
-                    prefs.remove("chset_bw");
-                    prefs.remove("chset_mask");
-                    ESP_LOGI("BLE", "[CHSET] BW changed — skip-mask invalidated");
-                }
-                prefs.end();
-
-                // Verify NVS write by reading back
-                prefs.begin("lora", false);
-                float verify_freq = prefs.getFloat("freq", 0.0f);
-                prefs.end();
-                ESP_LOGI("CFG", "NVS LoRa verify: wrote %.1f, read back %.1f",
-                              (double)lora_freq_mhz, (double)verify_freq);
-
-                // Try to apply to live radio (may fail if not yet initialized)
-                if (lora_comms.reconfigure(new_freq, new_sf, new_bw, new_cr, new_pwr))
-                {
-                    lora_comms.startReceive();
-                    ESP_LOGI("BLE", "LoRa reconfigured + saved: %.1f MHz SF%u BW%.0f CR%u %d dBm",
-                                  (double)lora_freq_mhz, (unsigned)lora_sf,
-                                  (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
-                }
-                else
-                {
-                    ESP_LOGI("BLE", "LoRa saved (radio not ready): %.1f MHz SF%u BW%.0f CR%u %d dBm",
-                                  (double)lora_freq_mhz, (unsigned)lora_sf,
-                                  (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
-                }
-                sendCurrentConfig();
-            }
+            // Direct LoRa reconfig over BLE is no longer accepted on the
+            // rocket side (#106).  LoRa link parameters are owned by the
+            // base station; allowing the rocket to change them out-of-band
+            // can desync the pair (the BS keeps its own copy in NVS and
+            // never learns about a rocket-only change).  The iOS Settings
+            // view should be sending cmd 10 to the BS, which then relays
+            // via uplink cmd 10 (handled separately above) and persists.
+            //
+            // We send a config readback so the app's UI snaps back to the
+            // rocket's actual LoRa values rather than appearing to apply.
+            ESP_LOGW("BLE", "Cmd 10 refused on rocket: LoRa params are BS-controlled (#106). Send to base station instead.");
+            sendCurrentConfig();
         }
         else if (ble_cmd == 11)
         {


### PR DESCRIPTION
## Summary
Closes #106.

- **Audit**: the only place a rocket could independently change LoRa link parameters was OC's BLE cmd 10 handler — a phone connected directly to the rocket could persist a different LoRa config on the OC's NVS than the BS held in its NVS, causing immediate desync. The iOS Settings UI already gates the LoRa edit affordance behind `isBaseStation`, but the firmware accepted the cmd from anyone, so this PR closes the firmware-level leak.
- **New `LORA_CMD_SET_HOP_DISABLED = 17`**: BS-controlled toggle that suppresses per-packet channel hopping in PRELAUNCH/INFLIGHT and pins both ends to `lora_freq_mhz`. Useful for fixed-frequency diagnostics and link-sustainment debugging (#105). Persisted to NVS on both sides.

## Changes

| Component | Change |
| --- | --- |
| OC | BLE cmd 10 now refuses + sends config readback so the iOS UI snaps back. Adds `lora_hop_disabled` (NVS), gates `updateHopFromState`, handles uplink cmd 17, exposes `"lhd"` in config JSON. |
| BS | Adds `lora_hop_disabled` (NVS), gates the per-packet hop activation in the RX handler, BLE cmd 17 → persist + relay via uplink + immediate hop drop, exposes `"lhd"` in config JSON. |
| Shared | New `LORA_CMD_SET_HOP_DISABLED = 17` constant in `RocketComputerTypes.h`. |
| iOS | Decodes `"lhd"` into `RocketConfig.loraHopDisabled`, adds `BLEDevice.sendLoRaHopDisabled(_:)`, and adds a "Disable hopping (fixed frequency)" toggle in the BS-only LoRa Settings section. iOS already gated the existing LoRa edit UI on `isBaseStation`, so no UI change is needed for the audit fix. |

## Out of scope
Issue mentions auditing other rocket-side setters. BLE cmd 41 (`network_id`) on the OC also lets a phone change identity directly — that's a separate concern (multi-rocket / multi-network identity) not strictly LoRa link parameters. Leaving for a follow-up issue if you want it locked down too.

## Test plan
- [x] `out_computer` builds clean
- [x] `base_station` builds clean
- [x] iOS app builds clean (xcodebuild generic iOS device, Debug, no codesign)
- [ ] Bench: connect iOS to BS, toggle "Disable hopping" — confirm `lhd:true` in BS serial, `LORA_CMD_SET_HOP_DISABLED` uplink fires, OC logs the change and persists, and a subsequent PRELAUNCH transition does NOT activate hopping
- [ ] Bench: connect iOS directly to rocket, attempt to apply LoRa config — confirm OC logs "Cmd 10 refused on rocket" and the iOS UI doesn't expose Apply (it shouldn't — UI is already gated)
- [ ] Field: fixed-frequency diagnostic flight to verify the hop-disable mode actually keeps the BS and rocket on a single channel through PRELAUNCH→INFLIGHT→LANDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
