### PR TITLE
lora: hop diagnostics + robust hopping redesign (#105)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -98,10 +98,13 @@ struct SettingsView: View {
     @State private var servoApplied = false
     @State private var pidApplied = false
 
-    // Hop disable (#106) — local mirror of base-station's lora_hop_disabled flag.
+    // Hop enable (#106) — local mirror of the BS's lora_hop_disabled flag,
+    // inverted to match the UI's "Enable frequency hopping" toggle phrasing.
     // We keep a State so the toggle is responsive; the truth lives on the BS
-    // and is restored whenever a config readback arrives.
-    @State private var loraHopDisabled = false
+    // and is restored whenever a config readback arrives.  Wire format is
+    // still "disabled" semantics (cmd 17 payload 1 = disabled), so any place
+    // that talks to BLE inverts at the boundary.
+    @State private var loraHopEnabled = true
 
     private var selectedPreset: LoRaPreset {
         loraPresets.first(where: { $0.id == presetId }) ?? loraPresets[1]
@@ -233,14 +236,14 @@ struct SettingsView: View {
                     // Sends cmd 17 to the BS, which persists and uplinks
                     // the same byte to every tracked rocket.
                     Section(header: Text("LoRa Frequency Hopping"),
-                            footer: Text(loraHopDisabled
-                                ? "DISABLED — both ends stay on the configured frequency. Not FHSS-compliant; use for diagnostics only."
-                                : "Enabled (default). Channels hop during PRELAUNCH and INFLIGHT.")) {
-                        Toggle("Disable hopping (fixed frequency)", isOn: Binding(
-                            get: { loraHopDisabled },
+                            footer: Text(loraHopEnabled
+                                ? "Enabled (default). Channels hop during PRELAUNCH and INFLIGHT."
+                                : "DISABLED — both ends stay on the configured frequency. Not FHSS-compliant; use for diagnostics only.")) {
+                        Toggle("Enable frequency hopping", isOn: Binding(
+                            get: { loraHopEnabled },
                             set: { newValue in
-                                loraHopDisabled = newValue
-                                device.sendLoRaHopDisabled(newValue)
+                                loraHopEnabled = newValue
+                                device.sendLoRaHopDisabled(!newValue)
                             }
                         ))
                     }
@@ -536,11 +539,13 @@ struct SettingsView: View {
                 if let pwr = cfg.loraTxPower {
                     txPower = Double(pwr)
                 }
-                // #106 — sync hop-disable from device.  Older firmware doesn't
-                // emit "lhd"; in that case we leave the toggle showing its
-                // last value (defaults to false on first load).
+                // #106 — sync hop state from device.  Wire format is the
+                // "disabled" flag (lhd: true means hopping is OFF), so we
+                // invert into our UI-side "enabled" state.  Older firmware
+                // doesn't emit "lhd"; in that case we leave the toggle
+                // showing its last value (defaults to enabled on first load).
                 if let hopDis = cfg.loraHopDisabled {
-                    loraHopDisabled = hopDis
+                    loraHopEnabled = !hopDis
                 }
                 loadStringsFromStorage()
             }

--- a/tests_cpp/test_lora_roundtrip.cpp
+++ b/tests_cpp/test_lora_roundtrip.cpp
@@ -252,20 +252,24 @@ TEST_F(LoRaRoundtripTest, ByteLevel_PackUnpack) {
     EXPECT_NEAR(out.acc_z, 9.8f, 0.1f);
 }
 
-TEST_F(LoRaRoundtripTest, Seq_AllByteValues) {
-    // The seq byte (#105) must roundtrip the full 0..255 range without
-    // collision with adjacent fields.  A bit-mask bug here would silently
-    // corrupt either seq or next_channel_idx and the BS-side observed-loss
-    // computation would chase ghosts.
-    for (int s = 0; s <= 255; s++) {
+TEST_F(LoRaRoundtripTest, Seq_FullU16Range) {
+    // Proto v4 widened seq to 16 bits so the slow-hop seq-anchored
+    // schedule can cover all channel counts (BW=125 → 139 channels at
+    // dwell=4 needs 556 distinct seq positions, way past u8).  Verify
+    // the round-trip works at byte boundaries, mid-range, and the wrap.
+    const uint16_t test_seqs[] = {
+        0, 1, 127, 128, 255, 256, 257,                 // u8 boundary
+        1000, 16384, 32768, 49152,                     // mid-range
+        65532, 65533, 65534, 65535                     // wrap edge
+    };
+    for (uint16_t s : test_seqs) {
         LoRaDataSI in = makeNominal();
-        in.seq = (uint8_t)s;
-        // Pin some neighbours so we'd notice if seq writes overflowed
-        // into them — these are the routing-header neighbours and a
-        // payload byte right after the appended seq slot.
+        in.seq = s;
+        // Pin neighbours so we'd notice if seq writes overflowed into them.
         in.network_id       = 42;
         in.rocket_id        = 7;
         in.next_channel_idx = 99;
+        in.num_sats         = 12;
         in.speed            = 1234.0f;
 
         LoRaData packed{};
@@ -273,10 +277,11 @@ TEST_F(LoRaRoundtripTest, Seq_AllByteValues) {
         LoRaDataSI out{};
         conv.unpackLoRa(packed, out);
 
-        EXPECT_EQ(out.seq, (uint8_t)s)         << "seq=" << s;
+        EXPECT_EQ(out.seq, s)                  << "seq=" << s;
         EXPECT_EQ(out.network_id, 42)          << "seq=" << s;
         EXPECT_EQ(out.rocket_id,   7)          << "seq=" << s;
         EXPECT_EQ(out.next_channel_idx, 99)    << "seq=" << s;
+        EXPECT_EQ(out.num_sats, 12)            << "seq=" << s;
         EXPECT_NEAR(out.speed, 1234.0f, 1.0f)  << "seq=" << s;
     }
 }

--- a/tests_cpp/test_lora_roundtrip.cpp
+++ b/tests_cpp/test_lora_roundtrip.cpp
@@ -22,6 +22,7 @@ protected:
         si.network_id = 1;
         si.rocket_id = 1;
         si.next_channel_idx = 47;  // realistic mid-table hop target
+        si.seq = 123;              // free-running TX seq (#105)
         si.num_sats = 12;
         si.pdop = 1.5f;
         si.ecef_x = -2430601.0;
@@ -73,6 +74,7 @@ TEST_F(LoRaRoundtripTest, NominalFlight_Roundtrip) {
     EXPECT_EQ(out.network_id, 1);
     EXPECT_EQ(out.rocket_id, 1);
     EXPECT_EQ(out.next_channel_idx, 47);  // hop byte must roundtrip exactly
+    EXPECT_EQ(out.seq, 123);              // seq byte must roundtrip exactly (#105)
     EXPECT_EQ(out.num_sats, 12);
     EXPECT_NEAR(out.pdop, 2.0f, 0.6f); // u8 0..100, integer only
     EXPECT_NEAR(out.ecef_x, in.ecef_x, 1.0);
@@ -248,4 +250,33 @@ TEST_F(LoRaRoundtripTest, ByteLevel_PackUnpack) {
     EXPECT_EQ(out.num_sats, 12);
     EXPECT_TRUE(out.launch_flag);
     EXPECT_NEAR(out.acc_z, 9.8f, 0.1f);
+}
+
+TEST_F(LoRaRoundtripTest, Seq_AllByteValues) {
+    // The seq byte (#105) must roundtrip the full 0..255 range without
+    // collision with adjacent fields.  A bit-mask bug here would silently
+    // corrupt either seq or next_channel_idx and the BS-side observed-loss
+    // computation would chase ghosts.
+    for (int s = 0; s <= 255; s++) {
+        LoRaDataSI in = makeNominal();
+        in.seq = (uint8_t)s;
+        // Pin some neighbours so we'd notice if seq writes overflowed
+        // into them — these are the routing-header neighbours and a
+        // payload byte right after the appended seq slot.
+        in.network_id       = 42;
+        in.rocket_id        = 7;
+        in.next_channel_idx = 99;
+        in.speed            = 1234.0f;
+
+        LoRaData packed{};
+        conv.packLoRa(in, packed);
+        LoRaDataSI out{};
+        conv.unpackLoRa(packed, out);
+
+        EXPECT_EQ(out.seq, (uint8_t)s)         << "seq=" << s;
+        EXPECT_EQ(out.network_id, 42)          << "seq=" << s;
+        EXPECT_EQ(out.rocket_id,   7)          << "seq=" << s;
+        EXPECT_EQ(out.next_channel_idx, 99)    << "seq=" << s;
+        EXPECT_NEAR(out.speed, 1234.0f, 1.0f)  << "seq=" << s;
+    }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -25,7 +25,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(MMC5983MAData),  16u);
     EXPECT_EQ(sizeof(POWERData),      10u);
     EXPECT_EQ(sizeof(NonSensorData),  43u);
-    EXPECT_EQ(sizeof(LoRaData),       60u);  // 3-byte routing header + 57-byte payload
+    EXPECT_EQ(sizeof(LoRaData),       61u);  // 4-byte routing header (incl. seq) + 57-byte payload
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);
 }
@@ -475,6 +475,75 @@ TEST(RocketLikelyHopping, RecentNonHopStateFalse) {
     EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, READY,         10000));
     EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, INITIALIZATION,10000));
     EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, LANDED,        10000));
+}
+
+// ============================================================================
+// Issue #105: observed-loss attribution from the per-TX seq counter
+// ============================================================================
+
+TEST(LoraComputeObservedLoss, FirstContactReturnsUnknown) {
+    // No prior packet → BS can't compute loss; -1 means "unknown".
+    EXPECT_EQ(loraComputeObservedLoss(/*prev_seq=*/-1, /*curr=*/0),    -1);
+    EXPECT_EQ(loraComputeObservedLoss(/*prev_seq=*/-1, /*curr=*/200),  -1);
+}
+
+TEST(LoraComputeObservedLoss, ConsecutivePacketsHaveZeroLoss) {
+    // Healthy link: every TX gets through, gap=0.
+    EXPECT_EQ(loraComputeObservedLoss(0, 1),    0);
+    EXPECT_EQ(loraComputeObservedLoss(50, 51),  0);
+    EXPECT_EQ(loraComputeObservedLoss(254, 255), 0);
+}
+
+TEST(LoraComputeObservedLoss, SmallForwardJumpsReportRealLoss) {
+    // delta=N → (N-1) packets lost between RXes.
+    EXPECT_EQ(loraComputeObservedLoss(0, 2),   1);   // missed seq 1
+    EXPECT_EQ(loraComputeObservedLoss(0, 11), 10);   // missed 1..10
+    EXPECT_EQ(loraComputeObservedLoss(95, 100), 4);  // missed 96..99
+}
+
+TEST(LoraComputeObservedLoss, WrapAroundIsSeenAsForward) {
+    // 8-bit wrap: prev=250, curr=5 → modular delta = 11, loss = 10.
+    EXPECT_EQ(loraComputeObservedLoss(250, 5), 10);
+    EXPECT_EQ(loraComputeObservedLoss(255, 0), 0);   // exact wrap, no loss
+}
+
+TEST(LoraComputeObservedLoss, ImplausibleDeltaReturnsUnknown) {
+    // Modular 8-bit math: a "backward" jump only looks implausible once
+    // the wrap-forward distance exceeds the threshold.  A reboot in which
+    // the rocket happens to land near a multiple of 256 of its previous
+    // seq looks like a small forward run — that's a known limitation we
+    // accept; cross-checking against rocket_state covers the gap when it
+    // matters.  These cases are unambiguously implausible:
+    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/100, /*curr=*/99),  -1);  // delta=255
+    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/10,  /*curr=*/254), -1);  // delta=244
+    // Threshold is 100 by default; delta=101 must trip it.
+    EXPECT_EQ(loraComputeObservedLoss(0, 101),                     -1);
+    // delta=100 is right at the threshold — should still report (loss=99).
+    EXPECT_EQ(loraComputeObservedLoss(0, 100),                     99);
+}
+
+TEST(LoraComputeObservedLoss, AmbiguousRebootIsCountedAsLoss) {
+    // Documents the known reboot-detection blind spot: prev=200, curr=0
+    // (rocket sent 201..255 then rebooted to 0) has modular delta=56,
+    // which the helper reports as 55 lost packets.  We accept this — the
+    // operator should disambiguate using rocket_state (a fresh boot
+    // arrives in INITIALIZATION, not the prior PRELAUNCH/INFLIGHT).
+    EXPECT_EQ(loraComputeObservedLoss(200, 0), 55);
+}
+
+TEST(LoraComputeObservedLoss, DuplicateSeqIsAnomaly) {
+    // Same seq twice in a row: protocol violation (duplicate or replay).
+    // We don't try to be clever — flag as unknown so the operator sees it.
+    EXPECT_EQ(loraComputeObservedLoss(7,   7),   -1);
+    EXPECT_EQ(loraComputeObservedLoss(255, 255), -1);
+}
+
+TEST(LoraComputeObservedLoss, CustomThresholdHonoured) {
+    // A test or operator can dial the plausibility cap.  At threshold=10
+    // a delta of 50 is rejected even though it'd be accepted at default.
+    EXPECT_EQ(loraComputeObservedLoss(0, 50, /*plausibility_max=*/10), -1);
+    EXPECT_EQ(loraComputeObservedLoss(0,  9, /*plausibility_max=*/10),  8);
+    EXPECT_EQ(loraComputeObservedLoss(0, 10, /*plausibility_max=*/10),  9);
 }
 
 TEST(RocketLikelyHopping, StaleRxFalseEvenInHopState) {

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -123,24 +123,15 @@ TEST(LoraNextActiveChannel, AllMaskedDegenerateSafe) {
     EXPECT_LT(next, 10);  // Some valid index in range; just don't crash.
 }
 
-TEST(LoraSelectChannelSet, NoScanResultsFallbacks) {
-    // No scan input: rendezvous = fallback, mask all-zero.
+TEST(LoraSelectChannelSet, NoScanResultsLeavesEmptyMask) {
+    // No scan input: skip-mask all-zero, n_channels reflects the BW table.
+    // Rendezvous freq is no longer computed by this function (it's
+    // compile-time hardcoded — see LORA_FACTORY_RENDEZVOUS_MHZ).
     LoRaChannelSetSelection out{};
-    loraSelectChannelSet(nullptr, nullptr, 0, /*bw_khz=*/250.0f,
-                          /*fallback=*/915.0f, &out);
-    EXPECT_FLOAT_EQ(out.rendezvous_mhz, 915.0f);
+    loraSelectChannelSet(nullptr, nullptr, 0, /*bw_khz=*/250.0f, &out);
     EXPECT_EQ(out.n_channels, loraChannelCount(250.0f));
     for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++)
         EXPECT_EQ(out.skip_mask[i], 0u) << "byte " << i;
-}
-
-TEST(LoraSelectChannelSet, RendezvousIsScanMinimum) {
-    // Three scan points; pick the lowest-RSSI one as rendezvous.
-    const float   freqs[] = { 910.0f, 915.0f, 920.0f };
-    const int8_t  rssi[]  = {  -75,    -95,    -80 };  // 915 quietest
-    LoRaChannelSetSelection out{};
-    loraSelectChannelSet(freqs, rssi, 3, 250.0f, 915.0f, &out);
-    EXPECT_FLOAT_EQ(out.rendezvous_mhz, 915.0f);
 }
 
 TEST(LoraSelectChannelSet, NoiseAboveThresholdGetsSkipped) {
@@ -159,17 +150,13 @@ TEST(LoraSelectChannelSet, NoiseAboveThresholdGetsSkipped) {
     rssi[10] = -60;   // very loud
     rssi[55] = -50;   // very loud
     LoRaChannelSetSelection out{};
-    loraSelectChannelSet(freqs, rssi, N, 125.0f, 915.0f, &out);
+    loraSelectChannelSet(freqs, rssi, N, 125.0f, &out);
 
     EXPECT_EQ(out.n_channels, n_chan);
     EXPECT_TRUE (loraSkipMaskTest(out.skip_mask, 10));
     EXPECT_TRUE (loraSkipMaskTest(out.skip_mask, 55));
     EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, 11));
     EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, 0));
-
-    // Rendezvous picks one of the quiet -110 channels (any is fine).
-    EXPECT_NE(out.rendezvous_mhz, freqs[10]);
-    EXPECT_NE(out.rendezvous_mhz, freqs[55]);
 }
 
 TEST(LoraSelectChannelSet, FccFloorEnforced_BW250) {
@@ -189,7 +176,7 @@ TEST(LoraSelectChannelSet, FccFloorEnforced_BW250) {
         rssi[i] = (i % 5 == 0) ? -100 : -50;
     }
     LoRaChannelSetSelection out{};
-    loraSelectChannelSet(freqs, rssi, M, 250.0f, 915.0f, &out);
+    loraSelectChannelSet(freqs, rssi, M, 250.0f, &out);
 
     // Count active (non-skipped).  Must be ≥ fhss_min = 50.
     uint8_t active = 0;
@@ -209,7 +196,7 @@ TEST(LoraSelectChannelSet, AllQuietSkipsNothing) {
         rssi[i]  = -105 + (int8_t)(i % 3);  // tiny variation
     }
     LoRaChannelSetSelection out{};
-    loraSelectChannelSet(freqs, rssi, N, 250.0f, 915.0f, &out);
+    loraSelectChannelSet(freqs, rssi, N, 250.0f, &out);
 
     for (uint8_t i = 0; i < out.n_channels; i++)
         EXPECT_FALSE(loraSkipMaskTest(out.skip_mask, i)) << "channel " << (int)i;

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -25,7 +25,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(MMC5983MAData),  16u);
     EXPECT_EQ(sizeof(POWERData),      10u);
     EXPECT_EQ(sizeof(NonSensorData),  43u);
