### PR TITLE
mag-cal: tumble-driven sphere fit + IIS2MDC OFFSET persistence (#96)

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -862,6 +862,32 @@ void TR_BLE_To_APP::sendScanResults(float start_mhz, float step_khz,
              (unsigned)total, (unsigned)n);
 }
 
+void TR_BLE_To_APP::sendMagCalStatus(const uint8_t* status_bytes, size_t len)
+{
+    if (!device_connected_ || status_bytes == nullptr || len == 0) return;
+    // 0xCA marker + payload.  Cap len defensively so a malformed FC frame
+    // can't blow the local buffer; the real payload is fixed at 22 bytes
+    // (sizeof(MagCalStatusData)).
+    constexpr size_t MAX_PAYLOAD = 64;
+    if (len > MAX_PAYLOAD) len = MAX_PAYLOAD;
+
+    uint8_t buf[1 + MAX_PAYLOAD];
+    buf[0] = 0xCA;
+    memcpy(&buf[1], status_bytes, len);
+
+    int rc = notify_data(conn_handle_, file_ops_val_handle_, buf, 1 + len);
+    if (rc != 0)
+    {
+        // Don't spam at high cadence — log once per failure burst.
+        static uint32_t fail_count = 0;
+        if ((fail_count++ % 32) == 0)
+        {
+            ESP_LOGW(BLE_TAG, "Mag-cal status notify failed, rc=%d (count=%lu)",
+                     rc, (unsigned long)fail_count);
+        }
+    }
+}
+
 void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
                                    size_t len, bool eof)
 {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -154,6 +154,15 @@ public:
     void sendScanResults(float start_mhz, float step_khz,
                          const int8_t* rssi, uint8_t n);
 
+    // Send a magnetometer calibration status frame as a compact binary
+    // blob on the file-ops characteristic (issue #96).  Format:
+    //   [0][0xCA marker] [1..22][MagCalStatusData LE bytes]
+    // Distinct discriminator from sendScanResults' 0xAA so the iOS app
+    // can route both off the same subscription.  The JSON responses (file
+    // list, config) start with '[' or '{' which can never collide with
+    // 0xAA / 0xCA, so all four payload kinds coexist on this channel.
+    void sendMagCalStatus(const uint8_t* status_bytes, size_t len);
+
     // Get pending download filename (empty if none)
     // Clears the filename after reading
     String getDownloadFilename();

--- a/tinkerrocket-idf/components/TR_IIS2MDC/TR_IIS2MDC.cpp
+++ b/tinkerrocket-idf/components/TR_IIS2MDC/TR_IIS2MDC.cpp
@@ -154,6 +154,28 @@ TR_IIS2MDCStatus TR_IIS2MDC::readWhoAmI(uint8_t *id)
 }
 
 // ---------------------------------------------------------------------------
