### PR TITLE
ble: tag BS periodic-push telemetry as live/stale/syncing (#95)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -97,6 +97,13 @@ struct TelemetryData: Codable {
     var source_rocket_id: Int?        // rocket_id from LoRa header
     var source_unit_name: String?     // rocket unit name from LoRa beacon
 
+    // Telemetry freshness status (#95).  Sent by the BS in periodic-push
+    // payloads; absent from RX-path payloads (which are always live) and
+    // from direct rocket connections.  iOS treats a missing "ds" as live.
+    enum DataStatus: Int, Codable { case live = 0, stale = 1, syncing = 2 }
+    var data_status: DataStatus = .live
+    var data_age_ms: UInt32 = 0      // only meaningful when .stale
+
     // Pyro channel status (packed bitfield from "ps" JSON key, decoded in init)
     var pyro_status_bits: Int = 0
     var pyro1_armed: Bool { (pyro_status_bits & 0x01) != 0 }
@@ -151,6 +158,8 @@ struct TelemetryData: Codable {
         case pyro_status_bits = "ps"  // packed bitfield: b0=ch1_armed, b1=ch1_cont, b2=ch1_fired, b3=ch2_armed, b4=ch2_cont, b5=ch2_fired
         case source_rocket_id = "rid"
         case source_unit_name = "run"
+        case data_status = "ds"        // #95
+        case data_age_ms = "age"       // #95
     }
 
     // Custom decoder: non-optional fields with defaults need decodeIfPresent
@@ -203,6 +212,10 @@ struct TelemetryData: Codable {
         pyro_status_bits = try c.decodeIfPresent(Int.self, forKey: .pyro_status_bits) ?? 0
         source_rocket_id = try c.decodeIfPresent(Int.self, forKey: .source_rocket_id)
         source_unit_name = try c.decodeIfPresent(String.self, forKey: .source_unit_name)
+        // #95: missing "ds" → .live (older firmware doesn't emit it)
+        let dsRaw = try c.decodeIfPresent(Int.self, forKey: .data_status) ?? 0
+        data_status = DataStatus(rawValue: dsRaw) ?? .live
+        data_age_ms = try c.decodeIfPresent(UInt32.self, forKey: .data_age_ms) ?? 0
     }
 
     // Default memberwise init (for creating empty telemetry)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -282,7 +282,26 @@ struct ConnectedDashboardView: View {
             }
         } else {
             // --- Powered ON (or base station): full telemetry dashboard ---
-            RocketStateView(state: device.telemetry.state)
+
+            // #95: telemetry freshness gate.  When BS is in SYNCING (no
+            // rocket caught yet) we hide the rocket-data views so the
+            // operator doesn't see the empty zero-init values rendered as
+            // a fake "INIT" rocket.  When STALE we keep the views visible
+            // but dim them and show a banner with the age.  Direct rocket
+            // connections always come through as .live (no banner, no dim).
+            let dataStatus = device.telemetry.data_status
+            let showRocketViews = dataStatus != .syncing
+            let staleOpacity: Double = dataStatus == .stale ? 0.5 : 1.0
+
+            if device.isBaseStation && dataStatus != .live {
+                TelemetryStatusBanner(status: dataStatus,
+                                      ageMs: device.telemetry.data_age_ms)
+            }
+
+            if showRocketViews {
+                RocketStateView(state: device.telemetry.state)
+                    .opacity(staleOpacity)
+            }
 
             if device.simLaunched {
                 SimModeBannerView {
@@ -298,8 +317,9 @@ struct ConnectedDashboardView: View {
                 }
             }
 
-            if device.isBaseStation {
+            if showRocketViews && device.isBaseStation {
                 FlightSummaryView(telemetry: device.telemetry)
+                    .opacity(staleOpacity)
             }
 
             SignalStrengthView(
@@ -309,20 +329,39 @@ struct ConnectedDashboardView: View {
                 locationManager: device.isBaseStation ? locationManager : nil
             )
 
-            BatteryView(telemetry: device.telemetry,
-                        isBaseStation: device.isBaseStation)
-
-            IMUView(telemetry: device.telemetry,
-                    isBaseStation: device.isBaseStation)
-
-            if !device.isBaseStation {
-                FlightSummaryView(telemetry: device.telemetry)
+            // BatteryView shows BS battery (always live) + rocket battery.
+            // When syncing/stale the rocket row is meaningless; we still
+            // render the view (BS battery row is useful) but dim it on
+            // stale to match the rest, and hide it entirely on syncing
+            // since both rows would be empty/cached.
+            if device.isBaseStation && dataStatus == .syncing {
+                // BS-only: show a stripped view with just the BS battery row
+                BSOnlyBatteryView(telemetry: device.telemetry)
+            } else {
+                BatteryView(telemetry: device.telemetry,
+                            isBaseStation: device.isBaseStation)
+                    .opacity(staleOpacity)
             }
 
-            GPSView(telemetry: device.telemetry, compact: true)
+            if showRocketViews {
+                IMUView(telemetry: device.telemetry,
+                        isBaseStation: device.isBaseStation)
+                    .opacity(staleOpacity)
+            }
+
+            if showRocketViews && !device.isBaseStation {
+                FlightSummaryView(telemetry: device.telemetry)
+                    .opacity(staleOpacity)
+            }
+
+            if showRocketViews {
+                GPSView(telemetry: device.telemetry, compact: true)
+                    .opacity(staleOpacity)
+            }
 
             StatusFlagsView(telemetry: device.telemetry,
                             isBaseStation: device.isBaseStation)
+                .opacity(showRocketViews ? staleOpacity : 1.0)
 
             if !device.isBaseStation {
                 PyroChannelsView(device: device)
@@ -513,6 +552,51 @@ struct RocketStateView: View {
     }
 }
 
+/// Banner shown when the BS is reporting non-LIVE telemetry status (#95).
+/// SYNCING: BS hasn't caught the rocket yet — operator-facing "searching"
+/// hint, paired with hiding rocket-data views in the parent.
+/// STALE: BS is still re-pushing cached values older than the staleness
+/// threshold — show how old in seconds so the operator knows it's not
+/// live; parent dims rocket-data views.
+struct TelemetryStatusBanner: View {
+    let status: TelemetryData.DataStatus
+    let ageMs: UInt32
+
+    private var icon: String {
+        status == .syncing ? "antenna.radiowaves.left.and.right.slash" : "clock.badge.exclamationmark"
+    }
+    private var title: String {
+        status == .syncing ? "Searching for rocket…" : "Telemetry stale"
+    }
+    private var subtitle: String {
+        switch status {
+        case .syncing: return "Base station hasn't received any telemetry yet. Power on the rocket and wait for the link to sync."
+        case .stale:   return String(format: "Last packet %.1f s ago. Showing cached values.", Double(ageMs) / 1000.0)
+        case .live:    return ""
+        }
+    }
+    private var tint: Color {
+        status == .syncing ? .blue : .orange
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundColor(tint)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.headline)
+                Text(subtitle).font(.caption).foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tint.opacity(0.1))
+        .cornerRadius(10)
+    }
+}
+
 struct SimModeBannerView: View {
     var onStop: () -> Void
 
@@ -623,6 +707,41 @@ struct BatteryView: View {
                            voltage: telemetry.bsVoltageDisplay,
                            current: telemetry.bsCurrentDisplay)
             }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
+        .cornerRadius(10)
+    }
+}
+
+/// Stripped-down BatteryView used while the BS hasn't caught the rocket yet
+/// (#95).  Hides the rocket row entirely (its values would be empty/cached)
+/// and shows only the live BS battery row, so the operator still has a
+/// useful battery indicator without the misleading rocket data.
+struct BSOnlyBatteryView: View {
+    let telemetry: TelemetryData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Battery")
+                .font(.headline)
+
+            HStack(spacing: 0) {
+                Text("")
+                    .frame(width: 70, alignment: .leading)
+                Text("Charge").font(.caption).foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+                Text("Voltage").font(.caption).foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+                Text("Current").font(.caption).foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+
+            BatteryRow(label: "Base Stn",
+                       charge: telemetry.bsSocDisplay,
+                       voltage: telemetry.bsVoltageDisplay,
+                       current: telemetry.bsCurrentDisplay)
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1079,6 +1079,15 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
         }
     }
 
+    // #95: data freshness status.  LIVE is the default and is omitted
+    // entirely to save bytes — the iOS app treats "ds" absent as LIVE.
+    if (data.data_status != TelemetryData::DataStatus::LIVE) {
+        addInt("ds", (int)data.data_status);
+        if (data.data_status == TelemetryData::DataStatus::STALE) {
+            addUint("age", data.data_age_ms);
+        }
+    }
+
     buf[pos++] = '}';
     buf[pos] = '\0';
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -89,6 +89,16 @@ public:
         // Source rocket identity (base station only — for multi-rocket demux)
         uint8_t source_rocket_id;       // 0 = not set (direct connection)
         const char* source_unit_name;   // nullptr = not set
+
+        // Telemetry freshness status (#95).  LIVE = packet just decoded
+        // (default).  STALE = BS re-pushing cached data older than
+        // BLE_TELEMETRY_STALE_MS; iOS dims + shows "stale (Ns ago)".
+        // SYNCING = no rocket has ever been caught; iOS hides rocket
+        // fields and shows "Searching for rocket…".  Direct rocket
+        // connections always send LIVE.
+        enum class DataStatus : uint8_t { LIVE = 0, STALE = 1, SYNCING = 2 };
+        DataStatus data_status;
+        uint32_t   data_age_ms;         // only meaningful when STALE
     };
 
     // Constructor

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -67,6 +67,16 @@ namespace config
     static constexpr uint32_t LOG_FLUSH_INTERVAL_MS  = 10000;   // Periodic flush to flash (10s)
     static constexpr uint32_t LOG_OPEN_RETRY_MS      = 5000;    // Retry fopen() at most this often when a start attempt fails (#107)
 