-    EXPECT_EQ(sizeof(LoRaData),       61u);  // 4-byte routing header (incl. seq) + 57-byte payload
+    EXPECT_EQ(sizeof(LoRaData),       62u);  // 5-byte routing header (incl. 16-bit seq) + 57-byte payload
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);
 }
@@ -476,53 +476,58 @@ TEST(LoraComputeObservedLoss, FirstContactReturnsUnknown) {
 
 TEST(LoraComputeObservedLoss, ConsecutivePacketsHaveZeroLoss) {
     // Healthy link: every TX gets through, gap=0.
-    EXPECT_EQ(loraComputeObservedLoss(0, 1),    0);
-    EXPECT_EQ(loraComputeObservedLoss(50, 51),  0);
-    EXPECT_EQ(loraComputeObservedLoss(254, 255), 0);
+    EXPECT_EQ(loraComputeObservedLoss(0, 1),         0);
+    EXPECT_EQ(loraComputeObservedLoss(50, 51),       0);
+    EXPECT_EQ(loraComputeObservedLoss(65534, 65535), 0);
 }
 
 TEST(LoraComputeObservedLoss, SmallForwardJumpsReportRealLoss) {
     // delta=N → (N-1) packets lost between RXes.
-    EXPECT_EQ(loraComputeObservedLoss(0, 2),   1);   // missed seq 1
-    EXPECT_EQ(loraComputeObservedLoss(0, 11), 10);   // missed 1..10
-    EXPECT_EQ(loraComputeObservedLoss(95, 100), 4);  // missed 96..99
+    EXPECT_EQ(loraComputeObservedLoss(0, 2),     1);   // missed seq 1
+    EXPECT_EQ(loraComputeObservedLoss(0, 11),   10);   // missed 1..10
+    EXPECT_EQ(loraComputeObservedLoss(95, 100),  4);   // missed 96..99
+    EXPECT_EQ(loraComputeObservedLoss(0, 500), 499);   // far inside default 1000 cap
 }
 
 TEST(LoraComputeObservedLoss, WrapAroundIsSeenAsForward) {
-    // 8-bit wrap: prev=250, curr=5 → modular delta = 11, loss = 10.
-    EXPECT_EQ(loraComputeObservedLoss(250, 5), 10);
-    EXPECT_EQ(loraComputeObservedLoss(255, 0), 0);   // exact wrap, no loss
+    // 16-bit wrap (proto v4): prev near top of u16, curr just past wrap.
+    EXPECT_EQ(loraComputeObservedLoss(65530, 5),  10);  // delta=11, loss=10
+    EXPECT_EQ(loraComputeObservedLoss(65535, 0),   0);  // exact wrap, no loss
+    EXPECT_EQ(loraComputeObservedLoss(65000, 99), 634); // delta=635, loss=634 (still inside cap)
 }
 
 TEST(LoraComputeObservedLoss, ImplausibleDeltaReturnsUnknown) {
-    // Modular 8-bit math: a "backward" jump only looks implausible once
-    // the wrap-forward distance exceeds the threshold.  A reboot in which
-    // the rocket happens to land near a multiple of 256 of its previous
-    // seq looks like a small forward run — that's a known limitation we
-    // accept; cross-checking against rocket_state covers the gap when it
-    // matters.  These cases are unambiguously implausible:
-    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/100, /*curr=*/99),  -1);  // delta=255
-    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/10,  /*curr=*/254), -1);  // delta=244
-    // Threshold is 100 by default; delta=101 must trip it.
-    EXPECT_EQ(loraComputeObservedLoss(0, 101),                     -1);
-    // delta=100 is right at the threshold — should still report (loss=99).
-    EXPECT_EQ(loraComputeObservedLoss(0, 100),                     99);
+    // 16-bit math: a "backward" jump only looks implausible once the
+    // wrap-forward distance exceeds the threshold.  A reboot near a
+    // multiple of 65536 of the prior seq looks like a small forward run
+    // — known limitation; cross-check rocket_state to disambiguate.
+    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/100, /*curr=*/99),  -1);  // delta=65535
+    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/500, /*curr=*/0),   -1);  // delta=65036
+    // Threshold is 1000 by default; delta=1001 must trip it.
+    EXPECT_EQ(loraComputeObservedLoss(0, 1001),                    -1);
+    // delta=1000 is right at the threshold — should still report.
+    EXPECT_EQ(loraComputeObservedLoss(0, 1000),                   999);
 }
 
 TEST(LoraComputeObservedLoss, AmbiguousRebootIsCountedAsLoss) {
-    // Documents the known reboot-detection blind spot: prev=200, curr=0
-    // (rocket sent 201..255 then rebooted to 0) has modular delta=56,
-    // which the helper reports as 55 lost packets.  We accept this — the
-    // operator should disambiguate using rocket_state (a fresh boot
-    // arrives in INITIALIZATION, not the prior PRELAUNCH/INFLIGHT).
-    EXPECT_EQ(loraComputeObservedLoss(200, 0), 55);
+    // Reboot blind spot from proto v3 is GONE for the common case: with
+    // 16-bit seq, a rocket that rebooted from seq=200 to seq=0 now has
+    // modular delta=65336 (way past the 1000 threshold) and is correctly
+    // flagged unknown.  Documenting here so the regression doesn't
+    // sneak back in if someone narrows seq again.
+    EXPECT_EQ(loraComputeObservedLoss(200, 0),    -1);
+    EXPECT_EQ(loraComputeObservedLoss(50000, 0),  -1);
+    // The remaining blind spot: a reboot that lands within the
+    // plausibility window still looks like real loss.  Operator should
+    // disambiguate via rocket_state (INITIALIZATION on fresh boot).
+    EXPECT_EQ(loraComputeObservedLoss(/*prev=*/0, /*curr=*/100), 99);
 }
 
 TEST(LoraComputeObservedLoss, DuplicateSeqIsAnomaly) {
     // Same seq twice in a row: protocol violation (duplicate or replay).
     // We don't try to be clever — flag as unknown so the operator sees it.
-    EXPECT_EQ(loraComputeObservedLoss(7,   7),   -1);
-    EXPECT_EQ(loraComputeObservedLoss(255, 255), -1);
+    EXPECT_EQ(loraComputeObservedLoss(7,   7),     -1);
+    EXPECT_EQ(loraComputeObservedLoss(65535, 65535), -1);
 }
 
 TEST(LoraComputeObservedLoss, CustomThresholdHonoured) {
@@ -531,6 +536,123 @@ TEST(LoraComputeObservedLoss, CustomThresholdHonoured) {
     EXPECT_EQ(loraComputeObservedLoss(0, 50, /*plausibility_max=*/10), -1);
     EXPECT_EQ(loraComputeObservedLoss(0,  9, /*plausibility_max=*/10),  8);
     EXPECT_EQ(loraComputeObservedLoss(0, 10, /*plausibility_max=*/10),  9);
+}
+
+// ============================================================================
+// Issue #105 follow-up: seq-anchored slow-hop channel schedule
+// ============================================================================
+
+TEST(LoraHopChannelForSeq, DwellOneMatchesNaiveModulo) {
+    // dwell=1 is the "advance every TX" baseline.  With an empty mask,
+    // channel = seq % n_channels.  Both rocket and BS compute identically.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    for (uint16_t s = 0; s < 200; s++) {
+        EXPECT_EQ(loraHopChannelForSeq(s, /*dwell=*/1, mask, /*n=*/35),
+                  (uint8_t)(s % 35)) << "seq=" << s;
+    }
+}
+
+TEST(LoraHopChannelForSeq, DwellHoldsForNPackets) {
+    // dwell=4 holds the same channel for 4 consecutive seq values then
+    // advances exactly once.  This is the slow-hop property the BS
+    // depends on for tolerating single missed packets.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    constexpr uint8_t n     = 35;
+    constexpr uint8_t dwell = 4;
+    for (uint16_t s = 0; s < 4 * n; s++) {
+        EXPECT_EQ(loraHopChannelForSeq(s, dwell, mask, n),
+                  (uint8_t)((s / dwell) % n)) << "seq=" << s;
+    }
+}
+
+TEST(LoraHopChannelForSeq, U8WouldStarveChannels_U16CoversAll) {
+    // The motivation for proto v4 widening seq to 16 bits: with 8-bit
+    // seq + dwell=4, only 256/4 = 64 distinct positions exist, so any
+    // channel count > 64 starves the high-numbered channels.  Verify
+    // that with u16 we actually cover all 69 channels at BW=250.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    constexpr uint8_t n     = 69;
+    constexpr uint8_t dwell = 4;
+    bool seen[256] = {false};
+    // (seq / dwell) needs to reach n-1 for full coverage; with dwell=4
+    // and n=69 that requires seq >= 4*68 = 272 — well past u8 wrap.
+    for (uint16_t s = 0; s < dwell * n; s++) {
+        seen[loraHopChannelForSeq(s, dwell, mask, n)] = true;
+    }
+    for (uint8_t i = 0; i < n; i++) {
+        EXPECT_TRUE(seen[i]) << "channel " << (int)i << " never visited";
+    }
+}
+
+TEST(LoraHopChannelForSeq, SkipMaskExcludesMaskedChannels) {
+    // Channels marked in the skip mask are never returned.  Active
+    // channels are visited in their natural order.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    loraSkipMaskSet(mask, 3);
+    loraSkipMaskSet(mask, 7);
+    loraSkipMaskSet(mask, 8);
+    constexpr uint8_t n     = 10;
+    constexpr uint8_t dwell = 1;
+    for (uint16_t s = 0; s < 50; s++) {
+        const uint8_t ch = loraHopChannelForSeq(s, dwell, mask, n);
+        EXPECT_FALSE(loraSkipMaskTest(mask, ch))
+            << "seq=" << s << " landed on masked channel " << (int)ch;
+    }
+}
+
+TEST(LoraHopChannelForSeq, SkipMaskWalksActiveChannelsInOrder) {
+    // Active channels: 0, 1, 2, 4, 5, 6, 9 (mask 3,7,8 + 7 active).
+    // dwell=1: schedule cycles 0→1→2→4→5→6→9→0→...
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    loraSkipMaskSet(mask, 3);
+    loraSkipMaskSet(mask, 7);
+    loraSkipMaskSet(mask, 8);
+    const uint8_t expected[] = { 0, 1, 2, 4, 5, 6, 9, 0, 1, 2, 4, 5, 6, 9 };
+    for (size_t i = 0; i < sizeof(expected); i++) {
+        EXPECT_EQ(loraHopChannelForSeq((uint16_t)i, 1, mask, 10), expected[i])
+            << "seq=" << i;
+    }
+}
+
+TEST(LoraHopChannelForSeq, BothSidesAgreeAcrossWrapBoundary) {
+    // The seq-anchored property means BS and rocket compute identically
+    // from the same seq.  Hammer the wrap point to verify behaviour is
+    // continuous across u16 rollover.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    constexpr uint8_t n     = 69;
+    constexpr uint8_t dwell = 4;
+    // Both sides (rocket-perspective vs BS-perspective) compute the
+    // same value for any seq — just confirm the call is pure and
+    // deterministic at the wrap.
+    for (uint32_t s = 65530; s < 65540; s++) {
+        const uint16_t s16 = (uint16_t)s;
+        const uint8_t ch_a = loraHopChannelForSeq(s16, dwell, mask, n);
+        const uint8_t ch_b = loraHopChannelForSeq(s16, dwell, mask, n);
+        EXPECT_EQ(ch_a, ch_b);
+    }
+    // After u16 wrap, schedule continues from seq=0,1,2,3 → channel 0.
+    EXPECT_EQ(loraHopChannelForSeq(0, dwell, mask, n), 0);
+    EXPECT_EQ(loraHopChannelForSeq(3, dwell, mask, n), 0);
+    EXPECT_EQ(loraHopChannelForSeq(4, dwell, mask, n), 1);
+}
+
+TEST(LoraHopChannelForSeq, ZeroOrInvalidArgsAreSafe) {
+    // Defensive: callers shouldn't hit these but we don't want UB.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    EXPECT_EQ(loraHopChannelForSeq(0, 4, mask, 0),  0);  // n_channels=0
+    EXPECT_EQ(loraHopChannelForSeq(7, 0, mask, 35), 0);  // dwell=0
+}
+
+TEST(LoraHopChannelForSeq, AllMaskedFallsBackToRawMod) {
+    // FCC floor prevents this in production, but the helper must not
+    // crash.  Falls back to raw modulo so it still makes progress.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES];
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) mask[i] = 0xFF;
+    constexpr uint8_t n     = 16;
+    constexpr uint8_t dwell = 4;
+    EXPECT_EQ(loraHopChannelForSeq(0,  dwell, mask, n), 0);
+    EXPECT_EQ(loraHopChannelForSeq(4,  dwell, mask, n), 1);
+    EXPECT_EQ(loraHopChannelForSeq(60, dwell, mask, n), 15);
 }
 
 TEST(RocketLikelyHopping, StaleRxFalseEvenInHopState) {

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -147,6 +147,7 @@ void TR_LoRa_Comms::service()
         }
     }
     tx_ongoing_ = false;
+    tx_started_ms_ = 0;  // watchdog clear (#105)
     stats_.transmitting = false;
 
     // Return to RX mode so uplink commands can be received between sends
@@ -182,6 +183,7 @@ bool TR_LoRa_Comms::send(const uint8_t* payload, size_t len)
     }
 
     tx_ongoing_ = true;
+    tx_started_ms_ = millis();  // watchdog stamp (#105)
     stats_.transmitting = true;
     stats_.tx_started++;
     return true;
@@ -213,6 +215,7 @@ bool TR_LoRa_Comms::startReceive()
     rx_mode_ = true;
     rx_done_ = false;
     tx_ongoing_ = false;
+    tx_started_ms_ = 0;  // watchdog clear (#105)
 
     int16_t st;
     LORA_STALL_INSTR("startReceive radio_->startReceive", st = radio_->startReceive());
@@ -320,6 +323,62 @@ void TR_LoRa_Comms::pollDio1()
         }
     }
     portENABLE_INTERRUPTS();
+}
+
+// ============================================================================
+// TX watchdog (#105 follow-up)
+// ============================================================================
+// Force-clears tx_ongoing_ when it has been stuck for longer than any
+// plausible TX could take.  Without this, a missed DIO1 IRQ + a
+// misclassified pollDio1 (rx_mode_ momentarily true at the polling
+// instant during a hopToFrequencyMHz retune) leaves tx_ongoing_=true
+// forever — wedging hopToFrequencyMHz, reconfigure, send, and ultimately
+// the entire LoRa link until reboot.  Field-confirmed failure mode in
+// the #105 hop testing.
+//
+// The watchdog is deliberately generous (TX_WATCHDOG_MS = 3 s) to
+// accommodate worst-case ToA at SF12 BW125 (~2.5 s for a 60-byte frame).
+// A real TX always completes well inside this window; if we hit it,
+// something is genuinely wrong and the recovery is to put the radio
+// back into a known RX state.
+void TR_LoRa_Comms::serviceTxWatchdog()
+{
+    if (!enabled_ || radio_ == nullptr) return;
+    if (!tx_ongoing_)                   return;
+    if (tx_started_ms_ == 0)            return;  // not yet stamped
+    const uint32_t elapsed = millis() - tx_started_ms_;
+    if (elapsed < TX_WATCHDOG_MS)       return;
+
+    ESP_LOGW(TAG, "TX watchdog: tx_ongoing_ stuck %u ms — force-clearing "
+                  "(tx_done=%d rx_mode=%d isr_count=%lu last_err=%d)",
+             (unsigned)elapsed,
+             (int)tx_done_, (int)rx_mode_,
+             (unsigned long)isr_count_,
+             (int)stats_.last_error);
+    stats_.tx_watchdog_fires++;
+
+    // Clear the stuck flags so the rest of the system unwedges.
+    portDISABLE_INTERRUPTS();
+    tx_ongoing_   = false;
+    tx_done_      = false;
+    tx_started_ms_ = 0;
+    portENABLE_INTERRUPTS();
+    stats_.transmitting = false;
+
+    // Best-effort radio recovery: standby, then re-enter RX so the radio
+    // and the driver agree on state.  We don't propagate errors — if
+    // these calls fail, the radio is even more wedged and the next
+    // bigger hammer (reconfigure on a recovery cycle) will handle it.
+    (void)radio_->standby();
+    if (radio_->startReceive() == RADIOLIB_ERR_NONE)
+    {
+        rx_mode_ = true;
+        rx_done_ = false;
+    }
+    else
+    {
+        rx_mode_ = false;
+    }
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -40,6 +40,7 @@ public:
         uint32_t rx_count = 0;
         uint32_t rx_crc_fail = 0;
         uint32_t isr_count = 0;
+        uint32_t tx_watchdog_fires = 0;  // tx_ongoing_ force-cleared by watchdog (#105)
         float last_rssi = 0.0f;
         float last_snr = 0.0f;
         int16_t last_error = RADIOLIB_ERR_NONE;
@@ -62,6 +63,18 @@ public:
 
     // Poll DIO1 pin directly (fallback if hardware interrupt doesn't fire)
     void pollDio1();
+
+    // TX watchdog (#105 follow-up).  Force-clears tx_ongoing_ if it has
+    // been stuck for longer than any plausible TX could take.  Without
+    // this, a missed DIO1 IRQ + a misclassified pollDio1 (rx_mode_ true
+    // at the moment of polling) wedges the radio: hopToFrequencyMHz and
+    // reconfigure both refuse to run while tx_ongoing_=true, so the
+    // entire link locks up until the device reboots.  Field-confirmed
+    // failure mode where reconfigure hits its 2 s wait deadline.
+    //
+    // Designed to be called every main-loop iteration (alongside
+    // pollDio1).  Cheap when not stuck (one millis() compare).
+    void serviceTxWatchdog();
 
     // Runtime reconfiguration (LLCC68: must set BW before SF)
     bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power);
