### PR TITLE
oc: bump I2S parser priority 1 -> 6 to fix Core 1 starvation (#104)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3579,9 +3579,16 @@ void initPeripherals()
             ESP_LOGE("PWR", "I2S recv callback failed: %s", esp_err_to_name(cb_err));
 
         // Parser task — woken by DMA callback, parses frames from rx_ring.
-        // Runs on Core 1 at same priority as loopTask so they round-robin.
+        // Pinned to Core 1 at priority 6 (one above loopTask at prio 5).
+        // Parser preempts loopTask whenever DMA notifies; loopTask runs
+        // in the gaps when parser blocks in ulTaskNotifyTake.  Parser is
+        // bursty by design (sleeps when rx_ring is empty) so it can't
+        // starve loopTask.  Originally created at prio 1 with a
+        // misleading "round-robin" comment — the actual scheduling left
+        // parser starved during high-throughput INFLIGHT, causing
+        // rx_ring to fill until drop_oldest evicted bytes (#104).
         xTaskCreatePinnedToCore(i2sParserTask, "I2S Parse", 4096,
-                                nullptr, 1, &i2s_rx_task_handle, 1);
+                                nullptr, 6, &i2s_rx_task_handle, 1);
     }
 
     // NOTE: do NOT pre-queue a status response here.  With the new


### PR DESCRIPTION
## Summary

Bumps the I2S parser task priority from **1** to **6** (one above `oc_loop` at prio 5). Fixes the Core-1 starvation that PR #130's instrumentation just pinpointed — parser was getting almost no CPU during INFLIGHT, `rx_ring` was filling and overflowing, and frames were silently lost as bytes were evicted byte-by-byte. This is the cause of the 12 × ~745 ms post-launch gaps that remained after #129 fixed Pattern B.

## Evidence

From the latest sim flight ([flight_20260507_003925.bin](tests/test_data/flight_20260507_003925.bin)) with PR #130's instrumentation:

```
I (74519) ... rx_ovf=0    rx_peak=10679  parser_max=0 us       ← parser silent
I (75519) ... rx_ovf=0    rx_peak=21605  parser_max=0 us
I (76519) ... rx_ovf=0    rx_peak=32680  parser_max=0 us
I (77522) ... rx_ovf=0    rx_peak=44230  parser_max=0 us
I (78522) ... rx_ovf=0    rx_peak=56473  parser_max=0 us
I (79522) ... rx_ovf=530  rx_peak=65535  parser_max=0 us       ← OVERFLOW
I (80522) ... rx_ovf=1320 rx_peak=65535  parser_max=6069965 us ← parser ran ONCE for 6 s
I (81522) ... rx_ovf=0    rx_peak=19991  parser_max=0 us       ← cycle repeats
```

`rx_peak` growing while `parser_max=0` means the ISR is firing (bytes are being pushed into `rx_ring`) but the parser task is stuck inside one `parseRxStream()` call that takes 5-9 seconds because it gets so little CPU between preemptions by `oc_loop`.

## The latent bug

[main.cpp:3581-3584](tinkerrocket-idf/projects/out_computer/main/main.cpp:3581) before the fix:

```cpp
// Parser task — woken by DMA callback, parses frames from rx_ring.
// Runs on Core 1 at same priority as loopTask so they round-robin.
xTaskCreatePinnedToCore(i2sParserTask, "I2S Parse", 4096,
                        nullptr, 1, &i2s_rx_task_handle, 1);
//                              ^prio 1                  ^Core 1
```

`oc_loop` is on Core 1 at prio 5. The comment claimed parser was "same priority as loopTask so they round-robin" but the actual prio was **1**, not 5. Latent since the original commit (`915fb5ce`, 2026-04-07); exposed now because #129's snapshot traffic pushed I2S bandwidth closer to its ceiling and the deficit became visible as periodic loss.

## Why prio 6 (not 5)

- Prio 5 (round-robin with `oc_loop`) would split CPU time evenly via FreeRTOS time-slicing — better than today, but parser still has to wait its turn and could fall behind during sustained bursts.
- Prio 6 (parser preempts `oc_loop`) means parser runs the moment DMA notifies it, drains `rx_ring` in microseconds, then sleeps in `ulTaskNotifyTake`. `oc_loop` runs in the gaps.

Parser is bursty by design — it self-throttles by sleeping when the ring is empty. CPU budget:
- ~80 µs per frame (`mramWriteBytes` + `processFrame`)
- ~2400 frames/s → ~190 ms/s parser CPU = **~19% of Core 1**
- Other 81% goes to `oc_loop`, which only needs ~7-12 ms per iteration

`oc_loop` already explicitly yields with `vTaskDelay(1)` between iterations, so giving up some ms to parser bursts won't hurt it.

## Risk

- Tiny one-line change (prio 1 → 6).
- Parser doesn't poll, only wakes on notification — can't burn CPU.
- Built clean.

## Test plan

- [ ] Sim flight with this OC firmware (FC can be `main` or `fc-snapshot-via-mram`)
- [ ] Confirm: `rx_ovf=0` throughout INFLIGHT, `rx_peak` stays small (<1 KB), `parser_max` reflects per-call timing (single-digit ms)
- [ ] Confirm: `oc_loop` LOG TIMING `iter` stays in the 7-12 ms range (parser preemption shouldn't destabilize the flush path)
- [ ] Confirm: bin shows no periodic 745 ms gaps post-launch

## Related

- #104 — periodic post-launch gaps (this should close it once we land #129 + this)
- #129 — open: FC snapshot via MRAM (Pattern B fix)
- #130 — open: OC RX-path instrumentation (the diagnostic that found this)

Generated with [Claude Code](https://claude.com/claude-code)