+    // --- BLE telemetry staleness (#95) ---
+    // The BS periodic push re-sends the most recent rocket telemetry every
+    // PWR_UPDATE_PERIOD_MS so battery / RSSI stay live even between LoRa
+    // packets.  Once the underlying packet is older than BLE_TELEMETRY_STALE_MS
+    // we mark the BLE payload as stale (with age) so the iOS app can dim
+    // the values + show a "stale (Ns ago)" badge instead of pretending the
+    // numbers are fresh.  Sized just above the slowest steady-state packet
+    // cadence (Long Range preset ≈ 2 Hz) plus a couple of misses.
+    static constexpr uint32_t BLE_TELEMETRY_STALE_MS = 3000;
+
     // --- I2C Bus (MAX17205G fuel gauge) ---
     static constexpr int      I2C_SCL_PIN       = 37;
     static constexpr int      I2C_SDA_PIN       = 38;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -2386,9 +2386,14 @@ static void loop_bs()
                 TR_LoRa_Comms::Stats ls = {};
                 lora_comms.getStats(ls);
 
-                // Convert ECEF to lat/lon
+                // Convert ECEF to lat/lon — but only when the rocket reports
+                // an actual GPS fix.  The rocket sometimes packs nonzero ECEF
+                // even with num_sats == 0 (stale GNSS register read), which
+                // would otherwise yield a "valid-looking" lat/lon while the
+                // fix is invalid (#95).
                 double lat_deg = NAN, lon_deg = NAN, alt_m = NAN;