+//  setHardIronOffset – write OFFSET_X/Y/Z (0x45..0x4A) in raw LSB units
+// ---------------------------------------------------------------------------
+TR_IIS2MDCStatus TR_IIS2MDC::setHardIronOffset(int16_t cx, int16_t cy, int16_t cz)
+{
+    // Datasheet 9.7: each axis is a signed 16-bit offset stored L then H.
+    // Sub-address auto-increments across the 6-byte block on multi-byte
+    // writes (datasheet 6.1.1), but we issue 6 single-byte writes for
+    // simplicity — this is one-shot per cal accept / boot, not a hot path.
+    const uint16_t ux = (uint16_t)cx;
+    const uint16_t uy = (uint16_t)cy;
+    const uint16_t uz = (uint16_t)cz;
+
+    if (writeRegister(IIS2MDC_Reg::OFFSET_X_REG_L, (uint8_t)(ux & 0xFF))      != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    if (writeRegister(IIS2MDC_Reg::OFFSET_X_REG_H, (uint8_t)((ux >> 8) & 0xFF)) != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    if (writeRegister(IIS2MDC_Reg::OFFSET_Y_REG_L, (uint8_t)(uy & 0xFF))      != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    if (writeRegister(IIS2MDC_Reg::OFFSET_Y_REG_H, (uint8_t)((uy >> 8) & 0xFF)) != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    if (writeRegister(IIS2MDC_Reg::OFFSET_Z_REG_L, (uint8_t)(uz & 0xFF))      != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    if (writeRegister(IIS2MDC_Reg::OFFSET_Z_REG_H, (uint8_t)((uz >> 8) & 0xFF)) != TR_IIS2MDC_OK) return TR_IIS2MDC_ERROR;
+    return TR_IIS2MDC_OK;
+}
+
+// ---------------------------------------------------------------------------
 //  Low-level I2C register access (8-bit registers)
 // ---------------------------------------------------------------------------
 TR_IIS2MDCStatus TR_IIS2MDC::writeRegister(uint8_t reg, uint8_t value)

--- a/tinkerrocket-idf/components/TR_IIS2MDC/TR_IIS2MDC.h
+++ b/tinkerrocket-idf/components/TR_IIS2MDC/TR_IIS2MDC.h
@@ -121,6 +121,13 @@ public:
     /// Read X, Y, Z magnetic field as raw signed 16-bit counts (one 6-byte burst).
     TR_IIS2MDCStatus readRawXYZ(IIS2MDC_RawData *out);
 
+    /// Program the chip's hard-iron OFFSET_X/Y/Z registers.  Values are in
+    /// raw LSB units (0.15 µT/LSB, signed 16-bit).  The chip subtracts
+    /// these from every sample before producing OUT registers, so the
+    /// I2S-streamed counts are already corrected — no further work for
+    /// downstream consumers (OC, EKF, telemetry).  Issue #96.
+    TR_IIS2MDCStatus setHardIronOffset(int16_t cx, int16_t cy, int16_t cz);
+
     /// Read X, Y, Z magnetic field in microtesla.
     TR_IIS2MDCStatus readFieldsXYZ_uT(float *x_uT, float *y_uT, float *z_uT);
 

--- a/tinkerrocket-idf/components/TR_MagCalibrator/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "TR_MagCalibrator.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_RocketComputerTypes)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -1,0 +1,376 @@
+#include "TR_MagCalibrator.h"
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char* TAG = "MAGCAL";
+#endif
+
+// IIS2MDC native sensitivity: 0.15 µT/LSB (datasheet 9.13).  The
+// calibrator works in raw int16 counts so the fit can be programmed
+// directly into OFFSET_X/Y/Z without scaling round-trips; this constant
+// only shows up where we need µT for the R-band gate or BLE telemetry.
+static constexpr float IIS2MDC_LSB_TO_uT = 0.15f;
+
+// Gaussian-elimination 4×4 solver (in-place; A is destroyed).  Returns
+// false if the matrix is singular (degenerate sample geometry, e.g. all
+// samples on a great circle — happens if the user only spins around one
+// axis).  Partial pivoting is enough; the system is symmetric PSD when
+// well-conditioned.
+static bool solve4x4(double A[4][4], double b[4], double x[4])
+{
+    for (int col = 0; col < 4; col++)
+    {
+        // Partial pivot
+        int piv = col;
+        double piv_abs = fabs(A[col][col]);
+        for (int row = col + 1; row < 4; row++)
+        {
+            double a = fabs(A[row][col]);
+            if (a > piv_abs) { piv = row; piv_abs = a; }
+        }
+        if (piv_abs < 1e-9) return false;
+        if (piv != col)
+        {
+            for (int k = 0; k < 4; k++) { double t = A[col][k]; A[col][k] = A[piv][k]; A[piv][k] = t; }
+            double t = b[col]; b[col] = b[piv]; b[piv] = t;
+        }
+        // Eliminate below
+        for (int row = col + 1; row < 4; row++)
+        {
+            const double f = A[row][col] / A[col][col];
+            for (int k = col; k < 4; k++) A[row][k] -= f * A[col][k];
+            b[row] -= f * b[col];
+        }
+    }
+    // Back-substitute
+    for (int row = 3; row >= 0; row--)
+    {
+        double s = b[row];
+        for (int k = row + 1; k < 4; k++) s -= A[row][k] * x[k];
+        x[row] = s / A[row][row];
+    }
+    return true;
+}
+
+MagCalibrator::MagCalibrator()
+    : n_samples_(0),
+      coverage_mask_(0),
+      last_x_(0), last_y_(0), last_z_(0),
+      fit_cx_(0), fit_cy_(0), fit_cz_(0),
+      fit_R_uT_(0.0f),
+      fit_residual_uT_(0.0f),
+      fit_reject_code_(MAG_CAL_OK),
+      fit_valid_(false),
+      state_(State::IDLE)
+{}
+
+void MagCalibrator::start()
+{
+    n_samples_ = 0;
+    coverage_mask_ = 0;
+    last_x_ = last_y_ = last_z_ = 0;
+    fit_valid_ = false;
+    fit_cx_ = fit_cy_ = fit_cz_ = 0;
+    fit_R_uT_ = 0.0f;
+    fit_residual_uT_ = 0.0f;
+    fit_reject_code_ = MAG_CAL_OK;
+    state_ = State::SAMPLING;
+#ifdef ESP_PLATFORM
+    ESP_LOGI(TAG, "start: SAMPLING, target=%u samples", (unsigned)MAX_SAMPLES);
+#endif
+}
+
+void MagCalibrator::abort()
+{
+    state_ = State::ABORTED;
+#ifdef ESP_PLATFORM
+    ESP_LOGI(TAG, "abort: ABORTED (n=%u)", (unsigned)n_samples_);
+#endif
+}
+
+void MagCalibrator::retry()
+{
+    start();
+}
+
+bool MagCalibrator::accept()
+{
+    if (state_ != State::REVIEW || !fit_valid_) return false;
+    state_ = State::APPLIED;
+#ifdef ESP_PLATFORM
+    ESP_LOGI(TAG, "accept: APPLIED (cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT)",
+             (int)fit_cx_, (int)fit_cy_, (int)fit_cz_,
+             (double)fit_R_uT_, (double)fit_residual_uT_);
+#endif
+    return true;
+}
+
+void MagCalibrator::clear()
+{
+    state_ = State::IDLE;
+}
+
+bool MagCalibrator::addSample(int16_t x, int16_t y, int16_t z)
+{
+    if (state_ != State::SAMPLING) return false;
+    if (n_samples_ >= MAX_SAMPLES) return false;
+
+    samples_x_[n_samples_] = x;
+    samples_y_[n_samples_] = y;
+    samples_z_[n_samples_] = z;
+    n_samples_++;
+
+    last_x_ = x;
+    last_y_ = y;
+    last_z_ = z;
+
+    const uint8_t wedge = directionWedge(x, y, z);
+    if (wedge < 27) coverage_mask_ |= (1u << wedge);
+
+    if (n_samples_ >= MAX_SAMPLES)
+    {
+        runFit();
+        state_ = State::REVIEW;
+#ifdef ESP_PLATFORM
+        ESP_LOGI(TAG, "fit complete: cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT cov=%u/26 reject=%u",
+                 (int)fit_cx_, (int)fit_cy_, (int)fit_cz_,
+                 (double)fit_R_uT_, (double)fit_residual_uT_,
+                 (unsigned)__builtin_popcount(coverage_mask_),
+                 (unsigned)fit_reject_code_);
+#endif
+        return true;
+    }
+    return false;
+}
+
+void MagCalibrator::getProgress(uint16_t& sample_count,
+                                uint8_t&  coverage_bins,
+                                float&    inst_field_uT) const
+{
+    sample_count = n_samples_;
+    coverage_bins = (uint8_t)__builtin_popcount(coverage_mask_);
+    // |B| of the most recent sample, in µT.  Note: this is pre-fit-apply
+    // — the IIS2MDC chip's OFFSET registers haven't been programmed yet
+    // during cal, so this includes the hard-iron contribution.  After
+    // accept(), boot-time apply zeroes the offset out of the raw stream.
+    const float fx = (float)last_x_ * IIS2MDC_LSB_TO_uT;
+    const float fy = (float)last_y_ * IIS2MDC_LSB_TO_uT;
+    const float fz = (float)last_z_ * IIS2MDC_LSB_TO_uT;
+    inst_field_uT = sqrtf(fx*fx + fy*fy + fz*fz);
+}
+
+void MagCalibrator::getResult(int16_t& cx, int16_t& cy, int16_t& cz,
+                              float& R_uT, float& residual_uT,
+                              uint8_t& reject_code) const
+{
+    cx = fit_cx_;
+    cy = fit_cy_;
+    cz = fit_cz_;
+    R_uT = fit_R_uT_;
+    residual_uT = fit_residual_uT_;
+    reject_code = fit_reject_code_;
+}
+
+void MagCalibrator::buildStatusFrame(uint32_t time_us, MagCalStatusData& out) const
+{
+    memset(&out, 0, sizeof(out));
+    out.time_us = time_us;
+
+    switch (state_)
+    {
+        case State::IDLE:     out.sub_type = MAG_CAL_SUB_IDLE;     break;
+        case State::SAMPLING: out.sub_type = MAG_CAL_SUB_SAMPLING; break;
+        case State::REVIEW:   out.sub_type = MAG_CAL_SUB_REVIEW;   break;
+        case State::APPLIED:  out.sub_type = MAG_CAL_SUB_APPLIED;  break;
+        case State::ABORTED:  out.sub_type = MAG_CAL_SUB_ABORTED;  break;
+    }
+
+    out.coverage_bins = (uint8_t)__builtin_popcount(coverage_mask_);
+    out.sample_count  = n_samples_;
+
+    // Instantaneous field magnitude (most recent sample).
+    {
+        const float fx = (float)last_x_ * IIS2MDC_LSB_TO_uT;
+        const float fy = (float)last_y_ * IIS2MDC_LSB_TO_uT;
+        const float fz = (float)last_z_ * IIS2MDC_LSB_TO_uT;
+        const float mag_uT = sqrtf(fx*fx + fy*fy + fz*fz);
+        const float mag_x10 = mag_uT * 10.0f;
+        out.inst_field_uT_x10 = (mag_x10 < 0.0f) ? 0u
+                              : (mag_x10 > 65535.0f) ? 65535u
+                              : (uint16_t)mag_x10;
+    }
+
+    if (fit_valid_)
+    {
+        out.offset_x = fit_cx_;
+        out.offset_y = fit_cy_;
+        out.offset_z = fit_cz_;
+        const float r_x10 = fit_R_uT_ * 10.0f;
+        const float res_x10 = fit_residual_uT_ * 10.0f;
+        out.field_R_uT_x10  = (r_x10 < 0.0f) ? 0u : (r_x10 > 65535.0f) ? 65535u : (uint16_t)r_x10;
+        out.residual_uT_x10 = (res_x10 < 0.0f) ? 0u : (res_x10 > 65535.0f) ? 65535u : (uint16_t)res_x10;
+        out.reject_code     = fit_reject_code_;
+    }
+}
+
+uint8_t MagCalibrator::directionWedge(int16_t x, int16_t y, int16_t z)
+{
+    // Reject the zero vector (sample exactly at origin — implausible from
+    // a real sensor, but defends against a degenerate path).
+    const double xx = (double)x * (double)x;
+    const double yy = (double)y * (double)y;
+    const double zz = (double)z * (double)z;
+    const double r2 = xx + yy + zz;
+    if (r2 <= 0.0) return 27;  // sentinel = invalid
+
+    const double r = sqrt(r2);
+    const double ux = (double)x / r;
+    const double uy = (double)y / r;
+    const double uz = (double)z / r;
+
+    // Threshold = 0.4: a unit vector with all three |components| < 0.4
+    // would need r < sqrt(3) * 0.4 ≈ 0.69, which is impossible — so the
+    // (0,0,0) center cell never lights up and we get exactly 26 reachable
+    // wedges.
+    constexpr double T = 0.4;
+    auto bin = [](double v) -> int {
+        return (v < -T) ? 0 : (v > T) ? 2 : 1;
+    };
+    const int bx = bin(ux);
+    const int by = bin(uy);
+    const int bz = bin(uz);
+    return (uint8_t)(bx * 9 + by * 3 + bz);  // 0..26 (13 = center, never set)
+}
+
+void MagCalibrator::runFit()
+{
+    fit_valid_ = false;
+    fit_cx_ = fit_cy_ = fit_cz_ = 0;
+    fit_R_uT_ = 0.0f;
+    fit_residual_uT_ = 0.0f;
+    fit_reject_code_ = MAG_CAL_OK;
+
+    if (n_samples_ < MAG_CAL_MIN_SAMPLES) return;
+
+    // Accumulate sums in double.  Centroid-shifting before solving keeps
+    // the cross-product sums small (cancel the bulk of the offset before
+    // squaring), which preserves ~7+ digits of precision in the normal
+    // equations even with raw counts in the ~1e4 range.
+    double sx = 0.0, sy = 0.0, sz = 0.0;
+    for (uint16_t i = 0; i < n_samples_; i++)
+    {
+        sx += (double)samples_x_[i];
+        sy += (double)samples_y_[i];
+        sz += (double)samples_z_[i];
+    }
+    const double mx = sx / (double)n_samples_;
+    const double my = sy / (double)n_samples_;
+    const double mz = sz / (double)n_samples_;
+
+    // Normal-equation accumulators on centered samples (xc = x - mx etc).
+    // A row = [2·xc, 2·yc, 2·zc, 1]; b = xc² + yc² + zc².
+    double sxx = 0.0, syy = 0.0, szz = 0.0;
+    double sxy = 0.0, sxz = 0.0, syz = 0.0;
+    double sx_c = 0.0, sy_c = 0.0, sz_c = 0.0;  // first-moments of centered samples (≈ 0 by construction)
+    double sb = 0.0;
+    double sxb = 0.0, syb = 0.0, szb = 0.0;
+
+    for (uint16_t i = 0; i < n_samples_; i++)
+    {
+        const double xc = (double)samples_x_[i] - mx;
+        const double yc = (double)samples_y_[i] - my;
+        const double zc = (double)samples_z_[i] - mz;
+        const double bi = xc*xc + yc*yc + zc*zc;
+
+        sxx += xc*xc; syy += yc*yc; szz += zc*zc;
+        sxy += xc*yc; sxz += xc*zc; syz += yc*zc;
+        sx_c += xc; sy_c += yc; sz_c += zc;
+        sb += bi;
+        sxb += xc * bi;
+        syb += yc * bi;
+        szb += zc * bi;
+    }
+
+    // Build symmetric AᵀA (4×4) and Aᵀb (4×1) for the centered solve.
+    double M[4][4] = {
+        { 4*sxx, 4*sxy, 4*sxz, 2*sx_c },
+        { 4*sxy, 4*syy, 4*syz, 2*sy_c },
+        { 4*sxz, 4*syz, 4*szz, 2*sz_c },
+        { 2*sx_c, 2*sy_c, 2*sz_c, (double)n_samples_ }
+    };
+    double rhs[4] = { 2*sxb, 2*syb, 2*szb, sb };
+    double p[4] = { 0, 0, 0, 0 };
+
+    if (!solve4x4(M, rhs, p))
+    {
+        // Singular (samples collinear / coplanar) — caller will flag low
+        // coverage, but mark fit as bad explicitly so accept() refuses.
+        fit_reject_code_ = MAG_CAL_REJECT_LOW_COVERAGE;
+        return;
+    }
+
+    // p in centered frame: cx_c, cy_c, cz_c, k_c where
+    //   (xc - cx_c)² + (yc - cy_c)² + (zc - cz_c)² = R²
+    // Translate back: cx = cx_c + mx, etc.  R is the same in both frames.
+    const double cx_c = p[0];
+    const double cy_c = p[1];
+    const double cz_c = p[2];
+    const double k_c  = p[3];
+    const double R2 = k_c + cx_c*cx_c + cy_c*cy_c + cz_c*cz_c;
+    if (!(R2 > 0.0))
+    {
+        fit_reject_code_ = MAG_CAL_REJECT_LOW_COVERAGE;
+        return;
+    }
+    const double R = sqrt(R2);
+
+    const double cx = cx_c + mx;
+    const double cy = cy_c + my;
+    const double cz = cz_c + mz;
+
+    // RMS residual in raw counts (then scaled to µT).
+    double rss = 0.0;
+    for (uint16_t i = 0; i < n_samples_; i++)
+    {
+        const double dx = (double)samples_x_[i] - cx;
+        const double dy = (double)samples_y_[i] - cy;
+        const double dz = (double)samples_z_[i] - cz;
+        const double ri = sqrt(dx*dx + dy*dy + dz*dz);
+        const double e = ri - R;
+        rss += e*e;
+    }
+    const double rms_counts = sqrt(rss / (double)n_samples_);
+
+    // Scale to µT for gating + reporting.
+    const float R_uT = (float)R * IIS2MDC_LSB_TO_uT;
+    const float res_uT = (float)rms_counts * IIS2MDC_LSB_TO_uT;
+
+    // Clamp offsets to int16 so OFFSET_X/Y/Z can hold them.  A clamp here
+    // means the underlying offset is bigger than the chip's tracking
+    // range — extremely unlikely in practice (current bench reads
+    // ~1640 µT ≈ 11k LSB, comfortably inside int16 ±32k).
+    auto clamp_i16 = [](double v) -> int16_t {
+        if (v >  32767.0) return  32767;
+        if (v < -32768.0) return -32768;
+        return (int16_t)lrint(v);
+    };
+    fit_cx_ = clamp_i16(cx);
+    fit_cy_ = clamp_i16(cy);
+    fit_cz_ = clamp_i16(cz);
+    fit_R_uT_ = R_uT;
+    fit_residual_uT_ = res_uT;
+    fit_valid_ = true;
+
+    // Gate the fit.  Order: coverage first (fastest reason to retry),
+    // then R band, then residual.  These are advisory codes — caller
+    // shows the right error in the iOS UI.
+    const uint8_t cov = (uint8_t)__builtin_popcount(coverage_mask_);
+    if (cov < MAG_CAL_MIN_COVERAGE_BINS)        fit_reject_code_ = MAG_CAL_REJECT_LOW_COVERAGE;
+    else if (R_uT < MAG_CAL_R_MIN_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_LOW;
+    else if (R_uT > MAG_CAL_R_MAX_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_HIGH;
+    else if (res_uT > MAG_CAL_MAX_RESIDUAL_UT)  fit_reject_code_ = MAG_CAL_REJECT_HIGH_RESIDUAL;
+    else                                         fit_reject_code_ = MAG_CAL_OK;
+}

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
@@ -1,0 +1,138 @@
+#ifndef TR_MAG_CALIBRATOR_H
+#define TR_MAG_CALIBRATOR_H
+
+// TR_MagCalibrator — hard-iron magnetometer calibration state machine.
+//
+// Issue #96.  Tumble-based sphere fit: the user rotates the rocket through
+// all orientations while the FC accumulates raw mag samples; the
+// calibrator solves a linear least-squares sphere fit to recover the
+// hard-iron offset (cx, cy, cz) and local field magnitude R.
+//
+// Math: a perfect magnetometer in a uniform Earth field traces a sphere
+// of radius |B_earth| (~50 µT) centered at the origin as the chip rotates.
+// A hard-iron source (magnetized component on the PCB, steel hardware)
+// shifts that sphere away from the origin; the offset is the new center.
+// Soft-iron distortion would warp the sphere into an ellipsoid — out of
+// scope for v1, see issue #96 follow-ups.
+//
+// Linear-LSQ form:
+//   (x − cx)² + (y − cy)² + (z − cz)² = R²
+//   2x·cx + 2y·cy + 2z·cz + k = x² + y² + z²       where k = R² − (cx² + cy² + cz²)
+// → 4×4 normal equations; hand-rolled Gaussian elimination keeps the
+// component dependency-free (no Eigen pull-in).
+//
+// Coverage: each sample's *direction* is binned into a 3×3×3 cube grid
+// (axis-aligned thresholds at ±0.4 of the unit vector).  The (0,0,0)
+// center cell is unreachable for a unit vector, leaving 26 wedges; a
+// well-tumbled capture lights up ≥ 18 of them (issue #96 gate).
+//
+// Units: samples come in as raw int16 LSB counts (IIS2MDC: 0.15 µT/LSB).
+// The fit is computed in raw counts and converted to µT only for the
+// review/reject decisions.  This keeps the offset programmable directly
+// into IIS2MDC OFFSET_X/Y/Z without scaling round-trips.
+
+#include <compat.h>
+#include <RocketComputerTypes.h>
+#include <stdint.h>
+
+class MagCalibrator
+{
+public:
+    enum class State : uint8_t {
+        IDLE      = 0,   // not running
+        SAMPLING  = 1,   // accumulating samples; waiting for cap or user-stop
+        REVIEW    = 2,   // sample cap hit, fit computed, awaiting user accept/retry/abort
+        APPLIED   = 3,   // user accepted; one-shot terminal so the FC can latch + transition
+        ABORTED   = 4    // user aborted or fit rejected during sampling-end → ready for IDLE
+    };
+
+    MagCalibrator();
+
+    // Begin sampling.  Clears prior buffer + coverage state.  Safe to call
+    // from any internal state — semantically identical to abort() then start().
+    void start();
+
+    // User-requested abort.  Drops samples, transitions to ABORTED so the
+    // FC can publish one final status frame before going IDLE.
+    void abort();
+
+    // User-requested retry from REVIEW.  Equivalent to start() — clears
+    // samples and goes back to SAMPLING.
+    void retry();
+
+    // User-accepted fit.  Returns false (and stays in REVIEW) if no fit is
+    // currently available (e.g. called before sample cap).  On success
+    // transitions to APPLIED; the caller should pull the fit via
+    // getResult() and then call clear() before the next start().
+    bool accept();
+
+    // Reset to IDLE.  Call after consuming an APPLIED or ABORTED state.
+    void clear();
+
+    // Feed one raw sample (int16 LSB counts, sensor frame — same units the
+    // IIS2MDC OFFSET registers consume).  No-op outside SAMPLING.  Returns
+    // true if the sample was the one that filled the buffer and triggered
+    // the fit + REVIEW transition (so the caller can publish a status
+    // frame promptly).
+    bool addSample(int16_t x, int16_t y, int16_t z);
+
+    State getState() const { return state_; }
+
+    // Live progress — meaningful in SAMPLING/REVIEW.  inst_field_uT is the
+    // |B| of the most recent sample (post-offset-subtract if a prior fit
+    // was applied; pre-offset on a fresh capture).
+    void getProgress(uint16_t& sample_count,
+                     uint8_t&  coverage_bins,
+                     float&    inst_field_uT) const;
+
+    // Final fit — meaningful only in REVIEW or APPLIED.  Caller checks
+    // reject_code: 0 = ready to accept, non-zero = retry recommended.
+    // R_uT is the fitted Earth-field magnitude in µT.  residual_uT is the
+    // RMS deviation of samples from the fitted sphere, in µT.
+    void getResult(int16_t& cx, int16_t& cy, int16_t& cz,
+                   float& R_uT, float& residual_uT,
+                   uint8_t& reject_code) const;
+
+    // Convenience: pack the current state into a MagCalStatusData ready
+    // for I2S TX.  time_us must be supplied by the caller (FC's monotonic
+    // clock).  Always returns a valid frame regardless of state.
+    void buildStatusFrame(uint32_t time_us, MagCalStatusData& out) const;
+
+private:
+    // Tunables — see MAG_CAL_* constants in RocketComputerTypes.h.
+    static constexpr uint16_t MAX_SAMPLES = MAG_CAL_MAX_SAMPLES;
+
+    // Sample storage.  3 × int16 × 1024 = 6 KiB on the FC heap.
+    int16_t samples_x_[MAX_SAMPLES];
+    int16_t samples_y_[MAX_SAMPLES];
+    int16_t samples_z_[MAX_SAMPLES];
+    uint16_t n_samples_;
+
+    // 3³ - 1 = 26 wedges (the all-center cell is unreachable for unit
+    // vectors).  Bit i set means wedge i has at least one sample.
+    uint32_t coverage_mask_;
+
+    // Most recent sample (for inst_field_uT progress reporting).
+    int16_t last_x_, last_y_, last_z_;
+
+    // Fit results in raw LSB counts.  R_lsb_ stays in raw units to dodge
+    // a scaling round-trip when programming OFFSET_X/Y/Z.  R is what we
+    // gate on, so cache it as float µT for cheap comparison.
+    int16_t fit_cx_, fit_cy_, fit_cz_;
+    float   fit_R_uT_;
+    float   fit_residual_uT_;
+    uint8_t fit_reject_code_;
+    bool    fit_valid_;
+
+    State state_;
+
+    // Map a unit-vector direction to a wedge index 0..25.  Returns
+    // 26 (= invalid) if the input is the zero vector.
+    static uint8_t directionWedge(int16_t x, int16_t y, int16_t z);
+
+    // Run the sphere fit on the current sample buffer.  Sets fit_*.  No-op
+    // if n_samples_ < MAG_CAL_MIN_SAMPLES.
+    void runFit();
+};
+
+#endif // TR_MAG_CALIBRATOR_H

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -38,13 +38,22 @@ static_assert(sizeof(DataReadyFlags) == 1,
               "DataReadyFlags must be 1 byte");
 
 // Rocket‐state enum
+//
+// MAG_CALIBRATION is an optional ground-only excursion from READY for the
+// hard-iron magnetometer cal flow (issue #96).  Entered by user request via
+// BLE cmd MAG_CAL_START, exits back to READY on accept/abort/retry.
+// Refused if the rocket is in PRELAUNCH/INFLIGHT/LANDED — only safe on the
+// pad / bench.  Sticky-flight, beacon, and hop predicates above all leave
+// MAG_CALIBRATION at their ground-state defaults (no lock, beacons on, no
+// hopping).
 enum RocketState : uint8_t
 {
     INITIALIZATION,
     READY,
     PRELAUNCH,
     INFLIGHT,
-    LANDED
+    LANDED,
+    MAG_CALIBRATION
 };
 
 // ============================================================================
@@ -675,6 +684,98 @@ typedef struct
     double mag_z_uT;
 } IIS2MDCDataSI;
 
+// --- Magnetometer hard-iron calibration status (#96) ---
+// Single fixed-size frame carrying either live progress, final fit (review),
+// applied (post-NVS-save), aborted, or idle.  FC→OC over I2S, and OC
+// forwards verbatim to the iOS app over BLE on the file_ops characteristic
+// with a 0xCA discriminator byte prepended.  Sized small so the OC→BLE
+// notification stays well under MTU regardless of negotiated value.
+//
+// Field encoding:
+//   offset_*       — raw IIS2MDC LSB units, signed 16-bit, 0.15 µT/LSB.
+//                    On the MMC5983MA path these are the centered-counts
+//                    offset (caller multiplies by UT_PER_COUNT for µT).
+//   *_uT_x10       — magnitude in tenths of µT (range 0..6553.5 µT, ~130×
+//                    Earth's field — plenty of headroom over the 50 µT
+//                    nominal and the 1640 µT residual seen on the new PCB).
+//   reject_code    — only meaningful when sub_type == REVIEW. 0 = fit
+//                    passes the R-band gate AND has sufficient coverage —
+//                    iOS shows "Accept".  Non-zero codes describe why iOS
+//                    should show "Retry".
+enum MagCalSubType : uint8_t {
+    MAG_CAL_SUB_IDLE     = 0,
+    MAG_CAL_SUB_SAMPLING = 1,
+    MAG_CAL_SUB_REVIEW   = 2,
+    MAG_CAL_SUB_APPLIED  = 3,
+    MAG_CAL_SUB_ABORTED  = 4
+};
+
+enum MagCalRejectCode : uint8_t {
+    MAG_CAL_OK                    = 0,
+    MAG_CAL_REJECT_R_TOO_LOW      = 1,  // fitted R < 20 µT
+    MAG_CAL_REJECT_R_TOO_HIGH     = 2,  // fitted R > 80 µT
+    MAG_CAL_REJECT_HIGH_RESIDUAL  = 3,  // RMS residual > threshold (poor sphere fit)
+    MAG_CAL_REJECT_LOW_COVERAGE   = 4   // < min populated wedges
+};
+
+typedef struct __attribute__((packed))
+{
+    uint32_t time_us;
+    uint8_t  sub_type;            // MagCalSubType
+    uint8_t  coverage_bins;       // 0..26 (3³ - 1 = 26 directional wedges populated)
+    uint16_t sample_count;        // total samples accumulated this run
+    uint16_t inst_field_uT_x10;   // |B| of the most recent sample × 10
+    int16_t  offset_x;            // fitted hard-iron offset (raw LSB units), or 0 if no fit
+    int16_t  offset_y;
+    int16_t  offset_z;
+    uint16_t field_R_uT_x10;      // fitted Earth-field magnitude × 10, or 0 if no fit
+    uint16_t residual_uT_x10;     // fit RMS residual × 10
+    uint8_t  reject_code;         // MagCalRejectCode (only valid in REVIEW)
+    uint8_t  _pad;
+} MagCalStatusData;
+static_assert(sizeof(MagCalStatusData) == 22,
+              "MagCalStatusData must be 22 bytes");
+
+// MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
+// int32_t in the same 18-bit signed centered-counts space as
+// mmc5983ma_centered_counts() returns.  Subtracted before scaling to µT.
+typedef struct __attribute__((packed))
+{
+    int32_t cx_counts;
+    int32_t cy_counts;
+    int32_t cz_counts;
+} MagCalMMCOffset;
+static_assert(sizeof(MagCalMMCOffset) == 12,
+              "MagCalMMCOffset must be 12 bytes");
+
+// Sphere-fit R sanity gate (issue #96).  WMM total field at Earth's
+// surface ranges ~22-67 µT.  20-80 µT covers everywhere with margin and
+// rejects fits dominated by a moving magnet during tumble.
+static constexpr float MAG_CAL_R_MIN_UT = 20.0f;
+static constexpr float MAG_CAL_R_MAX_UT = 80.0f;
+
+// Coverage gate — minimum populated wedges (out of 26) for the fit to be
+// considered well-conditioned.  A perfect tumble hits all 26; insisting on
+// 26 is fragile, so we accept ≥ 18 (8 octants + ~10 of the edges/faces).
+static constexpr uint8_t MAG_CAL_MIN_COVERAGE_BINS = 18;
+
+// Residual gate — RMS deviation from the fitted sphere, in µT.  A clean
+// sphere on the bench should sit well under 5 µT; bigger means soft-iron
+// or moving interferer dominated the capture.
+static constexpr float MAG_CAL_MAX_RESIDUAL_UT = 8.0f;
+
+// Sample-buffer cap.  At 100 Hz IIS2MDC ODR, 1024 samples = ~10 s of
+// tumble — long enough to cover all wedges with normal hand-tumble pace.
+static constexpr uint16_t MAG_CAL_MAX_SAMPLES = 1024;
+
+// Minimum samples before we'll attempt a fit.  Matches the issue's "≥500
+// samples (~5 s at 100 Hz)" guidance.
+static constexpr uint16_t MAG_CAL_MIN_SAMPLES = 500;
+
+// NVS schema version for the mag_cal namespace.  Bump if the persisted
+// field set changes meaningfully so old persisted state is ignored.
+static constexpr uint8_t MAG_CAL_NVS_SCHEMA_VERSION = 1;
+
 // --- Non sensor data ---
 typedef struct __attribute__((packed))
 {
@@ -1055,6 +1156,16 @@ static constexpr uint8_t IIS2MDC_MSG          = 0xD1;  // new-PCB IIS2MDC magnet
 static constexpr uint8_t SNAPSHOT_MSG         = 0xD2;  // FlightSnapshotData — FC→OC over I2S during INFLIGHT,
                                                        // and OC→FC over I2C as the response to GET_FLIGHT_SNAPSHOT
 static constexpr uint8_t GET_FLIGHT_SNAPSHOT  = 0xD3;  // FC→OC: request the latest snapshot from MRAM at boot
+
+// --- Magnetometer hard-iron cal (issue #96) ---
+// OC→FC commands (passed via I2C as setPendingCommand byte) and a single
+// FC→OC status message that carries either live progress or the final fit.
+static constexpr uint8_t MAG_CAL_START        = 0xD4;  // OC→FC: enter MAG_CALIBRATION + begin sampling
+static constexpr uint8_t MAG_CAL_ABORT        = 0xD5;  // OC→FC: drop sampling, return to READY
+static constexpr uint8_t MAG_CAL_ACCEPT       = 0xD6;  // OC→FC: persist current fit, apply offsets, return to READY
+static constexpr uint8_t MAG_CAL_RETRY        = 0xD7;  // OC→FC: discard fit, restart sampling
+static constexpr uint8_t MAG_CAL_STATUS_MSG   = 0xD8;  // FC→OC: live progress / final result (MagCalStatusData)
+
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
 // Camera types

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -838,6 +838,12 @@ bool SensorCollector::getIIS2MDCData(IIS2MDCData& iis2mdc_out)
     return false;
 }
 
+bool SensorCollector::setIIS2MDCHardIronOffset(int16_t cx, int16_t cy, int16_t cz)
+{
+    if (!iis2mdc_active) return false;
+    return iis2mdc.setHardIronOffset(cx, cy, cz) == TR_IIS2MDC_OK;
+}
+
 bool SensorCollector::getGNSSData(GNSSData& gnss_out)
 {
     if (gnss_data_ready && xSemaphoreTake(gnssDataSemaphore, 0) == pdTRUE)

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -116,6 +116,15 @@ public:
     int16_t gyro_cal_y;
     int16_t gyro_cal_z;
 
+    // True iff IIS2MDC was detected at boot and is the active mag path.
+    // (Issue #96 — needed by the cal flow to choose IIS2MDC OFFSET regs
+    // vs. MMC software offset.)
+    bool isIIS2MDCActive() const { return iis2mdc_active; }
+
+    // Program IIS2MDC OFFSET_X/Y/Z hard-iron registers.  Returns false if
+    // the IIS2MDC isn't active or the I2C write failed.  Issue #96.
+    bool setIIS2MDCHardIronOffset(int16_t cx, int16_t cy, int16_t cz);
+
     // Calibration results (populated by calibrateGyro)
     float hg_bias_x = 0.0f, hg_bias_y = 0.0f, hg_bias_z = 0.0f;  // m/s², body frame
     float cal_gravity_mag = 0.0f;  // measured gravity magnitude from low-g (m/s²)

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -68,6 +68,18 @@ void SensorCollectorSim::calibrateGyro(float rotation_z_deg)
     cal_gravity_mag  = real_.cal_gravity_mag;
 }
 
+bool SensorCollectorSim::setIIS2MDCHardIronOffset(int16_t cx, int16_t cy, int16_t cz)
+{
+    if (isSimActive())
+    {
+        // No physical IIS2MDC interaction in sim mode; cal flow is gated on
+        // READY and we don't enter sim from there, so this branch is mostly
+        // defensive.
+        return false;
+    }
+    return real_.setIIS2MDCHardIronOffset(cx, cy, cz);
+}
+
 // ============================================================================
 // Sim Control
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
@@ -47,6 +47,13 @@ public:
     float hg_bias_x = 0.0f, hg_bias_y = 0.0f, hg_bias_z = 0.0f;
     float cal_gravity_mag = 0.0f;
 
+    // Mag hard-iron offset passthrough (issue #96).  In sim, the IIS2MDC
+    // path is offline so the setter is a no-op; isIIS2MDCActive() returns
+    // the real-collector's state regardless of sim mode so the boot apply
+    // path still works after reverting from sim to live.
+    bool isIIS2MDCActive() const { return real_.isIIS2MDCActive(); }
+    bool setIIS2MDCHardIronOffset(int16_t cx, int16_t cy, int16_t cz);
+
     // ---- Sim control ----
     void configureSim(const SimConfigData& cfg);
     void configureSimRotation(float ism6_rot_z_deg);

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -74,6 +74,21 @@ void SensorConverter::setHighGBias(float bx, float by, float bz)
 #endif
 }
 
+void SensorConverter::setMMCOffset(int32_t cx_counts, int32_t cy_counts, int32_t cz_counts)
+{
+    if (cx_counts == mmc_offset_cx_ && cy_counts == mmc_offset_cy_ && cz_counts == mmc_offset_cz_)
+    {
+        return;  // No change
+    }
+    mmc_offset_cx_ = cx_counts;
+    mmc_offset_cy_ = cy_counts;
+    mmc_offset_cz_ = cz_counts;
+#ifdef ESP_PLATFORM
+    ESP_LOGI("Converter", "MMC hard-iron offset set: %ld, %ld, %ld counts",
+             (long)cx_counts, (long)cy_counts, (long)cz_counts);
+#endif
+}
+
 
 // --- GNSS ---
 void SensorConverter::convertGNSSData(const GNSSData& in, GNSSDataSI& out)
@@ -205,9 +220,13 @@ void SensorConverter::convertMMC5983MAData(const MMC5983MAData& in, MMC5983MADat
 {
   out.time_us = in.time_us;
 
-  const int32_t cx = mmc5983ma_centered_counts(in.mag_x);
-  const int32_t cy = mmc5983ma_centered_counts(in.mag_y);
-  const int32_t cz = mmc5983ma_centered_counts(in.mag_z);
+  // Subtract the hard-iron offset (issue #96).  The MMC chip has no
+  // on-board offset register, so the cal flow stores the offset in the
+  // converter and we apply it post-centering.  Defaults to zero, so
+  // behaviour is unchanged on uncalibrated boards.
+  const int32_t cx = mmc5983ma_centered_counts(in.mag_x) - mmc_offset_cx_;
+  const int32_t cy = mmc5983ma_centered_counts(in.mag_y) - mmc_offset_cy_;
+  const int32_t cz = mmc5983ma_centered_counts(in.mag_z) - mmc_offset_cz_;
 
   // Gauss = centered * (8 / 131072)
   // SI: uT = Gauss * 100
@@ -227,9 +246,10 @@ void SensorConverter::convertMMC5983MAData(const MMC5983MAData& in, MMC5983MADat
 }
 
 // --- IIS2MDC (new-PCB magnetometer) ---
-// Sensitivity per datasheet 9.13: 1.5 mgauss/LSB = 0.15 uT/LSB. Raw is
-// already signed int16 centered at 0 (no offset register subtract here —
-// see TR_IIS2MDC's softReset path which zeroes OFFSET_X/Y/Z).
+// Sensitivity per datasheet 9.13: 1.5 mgauss/LSB = 0.15 uT/LSB.  Raw is
+// already signed int16 centered at 0; if the FC has loaded a hard-iron
+// calibration (issue #96), the chip's OFFSET_X/Y/Z registers have already
+// subtracted the offset upstream — no software subtract needed here.
 void SensorConverter::convertIIS2MDCData(const IIS2MDCData& in, IIS2MDCDataSI& out)
 {
     out.time_us = in.time_us;

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
@@ -49,6 +49,13 @@ public:
     // Subtracted from ISM6HG256 high-g output during conversion.
     void setHighGBias(float bx, float by, float bz);
 
+    // Set MMC5983MA hard-iron offset in centered-counts (issue #96).
+    // The MMC chip has no on-board offset register, so the offset is
+    // applied here — subtracted from the post-centering counts before
+    // scaling to µT.  IIS2MDC has its own OFFSET_X/Y/Z registers so this
+    // setter is irrelevant on the new PCB rev's mag path.
+    void setMMCOffset(int32_t cx_counts, int32_t cy_counts, int32_t cz_counts);
+
     // --- Data Conversion Functions ---
     // Convert from packed to human readable SI
     void convertGNSSData(const GNSSData& in, 
@@ -90,6 +97,11 @@ private:
 
     // High-g accelerometer bias (m/s², body frame)
     float hg_bias_x_ = 0.0f, hg_bias_y_ = 0.0f, hg_bias_z_ = 0.0f;
+
+    // MMC5983MA hard-iron offset (centered-counts, issue #96).  Applied in
+    // convertMMC5983MAData; zero by default so behaviour is unchanged
+    // until the FC pushes a calibrated offset via setMMCOffset.
+    int32_t mmc_offset_cx_ = 0, mmc_offset_cy_ = 0, mmc_offset_cz_ = 0;
   
     // --- Encode/Decode Helpers ---
     static float decodeVoltageFromInt(uint16_t raw);

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -789,6 +789,7 @@ static const char* rocketStateToString(uint8_t state)
         case 2:  return "PRELAUNCH";
         case 3:  return "INFLIGHT";
         case 4:  return "LANDED";
+        case 5:  return "MAG_CAL";
         default: return "UNKNOWN";
     }
 }

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
         TR_Sensor_Data_Converter
         TR_GpsInsEKF
         TR_KinematicChecks
+        TR_MagCalibrator
         TR_ServoControl_ledc_mult
         TR_GuidancePN
         TR_ControlMixer

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -12,6 +12,7 @@
 #include <TR_Sensor_Data_Converter.h>
 #include <TR_GpsInsEKF.h>
 #include <TR_KinematicChecks.h>
+#include <TR_MagCalibrator.h>
 #include <TR_ServoControl_ledc_mult.h>
 #include <TR_GuidancePN.h>
 #include <TR_ControlMixer.h>
@@ -72,6 +73,18 @@ TR_I2C_Interface i2c_interface(config::ESP_I2C_ADR);
 // I2S stream for high-frequency telemetry to OutComputer
 static TR_I2S_Stream i2s_stream;
 SensorConverter sensor_converter;
+
+// Hard-iron mag calibration (issue #96).  Runs only while rocket_state ==
+// MAG_CALIBRATION; pad cal flow only, gated against any in-air state.
+static MagCalibrator mag_calibrator;
+static int64_t mag_cal_last_status_us = 0;
+static bool    mag_cal_status_dirty   = false;  // true → publish on next tick regardless of cadence
+
+// IIS2MDC OFFSET regs are zeroed by softReset() inside sensor_collector.begin(),
+// so a calibrated boot has to defer the chip-side write until after begin()
+// completes.  Loaded from NVS in setup(); applied after sensor_collector.begin().
+static int16_t pending_mag_cx = 0, pending_mag_cy = 0, pending_mag_cz = 0;
+static bool    pending_mag_apply = false;
 
 static ISM6HG256Data ism6hg256_data;
 static uint8_t ism6hg256_data_buffer[SIZE_OF_ISM6HG256_DATA];
@@ -1277,6 +1290,49 @@ static void setup_fc()
     }
     prefs.end();
 
+    // Restore magnetometer hard-iron offset from NVS (namespace "mag_cal", issue #96).
+    // Apply to IIS2MDC OFFSET_X/Y/Z if the chip is active, and to the
+    // MMC5983MA software-offset path in the converter regardless (the
+    // converter is a no-op on uncalibrated MMC counts since defaults are
+    // zero).  IIS2MDC offsets must be reapplied AFTER sensor_collector.begin()
+    // because softReset() inside begin() zeroes them — ensure call order
+    // below.  The converter offset is set here too even though the IIS2MDC
+    // chip handles its own subtraction; this lets a single NVS schema cover
+    // both mag chips without divergence.
+    prefs.begin("mag_cal", false);
+    if (prefs.isKey("ver"))
+    {
+        const uint8_t schema = prefs.getUChar("ver", 0);
+        if (schema == MAG_CAL_NVS_SCHEMA_VERSION && prefs.getBool("done", false))
+        {
+            const int16_t cx = (int16_t)prefs.getShort("cx", 0);
+            const int16_t cy = (int16_t)prefs.getShort("cy", 0);
+            const int16_t cz = (int16_t)prefs.getShort("cz", 0);
+            const float   R  = prefs.getFloat("R_uT", 0.0f);
+            const int32_t mmc_cx = prefs.getInt("mmc_cx", 0);
+            const int32_t mmc_cy = prefs.getInt("mmc_cy", 0);
+            const int32_t mmc_cz = prefs.getInt("mmc_cz", 0);
+            sensor_converter.setMMCOffset(mmc_cx, mmc_cy, mmc_cz);
+            ESP_LOGI(TAG, "NVS mag_cal: offset=(%d,%d,%d) raw counts, R=%.2f µT (apply after sensor_collector.begin)",
+                          (int)cx, (int)cy, (int)cz, (double)R);
+            // Stash on the side; we'll apply to the IIS2MDC chip after begin()
+            // returns (softReset inside begin() zeroes OFFSET_X/Y/Z).
+            pending_mag_cx = cx;
+            pending_mag_cy = cy;
+            pending_mag_cz = cz;
+            pending_mag_apply = true;
+        }
+        else if (schema != MAG_CAL_NVS_SCHEMA_VERSION)
+        {
+            ESP_LOGW(TAG, "NVS mag_cal: schema %u != %u, ignoring", schema, (unsigned)MAG_CAL_NVS_SCHEMA_VERSION);
+        }
+    }
+    else
+    {
+        ESP_LOGI(TAG, "NVS mag_cal: none (uncalibrated)");
+    }
+    prefs.end();
+
     // Load roll profile from NVS (namespace "rollp")
     prefs.begin("rollp", false);  // read-write (creates namespace on first boot)
     if (prefs.isKey("prof"))
@@ -1345,6 +1401,17 @@ static void setup_fc()
     sensor_converter.configureMMC5983MARotationZ(config::MMC5983MA_ROT_Z_DEG);
     sensor_converter.configureIIS2MDCRotationZ(config::IIS2MDC_ROT_Z_DEG);
     sensor_collector.configureSimRotation(config::ISM6HG256_ROT_Z_DEG);
+
+    // Apply mag hard-iron offset to the IIS2MDC chip now that begin() has
+    // finished its softReset (which zeroes OFFSET_X/Y/Z).  Issue #96.
+    if (pending_mag_apply && sensor_collector.isIIS2MDCActive())
+    {
+        const bool ok = sensor_collector.setIIS2MDCHardIronOffset(
+                          pending_mag_cx, pending_mag_cy, pending_mag_cz);
+        ESP_LOGI(TAG, "IIS2MDC OFFSET applied: (%d,%d,%d) %s",
+                 (int)pending_mag_cx, (int)pending_mag_cy, (int)pending_mag_cz,
+                 ok ? "OK" : "FAILED");
+    }
 
     out_status_query_data.ism6_low_g_fs_g = config::ISM6_LOW_G_FS_G;
     out_status_query_data.ism6_high_g_fs_g = config::ISM6_HIGH_G_FS_G;
@@ -1716,6 +1783,21 @@ static void loop_fc()
         (void)enqueueI2STx(IIS2MDC_MSG,
                            iis2mdc_data_buffer,
                            SIZE_OF_IIS2MDC_DATA);
+
+        // Issue #96 — feed every fresh raw sample into the calibrator while
+        // we're in MAG_CALIBRATION.  Outside that state the calibrator is
+        // IDLE and addSample() short-circuits.  When the buffer fills it
+        // returns true so we publish the REVIEW frame promptly without
+        // waiting for the 5 Hz cadence.
+        if (rocket_state == MAG_CALIBRATION)
+        {
+            if (mag_calibrator.addSample(iis2mdc_data.mag_x,
+                                         iis2mdc_data.mag_y,
+                                         iis2mdc_data.mag_z))
+            {
+                mag_cal_status_dirty = true;
+            }
+        }
     }
 
     if (sensor_collector.getGNSSData(gnss_data))
@@ -1732,6 +1814,28 @@ static void loop_fc()
         (void)enqueueI2STx(GNSS_MSG,
                            gnss_data_buffer,
                            SIZE_OF_GNSS_DATA);
+    }
+
+    // Issue #96 — periodic mag-cal status frame.  5 Hz cadence in
+    // SAMPLING; immediate publish on REVIEW/APPLIED/ABORTED transitions
+    // (mag_cal_status_dirty).  Outside MAG_CALIBRATION the calibrator is
+    // IDLE; we still publish ABORTED/APPLIED transitions but otherwise
+    // stay quiet so the BLE channel isn't carrying useless idle frames.
+    {
+        constexpr int64_t MAG_CAL_STATUS_PERIOD_US = 200000;  // 5 Hz
+        const int64_t now = esp_timer_get_time();
+        const bool in_state = (rocket_state == MAG_CALIBRATION);
+        const bool elapsed  = (now - mag_cal_last_status_us) >= MAG_CAL_STATUS_PERIOD_US;
+        if (mag_cal_status_dirty || (in_state && elapsed))
+        {
+            MagCalStatusData s{};
+            mag_calibrator.buildStatusFrame((uint32_t)now, s);
+            uint8_t buf[sizeof(MagCalStatusData)];
+            memcpy(buf, &s, sizeof(buf));
+            (void)enqueueI2STx(MAG_CAL_STATUS_MSG, buf, sizeof(buf));
+            mag_cal_last_status_us = now;
+            mag_cal_status_dirty = false;
+        }
     }
 
     // --- Flight logic update ---
@@ -1760,7 +1864,8 @@ static void loop_fc()
             // logic is tested in simulation.
             if (bmp_latest_si.pressure > 0.0f &&
                 (rocket_state == INITIALIZATION ||
-                 rocket_state == READY))
+                 rocket_state == READY ||
+                 rocket_state == MAG_CALIBRATION))
             {
                 ground_pressure_pa = bmp_latest_si.pressure;
                 ground_pressure_found = true;
@@ -2405,6 +2510,99 @@ static void loop_fc()
                 prefs.putFloat("hgbz", sensor_collector.hg_bias_z);
                 prefs.end();
                 ESP_LOGI(TAG, "[CAL] Sensor calibration complete (saved to NVS)");
+            }
+            // Issue #96 — magnetometer hard-iron cal: start / abort / accept / retry.
+            // Entry is gated to READY only.  All transitions produce one
+            // immediate status frame so the iOS UI updates without waiting
+            // for the 5 Hz cadence.
+            else if (out_pending_command == MAG_CAL_START)
+            {
+                if (rocket_state != READY)
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] start refused: state=%u (require READY)",
+                             (unsigned)rocket_state);
+                }
+                else
+                {
+                    ESP_LOGI(TAG, "[MAGCAL] start: entering MAG_CALIBRATION");
+                    rocket_state = MAG_CALIBRATION;
+                    mag_calibrator.start();
+                    mag_cal_status_dirty = true;
+                }
+            }
+            else if (out_pending_command == MAG_CAL_ABORT)
+            {
+                ESP_LOGI(TAG, "[MAGCAL] abort");
+                mag_calibrator.abort();
+                mag_cal_status_dirty = true;
+                if (rocket_state == MAG_CALIBRATION) rocket_state = READY;
+                mag_calibrator.clear();
+            }
+            else if (out_pending_command == MAG_CAL_RETRY)
+            {
+                if (rocket_state != MAG_CALIBRATION)
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] retry refused: not in MAG_CALIBRATION");
+                }
+                else
+                {
+                    ESP_LOGI(TAG, "[MAGCAL] retry");
+                    mag_calibrator.retry();
+                    mag_cal_status_dirty = true;
+                }
+            }
+            else if (out_pending_command == MAG_CAL_ACCEPT)
+            {
+                if (rocket_state != MAG_CALIBRATION)
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] accept refused: not in MAG_CALIBRATION");
+                }
+                else if (!mag_calibrator.accept())
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] accept refused: no fit available (still SAMPLING?)");
+                }
+                else
+                {
+                    int16_t cx, cy, cz;
+                    float R_uT, res_uT;
+                    uint8_t reject;
+                    mag_calibrator.getResult(cx, cy, cz, R_uT, res_uT, reject);
+
+                    // Apply to active mag chip immediately so the user can
+                    // verify the fix without a reboot.
+                    if (sensor_collector.isIIS2MDCActive())
+                    {
+                        const bool ok = sensor_collector.setIIS2MDCHardIronOffset(cx, cy, cz);
+                        ESP_LOGI(TAG, "[MAGCAL] IIS2MDC OFFSET applied: (%d,%d,%d) %s",
+                                 (int)cx, (int)cy, (int)cz, ok ? "OK" : "FAIL");
+                    }
+                    // The MMC software-offset path requires int32 centered-counts;
+                    // the sphere fit was run in IIS2MDC int16 LSB units so it
+                    // doesn't apply directly.  Persist zeros for MMC; legacy
+                    // boards that need MMC cal can be added in a follow-up.
+                    sensor_converter.setMMCOffset(0, 0, 0);
+
+                    // Persist to NVS so boot reapplies the offset.
+                    prefs.begin("mag_cal", false);
+                    prefs.putUChar("ver",    MAG_CAL_NVS_SCHEMA_VERSION);
+                    prefs.putBool ("done",   true);
+                    prefs.putShort("cx",     cx);
+                    prefs.putShort("cy",     cy);
+                    prefs.putShort("cz",     cz);
+                    prefs.putFloat("R_uT",   R_uT);
+                    prefs.putFloat("res_uT", res_uT);
+                    prefs.putInt  ("mmc_cx", 0);
+                    prefs.putInt  ("mmc_cy", 0);
+                    prefs.putInt  ("mmc_cz", 0);
+                    prefs.end();
+
+                    ESP_LOGI(TAG, "[MAGCAL] accepted + saved: cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT",
+                             (int)cx, (int)cy, (int)cz, (double)R_uT, (double)res_uT);
+
+                    mag_cal_status_dirty = true;
+                    rocket_state = READY;
+                    mag_calibrator.clear();
+                }
             }
             else if (out_pending_command == GAIN_SCHED_ENABLE)
             {
@@ -3212,6 +3410,15 @@ static void loop_fc()
                         }
                     }
                 }
