### PR TITLE
mag-cal: iOS app calibration screen (#96)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -529,14 +529,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
     // MARK: - Magnetometer hard-iron calibration (issue #96)
     //
-    // Four single-byte commands.  The OC routes each to the FC over I2C,
+    // Five single-byte commands.  The OC routes each to the FC over I2C,
     // and the FC publishes back a binary status frame on the file_ops
     // characteristic (parsed into magCalStatus).  Entry guard lives on
     // the FC: START is only honoured when rocket_state == READY.
-    func sendMagCalStart()  { sendCommand(50) }
-    func sendMagCalAbort()  { sendCommand(51) }
-    func sendMagCalAccept() { sendCommand(52) }
-    func sendMagCalRetry()  { sendCommand(53) }
+    func sendMagCalStart()      { sendCommand(50) }
+    func sendMagCalAbort()      { sendCommand(51) }
+    func sendMagCalAccept()     { sendCommand(52) }
+    func sendMagCalRetry()      { sendCommand(53) }
+    /// Tell the FC: stop accumulating, run the sphere fit on what we
+    /// have, transition to REVIEW.  Replaces the old
+    /// auto-completion-at-buffer-fill so the user owns when the cal
+    /// "finishes."
+    func sendMagCalComputeFit() { sendCommand(54) }
 
     func sendToggleLogging() {
         sendCommand(23)

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -51,6 +51,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var scanSamples: [FrequencyScanSample] = []
     @Published var isScanning: Bool = false
 
+    // Magnetometer hard-iron calibration status (issue #96).  Latest frame
+    // received from the FC over BLE on the file_ops characteristic with a
+    // 0xCA discriminator.  nil until the first frame arrives; reset on
+    // disconnect so a stale REVIEW state doesn't bleed across sessions.
+    @Published var magCalStatus: MagCalStatus?
+
     /// Set once per connected-session after the first-time-seen base station
     /// has auto-picked and pushed a quiet channel.  Gates the auto-pick so it
     /// only runs once per session; cleared on disconnect so that a BS reboot
@@ -151,6 +157,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // finish anyway.
         hasAutoSelectedChannel = false
         pendingAutoApply = false
+        // Drop any cached mag-cal status so a stale REVIEW from a previous
+        // session doesn't show up on reconnect (issue #96).  The FC
+        // republishes IDLE on reconnect anyway.
+        magCalStatus = nil
         flightAnnouncer?.reset()
         UIApplication.shared.isIdleTimerDisabled = false
     }
@@ -516,6 +526,17 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     func sendPyroFire(channel: UInt8) {
         sendRawCommand(36, payload: Data([channel]))
     }
+
+    // MARK: - Magnetometer hard-iron calibration (issue #96)
+    //
+    // Four single-byte commands.  The OC routes each to the FC over I2C,
+    // and the FC publishes back a binary status frame on the file_ops
+    // characteristic (parsed into magCalStatus).  Entry guard lives on
+    // the FC: START is only honoured when rocket_state == READY.
+    func sendMagCalStart()  { sendCommand(50) }
+    func sendMagCalAbort()  { sendCommand(51) }
+    func sendMagCalAccept() { sendCommand(52) }
+    func sendMagCalRetry()  { sendCommand(53) }
 
     func sendToggleLogging() {
         sendCommand(23)
@@ -909,12 +930,14 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             parseTelemetryData(characteristic.value)
         } else if characteristic.uuid == fileOpsCharUUID {
             if let data = characteristic.value {
-                // Scan results use a 0xAA binary prefix; JSON responses start
-                // with '{' or '[' so the first byte is enough to disambiguate.
-                if data.first == 0xAA {
-                    parseScanResult(data)
-                } else {
-                    parseFileList(data)
+                // Multiple binary frame kinds + JSON share this characteristic;
+                // disambiguate by the first byte.  JSON always starts with '{'
+                // or '[' so the binary discriminators (0xAA scan, 0xCA mag-cal)
+                // can never collide with it.
+                switch data.first {
+                case 0xAA: parseScanResult(data)
+                case 0xCA: parseMagCalStatus(data)   // issue #96
+                default:   parseFileList(data)
                 }
             }
         } else if characteristic.uuid == fileTransferCharUUID {
@@ -1054,6 +1077,25 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// We copy into a `[UInt8]` first so indexing is always zero-based, which
     /// avoids the `Data` slice-startIndex footgun if CoreBluetooth ever hands
     /// us a sliced buffer.
+    /// Parse a magnetometer hard-iron cal status frame (issue #96).
+    /// Format: [0xCA][22-byte MagCalStatusData LE].  The FC sends one
+    /// frame on every state transition (SAMPLING entry, REVIEW entry,
+    /// APPLIED, ABORTED) plus a 5 Hz heartbeat in SAMPLING — so the iOS
+    /// UI can update progress smoothly without polling.
+    private func parseMagCalStatus(_ data: Data) {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 23, bytes[0] == 0xCA else {
+            print("[MAGCAL] malformed status (\(bytes.count) bytes)")
+            return
+        }
+        let payload = Array(bytes[1..<bytes.count])
+        guard let status = MagCalStatus.decode(payload) else {
+            print("[MAGCAL] decode failed (payload=\(payload.count) bytes)")
+            return
+        }
+        magCalStatus = status
+    }
+
     private func parseScanResult(_ data: Data) {
         print("[SCAN] parseScanResult: \(data.count) bytes, first=\(data.first.map { String(format: "0x%02X", $0) } ?? "nil")")
         let bytes = [UInt8](data)

--- a/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
@@ -78,6 +78,15 @@ struct MagCalStatus: Equatable {
     /// then falls back to a simple timer cycle.
     let coverageMask: UInt32
 
+    /// Live raw mag-vector components in µT (most recent sample).
+    /// Lets the iOS UI render real-time direction feedback so the
+    /// user can verify which axis is currently dominant and adjust
+    /// the rocket to match the target orientation.  All zero on old
+    /// firmware (< 32-byte payload).
+    let liveX_uT: Float
+    let liveY_uT: Float
+    let liveZ_uT: Float
+
     /// Convenience: human-readable explanation for a non-zero rejectCode.
     var rejectMessage: String {
         switch rejectCode {
@@ -136,7 +145,15 @@ struct MagCalStatus: Equatable {
         let rejectRaw     = bytes[20]
         // bytes[21]      = _pad
         // bytes[22..25]  = uint32 coverage_mask  (new in 26-byte payload)
+        // bytes[26..31]  = int16 inst_x/y/z LSB   (new in 32-byte payload)
         let coverageMask: UInt32 = (bytes.count >= 26) ? u32(22) : 0
+        let liveX_lsb: Int16 = (bytes.count >= 32) ? i16(26) : 0
+        let liveY_lsb: Int16 = (bytes.count >= 32) ? i16(28) : 0
+        let liveZ_lsb: Int16 = (bytes.count >= 32) ? i16(30) : 0
+
+        // IIS2MDC sensitivity is 0.15 µT/LSB (datasheet 9.13).  Mirrors
+        // the firmware-side IIS2MDC_LSB_TO_uT constant.
+        let LSB_TO_uT: Float = 0.15
 
         let sub    = MagCalSubType(rawValue: subTypeRaw) ?? .idle
         let reject = MagCalRejectCode(rawValue: rejectRaw) ?? .ok
@@ -152,7 +169,10 @@ struct MagCalStatus: Equatable {
             fieldR_uT: Float(RUTx10) / 10.0,
             residualUT: Float(resUTx10) / 10.0,
             rejectCode: reject,
-            coverageMask: coverageMask
+            coverageMask: coverageMask,
+            liveX_uT: Float(liveX_lsb) * LSB_TO_uT,
+            liveY_uT: Float(liveY_lsb) * LSB_TO_uT,
+            liveZ_uT: Float(liveZ_lsb) * LSB_TO_uT
         )
     }
 }
@@ -219,6 +239,40 @@ enum MagCalAxis: CaseIterable {
         case .leftSide:  return "Left"
         case .frontFace: return "Front"
         case .backFace:  return "Back"
+        }
+    }
+
+    /// Which body-frame axis (X/Y/Z) this orientation targets.
+    var component: MagCalComponent {
+        switch self {
+        case .noseUp, .noseDown:     return .x
+        case .rightSide, .leftSide:  return .y
+        case .frontFace, .backFace:  return .z
+        }
+    }
+
+    /// Sign the target component should have when correctly oriented.
+    /// e.g. nose-up → +X (sign +1); nose-down → -X (sign -1).
+    var sign: Float {
+        switch self {
+        case .noseUp, .rightSide, .frontFace: return  1.0
+        case .noseDown, .leftSide, .backFace: return -1.0
+        }
+    }
+}
+
+/// Sensor-frame component axis labels for the direction-feedback bars.
+enum MagCalComponent: String, CaseIterable {
+    case x = "X"
+    case y = "Y"
+    case z = "Z"
+
+    /// Pull the live µT reading for this component out of a status frame.
+    func value(in status: MagCalStatus) -> Float {
+        switch self {
+        case .x: return status.liveX_uT
+        case .y: return status.liveY_uT
+        case .z: return status.liveZ_uT
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
@@ -288,7 +288,7 @@ extension MagCalStatus {
 // drift from the FC's accept/reject decision.  The FC is the source of
 // truth via rejectCode — these constants are just for the progress UI.
 enum MagCalConstants {
-    static let maxSamples: UInt16 = 2048
+    static let maxSamples: UInt16 = 2700   // 27 accel-wedges × 100 slots each
     static let minSamples: UInt16 = 500
     static let minCoverageBins: UInt8 = 18
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
@@ -163,10 +163,11 @@ struct MagCalStatus: Equatable {
 // 3×3×3 encoding in TR_MagCalibrator.cpp (bx*9 + by*3 + bz with each
 // component in {0,1,2} for {<-T, [-T,T], >T}).
 //
-// The mapping below assumes the IIS2MDC body frame after the configured
-// rotation, with +Z = nose tip, +X = "right" side, +Y = "front" face.
-// If the user reports the prompts feel mirrored, swap the matching
-// constants here — none of the firmware needs to change.
+// Body-frame convention (empirical, verified by the user on the flight
+// computer): nose-up populates the +X wedge.  Sides and faces follow
+// from the right-hand rule around that — if any axis turns out to be
+// flipped on the rocket, swap the +Y/+Z assignments here without
+// touching the firmware.
 enum MagCalAxis: CaseIterable {
     case noseUp, noseDown
     case rightSide, leftSide
@@ -176,12 +177,12 @@ enum MagCalAxis: CaseIterable {
     var wedgeBit: UInt32 {
         switch self {
         // bx, by, bz ∈ {0,1,2} → index = bx*9 + by*3 + bz
-        case .noseUp:    return 1 * 9 + 1 * 3 + 2  // (0,0,+) = 14
-        case .noseDown:  return 1 * 9 + 1 * 3 + 0  // (0,0,-) = 12
-        case .rightSide: return 2 * 9 + 1 * 3 + 1  // (+,0,0) = 22
-        case .leftSide:  return 0 * 9 + 1 * 3 + 1  // (-,0,0) = 4
-        case .frontFace: return 1 * 9 + 2 * 3 + 1  // (0,+,0) = 16
-        case .backFace:  return 1 * 9 + 0 * 3 + 1  // (0,-,0) = 10
+        case .noseUp:    return 2 * 9 + 1 * 3 + 1  // (+,0,0) = 22  — user-confirmed: Up = +X
+        case .noseDown:  return 0 * 9 + 1 * 3 + 1  // (-,0,0) =  4
+        case .rightSide: return 1 * 9 + 2 * 3 + 1  // (0,+,0) = 16
+        case .leftSide:  return 1 * 9 + 0 * 3 + 1  // (0,-,0) = 10
+        case .frontFace: return 1 * 9 + 1 * 3 + 2  // (0,0,+) = 14
+        case .backFace:  return 1 * 9 + 1 * 3 + 0  // (0,0,-) = 12
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
@@ -1,0 +1,144 @@
+//
+//  MagCalStatus.swift
+//  TinkerRocketApp
+//
+//  Decoded form of the FC's MagCalStatusData binary frame (issue #96).
+//  The wire frame is 22 bytes, little-endian, prefixed with a 0xCA byte
+//  on the BLE file_ops characteristic (sibling of the 0xAA scan-results
+//  prefix).  Field layout is mirrored from
+//  tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+//  — keep both in sync if the wire format ever changes.
+//
+
+import Foundation
+
+enum MagCalSubType: UInt8 {
+    case idle     = 0
+    case sampling = 1
+    case review   = 2
+    case applied  = 3
+    case aborted  = 4
+}
+
+enum MagCalRejectCode: UInt8 {
+    case ok               = 0
+    case rTooLow          = 1   // fitted R < 20 µT
+    case rTooHigh         = 2   // fitted R > 80 µT
+    case highResidual     = 3   // RMS residual above threshold (poor sphere fit)
+    case lowCoverage      = 4   // < min populated wedges (insufficient tumble coverage)
+}
+
+struct MagCalStatus: Equatable {
+    /// Sub-state of the cal flow.  Drives the iOS UI: SAMPLING shows a
+    /// progress bar, REVIEW shows the fit + Accept/Retry buttons, APPLIED
+    /// shows a one-shot success banner, ABORTED dismisses to settings.
+    let subType: MagCalSubType
+
+    /// Number of distinct directional wedges populated, out of 26 (3³ - 1
+    /// — the (0,0,0) center cell is unreachable for a unit vector so we
+    /// only count the 26 reachable wedges).  Hits ~26 on a clean tumble.
+    let coverageBins: UInt8
+
+    /// Total raw samples accumulated this run, capped at MAX_SAMPLES.
+    let sampleCount: UInt16
+
+    /// Magnitude of the most recent raw sample, in µT (post-IIS2MDC OFFSET
+    /// chip subtract during SAMPLING — i.e. this is the *uncalibrated*
+    /// reading the cal flow is trying to fix).  0 before the first sample.
+    let instantaneousFieldUT: Float
+
+    /// Fitted hard-iron offset in raw IIS2MDC LSB units (0.15 µT/LSB).
+    /// Zero in SAMPLING/IDLE/ABORTED, populated in REVIEW/APPLIED.
+    let offsetX: Int16
+    let offsetY: Int16
+    let offsetZ: Int16
+
+    /// Fitted Earth-field magnitude in µT.  0 if no fit yet.  Should land
+    /// in [20, 80] µT for the fit to pass the R-band sanity gate.
+    let fieldR_uT: Float
+
+    /// RMS residual of samples from the fitted sphere, in µT.  Smaller is
+    /// better; values > MAG_CAL_MAX_RESIDUAL_UT (~8 µT) usually mean
+    /// soft-iron distortion or a moving interferer during the tumble.
+    let residualUT: Float
+
+    /// 0 = fit accepted, non-zero = fit failed a gate; the iOS UI shows
+    /// the right error and offers Retry instead of Accept.
+    let rejectCode: MagCalRejectCode
+
+    /// Convenience: human-readable explanation for a non-zero rejectCode.
+    var rejectMessage: String {
+        switch rejectCode {
+        case .ok:           return "Looks good"
+        case .rTooLow:      return "Field magnitude too low — interference?"
+        case .rTooHigh:     return "Field magnitude too high — magnet nearby?"
+        case .highResidual: return "Sphere fit poor — likely soft-iron distortion"
+        case .lowCoverage:  return "Insufficient orientation coverage — keep tumbling"
+        }
+    }
+
+    /// Convenience: progress fraction in [0, 1] for the SAMPLING UI.
+    /// Combines the sample-count cap and the coverage gate so the bar
+    /// only fills once both are healthy.
+    func samplingProgress(targetSamples: UInt16, minCoverage: UInt8) -> Double {
+        let s = min(Double(sampleCount) / Double(targetSamples), 1.0)
+        let c = min(Double(coverageBins) / Double(minCoverage), 1.0)
+        return min(s, c)
+    }
+
+    /// Decode a 22-byte little-endian payload (the bytes *after* the 0xCA
+    /// discriminator).  Returns nil if the buffer is too short.
+    static func decode(_ bytes: [UInt8]) -> MagCalStatus? {
+        guard bytes.count >= 22 else { return nil }
+
+        // Helpers — Data slicing is alignment-safe even at odd offsets.
+        func u16(_ offset: Int) -> UInt16 {
+            return bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: offset, as: UInt16.self)
+            }
+        }
+        func i16(_ offset: Int) -> Int16 {
+            return bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: offset, as: Int16.self)
+            }
+        }
+
+        // bytes[0..3]   = uint32 time_us (unused on iOS — we use phone clock for UI)
+        let subTypeRaw    = bytes[4]
+        let coverage      = bytes[5]
+        let sampleCount   = u16(6)
+        let instUTx10     = u16(8)
+        let offX          = i16(10)
+        let offY          = i16(12)
+        let offZ          = i16(14)
+        let RUTx10        = u16(16)
+        let resUTx10      = u16(18)
+        let rejectRaw     = bytes[20]
+        // bytes[21] is _pad
+
+        let sub    = MagCalSubType(rawValue: subTypeRaw) ?? .idle
+        let reject = MagCalRejectCode(rawValue: rejectRaw) ?? .ok
+
+        return MagCalStatus(
+            subType: sub,
+            coverageBins: coverage,
+            sampleCount: sampleCount,
+            instantaneousFieldUT: Float(instUTx10) / 10.0,
+            offsetX: offX,
+            offsetY: offY,
+            offsetZ: offZ,
+            fieldR_uT: Float(RUTx10) / 10.0,
+            residualUT: Float(resUTx10) / 10.0,
+            rejectCode: reject
+        )
+    }
+}
+
+// Match firmware-side gates (RocketComputerTypes.h) so the UI doesn't
+// drift from the FC's accept/reject decision.  The FC is the source of
+// truth via rejectCode — these constants are just for the progress UI.
+enum MagCalConstants {
+    static let maxSamples: UInt16 = 1024
+    static let minSamples: UInt16 = 500
+    static let minCoverageBins: UInt8 = 18
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift
@@ -3,11 +3,15 @@
 //  TinkerRocketApp
 //
 //  Decoded form of the FC's MagCalStatusData binary frame (issue #96).
-//  The wire frame is 22 bytes, little-endian, prefixed with a 0xCA byte
+//  The wire frame is 26 bytes, little-endian, prefixed with a 0xCA byte
 //  on the BLE file_ops characteristic (sibling of the 0xAA scan-results
 //  prefix).  Field layout is mirrored from
 //  tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
 //  — keep both in sync if the wire format ever changes.
+//
+//  Older firmware ships a 22-byte payload (no coverage_mask trailer);
+//  the decoder accepts both and defaults coverageMask to 0 on old FC
+//  builds so the UI degrades to timer-based prompts.
 //
 
 import Foundation
@@ -66,6 +70,14 @@ struct MagCalStatus: Equatable {
     /// the right error and offers Retry instead of Accept.
     let rejectCode: MagCalRejectCode
 
+    /// Bitmap of populated 3³ wedges; bit i corresponds to wedge i in
+    /// directionWedge() (firmware-side TR_MagCalibrator).  Drives the
+    /// per-direction progress grid and the gated orientation-prompt
+    /// cycle.  Bit 13 is the unreachable centre cell and is always 0.
+    /// 0 on old firmware builds that ship the 22-byte payload — UI
+    /// then falls back to a simple timer cycle.
+    let coverageMask: UInt32
+
     /// Convenience: human-readable explanation for a non-zero rejectCode.
     var rejectMessage: String {
         switch rejectCode {
@@ -86,8 +98,11 @@ struct MagCalStatus: Equatable {
         return min(s, c)
     }
 
-    /// Decode a 22-byte little-endian payload (the bytes *after* the 0xCA
-    /// discriminator).  Returns nil if the buffer is too short.
+    /// Decode the wire payload (bytes *after* the 0xCA discriminator).
+    /// Accepts both the original 22-byte layout and the 26-byte layout
+    /// that trails a uint32 coverage_mask — old firmware → coverageMask=0
+    /// and UI falls back to a timer-only prompt cycle.  Returns nil if
+    /// the buffer is too short to be the original payload.
     static func decode(_ bytes: [UInt8]) -> MagCalStatus? {
         guard bytes.count >= 22 else { return nil }
 
@@ -95,6 +110,11 @@ struct MagCalStatus: Equatable {
         func u16(_ offset: Int) -> UInt16 {
             return bytes.withUnsafeBufferPointer {
                 UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: offset, as: UInt16.self)
+            }
+        }
+        func u32(_ offset: Int) -> UInt32 {
+            return bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: offset, as: UInt32.self)
             }
         }
         func i16(_ offset: Int) -> Int16 {
@@ -114,7 +134,9 @@ struct MagCalStatus: Equatable {
         let RUTx10        = u16(16)
         let resUTx10      = u16(18)
         let rejectRaw     = bytes[20]
-        // bytes[21] is _pad
+        // bytes[21]      = _pad
+        // bytes[22..25]  = uint32 coverage_mask  (new in 26-byte payload)
+        let coverageMask: UInt32 = (bytes.count >= 26) ? u32(22) : 0
 
         let sub    = MagCalSubType(rawValue: subTypeRaw) ?? .idle
         let reject = MagCalRejectCode(rawValue: rejectRaw) ?? .ok
@@ -129,8 +151,81 @@ struct MagCalStatus: Equatable {
             offsetZ: offZ,
             fieldR_uT: Float(RUTx10) / 10.0,
             residualUT: Float(resUTx10) / 10.0,
-            rejectCode: reject
+            rejectCode: reject,
+            coverageMask: coverageMask
         )
+    }
+}
+
+// Six cardinal-axis "wedge caps" that the UI uses to drive the gated
+// prompt cycle (issue #96 follow-up).  These are the firmware
+// directionWedge() indices for unit vectors near ±X / ±Y / ±Z — see the
+// 3×3×3 encoding in TR_MagCalibrator.cpp (bx*9 + by*3 + bz with each
+// component in {0,1,2} for {<-T, [-T,T], >T}).
+//
+// The mapping below assumes the IIS2MDC body frame after the configured
+// rotation, with +Z = nose tip, +X = "right" side, +Y = "front" face.
+// If the user reports the prompts feel mirrored, swap the matching
+// constants here — none of the firmware needs to change.
+enum MagCalAxis: CaseIterable {
+    case noseUp, noseDown
+    case rightSide, leftSide
+    case frontFace, backFace
+
+    /// Bit index inside MagCalStatus.coverageMask.
+    var wedgeBit: UInt32 {
+        switch self {
+        // bx, by, bz ∈ {0,1,2} → index = bx*9 + by*3 + bz
+        case .noseUp:    return 1 * 9 + 1 * 3 + 2  // (0,0,+) = 14
+        case .noseDown:  return 1 * 9 + 1 * 3 + 0  // (0,0,-) = 12
+        case .rightSide: return 2 * 9 + 1 * 3 + 1  // (+,0,0) = 22
+        case .leftSide:  return 0 * 9 + 1 * 3 + 1  // (-,0,0) = 4
+        case .frontFace: return 1 * 9 + 2 * 3 + 1  // (0,+,0) = 16
+        case .backFace:  return 1 * 9 + 0 * 3 + 1  // (0,-,0) = 10
+        }
+    }
+
+    /// Big arrow glyph for the prompt card.
+    var icon: String {
+        switch self {
+        case .noseUp:    return "arrow.up"
+        case .noseDown:  return "arrow.down"
+        case .rightSide: return "arrow.right"
+        case .leftSide:  return "arrow.left"
+        case .frontFace: return "arrow.up.right"
+        case .backFace:  return "arrow.down.left"
+        }
+    }
+
+    /// Imperative direction for the prompt card.
+    var prompt: String {
+        switch self {
+        case .noseUp:    return "Point the nose UP"
+        case .noseDown:  return "Point the nose DOWN"
+        case .rightSide: return "Lay it on its RIGHT side"
+        case .leftSide:  return "Lay it on its LEFT side"
+        case .frontFace: return "Tilt the FRONT face up"
+        case .backFace:  return "Tilt the BACK face up"
+        }
+    }
+
+    /// Short label for the per-direction status grid.
+    var shortLabel: String {
+        switch self {
+        case .noseUp:    return "Up"
+        case .noseDown:  return "Down"
+        case .rightSide: return "Right"
+        case .leftSide:  return "Left"
+        case .frontFace: return "Front"
+        case .backFace:  return "Back"
+        }
+    }
+}
+
+extension MagCalStatus {
+    /// True iff the wedge for `axis` has been populated in this run.
+    func isAxisCovered(_ axis: MagCalAxis) -> Bool {
+        return (coverageMask & (UInt32(1) << axis.wedgeBit)) != 0
     }
 }
 
@@ -138,7 +233,7 @@ struct MagCalStatus: Equatable {
 // drift from the FC's accept/reject decision.  The FC is the source of
 // truth via rejectCode — these constants are just for the progress UI.
 enum MagCalConstants {
-    static let maxSamples: UInt16 = 1024
+    static let maxSamples: UInt16 = 2048
     static let minSamples: UInt16 = 500
     static let minCoverageBins: UInt8 = 18
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -532,6 +532,7 @@ struct RocketStateView: View {
         case "PRELAUNCH": return .orange
         case "INFLIGHT": return .red
         case "COMPLETE": return .blue
+        case "MAG_CAL": return .blue   // ground-only excursion (issue #96)
         default: return .gray
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -339,71 +339,56 @@ struct MagCalView: View {
 
 // MARK: - Sampling Hero
 
-/// Guidance card for the sampling phase.  Free-form orientation capture
-/// driven by the LOW-G ACCELEROMETER (gravity vector) — the user
-/// rotates the rocket through 6 unique orientations in whatever order
-/// is physically convenient, and each signed-axis (+X / -X / +Y / -Y /
-/// +Z / -Z) gets captured independently when the user holds that axis
-/// dominant for 1.5 s.  Earlier versions tried a fixed body-frame
-/// mapping (nose UP = +X, etc.); on the current rocket that mapping
-/// proved fragile (Down never triggered) so we drop the mapping
-/// entirely and let the bars + grid teach the user which physical
-/// rotation produces which signed axis.
+/// Guidance card for the sampling phase.  Tap-to-capture model:
 ///
-/// Per-axis state machine:
-///   pending   → no progress yet
-///   capturing → axis is currently the dominant one; progress fills
-///               toward HOLD_SECONDS, gentle half-rate decay if the
-///               user wobbles out of alignment briefly
-///   captured  → progress hit HOLD_SECONDS; cell turns green and stays
+/// - The 6 grid cells correspond to the six signed body-frame axes
+///   (+X, -X, +Y, -Y, +Z, -Z) the gravity vector can point to.
+/// - The user rotates the rocket to each orientation in turn and
+///   TAPS the corresponding cell to mark it captured.  Tapping is
+///   the source of truth — sensor weirdness, accel bias, or wedge
+///   thresholds can't silently block progress.
+/// - The live accel reading still gets shown as a per-cell highlight:
+///   whichever axis is currently dominant gets a blue ring + "scope"
+///   icon, so the user can see what their current orientation is
+///   producing.  That's purely informational, not gating.
 ///
-/// Mag-side coverage from the FC is still shown (as the "fit dvs"
-/// gauge) — that's the diversity of the sphere fit's input data, and
-/// it grows in parallel with the accel-driven capture loop.
+/// Captures don't drive the firmware-side fit — the FC keeps
+/// collecting mag samples continuously while in MAG_CALIBRATION.  The
+/// 6-axis grid is the user's mental checklist for "have I shown the
+/// rocket in 6 distinct orientations?"
 private struct SamplingHero: View {
     let status: MagCalStatus
     /// Live low-g accelerometer in body frame, m/s².  Pulled from the
-    /// regular telemetry stream by the parent view.  Nil = telemetry
-    /// hasn't arrived yet; the hero shows a "waiting" state.
+    /// regular telemetry stream by the parent view.  Used only for the
+    /// per-cell "dominant axis" highlight.
     let ax: Float?
     let ay: Float?
     let az: Float?
 
-    /// Time the user must hold an axis aligned before it captures.
-    private static let HOLD_SECONDS: Double = 1.5
-    private static let TICK_SECONDS: Double = 0.05
-
-    /// Minimum component magnitude (m/s²) for an axis to count as
-    /// "dominant" — filters free-fall, slow tumble, in-between
-    /// orientations.  Gravity is ~9.81; 4 m/s² ≈ 24° off pure axis.
+    /// Threshold (m/s²) for an axis to be considered "dominant" in the
+    /// auto-detect highlight.  Below this, no cell is highlighted.
     private static let DOMINANT_THRESHOLD_MS2: Float = 4.0
 
-    /// Per-signed-axis hold progress, 0..HOLD_SECONDS.  Captured when ≥
-    /// HOLD_SECONDS.  Kept as a dict keyed by SignedAxis so we can
-    /// progress multiple axes across the run (each rotation captures
-    /// the one currently dominant).
-    @State private var captureProgress: [SignedAxis: Double] = [:]
+    /// Which signed axes the user has tapped to mark captured.  Set is
+    /// monotonic across the run — once captured, always captured (until
+    /// Abort or Retry).  This is the only state the hero owns; the FC
+    /// is sampling mag continuously regardless of what's in here.
+    @State private var capturedAxes: Set<SignedAxis> = []
 
-    /// State-machine tick.  Started in onAppear, torn down on disappear.
-    @State private var tickTimer: Timer?
-
-    /// Whichever signed axis is currently dominant in the accel reading,
-    /// or nil if no axis is above the dominance threshold (free-fall,
-    /// rapid tumble, near-zero gravity component).
-    private var currentlyAligned: SignedAxis? {
+    /// Whichever signed axis is currently dominant in the accel reading.
+    /// Pure-derived; no state.  Returns nil when no axis is above the
+    /// dominance threshold (free-fall, rapid tumble, near-zero gravity).
+    private var dominantAxis: SignedAxis? {
         guard let x = ax, let y = ay, let z = az else { return nil }
         let xa = abs(x), ya = abs(y), za = abs(z)
         let peak = max(xa, max(ya, za))
         guard peak >= SamplingHero.DOMINANT_THRESHOLD_MS2 else { return nil }
-
         if peak == xa { return SignedAxis(component: .x, positive: x > 0) }
         if peak == ya { return SignedAxis(component: .y, positive: y > 0) }
         return SignedAxis(component: .z, positive: z > 0)
     }
 
-    private var capturedCount: Int {
-        SignedAxis.allCases.filter { (captureProgress[$0] ?? 0) >= SamplingHero.HOLD_SECONDS }.count
-    }
+    private var capturedCount: Int { capturedAxes.count }
 
     /// Adaptive headline based on capture progress.
     private var headline: String {
@@ -428,8 +413,8 @@ private struct SamplingHero: View {
             orientationGrid
 
             HStack(spacing: 28) {
-                // Live |B| (raw, includes hard-iron bias).  Useful as a
-                // sanity check that mag is still sampling.
+                // Live |B| (raw, includes hard-iron bias).  Sanity
+                // check that mag is still sampling.
                 VStack(spacing: 2) {
                     Text(String(format: "%.0f", status.instantaneousFieldUT))
                         .font(.system(size: 32, weight: .bold, design: .monospaced))
@@ -437,11 +422,11 @@ private struct SamplingHero: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
-
-                // Sphere-fit diversity gauge — how many of the 26 wedges
-                // of MAGNETIC-space have been sampled.  Independent of
-                // the accel-driven capture grid above.  More wedges →
-                // better-conditioned sphere fit.
+                // FC-side sphere-fit diversity gauge.  Tracks how many
+                // of the 26 mag-space wedges have been visited; with a
+                // large hard-iron bias this can stay near zero even as
+                // sample_count grows — that's expected and the fit will
+                // still recover the bias.
                 ZStack {
                     Circle()
                         .stroke(Color.gray.opacity(0.20), lineWidth: 10)
@@ -462,178 +447,113 @@ private struct SamplingHero: View {
                 .frame(width: 76, height: 76)
             }
         }
-        .onAppear { startTimers() }
-        .onDisappear { stopTimers() }
     }
 
     // MARK: - Pieces
 
-    /// Status card above the grid.  Three visual states:
-    ///   - Aligned (not yet captured): blue, progress bar fills toward
-    ///     capture; tells the user "you're doing it, keep holding."
-    ///   - Aligned (already captured): green check; "Try a different
-    ///     orientation."
-    ///   - Not aligned: orange; "Rotate the rocket — watch the bars."
-    /// All three states use the live accel reading; no fixed body-frame
-    /// assumption.
+    /// Status card above the grid.  Hints at what the user should do
+    /// based on what's currently happening:
+    ///   - All 6 captured: "Tap Compute Fit when ready"
+    ///   - An axis is dominant + not yet captured: "Tap +X to mark captured"
+    ///   - An axis is dominant + already captured: "+X already done,
+    ///     rotate to a different orientation"
+    ///   - No axis dominant: "Rotate the rocket — watch the bars"
     @ViewBuilder
     private var currentTargetCard: some View {
         if capturedCount == 6 {
-            HStack(spacing: 12) {
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(.green)
-                    .frame(width: 44)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("All six orientations captured")
-                        .font(.headline)
-                    Text("Tap Compute Fit when ready.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background(Color.green.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
-        } else if let active = currentlyAligned {
-            let progress = captureProgress[active] ?? 0
-            let alreadyCaptured = progress >= SamplingHero.HOLD_SECONDS
-            HStack(spacing: 12) {
-                Image(systemName: alreadyCaptured ? "checkmark.circle.fill" : "scope")
-                    .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(alreadyCaptured ? .green : .blue)
-                    .frame(width: 44)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(alreadyCaptured
-                        ? "\(active.label) already captured"
-                        : "Capturing \(active.label) — hold steady")
-                        .font(.headline)
-                    if !alreadyCaptured {
-                        ProgressView(value: progress,
-                                     total: SamplingHero.HOLD_SECONDS)
-                            .progressViewStyle(.linear)
-                            .tint(.blue)
-                        Text(String(format: "%.0f%%",
-                                    100 * progress / SamplingHero.HOLD_SECONDS))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text("Rotate to a different orientation")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background((alreadyCaptured ? Color.green : Color.blue).opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
-            .animation(.easeInOut(duration: 0.20), value: alreadyCaptured)
+            heroCard(
+                icon: "checkmark.seal.fill",
+                color: .green,
+                title: "All six orientations captured",
+                subtitle: "Tap Compute Fit when ready."
+            )
+        } else if let active = dominantAxis {
+            let isAlreadyCaptured = capturedAxes.contains(active)
+            heroCard(
+                icon: isAlreadyCaptured ? "checkmark.circle.fill" : "hand.tap.fill",
+                color: isAlreadyCaptured ? .green : .blue,
+                title: isAlreadyCaptured
+                    ? "\(active.label) already captured"
+                    : "Tap the \(active.label) cell to capture",
+                subtitle: isAlreadyCaptured
+                    ? "Rotate to a different orientation."
+                    : "Hold the rocket steady while you tap."
+            )
         } else {
-            HStack(spacing: 12) {
-                Image(systemName: "arrow.triangle.2.circlepath")
-                    .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(.orange)
-                    .frame(width: 44)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Rotate the rocket")
-                        .font(.headline)
-                    Text("Watch the bars below — when one axis reaches ≈ ±9.8 m/s², hold steady.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background(Color.orange.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
+            heroCard(
+                icon: "arrow.triangle.2.circlepath",
+                color: .orange,
+                title: "Rotate the rocket",
+                subtitle: "Watch the bars below — when one axis reaches ≈ ±9.8 m/s², tap the matching cell."
+            )
         }
     }
 
-    /// 6-cell grid showing per-signed-axis capture state.  Labels are
-    /// the raw ±X / ±Y / ±Z signed axis (no body-frame guessing) so the
-    /// user can match directly against the accel bars.
+    private func heroCard(icon: String, color: Color, title: String, subtitle: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 36, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 44)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(color.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 8)
+    }
+
+    /// 6-cell grid.  Each cell is a tap-target: tap to mark that signed
+    /// axis captured.  Auto-detect (live accel dominance) drives a
+    /// blue ring around the matching cell as a hint, but doesn't gate
+    /// capture — the tap is what counts.
     private var orientationGrid: some View {
         let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
         return LazyVGrid(columns: cols, spacing: 8) {
             ForEach(SignedAxis.allCases, id: \.self) { axis in
-                let progress = captureProgress[axis] ?? 0
-                let captured = progress >= SamplingHero.HOLD_SECONDS
-                let isActive = currentlyAligned == axis && !captured
-                let capturing = progress > 0 && !captured
-                VStack(spacing: 4) {
-                    Image(systemName: captured ? "checkmark.circle.fill"
-                                  : isActive ? "scope"
-                                  : "circle")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundColor(captured ? .green
-                                       : isActive ? .blue
-                                       : (capturing ? .blue.opacity(0.5) : .gray))
-                    Text(axis.label)
-                        .font(.system(.headline, design: .monospaced))
-                        .foregroundColor(captured ? .primary : .secondary)
-                    if capturing {
-                        ProgressView(value: progress, total: SamplingHero.HOLD_SECONDS)
-                            .progressViewStyle(.linear)
-                            .tint(.blue)
-                            .frame(height: 3)
+                let captured = capturedAxes.contains(axis)
+                let isActive = dominantAxis == axis && !captured
+                Button {
+                    capturedAxes.insert(axis)
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: captured ? "checkmark.circle.fill"
+                                       : isActive ? "scope"
+                                       : "circle")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundColor(captured ? .green
+                                           : isActive ? .blue
+                                           : .gray)
+                        Text(axis.label)
+                            .font(.system(.headline, design: .monospaced))
+                            .foregroundColor(captured ? .primary : .secondary)
+                        Text(captured ? "captured" : isActive ? "tap to mark" : "")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
                     }
+                    .frame(maxWidth: .infinity, minHeight: 72)
+                    .padding(.vertical, 8)
+                    .background(captured ? Color.green.opacity(0.12)
+                              : isActive ? Color.blue.opacity(0.12)
+                              : Color.gray.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isActive ? Color.blue : Color.clear, lineWidth: 2)
+                    )
                 }
-                .frame(maxWidth: .infinity, minHeight: 64)
-                .padding(.vertical, 8)
-                .background(captured ? Color.green.opacity(0.12)
-                          : isActive ? Color.blue.opacity(0.12)
-                          : Color.gray.opacity(0.08))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(isActive ? Color.blue : Color.clear, lineWidth: 2)
-                )
+                .buttonStyle(.plain)
+                .disabled(captured)
             }
         }
         .padding(.horizontal, 8)
-    }
-
-    // MARK: - Timers / state-machine
-
-    private func startTimers() {
-        tickTimer?.invalidate()
-        tickTimer = Timer.scheduledTimer(withTimeInterval: SamplingHero.TICK_SECONDS,
-                                          repeats: true) { _ in
-            DispatchQueue.main.async { advance() }
-        }
-    }
-
-    private func stopTimers() {
-        tickTimer?.invalidate(); tickTimer = nil
-    }
-
-    /// One tick of the state machine.  If an axis is currently dominant
-    /// in the accel reading, fill its progress.  Otherwise, gently
-    /// decay any in-progress (non-captured) axes so brief wobble
-    /// doesn't reset progress on whichever axis the user is working on.
-    private func advance() {
-        let step = SamplingHero.TICK_SECONDS
-        if let active = currentlyAligned {
-            let p = captureProgress[active] ?? 0
-            if p < SamplingHero.HOLD_SECONDS {
-                captureProgress[active] = min(SamplingHero.HOLD_SECONDS, p + step)
-            }
-        } else {
-            for axis in SignedAxis.allCases {
-                let p = captureProgress[axis] ?? 0
-                if p > 0 && p < SamplingHero.HOLD_SECONDS {
-                    captureProgress[axis] = max(0, p - step * 0.5)
-                }
-            }
-        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -307,68 +307,93 @@ struct MagCalView: View {
 
 // MARK: - Sampling Hero
 
-/// Guidance card shown at the top of the sampling phase.  Built around
-/// the FC's `coverageMask` — bit i is set once the user has dwelt long
-/// enough in wedge i for the calibrator to pick up that orientation.
+/// Guidance card for the sampling phase.  Walks the user through each
+/// cardinal orientation one at a time with a deterministic state
+/// machine:
+///   prompting(axis)  → user matches the axis; the live FC coverageMask
+///                       lights up the corresponding wedge bit
+///   holding(axis, t) → orientation matched; a visible countdown ticks
+///                       down while the user holds it.  Tells the user
+///                       "yes, this is working, just keep holding."
+///   prompting(next)  → after countdown elapses, advance.
+///   allDone          → all 6 cardinals walked; FC continues sampling
+///                       through diagonals for the full 2048-sample
+///                       window so coverage hits the 18-wedge gate.
 ///
-/// The hero shows three things, all driven off the live mask:
-///   1. A "current target" card — one of six cardinal axes (nose UP,
-///      DOWN, LEFT side, RIGHT side, FRONT face, BACK face).  We pick
-///      the first uncovered axis in a fixed order and stay on it until
-///      the FC reports the corresponding wedge bit is set.  The card
-///      flips to a green checkmark for ~0.5 s before advancing — that
-///      micro-pause is the user-visible confirmation that the firmware
-///      and the app agree this orientation is captured.
-///   2. A 6-cell orientation grid showing which cardinal axes are done.
-///      Replaces the spinning-globe icon: users can see at a glance
-///      exactly how many more orientations are left, and which.
-///   3. A live |B| readout in µT so the user trusts that sampling is
-///      running.  Big monospaced digits — eye spots the change.
+/// State is local to the view.  Coverage state from the FC drives the
+/// prompting→holding transition only; once we've finished a hold for
+/// an axis, we advance regardless of whether its bit clears later
+/// (which won't happen — bits are sticky on the FC side).
 ///
-/// Old firmware (22-byte payload, coverageMask=0) means no per-axis
-/// info; in that case we fall back to a slow timer cycle through all
-/// six prompts so the UX still works.
+/// Old firmware (22-byte payload, coverageMask=0) leaves the state
+/// machine stuck in prompting forever, so we additionally drive a
+/// slow time-based cycle in that case as a degraded fallback.
 private struct SamplingHero: View {
     let status: MagCalStatus
 
     /// All six cardinal axes in the order the user is walked through them.
-    /// The fixed order means muscle memory carries between runs.
+    /// Order = nose along the body, then the four sides.  Fixed across
+    /// runs so users build muscle memory.
     private static let axisOrder: [MagCalAxis] = [
         .noseUp, .noseDown, .rightSide, .leftSide, .frontFace, .backFace
     ]
 
-    /// Last target we showed — used to detect a "just covered" transition
-    /// so we can briefly hold the green-check confirmation.
-    @State private var lastSeenTarget: MagCalAxis?
+    /// Hold duration before advancing — long enough to give the user
+    /// satisfying visual confirmation, short enough that 6 × HOLD plus
+    /// transition time still fits in the FC's 20 s sample window.
+    private static let HOLD_SECONDS: Double = 1.5
 
-    /// When non-nil, the card shows this axis as just-captured (green
-    /// check) for ~0.6 s before the prompt advances.  Bridges the gap
-    /// between "wedge bit flipped" and "user has time to register it."
-    @State private var heldCoveredAxis: MagCalAxis?
+    /// State-machine tick — fast enough for a smooth countdown bar.
+    private static let TICK_SECONDS: Double = 0.05
 
-    /// Old-firmware fallback: cycle index for the timer-driven path.
-    @State private var fallbackIndex: Int = 0
+    /// Index into axisOrder of the orientation we're currently prompting
+    /// for.  Moves forward only — once an axis is held to completion we
+    /// don't revisit it (even if its wedge bit somehow clears).
+    @State private var currentAxisIndex: Int = 0
 
-    /// Are we running against firmware that ships the coverage mask?
-    /// True any time the mask carries information OR no samples have
-    /// landed yet (so coverage_bins==0 isn't mistaken for "old FC").
+    /// Seconds remaining in the current hold.  When this reaches zero
+    /// we advance currentAxisIndex.  Zero = not currently holding.
+    @State private var holdRemaining: Double = 0
+
+    /// Old-firmware fallback timer — only kicks in when coverageMask is
+    /// always zero.  Cycles the prompt every 3 s as a degraded UX.
+    @State private var fallbackTimer: Timer?
+
+    /// State-machine driver — fires every TICK_SECONDS while the view
+    /// is visible.  Started in onAppear, torn down in onDisappear.
+    @State private var tickTimer: Timer?
+
+    /// True any time the FC's wire frame can carry per-wedge info.
+    /// Zero-mask + zero-bins (no samples yet) still counts as "live" so
+    /// a fresh entry isn't misread as old firmware.
     private var hasLiveMask: Bool { status.coverageMask != 0 || status.coverageBins == 0 }
 
-    /// First uncovered axis in fixed order — the "do this now" target.
-    /// nil once all six cardinals are covered.
-    private var nextUncoveredAxis: MagCalAxis? {
-        SamplingHero.axisOrder.first { !status.isAxisCovered($0) }
+    /// The axis the user should be aiming for right now (nil = all 6 done).
+    private var currentAxis: MagCalAxis? {
+        currentAxisIndex < SamplingHero.axisOrder.count
+            ? SamplingHero.axisOrder[currentAxisIndex]
+            : nil
     }
 
-    /// Adaptive headline so the user gets feedback even between cardinal
-    /// transitions.  Computed off the coverage bin count, not the mask,
-    /// so this also works on old firmware.
+    /// True if the user is in the right orientation for the current
+    /// target — the corresponding wedge bit is set on the FC side.
+    private var currentAxisMatched: Bool {
+        guard hasLiveMask, let axis = currentAxis else { return false }
+        return status.isAxisCovered(axis)
+    }
+
+    private var isHolding: Bool { holdRemaining > 0 }
+
+    /// Adaptive headline.  Drives off the local prompt index so it
+    /// updates in lock-step with what the user actually sees, rather
+    /// than off the FC's coverage count which can include diagonals.
     private var headline: String {
-        switch status.coverageBins {
-        case 0..<6:   return "Start tumbling"
-        case 6..<14:  return "Good — keep going"
-        case 14..<22: return "Almost there"
-        default:      return "Excellent coverage"
+        if currentAxis == nil { return "All orientations captured" }
+        switch currentAxisIndex {
+        case 0:     return "Let's start"
+        case 1, 2:  return "Nice — keep going"
+        case 3, 4:  return "Almost there"
+        default:    return "Last one"
         }
     }
 
@@ -379,12 +404,11 @@ private struct SamplingHero: View {
                 .fontWeight(.semibold)
 
             currentTargetCard
-
             orientationGrid
 
             HStack(spacing: 28) {
-                // Live |B|.  Big monospaced digits so the eye spots the
-                // movement and the user trusts that sampling is live.
+                // Live |B|.  Big monospaced digits so the eye sees motion
+                // and trusts that sampling is live.
                 VStack(spacing: 2) {
                     Text(String(format: "%.0f", status.instantaneousFieldUT))
                         .font(.system(size: 36, weight: .bold, design: .monospaced))
@@ -393,10 +417,8 @@ private struct SamplingHero: View {
                         .foregroundColor(.secondary)
                 }
 
-                // Total-coverage gauge.  Circular feels more "spherical"
-                // than a linear bar — the cal is literally about lighting
-                // up wedges of a sphere.  Counts all 26 wedges, including
-                // the diagonals; the six-axis grid above shows only the
+                // Total-coverage gauge.  Counts all 26 wedges (including
+                // diagonals); the six-axis grid above shows only the
                 // cardinals.
                 ZStack {
                     Circle()
@@ -418,126 +440,153 @@ private struct SamplingHero: View {
                 .frame(width: 84, height: 84)
             }
         }
-        .onChange(of: status.coverageMask) { _ in
-            guard hasLiveMask else { return }
-            // Detect the "previous target just got captured" transition:
-            // the axis we were prompting for now has its wedge bit set.
-            // Flash it green for a beat before the prompt advances.
-            if let prev = lastSeenTarget,
-               prev != nextUncoveredAxis,
-               status.isAxisCovered(prev),
-               heldCoveredAxis == nil {
-                heldCoveredAxis = prev
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                    heldCoveredAxis = nil
-                }
-            }
-            lastSeenTarget = nextUncoveredAxis
-        }
-        .onAppear {
-            lastSeenTarget = nextUncoveredAxis
-            if !hasLiveMask { startFallbackCycle() }
-        }
+        .onAppear { startTimers() }
+        .onDisappear { stopTimers() }
     }
 
     // MARK: - Pieces
 
-    /// Display priority for the prompt card: held-just-captured → next
-    /// uncovered → cycle fallback (old firmware).  `covered` is true
-    /// only when we're displaying a just-captured axis.
-    private var promptDisplay: (axis: MagCalAxis?, covered: Bool) {
-        if let held = heldCoveredAxis {
-            return (held, true)
-        }
-        if hasLiveMask {
-            return (nextUncoveredAxis, false)
-        }
-        return (SamplingHero.axisOrder[fallbackIndex % SamplingHero.axisOrder.count], false)
-    }
-
-    /// The big "do this now" prompt card.  Stays on the same axis until
-    /// the firmware reports its wedge is populated, then flashes a green
-    /// "Captured!" for ~0.6 s before moving to the next.
+    /// The big "do this now" prompt card.  Three visual states:
+    ///   - Prompting: orange arrow icon + "Point the nose UP" + caption
+    ///   - Holding:   green check + "Captured! Hold steady…" + countdown bar
+    ///   - All done:  seal + "All orientations captured" message
     @ViewBuilder
     private var currentTargetCard: some View {
-        let display = promptDisplay
-        let axisToShow = display.axis
-        let covered = display.covered
-
-        HStack(spacing: 12) {
-            if let axis = axisToShow {
-                Image(systemName: covered ? "checkmark.circle.fill" : axis.icon)
+        if let axis = currentAxis {
+            let holding = isHolding
+            HStack(spacing: 12) {
+                Image(systemName: holding ? "checkmark.circle.fill" : axis.icon)
                     .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(covered ? .green : .orange)
+                    .foregroundColor(holding ? .green : .orange)
                     .frame(width: 44)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(covered ? "Captured!" : axis.prompt)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(holding ? "Captured — hold steady" : axis.prompt)
                         .font(.headline)
-                    Text(covered ? "Moving to next orientation…" : "Hold this position")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if holding {
+                        // Countdown bar shrinks from full → empty over
+                        // HOLD_SECONDS.  More tangible than a "1.4 s"
+                        // number that flickers.
+                        ProgressView(value: max(0, holdRemaining),
+                                     total: SamplingHero.HOLD_SECONDS)
+                            .progressViewStyle(.linear)
+                            .tint(.green)
+                        Text(String(format: "Advancing in %.1f s", holdRemaining))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Text("Hold this position until it turns green")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
                 Spacer()
-            } else {
-                // All six cardinal axes done — the FC fit-gate is on 18
-                // total wedges, so coverage may still be growing through
-                // the diagonals; keep encouraging the user.
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background((holding ? Color.green : Color.orange).opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
+            .animation(.easeInOut(duration: 0.25), value: holding)
+        } else {
+            HStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")
                     .font(.system(size: 36, weight: .semibold))
                     .foregroundColor(.green)
                     .frame(width: 44)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("All six axes captured")
+                    Text("All orientations captured")
                         .font(.headline)
-                    Text("Keep rolling for full coverage…")
+                    Text("Keep rolling slowly for a clean fit…")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
                 Spacer()
             }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(Color.green.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background((covered ? Color.green : Color.orange).opacity(0.12))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding(.horizontal, 8)
-        .animation(.easeInOut(duration: 0.25), value: covered)
     }
 
-    /// 6-cell grid showing which cardinal axes are captured.  Replaces
-    /// the spinning globe — gives the user an at-a-glance map of what
-    /// orientations remain.
+    /// 6-cell grid showing per-axis progress.  Each cell turns green
+    /// once we've held that axis to completion (currentAxisIndex moved
+    /// past it).  The CURRENT target also gets a blue ring + pulse so
+    /// it's obvious which one we're prompting for.
     private var orientationGrid: some View {
         let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
         return LazyVGrid(columns: cols, spacing: 8) {
-            ForEach(SamplingHero.axisOrder, id: \.self) { axis in
-                let covered = hasLiveMask && status.isAxisCovered(axis)
+            ForEach(Array(SamplingHero.axisOrder.enumerated()), id: \.offset) { (idx, axis) in
+                let done = idx < currentAxisIndex
+                let isCurrent = idx == currentAxisIndex
                 VStack(spacing: 4) {
-                    Image(systemName: covered ? "checkmark.circle.fill" : axis.icon)
+                    Image(systemName: done ? "checkmark.circle.fill" : axis.icon)
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundColor(covered ? .green : .gray)
+                        .foregroundColor(done ? .green : (isCurrent ? .blue : .gray))
                     Text(axis.shortLabel)
                         .font(.caption2)
-                        .foregroundColor(covered ? .primary : .secondary)
+                        .foregroundColor(done || isCurrent ? .primary : .secondary)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 8)
-                .background(covered
+                .background(done
                     ? Color.green.opacity(0.12)
-                    : Color.gray.opacity(0.08))
+                    : (isCurrent ? Color.blue.opacity(0.12) : Color.gray.opacity(0.08)))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isCurrent ? Color.blue : Color.clear, lineWidth: 2)
+                )
             }
         }
         .padding(.horizontal, 8)
     }
 
-    // MARK: - Old-firmware fallback (timer cycle)
+    // MARK: - Timers / state-machine
 
-    private func startFallbackCycle() {
-        Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
+    private func startTimers() {
+        // Main state-machine tick.
+        tickTimer?.invalidate()
+        tickTimer = Timer.scheduledTimer(withTimeInterval: SamplingHero.TICK_SECONDS,
+                                          repeats: true) { _ in
+            DispatchQueue.main.async { advance() }
+        }
+        // Old-firmware fallback: if we never get a real mask, walk the
+        // axis cycle on a slow timer so the user still gets prompts.
+        // The FC fit will still run, just without per-orientation
+        // confirmation.
+        fallbackTimer?.invalidate()
+        fallbackTimer = Timer.scheduledTimer(withTimeInterval: 3.0,
+                                              repeats: true) { _ in
             DispatchQueue.main.async {
-                fallbackIndex = (fallbackIndex + 1) % SamplingHero.axisOrder.count
+                if !hasLiveMask && !isHolding && currentAxisIndex < SamplingHero.axisOrder.count {
+                    // No live coverage info — simulate a hold completing.
+                    holdRemaining = 0
+                    currentAxisIndex += 1
+                }
             }
+        }
+    }
+
+    private func stopTimers() {
+        tickTimer?.invalidate(); tickTimer = nil
+        fallbackTimer?.invalidate(); fallbackTimer = nil
+    }
+
+    /// One tick of the state machine.  Either tick down a running hold,
+    /// or start one if the current target's wedge bit is now set.
+    private func advance() {
+        guard currentAxis != nil else { return }
+        if isHolding {
+            holdRemaining = max(0, holdRemaining - SamplingHero.TICK_SECONDS)
+            if holdRemaining == 0 {
+                // Hold done — advance past the current axis.
+                currentAxisIndex += 1
+            }
+        } else if currentAxisMatched {
+            // Orientation just matched — kick off the visible hold.
+            holdRemaining = SamplingHero.HOLD_SECONDS
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -117,18 +117,25 @@ struct MagCalView: View {
 
     /// Sampling: orientation-progress hero, live direction bars, Compute
     /// Fit button (user-driven completion — no auto-timeout), and abort.
-    /// All driven off the FC's 5 Hz status frame.
+    /// Orientation detection runs off the low-g accelerometer (gravity
+    /// vector), not the magnetometer — the mag is precisely what we're
+    /// trying to calibrate, so it's unreliable as an orientation source.
+    /// Accel data comes from the regular telemetry stream that runs in
+    /// parallel with the cal status frames.
     private var samplingSection: some View {
         Group {
             if let s = status {
+                let ax = device.telemetry.low_g_x
+                let ay = device.telemetry.low_g_y
+                let az = device.telemetry.low_g_z
                 Section {
-                    SamplingHero(status: s)
+                    SamplingHero(status: s, ax: ax, ay: ay, az: az)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
                 }
-                Section(header: Text("Live mag vector"),
-                        footer: Text("Use the bars to verify which axis is dominant. The current target's bar is highlighted — adjust the rocket until its bar reaches the target marker.")) {
-                    DirectionBars(status: s)
+                Section(header: Text("Live accel (gravity)"),
+                        footer: Text("These bars show the gravity direction in the rocket's body frame. Whichever axis reads ≈ ±9.8 m/s² is the one pointing up or down. Adjust the rocket so the target axis dominates.")) {
+                    DirectionBars(ax: ax, ay: ay, az: az)
                         .padding(.vertical, 4)
                 }
                 Section(header: Text("Progress")) {
@@ -333,65 +340,61 @@ struct MagCalView: View {
 // MARK: - Sampling Hero
 
 /// Guidance card for the sampling phase.  Walks the user through each
-/// cardinal orientation one at a time with a deterministic state
-/// machine:
-///   prompting(axis)  → user matches the axis; the live FC coverageMask
-///                       lights up the corresponding wedge bit
-///   holding(axis, t) → orientation matched; a visible countdown ticks
-///                       down while the user holds it.  Tells the user
-///                       "yes, this is working, just keep holding."
-///   prompting(next)  → after countdown elapses, advance.
-///   allDone          → all 6 cardinals walked; FC continues sampling
-///                       through diagonals for the full 2048-sample
-///                       window so coverage hits the 18-wedge gate.
+/// cardinal orientation using the LOW-G ACCELEROMETER (gravity vector)
+/// as the orientation reference — never the magnetometer, which is
+/// exactly what we're trying to calibrate and may report wildly biased
+/// values until the fit is applied.
 ///
-/// State is local to the view.  Coverage state from the FC drives the
-/// prompting→holding transition only; once we've finished a hold for
-/// an axis, we advance regardless of whether its bit clears later
-/// (which won't happen — bits are sticky on the FC side).
+/// State machine:
+///   prompting(axis)  → user rotates the rocket; accel-dominant axis
+///                       compared with the target.
+///   filling(axis, p) → orientation matched; a progress bar fills from
+///                       0 → 1.  Gentle decay if alignment briefly
+///                       wobbles, so small movements don't reset.
+///   captured(axis)   → bar full; axis goes into capturedAxes; advance.
+///   allDone          → all 6 cardinals captured; FC keeps sampling
+///                       in the background until the user taps Compute Fit.
 ///
-/// Old firmware (22-byte payload, coverageMask=0) leaves the state
-/// machine stuck in prompting forever, so we additionally drive a
-/// slow time-based cycle in that case as a degraded fallback.
+/// All orientation state is local to the view.  The FC's mag coverage
+/// is shown separately as a fit-quality indicator (it's the diversity
+/// of the sphere fit's input data, not whether the user reached the
+/// target physical orientations).
 private struct SamplingHero: View {
     let status: MagCalStatus
+    /// Live low-g accelerometer in body frame, m/s².  Pulled from the
+    /// regular telemetry stream by the parent view.  Nil = telemetry
+    /// hasn't arrived yet; the hero shows a "waiting" state.
+    let ax: Float?
+    let ay: Float?
+    let az: Float?
 
-    /// All six cardinal axes in the order the user is walked through them.
-    /// Order = nose along the body, then the four sides.  Fixed across
-    /// runs so users build muscle memory.
+    /// All six cardinal axes in the order the user walks through them.
+    /// Fixed across runs so users build muscle memory.
     private static let axisOrder: [MagCalAxis] = [
         .noseUp, .noseDown, .rightSide, .leftSide, .frontFace, .backFace
     ]
 
-    /// Hold duration before advancing — long enough to give the user
-    /// satisfying visual confirmation, short enough that 6 × HOLD plus
-    /// transition time still fits in the FC's 20 s sample window.
+    /// Time the user must hold the alignment before the axis captures.
+    /// Long enough to feel deliberate; short enough that 6 axes plus
+    /// re-orientation time fits in a reasonable session.
     private static let HOLD_SECONDS: Double = 1.5
-
-    /// State-machine tick — fast enough for a smooth countdown bar.
     private static let TICK_SECONDS: Double = 0.05
 
+    /// Minimum component magnitude (m/s²) for an axis to count as
+    /// "dominant" — filters free-fall, slow tumble, in-between
+    /// orientations.  Gravity is ~9.81; 4 m/s² ≈ 24° off pure axis.
+    private static let DOMINANT_THRESHOLD_MS2: Float = 4.0
+
     /// Index into axisOrder of the orientation we're currently prompting
-    /// for.  Moves forward only — once an axis is held to completion we
-    /// don't revisit it (even if its wedge bit somehow clears).
+    /// for.  Moves forward only.
     @State private var currentAxisIndex: Int = 0
 
-    /// Seconds remaining in the current hold.  When this reaches zero
-    /// we advance currentAxisIndex.  Zero = not currently holding.
-    @State private var holdRemaining: Double = 0
+    /// Hold progress for the current axis, 0..HOLD_SECONDS.  When this
+    /// reaches HOLD_SECONDS we capture and advance.
+    @State private var holdAccumulated: Double = 0
 
-    /// Old-firmware fallback timer — only kicks in when coverageMask is
-    /// always zero.  Cycles the prompt every 3 s as a degraded UX.
-    @State private var fallbackTimer: Timer?
-
-    /// State-machine driver — fires every TICK_SECONDS while the view
-    /// is visible.  Started in onAppear, torn down in onDisappear.
+    /// State-machine tick.  Started in onAppear, torn down on disappear.
     @State private var tickTimer: Timer?
-
-    /// True any time the FC's wire frame can carry per-wedge info.
-    /// Zero-mask + zero-bins (no samples yet) still counts as "live" so
-    /// a fresh entry isn't misread as old firmware.
-    private var hasLiveMask: Bool { status.coverageMask != 0 || status.coverageBins == 0 }
 
     /// The axis the user should be aiming for right now (nil = all 6 done).
     private var currentAxis: MagCalAxis? {
@@ -400,18 +403,39 @@ private struct SamplingHero: View {
             : nil
     }
 
-    /// True if the user is in the right orientation for the current
-    /// target — the corresponding wedge bit is set on the FC side.
-    private var currentAxisMatched: Bool {
-        guard hasLiveMask, let axis = currentAxis else { return false }
-        return status.isAxisCovered(axis)
+    /// True if the live accel vector indicates the rocket is in the
+    /// orientation the current target axis prompts for.
+    private var isAlignedWithTarget: Bool {
+        guard let target = currentAxis,
+              let x = ax, let y = ay, let z = az else { return false }
+        return SamplingHero.isAligned(target: target, ax: x, ay: y, az: z)
     }
 
-    private var isHolding: Bool { holdRemaining > 0 }
+    /// Per-axis alignment check.  An axis "matches" the accel vector
+    /// when (a) the target's component (X/Y/Z) is the dominant one, and
+    /// (b) that component's sign matches the target.  Threshold filters
+    /// out near-zero components so wobble doesn't accidentally count.
+    static func isAligned(target: MagCalAxis, ax: Float, ay: Float, az: Float) -> Bool {
+        let xa = abs(ax), ya = abs(ay), za = abs(az)
+        let peak = max(xa, max(ya, za))
+        guard peak >= SamplingHero.DOMINANT_THRESHOLD_MS2 else { return false }
 
-    /// Adaptive headline.  Drives off the local prompt index so it
-    /// updates in lock-step with what the user actually sees, rather
-    /// than off the FC's coverage count which can include diagonals.
+        let dominant: MagCalComponent
+        if peak == xa { dominant = .x }
+        else if peak == ya { dominant = .y }
+        else { dominant = .z }
+        guard dominant == target.component else { return false }
+
+        let signed: Float
+        switch dominant {
+        case .x: signed = ax
+        case .y: signed = ay
+        case .z: signed = az
+        }
+        return (signed > 0) == (target.sign > 0)
+    }
+
+    /// Adaptive headline.  Drives off the local prompt index.
     private var headline: String {
         if currentAxis == nil { return "All orientations captured" }
         switch currentAxisIndex {
@@ -432,19 +456,20 @@ private struct SamplingHero: View {
             orientationGrid
 
             HStack(spacing: 28) {
-                // Live |B|.  Big monospaced digits so the eye sees motion
-                // and trusts that sampling is live.
+                // Live |B| (raw, includes hard-iron bias).  Useful as a
+                // sanity check that mag is still sampling.
                 VStack(spacing: 2) {
                     Text(String(format: "%.0f", status.instantaneousFieldUT))
-                        .font(.system(size: 36, weight: .bold, design: .monospaced))
-                    Text("µT field")
+                        .font(.system(size: 32, weight: .bold, design: .monospaced))
+                    Text("µT raw |B|")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
 
-                // Total-coverage gauge.  Counts all 26 wedges (including
-                // diagonals); the six-axis grid above shows only the
-                // cardinals.
+                // Sphere-fit diversity gauge — how many of the 26 wedges
+                // of MAGNETIC-space have been sampled.  Independent of
+                // the cardinal-orientation walk above.  More wedges →
+                // better-conditioned sphere fit.
                 ZStack {
                     Circle()
                         .stroke(Color.gray.opacity(0.20), lineWidth: 10)
@@ -456,13 +481,13 @@ private struct SamplingHero: View {
                         .animation(.easeInOut(duration: 0.4), value: status.coverageBins)
                     VStack(spacing: 0) {
                         Text("\(status.coverageBins)")
-                            .font(.system(size: 22, weight: .bold, design: .monospaced))
-                        Text("/ 26")
+                            .font(.system(size: 20, weight: .bold, design: .monospaced))
+                        Text("fit dvs")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }
                 }
-                .frame(width: 84, height: 84)
+                .frame(width: 76, height: 76)
             }
         }
         .onAppear { startTimers() }
@@ -472,46 +497,43 @@ private struct SamplingHero: View {
     // MARK: - Pieces
 
     /// The big "do this now" prompt card.  Three visual states:
-    ///   - Prompting: orange arrow icon + "Point the nose UP" + caption
-    ///   - Holding:   green check + "Captured! Hold steady…" + countdown bar
-    ///   - All done:  seal + "All orientations captured" message
+    ///   - Prompting:  orange arrow icon + "Point the nose UP" + caption
+    ///   - Filling:    green check + progress bar growing toward capture
+    ///   - All done:   seal + "All orientations captured"
+    /// The fill bar uses accel-driven `holdAccumulated` rather than a
+    /// blind timer — if the user wobbles out of alignment, fill stops
+    /// (and gently decays); if they hold, it advances.
     @ViewBuilder
     private var currentTargetCard: some View {
         if let axis = currentAxis {
-            let holding = isHolding
+            let aligned = isAlignedWithTarget
             HStack(spacing: 12) {
-                Image(systemName: holding ? "checkmark.circle.fill" : axis.icon)
+                Image(systemName: aligned ? "checkmark.circle.fill" : axis.icon)
                     .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(holding ? .green : .orange)
+                    .foregroundColor(aligned ? .green : .orange)
                     .frame(width: 44)
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(holding ? "Captured — hold steady" : axis.prompt)
+                    Text(aligned ? "Aligned — hold steady" : axis.prompt)
                         .font(.headline)
-                    if holding {
-                        // Countdown bar shrinks from full → empty over
-                        // HOLD_SECONDS.  More tangible than a "1.4 s"
-                        // number that flickers.
-                        ProgressView(value: max(0, holdRemaining),
-                                     total: SamplingHero.HOLD_SECONDS)
-                            .progressViewStyle(.linear)
-                            .tint(.green)
-                        Text(String(format: "Advancing in %.1f s", holdRemaining))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text("Hold this position until it turns green")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+                    ProgressView(value: holdAccumulated,
+                                 total: SamplingHero.HOLD_SECONDS)
+                        .progressViewStyle(.linear)
+                        .tint(aligned ? .green : .orange)
+                    Text(aligned
+                        ? String(format: "Capturing… %.0f%%",
+                                 100 * holdAccumulated / SamplingHero.HOLD_SECONDS)
+                        : "Use the bars below to see which axis is dominant")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
                 Spacer()
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 14)
-            .background((holding ? Color.green : Color.orange).opacity(0.12))
+            .background((aligned ? Color.green : Color.orange).opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 8)
-            .animation(.easeInOut(duration: 0.25), value: holding)
+            .animation(.easeInOut(duration: 0.20), value: aligned)
         } else {
             HStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")
@@ -521,7 +543,7 @@ private struct SamplingHero: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("All orientations captured")
                         .font(.headline)
-                    Text("Keep rolling slowly for a clean fit…")
+                    Text("Tap Compute Fit when ready, or keep rolling for better diversity.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -535,10 +557,8 @@ private struct SamplingHero: View {
         }
     }
 
-    /// 6-cell grid showing per-axis progress.  Each cell turns green
-    /// once we've held that axis to completion (currentAxisIndex moved
-    /// past it).  The CURRENT target also gets a blue ring + pulse so
-    /// it's obvious which one we're prompting for.
+    /// 6-cell grid showing per-axis capture state.  Captured = green,
+    /// current target = blue ring, future = grey.
     private var orientationGrid: some View {
         let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
         return LazyVGrid(columns: cols, spacing: 8) {
@@ -571,108 +591,103 @@ private struct SamplingHero: View {
     // MARK: - Timers / state-machine
 
     private func startTimers() {
-        // Main state-machine tick.
         tickTimer?.invalidate()
         tickTimer = Timer.scheduledTimer(withTimeInterval: SamplingHero.TICK_SECONDS,
                                           repeats: true) { _ in
             DispatchQueue.main.async { advance() }
         }
-        // Old-firmware fallback: if we never get a real mask, walk the
-        // axis cycle on a slow timer so the user still gets prompts.
-        // The FC fit will still run, just without per-orientation
-        // confirmation.
-        fallbackTimer?.invalidate()
-        fallbackTimer = Timer.scheduledTimer(withTimeInterval: 3.0,
-                                              repeats: true) { _ in
-            DispatchQueue.main.async {
-                if !hasLiveMask && !isHolding && currentAxisIndex < SamplingHero.axisOrder.count {
-                    // No live coverage info — simulate a hold completing.
-                    holdRemaining = 0
-                    currentAxisIndex += 1
-                }
-            }
-        }
     }
 
     private func stopTimers() {
         tickTimer?.invalidate(); tickTimer = nil
-        fallbackTimer?.invalidate(); fallbackTimer = nil
     }
 
-    /// One tick of the state machine.  Either tick down a running hold,
-    /// or start one if the current target's wedge bit is now set.
+    /// One tick of the state machine.  Fills holdAccumulated when the
+    /// rocket is aligned with the current target; gently decays it when
+    /// it isn't (so brief wobble doesn't reset everything).  When the
+    /// bar fills, capture the axis and move to the next.
     private func advance() {
         guard currentAxis != nil else { return }
-        if isHolding {
-            holdRemaining = max(0, holdRemaining - SamplingHero.TICK_SECONDS)
-            if holdRemaining == 0 {
-                // Hold done — advance past the current axis.
+        let step = SamplingHero.TICK_SECONDS
+        if isAlignedWithTarget {
+            holdAccumulated = min(SamplingHero.HOLD_SECONDS,
+                                  holdAccumulated + step)
+            if holdAccumulated >= SamplingHero.HOLD_SECONDS {
                 currentAxisIndex += 1
+                holdAccumulated = 0
             }
-        } else if currentAxisMatched {
-            // Orientation just matched — kick off the visible hold.
-            holdRemaining = SamplingHero.HOLD_SECONDS
+        } else {
+            // Gentle decay — half the fill rate so a brief wobble
+            // doesn't wipe several seconds of work.
+            holdAccumulated = max(0, holdAccumulated - step * 0.5)
         }
     }
 }
 
 // MARK: - Direction Bars
 
-/// Live mag-vector display: three signed horizontal bars for X, Y, Z
-/// (µT, post-IIS2MDC-OFFSET-subtract).  Centred at zero with a ±100 µT
-/// full-scale so an Earth field (~50 µT) reaches roughly half-bar.  The
-/// currently dominant component (largest |value|, above a small dead
-/// zone) is highlighted in blue so the user can see at a glance which
-/// axis their orientation is producing — the key feedback that was
-/// missing when the user couldn't tell whether nose-up was actually
-/// being detected.
+/// Live low-g accelerometer (gravity) display: three signed horizontal
+/// bars for X, Y, Z (m/s²).  Drives orientation feedback during the cal
+/// because the magnetometer is unreliable as an orientation reference
+/// — it's literally what we're trying to calibrate, and at the start of
+/// a cal session it can be biased by 30× Earth's field.  Gravity is a
+/// dependable ±9.81 m/s² reference vector that's always in the body
+/// frame.
 ///
-/// Falls back to a "waiting for live data" placeholder when running
-/// against firmware older than the 32-byte payload (all three components
-/// zero).
+/// The currently dominant axis (largest |value| above a small dead
+/// zone) is highlighted in blue so the user can verify at a glance
+/// which body axis is currently pointing up or down.
+///
+/// nil accel inputs render a "waiting for telemetry" placeholder.
 private struct DirectionBars: View {
-    let status: MagCalStatus
+    let ax: Float?
+    let ay: Float?
+    let az: Float?
 
-    /// Bar full-scale.  Fixed (not auto-scaling) so the bars don't
-    /// jitter as the user tumbles.  Earth fields land ~50 µT; the
-    /// uncalibrated PCB residual seen on this board is ~1640 µT so we
-    /// clamp wider — values past full-scale stay pinned at the end.
-    private static let RANGE_UT: Float = 100.0
+    /// Bar full-scale.  Set just above 1 g so a clean cardinal
+    /// orientation reads ~80% of the bar — visually saturated without
+    /// being pinned at the edge.
+    private static let RANGE_MS2: Float = 12.0
 
-    /// Components below this (in µT abs) don't count as "dominant" —
-    /// avoids flickering the highlight between near-zero axes when the
-    /// rocket is between orientations.
-    private static let DEAD_ZONE_UT: Float = 5.0
+    /// Components below this (m/s²) don't count as "dominant" — avoids
+    /// flickering the highlight between near-zero axes when the rocket
+    /// is in between orientations or tumbling.
+    private static let DEAD_ZONE_MS2: Float = 2.0
 
     private var hasLiveVector: Bool {
-        status.liveX_uT != 0 || status.liveY_uT != 0 || status.liveZ_uT != 0
+        ax != nil && ay != nil && az != nil
     }
 
-    /// Which axis is currently dominant (largest absolute value), or nil
-    /// if all three are below the dead zone.
+    /// Which axis is currently dominant, or nil if all three are below
+    /// the dead zone.
     private var dominantAxis: MagCalComponent? {
-        let xAbs = abs(status.liveX_uT)
-        let yAbs = abs(status.liveY_uT)
-        let zAbs = abs(status.liveZ_uT)
+        guard let x = ax, let y = ay, let z = az else { return nil }
+        let xAbs = abs(x), yAbs = abs(y), zAbs = abs(z)
         let peak = max(xAbs, max(yAbs, zAbs))
-        if peak < DirectionBars.DEAD_ZONE_UT { return nil }
+        if peak < DirectionBars.DEAD_ZONE_MS2 { return nil }
         if peak == xAbs { return .x }
         if peak == yAbs { return .y }
         return .z
     }
 
     var body: some View {
-        if hasLiveVector {
+        if hasLiveVector, let x = ax, let y = ay, let z = az {
             VStack(spacing: 10) {
-                ForEach(MagCalComponent.allCases, id: \.rawValue) { comp in
-                    ComponentBar(label: comp.rawValue,
-                                 value: comp.value(in: status),
-                                 range: DirectionBars.RANGE_UT,
-                                 isDominant: comp == dominantAxis)
-                }
+                ComponentBar(label: "X", value: x,
+                             range: DirectionBars.RANGE_MS2,
+                             isDominant: dominantAxis == .x,
+                             unitSuffix: " m/s²")
+                ComponentBar(label: "Y", value: y,
+                             range: DirectionBars.RANGE_MS2,
+                             isDominant: dominantAxis == .y,
+                             unitSuffix: " m/s²")
+                ComponentBar(label: "Z", value: z,
+                             range: DirectionBars.RANGE_MS2,
+                             isDominant: dominantAxis == .z,
+                             unitSuffix: " m/s²")
             }
         } else {
-            Text("Waiting for live mag data… (re-flash firmware if this persists)")
+            Text("Waiting for accelerometer telemetry…")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
@@ -684,6 +699,10 @@ private struct ComponentBar: View {
     let value: Float
     let range: Float
     let isDominant: Bool
+    /// e.g. " µT" or " m/s²".  Currently unused in the trailing readout
+    /// (we keep it compact at "+9.8") but lives here so a future Detail
+    /// row can show the full unit.
+    let unitSuffix: String
 
     var body: some View {
         HStack(spacing: 12) {
@@ -720,7 +739,7 @@ private struct ComponentBar: View {
             }
             .frame(height: 24)
 
-            Text(String(format: "%+.0f", value))
+            Text(String(format: "%+.1f", value))
                 .font(.system(size: 14, weight: .semibold, design: .monospaced))
                 .frame(width: 56, alignment: .trailing)
                 .foregroundColor(isDominant ? .blue : .secondary)

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -339,26 +339,27 @@ struct MagCalView: View {
 
 // MARK: - Sampling Hero
 
-/// Guidance card for the sampling phase.  Walks the user through each
-/// cardinal orientation using the LOW-G ACCELEROMETER (gravity vector)
-/// as the orientation reference — never the magnetometer, which is
-/// exactly what we're trying to calibrate and may report wildly biased
-/// values until the fit is applied.
+/// Guidance card for the sampling phase.  Free-form orientation capture
+/// driven by the LOW-G ACCELEROMETER (gravity vector) — the user
+/// rotates the rocket through 6 unique orientations in whatever order
+/// is physically convenient, and each signed-axis (+X / -X / +Y / -Y /
+/// +Z / -Z) gets captured independently when the user holds that axis
+/// dominant for 1.5 s.  Earlier versions tried a fixed body-frame
+/// mapping (nose UP = +X, etc.); on the current rocket that mapping
+/// proved fragile (Down never triggered) so we drop the mapping
+/// entirely and let the bars + grid teach the user which physical
+/// rotation produces which signed axis.
 ///
-/// State machine:
-///   prompting(axis)  → user rotates the rocket; accel-dominant axis
-///                       compared with the target.
-///   filling(axis, p) → orientation matched; a progress bar fills from
-///                       0 → 1.  Gentle decay if alignment briefly
-///                       wobbles, so small movements don't reset.
-///   captured(axis)   → bar full; axis goes into capturedAxes; advance.
-///   allDone          → all 6 cardinals captured; FC keeps sampling
-///                       in the background until the user taps Compute Fit.
+/// Per-axis state machine:
+///   pending   → no progress yet
+///   capturing → axis is currently the dominant one; progress fills
+///               toward HOLD_SECONDS, gentle half-rate decay if the
+///               user wobbles out of alignment briefly
+///   captured  → progress hit HOLD_SECONDS; cell turns green and stays
 ///
-/// All orientation state is local to the view.  The FC's mag coverage
-/// is shown separately as a fit-quality indicator (it's the diversity
-/// of the sphere fit's input data, not whether the user reached the
-/// target physical orientations).
+/// Mag-side coverage from the FC is still shown (as the "fit dvs"
+/// gauge) — that's the diversity of the sphere fit's input data, and
+/// it grows in parallel with the accel-driven capture loop.
 private struct SamplingHero: View {
     let status: MagCalStatus
     /// Live low-g accelerometer in body frame, m/s².  Pulled from the
@@ -368,15 +369,7 @@ private struct SamplingHero: View {
     let ay: Float?
     let az: Float?
 
-    /// All six cardinal axes in the order the user walks through them.
-    /// Fixed across runs so users build muscle memory.
-    private static let axisOrder: [MagCalAxis] = [
-        .noseUp, .noseDown, .rightSide, .leftSide, .frontFace, .backFace
-    ]
-
-    /// Time the user must hold the alignment before the axis captures.
-    /// Long enough to feel deliberate; short enough that 6 axes plus
-    /// re-orientation time fits in a reasonable session.
+    /// Time the user must hold an axis aligned before it captures.
     private static let HOLD_SECONDS: Double = 1.5
     private static let TICK_SECONDS: Double = 0.05
 
@@ -385,64 +378,40 @@ private struct SamplingHero: View {
     /// orientations.  Gravity is ~9.81; 4 m/s² ≈ 24° off pure axis.
     private static let DOMINANT_THRESHOLD_MS2: Float = 4.0
 
-    /// Index into axisOrder of the orientation we're currently prompting
-    /// for.  Moves forward only.
-    @State private var currentAxisIndex: Int = 0
-
-    /// Hold progress for the current axis, 0..HOLD_SECONDS.  When this
-    /// reaches HOLD_SECONDS we capture and advance.
-    @State private var holdAccumulated: Double = 0
+    /// Per-signed-axis hold progress, 0..HOLD_SECONDS.  Captured when ≥
+    /// HOLD_SECONDS.  Kept as a dict keyed by SignedAxis so we can
+    /// progress multiple axes across the run (each rotation captures
+    /// the one currently dominant).
+    @State private var captureProgress: [SignedAxis: Double] = [:]
 
     /// State-machine tick.  Started in onAppear, torn down on disappear.
     @State private var tickTimer: Timer?
 
-    /// The axis the user should be aiming for right now (nil = all 6 done).
-    private var currentAxis: MagCalAxis? {
-        currentAxisIndex < SamplingHero.axisOrder.count
-            ? SamplingHero.axisOrder[currentAxisIndex]
-            : nil
-    }
-
-    /// True if the live accel vector indicates the rocket is in the
-    /// orientation the current target axis prompts for.
-    private var isAlignedWithTarget: Bool {
-        guard let target = currentAxis,
-              let x = ax, let y = ay, let z = az else { return false }
-        return SamplingHero.isAligned(target: target, ax: x, ay: y, az: z)
-    }
-
-    /// Per-axis alignment check.  An axis "matches" the accel vector
-    /// when (a) the target's component (X/Y/Z) is the dominant one, and
-    /// (b) that component's sign matches the target.  Threshold filters
-    /// out near-zero components so wobble doesn't accidentally count.
-    static func isAligned(target: MagCalAxis, ax: Float, ay: Float, az: Float) -> Bool {
-        let xa = abs(ax), ya = abs(ay), za = abs(az)
+    /// Whichever signed axis is currently dominant in the accel reading,
+    /// or nil if no axis is above the dominance threshold (free-fall,
+    /// rapid tumble, near-zero gravity component).
+    private var currentlyAligned: SignedAxis? {
+        guard let x = ax, let y = ay, let z = az else { return nil }
+        let xa = abs(x), ya = abs(y), za = abs(z)
         let peak = max(xa, max(ya, za))
-        guard peak >= SamplingHero.DOMINANT_THRESHOLD_MS2 else { return false }
+        guard peak >= SamplingHero.DOMINANT_THRESHOLD_MS2 else { return nil }
 
-        let dominant: MagCalComponent
-        if peak == xa { dominant = .x }
-        else if peak == ya { dominant = .y }
-        else { dominant = .z }
-        guard dominant == target.component else { return false }
-
-        let signed: Float
-        switch dominant {
-        case .x: signed = ax
-        case .y: signed = ay
-        case .z: signed = az
-        }
-        return (signed > 0) == (target.sign > 0)
+        if peak == xa { return SignedAxis(component: .x, positive: x > 0) }
+        if peak == ya { return SignedAxis(component: .y, positive: y > 0) }
+        return SignedAxis(component: .z, positive: z > 0)
     }
 
-    /// Adaptive headline.  Drives off the local prompt index.
+    private var capturedCount: Int {
+        SignedAxis.allCases.filter { (captureProgress[$0] ?? 0) >= SamplingHero.HOLD_SECONDS }.count
+    }
+
+    /// Adaptive headline based on capture progress.
     private var headline: String {
-        if currentAxis == nil { return "All orientations captured" }
-        switch currentAxisIndex {
-        case 0:     return "Let's start"
-        case 1, 2:  return "Nice — keep going"
-        case 3, 4:  return "Almost there"
-        default:    return "Last one"
+        switch capturedCount {
+        case 6:     return "All six orientations captured"
+        case 4...5: return "Almost there"
+        case 1...3: return "Keep rotating"
+        default:    return "Rotate to any orientation"
         }
     }
 
@@ -451,6 +420,9 @@ private struct SamplingHero: View {
             Text(headline)
                 .font(.title3)
                 .fontWeight(.semibold)
+            Text("\(capturedCount) of 6 directions captured")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
 
             currentTargetCard
             orientationGrid
@@ -468,7 +440,7 @@ private struct SamplingHero: View {
 
                 // Sphere-fit diversity gauge — how many of the 26 wedges
                 // of MAGNETIC-space have been sampled.  Independent of
-                // the cardinal-orientation walk above.  More wedges →
+                // the accel-driven capture grid above.  More wedges →
                 // better-conditioned sphere fit.
                 ZStack {
                     Circle()
@@ -496,54 +468,26 @@ private struct SamplingHero: View {
 
     // MARK: - Pieces
 
-    /// The big "do this now" prompt card.  Three visual states:
-    ///   - Prompting:  orange arrow icon + "Point the nose UP" + caption
-    ///   - Filling:    green check + progress bar growing toward capture
-    ///   - All done:   seal + "All orientations captured"
-    /// The fill bar uses accel-driven `holdAccumulated` rather than a
-    /// blind timer — if the user wobbles out of alignment, fill stops
-    /// (and gently decays); if they hold, it advances.
+    /// Status card above the grid.  Three visual states:
+    ///   - Aligned (not yet captured): blue, progress bar fills toward
+    ///     capture; tells the user "you're doing it, keep holding."
+    ///   - Aligned (already captured): green check; "Try a different
+    ///     orientation."
+    ///   - Not aligned: orange; "Rotate the rocket — watch the bars."
+    /// All three states use the live accel reading; no fixed body-frame
+    /// assumption.
     @ViewBuilder
     private var currentTargetCard: some View {
-        if let axis = currentAxis {
-            let aligned = isAlignedWithTarget
-            HStack(spacing: 12) {
-                Image(systemName: aligned ? "checkmark.circle.fill" : axis.icon)
-                    .font(.system(size: 36, weight: .semibold))
-                    .foregroundColor(aligned ? .green : .orange)
-                    .frame(width: 44)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(aligned ? "Aligned — hold steady" : axis.prompt)
-                        .font(.headline)
-                    ProgressView(value: holdAccumulated,
-                                 total: SamplingHero.HOLD_SECONDS)
-                        .progressViewStyle(.linear)
-                        .tint(aligned ? .green : .orange)
-                    Text(aligned
-                        ? String(format: "Capturing… %.0f%%",
-                                 100 * holdAccumulated / SamplingHero.HOLD_SECONDS)
-                        : "Use the bars below to see which axis is dominant")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background((aligned ? Color.green : Color.orange).opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
-            .animation(.easeInOut(duration: 0.20), value: aligned)
-        } else {
+        if capturedCount == 6 {
             HStack(spacing: 12) {
                 Image(systemName: "checkmark.seal.fill")
                     .font(.system(size: 36, weight: .semibold))
                     .foregroundColor(.green)
                     .frame(width: 44)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("All orientations captured")
+                    Text("All six orientations captured")
                         .font(.headline)
-                    Text("Tap Compute Fit when ready, or keep rolling for better diversity.")
+                    Text("Tap Compute Fit when ready.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -554,34 +498,103 @@ private struct SamplingHero: View {
             .background(Color.green.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 8)
+        } else if let active = currentlyAligned {
+            let progress = captureProgress[active] ?? 0
+            let alreadyCaptured = progress >= SamplingHero.HOLD_SECONDS
+            HStack(spacing: 12) {
+                Image(systemName: alreadyCaptured ? "checkmark.circle.fill" : "scope")
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundColor(alreadyCaptured ? .green : .blue)
+                    .frame(width: 44)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(alreadyCaptured
+                        ? "\(active.label) already captured"
+                        : "Capturing \(active.label) — hold steady")
+                        .font(.headline)
+                    if !alreadyCaptured {
+                        ProgressView(value: progress,
+                                     total: SamplingHero.HOLD_SECONDS)
+                            .progressViewStyle(.linear)
+                            .tint(.blue)
+                        Text(String(format: "%.0f%%",
+                                    100 * progress / SamplingHero.HOLD_SECONDS))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Text("Rotate to a different orientation")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background((alreadyCaptured ? Color.green : Color.blue).opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
+            .animation(.easeInOut(duration: 0.20), value: alreadyCaptured)
+        } else {
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundColor(.orange)
+                    .frame(width: 44)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Rotate the rocket")
+                        .font(.headline)
+                    Text("Watch the bars below — when one axis reaches ≈ ±9.8 m/s², hold steady.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(Color.orange.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
         }
     }
 
-    /// 6-cell grid showing per-axis capture state.  Captured = green,
-    /// current target = blue ring, future = grey.
+    /// 6-cell grid showing per-signed-axis capture state.  Labels are
+    /// the raw ±X / ±Y / ±Z signed axis (no body-frame guessing) so the
+    /// user can match directly against the accel bars.
     private var orientationGrid: some View {
         let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
         return LazyVGrid(columns: cols, spacing: 8) {
-            ForEach(Array(SamplingHero.axisOrder.enumerated()), id: \.offset) { (idx, axis) in
-                let done = idx < currentAxisIndex
-                let isCurrent = idx == currentAxisIndex
+            ForEach(SignedAxis.allCases, id: \.self) { axis in
+                let progress = captureProgress[axis] ?? 0
+                let captured = progress >= SamplingHero.HOLD_SECONDS
+                let isActive = currentlyAligned == axis && !captured
+                let capturing = progress > 0 && !captured
                 VStack(spacing: 4) {
-                    Image(systemName: done ? "checkmark.circle.fill" : axis.icon)
+                    Image(systemName: captured ? "checkmark.circle.fill"
+                                  : isActive ? "scope"
+                                  : "circle")
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundColor(done ? .green : (isCurrent ? .blue : .gray))
-                    Text(axis.shortLabel)
-                        .font(.caption2)
-                        .foregroundColor(done || isCurrent ? .primary : .secondary)
+                        .foregroundColor(captured ? .green
+                                       : isActive ? .blue
+                                       : (capturing ? .blue.opacity(0.5) : .gray))
+                    Text(axis.label)
+                        .font(.system(.headline, design: .monospaced))
+                        .foregroundColor(captured ? .primary : .secondary)
+                    if capturing {
+                        ProgressView(value: progress, total: SamplingHero.HOLD_SECONDS)
+                            .progressViewStyle(.linear)
+                            .tint(.blue)
+                            .frame(height: 3)
+                    }
                 }
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, minHeight: 64)
                 .padding(.vertical, 8)
-                .background(done
-                    ? Color.green.opacity(0.12)
-                    : (isCurrent ? Color.blue.opacity(0.12) : Color.gray.opacity(0.08)))
+                .background(captured ? Color.green.opacity(0.12)
+                          : isActive ? Color.blue.opacity(0.12)
+                          : Color.gray.opacity(0.08))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(isCurrent ? Color.blue : Color.clear, lineWidth: 2)
+                        .stroke(isActive ? Color.blue : Color.clear, lineWidth: 2)
                 )
             }
         }
@@ -602,25 +615,46 @@ private struct SamplingHero: View {
         tickTimer?.invalidate(); tickTimer = nil
     }
 
-    /// One tick of the state machine.  Fills holdAccumulated when the
-    /// rocket is aligned with the current target; gently decays it when
-    /// it isn't (so brief wobble doesn't reset everything).  When the
-    /// bar fills, capture the axis and move to the next.
+    /// One tick of the state machine.  If an axis is currently dominant
+    /// in the accel reading, fill its progress.  Otherwise, gently
+    /// decay any in-progress (non-captured) axes so brief wobble
+    /// doesn't reset progress on whichever axis the user is working on.
     private func advance() {
-        guard currentAxis != nil else { return }
         let step = SamplingHero.TICK_SECONDS
-        if isAlignedWithTarget {
-            holdAccumulated = min(SamplingHero.HOLD_SECONDS,
-                                  holdAccumulated + step)
-            if holdAccumulated >= SamplingHero.HOLD_SECONDS {
-                currentAxisIndex += 1
-                holdAccumulated = 0
+        if let active = currentlyAligned {
+            let p = captureProgress[active] ?? 0
+            if p < SamplingHero.HOLD_SECONDS {
+                captureProgress[active] = min(SamplingHero.HOLD_SECONDS, p + step)
             }
         } else {
-            // Gentle decay — half the fill rate so a brief wobble
-            // doesn't wipe several seconds of work.
-            holdAccumulated = max(0, holdAccumulated - step * 0.5)
+            for axis in SignedAxis.allCases {
+                let p = captureProgress[axis] ?? 0
+                if p > 0 && p < SamplingHero.HOLD_SECONDS {
+                    captureProgress[axis] = max(0, p - step * 0.5)
+                }
+            }
         }
+    }
+}
+
+/// A signed body-frame axis — the six unique directions a rocket's
+/// gravity vector can point.  Used as the unit of "captured
+/// orientation" in the cal hero.
+private struct SignedAxis: Hashable {
+    let component: MagCalComponent
+    let positive: Bool
+
+    static let allCases: [SignedAxis] = [
+        SignedAxis(component: .x, positive: true),
+        SignedAxis(component: .x, positive: false),
+        SignedAxis(component: .y, positive: true),
+        SignedAxis(component: .y, positive: false),
+        SignedAxis(component: .z, positive: true),
+        SignedAxis(component: .z, positive: false),
+    ]
+
+    var label: String {
+        "\(positive ? "+" : "-")\(component.rawValue)"
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -510,10 +510,11 @@ private struct SamplingHero: View {
         .padding(.horizontal, 8)
     }
 
-    /// 6-cell grid.  Each cell is a tap-target: tap to mark that signed
-    /// axis captured.  Auto-detect (live accel dominance) drives a
-    /// blue ring around the matching cell as a hint, but doesn't gate
-    /// capture — the tap is what counts.
+    /// 6-cell grid.  Each cell is a tap-target — tap toggles capture
+    /// for that signed axis so an accidental tap can be undone without
+    /// restarting the whole cal.  Auto-detect (live accel dominance)
+    /// drives a blue ring around the matching cell as a hint but
+    /// doesn't gate capture — the tap is what counts.
     private var orientationGrid: some View {
         let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
         return LazyVGrid(columns: cols, spacing: 8) {
@@ -521,7 +522,13 @@ private struct SamplingHero: View {
                 let captured = capturedAxes.contains(axis)
                 let isActive = dominantAxis == axis && !captured
                 Button {
-                    capturedAxes.insert(axis)
+                    // Toggle: tap an unmarked cell to capture, tap a
+                    // captured cell to clear it (undo a misclick).
+                    if capturedAxes.contains(axis) {
+                        capturedAxes.remove(axis)
+                    } else {
+                        capturedAxes.insert(axis)
+                    }
                 } label: {
                     VStack(spacing: 4) {
                         Image(systemName: captured ? "checkmark.circle.fill"
@@ -534,7 +541,9 @@ private struct SamplingHero: View {
                         Text(axis.label)
                             .font(.system(.headline, design: .monospaced))
                             .foregroundColor(captured ? .primary : .secondary)
-                        Text(captured ? "captured" : isActive ? "tap to mark" : "")
+                        Text(captured ? "tap to undo"
+                           : isActive ? "tap to mark"
+                           : "")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }
@@ -550,7 +559,6 @@ private struct SamplingHero: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .disabled(captured)
             }
         }
         .padding(.horizontal, 8)

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -115,55 +115,48 @@ struct MagCalView: View {
         }
     }
 
-    /// Sampling: progress bar + live count + coverage + |B|.
+    /// Sampling: animated tumble guidance, live |B|, circular coverage
+    /// gauge, and a cycling orientation prompt so the user always knows
+    /// what to do next.  Drives all visuals off the FC's 5 Hz status
+    /// frame — no extra polling.
     private var samplingSection: some View {
         Group {
-            Section(header: Text("Tumble the rocket")) {
-                if let s = status {
-                    let progress = s.samplingProgress(
-                        targetSamples: MagCalConstants.maxSamples,
-                        minCoverage: 26  // visualise approach to full coverage; FC uses 18 as the gate
-                    )
-                    VStack(alignment: .leading, spacing: 12) {
-                        ProgressView(value: progress)
-                            .progressViewStyle(.linear)
-                        HStack {
-                            Text("Samples")
-                            Spacer()
-                            Text("\(s.sampleCount) / \(MagCalConstants.maxSamples)")
-                                .foregroundColor(.secondary)
-                                .font(.system(.body, design: .monospaced))
-                        }
-                        HStack {
-                            Text("Coverage")
-                            Spacer()
-                            Text("\(s.coverageBins) / 26 wedges")
-                                .foregroundColor(.secondary)
-                                .font(.system(.body, design: .monospaced))
-                        }
-                        HStack {
-                            Text("|B|")
-                            Spacer()
-                            Text(String(format: "%.1f µT", s.instantaneousFieldUT))
-                                .foregroundColor(.secondary)
-                                .font(.system(.body, design: .monospaced))
-                        }
-                    }
-                    .padding(.vertical, 4)
-                } else {
-                    ProgressView("Waiting for rocket…")
+            if let s = status {
+                Section {
+                    SamplingHero(status: s)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
                 }
-            }
-
-            Section {
-                Button(role: .destructive) {
-                    device.sendMagCalAbort()
-                } label: {
+                Section(header: Text("Progress")) {
                     HStack {
-                        Image(systemName: "xmark.circle")
-                        Text("Abort")
+                        Text("Coverage")
                         Spacer()
+                        Text("\(s.coverageBins) / 26 wedges")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
                     }
+                    HStack {
+                        Text("Samples")
+                        Spacer()
+                        Text("\(s.sampleCount) / \(MagCalConstants.maxSamples)")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                }
+                Section {
+                    Button(role: .destructive) {
+                        device.sendMagCalAbort()
+                    } label: {
+                        HStack {
+                            Image(systemName: "xmark.circle")
+                            Text("Abort")
+                            Spacer()
+                        }
+                    }
+                }
+            } else {
+                Section {
+                    ProgressView("Waiting for rocket…")
                 }
             }
         }
@@ -307,6 +300,133 @@ struct MagCalView: View {
                     }
                     .listRowBackground(Color.blue)
                 }
+            }
+        }
+    }
+}
+
+// MARK: - Sampling Hero
+
+/// Animated guidance card shown at the top of the sampling phase.  Three
+/// pieces of information that drive whether the user knows what to do:
+///   1. A rotation animation so they're not staring at a dead screen.
+///   2. A live |B| readout — the number changes immediately as they
+///      tumble, which is the most visceral confirmation that sampling
+///      is happening.
+///   3. A cycling orientation prompt with an arrow icon, so they always
+///      have an explicit "now do this" instead of a vague "tumble it."
+///
+/// All three drive off the FC's status frames + a local 2.5 s prompt
+/// timer; nothing requires extra firmware support.
+private struct SamplingHero: View {
+    let status: MagCalStatus
+
+    @State private var promptIndex: Int = 0
+    @State private var rotation: Double = 0
+
+    private static let prompts: [(icon: String, text: String)] = [
+        ("arrow.up",                "Point the nose UP"),
+        ("arrow.down",              "Now point the nose DOWN"),
+        ("arrow.left",              "Lay it on its LEFT side"),
+        ("arrow.right",             "Lay it on its RIGHT side"),
+        ("arrow.up.right",          "Tilt at an angle"),
+        ("arrow.triangle.2.circlepath", "Slowly roll it through every direction"),
+    ]
+
+    /// Headline that adapts to coverage so the user gets feedback even
+    /// when they're between cardinal-direction prompts.
+    private var headline: String {
+        switch status.coverageBins {
+        case 0..<6:   return "Start tumbling"
+        case 6..<14:  return "Good — keep going"
+        case 14..<22: return "Almost there"
+        default:      return "Excellent coverage"
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Text(headline)
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            // Rotating icon — visible motion is the cheapest signal that
+            // sampling is live.  Stops when the user accepts or aborts
+            // because the parent view replaces this hero entirely.
+            Image(systemName: "rotate.3d")
+                .font(.system(size: 64))
+                .foregroundColor(.blue)
+                .rotationEffect(.degrees(rotation))
+                .onAppear {
+                    withAnimation(.linear(duration: 3.0).repeatForever(autoreverses: false)) {
+                        rotation = 360
+                    }
+                }
+
+            // Cycling orientation prompt.  2.5 s/step × 6 steps = 15 s,
+            // longer than the ~10 s sample window so the user sees most
+            // of the cardinal cues at least once.
+            HStack(spacing: 12) {
+                Image(systemName: SamplingHero.prompts[promptIndex].icon)
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundColor(.orange)
+                    .frame(width: 36)
+                Text(SamplingHero.prompts[promptIndex].text)
+                    .font(.headline)
+                    .multilineTextAlignment(.leading)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.orange.opacity(0.10))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
+            .onAppear { startPromptCycle() }
+
+            HStack(spacing: 28) {
+                // Live |B|.  Big monospaced digits so the eye spots the
+                // movement and the user trusts that sampling is live.
+                VStack(spacing: 2) {
+                    Text(String(format: "%.0f", status.instantaneousFieldUT))
+                        .font(.system(size: 36, weight: .bold, design: .monospaced))
+                    Text("µT field")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                // Coverage gauge.  Circular feels more "spherical" than
+                // a linear bar — and the cal is literally about lighting
+                // up wedges of a sphere.
+                ZStack {
+                    Circle()
+                        .stroke(Color.gray.opacity(0.20), lineWidth: 10)
+                    Circle()
+                        .trim(from: 0, to: CGFloat(min(Double(status.coverageBins) / 26.0, 1.0)))
+                        .stroke(Color.green,
+                                style: StrokeStyle(lineWidth: 10, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                        .animation(.easeInOut(duration: 0.4), value: status.coverageBins)
+                    VStack(spacing: 0) {
+                        Text("\(status.coverageBins)")
+                            .font(.system(size: 22, weight: .bold, design: .monospaced))
+                        Text("/ 26")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .frame(width: 84, height: 84)
+            }
+        }
+    }
+
+    private func startPromptCycle() {
+        Timer.scheduledTimer(withTimeInterval: 2.5, repeats: true) { timer in
+            // The hero is created fresh on each entry to .sampling, so the
+            // timer's lifetime is bounded by the view.  We invalidate
+            // explicitly when the index would go out of range — defensive
+            // against the prompts array shrinking later.
+            DispatchQueue.main.async {
+                promptIndex = (promptIndex + 1) % SamplingHero.prompts.count
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -307,34 +307,62 @@ struct MagCalView: View {
 
 // MARK: - Sampling Hero
 
-/// Animated guidance card shown at the top of the sampling phase.  Three
-/// pieces of information that drive whether the user knows what to do:
-///   1. A rotation animation so they're not staring at a dead screen.
-///   2. A live |B| readout — the number changes immediately as they
-///      tumble, which is the most visceral confirmation that sampling
-///      is happening.
-///   3. A cycling orientation prompt with an arrow icon, so they always
-///      have an explicit "now do this" instead of a vague "tumble it."
+/// Guidance card shown at the top of the sampling phase.  Built around
+/// the FC's `coverageMask` — bit i is set once the user has dwelt long
+/// enough in wedge i for the calibrator to pick up that orientation.
 ///
-/// All three drive off the FC's status frames + a local 2.5 s prompt
-/// timer; nothing requires extra firmware support.
+/// The hero shows three things, all driven off the live mask:
+///   1. A "current target" card — one of six cardinal axes (nose UP,
+///      DOWN, LEFT side, RIGHT side, FRONT face, BACK face).  We pick
+///      the first uncovered axis in a fixed order and stay on it until
+///      the FC reports the corresponding wedge bit is set.  The card
+///      flips to a green checkmark for ~0.5 s before advancing — that
+///      micro-pause is the user-visible confirmation that the firmware
+///      and the app agree this orientation is captured.
+///   2. A 6-cell orientation grid showing which cardinal axes are done.
+///      Replaces the spinning-globe icon: users can see at a glance
+///      exactly how many more orientations are left, and which.
+///   3. A live |B| readout in µT so the user trusts that sampling is
+///      running.  Big monospaced digits — eye spots the change.
+///
+/// Old firmware (22-byte payload, coverageMask=0) means no per-axis
+/// info; in that case we fall back to a slow timer cycle through all
+/// six prompts so the UX still works.
 private struct SamplingHero: View {
     let status: MagCalStatus
 
-    @State private var promptIndex: Int = 0
-    @State private var rotation: Double = 0
-
-    private static let prompts: [(icon: String, text: String)] = [
-        ("arrow.up",                "Point the nose UP"),
-        ("arrow.down",              "Now point the nose DOWN"),
-        ("arrow.left",              "Lay it on its LEFT side"),
-        ("arrow.right",             "Lay it on its RIGHT side"),
-        ("arrow.up.right",          "Tilt at an angle"),
-        ("arrow.triangle.2.circlepath", "Slowly roll it through every direction"),
+    /// All six cardinal axes in the order the user is walked through them.
+    /// The fixed order means muscle memory carries between runs.
+    private static let axisOrder: [MagCalAxis] = [
+        .noseUp, .noseDown, .rightSide, .leftSide, .frontFace, .backFace
     ]
 
-    /// Headline that adapts to coverage so the user gets feedback even
-    /// when they're between cardinal-direction prompts.
+    /// Last target we showed — used to detect a "just covered" transition
+    /// so we can briefly hold the green-check confirmation.
+    @State private var lastSeenTarget: MagCalAxis?
+
+    /// When non-nil, the card shows this axis as just-captured (green
+    /// check) for ~0.6 s before the prompt advances.  Bridges the gap
+    /// between "wedge bit flipped" and "user has time to register it."
+    @State private var heldCoveredAxis: MagCalAxis?
+
+    /// Old-firmware fallback: cycle index for the timer-driven path.
+    @State private var fallbackIndex: Int = 0
+
+    /// Are we running against firmware that ships the coverage mask?
+    /// True any time the mask carries information OR no samples have
+    /// landed yet (so coverage_bins==0 isn't mistaken for "old FC").
+    private var hasLiveMask: Bool { status.coverageMask != 0 || status.coverageBins == 0 }
+
+    /// First uncovered axis in fixed order — the "do this now" target.
+    /// nil once all six cardinals are covered.
+    private var nextUncoveredAxis: MagCalAxis? {
+        SamplingHero.axisOrder.first { !status.isAxisCovered($0) }
+    }
+
+    /// Adaptive headline so the user gets feedback even between cardinal
+    /// transitions.  Computed off the coverage bin count, not the mask,
+    /// so this also works on old firmware.
     private var headline: String {
         switch status.coverageBins {
         case 0..<6:   return "Start tumbling"
@@ -350,38 +378,9 @@ private struct SamplingHero: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            // Rotating icon — visible motion is the cheapest signal that
-            // sampling is live.  Stops when the user accepts or aborts
-            // because the parent view replaces this hero entirely.
-            Image(systemName: "rotate.3d")
-                .font(.system(size: 64))
-                .foregroundColor(.blue)
-                .rotationEffect(.degrees(rotation))
-                .onAppear {
-                    withAnimation(.linear(duration: 3.0).repeatForever(autoreverses: false)) {
-                        rotation = 360
-                    }
-                }
+            currentTargetCard
 
-            // Cycling orientation prompt.  2.5 s/step × 6 steps = 15 s,
-            // longer than the ~10 s sample window so the user sees most
-            // of the cardinal cues at least once.
-            HStack(spacing: 12) {
-                Image(systemName: SamplingHero.prompts[promptIndex].icon)
-                    .font(.system(size: 28, weight: .semibold))
-                    .foregroundColor(.orange)
-                    .frame(width: 36)
-                Text(SamplingHero.prompts[promptIndex].text)
-                    .font(.headline)
-                    .multilineTextAlignment(.leading)
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(Color.orange.opacity(0.10))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
-            .onAppear { startPromptCycle() }
+            orientationGrid
 
             HStack(spacing: 28) {
                 // Live |B|.  Big monospaced digits so the eye spots the
@@ -394,9 +393,11 @@ private struct SamplingHero: View {
                         .foregroundColor(.secondary)
                 }
 
-                // Coverage gauge.  Circular feels more "spherical" than
-                // a linear bar — and the cal is literally about lighting
-                // up wedges of a sphere.
+                // Total-coverage gauge.  Circular feels more "spherical"
+                // than a linear bar — the cal is literally about lighting
+                // up wedges of a sphere.  Counts all 26 wedges, including
+                // the diagonals; the six-axis grid above shows only the
+                // cardinals.
                 ZStack {
                     Circle()
                         .stroke(Color.gray.opacity(0.20), lineWidth: 10)
@@ -417,16 +418,125 @@ private struct SamplingHero: View {
                 .frame(width: 84, height: 84)
             }
         }
+        .onChange(of: status.coverageMask) { _ in
+            guard hasLiveMask else { return }
+            // Detect the "previous target just got captured" transition:
+            // the axis we were prompting for now has its wedge bit set.
+            // Flash it green for a beat before the prompt advances.
+            if let prev = lastSeenTarget,
+               prev != nextUncoveredAxis,
+               status.isAxisCovered(prev),
+               heldCoveredAxis == nil {
+                heldCoveredAxis = prev
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    heldCoveredAxis = nil
+                }
+            }
+            lastSeenTarget = nextUncoveredAxis
+        }
+        .onAppear {
+            lastSeenTarget = nextUncoveredAxis
+            if !hasLiveMask { startFallbackCycle() }
+        }
     }
 
-    private func startPromptCycle() {
-        Timer.scheduledTimer(withTimeInterval: 2.5, repeats: true) { timer in
-            // The hero is created fresh on each entry to .sampling, so the
-            // timer's lifetime is bounded by the view.  We invalidate
-            // explicitly when the index would go out of range — defensive
-            // against the prompts array shrinking later.
+    // MARK: - Pieces
+
+    /// Display priority for the prompt card: held-just-captured → next
+    /// uncovered → cycle fallback (old firmware).  `covered` is true
+    /// only when we're displaying a just-captured axis.
+    private var promptDisplay: (axis: MagCalAxis?, covered: Bool) {
+        if let held = heldCoveredAxis {
+            return (held, true)
+        }
+        if hasLiveMask {
+            return (nextUncoveredAxis, false)
+        }
+        return (SamplingHero.axisOrder[fallbackIndex % SamplingHero.axisOrder.count], false)
+    }
+
+    /// The big "do this now" prompt card.  Stays on the same axis until
+    /// the firmware reports its wedge is populated, then flashes a green
+    /// "Captured!" for ~0.6 s before moving to the next.
+    @ViewBuilder
+    private var currentTargetCard: some View {
+        let display = promptDisplay
+        let axisToShow = display.axis
+        let covered = display.covered
+
+        HStack(spacing: 12) {
+            if let axis = axisToShow {
+                Image(systemName: covered ? "checkmark.circle.fill" : axis.icon)
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundColor(covered ? .green : .orange)
+                    .frame(width: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(covered ? "Captured!" : axis.prompt)
+                        .font(.headline)
+                    Text(covered ? "Moving to next orientation…" : "Hold this position")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            } else {
+                // All six cardinal axes done — the FC fit-gate is on 18
+                // total wedges, so coverage may still be growing through
+                // the diagonals; keep encouraging the user.
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundColor(.green)
+                    .frame(width: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("All six axes captured")
+                        .font(.headline)
+                    Text("Keep rolling for full coverage…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background((covered ? Color.green : Color.orange).opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 8)
+        .animation(.easeInOut(duration: 0.25), value: covered)
+    }
+
+    /// 6-cell grid showing which cardinal axes are captured.  Replaces
+    /// the spinning globe — gives the user an at-a-glance map of what
+    /// orientations remain.
+    private var orientationGrid: some View {
+        let cols = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
+        return LazyVGrid(columns: cols, spacing: 8) {
+            ForEach(SamplingHero.axisOrder, id: \.self) { axis in
+                let covered = hasLiveMask && status.isAxisCovered(axis)
+                VStack(spacing: 4) {
+                    Image(systemName: covered ? "checkmark.circle.fill" : axis.icon)
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(covered ? .green : .gray)
+                    Text(axis.shortLabel)
+                        .font(.caption2)
+                        .foregroundColor(covered ? .primary : .secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(covered
+                    ? Color.green.opacity(0.12)
+                    : Color.gray.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    // MARK: - Old-firmware fallback (timer cycle)
+
+    private func startFallbackCycle() {
+        Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
             DispatchQueue.main.async {
-                promptIndex = (promptIndex + 1) % SamplingHero.prompts.count
+                fallbackIndex = (fallbackIndex + 1) % SamplingHero.axisOrder.count
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -115,10 +115,9 @@ struct MagCalView: View {
         }
     }
 
-    /// Sampling: animated tumble guidance, live |B|, circular coverage
-    /// gauge, and a cycling orientation prompt so the user always knows
-    /// what to do next.  Drives all visuals off the FC's 5 Hz status
-    /// frame — no extra polling.
+    /// Sampling: orientation-progress hero, live direction bars, Compute
+    /// Fit button (user-driven completion — no auto-timeout), and abort.
+    /// All driven off the FC's 5 Hz status frame.
     private var samplingSection: some View {
         Group {
             if let s = status {
@@ -126,6 +125,11 @@ struct MagCalView: View {
                     SamplingHero(status: s)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
+                }
+                Section(header: Text("Live mag vector"),
+                        footer: Text("Use the bars to verify which axis is dominant. The current target's bar is highlighted — adjust the rocket until its bar reaches the target marker.")) {
+                    DirectionBars(status: s)
+                        .padding(.vertical, 4)
                 }
                 Section(header: Text("Progress")) {
                     HStack {
@@ -142,6 +146,27 @@ struct MagCalView: View {
                             .foregroundColor(.secondary)
                             .font(.system(.body, design: .monospaced))
                     }
+                }
+                // Compute Fit replaces the old auto-completion-at-buffer-fill.
+                // Disabled until min samples reached so the user can't ship a
+                // bad fit; styled as the primary action once ready.
+                let canFit = s.sampleCount >= MagCalConstants.minSamples
+                Section(footer: Text(canFit
+                    ? "When you're happy with the coverage, tap Compute Fit to run the sphere fit and review the result."
+                    : "Need ≥ \(MagCalConstants.minSamples) samples before fitting. Keep tumbling…")) {
+                    Button {
+                        device.sendMagCalComputeFit()
+                    } label: {
+                        HStack {
+                            Image(systemName: "checkmark.circle.fill")
+                            Text("Compute Fit")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                        .foregroundColor(.white)
+                    }
+                    .listRowBackground(canFit ? Color.blue : Color.gray)
+                    .disabled(!canFit)
                 }
                 Section {
                     Button(role: .destructive) {
@@ -587,6 +612,118 @@ private struct SamplingHero: View {
         } else if currentAxisMatched {
             // Orientation just matched — kick off the visible hold.
             holdRemaining = SamplingHero.HOLD_SECONDS
+        }
+    }
+}
+
+// MARK: - Direction Bars
+
+/// Live mag-vector display: three signed horizontal bars for X, Y, Z
+/// (µT, post-IIS2MDC-OFFSET-subtract).  Centred at zero with a ±100 µT
+/// full-scale so an Earth field (~50 µT) reaches roughly half-bar.  The
+/// currently dominant component (largest |value|, above a small dead
+/// zone) is highlighted in blue so the user can see at a glance which
+/// axis their orientation is producing — the key feedback that was
+/// missing when the user couldn't tell whether nose-up was actually
+/// being detected.
+///
+/// Falls back to a "waiting for live data" placeholder when running
+/// against firmware older than the 32-byte payload (all three components
+/// zero).
+private struct DirectionBars: View {
+    let status: MagCalStatus
+
+    /// Bar full-scale.  Fixed (not auto-scaling) so the bars don't
+    /// jitter as the user tumbles.  Earth fields land ~50 µT; the
+    /// uncalibrated PCB residual seen on this board is ~1640 µT so we
+    /// clamp wider — values past full-scale stay pinned at the end.
+    private static let RANGE_UT: Float = 100.0
+
+    /// Components below this (in µT abs) don't count as "dominant" —
+    /// avoids flickering the highlight between near-zero axes when the
+    /// rocket is between orientations.
+    private static let DEAD_ZONE_UT: Float = 5.0
+
+    private var hasLiveVector: Bool {
+        status.liveX_uT != 0 || status.liveY_uT != 0 || status.liveZ_uT != 0
+    }
+
+    /// Which axis is currently dominant (largest absolute value), or nil
+    /// if all three are below the dead zone.
+    private var dominantAxis: MagCalComponent? {
+        let xAbs = abs(status.liveX_uT)
+        let yAbs = abs(status.liveY_uT)
+        let zAbs = abs(status.liveZ_uT)
+        let peak = max(xAbs, max(yAbs, zAbs))
+        if peak < DirectionBars.DEAD_ZONE_UT { return nil }
+        if peak == xAbs { return .x }
+        if peak == yAbs { return .y }
+        return .z
+    }
+
+    var body: some View {
+        if hasLiveVector {
+            VStack(spacing: 10) {
+                ForEach(MagCalComponent.allCases, id: \.rawValue) { comp in
+                    ComponentBar(label: comp.rawValue,
+                                 value: comp.value(in: status),
+                                 range: DirectionBars.RANGE_UT,
+                                 isDominant: comp == dominantAxis)
+                }
+            }
+        } else {
+            Text("Waiting for live mag data… (re-flash firmware if this persists)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+private struct ComponentBar: View {
+    let label: String
+    let value: Float
+    let range: Float
+    let isDominant: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.system(.headline, design: .monospaced))
+                .frame(width: 20)
+                .foregroundColor(isDominant ? .blue : .secondary)
+
+            // Two-sided bar centered at zero.  GeometryReader lets us
+            // size the half-bar in points and place it relative to the
+            // centre tick.
+            GeometryReader { geo in
+                let half = geo.size.width / 2
+                let mag = min(abs(value), range)
+                let frac = CGFloat(mag) / CGFloat(range)
+                let barWidth = frac * half
+
+                ZStack(alignment: .leading) {
+                    // Track
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.gray.opacity(0.15))
+                        .frame(height: 18)
+                    // Centre tick
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.5))
+                        .frame(width: 1, height: 24)
+                        .offset(x: half - 0.5)
+                    // Signed bar
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(isDominant ? Color.blue : Color.blue.opacity(0.45))
+                        .frame(width: barWidth, height: 16)
+                        .offset(x: value >= 0 ? half : (half - barWidth))
+                }
+            }
+            .frame(height: 24)
+
+            Text(String(format: "%+.0f", value))
+                .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                .frame(width: 56, alignment: .trailing)
+                .foregroundColor(isDominant ? .blue : .secondary)
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import Combine
 
 struct MagCalView: View {
     @ObservedObject var device: BLEDevice
@@ -27,6 +28,12 @@ struct MagCalView: View {
     /// (e.g. just navigated in, before tapping Start).  In that case the
     /// view shows the intro/Start state.
     private var status: MagCalStatus? { device.magCalStatus }
+
+    /// Accel-driven orientation coverage tracker.  Owned at the view
+    /// level so both the SamplingHero gauge and the Progress section
+    /// read the same value.  Reset whenever a fresh sampling run
+    /// starts (sample_count transitions to 0).
+    @StateObject private var accelCoverage = AccelCoverageTracker()
 
     var body: some View {
         Form {
@@ -129,7 +136,8 @@ struct MagCalView: View {
                 let ay = device.telemetry.low_g_y
                 let az = device.telemetry.low_g_z
                 Section {
-                    SamplingHero(status: s, ax: ax, ay: ay, az: az)
+                    SamplingHero(status: s, ax: ax, ay: ay, az: az,
+                                 accelCoverage: accelCoverage)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
                 }
@@ -138,18 +146,19 @@ struct MagCalView: View {
                     DirectionBars(ax: ax, ay: ay, az: az)
                         .padding(.vertical, 4)
                 }
-                Section(header: Text("Progress")) {
+                Section(header: Text("Progress"),
+                        footer: Text("Coverage counts gravity-direction wedges visited during this run — independent of the mag samples. The fit-quality coverage (mag wedges, post-centring) is shown on the Review screen.")) {
                     HStack {
-                        Text("Coverage")
+                        Text("Orientation coverage")
                         Spacer()
-                        Text("\(s.coverageBins) / 26 wedges")
+                        Text("\(accelCoverage.coverageCount) / 26 wedges")
                             .foregroundColor(.secondary)
                             .font(.system(.body, design: .monospaced))
                     }
                     HStack {
                         Text("Samples")
                         Spacer()
-                        Text("\(s.sampleCount) / \(MagCalConstants.maxSamples)")
+                        Text("\(s.sampleCount) / \(MagCalConstants.maxSamples) (rolling)")
                             .foregroundColor(.secondary)
                             .font(.system(.body, design: .monospaced))
                     }
@@ -375,6 +384,11 @@ private struct SamplingHero: View {
     /// is sampling mag continuously regardless of what's in here.
     @State private var capturedAxes: Set<SignedAxis> = []
 
+    /// Accel-driven orientation coverage tracker, supplied by the parent
+    /// view so the gauge here and the row in the Progress section read
+    /// the same value.
+    @ObservedObject var accelCoverage: AccelCoverageTracker
+
     /// Whichever signed axis is currently dominant in the accel reading.
     /// Pure-derived; no state.  Returns nil when no axis is above the
     /// dominance threshold (free-fall, rapid tumble, near-zero gravity).
@@ -422,24 +436,25 @@ private struct SamplingHero: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
-                // FC-side sphere-fit diversity gauge.  Tracks how many
-                // of the 26 mag-space wedges have been visited; with a
-                // large hard-iron bias this can stay near zero even as
-                // sample_count grows — that's expected and the fit will
-                // still recover the bias.
+                // Accel-based orientation coverage gauge.  Counts how
+                // many of 26 wedges of the gravity-direction sphere the
+                // user has rotated through.  Drives the meaningful
+                // "have I rotated through enough orientations?" signal
+                // during sampling, in place of the mag-side coverage
+                // that's biased and useless until the fit runs.
                 ZStack {
                     Circle()
                         .stroke(Color.gray.opacity(0.20), lineWidth: 10)
                     Circle()
-                        .trim(from: 0, to: CGFloat(min(Double(status.coverageBins) / 26.0, 1.0)))
+                        .trim(from: 0, to: CGFloat(min(Double(accelCoverage.coverageCount) / 26.0, 1.0)))
                         .stroke(Color.green,
                                 style: StrokeStyle(lineWidth: 10, lineCap: .round))
                         .rotationEffect(.degrees(-90))
-                        .animation(.easeInOut(duration: 0.4), value: status.coverageBins)
+                        .animation(.easeInOut(duration: 0.4), value: accelCoverage.coverageCount)
                     VStack(spacing: 0) {
-                        Text("\(status.coverageBins)")
+                        Text("\(accelCoverage.coverageCount)")
                             .font(.system(size: 20, weight: .bold, design: .monospaced))
-                        Text("fit dvs")
+                        Text("/ 26")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }
@@ -447,6 +462,22 @@ private struct SamplingHero: View {
                 .frame(width: 76, height: 76)
             }
         }
+        // Reset accel coverage whenever the user starts a fresh
+        // sampling run (Start / Retry both increment sample_count from
+        // 0, so a drop to zero is the signal).
+        .onChange(of: status.sampleCount) { newValue in
+            if newValue == 0 {
+                accelCoverage.reset()
+                capturedAxes.removeAll()
+            }
+        }
+        // Feed live accel to the tracker on each new reading.  Watching
+        // all three components catches every refresh — the regular
+        // telemetry stream delivers low_g_x/y/z together, so this fires
+        // at the telemetry rate (~10 Hz).
+        .onChange(of: ax) { _ in accelCoverage.update(ax: ax, ay: ay, az: az) }
+        .onChange(of: ay) { _ in accelCoverage.update(ax: ax, ay: ay, az: az) }
+        .onChange(of: az) { _ in accelCoverage.update(ax: ax, ay: ay, az: az) }
     }
 
     // MARK: - Pieces
@@ -706,5 +737,61 @@ private struct ComponentBar: View {
                 .frame(width: 56, alignment: .trailing)
                 .foregroundColor(isDominant ? .blue : .secondary)
         }
+    }
+}
+
+// MARK: - Accel coverage tracker
+
+/// Live orientation-coverage counter for the mag-cal sampling phase.
+/// Bins the gravity-direction unit vector into the same 3³ = 27-cell
+/// grid the firmware uses for its post-fit mag coverage (the (0,0,0)
+/// centre cell is unreachable for a unit vector → 26 reachable wedges).
+/// Each .update call OR's the current wedge bit into the mask; popcount
+/// is the count displayed in the UI.
+///
+/// Kept as an ObservableObject because @State + struct-view + Timer
+/// combinations have repeatedly bitten us on this screen (stale-self
+/// captures, missed updates).  Reference-type state behaves predictably
+/// across SwiftUI re-renders.
+@MainActor
+final class AccelCoverageTracker: ObservableObject {
+    @Published private(set) var coverageMask: UInt32 = 0
+
+    /// How many wedges have been visited (0..26).
+    var coverageCount: Int { coverageMask.nonzeroBitCount }
+
+    /// Components below this magnitude (m/s²) don't bin — avoids
+    /// counting a free-fall blip as a unique orientation.
+    private static let MIN_MAGNITUDE_MS2: Float = 5.0
+
+    /// Same threshold the firmware's directionWedge uses (0.4 of the
+    /// unit vector).  Keeps the wedge encoding bit-identical so the
+    /// post-fit FC coverage and this live counter use the same scheme.
+    private static let T: Float = 0.4
+
+    func update(ax: Float?, ay: Float?, az: Float?) {
+        guard let x = ax, let y = ay, let z = az else { return }
+        let mag = sqrtf(x * x + y * y + z * z)
+        guard mag >= AccelCoverageTracker.MIN_MAGNITUDE_MS2 else { return }
+        let ux = x / mag
+        let uy = y / mag
+        let uz = z / mag
+
+        func bin(_ v: Float) -> Int {
+            return v < -AccelCoverageTracker.T ? 0
+                 : v >  AccelCoverageTracker.T ? 2
+                 : 1
+        }
+        let wedge = bin(ux) * 9 + bin(uy) * 3 + bin(uz)
+        // wedge ∈ [0, 26]; 13 = (1,1,1) is the centre cell and never
+        // sets for a unit vector, but we don't special-case it here —
+        // it just stays at 0 in the mask.
+        if wedge >= 0 && wedge < 27 {
+            coverageMask |= (UInt32(1) << wedge)
+        }
+    }
+
+    func reset() {
+        coverageMask = 0
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -1,0 +1,313 @@
+//
+//  MagCalView.swift
+//  TinkerRocketApp
+//
+//  Magnetometer hard-iron calibration screen (issue #96).  The user opens
+//  this from the rocket Settings page; tapping Start asks the FC to enter
+//  MAG_CALIBRATION and begin sampling.  The user tumbles the rocket
+//  through all orientations for ~10 s while a progress bar tracks
+//  sample count and orientation coverage.  When the buffer fills, the FC
+//  computes a sphere fit and ships the result back; the view shows the
+//  fitted offset, fitted Earth-field magnitude (R), and RMS residual.
+//  Accept persists to FC NVS and programs the IIS2MDC OFFSET registers;
+//  Retry restarts sampling; Abort drops the run and returns to READY.
+//
+//  All state lives on the FC.  The view is just a renderer + a few
+//  one-byte command buttons; magCalStatus on the BLEDevice is the source
+//  of truth and updates at 5 Hz during sampling.
+//
+
+import SwiftUI
+
+struct MagCalView: View {
+    @ObservedObject var device: BLEDevice
+    @Environment(\.dismiss) var dismiss
+
+    /// Latest status frame, or nil if the FC hasn't published one yet
+    /// (e.g. just navigated in, before tapping Start).  In that case the
+    /// view shows the intro/Start state.
+    private var status: MagCalStatus? { device.magCalStatus }
+
+    var body: some View {
+        Form {
+            // The view is mostly status-driven: intro/start, sampling,
+            // review (accept/retry), applied success, aborted return.
+            switch status?.subType ?? .idle {
+            case .idle, .aborted:    introSection
+            case .sampling:           samplingSection
+            case .review:             reviewSection
+            case .applied:            appliedSection
+            }
+        }
+        .navigationTitle("Mag Calibration")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                if status?.subType == .sampling || status?.subType == .review {
+                    // Belt-and-suspenders abort: if the user tries to
+                    // back out mid-cal, send abort so the FC drops back
+                    // to READY rather than staying in MAG_CALIBRATION.
+                    Button("Cancel") {
+                        device.sendMagCalAbort()
+                        dismiss()
+                    }
+                } else {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - States
+
+    /// Intro: explain the flow + show a Start button.
+    private var introSection: some View {
+        Group {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Magnetometer Hard-Iron Calibration")
+                        .font(.headline)
+                    Text("Solves for the fixed magnetic offset on the rocket PCB so the magnetometer reads true Earth field. Run this once per board (or after any hardware change near the mag chip).")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section(header: Text("How to tumble")) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Hold the rocket clear of laptops, phones, speakers.", systemImage: "1.circle.fill")
+                    Label("Slowly rotate through every orientation for ~10 s.", systemImage: "2.circle.fill")
+                    Label("Aim to point each end of the rocket up, down, and sideways.", systemImage: "3.circle.fill")
+                }
+                .font(.subheadline)
+            }
+
+            // Show the prior aborted-status message inline so a re-entry
+            // after Cancel doesn't look like a no-op.
+            if status?.subType == .aborted {
+                Section {
+                    Label("Previous run cancelled.", systemImage: "info.circle")
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Section {
+                Button {
+                    device.sendMagCalStart()
+                } label: {
+                    HStack {
+                        Image(systemName: "play.fill")
+                        Text("Start Calibration")
+                            .fontWeight(.semibold)
+                        Spacer()
+                    }
+                    .foregroundColor(.white)
+                }
+                .listRowBackground(Color.blue)
+            }
+
+            Section {
+                Text("Calibration is only allowed when the rocket is in READY state. Launch is gated against this mode — no risk of an accidental flight detection while tumbling.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// Sampling: progress bar + live count + coverage + |B|.
+    private var samplingSection: some View {
+        Group {
+            Section(header: Text("Tumble the rocket")) {
+                if let s = status {
+                    let progress = s.samplingProgress(
+                        targetSamples: MagCalConstants.maxSamples,
+                        minCoverage: 26  // visualise approach to full coverage; FC uses 18 as the gate
+                    )
+                    VStack(alignment: .leading, spacing: 12) {
+                        ProgressView(value: progress)
+                            .progressViewStyle(.linear)
+                        HStack {
+                            Text("Samples")
+                            Spacer()
+                            Text("\(s.sampleCount) / \(MagCalConstants.maxSamples)")
+                                .foregroundColor(.secondary)
+                                .font(.system(.body, design: .monospaced))
+                        }
+                        HStack {
+                            Text("Coverage")
+                            Spacer()
+                            Text("\(s.coverageBins) / 26 wedges")
+                                .foregroundColor(.secondary)
+                                .font(.system(.body, design: .monospaced))
+                        }
+                        HStack {
+                            Text("|B|")
+                            Spacer()
+                            Text(String(format: "%.1f µT", s.instantaneousFieldUT))
+                                .foregroundColor(.secondary)
+                                .font(.system(.body, design: .monospaced))
+                        }
+                    }
+                    .padding(.vertical, 4)
+                } else {
+                    ProgressView("Waiting for rocket…")
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    device.sendMagCalAbort()
+                } label: {
+                    HStack {
+                        Image(systemName: "xmark.circle")
+                        Text("Abort")
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Review: show fit + accept/retry buttons.  rejectCode != .ok forces
+    /// retry-only (Accept is hidden).
+    private var reviewSection: some View {
+        Group {
+            if let s = status {
+                Section(header: Text("Fit result")) {
+                    HStack {
+                        Label("Status", systemImage: s.rejectCode == .ok ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                        Spacer()
+                        Text(s.rejectMessage)
+                            .foregroundColor(s.rejectCode == .ok ? .green : .orange)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    HStack {
+                        Text("Earth field |R|")
+                        Spacer()
+                        Text(String(format: "%.1f µT", s.fieldR_uT))
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    HStack {
+                        Text("RMS residual")
+                        Spacer()
+                        Text(String(format: "%.1f µT", s.residualUT))
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    HStack {
+                        Text("Coverage")
+                        Spacer()
+                        Text("\(s.coverageBins) / 26 wedges")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                }
+
+                Section(header: Text("Hard-iron offset (raw counts)")) {
+                    HStack {
+                        Text("X")
+                        Spacer()
+                        Text("\(s.offsetX)")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    HStack {
+                        Text("Y")
+                        Spacer()
+                        Text("\(s.offsetY)")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    HStack {
+                        Text("Z")
+                        Spacer()
+                        Text("\(s.offsetZ)")
+                            .foregroundColor(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    Text("0.15 µT per LSB. The chip subtracts these from every sample once accepted.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                if s.rejectCode == .ok {
+                    Section {
+                        Button {
+                            device.sendMagCalAccept()
+                        } label: {
+                            HStack {
+                                Image(systemName: "checkmark.circle.fill")
+                                Text("Accept and Save")
+                                    .fontWeight(.semibold)
+                                Spacer()
+                            }
+                            .foregroundColor(.white)
+                        }
+                        .listRowBackground(Color.green)
+                    }
+                }
+                Section {
+                    Button {
+                        device.sendMagCalRetry()
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.counterclockwise")
+                            Text("Retry")
+                            Spacer()
+                        }
+                    }
+                    Button(role: .destructive) {
+                        device.sendMagCalAbort()
+                        dismiss()
+                    } label: {
+                        HStack {
+                            Image(systemName: "xmark.circle")
+                            Text("Abort")
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// One-shot success: FC just persisted + applied the offset.
+    private var appliedSection: some View {
+        Group {
+            if let s = status {
+                Section {
+                    VStack(spacing: 12) {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.system(size: 48))
+                            .foregroundColor(.green)
+                        Text("Calibration applied")
+                            .font(.headline)
+                        Text(String(format: "Earth field locked at %.1f µT, residual %.1f µT.",
+                                    s.fieldR_uT, s.residualUT))
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                }
+                Section {
+                    Button {
+                        dismiss()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            Text("Done")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                        .foregroundColor(.white)
+                    }
+                    .listRowBackground(Color.blue)
+                }
+            }
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -167,6 +167,15 @@ struct SettingsView: View {
                             .onChange(of: servoControlEnabled) { newValue in
                                 device.sendServoControlConfig(enabled: newValue)
                             }
+                        // Hard-iron magnetometer cal entry (issue #96).  Only
+                        // shown for direct rocket connections — the cal flow
+                        // runs on the FC itself and the OC publishes status
+                        // back over the same BLE link.
+                        NavigationLink {
+                            MagCalView(device: device)
+                        } label: {
+                            Label("Magnetometer Calibration", systemImage: "location.north.line")
+                        }
                         Text("Persists across reboots.")
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -57,6 +57,7 @@ static bool solve4x4(double A[4][4], double b[4], double x[4])
 
 MagCalibrator::MagCalibrator()
     : n_samples_(0),
+      write_idx_(0),
       coverage_mask_(0),
       last_x_(0), last_y_(0), last_z_(0),
       fit_cx_(0), fit_cy_(0), fit_cz_(0),
@@ -70,6 +71,7 @@ MagCalibrator::MagCalibrator()
 void MagCalibrator::start()
 {
     n_samples_ = 0;
+    write_idx_ = 0;
     coverage_mask_ = 0;
     last_x_ = last_y_ = last_z_ = 0;
     fit_valid_ = false;
@@ -117,36 +119,31 @@ bool MagCalibrator::addSample(int16_t x, int16_t y, int16_t z)
 {
     if (state_ != State::SAMPLING) return false;
 
-    // Keep updating the "live" vector even after the buffer fills, so
-    // the iOS direction-feedback UI keeps ticking.  Coverage mask also
-    // stays in sync — the user might tumble through new wedges after
-    // the buffer is full.
+    // Live vector + coverage update regardless of buffer state — the
+    // iOS direction-feedback UI keeps ticking and the coverage mask
+    // stays in sync if the user tumbles into new wedges.
     last_x_ = x;
     last_y_ = y;
     last_z_ = z;
     const uint8_t wedge = directionWedge(x, y, z);
     if (wedge < 27) coverage_mask_ |= (1u << wedge);
 
-    if (n_samples_ >= MAX_SAMPLES)
-    {
-        // Buffer full — stop adding to it, but DO NOT auto-fit.  The fit
-        // is user-driven via computeFit() (BLE cmd MAG_CAL_COMPUTE_FIT),
-        // so the user gets to decide when they're done tumbling.  Return
-        // false here so callers don't see a misleading "buffer just
-        // filled" pulse on every subsequent sample.
-        return false;
-    }
+    // Ring buffer: write at the current index, advance modulo
+    // MAX_SAMPLES, and let n_samples_ saturate at MAX_SAMPLES once we
+    // wrap.  This means the user can keep sampling indefinitely — they
+    // don't lose orientations because the buffer "ran out" 20 s in.
+    // The fit always sees the most recent MAX_SAMPLES, which captures
+    // whatever orientations the user just finished rotating through.
+    samples_x_[write_idx_] = x;
+    samples_y_[write_idx_] = y;
+    samples_z_[write_idx_] = z;
+    write_idx_ = (uint16_t)((write_idx_ + 1) % MAX_SAMPLES);
+    if (n_samples_ < MAX_SAMPLES) n_samples_++;
 
-    samples_x_[n_samples_] = x;
-    samples_y_[n_samples_] = y;
-    samples_z_[n_samples_] = z;
-    n_samples_++;
-
-    // Caller cue: buffer just filled on this sample.  Used by main.cpp
-    // to publish an immediate status frame so the iOS UI flips its
-    // "Compute Fit" button to a primary-action style without waiting
-    // for the next 5 Hz tick.
-    return (n_samples_ == MAX_SAMPLES);
+    // Ring buffer means sampling never "completes" — the 5 Hz status
+    // cadence in the FC main loop keeps the iOS UI updated.  No more
+    // one-shot "buffer just filled" pulse.
+    return false;
 }
 
 bool MagCalibrator::computeFit()

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -189,6 +189,7 @@ void MagCalibrator::buildStatusFrame(uint32_t time_us, MagCalStatusData& out) co
     }
 
     out.coverage_bins = (uint8_t)__builtin_popcount(coverage_mask_);
+    out.coverage_mask = coverage_mask_;
     out.sample_count  = n_samples_;
 
     // Instantaneous field magnitude (most recent sample).

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -57,7 +57,6 @@ static bool solve4x4(double A[4][4], double b[4], double x[4])
 
 MagCalibrator::MagCalibrator()
     : n_samples_(0),
-      write_idx_(0),
       coverage_mask_(0),
       last_x_(0), last_y_(0), last_z_(0),
       fit_cx_(0), fit_cy_(0), fit_cz_(0),
@@ -65,15 +64,23 @@ MagCalibrator::MagCalibrator()
       fit_residual_uT_(0.0f),
       fit_reject_code_(MAG_CAL_OK),
       fit_valid_(false),
+      accel_x_(0), accel_y_(0), accel_z_(0),
+      accel_valid_(false),
       state_(State::IDLE)
-{}
+{
+    memset(wedge_count_, 0, sizeof(wedge_count_));
+    memset(wedge_write_, 0, sizeof(wedge_write_));
+}
 
 void MagCalibrator::start()
 {
     n_samples_ = 0;
-    write_idx_ = 0;
+    memset(wedge_count_, 0, sizeof(wedge_count_));
+    memset(wedge_write_, 0, sizeof(wedge_write_));
     coverage_mask_ = 0;
     last_x_ = last_y_ = last_z_ = 0;
+    // accel_valid_ stays as-is: the IMU is sampling regardless of cal
+    // state, so accel readings from before Start are still fresh.
     fit_valid_ = false;
     fit_cx_ = fit_cy_ = fit_cz_ = 0;
     fit_R_uT_ = 0.0f;
@@ -115,34 +122,57 @@ void MagCalibrator::clear()
     state_ = State::IDLE;
 }
 
+void MagCalibrator::setLiveAccel(int16_t ax, int16_t ay, int16_t az)
+{
+    accel_x_ = ax;
+    accel_y_ = ay;
+    accel_z_ = az;
+    accel_valid_ = true;
+}
+
 bool MagCalibrator::addSample(int16_t x, int16_t y, int16_t z)
 {
     if (state_ != State::SAMPLING) return false;
 
-    // Live vector + coverage update regardless of buffer state — the
+    // Live vector + coverage update regardless of bucket state — the
     // iOS direction-feedback UI keeps ticking and the coverage mask
-    // stays in sync if the user tumbles into new wedges.
+    // tracks which accel-direction wedges have been visited so far.
     last_x_ = x;
     last_y_ = y;
     last_z_ = z;
-    const uint8_t wedge = directionWedge(x, y, z);
-    if (wedge < 27) coverage_mask_ |= (1u << wedge);
 
-    // Ring buffer: write at the current index, advance modulo
-    // MAX_SAMPLES, and let n_samples_ saturate at MAX_SAMPLES once we
-    // wrap.  This means the user can keep sampling indefinitely — they
-    // don't lose orientations because the buffer "ran out" 20 s in.
-    // The fit always sees the most recent MAX_SAMPLES, which captures
-    // whatever orientations the user just finished rotating through.
-    samples_x_[write_idx_] = x;
-    samples_y_[write_idx_] = y;
-    samples_z_[write_idx_] = z;
-    write_idx_ = (uint16_t)((write_idx_ + 1) % MAX_SAMPLES);
-    if (n_samples_ < MAX_SAMPLES) n_samples_++;
+    // Without a recent accel reading we can't bin the sample by
+    // orientation, so drop it rather than piling everything into a
+    // single bucket.  Should only happen during the brief startup
+    // window before the first IMU sample lands.
+    if (!accel_valid_) return false;
 
-    // Ring buffer means sampling never "completes" — the 5 Hz status
-    // cadence in the FC main loop keeps the iOS UI updated.  No more
-    // one-shot "buffer just filled" pulse.
+    const uint8_t accel_wedge = directionWedge(accel_x_, accel_y_, accel_z_);
+    if (accel_wedge >= NUM_ACCEL_WEDGES) return false;
+
+    // Update the accel-driven coverage mask up-front so the iOS UI
+    // sees the new wedge as soon as it's been visited, even if its
+    // slot ring buffer is full and an oldest sample gets evicted.
+    coverage_mask_ |= (1u << accel_wedge);
+
+    // Ring buffer inside the wedge bucket.  Up to SAMPLES_PER_WEDGE
+    // samples are kept per accel-wedge; when full, newest overwrites
+    // oldest WITHIN THAT WEDGE.  Samples from other orientations are
+    // never disturbed, so a user lingering in one position can't
+    // wipe out the diversity gathered earlier.
+    const uint16_t base = (uint16_t)accel_wedge * SAMPLES_PER_WEDGE;
+    const uint16_t slot = base + wedge_write_[accel_wedge];
+    samples_x_[slot] = x;
+    samples_y_[slot] = y;
+    samples_z_[slot] = z;
+    wedge_write_[accel_wedge] = (uint8_t)((wedge_write_[accel_wedge] + 1) % SAMPLES_PER_WEDGE);
+    if (wedge_count_[accel_wedge] < SAMPLES_PER_WEDGE) {
+        wedge_count_[accel_wedge]++;
+        n_samples_++;  // saturates at NUM_ACCEL_WEDGES * SAMPLES_PER_WEDGE
+    }
+
+    // Sampling never "completes" — the 5 Hz status cadence in the FC
+    // main loop keeps the iOS UI updated.  No "buffer just filled" pulse.
     return false;
 }
 
@@ -279,17 +309,31 @@ void MagCalibrator::runFit()
 
     if (n_samples_ < MAG_CAL_MIN_SAMPLES) return;
 
+    // All sample iteration walks the per-wedge bucket arrays.  Helper
+    // lambda captures the "for each valid sample" pattern so the three
+    // passes (centroid, normal eqs, residual) share the same indexing
+    // logic and stay in sync if the storage layout changes.
+    auto forEachSample = [this](auto&& fn) {
+        for (uint8_t w = 0; w < NUM_ACCEL_WEDGES; w++) {
+            const uint16_t base = (uint16_t)w * SAMPLES_PER_WEDGE;
+            const uint8_t  count = wedge_count_[w];
+            for (uint8_t i = 0; i < count; i++) {
+                const uint16_t slot = base + i;
+                fn(samples_x_[slot], samples_y_[slot], samples_z_[slot]);
+            }
+        }
+    };
+
     // Accumulate sums in double.  Centroid-shifting before solving keeps
     // the cross-product sums small (cancel the bulk of the offset before
     // squaring), which preserves ~7+ digits of precision in the normal
     // equations even with raw counts in the ~1e4 range.
     double sx = 0.0, sy = 0.0, sz = 0.0;
-    for (uint16_t i = 0; i < n_samples_; i++)
-    {
-        sx += (double)samples_x_[i];
-        sy += (double)samples_y_[i];
-        sz += (double)samples_z_[i];
-    }
+    forEachSample([&](int16_t x, int16_t y, int16_t z) {
+        sx += (double)x;
+        sy += (double)y;
+        sz += (double)z;
+    });
     const double mx = sx / (double)n_samples_;
     const double my = sy / (double)n_samples_;
     const double mz = sz / (double)n_samples_;
@@ -302,11 +346,10 @@ void MagCalibrator::runFit()
     double sb = 0.0;
     double sxb = 0.0, syb = 0.0, szb = 0.0;
 
-    for (uint16_t i = 0; i < n_samples_; i++)
-    {
-        const double xc = (double)samples_x_[i] - mx;
-        const double yc = (double)samples_y_[i] - my;
-        const double zc = (double)samples_z_[i] - mz;
+    forEachSample([&](int16_t x, int16_t y, int16_t z) {
+        const double xc = (double)x - mx;
+        const double yc = (double)y - my;
+        const double zc = (double)z - mz;
         const double bi = xc*xc + yc*yc + zc*zc;
 
         sxx += xc*xc; syy += yc*yc; szz += zc*zc;
@@ -316,7 +359,7 @@ void MagCalibrator::runFit()
         sxb += xc * bi;
         syb += yc * bi;
         szb += zc * bi;
-    }
+    });
 
     // Build symmetric AᵀA (4×4) and Aᵀb (4×1) for the centered solve.
     double M[4][4] = {
@@ -357,15 +400,14 @@ void MagCalibrator::runFit()
 
     // RMS residual in raw counts (then scaled to µT).
     double rss = 0.0;
-    for (uint16_t i = 0; i < n_samples_; i++)
-    {
-        const double dx = (double)samples_x_[i] - cx;
-        const double dy = (double)samples_y_[i] - cy;
-        const double dz = (double)samples_z_[i] - cz;
+    forEachSample([&](int16_t x, int16_t y, int16_t z) {
+        const double dx = (double)x - cx;
+        const double dy = (double)y - cy;
+        const double dz = (double)z - cz;
         const double ri = sqrt(dx*dx + dy*dy + dz*dz);
         const double e = ri - R;
         rss += e*e;
-    }
+    });
     const double rms_counts = sqrt(rss / (double)n_samples_);
 
     // Scale to µT for gating + reporting.
@@ -400,13 +442,12 @@ void MagCalibrator::runFit()
     // below and the iOS REVIEW screen's coverage row.
     {
         uint32_t post_fit_mask = 0;
-        for (uint16_t i = 0; i < n_samples_; i++)
-        {
-            const double dx = (double)samples_x_[i] - cx;
-            const double dy = (double)samples_y_[i] - cy;
-            const double dz = (double)samples_z_[i] - cz;
+        forEachSample([&](int16_t x, int16_t y, int16_t z) {
+            const double dx = (double)x - cx;
+            const double dy = (double)y - cy;
+            const double dz = (double)z - cz;
             const double r2 = dx*dx + dy*dy + dz*dz;
-            if (!(r2 > 0.0)) continue;
+            if (!(r2 > 0.0)) return;
             const double r = sqrt(r2);
             const double ux = dx / r;
             const double uy = dy / r;
@@ -417,7 +458,7 @@ void MagCalibrator::runFit()
             };
             const uint8_t wedge = (uint8_t)(bin(ux) * 9 + bin(uy) * 3 + bin(uz));
             if (wedge < 27) post_fit_mask |= (1u << wedge);
-        }
+        });
         coverage_mask_ = post_fit_mask;
     }
 

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -424,13 +424,18 @@ void MagCalibrator::runFit()
         coverage_mask_ = post_fit_mask;
     }
 
-    // Gate the fit.  Order: coverage first (fastest reason to retry),
-    // then R band, then residual.  These are advisory codes — caller
-    // shows the right error in the iOS UI.  Coverage check uses the
-    // post-fit-recomputed mask from the block above.
-    const uint8_t cov = (uint8_t)__builtin_popcount(coverage_mask_);
-    if (cov < MAG_CAL_MIN_COVERAGE_BINS)        fit_reject_code_ = MAG_CAL_REJECT_LOW_COVERAGE;
-    else if (R_uT < MAG_CAL_R_MIN_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_LOW;
+    // Gate the fit.  R and residual are the direct, quantitative
+    // measures of fit quality: a fitted R inside the WMM band that
+    // produces a sub-µT-class RMS residual is mathematically a clean
+    // sphere fit through the sample cloud.  Coverage USED to be the
+    // first check, but it's a poor proxy when the hard-iron bias is
+    // big — samples cluster in raw mag-space regardless of rotation,
+    // and even after post-fit centring the user typically only hits
+    // 6-12 wedges (one per cardinal orientation), not the 18+ the
+    // original threshold was set for.  Coverage stays in the status
+    // frame as an informational diagnostic, but it no longer rejects
+    // an otherwise-healthy fit.  Issue #96.
+    if      (R_uT < MAG_CAL_R_MIN_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_LOW;
     else if (R_uT > MAG_CAL_R_MAX_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_HIGH;
     else if (res_uT > MAG_CAL_MAX_RESIDUAL_UT)  fit_reject_code_ = MAG_CAL_REJECT_HIGH_RESIDUAL;
     else                                         fit_reject_code_ = MAG_CAL_OK;

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -116,34 +116,54 @@ void MagCalibrator::clear()
 bool MagCalibrator::addSample(int16_t x, int16_t y, int16_t z)
 {
     if (state_ != State::SAMPLING) return false;
-    if (n_samples_ >= MAX_SAMPLES) return false;
+
+    // Keep updating the "live" vector even after the buffer fills, so
+    // the iOS direction-feedback UI keeps ticking.  Coverage mask also
+    // stays in sync — the user might tumble through new wedges after
+    // the buffer is full.
+    last_x_ = x;
+    last_y_ = y;
+    last_z_ = z;
+    const uint8_t wedge = directionWedge(x, y, z);
+    if (wedge < 27) coverage_mask_ |= (1u << wedge);
+
+    if (n_samples_ >= MAX_SAMPLES)
+    {
+        // Buffer full — stop adding to it, but DO NOT auto-fit.  The fit
+        // is user-driven via computeFit() (BLE cmd MAG_CAL_COMPUTE_FIT),
+        // so the user gets to decide when they're done tumbling.  Return
+        // false here so callers don't see a misleading "buffer just
+        // filled" pulse on every subsequent sample.
+        return false;
+    }
 
     samples_x_[n_samples_] = x;
     samples_y_[n_samples_] = y;
     samples_z_[n_samples_] = z;
     n_samples_++;
 
-    last_x_ = x;
-    last_y_ = y;
-    last_z_ = z;
+    // Caller cue: buffer just filled on this sample.  Used by main.cpp
+    // to publish an immediate status frame so the iOS UI flips its
+    // "Compute Fit" button to a primary-action style without waiting
+    // for the next 5 Hz tick.
+    return (n_samples_ == MAX_SAMPLES);
+}
 
-    const uint8_t wedge = directionWedge(x, y, z);
-    if (wedge < 27) coverage_mask_ |= (1u << wedge);
-
-    if (n_samples_ >= MAX_SAMPLES)
-    {
-        runFit();
-        state_ = State::REVIEW;
+bool MagCalibrator::computeFit()
+{
+    if (state_ != State::SAMPLING) return false;
+    if (n_samples_ < MAG_CAL_MIN_SAMPLES) return false;
+    runFit();
+    state_ = State::REVIEW;
 #ifdef ESP_PLATFORM
-        ESP_LOGI(TAG, "fit complete: cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT cov=%u/26 reject=%u",
-                 (int)fit_cx_, (int)fit_cy_, (int)fit_cz_,
-                 (double)fit_R_uT_, (double)fit_residual_uT_,
-                 (unsigned)__builtin_popcount(coverage_mask_),
-                 (unsigned)fit_reject_code_);
+    ESP_LOGI(TAG, "user-triggered fit complete: cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT cov=%u/26 reject=%u (n=%u)",
+             (int)fit_cx_, (int)fit_cy_, (int)fit_cz_,
+             (double)fit_R_uT_, (double)fit_residual_uT_,
+             (unsigned)__builtin_popcount(coverage_mask_),
+             (unsigned)fit_reject_code_,
+             (unsigned)n_samples_);
 #endif
-        return true;
-    }
-    return false;
+    return true;
 }
 
 void MagCalibrator::getProgress(uint16_t& sample_count,
@@ -191,6 +211,12 @@ void MagCalibrator::buildStatusFrame(uint32_t time_us, MagCalStatusData& out) co
     out.coverage_bins = (uint8_t)__builtin_popcount(coverage_mask_);
     out.coverage_mask = coverage_mask_;
     out.sample_count  = n_samples_;
+
+    // Live raw vector for the iOS direction-feedback UI.  Raw LSB
+    // matches the sphere-fit's working units so no conversion drift.
+    out.inst_x_lsb = last_x_;
+    out.inst_y_lsb = last_y_;
+    out.inst_z_lsb = last_z_;
 
     // Instantaneous field magnitude (most recent sample).
     {

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp
@@ -391,9 +391,43 @@ void MagCalibrator::runFit()
     fit_residual_uT_ = res_uT;
     fit_valid_ = true;
 
+    // Recompute coverage_mask_ using samples *relative to the fit
+    // centre* (issue #96 follow-up).  The original mask binned raw
+    // samples by direction in mag space, which is misleading when the
+    // hard-iron bias dominates: with a ~1640 µT bias every sample
+    // lands in the same +X wedge even though the samples actually
+    // span the offset sphere correctly.  After centring on (cx, cy, cz)
+    // the samples should sit on a unit-radius shell around the origin,
+    // and the wedge mask becomes a meaningful "did the user rotate
+    // through the field?" indicator that drives the coverage gate
+    // below and the iOS REVIEW screen's coverage row.
+    {
+        uint32_t post_fit_mask = 0;
+        for (uint16_t i = 0; i < n_samples_; i++)
+        {
+            const double dx = (double)samples_x_[i] - cx;
+            const double dy = (double)samples_y_[i] - cy;
+            const double dz = (double)samples_z_[i] - cz;
+            const double r2 = dx*dx + dy*dy + dz*dz;
+            if (!(r2 > 0.0)) continue;
+            const double r = sqrt(r2);
+            const double ux = dx / r;
+            const double uy = dy / r;
+            const double uz = dz / r;
+            constexpr double T = 0.4;
+            auto bin = [](double v) -> int {
+                return (v < -T) ? 0 : (v > T) ? 2 : 1;
+            };
+            const uint8_t wedge = (uint8_t)(bin(ux) * 9 + bin(uy) * 3 + bin(uz));
+            if (wedge < 27) post_fit_mask |= (1u << wedge);
+        }
+        coverage_mask_ = post_fit_mask;
+    }
+
     // Gate the fit.  Order: coverage first (fastest reason to retry),
     // then R band, then residual.  These are advisory codes — caller
-    // shows the right error in the iOS UI.
+    // shows the right error in the iOS UI.  Coverage check uses the
+    // post-fit-recomputed mask from the block above.
     const uint8_t cov = (uint8_t)__builtin_popcount(coverage_mask_);
     if (cov < MAG_CAL_MIN_COVERAGE_BINS)        fit_reject_code_ = MAG_CAL_REJECT_LOW_COVERAGE;
     else if (R_uT < MAG_CAL_R_MIN_UT)           fit_reject_code_ = MAG_CAL_REJECT_R_TOO_LOW;

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
@@ -110,11 +110,17 @@ private:
     // Tunables — see MAG_CAL_* constants in RocketComputerTypes.h.
     static constexpr uint16_t MAX_SAMPLES = MAG_CAL_MAX_SAMPLES;
 
-    // Sample storage.  3 × int16 × 1024 = 6 KiB on the FC heap.
+    // Sample storage.  3 × int16 × 2048 = 12 KiB on the FC heap.  Used
+    // as a ring buffer once full so the user can keep sampling past
+    // MAX_SAMPLES — newest samples overwrite the oldest, and the fit
+    // always runs on the latest MAX_SAMPLES.  write_idx_ tracks where
+    // the next sample lands; n_samples_ saturates at MAX_SAMPLES once
+    // the buffer wraps.
     int16_t samples_x_[MAX_SAMPLES];
     int16_t samples_y_[MAX_SAMPLES];
     int16_t samples_z_[MAX_SAMPLES];
     uint16_t n_samples_;
+    uint16_t write_idx_;
 
     // 3³ - 1 = 26 wedges (the all-center cell is unreachable for unit
     // vectors).  Bit i set means wedge i has at least one sample.

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
@@ -69,13 +69,25 @@ public:
     // Reset to IDLE.  Call after consuming an APPLIED or ABORTED state.
     void clear();
 
-    // Feed one raw sample (int16 LSB counts, sensor frame — same units the
-    // IIS2MDC OFFSET registers consume).  No-op outside SAMPLING.  Returns
-    // true if the sample was the one that filled the buffer (the caller
-    // can use this as a "buffer full, stop pacing samples" hint, though
-    // additional samples silently no-op once full).  Sampling NEVER
-    // auto-transitions to REVIEW — that's user-driven via computeFit().
+    // Feed one raw mag sample (int16 LSB counts, sensor frame — same
+    // units the IIS2MDC OFFSET registers consume).  No-op outside
+    // SAMPLING.  Always returns false: the ring-buffer-per-wedge model
+    // never has a "buffer full" pulse — the 5 Hz status cadence handles
+    // iOS updates.  Each sample lands in the bucket for the rocket's
+    // current accel-direction wedge (set via setLiveAccel), so samples
+    // from one orientation can't crowd out samples from another.
+    // Sampling NEVER auto-transitions to REVIEW — that's user-driven
+    // via computeFit().
     bool addSample(int16_t x, int16_t y, int16_t z);
+
+    // Set the latest low-g accelerometer reading (raw int16 counts,
+    // body frame).  Used to bucket subsequent mag samples by physical
+    // orientation: each call to addSample lands its sample in the
+    // bucket for the wedge of (accel_x_, accel_y_, accel_z_).  Should
+    // be called from the FC's IMU sample path; mag samples that
+    // arrive before any accel reading are dropped (otherwise they'd
+    // all pile into wedge 0).
+    void setLiveAccel(int16_t ax, int16_t ay, int16_t az);
 
     // Run the sphere fit on the current sample buffer and transition to
     // REVIEW.  Returns false (and stays in SAMPLING) if fewer than
@@ -107,20 +119,37 @@ public:
     void buildStatusFrame(uint32_t time_us, MagCalStatusData& out) const;
 
 private:
-    // Tunables — see MAG_CAL_* constants in RocketComputerTypes.h.
-    static constexpr uint16_t MAX_SAMPLES = MAG_CAL_MAX_SAMPLES;
+    // Per-accel-wedge sample bucketing.  The flat ring buffer (older
+    // design) lost diverse samples when the user lingered in one
+    // orientation — newest samples blindly overwrote everything.  Now
+    // each of the 27 (3³) accel-direction wedges has its own
+    // SAMPLES_PER_WEDGE ring buffer, so samples from one orientation
+    // can only displace other samples from the SAME orientation.
+    // Memory: 27 × 100 × 3 × int16 ≈ 16 KiB, comfortably small on the
+    // ESP32-P4.  Wedge 13 (the all-centre cell) is unreachable for a
+    // unit accel vector so its slots stay unused — kept in the array
+    // for index arithmetic simplicity.
+    static constexpr uint8_t  NUM_ACCEL_WEDGES   = 27;
+    static constexpr uint8_t  SAMPLES_PER_WEDGE  = 100;
+    static constexpr uint16_t MAX_TOTAL_SAMPLES  =
+        (uint16_t)NUM_ACCEL_WEDGES * SAMPLES_PER_WEDGE;
+    // Exposed for callers (e.g. iOS display caps); matches the old
+    // MAG_CAL_MAX_SAMPLES contract.
+    static constexpr uint16_t MAX_SAMPLES = MAX_TOTAL_SAMPLES;
 
-    // Sample storage.  3 × int16 × 2048 = 12 KiB on the FC heap.  Used
-    // as a ring buffer once full so the user can keep sampling past
-    // MAX_SAMPLES — newest samples overwrite the oldest, and the fit
-    // always runs on the latest MAX_SAMPLES.  write_idx_ tracks where
-    // the next sample lands; n_samples_ saturates at MAX_SAMPLES once
-    // the buffer wraps.
-    int16_t samples_x_[MAX_SAMPLES];
-    int16_t samples_y_[MAX_SAMPLES];
-    int16_t samples_z_[MAX_SAMPLES];
-    uint16_t n_samples_;
-    uint16_t write_idx_;
+    int16_t samples_x_[MAX_TOTAL_SAMPLES];
+    int16_t samples_y_[MAX_TOTAL_SAMPLES];
+    int16_t samples_z_[MAX_TOTAL_SAMPLES];
+    uint8_t wedge_count_[NUM_ACCEL_WEDGES];  // 0..SAMPLES_PER_WEDGE per wedge
+    uint8_t wedge_write_[NUM_ACCEL_WEDGES];  // ring write index per wedge
+    uint16_t n_samples_;                      // sum of wedge_count_, kept in sync
+
+    // Latest accel reading, used to pick the wedge bucket for each
+    // incoming mag sample.  accel_valid_ stays false until the first
+    // setLiveAccel call so we don't pile mag samples into wedge 0
+    // before any orientation info has arrived.
+    int16_t accel_x_, accel_y_, accel_z_;
+    bool    accel_valid_;
 
     // 3³ - 1 = 26 wedges (the all-center cell is unreachable for unit
     // vectors).  Bit i set means wedge i has at least one sample.

--- a/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
+++ b/tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.h
@@ -71,10 +71,18 @@ public:
 
     // Feed one raw sample (int16 LSB counts, sensor frame — same units the
     // IIS2MDC OFFSET registers consume).  No-op outside SAMPLING.  Returns
-    // true if the sample was the one that filled the buffer and triggered
-    // the fit + REVIEW transition (so the caller can publish a status
-    // frame promptly).
+    // true if the sample was the one that filled the buffer (the caller
+    // can use this as a "buffer full, stop pacing samples" hint, though
+    // additional samples silently no-op once full).  Sampling NEVER
+    // auto-transitions to REVIEW — that's user-driven via computeFit().
     bool addSample(int16_t x, int16_t y, int16_t z);
+
+    // Run the sphere fit on the current sample buffer and transition to
+    // REVIEW.  Returns false (and stays in SAMPLING) if fewer than
+    // MAG_CAL_MIN_SAMPLES have landed.  Decoupling fit from buffer-fill
+    // lets the iOS UI offer an explicit "Compute Fit" button: the user
+    // tumbles as long as they want, then decides when to commit.
+    bool computeFit();
 
     State getState() const { return state_; }
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -739,9 +739,17 @@ typedef struct __attribute__((packed))
     // up).  Bit 13 = the (0,0,0) center cell is unreachable for a unit
     // vector so never sets; the remaining 26 bits map 1:1 to wedges.
     uint32_t coverage_mask;
+    // Live raw mag vector (last sample), in IIS2MDC LSB units
+    // (0.15 µT/LSB).  Lets iOS render real-time direction feedback so
+    // the user can see which body axis is currently dominant and
+    // adjust the orientation — without this they're guessing whether
+    // the rocket is "really" pointing up.
+    int16_t  inst_x_lsb;
+    int16_t  inst_y_lsb;
+    int16_t  inst_z_lsb;
 } MagCalStatusData;
-static_assert(sizeof(MagCalStatusData) == 26,
-              "MagCalStatusData must be 26 bytes");
+static_assert(sizeof(MagCalStatusData) == 32,
+              "MagCalStatusData must be 32 bytes");
 
 // MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
 // int32_t in the same 18-bit signed centered-counts space as
@@ -1175,6 +1183,7 @@ static constexpr uint8_t MAG_CAL_ABORT        = 0xD5;  // OC→FC: drop sampling
 static constexpr uint8_t MAG_CAL_ACCEPT       = 0xD6;  // OC→FC: persist current fit, apply offsets, return to READY
 static constexpr uint8_t MAG_CAL_RETRY        = 0xD7;  // OC→FC: discard fit, restart sampling
 static constexpr uint8_t MAG_CAL_STATUS_MSG   = 0xD8;  // FC→OC: live progress / final result (MagCalStatusData)
+static constexpr uint8_t MAG_CAL_COMPUTE_FIT  = 0xD9;  // OC→FC: run sphere fit on current buffer, transition to REVIEW
 
 static constexpr uint8_t LORA_MSG            = 0xF1;
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -722,7 +722,7 @@ typedef struct __attribute__((packed))
 {
     uint32_t time_us;
     uint8_t  sub_type;            // MagCalSubType
-    uint8_t  coverage_bins;       // 0..26 (3³ - 1 = 26 directional wedges populated)
+    uint8_t  coverage_bins;       // 0..26 (3³ - 1 = 26 directional wedges populated; == popcount(coverage_mask))
     uint16_t sample_count;        // total samples accumulated this run
     uint16_t inst_field_uT_x10;   // |B| of the most recent sample × 10
     int16_t  offset_x;            // fitted hard-iron offset (raw LSB units), or 0 if no fit
@@ -732,9 +732,16 @@ typedef struct __attribute__((packed))
     uint16_t residual_uT_x10;     // fit RMS residual × 10
     uint8_t  reject_code;         // MagCalRejectCode (only valid in REVIEW)
     uint8_t  _pad;
+    // Bitmap of populated 3³ wedges (bit i = wedge i, see directionWedge()
+    // in TR_MagCalibrator).  Drives the iOS UI's per-direction progress
+    // grid and the gated orientation-prompt cycle (issue #96 follow-up
+    // — don't advance the prompt until the current target wedge lights
+    // up).  Bit 13 = the (0,0,0) center cell is unreachable for a unit
+    // vector so never sets; the remaining 26 bits map 1:1 to wedges.
+    uint32_t coverage_mask;
 } MagCalStatusData;
-static_assert(sizeof(MagCalStatusData) == 22,
-              "MagCalStatusData must be 22 bytes");
+static_assert(sizeof(MagCalStatusData) == 26,
+              "MagCalStatusData must be 26 bytes");
 
 // MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
 // int32_t in the same 18-bit signed centered-counts space as
@@ -764,9 +771,12 @@ static constexpr uint8_t MAG_CAL_MIN_COVERAGE_BINS = 18;
 // or moving interferer dominated the capture.
 static constexpr float MAG_CAL_MAX_RESIDUAL_UT = 8.0f;
 
-// Sample-buffer cap.  At 100 Hz IIS2MDC ODR, 1024 samples = ~10 s of
-// tumble — long enough to cover all wedges with normal hand-tumble pace.
-static constexpr uint16_t MAG_CAL_MAX_SAMPLES = 1024;
+// Sample-buffer cap.  At 100 Hz IIS2MDC ODR, 2048 samples = ~20 s of
+// tumble — long enough to cover all wedges at a relaxed pace, especially
+// with the iOS UI gating each orientation prompt on the corresponding
+// wedge actually lighting up (so the user can dwell on each direction
+// until it's captured).  Heap cost: 2048 × 3 × int16 = 12 KiB.
+static constexpr uint16_t MAG_CAL_MAX_SAMPLES = 2048;
 
 // Minimum samples before we'll attempt a fit.  Matches the issue's "≥500
 // samples (~5 s at 100 Hz)" guidance.

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -779,12 +779,11 @@ static constexpr uint8_t MAG_CAL_MIN_COVERAGE_BINS = 18;
 // or moving interferer dominated the capture.
 static constexpr float MAG_CAL_MAX_RESIDUAL_UT = 8.0f;
 
-// Sample-buffer cap.  At 100 Hz IIS2MDC ODR, 2048 samples = ~20 s of
-// tumble — long enough to cover all wedges at a relaxed pace, especially
-// with the iOS UI gating each orientation prompt on the corresponding
-// wedge actually lighting up (so the user can dwell on each direction
-// until it's captured).  Heap cost: 2048 × 3 × int16 = 12 KiB.
-static constexpr uint16_t MAG_CAL_MAX_SAMPLES = 2048;
+// Sample-buffer cap.  Bucketed per accel-wedge (27 wedges × 100 slots
+// each = 2700 total) so a user lingering in one orientation can't
+// crowd out samples from other orientations — diversity is preserved
+// even across long sessions.  Heap cost: 2700 × 3 × int16 ≈ 16 KiB.
+static constexpr uint16_t MAG_CAL_MAX_SAMPLES = 2700;
 
 // Minimum samples before we'll attempt a fit.  Matches the issue's "≥500
 // samples (~5 s at 100 Hz)" guidance.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2551,6 +2551,25 @@ static void loop_fc()
                     mag_cal_status_dirty = true;
                 }
             }
+            else if (out_pending_command == MAG_CAL_COMPUTE_FIT)
+            {
+                if (rocket_state != MAG_CALIBRATION)
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] compute_fit refused: not in MAG_CALIBRATION");
+                }
+                else if (!mag_calibrator.computeFit())
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] compute_fit refused: insufficient samples");
+                    // Still publish a status frame so the iOS button
+                    // doesn't appear stuck.
+                    mag_cal_status_dirty = true;
+                }
+                else
+                {
+                    ESP_LOGI(TAG, "[MAGCAL] user-triggered fit complete, REVIEW state");
+                    mag_cal_status_dirty = true;
+                }
+            }
             else if (out_pending_command == MAG_CAL_ACCEPT)
             {
                 if (rocket_state != MAG_CALIBRATION)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1730,6 +1730,14 @@ static void loop_fc()
         sensor_converter.convertISM6HG256Data(ism6hg256_data, ism6_latest_si);
         have_ism6_si = true;
 
+        // Feed the live low-g accel to the mag calibrator so each
+        // incoming mag sample can be bucketed by physical orientation
+        // (issue #96 follow-up).  Raw int16 LSB units share the same
+        // sign convention as the mag direction-wedge encoding.
+        mag_calibrator.setLiveAccel(ism6hg256_data.acc_low_raw.x,
+                                    ism6hg256_data.acc_low_raw.y,
+                                    ism6hg256_data.acc_low_raw.z);
+
         memcpy(ism6hg256_data_buffer,
                &ism6hg256_data,
                SIZE_OF_ISM6HG256_DATA);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4808,6 +4808,11 @@ static void loop_oc()
             setPendingCommand(MAG_CAL_RETRY);
             ESP_LOGI("BLE", "Mag cal RETRY -> FlightComputer");
         }
+        else if (ble_cmd == 54)
+        {
+            setPendingCommand(MAG_CAL_COMPUTE_FIT);
+            ESP_LOGI("BLE", "Mag cal COMPUTE_FIT -> FlightComputer");
+        }
     }
 
     LOOP_STALL_INSTR("printStats", printStats());


### PR DESCRIPTION
## Summary

iOS app side for [issue #96](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/96) — magnetometer hard-iron calibration. Stacks on top of [#134](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/134) (FC firmware) — review/merge that one first.

User flow: open rocket Settings → tap "Magnetometer Calibration" → tap Start → tumble the rocket through all orientations for ~10 s while a progress bar tracks samples + coverage + live |B| → review the fit (offset vector, fitted Earth field, RMS residual) → Accept (persists to FC NVS, programs IIS2MDC OFFSET regs) or Retry.

## Approach

- **`MagCalStatus` model** ([MagCalStatus.swift](TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift)) — decoder for the FC's 22-byte `MagCalStatusData` frame (LE), enums for sub_type and reject_code, helper for the sampling-progress fraction. Field layout mirrors the firmware `RocketComputerTypes.h` so the wire contract is clear in both repos.
- **`BLEDevice`** — new `@Published var magCalStatus`, parser dispatch on the `0xCA` discriminator on the file_ops characteristic (sibling of the `0xAA` scan-results discriminator already wired there), and four single-byte command senders (`sendMagCalStart/Abort/Accept/Retry` → BLE cmds 50/51/52/53).
- **`MagCalView`** ([MagCalView.swift](TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift)) — state-driven screen with four phases: intro/Start, sampling (progress bar + sample count + coverage + instantaneous |B|), review (fit + offsets + Accept/Retry), applied success banner. Cancel mid-cal sends abort so the FC drops back to READY rather than staying in `MAG_CALIBRATION`.
- **`SettingsView`** — `NavigationLink` under the existing "Rocket Settings" section. Hidden for base-station connections (the cal flow needs a direct rocket BLE link, since the BS relay path can't carry the binary status frames).
- **`DashboardView`** — blue color for the new `MAG_CAL` rocket-state string so the dashboard pill is visually distinct from `READY`/`PRELAUNCH`.

## Test plan

- [x] iOS app builds clean for `generic/platform=iOS` (Debug, no codesign).
- [ ] On a connected rocket, "Magnetometer Calibration" appears in Settings under Rocket Settings; hidden when connected via base station.
- [ ] Tap Start — FC enters `MAG_CALIBRATION`, sampling section appears, progress bar advances at 5 Hz as the rocket is tumbled.
- [ ] Sample count reaches 1024, fit completes, view transitions to Review with offsets + R + residual + Accept/Retry buttons.
- [ ] Accept persists + applies on FC; view shows the success banner; Done returns to Settings; subsequent dashboard reads show |B| ≈ 50 µT.
- [ ] Retry restarts sampling without leaving the screen.
- [ ] Cancel mid-cal sends abort and dismisses; FC returns to READY.
- [ ] Bad capture (wave a magnet during tumble) → Review shows `R too high`, Accept hidden, only Retry/Abort offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