@@ -124,6 +137,13 @@ private:
     bool rx_mode_ = false;
     volatile uint32_t isr_count_ = 0;
     int dio1_pin_ = -1;
+
+    // TX watchdog state (#105 follow-up).  tx_started_ms_ is set in
+    // send() and cleared whenever tx_ongoing_ becomes false.  The
+    // watchdog (serviceTxWatchdog) compares (now - tx_started_ms_)
+    // against TX_WATCHDOG_MS to detect a stuck flag.
+    uint32_t tx_started_ms_ = 0;
+    static constexpr uint32_t TX_WATCHDOG_MS = 3000;  // generous: SF12 BW125 ToA ~2.5s
 
     // Last-known-good radio config (for rollback on reconfigure failure)
     float   cfg_freq_mhz_ = 915.0f;

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -220,6 +220,32 @@ static inline float loraMinValidSnrDb(uint8_t sf)
     return sensitivity - 2.0f;
 }
 
+// Compute observed packet-loss between two consecutive RXes on the BS,
+// from the rocket's free-running TX sequence counter (#105).
+//
+//   prev_seq_signed  : last seq seen, or -1 if no prior packet (first contact).
+//   curr_seq         : seq from the just-received packet.
+//   plausibility_max : maximum forward delta to treat as a real run.  A
+//                      delta beyond this is almost certainly a rocket
+//                      reboot (seq reset to 0) or an extended outage we
+//                      can't attribute, so we report -1 ("unknown") rather
+//                      than a misleading "you lost 200 packets" reading.
+//
+// Returns the number of packets lost between the two RXes, or -1 when
+// not computable (first contact, duplicate seq, or implausible delta).
+// Pure / branch-only so it's safely host-testable without millis().
+static inline int16_t loraComputeObservedLoss(int16_t prev_seq_signed,
+                                                uint8_t  curr_seq,
+                                                uint16_t plausibility_max = 100)
+{
+    if (prev_seq_signed < 0)            return -1;            // first contact
+    const uint8_t prev   = (uint8_t)prev_seq_signed;
+    const uint16_t delta = (uint16_t)((curr_seq - prev) & 0xFFu);
+    if (delta == 0)                     return -1;            // duplicate / replay
+    if (delta > plausibility_max)       return -1;            // reboot or long outage
+    return (int16_t)(delta - 1);
+}
+
 // "Is the rocket presumed to be hopping right now, from the BS's
 // perspective?" — used to decide whether a BLE cmd 60 should take the
 // direct-scan or coordinated-pause path (#90).
@@ -716,8 +742,46 @@ typedef struct __attribute__((packed))
 } i24le_t;
 static_assert(sizeof(i24le_t) == 3, "i24le_t must be 3 bytes");
 
-// LoRa protocol version — bump on frame format changes
-static constexpr uint8_t LORA_PROTO_VERSION = 1;
+// ============================================================================
+// LoRa factory rendezvous (#105 follow-up): a single shared known-good config
+// ============================================================================
+// Hardcoded ONCE in this shared header so the BS and OC firmware are
+// guaranteed to compile against the same fallback.  Issue #105 hit the
+// chicken-and-egg case: both sides had matching factory defaults in their
+// per-project config.h files, but NVS-persisted operating freq drifted
+// (OC was on 926.5 MHz from a prior test, BS on 915), and neither side
+// knew where the other was so the BS uplink couldn't push corrections.
+//
+// Both projects' config.h re-export these as `LORA_RENDEZVOUS_*` so all
+// existing call sites keep working unchanged — the move just removes the
+// possibility of the two config.h files drifting apart in source.
+//
+// Frequency, BW, SF, CR, and TX power must ALL match between BS and OC for
+// the radios to decode each other (LLCC68 demodulator parameters), so the
+// rendezvous config carries the full modulation tuple, not just the freq.
+static constexpr float   LORA_FACTORY_RENDEZVOUS_MHZ    = 915.0f;
+static constexpr uint8_t LORA_FACTORY_RENDEZVOUS_SF     = 8;
+static constexpr float   LORA_FACTORY_RENDEZVOUS_BW_KHZ = 250.0f;
+static constexpr uint8_t LORA_FACTORY_RENDEZVOUS_CR     = 5;
+static constexpr int8_t  LORA_FACTORY_RENDEZVOUS_TX_DBM = 12;
+
+// LoRa NVS schema version (#105 follow-up).  Stored alongside the LoRa
+// settings; on boot, if the stored version doesn't match this constant,
+// the LoRa-related NVS keys are wiped so the device falls back to the
+// factory rendezvous above.  Bump whenever the NVS field set changes
+// meaningfully (new keys, repurposed keys, byte-format changes), or when
+// you ship a build that needs to force-clear stale settings.
+//   v1: original LoRa NVS layout
+//   v2: post-#105 — first version that gates on this field
+static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 2;
+
+// LoRa protocol version — bump on frame format changes.
+//   v1: original 60-byte frame with 2-byte routing header.
+//   v2: 60-byte frame with 3-byte routing header (next_channel_idx for #40/#41 hopping).
+//   v3: 61-byte frame, appends a 1-byte free-running TX sequence counter (#105
+//       lock-loss diagnostics).  BS uses the seq to compute observed loss
+//       rates and distinguish missed packets from full hop-table desync.
+static constexpr uint8_t LORA_PROTO_VERSION = 3;
 
 // LoRa name beacon sync byte (distinguishes from telemetry by size + prefix)
 static constexpr uint8_t LORA_BEACON_SYNC = 0xBE;
@@ -739,6 +803,7 @@ typedef struct __attribute__((packed))
     uint8_t network_id;      // LoRa network namespace (0..255)
     uint8_t rocket_id;       // Source rocket ID within network (1..254, 0=unset, 255=broadcast)
     uint8_t next_channel_idx;// 0..N-1 = hop to that channel after this RX; 0xFF = stay
+    uint8_t seq;             // free-running TX sequence (proto v3, #105) — wraps mod 256
 
     // --- Telemetry payload (unchanged from proto v0) ---
     uint8_t num_sats;        // 0..255
@@ -789,8 +854,8 @@ typedef struct __attribute__((packed))
 
 } LoRaData;
 
-static_assert(sizeof(LoRaData) == 60,
-              "LoRaData must be 60 bytes (3-byte header + 57-byte payload)");
+static_assert(sizeof(LoRaData) == 61,
+              "LoRaData must be 61 bytes (4-byte routing header + 57-byte telemetry payload)");
 
 static constexpr uint8_t LORA_LAUNCH      = (1u << 0);  // bit 0
 static constexpr uint8_t LORA_VEL_APOGEE  = (1u << 1);  // bit 1
@@ -808,6 +873,7 @@ typedef struct
     uint8_t network_id;             // Routing header: network namespace
     uint8_t rocket_id;              // Routing header: source rocket ID
     uint8_t next_channel_idx;       // Routing header: 0..N-1 hop target, 0xFF = stay
+    uint8_t seq;                    // Routing header: free-running TX seq (#105)
     uint8_t num_sats;               // int          : 0 to 255
     float   pdop;                   // meter        : 0 to 100
     double  ecef_x, ecef_y, ecef_z; // meter        : +/- 7,000,000

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -221,29 +221,37 @@ static inline float loraMinValidSnrDb(uint8_t sf)
 }
 
 // Compute observed packet-loss between two consecutive RXes on the BS,
-// from the rocket's free-running TX sequence counter (#105).
+// from the rocket's free-running TX sequence counter (#105).  Widened to
+// 16-bit seq in proto v4 (slow-hop seq-anchored hop schedule needs the
+// extra range — see LORA_HOP_DWELL_PACKETS).
 //
-//   prev_seq_signed  : last seq seen, or -1 if no prior packet (first contact).
+//   prev_seq_signed  : last seq seen (cast from uint16_t), or -1 if no
+//                      prior packet (first contact).  Caller stores as
+//                      int32_t to hold the full uint16 range plus the -1
+//                      sentinel.
 //   curr_seq         : seq from the just-received packet.
 //   plausibility_max : maximum forward delta to treat as a real run.  A
 //                      delta beyond this is almost certainly a rocket
 //                      reboot (seq reset to 0) or an extended outage we
 //                      can't attribute, so we report -1 ("unknown") rather
-//                      than a misleading "you lost 200 packets" reading.
+//                      than a misleading "you lost N packets" reading.
+//                      Default raised to 1000 to track the wider seq
+//                      range; a 1000-packet outage at 2 Hz is 8 minutes,
+//                      well past the rocket's slow-rendezvous timer.
 //
 // Returns the number of packets lost between the two RXes, or -1 when
 // not computable (first contact, duplicate seq, or implausible delta).
 // Pure / branch-only so it's safely host-testable without millis().
-static inline int16_t loraComputeObservedLoss(int16_t prev_seq_signed,
-                                                uint8_t  curr_seq,
-                                                uint16_t plausibility_max = 100)
+static inline int32_t loraComputeObservedLoss(int32_t  prev_seq_signed,
+                                                uint16_t curr_seq,
+                                                uint32_t plausibility_max = 1000)
 {
     if (prev_seq_signed < 0)            return -1;            // first contact
-    const uint8_t prev   = (uint8_t)prev_seq_signed;
-    const uint16_t delta = (uint16_t)((curr_seq - prev) & 0xFFu);
+    const uint16_t prev  = (uint16_t)prev_seq_signed;
+    const uint32_t delta = (uint32_t)((uint16_t)(curr_seq - prev));
     if (delta == 0)                     return -1;            // duplicate / replay
     if (delta > plausibility_max)       return -1;            // reboot or long outage
-    return (int16_t)(delta - 1);
+    return (int32_t)(delta - 1);
 }
 
 // "Is the rocket presumed to be hopping right now, from the BS's
@@ -310,6 +318,57 @@ static inline uint8_t loraNextActiveChannelIdx(
         if (!loraSkipMaskTest(mask, cand)) return cand;
     }
     return (uint8_t)((current_idx + 1) % n_channels);
+}
+
+// Seq-anchored hop schedule (#105 follow-up).  Both sides compute the
+// physical channel for a given TX seq deterministically from this
+// function — no chained handoff via next_channel_idx.  If the BS misses
+// a packet within a dwell window, the *next* received packet's seq tells
+// it exactly where the rocket is, allowing single-packet self-correction.
+//
+// Schedule:
+//   active_idx = (seq / dwell) % n_active   -- which active-channel slot
+//   physical_idx = the active_idx-th non-skipped channel in mask
+//
+// dwell == 1 reduces to the original "advance every TX" behaviour;
+// dwell >= 2 keeps the rocket on a channel for `dwell` consecutive
+// packets before advancing.  See LORA_HOP_DWELL_PACKETS for the
+// production value.
+//
+// Pure helper, host-testable.  O(n_channels) lookup — fine for n ≤ 144.
+static inline uint8_t loraHopChannelForSeq(
+    uint16_t seq, uint8_t dwell,
+    const uint8_t* mask, uint8_t n_channels)
+{
+    if (n_channels == 0 || dwell == 0) return 0;
+
+    // Count active (non-skipped) channels.  Empty mask → n_active == n_channels.
+    uint8_t n_active = 0;
+    for (uint8_t i = 0; i < n_channels; i++)
+    {
+        if (!loraSkipMaskTest(mask, i)) n_active++;
+    }
+    // Defensive: every channel masked (FCC floor prevents this).  Fall
+    // back to raw mod-n_channels so we still make forward progress.
+    if (n_active == 0)
+    {
+        return (uint8_t)((seq / dwell) % n_channels);
+    }
+
+    const uint16_t active_idx = (uint16_t)((seq / dwell) % n_active);
+
+    // Walk the channel space, counting non-skipped channels until we
+    // hit the active_idx-th one.
+    uint16_t found = 0;
+    for (uint8_t i = 0; i < n_channels; i++)
+    {
+        if (!loraSkipMaskTest(mask, i))
+        {
+            if (found == active_idx) return i;
+            found++;
+        }
+    }
+    return 0;  // unreachable given the n_active check above
 }
 
 // Skip-mask + channel count produced by the pre-launch noise scan.  The
@@ -781,7 +840,26 @@ static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 3;
 //   v3: 61-byte frame, appends a 1-byte free-running TX sequence counter (#105
 //       lock-loss diagnostics).  BS uses the seq to compute observed loss
 //       rates and distinguish missed packets from full hop-table desync.
-static constexpr uint8_t LORA_PROTO_VERSION = 3;
+//   v4: 62-byte frame, seq widened to 16 bits for slow-hop seq-anchored
+//       hop schedule.  With dwell=4 and BW=250 (69 channels) an 8-bit seq
+//       only spans 64 active positions, leaving 5 channels unreachable —
+//       16 bits covers any (BW, dwell) combination we'd reasonably pick.
+static constexpr uint8_t LORA_PROTO_VERSION = 4;
+
+// Slow-hop dwell — how many consecutive packets the rocket transmits on a
+// single channel before advancing.  At 2 Hz TX with dwell=4, channel
+// changes every 2 s instead of every 500 ms.  This gives the BS up to
+// (dwell-1) consecutive missed packets per channel before it falls out of
+// sync, eliminates BS-side TX-vs-retune races (heartbeat retries no
+// longer collide with hop boundaries), and reduces per-cycle radio churn
+// 4x.  Both rocket and BS compile against the same value; bumping it
+// requires a coordinated re-flash.
+//
+// FCC compliance: we operate as DTS, not FHSS, so there is no specific
+// per-channel dwell-time limit.  At dwell=4 + 2 Hz we still hit every
+// channel inside 140 s (BW=250, 69 channels), enough interference
+// diversity for our use case.
+static constexpr uint8_t LORA_HOP_DWELL_PACKETS = 4;
 
 // LoRa name beacon sync byte (distinguishes from telemetry by size + prefix)
 static constexpr uint8_t LORA_BEACON_SYNC = 0xBE;
@@ -800,10 +878,10 @@ static constexpr uint8_t LORA_CMD_HEARTBEAT = 0xFE;
 typedef struct __attribute__((packed))
 {
     // --- Routing header (proto v2: hop byte added for #40/#41) ---
-    uint8_t network_id;      // LoRa network namespace (0..255)
-    uint8_t rocket_id;       // Source rocket ID within network (1..254, 0=unset, 255=broadcast)
-    uint8_t next_channel_idx;// 0..N-1 = hop to that channel after this RX; 0xFF = stay
-    uint8_t seq;             // free-running TX sequence (proto v3, #105) — wraps mod 256
+    uint8_t  network_id;      // LoRa network namespace (0..255)
+    uint8_t  rocket_id;       // Source rocket ID within network (1..254, 0=unset, 255=broadcast)
+    uint8_t  next_channel_idx;// 0..N-1 = hop to that channel after this RX; 0xFF = stay
+    uint16_t seq;             // free-running TX sequence (proto v4, #105) — wraps mod 65536
 
     // --- Telemetry payload (unchanged from proto v0) ---
     uint8_t num_sats;        // 0..255
@@ -854,8 +932,8 @@ typedef struct __attribute__((packed))
 
 } LoRaData;
 
-static_assert(sizeof(LoRaData) == 61,
-              "LoRaData must be 61 bytes (4-byte routing header + 57-byte telemetry payload)");
+static_assert(sizeof(LoRaData) == 62,
+              "LoRaData must be 62 bytes (5-byte routing header incl. 16-bit seq + 57-byte telemetry payload)");
 
 static constexpr uint8_t LORA_LAUNCH      = (1u << 0);  // bit 0
 static constexpr uint8_t LORA_VEL_APOGEE  = (1u << 1);  // bit 1