-                if (decoded.ecef_x != 0.0 || decoded.ecef_y != 0.0 || decoded.ecef_z != 0.0)
+                if (decoded.num_sats > 0 &&
+                    (decoded.ecef_x != 0.0 || decoded.ecef_y != 0.0 || decoded.ecef_z != 0.0))
                 {
                     coord.ecefToGeodetic(decoded.ecef_x, decoded.ecef_y, decoded.ecef_z,
                                          lat_deg, lon_deg, alt_m);
@@ -2593,8 +2598,15 @@ static void loop_bs()
         last_battery_ms = millis();
         updateBattery();
 
-        // Always push base station stats to BLE, even without LoRa packets.
-        // Re-send last-known rocket telemetry so battery/RSSI stay up to date.
+        // Always push base station stats to BLE, even without LoRa packets,
+        // so BS battery / logging state / RSSI stay live.  Tag each push
+        // with a freshness status (#95) so the iOS app can distinguish:
+        //   • LIVE    — re-pushing telemetry that's still recent
+        //   • STALE   — re-pushing cached telemetry older than the threshold
+        //               (iOS dims + shows "stale (Ns ago)")
+        //   • SYNCING — no rocket has ever been caught
+        //               (iOS hides rocket fields, shows "Searching for rocket…")
+        // The RX path always sends LIVE because it fires on a fresh decode.
         if (ble_app.isConnected())
         {
             TR_BLE_To_APP::TelemetryData ble_telem = {};
@@ -2606,14 +2618,22 @@ static void loop_bs()
                 if (tr.unit_name[0]) {
                     ble_telem.source_unit_name = tr.unit_name;
                 }
+                const uint32_t age_ms = millis() - tr.last_seen_ms;
+                if (age_ms > config::BLE_TELEMETRY_STALE_MS)
+                {
+                    ble_telem.data_status = TR_BLE_To_APP::TelemetryData::DataStatus::STALE;
+                    ble_telem.data_age_ms = age_ms;
+                }
             }
             else
             {
-                // No rocket tracked — publish base-station-only fields so the
-                // app still sees BS battery/logging state. Rocket-side fields
-                // stay NaN/zero.
+                // No rocket tracked — publish base-station-only fields with
+                // a SYNCING tag so the iOS app shows "Searching for rocket…"
+                // rather than rendering the empty zero-init values as if
+                // they were a rocket sitting in INIT.
                 LoRaDataSI empty = {};
                 buildBLETelemetry(empty, NAN, NAN, NAN, NAN, NAN, ble_telem);
+                ble_telem.data_status = TR_BLE_To_APP::TelemetryData::DataStatus::SYNCING;
             }
             ble_app.sendTelemetry(ble_telem);
         }