+                break;
+            }
+            case MAG_CALIBRATION:
+            {
+                // No state-machine transitions out — driven entirely by
+                // BLE commands (MAG_CAL_ABORT/ACCEPT/RETRY).  The user is
+                // physically tumbling the rocket on the bench, so we
+                // explicitly do NOT promote to PRELAUNCH on motion or any
+                // other auto-detect.  Issue #96.
                 break;
             }
             default:

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1176,6 +1176,7 @@ static const char* rocketStateToString(RocketState s)
         case PRELAUNCH:      return "PRELAUNCH";
         case INFLIGHT:       return "INFLIGHT";
         case LANDED:         return "LANDED";
+        case MAG_CALIBRATION: return "MAG_CAL";
         default:             return "UNKNOWN";
     }
 }
@@ -1228,6 +1229,7 @@ static bool isKnownMessageType(uint8_t type)
         case LORA_MSG:
         case SNAPSHOT_MSG:           // FC→OC over I2S during INFLIGHT
         case GET_FLIGHT_SNAPSHOT:    // FC→OC over I2C at boot recovery
+        case MAG_CAL_STATUS_MSG:     // FC→OC over I2S — issue #96
             return true;
         default:
             return false;
@@ -1397,6 +1399,19 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             memcpy(&latest_iis2mdc_raw, payload, sizeof(IIS2MDCData));
             sensor_converter.convertIIS2MDCData(latest_iis2mdc_raw, latest_iis2mdc_si);
             latest_iis2mdc_valid = true;