@@ -870,10 +948,10 @@ static constexpr uint8_t LORA_LOGGING_BIT = 0x80;
 // Readable LoRa data structure
 typedef struct
 {                                   // Precision    : Range
-    uint8_t network_id;             // Routing header: network namespace
-    uint8_t rocket_id;              // Routing header: source rocket ID
-    uint8_t next_channel_idx;       // Routing header: 0..N-1 hop target, 0xFF = stay
-    uint8_t seq;                    // Routing header: free-running TX seq (#105)
+    uint8_t  network_id;             // Routing header: network namespace
+    uint8_t  rocket_id;              // Routing header: source rocket ID
+    uint8_t  next_channel_idx;       // Routing header: 0..N-1 hop target, 0xFF = stay
+    uint16_t seq;                    // Routing header: free-running TX seq (#105, proto v4)
     uint8_t num_sats;               // int          : 0 to 255
     float   pdop;                   // meter        : 0 to 100
     double  ecef_x, ecef_y, ecef_z; // meter        : +/- 7,000,000

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -312,9 +312,16 @@ static inline uint8_t loraNextActiveChannelIdx(
     return (uint8_t)((current_idx + 1) % n_channels);
 }
 
+// Skip-mask + channel count produced by the pre-launch noise scan.  The
+// rendezvous frequency was previously part of this struct (and thus part
+// of the cmd 15 payload) so the scan could pick the quietest channel as
+// the rendezvous, but that introduced a divergence path: BS and OC could
+// end up with different stored rdv_mhz values and never meet again.
+// Issue #105 follow-up: rendezvous is now hardcoded at compile time
+// (LORA_FACTORY_RENDEZVOUS_MHZ above) so both sides cannot disagree.
+// The skip-mask still drives hop-channel selection.
 typedef struct
 {
-    float   rendezvous_mhz;                     // best-quietest scan freq, or fallback
     uint8_t n_channels;                         // hop table size for the given BW
     uint8_t skip_mask[LORA_SKIP_MASK_MAX_BYTES]; // 1 = skip, LSB-first
 } LoRaChannelSetSelection;
@@ -353,16 +360,17 @@ static inline int8_t loraI8MedianInPlace(int8_t* arr, size_t n)
     return arr[n / 2];
 }
 
-// Pure orchestrator.  Computes rendezvous freq + skip-mask for the
-// current operating BW from a (freq, rssi) scan grid.  See the comment
-// block above for the threshold rule and FCC-floor handling.
+// Pure orchestrator.  Computes the skip-mask for the current operating
+// BW from a (freq, rssi) scan grid.  See the comment block above for the
+// threshold rule and FCC-floor handling.  Rendezvous freq is no longer
+// computed here — it is hardcoded to LORA_FACTORY_RENDEZVOUS_MHZ on both
+// sides of the link so they always agree on a meeting place (#105).
 //
-// fallback_rendezvous_mhz is used when scan_count == 0 (e.g., scan
-// never run yet, or skipped).  In that case skip_mask is left all-zero
-// (no skips) and n_channels reflects the BW table.
+// scan_count == 0 (e.g., scan never run yet) leaves skip_mask all-zero
+// (no skips) and n_channels reflecting the BW table.
 static inline void loraSelectChannelSet(
     const float* scan_freqs, const int8_t* scan_rssi, size_t scan_count,
-    float bw_khz, float fallback_rendezvous_mhz,
+    float bw_khz,
     LoRaChannelSetSelection* out)
 {
     out->n_channels = loraChannelCount(bw_khz);
@@ -370,18 +378,7 @@ static inline void loraSelectChannelSet(
 
     if (scan_count == 0 || out->n_channels == 0)
     {
-        out->rendezvous_mhz = fallback_rendezvous_mhz;
         return;
-    }
-
-    // (1) Rendezvous = lowest-RSSI scan point.
-    {
-        size_t best = 0;
-        for (size_t i = 1; i < scan_count; i++)
-        {
-            if (scan_rssi[i] < scan_rssi[best]) best = i;
-        }
-        out->rendezvous_mhz = scan_freqs[best];
     }
 
     // (2) Per-channel peak RSSI from the nearest scan grid point.
@@ -773,7 +770,10 @@ static constexpr int8_t  LORA_FACTORY_RENDEZVOUS_TX_DBM = 12;
 // you ship a build that needs to force-clear stale settings.
 //   v1: original LoRa NVS layout
 //   v2: post-#105 — first version that gates on this field
-static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 2;
+//   v3: dropped rdv_mhz NVS key (rendezvous freq is now compile-time
+//       hardcoded to LORA_FACTORY_RENDEZVOUS_MHZ; cmd 15 no longer
+//       carries a rendezvous freq either).
+static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 3;
 
 // LoRa protocol version — bump on frame format changes.
 //   v1: original 60-byte frame with 2-byte routing header.

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -314,6 +314,7 @@ void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
     out.network_id       = in.network_id;
     out.rocket_id        = in.rocket_id;
     out.next_channel_idx = in.next_channel_idx;
+    out.seq              = in.seq;
 
     // num_sats (bits 0-6) + logging_active (bit 7)
     out.num_sats = (uint8_t)lroundi32(clampf((float)in.num_sats, 0.f, 127.f));
@@ -443,6 +444,7 @@ void SensorConverter::unpackLoRa(const LoRaData& in, LoRaDataSI& out)
     out.network_id       = in.network_id;
     out.rocket_id        = in.rocket_id;
     out.next_channel_idx = in.next_channel_idx;
+    out.seq              = in.seq;
 
     out.num_sats = in.num_sats & 0x7F;  // bits 0-6
     out.logging_active = (in.num_sats & LORA_LOGGING_BIT) != 0;

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <RocketComputerTypes.h>  // LORA_FACTORY_RENDEZVOUS_* (#105)
 
 namespace config
 {
@@ -28,22 +29,15 @@ namespace config
     static constexpr bool    LORA_RX_BOOSTED_GAIN = true;
     static constexpr bool    LORA_SYNCWORD_PRIVATE = true;
 
-    // Known-good rendezvous mode (issue #71).  When the rocket and base
-    // station drift apart, both fall back to this complete LoRa config
-    // — frequency AND modulation parameters.  Frequency alone isn't
-    // enough: the user can configure SF/BW/CR/TX power via the iOS app
-    // ("Fast" / "Standard" / "Long Range" presets), and a divergence on
-    // those is just as fatal as a frequency mismatch.  All five values
-    // must be identical on both firmware builds; the constants below are
-    // the "Standard" preset, which is also the NVS factory default — so
-    // a fresh-NVS device is already in rendezvous mode at boot.  Never
-    // persisted to NVS; NVS holds the working config and this is always
-    // the same compile-time fallback.
-    static constexpr float   LORA_RENDEZVOUS_MHZ          = 915.0f;
-    static constexpr uint8_t LORA_RENDEZVOUS_SF           = 8;
-    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = 250.0f;
-    static constexpr uint8_t LORA_RENDEZVOUS_CR           = 5;
-    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = 12;
+    // Known-good rendezvous mode (issue #71).  Sourced from the shared
+    // RocketComputerTypes.h header (#105) so both BS and OC firmware are
+    // guaranteed to agree at compile time — see LORA_FACTORY_RENDEZVOUS_*
+    // there for the full justification.
+    static constexpr float   LORA_RENDEZVOUS_MHZ          = LORA_FACTORY_RENDEZVOUS_MHZ;
+    static constexpr uint8_t LORA_RENDEZVOUS_SF           = LORA_FACTORY_RENDEZVOUS_SF;
+    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = LORA_FACTORY_RENDEZVOUS_BW_KHZ;
+    static constexpr uint8_t LORA_RENDEZVOUS_CR           = LORA_FACTORY_RENDEZVOUS_CR;
+    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = LORA_FACTORY_RENDEZVOUS_TX_DBM;
 
     // --- LoRa Uplink (BaseStation → OutComputer) ---
     static constexpr uint8_t  UPLINK_SYNC_BYTE        = 0xCA;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -178,7 +178,11 @@ static bool     lora_hop_disabled = false;
 // `channel_set_bw_khz_` is the BW the mask was generated against — used
 // to detect when a cmd-10 BW change invalidates the mask (we revert to
 // "no skips" until the user re-runs the scan on the new BW).
-static float   rendezvous_mhz_     = config::LORA_RENDEZVOUS_MHZ;
+//
+// Rendezvous freq used to live here too (NVS-stored, scan-selected) but
+// that allowed the BS and rocket to drift apart with no recovery path —
+// see issue #105.  It's now compile-time hardcoded to the shared
+// LORA_FACTORY_RENDEZVOUS_MHZ on both sides.
 static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
 static uint8_t skip_mask_n_        = 0;        // 0 = no mask yet
 static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
@@ -1356,7 +1360,7 @@ static void serviceLoRaTransaction()
 // If the base station hears nothing from any rocket for RECOVERY_SILENCE_MS
 // while on the ground (not freq_locked_for_flight), hop through known-good
 // frequencies looking for the rocket:
-//   Phase A (rendezvous): tune to LORA_RENDEZVOUS_MHZ and listen 3 s.  If a
+//   Phase A (rendezvous): tune to LORA_FACTORY_RENDEZVOUS_MHZ and listen 3 s.  If a
 //     beacon / telem arrives, relay Cmd 10 with the saved NVS config to
 //     push the rocket back, then return to the saved NVS freq.
 //   Phase B (grid scan): if Phase A was silent, scan the saved NVS freq ±
@@ -1396,16 +1400,16 @@ static constexpr float    RECOVERY_PHASE_B_SPAN_MHZ = 2.0f;  // ±2 MHz around N
 
 // Hop to the full rendezvous mode (freq + SF/BW/CR/power).  Used for
 // Phase A — both ends agree on this exact config as a known-good
-// fallback, regardless of what the user set in NVS.
+// fallback, regardless of what the user set in NVS.  All five values
+// are compile-time constants in RocketComputerTypes.h so BS and OC
+// cannot disagree on the meeting place (#105 follow-up).
 static void recoveryHopToRendezvousMode()
 {
-    // rendezvous_mhz_ is scan-selected (#40 / #41 phase 3) and falls
-    // back to config::LORA_RENDEZVOUS_MHZ when no scan has been run.
-    if (lora_comms.reconfigure(rendezvous_mhz_,
-                                config::LORA_RENDEZVOUS_SF,
-                                config::LORA_RENDEZVOUS_BW_KHZ,
-                                config::LORA_RENDEZVOUS_CR,
-                                config::LORA_RENDEZVOUS_TX_POWER_DBM))
+    if (lora_comms.reconfigure(LORA_FACTORY_RENDEZVOUS_MHZ,
+                                LORA_FACTORY_RENDEZVOUS_SF,
+                                LORA_FACTORY_RENDEZVOUS_BW_KHZ,
+                                LORA_FACTORY_RENDEZVOUS_CR,
+                                LORA_FACTORY_RENDEZVOUS_TX_DBM))
     {
         lora_comms.startReceive();
     }
@@ -1438,9 +1442,9 @@ static void recoveryEnterPhaseA()
     recovery_phase_start_ms     = millis();
     recovery_state              = RecoveryState::PHASE_A_RENDEZVOUS;
     ESP_LOGW(TAG, "[RECOVER] Silent — Phase A rendezvous mode (%.2f MHz SF%u BW%.0f) for %u ms",
-             (double)rendezvous_mhz_,
-             (unsigned)config::LORA_RENDEZVOUS_SF,
-             (double)config::LORA_RENDEZVOUS_BW_KHZ,
+             (double)LORA_FACTORY_RENDEZVOUS_MHZ,
+             (unsigned)LORA_FACTORY_RENDEZVOUS_SF,
+             (double)LORA_FACTORY_RENDEZVOUS_BW_KHZ,
              (unsigned)RECOVERY_PHASE_A_DWELL_MS);
 }
 
@@ -1727,12 +1731,13 @@ static constexpr uint32_t COORD_HOP_RECENT_MS        = 10000;
 // Persist channel-set selection to NVS.  Skip-mask is keyed off the BW
 // it was generated for so a later cmd-10 BW change invalidates it
 // cleanly (loadChannelSetFromNvs detects mismatch and clears).
+// Rendezvous freq is no longer persisted — see #105 / LORA_NVS_SCHEMA_VERSION
+// v3 in RocketComputerTypes.h.
 static void saveChannelSetToNvs(const LoRaChannelSetSelection& sel,
                                 float bw_khz)
 {
     Preferences p;
     if (!p.begin("lora", false)) return;
-    p.putFloat("rdv_mhz", sel.rendezvous_mhz);
     p.putUChar("chset_n", sel.n_channels);
     p.putFloat("chset_bw", bw_khz);
     const size_t bytes_used = (sel.n_channels + 7) / 8;
@@ -1742,13 +1747,12 @@ static void saveChannelSetToNvs(const LoRaChannelSetSelection& sel,
 
 // Restore channel-set selection from NVS.  If the stored BW doesn't
 // match the active operating BW, the skip-mask is treated as stale and
-// the runtime state is reset to "no skips".  Rendezvous freq survives
-// a BW change (it isn't tied to the operating channel table).
+// the runtime state is reset to "no skips".  Rendezvous freq is no
+// longer NVS-stored (#105) — it's a compile-time constant.
 static void loadChannelSetFromNvs()
 {
     Preferences p;
     if (!p.begin("lora", true)) return;
-    rendezvous_mhz_ = p.getFloat("rdv_mhz", config::LORA_RENDEZVOUS_MHZ);
     const uint8_t n_stored  = p.getUChar("chset_n", 0);
     const float   bw_stored = p.getFloat("chset_bw", 0.0f);
     if (n_stored > 0 && bw_stored > 0.0f && bw_stored == lora_bw_khz)
@@ -1770,9 +1774,8 @@ static void loadChannelSetFromNvs()
     p.end();
 }
 
-// Clear stored skip-mask (rendezvous_mhz_ unchanged) — called on cmd-10
-// BW change so the rocket doesn't follow a stale skip-mask sized for
-// the previous BW.
+// Clear stored skip-mask — called on cmd-10 BW change so the rocket
+// doesn't follow a stale skip-mask sized for the previous BW.
 static void invalidateSkipMaskForBwChange()
 {
     skip_mask_n_        = 0;
@@ -1795,7 +1798,6 @@ static void applyAndPushChannelSet(const LoRaChannelSetSelection& sel,
                                     float bw_khz)
 {
     // Adopt locally
-    rendezvous_mhz_     = sel.rendezvous_mhz;
     skip_mask_n_        = sel.n_channels;
     channel_set_bw_khz_ = bw_khz;
     const size_t bytes_used = (sel.n_channels + 7) / 8;
@@ -1804,10 +1806,11 @@ static void applyAndPushChannelSet(const LoRaChannelSetSelection& sel,
 
     saveChannelSetToNvs(sel, bw_khz);
 
-    // Wire format: [rdv:f4][bw:f4][n:u1][mask: ceil(n/8)]
+    // Wire format: [bw:f4][n:u1][mask: ceil(n/8)]
+    // Rendezvous freq used to lead this payload but is now hardcoded on
+    // both sides (#105) — see LORA_FACTORY_RENDEZVOUS_MHZ.
     uint8_t payload[40] = {0};
     size_t  off = 0;
-    memcpy(payload + off, &sel.rendezvous_mhz, 4); off += 4;
     memcpy(payload + off, &bw_khz,             4); off += 4;
     payload[off++] = sel.n_channels;
     for (size_t i = 0; i < bytes_used; i++) payload[off++] = sel.skip_mask[i];
@@ -1816,9 +1819,9 @@ static void applyAndPushChannelSet(const LoRaChannelSetSelection& sel,
     uint8_t active = 0;
     for (uint8_t i = 0; i < sel.n_channels; i++)
         if (!loraSkipMaskTest(sel.skip_mask, i)) active++;
-    ESP_LOGI(TAG, "[CHSET] rendezvous=%.2f MHz, %u/%u channels active at BW=%.0f kHz "
+    ESP_LOGI(TAG, "[CHSET] %u/%u channels active at BW=%.0f kHz "
                   "(min FCC floor %u) — pushing to rocket",
-             (double)sel.rendezvous_mhz, (unsigned)active,
+             (unsigned)active,
              (unsigned)sel.n_channels, (double)bw_khz,
              (unsigned)loraFhssMinChannels(bw_khz));
 
@@ -1897,7 +1900,7 @@ static void analyzeAndPushFromCachedScan()
     }
     LoRaChannelSetSelection sel{};
     loraSelectChannelSet(scan_freqs, scan_peak_rssi_, scan_peak_count_,
-                          lora_bw_khz, config::LORA_RENDEZVOUS_MHZ, &sel);
+                          lora_bw_khz, &sel);
     applyAndPushChannelSet(sel, lora_bw_khz);
 }
 
@@ -2218,8 +2221,9 @@ static void setup_bs()
     // re-flashed device can come up on a stale operating freq the BS
     // doesn't know about — exactly the chicken-and-egg that motivated
     // this gate.  Single namespace clear is fine: every LoRa-related
-    // key (freq, sf, bw, cr, txpwr, hopdis, rdv_mhz, chset_*) lives
-    // under "lora", so one clear() takes them all together.
+    // key (freq, sf, bw, cr, txpwr, hopdis, chset_*, plus the now-defunct
+    // rdv_mhz from v2 schema) lives under "lora", so one clear() takes
+    // them all together.
     {
         const uint8_t stored_v = prefs.getUChar("schemv", 0);
         if (stored_v != LORA_NVS_SCHEMA_VERSION)
@@ -2253,23 +2257,23 @@ static void setup_bs()
              (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
              (int)lora_hop_disabled);
 
-    // Channel-set: rendezvous freq + skip-mask from the most recent
-    // pre-launch scan (#40 / #41 phase 3).  Falls back to defaults if
-    // never scanned, or if the stored mask was generated for a
-    // different BW.
+    // Channel-set: skip-mask from the most recent pre-launch scan
+    // (#40 / #41 phase 3).  Falls back to no-skips if never scanned, or
+    // if the stored mask was generated for a different BW.  Rendezvous
+    // freq is no longer scan-selected; both sides use the shared
+    // hardcoded LORA_FACTORY_RENDEZVOUS_MHZ (#105).
     loadChannelSetFromNvs();
     if (skip_mask_n_ > 0)
     {
         uint8_t active = 0;
         for (uint8_t i = 0; i < skip_mask_n_; i++)
             if (!loraSkipMaskTest(skip_mask_, i)) active++;
-        ESP_LOGI(TAG, "[CHSET] NVS: rendezvous=%.2f MHz, %u/%u channels active",
-                 (double)rendezvous_mhz_, (unsigned)active, (unsigned)skip_mask_n_);
+        ESP_LOGI(TAG, "[CHSET] NVS: %u/%u channels active",
+                 (unsigned)active, (unsigned)skip_mask_n_);
     }
     else
     {
-        ESP_LOGI(TAG, "[CHSET] NVS: rendezvous=%.2f MHz (default), no skip-mask",
-                 (double)rendezvous_mhz_);
+        ESP_LOGI(TAG, "[CHSET] NVS: no skip-mask");
     }
 
     // Load cached servo config from NVS

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -197,6 +197,22 @@ static void analyzeAndPushFromCachedScan();
 // without holding the radio hostage if the rocket really has vanished.
 static constexpr uint32_t HOP_SILENCE_FALLBACK_MS = 3000;
 
+// ----------------------------------------------------------------------------
+// Hop-session diagnostics (#105)
+// ----------------------------------------------------------------------------
+// A "hop session" begins when hop_active_ flips false→true (BS starts
+// following the rocket's hop schedule) and ends on either silence-fallback
+// or rocket-state-change.  The counters here let the operator see, after a
+// flight, how often lock was lost, how long sessions lasted, and how many
+// packets the BS *observed* missing during each session — together with
+// the seq-derived per-packet loss in the CSV, this is the post-flight
+// view that issue #105 was opened to enable.
+static uint32_t hop_silence_events_count   = 0;   // lifetime, since boot
+static uint32_t hop_session_started_ms     = 0;   // 0 = no active session
+static uint32_t hop_session_total_pkts     = 0;   // accepted while hop_active_
+static uint32_t hop_session_observed_loss  = 0;   // sum of observed gaps (#105)
+static uint32_t lora_total_observed_loss   = 0;   // lifetime, since boot
+
 // Per-rocket tracker (replaces single last_decoded for multi-rocket support)
 static constexpr int MAX_TRACKED_ROCKETS = 4;
 struct TrackedRocket {
@@ -210,6 +226,11 @@ struct TrackedRocket {
     double     last_lon_deg = NAN;
     double     last_alt_m = NAN;
     uint32_t   last_seen_ms = 0;
+    // Free-running TX seq from the rocket (#105).  -1 = no prior packet
+    // ("first contact"); on a backward jump or implausible forward delta,
+    // we reset back to -1 and treat the next packet as fresh contact —
+    // most likely the rocket rebooted and lora_tx_seq restarted at 0.
+    int16_t    last_seq = -1;
 };
 static TrackedRocket tracked_rockets[MAX_TRACKED_ROCKETS];
 static uint8_t active_rocket_idx = 0;  // Which rocket the BLE telemetry currently shows
@@ -412,12 +433,17 @@ static void startLogging()
         return;
     }
 
-    // Write CSV header
+    // Write CSV header.  The trailing block (next_ch..event) was added
+    // for #105 lock-loss diagnostics: per-packet hop target, the freq the
+    // BS was actually tuned to, the rocket's free-running seq and the
+    // BS-derived gap to the last RX, plus an `event` column populated
+    // for non-telemetry rows (hop_active / hop_inactive / hop_silence).
     fprintf(log_file, "time_ms,state,num_sats,pdop,lat,lon,alt_m,h_acc,"
                       "acc_x,acc_y,acc_z,gyro_x,gyro_y,gyro_z,"
                       "pressure_alt,alt_rate,max_alt,max_speed,"
                       "voltage,current,soc,roll,pitch,yaw,speed,"
-                      "launch,vel_apo,alt_apo,landed,rssi,snr\n");
+                      "launch,vel_apo,alt_apo,landed,rssi,snr,"
+                      "next_ch,rx_freq_mhz,seq,gap,event\n");
 
     logging_active = true;
     log_start_ms = millis();
@@ -441,7 +467,8 @@ static void stopLogging()
 static uint32_t log_write_count = 0;  // Tracks calls for periodic flash check
 
 static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
-                          double lat, double lon, double alt)
+                          double lat, double lon, double alt,
+                          float rx_freq_mhz, int16_t observed_gap)
 {
     if (!logging_active) return;
 
@@ -484,7 +511,8 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                     "%.2f,%.2f,%.2f,%.1f,%.1f,%.1f,"
                     "%.1f,%.1f,%.1f,%.1f,"
                     "%.2f,%.0f,%.1f,%.1f,%.1f,%.1f,%.1f,"
-                    "%d,%d,%d,%d,%.0f,%.1f\n",
+                    "%d,%d,%d,%d,%.0f,%.1f,"
+                    "%u,%.3f,%u,%d,\n",   // trailing comma keeps `event` empty
                     (unsigned long)time_ms,
                     rocketStateToString(data.rocket_state),
                     (unsigned)data.num_sats,
@@ -502,7 +530,9 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                     data.vel_u_apogee_flag ? 1 : 0,
                     data.alt_apogee_flag ? 1 : 0,
                     data.alt_landed_flag ? 1 : 0,
-                    (double)rssi, (double)snr);
+                    (double)rssi, (double)snr,
+                    (unsigned)data.next_channel_idx, (double)rx_freq_mhz,
+                    (unsigned)data.seq, (int)observed_gap);
 
     if (written <= 0)
     {
@@ -510,6 +540,56 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
     }
 
     log_last_write_ms = millis();
+}
+
+// ----------------------------------------------------------------------------
+// CSV hop-event row (#105)
+// ----------------------------------------------------------------------------
+// Mirrors the column layout of logLoRaPacket() so a single pandas read_csv()
+// pass can ingest both — telemetry rows and event rows in chronological
+// order.  All telemetry-typed fields are left empty (",,,") so the event
+// stands out and the parsers can drop it with a simple `state == "EVENT"`
+// filter.  The `event` column carries a free-text description; downstream
+// scripts grep this to plot session timelines and loss histograms.
+//
+// Skipped when logging_active=false so we don't open a file just to record
+// an event with no surrounding telemetry.  Hop transitions still go to
+// ESP_LOG via the existing logging at the call site, so nothing is lost.
+static void logHopEvent(const char* event_str, float rx_freq_mhz)
+{
+    if (!logging_active || log_file == nullptr) return;
+    uint32_t time_ms = millis() - log_start_ms;
+    int written = fprintf(log_file,
+                    // 30 telemetry-typed fields blank, then next_ch=- (255 sentinel)
+                    // and rx_freq_mhz/seq/gap minimal so the event row still
+                    // tells you which freq the BS was sitting on at the moment.
+                    "%lu,EVENT,,,,,,,,,,,,,"   // time_ms, state, num_sats..gyro_z (14 cols)
+                    ",,,,"                    // pressure_alt, alt_rate, max_alt, max_speed
+                    ",,,,,,,"                 // voltage..speed (7)
+                    ",,,,,,"                  // launch, vel_apo, alt_apo, landed, rssi, snr
+                    "%u,%.3f,,,"              // next_ch=255 sentinel, rx_freq_mhz, seq=, gap=
+                    "%s\n",
+                    (unsigned long)time_ms,
+                    (unsigned)LORA_NEXT_CH_NO_HOP,
+                    (double)rx_freq_mhz,
+                    event_str);
+    if (written <= 0) {
+        ESP_LOGW(TAG, "[LOG] fprintf(event) failed");
+    }
+    log_last_write_ms = millis();
+}
+
+// Returns the radio's currently-tuned RX frequency for the hop diagnostics
+// CSV — i.e. the channel the BS was sitting on when this packet arrived
+// (or when this hop event fired).  Single source of truth so callers don't
+// have to re-derive lora_freq_mhz vs loraChannelMHz(...) inline.
+static inline float currentRxFreqMHz()
+{
+    if (hop_active_) {
+        const float f = loraChannelMHz(lora_bw_khz, hop_idx_);
+        if (f > 0.0f) return f;
+    }
+    return lora_freq_mhz;
 }
 
 // ============================================================================
@@ -873,6 +953,19 @@ static void printStats()
              (double)ls.last_rssi,
              (double)ls.last_snr,
              last_pkt_str);
+
+    // Hop diagnostics (#105).  hop_active=Y/N is the live link state; the
+    // session counters reflect the *current* session and reset on each
+    // hop_inactive / hop_silence event, so a "0 / 0" reading mid-flight
+    // means we just lost lock.  lifetime totals let the operator spot a
+    // run with abnormally many silence events at a glance.
+    ESP_LOGI(TAG, "[STATS] HOP: active=%c idx=%u session(pkts=%lu loss=%lu) lifetime(silence=%lu loss=%lu)",
+             hop_active_ ? 'Y' : 'N',
+             (unsigned)hop_idx_,
+             (unsigned long)hop_session_total_pkts,
+             (unsigned long)hop_session_observed_loss,
+             (unsigned long)hop_silence_events_count,
+             (unsigned long)lora_total_observed_loss);
 }
 
 // ============================================================================
@@ -2117,6 +2210,27 @@ static void setup_bs()
 
     // Load saved LoRa config from NVS (write config.h defaults if empty)
     prefs.begin("lora", false);  // read-write
+
+    // NVS schema gate (#105 follow-up).  If the stored schema version
+    // doesn't match the current build, wipe the lora namespace so the
+    // device falls back to the shared factory rendezvous and re-syncs
+    // with the BS via the standard rendezvous flow.  Without this, a
+    // re-flashed device can come up on a stale operating freq the BS
+    // doesn't know about — exactly the chicken-and-egg that motivated
+    // this gate.  Single namespace clear is fine: every LoRa-related
+    // key (freq, sf, bw, cr, txpwr, hopdis, rdv_mhz, chset_*) lives
+    // under "lora", so one clear() takes them all together.
+    {
+        const uint8_t stored_v = prefs.getUChar("schemv", 0);
+        if (stored_v != LORA_NVS_SCHEMA_VERSION)
+        {
+            ESP_LOGW(TAG, "[CFG] LoRa NVS schema mismatch (stored=%u, current=%u) — clearing",
+                     (unsigned)stored_v, (unsigned)LORA_NVS_SCHEMA_VERSION);
+            prefs.clear();
+            prefs.putUChar("schemv", LORA_NVS_SCHEMA_VERSION);
+        }
+    }
+
     if (!prefs.isKey("freq"))
     {
         // First boot or NVS erased — seed with config.h factory defaults
@@ -2288,8 +2402,25 @@ static void loop_bs()
         hop_last_rx_ms_ != 0 &&
         (millis() - hop_last_rx_ms_) > HOP_SILENCE_FALLBACK_MS)
     {
+        const uint32_t silence_ms = millis() - hop_last_rx_ms_;
+        const uint32_t dur_ms     = (hop_session_started_ms != 0)
+            ? (millis() - hop_session_started_ms) : 0;
         ESP_LOGW(TAG, "[HOP] Silence > %u ms — falling back to static channel",
                  (unsigned)HOP_SILENCE_FALLBACK_MS);
+        hop_silence_events_count++;
+        char ev[96];
+        snprintf(ev, sizeof(ev),
+                 "hop_silence duration_ms=%u pkts=%u loss=%u silence_ms=%u",
+                 (unsigned)dur_ms,
+                 (unsigned)hop_session_total_pkts,
+                 (unsigned)hop_session_observed_loss,
+                 (unsigned)silence_ms);
+        // Log the event row BEFORE flipping hop_active_ off so currentRxFreqMHz()
+        // still reports the hop channel we were sitting on at the moment of loss.
+        logHopEvent(ev, currentRxFreqMHz());
+        hop_session_started_ms    = 0;
+        hop_session_total_pkts    = 0;
+        hop_session_observed_loss = 0;
         hop_active_       = false;
         hop_needs_retune_ = true;
     }
@@ -2366,7 +2497,7 @@ static void loop_bs()
                 }
             }
         }