### PR DESCRIPTION
## Summary
Closes #95.

The BS re-pushed cached `tr.last_data` over BLE every `PWR_UPDATE_PERIOD_MS` regardless of how stale the underlying decode was. The iOS dashboard had no way to tell live telemetry apart from a 30-second-old snapshot or a never-synced session, so it rendered zero-init values as if a real rocket was sitting in INIT and stale lat/lon/altitude as if they were current. Plus a sub-issue: the ECEF→geodetic conversion fired on any nonzero ECEF even when `num_sats == 0`, producing a "valid-looking" lat/lon at zero-fix.

## What changed

- **BS firmware**: tags every periodic-push BLE payload with a `DataStatus` (LIVE / STALE / SYNCING) plus age. Threshold = `BLE_TELEMETRY_STALE_MS = 3000`. ECEF→geodetic now requires `num_sats > 0` so a fake lat/lon is impossible. RX path is unchanged (always LIVE since it fires on a fresh decode).
- **BLE JSON**: new `"ds"` and `"age"` keys, both omitted when LIVE so the most common payload pays no extra bytes. Older firmware decodes as LIVE on iOS (no breakage).
- **iOS**: new `TelemetryStatusBanner`. SYNCING hides the rocket-data views and renders a stripped `BSOnlyBatteryView` with just the BS battery row. STALE keeps everything visible but dims it to 0.5 opacity. Direct rocket connections always come through as LIVE so behavior there is unchanged.

## Test plan
- [x] `base_station` builds clean
- [x] `out_computer` builds clean (no shared-header regression)
- [x] iOS builds clean (xcodebuild generic iOS device, Debug)
- [ ] Bench: BS boots with rocket off → banner shows "Searching for rocket…", no rocket fields visible, BS battery still shown
- [ ] Bench: rocket on → banner clears within one packet, full dashboard renders
- [ ] Bench: power off rocket while linked → within ~3 s banner shows "Telemetry stale (Ns ago)", rocket fields dim
- [ ] Bench: direct rocket BLE connection → no banner, no dim (always LIVE)
- [ ] Bench: rocket telemetry packet with `nsat=0` → no lat/lon shown anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