+        }
+    }
+    else if (type == MAG_CAL_STATUS_MSG)
+    {
+        // Issue #96: FC→OC mag cal status frame.  Forward verbatim to BLE
+        // on the file-ops characteristic with a 0xCA discriminator added
+        // by sendMagCalStatus().  Only meaningful on a direct rocket BLE
+        // connection — base-station relay drops these (the BS doesn't
+        // process I2S frames from a remote rocket) and the cal flow runs
+        // only on the connected rocket anyway.
+        if (payload_len >= sizeof(MagCalStatusData))
+        {
+            ble_app.sendMagCalStatus(payload, sizeof(MagCalStatusData));
         }
     }
     else if (type == GNSS_MSG)
@@ -4768,6 +4783,30 @@ static void loop_oc()
                 sendCurrentConfig();
                 ESP_LOGI("BLE", "Rocket ID set: %u", (unsigned)rocket_id);
             }
+        }
+        // ---- Magnetometer hard-iron calibration (issue #96) ----
+        // Four single-byte commands grouped at 50–53.  Each is a thin
+        // pass-through: setPendingCommand routes to the FC over I2C, FC
+        // owns all the state-machine + sphere-fit logic.
+        else if (ble_cmd == 50)
+        {
+            setPendingCommand(MAG_CAL_START);
+            ESP_LOGI("BLE", "Mag cal START -> FlightComputer");
+        }
+        else if (ble_cmd == 51)
+        {
+            setPendingCommand(MAG_CAL_ABORT);
+            ESP_LOGI("BLE", "Mag cal ABORT -> FlightComputer");
+        }
+        else if (ble_cmd == 52)
+        {
+            setPendingCommand(MAG_CAL_ACCEPT);
+            ESP_LOGI("BLE", "Mag cal ACCEPT -> FlightComputer");
+        }
+        else if (ble_cmd == 53)
+        {
+            setPendingCommand(MAG_CAL_RETRY);
+            ESP_LOGI("BLE", "Mag cal RETRY -> FlightComputer");
         }
     }
 