-        // --- Telemetry packet: SIZE_OF_LORA_DATA (59) bytes ---
+        // --- Telemetry packet: SIZE_OF_LORA_DATA (61) bytes ---
         else if (rx_len == SIZE_OF_LORA_DATA)
         {
             // Decode the telemetry packet
@@ -2385,6 +2516,27 @@ static void loop_bs()
 
                 TR_LoRa_Comms::Stats ls = {};
                 lora_comms.getStats(ls);
+
+                // Observed-loss attribution (#105).  Use the rocket's free-
+                // running seq to compute how many telemetry packets we missed
+                // since the last RX from this rocket.  loraComputeObservedLoss
+                // returns -1 on first contact, duplicates, or implausible
+                // forward deltas (most likely a rocket reboot — lora_tx_seq
+                // resets to 0).  We update last_seq unconditionally so the
+                // next RX gets a clean baseline either way.
+                int16_t observed_gap = -1;
+                if (slot >= 0) {
+                    observed_gap = loraComputeObservedLoss(
+                        tracked_rockets[slot].last_seq, decoded.seq);
+                    tracked_rockets[slot].last_seq = (int16_t)decoded.seq;
+                    if (observed_gap > 0) {
+                        lora_total_observed_loss += (uint32_t)observed_gap;
+                        if (hop_active_) {
+                            hop_session_observed_loss += (uint32_t)observed_gap;
+                        }
+                    }
+                    if (hop_active_) hop_session_total_pkts++;
+                }
 
                 // Convert ECEF to lat/lon — but only when the rocket reports
                 // an actual GPS fix.  The rocket sometimes packs nonzero ECEF
@@ -2424,7 +2576,8 @@ static void loop_bs()
                 if (logging_active)
                 {
                     logLoRaPacket(decoded, ls.last_rssi, ls.last_snr,
-                                  lat_deg, lon_deg, alt_m);
+                                  lat_deg, lon_deg, alt_m,
+                                  currentRxFreqMHz(), observed_gap);
                 }
 
                 // Arm / disarm the INFLIGHT safety timer on state edges.
@@ -2501,11 +2654,24 @@ static void loop_bs()
                             hop_last_rx_ms_    = millis();
                             if (!was_active)
                             {
+                                // Start a fresh hop-session counter window
+                                // so the eventual hop_inactive / hop_silence
+                                // event reports stats for *this* session
+                                // (#105 diagnostics).
+                                hop_session_started_ms    = millis();
+                                hop_session_total_pkts    = 1;  // this packet counts
+                                hop_session_observed_loss = 0;
                                 ESP_LOGI(TAG, "[HOP] Active: %u channels at BW=%.0f kHz, "
                                               "first hop -> idx=%u (%.3f MHz)",
                                          (unsigned)n, (double)lora_bw_khz,
                                          (unsigned)hop_idx_,
                                          (double)loraChannelMHz(lora_bw_khz, hop_idx_));
+                                char ev[96];
+                                snprintf(ev, sizeof(ev),
+                                         "hop_active idx=%u nch=%u",
+                                         (unsigned)hop_idx_, (unsigned)n);
+                                logHopEvent(ev,
+                                            loraChannelMHz(lora_bw_khz, hop_idx_));
                             }
                         }
                     }
@@ -2517,8 +2683,21 @@ static void loop_bs()
                     // comms resume on a known frequency.
                     hop_active_       = false;
                     hop_needs_retune_ = true;
+                    const uint32_t dur_ms = (hop_session_started_ms != 0)
+                        ? (millis() - hop_session_started_ms) : 0;
                     ESP_LOGI(TAG, "[HOP] Inactive (rocket state changed): "
                                   "returning to %.2f MHz", (double)lora_freq_mhz);
