### PR TITLE
oc: lower stall thresholds to 20 ms to find sub-100 ms blocker (#94 / #104)

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -13,7 +13,9 @@ static const char* TAG = "LORA";
 // shared bus mutex).  Anything inside this file that takes longer than
 // LORA_STALL_THRESHOLD_US is logged with its step name so the next bench
 // run names the offending op.
-static constexpr int64_t LORA_STALL_THRESHOLD_US = 50'000;  // 50 ms
+// Lowered from 50 ms to 20 ms for #94 / #104 follow-up: chasing 70-90 ms
+// periodic OC-side stalls.  Revert to 50 ms once the culprit is identified.
+static constexpr int64_t LORA_STALL_THRESHOLD_US = 20'000;  // 20 ms (investigation)
 
 #define LORA_STALL_INSTR(name, expr) do {                                      \
     const int64_t _stall_t0_ = esp_timer_get_time();                           \

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3794,6 +3794,23 @@ static void loop_oc()
     // Use ESP-IDF console component or BLE commands for debug interaction.
     const int64_t _loop_oc_t0 = esp_timer_get_time();
 
+    // Preemption catch: time elapsed *between* iterations (after vTaskDelay).
+    // The body-only catch-all below misses cases where loop_oc yields with
+    // vTaskDelay(1) and a higher-prio task (NimBLE, hardware IRQs, etc.)
+    // holds Core 1 for tens or hundreds of ms before loop_oc resumes.  A
+    // long inter-iteration gap means the OS preempted oc_loop after it
+    // already passed the body-end timer.
+    static int64_t _loop_oc_last_entry_us = 0;
+    if (_loop_oc_last_entry_us != 0) {
+        const int64_t _inter_dt = _loop_oc_t0 - _loop_oc_last_entry_us;
+        if (_inter_dt > LOOP_STALL_THRESHOLD_US) {
+            ESP_LOGW("LOOP_STALL",
+                     "loop_oc inter-iteration gap %lld us (preempted on Core 1)",
+                     (long long)_inter_dt);
+        }
+    }
+    _loop_oc_last_entry_us = _loop_oc_t0;
+
     // --- Active mode: FlightComputer + sensors powered on ---
     if (pwr_pin_on)
     {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3768,16 +3768,16 @@ static void setup_oc()
 }
 
 // ============================================================================
-// loop_oc stall instrumentation (#90 follow-up — periodic 745 ms Core-1 stall)
+// loop_oc stall instrumentation (#94 / #104 follow-up — periodic Core-1 stall)
 // ============================================================================
-// Bench analysis showed all six sensor streams freezing for ~745 ms every
-// ~15 s with the Core-1 sensor pipeline resuming within 5 ms across streams
-// — a single Core-1 blocker preempting the I2S parser long enough to
-// overflow the DMA ring.  These macros log any blocking call inside loop_oc
-// (or the LoRa internals) that exceeds LOOP_STALL_THRESHOLD_US so the next
-// bench run names the offending op directly.  Modeled on the existing
-// LFS_TIMING / STALL_THRESHOLD_US instrumentation in TR_LogToFlash.cpp.
-static constexpr int64_t LOOP_STALL_THRESHOLD_US = 100'000;  // 100 ms
+// The original 745 ms / 9.5 s pattern (#94) appears to be resolved.  Field
+// flights on 2026-05-03 and a fresh bench on 2026-05-06 now show a different
+// signature: ~70-90 ms gaps every 100 ms post-launch, with OC POWER (read on
+// Core 1) gapping ~2 ms BEFORE FC sensor frames stop appearing in the log
+// — i.e. the blocker is on the OC, not the FC.  Threshold lowered from
+// 100 ms to 20 ms so the next bench run names the sub-100 ms op directly.
+// Revert to 100 ms once the culprit is identified.
+static constexpr int64_t LOOP_STALL_THRESHOLD_US = 20'000;  // 20 ms (investigation)
 
 #define LOOP_STALL_INSTR(name, expr) do {                                       \
     const int64_t _stall_t0_ = esp_timer_get_time();                            \


### PR DESCRIPTION
## Summary

Investigation step for #94 / #104 — lower the OC stall instrumentation thresholds so the next bench run can name the sub-100 ms periodic blocker that's causing the field gap pattern.

## Context

Gap analysis on the 2026-05-03 field flights (RolyPoly + RIM-66) and a fresh 2026-05-06 bench shows:

| Run | Big gaps (50–100 ms) | Cadence | Old #94 pattern (770–825 ms / 9.5 s) |
|---|---|---|---|
| RolyPoly 5/3 | 101 | 300 / 400 ms | absent |
| RIM-66 5/3 | 96 | 300 / 400 ms | absent |
| Bench 5/6 | 198 | 300 / 400 ms | absent (zero >150 ms gaps) |

**The original #94 stall appears resolved.** What remains is a different signature: ~70–90 ms gaps every 100 ms post-launch, costing ~25% of post-launch wall time.

Per-flight correlation of OC POWER (read in `loop_oc` on Core 1) vs FC ISM6 (sent over I2S):

```
Bench 5/6:    POWER gap starts -1.9 ms before FC gap, lasts 5-8 ms longer
RolyPoly 5/3: POWER gap starts -1.8 ms before FC gap, lasts 5-8 ms longer
```

POWER leading FC means **the OC's `loop_oc` is the blocker** — FC frames just stop appearing in the log a couple ms after OC blocks. But every existing `LOOP_STALL_INSTR` is set at 100 ms and every `LORA_STALL_INSTR` at 50 ms, so the 70–90 ms blocks slip through.

## Change

- `LOOP_STALL_THRESHOLD_US` in `out_computer/main/main.cpp`: **100 ms → 20 ms**
- `LORA_STALL_THRESHOLD_US` in `TR_LoRa_Comms.cpp`: **50 ms → 20 ms**

Both have a comment marking them as investigation-only; revert to original once the culprit is named.

## Risk

None — these only affect `ESP_LOGW` output. Expect more noise in serial during normal operation (e.g. legitimate LoRa SPI reconfigures around 20–50 ms will now log). That's the point: we want to see them.

## Test plan

- [ ] Flash the OC with this firmware
- [ ] Run a 60+ s bench similar to `tests/test_data/flight_20260506_021341.bin`
- [ ] Capture serial during the active phase
- [ ] Identify the `LOOP_STALL` / `LORA STALL` line(s) that fire at ~100 ms cadence post-launch
- [ ] Open a follow-up PR fixing the named blocker, and revert these thresholds

## Related

- #94 — original 745 ms / 9.5 s bench stall (appears fixed)
- #104 — field gaps on 5/3/26 flights (this investigation)

Generated with [Claude Code](https://claude.com/claude-code)