### PR DESCRIPTION
## Summary

FC-side firmware for [issue #96](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/96) — hard-iron magnetometer calibration. The user triggers a tumble cal from the iOS app, the FC fits a sphere to the captured samples, and (on accept) persists the offset to NVS and writes IIS2MDC `OFFSET_X/Y/Z` so subsequent reads arrive pre-corrected at zero runtime cost. iOS app side ships in a follow-up PR.

## Approach

- **New `TR_MagCalibrator` component** ([TR_MagCalibrator.h](tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h), [.cpp](tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp)) — state machine (IDLE → SAMPLING → REVIEW → APPLIED/ABORTED), centroid-shifted 4×4 linear-LSQ sphere fit via hand-rolled Gaussian elimination (no Eigen pull-in), 26-wedge coverage metric (3³ − 1), and discrete reject codes for R-band / coverage / residual gating.
- **`TR_IIS2MDC::setHardIronOffset`** writes the chip's `OFFSET_X/Y/Z` registers (0x45..0x4A) in raw LSB units.
- **`SensorConverter::setMMCOffset`** + offset subtract in `convertMMC5983MAData` for the legacy MMC path. Plumbing only — sphere fit doesn't run for MMC in this PR (active boards are IIS2MDC; follow-up if MMC ever needs it).
- **New `RocketState::MAG_CALIBRATION`** (state 5). No state-machine transitions out — the user owns the flow via accept/abort/retry. Entry gated to `READY` only.
- **BLE plumbing**: cmds 50/51/52/53 → `MAG_CAL_START/ABORT/ACCEPT/RETRY`, routed by OC to FC over I2C. FC publishes a binary 22-byte `MagCalStatusData` via I2S; OC forwards verbatim to the iOS app on the **existing** `file_ops` characteristic with a `0xCA` discriminator (sibling of `0xAA` scan-results). Keeps mag cal off the main JSON telemetry frame, which has had MTU-overflow trouble.
- **NVS namespace `mag_cal`** with schema-version byte for future-proofing. Boot reapplies the offset post-`sensor_collector.begin()` (softReset inside `begin()` zeroes the chip's `OFFSET` regs).

## Out of scope (follow-ups)

- iOS app calibration screen (next PR).
- Soft-iron / ellipsoid correction.
- In-flight recalibration.
- WMM-aware R band.
- MMC sphere-fit (the software-offset infrastructure is in place but uncalibrated).

## Test plan

- [x] FC + OC build clean (verified locally for esp32p4 and esp32s3 respectively).
- [ ] On bench, BLE cmd 50 transitions FC into `MAG_CALIBRATION` from `READY`; refused from `PRELAUNCH`/`INFLIGHT`/`LANDED`.
- [ ] Tumbling the rocket lights up ≥ 18 of 26 coverage wedges within ~10 s; sample buffer fills, fit completes, `MagCalStatusData` arrives at the iOS app with `sub_type=REVIEW` and `reject_code=0`.
- [ ] BLE cmd 52 (accept) writes the offset to IIS2MDC `OFFSET_X/Y/Z`, persists to NVS, returns to `READY`. Subsequent reads show |B| ≈ 50 µT (was ~1640 µT before).
- [ ] Reboot reapplies the offset from NVS — |B| stays in band.
- [ ] BLE cmd 51 (abort) returns to `READY` without writing NVS or programming the chip.
- [ ] BLE cmd 53 (retry) clears samples and restarts SAMPLING from the same MAG_CALIBRATION state.
- [ ] Deliberate bad capture (move a magnet near the rocket mid-tumble) → reject_code=2 (R too high) and Retry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