+                    char ev[96];
+                    snprintf(ev, sizeof(ev),
+                             "hop_inactive duration_ms=%u pkts=%u loss=%u "
+                             "reason=state",
+                             (unsigned)dur_ms,
+                             (unsigned)hop_session_total_pkts,
+                             (unsigned)hop_session_observed_loss);
+                    logHopEvent(ev, lora_freq_mhz);
+                    hop_session_started_ms    = 0;
+                    hop_session_total_pkts    = 0;
+                    hop_session_observed_loss = 0;
                 }
 
                 last_known_camera_recording = decoded.camera_recording;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1595,12 +1595,17 @@ static void serviceRecovery()
 // Only sent while we ARE hearing the rocket (last_packet_ms recent).  If
 // rocket goes silent, the recovery state machine takes over and we stop
 // heartbeating until comms are restored.  Uses 2 retries instead of 8 to
-// keep airtime negligible (<0.1%) — losing one heartbeat is fine, the
-// next one comes 30 s later, well inside the rocket's tolerance.
+// keep airtime per beat small (~100 ms total).
+//
+// Interval must be < OC RENDEZVOUS_TRIGGER_QUIET_MS (15 s in #105) with
+// margin for at least one missed beat — otherwise the rocket fires its
+// slow-rendezvous in steady state, drops to the rendezvous channel, and
+// the BS spends ~30 s syncing it back via Cmd-10 relay.  10 s gives the
+// OC two heartbeats per silence-tolerance window and keeps airtime ~1%.
 // (Defined here, after the LoRa transaction & recovery sections, so the
 // state-machine enums it depends on are in scope.)
 
-static constexpr uint32_t HEARTBEAT_INTERVAL_MS = 30000;  // every 30 s
+static constexpr uint32_t HEARTBEAT_INTERVAL_MS = 10000;  // every 10 s (#105)
 static constexpr uint32_t HEARTBEAT_RX_FRESH_MS = 5000;   // rocket "alive"
 static constexpr uint8_t  HEARTBEAT_RETRIES     = 2;
 static uint32_t last_heartbeat_tx_ms = 0;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -187,12 +187,25 @@ static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
 static uint8_t skip_mask_n_        = 0;        // 0 = no mask yet
 static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
 
+// Mask-drift auto-recovery (#105 follow-up).  Set in the hop RX path
+// when the rocket's announced next_channel_idx disagrees with the
+// BS-side seq-derived channel — that means BS and OC have diverged
+// skip-masks (typically: scan ran, cmd-15 push got displaced by a
+// follow-on cmd-10, OC never received the new mask).  serviceMaskDriftRepush
+// re-queues cmd 15 with a cooldown so it can't spam.
+static bool     chset_drift_repush_pending = false;
+static uint32_t chset_drift_repush_last_ms_ = 0;
+static constexpr uint32_t CHSET_DRIFT_REPUSH_COOLDOWN_MS = 30000;
+static uint32_t chset_drift_repush_count   = 0;  // for [STATS]
+
 // Forward declarations — definitions live further down with the other
 // channel-set machinery, but a couple of call sites (cmd-10 commit,
 // boot-time NVS load) need them earlier in the file.
 static void loadChannelSetFromNvs();
 static void invalidateSkipMaskForBwChange();
 static void analyzeAndPushFromCachedScan();
+static void pushCurrentChannelSet();
+static void serviceMaskDriftRepush();
 
 // If we're following a hopping rocket and packets dry up for this long,
 // give up and fall back to lora_freq_mhz so the existing silence /
@@ -965,14 +978,16 @@ static void printStats()
     // session counters reflect the *current* session and reset on each
     // hop_inactive / hop_silence event, so a "0 / 0" reading mid-flight
     // means we just lost lock.  lifetime totals let the operator spot a
-    // run with abnormally many silence events at a glance.
-    ESP_LOGI(TAG, "[STATS] HOP: active=%c idx=%u session(pkts=%lu loss=%lu) lifetime(silence=%lu loss=%lu)",
+    // run with abnormally many silence events at a glance.  drift_repush
+    // counts auto re-pushes of cmd 15 in response to BS/OC mask divergence.
+    ESP_LOGI(TAG, "[STATS] HOP: active=%c idx=%u session(pkts=%lu loss=%lu) lifetime(silence=%lu loss=%lu drift_repush=%lu)",
              hop_active_ ? 'Y' : 'N',
              (unsigned)hop_idx_,
              (unsigned long)hop_session_total_pkts,
              (unsigned long)hop_session_observed_loss,
              (unsigned long)hop_silence_events_count,
-             (unsigned long)lora_total_observed_loss);
+             (unsigned long)lora_total_observed_loss,
+             (unsigned long)chset_drift_repush_count);
 }
 
 // ============================================================================
@@ -1914,6 +1929,58 @@ static void analyzeAndPushFromCachedScan()
     applyAndPushChannelSet(sel, lora_bw_khz);
 }
 
+// Re-push the BS's current skip-mask state to the rocket — used by the
+// mask-drift auto-recovery (#105 follow-up) when the rocket's announced
+// next_channel_idx doesn't match the BS's seq-derived expectation.  No
+// re-analysis (no scan needed); just (re-)delivers what we already have.
+// Inert if we have no mask to push.
+static void pushCurrentChannelSet()
+{
+    if (skip_mask_n_ == 0) return;  // nothing to push
+    LoRaChannelSetSelection sel = {};
+    sel.n_channels = skip_mask_n_;
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) {
+        sel.skip_mask[i] = skip_mask_[i];
+    }
+    applyAndPushChannelSet(sel, channel_set_bw_khz_);
+}
+
+// Mask-drift auto-recovery service (#105 follow-up).  Watches the flag
+// set by the hop RX path and re-pushes cmd 15 when the radio state is
+// quiet enough to do so safely.  Cooldown prevents spam if drift
+// persists across multiple packets.
+static void serviceMaskDriftRepush()
+{
+    if (!chset_drift_repush_pending) return;
+    // Only push when nothing else is using the radio for TX.
+    if (uplink_pending)                        return;
+    if (lora_txn_state != LoRaTxnState::IDLE)  return;
+    if (recovery_state != RecoveryState::IDLE) return;
+    // Cooldown: don't re-push more than once every CHSET_DRIFT_REPUSH_COOLDOWN_MS.
+    // First-ever push (last_ms_=0) bypasses the cooldown.
+    const uint32_t now = millis();
+    if (chset_drift_repush_last_ms_ != 0 &&
+        (now - chset_drift_repush_last_ms_) < CHSET_DRIFT_REPUSH_COOLDOWN_MS)
+    {
+        // Cooldown active; clear the flag so we don't spin checking.
+        // Next drift event after the cooldown will set it again.
+        chset_drift_repush_pending = false;
+        return;
+    }
+    if (skip_mask_n_ == 0) {
+        // No mask to push — likely a brand-new BS without scan results.
+        // The drift warning is informational only in this case.
+        chset_drift_repush_pending = false;
+        return;
+    }
+    chset_drift_repush_pending = false;
+    chset_drift_repush_last_ms_ = now;
+    chset_drift_repush_count++;
+    ESP_LOGI(TAG, "[CHSET] Mask drift detected — re-pushing cmd 15 (count=%lu)",
+             (unsigned long)chset_drift_repush_count);
+    pushCurrentChannelSet();
+}
+
 // All passes done.  Ship results to BLE (preserving the existing
 // single-result protocol so the iOS app doesn't need to change), then
 // run the analyzer + push to the rocket.
@@ -2692,6 +2759,12 @@ static void loop_bs()
                                          (unsigned)decoded.seq,
                                          (unsigned)decoded.next_channel_idx,
                                          (unsigned)expected_next);
+                                // Schedule auto re-push of the mask via
+                                // cmd 15 — the rocket's mask is out of
+                                // sync with ours, fixed by re-sending
+                                // ours.  Cooldown enforced in
+                                // serviceMaskDriftRepush.
+                                chset_drift_repush_pending = true;
                             }
                             const bool was_active = hop_active_;
                             hop_idx_           = decoded.next_channel_idx;
@@ -3258,6 +3331,12 @@ static void loop_bs()
     // Silence recovery runs after the transaction service so a freshly
     // started transaction always wins over any pending recovery cycle.
     serviceRecovery();
+
+    // Mask-drift auto-recovery (#105 follow-up).  Re-pushes cmd 15 if
+    // the hop RX path detected a divergence between our skip-mask and
+    // the rocket's.  Cheap when no drift is pending; only acts when
+    // the radio is otherwise idle.
+    serviceMaskDriftRepush();
 
     // Heartbeat — quietly tells the rocket "we're hearing you" so its
     // slow-rendezvous timer doesn't expire during normal idle operation.

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -949,13 +949,14 @@ static void printStats()
         snprintf(last_pkt_str, sizeof(last_pkt_str), "never");
     }
 
-    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | low-SNR drop: %lu | ISR: %lu | rx_mode: %d | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
+    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | low-SNR drop: %lu | ISR: %lu | rx_mode: %d | TX wdog: %lu | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
              (unsigned long)ls.rx_count,
              (double)rx_hz,
              (unsigned long)ls.rx_crc_fail,
              (unsigned long)lora_low_snr_drops,
              (unsigned long)ls.isr_count,
              (int)ls.rx_mode,
+             (unsigned long)ls.tx_watchdog_fires,
              (double)ls.last_rssi,
              (double)ls.last_snr,
              last_pkt_str);
