### PR TITLE
fc: defer saveFlightSnapshot NVS write to Core 0 worker (#104)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -25,6 +25,8 @@
 #include <soc/gpio_sig_map.h>      // SIG_GPIO_OUT_IDX
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 #include <nvs_flash.h>
 #include <esp_log.h>
 #include <esp_task_wdt.h>
@@ -301,6 +303,94 @@ static uint32_t computeSnapshotCRC(const FlightSnapshot& snap)
     return crc.calc();
 }
 
+// --- Snapshot deferral (issue #104 follow-up) ---
+// Producer: loop_fc on Core 1 builds the snapshot at 10 Hz and drops it
+// into snap_pending_slot under a mutex.  Consumer: snap_worker_task on
+// Core 0 wakes on snap_signal, copies the slot out, and writes to NVS.
+// The Preferences.putBytes call blocks for 5-80 ms (NVS GC every 3-4
+// writes hits page erase) — keeping it on Core 0 keeps loop_fc rate at
+// 1 kHz.  Drop-old semantics: producer uses a 0-timeout mutex try-take,
+// so if the worker is mid-copy the producer just drops this tick.  The
+// next 100 ms tick will retry with newer data — only the latest
+// snapshot needs to survive a crash for recovery.
+//
+// clearFlightSnapshot also routes through the worker (CLEAR command)
+// to avoid the race where loop_fc clears NVS while the worker is
+// mid-write of an INFLIGHT snapshot — that race could resurrect the
+// just-cleared snapshot and trigger spurious recovery on next boot.
+enum class SnapCmd : uint8_t { NONE = 0, SAVE, CLEAR };
+static SemaphoreHandle_t snap_mutex = nullptr;
+static SemaphoreHandle_t snap_signal = nullptr;
+static FlightSnapshot    snap_pending_slot = {};
+static SnapCmd           snap_pending_cmd = SnapCmd::NONE;
+static TaskHandle_t      snap_worker_task_handle = nullptr;
+static uint32_t          snap_drops_mutex = 0;   // producer dropped: mutex contended
+static uint32_t          snap_writes_ok  = 0;
+static uint32_t          snap_clears_ok  = 0;
+static uint32_t          snap_max_write_us = 0;
+
+static void snapshotWorkerTask(void*)
+{
+    for (;;) {
+        // Wait until producer signals fresh work.
+        xSemaphoreTake(snap_signal, portMAX_DELAY);
+
+        // Copy slot to local under mutex.  NVS work happens OUTSIDE
+        // the mutex so the producer is never blocked by flash.
+        SnapCmd cmd = SnapCmd::NONE;
+        FlightSnapshot local;
+        if (xSemaphoreTake(snap_mutex, portMAX_DELAY) == pdTRUE) {
+            cmd = snap_pending_cmd;
+            if (cmd == SnapCmd::SAVE) {
+                local = snap_pending_slot;
+            }
+            snap_pending_cmd = SnapCmd::NONE;
+            xSemaphoreGive(snap_mutex);
+        }
+
+        const int64_t t0 = esp_timer_get_time();
+        if (cmd == SnapCmd::SAVE) {
+            Preferences snap_prefs;
+            if (snap_prefs.begin("fsnap", false)) {
+                snap_prefs.putBytes("s", &local, sizeof(local));
+                snap_prefs.end();
+                snap_writes_ok++;
+            }
+        } else if (cmd == SnapCmd::CLEAR) {
+            Preferences snap_prefs;
+            if (snap_prefs.begin("fsnap", false)) {
+                snap_prefs.remove("s");
+                snap_prefs.end();
+                snap_clears_ok++;
+            }
+        }
+        const uint32_t dt = (uint32_t)(esp_timer_get_time() - t0);
+        if (dt > snap_max_write_us) snap_max_write_us = dt;
+    }
+}
+
+static void initSnapshotWorker()
+{
+    snap_mutex = xSemaphoreCreateMutex();
+    snap_signal = xSemaphoreCreateBinary();
+    if (snap_mutex == nullptr || snap_signal == nullptr) {
+        ESP_LOGE(TAG, "[SNAP] failed to create deferral primitives — snapshots disabled");
+        return;
+    }
+    BaseType_t ok = xTaskCreatePinnedToCore(
+        snapshotWorkerTask,
+        "snap_worker",
+        4096,
+        nullptr,
+        1,                         // below I2S Sender (prio 2) and sensor tasks
+        &snap_worker_task_handle,
+        config::SENSOR_CORE);      // Core 0 — keep flight task (Core 1) clean
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "[SNAP] failed to create worker task — snapshots disabled");
+        snap_worker_task_handle = nullptr;
+    }
+}
+
 static void saveFlightSnapshot(uint32_t now_ms)
 {
     FlightSnapshot snap = {};
@@ -338,19 +428,44 @@ static void saveFlightSnapshot(uint32_t now_ms)
 
     snap.crc32 = computeSnapshotCRC(snap);
 
-    Preferences snap_prefs;
-    if (snap_prefs.begin("fsnap", false)) {
-        snap_prefs.putBytes("s", &snap, sizeof(snap));
-        snap_prefs.end();
+    // Hand off to the Core-0 worker.  Non-blocking try-take: if the
+    // worker is mid-copy, drop this tick — the next 100 ms tick will
+    // retry with newer state (only the latest snapshot matters for
+    // crash recovery, and Preferences.putBytes can block 5-80 ms).
+    if (snap_mutex == nullptr || snap_signal == nullptr) {
+        return;  // worker init failed — snapshots disabled
+    }
+    if (xSemaphoreTake(snap_mutex, 0) == pdTRUE) {
+        snap_pending_slot = snap;
+        snap_pending_cmd  = SnapCmd::SAVE;
+        xSemaphoreGive(snap_mutex);
+        xSemaphoreGive(snap_signal);
+    } else {
+        snap_drops_mutex++;
     }
 }
 
 static void clearFlightSnapshot()
 {
-    Preferences snap_prefs;
-    if (snap_prefs.begin("fsnap", false)) {
-        snap_prefs.remove("s");
-        snap_prefs.end();
+    // Sync fallback when the worker isn't up yet (boot-time call before
+    // initSnapshotWorker()).  Safe — runs once before loop_fc starts.
+    if (snap_mutex == nullptr || snap_signal == nullptr) {
+        Preferences snap_prefs;
+        if (snap_prefs.begin("fsnap", false)) {
+            snap_prefs.remove("s");
+            snap_prefs.end();
+        }
+        return;
+    }
+    // Worker is up — defer the clear so it serializes with any pending
+    // SAVE.  Without this, loop_fc could clear NVS while the worker is
+    // mid-write of an INFLIGHT snapshot, resurrecting it after the clear
+    // and triggering spurious recovery on next boot.  Block on the mutex
+    // (rather than try-take) since clear is rare (boot, LANDED, sim end).
+    if (xSemaphoreTake(snap_mutex, portMAX_DELAY) == pdTRUE) {
+        snap_pending_cmd = SnapCmd::CLEAR;  // overrides any pending SAVE
+        xSemaphoreGive(snap_mutex);
+        xSemaphoreGive(snap_signal);
     }
 }
 
@@ -1592,11 +1707,17 @@ static void setup_fc()
             }
         }
 