@@ -2396,7 +2397,8 @@ static void loop_bs()
 {
     // Service LoRa (complete any pending TX before checking for RX)
     lora_comms.service();
-    lora_comms.pollDio1();  // Fallback if DIO1 interrupt doesn't fire
+    lora_comms.pollDio1();          // Fallback if DIO1 interrupt doesn't fire
+    lora_comms.serviceTxWatchdog(); // Force-clear stuck tx_ongoing_ (#105)
 
     // Drive the coordinated-scan state machine first so AWAITING_PAUSE
     // → SCANNING transitions can kick off a scan in the same iteration
@@ -2669,22 +2671,31 @@ static void loop_bs()
                             const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
                             // Compute next channel from seq+1 — what the
                             // rocket will be on for the *next* packet.
-                            const uint8_t next_ch = loraHopChannelForSeq(
+                            // Trust the rocket's announced next_channel_idx
+                            // as the retune target — that's where the rocket
+                            // will actually transmit, regardless of whether
+                            // our local skip-mask agrees with theirs.  The
+                            // seq-derived computation below is a sanity
+                            // CHECK, not the source of truth: if it disagrees
+                            // with what the rocket announced, the masks have
+                            // drifted (cmd-15 push didn't reach this side, or
+                            // the BS just ran a fresh scan and the rocket
+                            // hasn't received the new mask yet).  In that
+                            // case the mask-warning fires but we still follow
+                            // the rocket so the link stays up.
+                            const uint8_t expected_next = loraHopChannelForSeq(
                                 (uint16_t)(decoded.seq + 1),
                                 LORA_HOP_DWELL_PACKETS, mask, n);
-                            // Sanity: rocket's announced next_channel_idx
-                            // should agree with our computation.  Log
-                            // (don't reject) on mismatch — usually means
-                            // the skip-mask is out of sync.
-                            if (decoded.next_channel_idx != next_ch) {
+                            if (decoded.next_channel_idx != expected_next) {
                                 ESP_LOGW(TAG, "[HOP] seq=%u: rocket says next=%u, "
-                                              "we compute next=%u (mask drift?)",
+                                              "we'd compute next=%u (mask drift "
+                                              "— following rocket)",
                                          (unsigned)decoded.seq,
                                          (unsigned)decoded.next_channel_idx,
-                                         (unsigned)next_ch);
+                                         (unsigned)expected_next);
                             }
                             const bool was_active = hop_active_;
-                            hop_idx_           = next_ch;
+                            hop_idx_           = decoded.next_channel_idx;
                             hop_active_        = true;
                             hop_needs_retune_  = true;
                             hop_last_rx_ms_    = millis();

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -230,11 +230,13 @@ struct TrackedRocket {
     double     last_lon_deg = NAN;
     double     last_alt_m = NAN;
     uint32_t   last_seen_ms = 0;
-    // Free-running TX seq from the rocket (#105).  -1 = no prior packet
-    // ("first contact"); on a backward jump or implausible forward delta,
-    // we reset back to -1 and treat the next packet as fresh contact —
-    // most likely the rocket rebooted and lora_tx_seq restarted at 0.
-    int16_t    last_seq = -1;
+    // Free-running TX seq from the rocket (#105, widened to 16 bits in
+    // proto v4).  -1 = no prior packet ("first contact"); on an
+    // implausible forward delta we reset to -1 and treat the next
+    // packet as fresh contact — most likely the rocket rebooted and
+    // lora_tx_seq restarted at 0.  int32_t to hold the full uint16
+    // range plus the -1 sentinel.
+    int32_t    last_seq = -1;
 };
 static TrackedRocket tracked_rockets[MAX_TRACKED_ROCKETS];
 static uint8_t active_rocket_idx = 0;  // Which rocket the BLE telemetry currently shows
@@ -472,7 +474,7 @@ static uint32_t log_write_count = 0;  // Tracks calls for periodic flash check
 
 static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                           double lat, double lon, double alt,
-                          float rx_freq_mhz, int16_t observed_gap)
+                          float rx_freq_mhz, int32_t observed_gap)
 {
     if (!logging_active) return;
 
@@ -1632,12 +1634,15 @@ static void serviceHeartbeat()
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (uplink_pending)                        return;  // Don't clobber a real cmd
-    // While hopping, only TX in the safe window right after a fresh
-    // rocket RX — see HOP_BS_TX_SAFE_WINDOW_MS comment.  Without this,
-    // the heartbeat's 2-retry burst (~200 ms) collides with the
-    // rocket's ~500 ms-spaced TX, desyncs the hop sequence, and the
-    // link drops until the 3 s hop-silence fallback fires.
-    if (!inHopSafeWindow())                    return;
+    // Suppress heartbeats entirely while hopping (#105 follow-up).  The
+    // BS heartbeat's 2-retry TX burst (~200 ms) racing with the rocket's
+    // 500 ms TX cycle was the proximate cause of repeated hop-session
+    // collapses: BS RX a packet, queue heartbeat, by the time TX
+    // completes the rocket has moved to the next channel.  The rocket's
+    // own hop_fallback (visit rendezvous after 30 s of in-hop silence)
+    // is the correct recovery mechanism during a hop session, so
+    // heartbeats here are both unnecessary and actively harmful.
+    if (hop_active_)                           return;
 
     const uint32_t now = millis();
     // Only heartbeat when we've recently heard the rocket.  If rocket has
@@ -2533,11 +2538,11 @@ static void loop_bs()
                 // forward deltas (most likely a rocket reboot — lora_tx_seq
                 // resets to 0).  We update last_seq unconditionally so the
                 // next RX gets a clean baseline either way.
-                int16_t observed_gap = -1;
+                int32_t observed_gap = -1;
                 if (slot >= 0) {
                     observed_gap = loraComputeObservedLoss(
                         tracked_rockets[slot].last_seq, decoded.seq);
-                    tracked_rockets[slot].last_seq = (int16_t)decoded.seq;
+                    tracked_rockets[slot].last_seq = (int32_t)decoded.seq;
                     if (observed_gap > 0) {
                         lora_total_observed_loss += (uint32_t)observed_gap;
                         if (hop_active_) {
@@ -2638,26 +2643,48 @@ static void loop_bs()
                 last_rocket_state = decoded.rocket_state;
                 updateFreqLockFromRocketState(decoded.rocket_state);
 
-                // Hop state follow (#40 / #41 phase 2a).  The rocket owns
-                // the schedule; we just retune to wherever its packet says
-                // we should be next.  Honoured as soon as the radio is
-                // idle (top of serviceLoRa) — we don't retune in the RX
-                // callback path because the radio still has work to do.
-                // #106: when the operator has disabled hopping, ignore the
-                // rocket's next_channel_idx and stay on lora_freq_mhz.  The
-                // rocket-side LORA_CMD_SET_HOP_DISABLED handler also clears
-                // its own hop_active_ so it stops emitting non-NO_HOP indices,
-                // but we belt-and-brace here in case the rocket missed the
-                // uplink and is still hopping.
+                // Hop state follow (#40 / #41 phase 2a, seq-anchored in
+                // #105 follow-up).  The rocket and the BS both compute
+                // the channel for any seq from loraHopChannelForSeq() —
+                // identical formula, no chained handoff.  This means a
+                // single missed packet within a dwell window doesn't
+                // desync us: the next received packet's seq tells us
+                // exactly where the rocket is.  next_channel_idx in the
+                // packet header is now a sanity hint; we still honour
+                // the NO_HOP sentinel as the "not currently hopping"
+                // signal, but for the actual channel we consult seq.
+                //
+                // #106: when the operator has disabled hopping, ignore
+                // the rocket's hop entirely and stay on lora_freq_mhz.
                 if (!lora_hop_disabled && shouldHopInState(decoded.rocket_state))
                 {
                     if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
                     {
                         const uint8_t n = loraChannelCount(lora_bw_khz);
-                        if (n > 0 && decoded.next_channel_idx < n)
+                        if (n > 0)
                         {
+                            const bool mask_valid = (skip_mask_n_ == n &&
+                                                      channel_set_bw_khz_ == lora_bw_khz);
+                            static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+                            const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                            // Compute next channel from seq+1 — what the
+                            // rocket will be on for the *next* packet.
+                            const uint8_t next_ch = loraHopChannelForSeq(
+                                (uint16_t)(decoded.seq + 1),
+                                LORA_HOP_DWELL_PACKETS, mask, n);
+                            // Sanity: rocket's announced next_channel_idx
+                            // should agree with our computation.  Log
+                            // (don't reject) on mismatch — usually means
+                            // the skip-mask is out of sync.
+                            if (decoded.next_channel_idx != next_ch) {
+                                ESP_LOGW(TAG, "[HOP] seq=%u: rocket says next=%u, "
+                                              "we compute next=%u (mask drift?)",
+                                         (unsigned)decoded.seq,
+                                         (unsigned)decoded.next_channel_idx,
+                                         (unsigned)next_ch);
+                            }
                             const bool was_active = hop_active_;
-                            hop_idx_           = decoded.next_channel_idx;
+                            hop_idx_           = next_ch;
                             hop_active_        = true;
                             hop_needs_retune_  = true;
                             hop_last_rx_ms_    = millis();
@@ -2670,15 +2697,17 @@ static void loop_bs()
                                 hop_session_started_ms    = millis();
                                 hop_session_total_pkts    = 1;  // this packet counts
                                 hop_session_observed_loss = 0;
-                                ESP_LOGI(TAG, "[HOP] Active: %u channels at BW=%.0f kHz, "
-                                              "first hop -> idx=%u (%.3f MHz)",
+                                ESP_LOGI(TAG, "[HOP] Active: %u channels at BW=%.0f kHz "
+                                              "dwell=%u, first hop -> idx=%u (%.3f MHz)",
                                          (unsigned)n, (double)lora_bw_khz,
+                                         (unsigned)LORA_HOP_DWELL_PACKETS,
                                          (unsigned)hop_idx_,
                                          (double)loraChannelMHz(lora_bw_khz, hop_idx_));
                                 char ev[96];
                                 snprintf(ev, sizeof(ev),
-                                         "hop_active idx=%u nch=%u",
-                                         (unsigned)hop_idx_, (unsigned)n);
+                                         "hop_active idx=%u nch=%u dwell=%u",
+                                         (unsigned)hop_idx_, (unsigned)n,
+                                         (unsigned)LORA_HOP_DWELL_PACKETS);
                                 logHopEvent(ev,
                                             loraChannelMHz(lora_bw_khz, hop_idx_));
                             }

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1635,15 +1635,14 @@ static void serviceHeartbeat()
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (uplink_pending)                        return;  // Don't clobber a real cmd
-    // Suppress heartbeats entirely while hopping (#105 follow-up).  The
-    // BS heartbeat's 2-retry TX burst (~200 ms) racing with the rocket's
-    // 500 ms TX cycle was the proximate cause of repeated hop-session
-    // collapses: BS RX a packet, queue heartbeat, by the time TX
-    // completes the rocket has moved to the next channel.  The rocket's
-    // own hop_fallback (visit rendezvous after 30 s of in-hop silence)
-    // is the correct recovery mechanism during a hop session, so
-    // heartbeats here are both unnecessary and actively harmful.
-    if (hop_active_)                           return;
+    // While hopping, only TX in the safe window right after a fresh
+    // rocket RX — see HOP_BS_TX_SAFE_WINDOW_MS comment.  With slow-hop
+    // dwell=4 (#105 follow-up) the rocket stays on a channel for 2 s,
+    // so a 250 ms heartbeat-with-retries fits comfortably inside the
+    // dwell.  Without heartbeats during hop, the rocket's
+    // hop_session_uplink_count stays 0 and its fallback fires every 30 s
+    // (HOP_FALLBACK_TRIGGER_INITIAL_MS), tearing down the session.
+    if (!inHopSafeWindow())                    return;
 
     const uint32_t now = millis();
     // Only heartbeat when we've recently heard the rocket.  If rocket has

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -2,6 +2,7 @@
 #define OUT_COMPUTER_CONFIG_H
 
 #include <stdint.h>
+#include <RocketComputerTypes.h>  // LORA_FACTORY_RENDEZVOUS_* (#105)
 
 struct config
 {
@@ -86,22 +87,15 @@ struct config
     static constexpr bool LORA_SYNCWORD_PRIVATE = true;
     static constexpr uint16_t LORA_TX_RATE_HZ = 2;
 
-    // Known-good rendezvous mode (issue #71).  When the rocket and base
-    // station drift apart, both fall back to this complete LoRa config
-    // — frequency AND modulation parameters.  Frequency alone isn't
-    // enough: the user can configure SF/BW/CR/TX power via the iOS app
-    // ("Fast" / "Standard" / "Long Range" presets), and a divergence on
-    // those is just as fatal as a frequency mismatch.  All five values
-    // must be identical on both firmware builds; the constants below are
-    // the "Standard" preset, which is also the NVS factory default — so
-    // a fresh-NVS device is already in rendezvous mode at boot.  Never
-    // persisted to NVS; NVS holds the working config and this is always
-    // the same compile-time fallback.
-    static constexpr float   LORA_RENDEZVOUS_MHZ          = 915.0f;
-    static constexpr uint8_t LORA_RENDEZVOUS_SF           = 8;
-    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = 250.0f;
-    static constexpr uint8_t LORA_RENDEZVOUS_CR           = 5;
-    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = 12;
+    // Known-good rendezvous mode (issue #71).  Sourced from the shared
+    // RocketComputerTypes.h header (#105) so both BS and OC firmware are
+    // guaranteed to agree at compile time — see LORA_FACTORY_RENDEZVOUS_*
+    // there for the full justification.
+    static constexpr float   LORA_RENDEZVOUS_MHZ          = LORA_FACTORY_RENDEZVOUS_MHZ;
+    static constexpr uint8_t LORA_RENDEZVOUS_SF           = LORA_FACTORY_RENDEZVOUS_SF;
+    static constexpr float   LORA_RENDEZVOUS_BW_KHZ       = LORA_FACTORY_RENDEZVOUS_BW_KHZ;
+    static constexpr uint8_t LORA_RENDEZVOUS_CR           = LORA_FACTORY_RENDEZVOUS_CR;
+    static constexpr int8_t  LORA_RENDEZVOUS_TX_POWER_DBM = LORA_FACTORY_RENDEZVOUS_TX_DBM;
 
     // --- LoRa Uplink RX (commands from BaseStation) ---
     static constexpr uint8_t UPLINK_SYNC_BYTE = 0xCA;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -592,10 +592,10 @@ static uint32_t last_lora_tx_ms = 0;
 
 // Free-running per-TX sequence counter (#105).  Stamped into LoRaData.seq
 // on every actual transmit so the BS can compute observed-loss rates and
-// distinguish dropped packets from full hop-table desync.  Wraps mod 256.
-// Resets to 0 on reboot — the BS handles the discontinuity by clearing
-// its per-rocket tracking when seq jumps backward.
-static uint8_t  lora_tx_seq = 0;
+// the slow-hop seq-anchored channel schedule.  Widened to 16 bits in
+// proto v4 — see LORA_HOP_DWELL_PACKETS for why u8 was insufficient.
+// Wraps mod 65536; resets to 0 on reboot.
+static uint16_t lora_tx_seq = 0;
 // lora_in_rx_mode forward-declared up with the hop state.
 static uint32_t lora_uplink_rx_count = 0;
 // CRC-passing decodes whose SNR was below loraMinValidSnrDb(current_sf)
@@ -1681,7 +1681,7 @@ static void serviceI2CIngress()
 }
 
 // ============================================================================
-static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint8_t seq)
+static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t seq)
 {
     if (out_payload == nullptr)
     {
@@ -1693,40 +1693,30 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint8_t seq
     lora.network_id = network_id;
     lora.rocket_id  = rocket_id;
     lora.seq        = seq;
-    // Hop byte (#40 / #41).  Either tell the BS where we'll be for the
-    // next packet, or send the no-hop sentinel.  During a rendezvous
-    // visit (phase 2b) we explicitly send the sentinel — we're parked
-    // on rendezvous, not following the hop schedule.
+    // Hop byte (#40 / #41).  Tells the BS where to expect packet seq+1.
+    // With seq-anchored slow-hop (#105 follow-up), this value is purely
+    // a sanity hint — the BS computes the same channel from the seq
+    // itself, which lets it self-correct after a single missed packet
+    // within the dwell window.  Sentinel 0xFF means "not hopping; stay
+    // on lora_freq_mhz".
     if (hop_active_ && hop_fallback_state == HopFallbackState::NORMAL)
     {
-        if (hop_first_pkt_)
+        const uint8_t n = loraChannelCount(lora_bw_khz);
+        if (n == 0)
         {
-            // Bootstrap: this packet still goes out on lora_freq_mhz.
-            // Tell the BS to follow us to channel 0 for the next one.
-            // (Channel 0 is intentionally always considered active even
-            // if the skip-mask covers it, since it's the bootstrap
-            // anchor — the next non-bootstrap packet will skip-advance.)
-            lora.next_channel_idx = 0;
+            lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;
         }
         else
         {
-            const uint8_t n = loraChannelCount(lora_bw_khz);
-            if (n == 0)
-            {
-                lora.next_channel_idx = LORA_NEXT_CH_NO_HOP;
-            }
-            else
-            {
-                // Skip-mask aware advance (#40 / #41 phase 3).  When no
-                // valid mask is loaded (n_chan == 0 or BW mismatch), the
-                // skip_mask_ is all-zeros so loraNextActiveChannelIdx
-                // degenerates to (idx + 1) % n.
-                const bool mask_valid = (skip_mask_n_ == n &&
-                                          channel_set_bw_khz_ == lora_bw_khz);
-                static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
-                const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
-                lora.next_channel_idx = loraNextActiveChannelIdx(hop_idx_, mask, n);
-            }
+            // Skip-mask aware schedule.  When no valid mask is loaded
+            // (n_chan == 0 or BW mismatch) the empty mask makes
+            // loraHopChannelForSeq degenerate to (seq/dwell) % n.
+            const bool mask_valid = (skip_mask_n_ == n &&
+                                      channel_set_bw_khz_ == lora_bw_khz);
+            static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+            const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+            lora.next_channel_idx = loraHopChannelForSeq(
+                (uint16_t)(seq + 1), LORA_HOP_DWELL_PACKETS, mask, n);
         }
     }
     else
@@ -1867,26 +1857,24 @@ static void serviceLoRa()
         {
             if (hop_first_pkt_)
             {
-                // Bootstrap packet just went out on lora_freq_mhz.
-                // hop_idx_ is already 0; clear the first-packet flag so
-                // the upcoming retune lands us on channel 0.
+                // Bootstrap packet just went out on lora_freq_mhz.  Clear
+                // the first-packet flag; the next packet (seq just
+                // incremented) will go on its scheduled hop channel.
                 hop_first_pkt_ = false;
             }
-            else
+            // Recompute hop_idx_ from the just-incremented seq via the
+            // seq-anchored schedule.  This MUST equal the next_channel_idx
+            // we put into the packet header in buildLoRaPayload — both
+            // sides derive from the same formula so they cannot disagree.
+            const uint8_t n = loraChannelCount(lora_bw_khz);
+            if (n > 0)
             {
-                // Skip-mask aware advance — must match the value we
-                // just wrote into the packet's next_channel_idx field
-                // in buildLoRaPayload, otherwise rocket and BS land on
-                // different channels.
-                const uint8_t n = loraChannelCount(lora_bw_khz);
-                if (n > 0)
-                {
-                    const bool mask_valid = (skip_mask_n_ == n &&
-                                              channel_set_bw_khz_ == lora_bw_khz);
-                    static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
-                    const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
-                    hop_idx_ = loraNextActiveChannelIdx(hop_idx_, mask, n);
-                }
+                const bool mask_valid = (skip_mask_n_ == n &&
+                                          channel_set_bw_khz_ == lora_bw_khz);
+                static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+                const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                hop_idx_ = loraHopChannelForSeq(
+                    lora_tx_seq, LORA_HOP_DWELL_PACKETS, mask, n);
             }
             hop_needs_retune_ = true;
         }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2435,6 +2435,7 @@ static void serviceLoRaUplink()
     // boards the interrupt may not trigger for RX-done.  pollDio1()
     // checks the pin level and sets rx_done_ if DIO1 is asserted.
     lora_comms.pollDio1();
+    lora_comms.serviceTxWatchdog();  // Force-clear stuck tx_ongoing_ (#105)
 
     // Non-blocking poll for uplink packet
     uint8_t rx_buf[32];

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -443,11 +443,11 @@ static uint32_t         hop_session_uplink_count    = 0;  // resets each hop ses
 static uint32_t         hop_pause_until_ms          = 0;  // wall-clock deadline for PAUSED_FOR_SCAN
 
 // Channel-set state pushed by the BS via LORA_CMD_CHANNEL_SET (#40 / #41
-// phase 3).  rendezvous_mhz_ replaces the hardcoded LORA_RENDEZVOUS_MHZ
-// constant for both slow_rendezvous and hop-silence visits.  skip_mask_
+// phase 3).  Rendezvous freq is no longer scan-selected (it's compile-
+// time hardcoded to LORA_FACTORY_RENDEZVOUS_MHZ on both sides — see
+// #105 for why); only the skip-mask is pushed via cmd 15 now.  skip_mask_
 // is consulted in the per-packet next_channel_idx advance so the hop
 // sequence skips noisy channels.
-static float   rendezvous_mhz_     = config::LORA_RENDEZVOUS_MHZ;
 static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
 static uint8_t skip_mask_n_        = 0;        // 0 = no mask (all active)
 static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
@@ -2306,19 +2306,20 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         setPendingCommand(enabled ? GUIDANCE_ENABLE : GUIDANCE_DISABLE);
         ESP_LOGI("LORA", "UPLINK Guidance: %s", enabled ? "ENABLE" : "DISABLE");
     }
-    else if (cmd == LORA_CMD_CHANNEL_SET && payload_len >= 9)
+    else if (cmd == LORA_CMD_CHANNEL_SET && payload_len >= 5)
     {
         // Channel-set push from BS (#40 / #41 phase 3).  Wire format:
-        //   [rdv:f4][bw:f4][n_channels:u1][skip_mask: ceil(n/8) bytes]
-        float new_rdv, new_bw;
-        memcpy(&new_rdv, payload + 0, 4);
-        memcpy(&new_bw,  payload + 4, 4);
-        const uint8_t new_n = payload[8];
+        //   [bw:f4][n_channels:u1][skip_mask: ceil(n/8) bytes]
+        // Rendezvous freq used to lead this payload but is now hardcoded
+        // on both sides (#105) — see LORA_FACTORY_RENDEZVOUS_MHZ.
+        float new_bw;
+        memcpy(&new_bw,  payload + 0, 4);
+        const uint8_t new_n = payload[4];
         const size_t  mask_bytes = (size_t)(new_n + 7) / 8;
-        if (payload_len < 9 + mask_bytes || mask_bytes > LORA_SKIP_MASK_MAX_BYTES)
+        if (payload_len < 5 + mask_bytes || mask_bytes > LORA_SKIP_MASK_MAX_BYTES)
         {
             ESP_LOGW("LORA", "UPLINK Cmd 15 ignored: payload truncated (len=%u, need %u)",
-                     (unsigned)payload_len, (unsigned)(9 + mask_bytes));
+                     (unsigned)payload_len, (unsigned)(5 + mask_bytes));
             return;
         }
         // Reject if BW doesn't match — the BS sent a mask sized for a
@@ -2333,17 +2334,15 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
                      (double)new_bw, (double)lora_bw_khz);
             return;
         }
-        rendezvous_mhz_     = new_rdv;
         skip_mask_n_        = new_n;
         channel_set_bw_khz_ = new_bw;
         for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) skip_mask_[i] = 0;
-        for (size_t i = 0; i < mask_bytes;          i++) skip_mask_[i] = payload[9 + i];
+        for (size_t i = 0; i < mask_bytes;          i++) skip_mask_[i] = payload[5 + i];
 
-        // Persist
+        // Persist (rdv_mhz no longer stored — see #105 / NVS schema v3)
         Preferences p;
         if (p.begin("lora", false))
         {
-            p.putFloat("rdv_mhz", rendezvous_mhz_);
             p.putUChar("chset_n", skip_mask_n_);
             p.putFloat("chset_bw", channel_set_bw_khz_);
             p.putBytes("chset_mask", skip_mask_, mask_bytes);
@@ -2353,8 +2352,8 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         uint8_t active = 0;
         for (uint8_t i = 0; i < skip_mask_n_; i++)
             if (!loraSkipMaskTest(skip_mask_, i)) active++;
-        ESP_LOGI("LORA", "UPLINK Cmd 15: rendezvous=%.2f MHz, %u/%u active at BW=%.0f kHz",
-                 (double)rendezvous_mhz_, (unsigned)active,
+        ESP_LOGI("LORA", "UPLINK Cmd 15: %u/%u active at BW=%.0f kHz",
+                 (unsigned)active,
                  (unsigned)skip_mask_n_, (double)channel_set_bw_khz_);
     }
     else if (cmd == LORA_CMD_HOP_PAUSE && payload_len >= 2)
@@ -2374,7 +2373,7 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         // Only meaningful while we're hopping.  In non-hop states the
         // BS uses the existing direct-scan path and never sends cmd 16.
         // Slow-rendezvous (#71) doesn't need to be checked here: while
-        // it's parking the radio on rendezvous_mhz_, the BS is on a
+        // it's parking the radio on the rendezvous channel, the BS is on a
         // hop channel and physically can't deliver cmd 16 to us.
         if (!hop_active_)
         {
@@ -2503,7 +2502,7 @@ static void serviceLoRaUplink()
 // Slow Rendezvous Cycle (issue #71)
 // ============================================================================
 // If the rocket has been silent (no uplink received) for long enough, hop
-// briefly to LORA_RENDEZVOUS_MHZ on a duty cycle so the base station's
+// briefly to LORA_FACTORY_RENDEZVOUS_MHZ on a duty cycle so the base station's
 // Phase-A recovery has a guaranteed meeting point even when the two NVS
 // freqs disagree by more than the BS's ±2 MHz scan range (e.g. the rocket
 // kept a previously-scanned channel like 921.5 MHz while the BS rebooted
@@ -2528,7 +2527,7 @@ static void serviceLoRaUplink()
 
 enum class RocketRendezvousState : uint8_t {
     IDLE,
-    ON_RENDEZVOUS,    // RENDEZVOUS_WINDOW_MS on LORA_RENDEZVOUS_MHZ
+    ON_RENDEZVOUS,    // RENDEZVOUS_WINDOW_MS on LORA_FACTORY_RENDEZVOUS_MHZ
     ON_SAVED,         // RENDEZVOUS_SAVED_MS back on lora_freq_mhz (NVS)
 };
 
@@ -2553,14 +2552,14 @@ static constexpr uint32_t RENDEZVOUS_SAVED_MS           = 20000;  // back on sav
 // fallback.
 static void rendezvousHopToRendezvousMode()
 {
-    // rendezvous_mhz_ is scan-selected (#40 / #41 phase 3) and falls
-    // back to config::LORA_RENDEZVOUS_MHZ when no scan-pushed value is
-    // in NVS.
-    if (lora_comms.reconfigure(rendezvous_mhz_,
-                                config::LORA_RENDEZVOUS_SF,
-                                config::LORA_RENDEZVOUS_BW_KHZ,
-                                config::LORA_RENDEZVOUS_CR,
-                                config::LORA_RENDEZVOUS_TX_POWER_DBM))
+    // All five values are compile-time constants in RocketComputerTypes.h
+    // so the BS and OC are guaranteed to agree on the meeting place even
+    // when each side's NVS has drifted (#105).
+    if (lora_comms.reconfigure(LORA_FACTORY_RENDEZVOUS_MHZ,
+                                LORA_FACTORY_RENDEZVOUS_SF,
+                                LORA_FACTORY_RENDEZVOUS_BW_KHZ,
+                                LORA_FACTORY_RENDEZVOUS_CR,
+                                LORA_FACTORY_RENDEZVOUS_TX_DBM))
     {
         lora_comms.startReceive();
         lora_in_rx_mode = true;
@@ -2648,9 +2647,9 @@ static void serviceRocketRendezvous()
                 rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
                 ESP_LOGW("OC", "[RENDEZVOUS] Silent %u s; hop to rendezvous mode %.2f MHz SF%u BW%.0f",
                          (unsigned)(silent_for / 1000),
-                         (double)rendezvous_mhz_,
-                         (unsigned)config::LORA_RENDEZVOUS_SF,
-                         (double)config::LORA_RENDEZVOUS_BW_KHZ);
+                         (double)LORA_FACTORY_RENDEZVOUS_MHZ,
+                         (unsigned)LORA_FACTORY_RENDEZVOUS_SF,
+                         (double)LORA_FACTORY_RENDEZVOUS_BW_KHZ);
             }
             break;
 
@@ -2728,15 +2727,15 @@ static void serviceHopFallback()
             }
             if ((now - ref) < trigger) return;
 
-            // Trigger: visit rendezvous.  reconfigure() switches
-            // BW/SF/CR/freq atomically (with rollback on failure) —
-            // same machinery as slow_rendezvous so the radio handling
-            // is identical and well-tested.
-            if (!lora_comms.reconfigure(rendezvous_mhz_,
-                                         config::LORA_RENDEZVOUS_SF,
-                                         config::LORA_RENDEZVOUS_BW_KHZ,
-                                         config::LORA_RENDEZVOUS_CR,
-                                         config::LORA_RENDEZVOUS_TX_POWER_DBM))
+            // Trigger: visit the shared hardcoded rendezvous (#105).
+            // reconfigure() switches BW/SF/CR/freq atomically (with
+            // rollback on failure) — same machinery as slow_rendezvous
+            // so the radio handling is identical and well-tested.
+            if (!lora_comms.reconfigure(LORA_FACTORY_RENDEZVOUS_MHZ,
+                                         LORA_FACTORY_RENDEZVOUS_SF,
+                                         LORA_FACTORY_RENDEZVOUS_BW_KHZ,
+                                         LORA_FACTORY_RENDEZVOUS_CR,
+                                         LORA_FACTORY_RENDEZVOUS_TX_DBM))
             {
                 ESP_LOGE("OC", "[HOP] Visit failed: reconfigure to rendezvous mode");
                 return;
@@ -2747,7 +2746,7 @@ static void serviceHopFallback()
             hop_fallback_state = HopFallbackState::VISITING_RENDEZVOUS;
             ESP_LOGW("OC", "[HOP] Silence %u s — visiting rendezvous %.2f MHz for %u s",
                      (unsigned)((now - ref) / 1000),
-                     (double)rendezvous_mhz_,
+                     (double)LORA_FACTORY_RENDEZVOUS_MHZ,
                      (unsigned)(HOP_FALLBACK_VISIT_MS / 1000));
             break;
         }
@@ -3432,12 +3431,11 @@ void initPeripherals()
         lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
         lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106 fixed-frequency override
 
-        // Channel-set restore (#40 / #41 phase 3): rendezvous freq +
-        // skip-mask pushed by the BS via cmd 15.  Skip-mask is keyed
-        // off the BW it was generated for; if NVS BW != active BW,
-        // discard the mask (the BS will re-push after the user re-runs
-        // the scan).
-        rendezvous_mhz_ = prefs.getFloat("rdv_mhz", config::LORA_RENDEZVOUS_MHZ);
+        // Channel-set restore (#40 / #41 phase 3): skip-mask pushed by
+        // the BS via cmd 15.  Skip-mask is keyed off the BW it was
+        // generated for; if NVS BW != active BW, discard the mask (the
+        // BS will re-push after the user re-runs the scan).  Rendezvous
+        // freq is no longer NVS-stored — see #105.
         const uint8_t chset_n  = prefs.getUChar("chset_n", 0);
         const float   chset_bw = prefs.getFloat("chset_bw", 0.0f);
         if (chset_n > 0 && chset_bw == lora_bw_khz)
@@ -3459,14 +3457,12 @@ void initPeripherals()
             uint8_t active = 0;
             for (uint8_t i = 0; i < skip_mask_n_; i++)
                 if (!loraSkipMaskTest(skip_mask_, i)) active++;
-            ESP_LOGI("CFG", "[CHSET] NVS: rendezvous=%.2f MHz, %u/%u channels active",
-                     (double)rendezvous_mhz_, (unsigned)active,
-                     (unsigned)skip_mask_n_);
+            ESP_LOGI("CFG", "[CHSET] NVS: %u/%u channels active",
+                     (unsigned)active, (unsigned)skip_mask_n_);
         }
         else
         {
-            ESP_LOGI("CFG", "[CHSET] NVS: rendezvous=%.2f MHz (default), no skip-mask",
-                     (double)rendezvous_mhz_);
+            ESP_LOGI("CFG", "[CHSET] NVS: no skip-mask");
         }
 
         // Load cached servo config from NVS
@@ -3892,7 +3888,7 @@ static void loop_oc()
         // Check for LoRa uplink commands between TX cycles
         LOOP_STALL_INSTR("serviceLoRaUplink", serviceLoRaUplink());
 
-        // Slow-rendezvous cycle: brief visits to LORA_RENDEZVOUS_MHZ when
+        // Slow-rendezvous cycle: brief visits to LORA_FACTORY_RENDEZVOUS_MHZ when
         // the rocket has been silent in READY for a long time, so the base
         // station's Phase-A recovery has a meeting point (issue #71).
         LOOP_STALL_INSTR("serviceRocketRendezvous", serviceRocketRendezvous());

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -589,6 +589,13 @@ static float max_speed_mps = 0.0f;
 static uint32_t lora_tx_ok = 0;
 static uint32_t lora_tx_fail = 0;
 static uint32_t last_lora_tx_ms = 0;
+
+// Free-running per-TX sequence counter (#105).  Stamped into LoRaData.seq
+// on every actual transmit so the BS can compute observed-loss rates and
+// distinguish dropped packets from full hop-table desync.  Wraps mod 256.
+// Resets to 0 on reboot — the BS handles the discontinuity by clearing
+// its per-rocket tracking when seq jumps backward.
+static uint8_t  lora_tx_seq = 0;
 // lora_in_rx_mode forward-declared up with the hop state.
 static uint32_t lora_uplink_rx_count = 0;
 // CRC-passing decodes whose SNR was below loraMinValidSnrDb(current_sf)
@@ -1674,7 +1681,7 @@ static void serviceI2CIngress()
 }
 
 // ============================================================================
-static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
+static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint8_t seq)
 {
     if (out_payload == nullptr)
     {
@@ -1685,6 +1692,7 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA])
     // Routing header
     lora.network_id = network_id;
     lora.rocket_id  = rocket_id;