-        // Clear stale snapshot on normal boot (prevents recovery on next power cycle)
+        // Clear stale snapshot on normal boot (prevents recovery on next power cycle).
+        // Sync NVS call here is fine — runs once at boot before loop_fc starts.
         if (!reboot_recovery) {
             clearFlightSnapshot();
         }
     }
+
+    // Spin up the snapshot worker AFTER any boot-time NVS work so the boot
+    // sync writes don't race the worker init.  From here on, every
+    // saveFlightSnapshot() call (10 Hz in INFLIGHT) is handed off to Core 0.
+    initSnapshotWorker();
 
     ESP_LOGI(TAG, "Setup complete");
     ESP_LOGI(TAG, "Setup complete…");


### PR DESCRIPTION
## Summary

Fixes the post-launch periodic ~70–90 ms / 100 ms data gaps documented in #104. Defers `saveFlightSnapshot()`'s NVS write off the FC's flight task (Core 1) to a dedicated Core-0 worker. EKF state, pyro flags, and references stay in the snapshot — recovery contract unchanged, just async.

## Root cause (recap from #127 investigation)

Field flights on 2026-05-03 (RolyPoly + RIM-66) and bench runs on 2026-05-06 show ~25% of post-launch wall time lost to gaps.

| Run | Big gaps (50–100 ms) post-launch | Cadence |
|---|---|---|
| RolyPoly 5/3 | 101 | 300 / 400 ms |
| RIM-66 5/3 | 96 | 300 / 400 ms |
| Sim bench 5/6 (`flight_20260506_151648.bin`) | 162 | 300 / 400 ms |
| Sim bench 5/6 (`flight_20260506_154423.bin`, with #127 inter-iter timer) | 201 | 300 / 400 ms |

PR #127 instrumentation (LOOP_STALL threshold dropped to 20 ms + new inter-iteration preemption catch) confirmed the OC main loop and flush task are clean during INFLIGHT — `iter=7-12 ms`, `ring_peak ≤ 334 bytes`, **zero** `LOOP_STALL` warnings, **zero** inter-iteration warnings, **zero** LORA STALL warnings. The gaps cannot be on the OC.

The cadence matches `saveFlightSnapshot()` exactly:
- Called every 100 ms in `loop_fc`'s INFLIGHT case ([flight_computer/main/main.cpp:2941](tinkerrocket-idf/projects/flight_computer/main/main.cpp:2941))
- `Preferences.putBytes()` blocks 5–80 ms; every 3rd or 4th write hits NVS page erase / GC (~70 ms)
- `loop_fc` runs at `configMAX_PRIORITIES-1` on Core 1 with no `vTaskDelay` — the NVS block freezes sensor sampling for the full duration
- `FlightSnapshot` is ~1056 bytes (EKF P matrix dominates). 4 KB NVS pages → ~3 records/page → erase every 3 writes = 300 ms big-gap cadence (predicted = observed)

## Design

Producer/consumer with drop-old semantics, modeled on #77's `prepareFlight` deferral.

**Producer side** ([loop_fc INFLIGHT case](tinkerrocket-idf/projects/flight_computer/main/main.cpp:3018)): builds the snapshot (fast — ~1 KB memcpy + EKF state read + CRC), then non-blocking try-take of a mutex, copies into a single slot, signals the worker. If the worker is mid-copy the producer drops this 100 ms tick (`snap_drops_mutex` counter). Only the latest snapshot needs to survive a crash for recovery, so dropping a tick is harmless.

**Consumer side**: `snap_worker_task` on **Core 0 at priority 1** (below I2S Sender at 2 and below sensor tasks). Wakes on `snap_signal`, takes mutex, copies slot to local, **releases mutex**, then does `Preferences.begin/putBytes/end`. NVS block stays on Core 0 — `loop_fc` never waits.

**`clearFlightSnapshot` also routes through the worker** (CLEAR command in the slot) to prevent a race where loop_fc clears NVS while the worker is mid-write of an INFLIGHT snapshot — that would resurrect the just-cleared snapshot and trigger spurious recovery on the next boot. Boot-time `clearFlightSnapshot` keeps a sync fallback (worker not yet up).

## Core 0 budget

Existing comment in `setup_fc` notes Core 0 at ~76% (sensor SPI + I2S send + GNSS). Snapshot worker adds ~10 Hz × ~10 ms typical = +10%. NVS GC blocks the worker (which releases CPU), so other Core 0 tasks aren't starved during the wait — only during the brief CPU portion of each write.

## Risk

- **Low**. Same code path as before, just on a different task. Recovery contract identical.
- The added worker has its own 4 KB stack on Core 0.
- Diagnostic counters (`snap_writes_ok`, `snap_clears_ok`, `snap_drops_mutex`, `snap_max_write_us`) accumulate but aren't currently printed — easy to wire into the periodic stats line later if useful.
- Built clean against ESP-IDF (no warnings).

## Test plan

- [ ] Sim flight: confirm post-launch periodic 70–90 ms gaps are gone (gap analysis on the bin)
- [ ] Reboot recovery: power-cycle mid-INFLIGHT, verify EKF state / pyro flags / `launch_time_millis` restore correctly
- [ ] LANDED transition: verify `clearFlightSnapshot` drains and the next boot does NOT trigger spurious recovery
- [ ] FC main-loop rate stays at 1 kHz under sustained snapshot writes (no regression vs current behavior on Core 1)

## Related

- #104 — periodic post-launch gaps (this fix)
- #127 — investigation/instrumentation that confirmed OC is clean (revert `LOOP_STALL_THRESHOLD_US` to 100 ms once this bench passes)
- #77 — Core-0 deferral pattern this PR follows for the snapshot worker

Generated with [Claude Code](https://claude.com/claude-code)