+    lora.seq        = seq;
     // Hop byte (#40 / #41).  Either tell the BS where we'll be for the
     // next packet, or send the no-hop sentinel.  During a rendezvous
     // visit (phase 2b) we explicitly send the sentinel — we're parked
@@ -1837,7 +1845,7 @@ static void serviceLoRa()
     }
 
     uint8_t payload[SIZE_OF_LORA_DATA] = {0};
-    if (!buildLoRaPayload(payload))
+    if (!buildLoRaPayload(payload, lora_tx_seq))
     {
         return;
     }
@@ -1846,6 +1854,9 @@ static void serviceLoRa()
     if (lora_comms.send(payload, sizeof(payload)))
     {
         lora_tx_ok++;
+        // Advance the seq AFTER a successful send — failed startTransmit()
+        // means nothing went over the air, so the BS shouldn't see a gap.
+        lora_tx_seq++;
 
         // Advance hop state and schedule the post-TX retune.  We can't
         // retune here directly (TX is still in progress); the top of
@@ -2524,8 +2535,13 @@ enum class RocketRendezvousState : uint8_t {
 static RocketRendezvousState rendezvous_state = RocketRendezvousState::IDLE;
 static uint32_t rendezvous_phase_start_ms = 0;
 
-static constexpr uint32_t RENDEZVOUS_TRIGGER_INITIAL_MS = 30000;  // never heard BS yet
-static constexpr uint32_t RENDEZVOUS_TRIGGER_QUIET_MS   = 120000; // BS seen, just idle
+// #105 follow-up: tightened from 30 s / 120 s to 15 s for both triggers so
+// the operator doesn't sit through a long silence after a flash with stale
+// NVS, or after any other source of channel divergence.  Cycle (window +
+// saved) still gives the BS Phase A 30 s window plenty of overlap for a
+// clean handshake.
+static constexpr uint32_t RENDEZVOUS_TRIGGER_INITIAL_MS = 15000;  // never heard BS yet
+static constexpr uint32_t RENDEZVOUS_TRIGGER_QUIET_MS   = 15000;  // BS seen, then silent
 static constexpr uint32_t RENDEZVOUS_WINDOW_MS          = 10000;  // on rendezvous freq
 static constexpr uint32_t RENDEZVOUS_SAVED_MS           = 20000;  // back on saved freq
 
@@ -2796,7 +2812,7 @@ static void printLoRaPayloadDebug()
     }
 
     uint8_t payload[SIZE_OF_LORA_DATA] = {0};
-    if (!buildLoRaPayload(payload))
+    if (!buildLoRaPayload(payload, lora_tx_seq))
     {
         return;
     }
@@ -3649,6 +3665,23 @@ static void setup_oc()
     // --- Load NVS settings early so config readback to app is correct ---
     {
         prefs.begin("lora", false);
+
+        // NVS schema gate (#105 follow-up).  Stored != current → clear the
+        // entire lora namespace so we fall back to the shared factory
+        // rendezvous values and let the BS re-sync us via the standard
+        // rendezvous flow.  Mirrors the BS side; both must agree on
+        // LORA_NVS_SCHEMA_VERSION (defined in RocketComputerTypes.h).
+        {
+            const uint8_t stored_v = prefs.getUChar("schemv", 0);
+            if (stored_v != LORA_NVS_SCHEMA_VERSION)
+            {
+                ESP_LOGW("CFG", "LoRa NVS schema mismatch (stored=%u, current=%u) — clearing",
+                         (unsigned)stored_v, (unsigned)LORA_NVS_SCHEMA_VERSION);
+                prefs.clear();
+                prefs.putUChar("schemv", LORA_NVS_SCHEMA_VERSION);
+            }
+        }
+
         if (prefs.isKey("freq"))
         {
             lora_freq_mhz = prefs.getFloat("freq", config::LORA_FREQ_MHZ);


### PR DESCRIPTION
## Summary

Closes #105. Diagnoses, mitigates, and redesigns LoRa frequency hopping after field tests showed frequent lock loss and slow recapture.

**Diagnostics added:**
- BS CSV gains `next_ch`, `rx_freq_mhz`, `seq`, `gap`, and `event` columns; per-packet `seq` (uint16) widens to cover all 69 channels at dwell=4.
- New EVENT rows: `hop_active`, `hop_inactive`, `hop_silence` (with duration, pkts, observed-loss, and silence_ms).
- `[STATS] HOP` line includes total observed loss, silence events, and (new) `drift_repush` count + `TX wdog: N`.

**Robust hop redesign:**
- **Slow-hop**: dwell=4 packets/channel (~2 s at 2 Hz), tolerant to single-packet drops without losing frequency lock.
- **Seq-anchored schedule**: channel computed from `seq / dwell % n_active`, not chained handoffs — recovers across missed packets.
- **BS follows rocket's `next_channel_idx`** as ground truth (mask drift between sides no longer breaks the link); seq-derived computation kept as a sanity warning.
- **Auto-repush on mask drift**: when the seq-derived warning fires, BS schedules a cmd-15 re-push (30 s cooldown) so the rocket converges to the BS's mask without operator action.
- **TX-stuck watchdog** in `TR_LoRa_Comms`: if `tx_ongoing_` stays set > 3 s (DIO1 IRQ missed + pollDio1 misclassification), force-clear and put the radio back in standby+RX. Counter exposed in stats.
- **Heartbeat gated by `inHopSafeWindow()`**: heartbeats only fire within 150 ms of a fresh rocket RX, keeping `last_uplink_rx_ms` warm without disturbing dwell-boundary retunes. Interval dropped 30s → 10s.

**Single-source rendezvous:**
- New `LORA_FACTORY_RENDEZVOUS_*` constants in `RocketComputerTypes.h` are the only source for fallback freq/SF/BW/CR/TX (closes the BS=915 vs OC=926.5 divergence we hit on first flash).
- `LORA_NVS_SCHEMA_VERSION` (currently 3) clears the `lora` namespace on cross-flash schema mismatch.
- OC rendezvous fallback drops 30s/120s → 15s/15s so re-sync after a long silence is fast for the operator.

**App / wire format:**
- Settings toggle inverted from "Disable frequency hopping" → "Enable frequency hopping" (cmd 17 polarity unchanged at the wire).
- LoRa proto bumped 1 → 4 (seq added, then widened to u16). cmd 15 wire format dropped its rendezvous_mhz field (skip-mask only).

## Test plan
- [x] 261/261 host tests pass (8 new gtests for `loraHopChannelForSeq`, expanded coverage on `loraComputeObservedLoss` u16 semantics, full-range u16 round-trip).
- [x] BS firmware builds clean.
- [x] OC firmware builds clean.
- [ ] Field flash both devices, confirm hop session sustains > 60 s with 0 hop_silence events on a clean run.
- [ ] Confirm `drift_repush` and `TX wdog` counters stay 0 in nominal operation.
- [ ] Toggle "Enable frequency hopping" off/on from the app; verify cmd 17 round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)