### PR TITLE
log: 5-min BS silence-close, strict filename parse, state-gated rocket-log indicator (#137)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -357,4 +357,19 @@ struct TelemetryData: Codable {
         }
         return "N/A"
     }
+
+    /// Whether the rocket itself is currently writing its onboard flight
+    /// log (#137 follow-up).  The raw `logging_active` flag comes from the
+    /// OC's `logger.isLoggingActive()` which returns true while the
+    /// end-flight queue is still draining — so post-flight (state =
+    /// LANDED → READY) it can stay true for several seconds, and if the
+    /// drain wedges (END_FLIGHT lost over I2C, etc.) it can stick true
+    /// indefinitely.  Trust the rocket state instead: the OC's flight log
+    /// only ever opens during INFLIGHT (auto-start at launch detection),
+    /// so a non-INFLIGHT state means the rocket can't really be writing.
+    /// Cleans up the "Rocket Log" indicator + "Stop Logging" button label
+    /// staying lit after a flight.
+    var rocketLoggingActive: Bool {
+        return logging_active && state == "INFLIGHT"
+    }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -978,7 +978,7 @@ struct StatusFlagsView: View {
                 )
                 StatusBadge(
                     label: isBaseStation ? "Rocket Log" : "Logging",
-                    active: telemetry.logging_active
+                    active: telemetry.rocketLoggingActive
                 )
                 if isBaseStation {
                     StatusBadge(
@@ -1533,7 +1533,9 @@ struct ControlsView: View {
             }) {
                 // Cmd 23 starts/stops logging on BOTH rocket and base station, so
                 // reflect "logging in progress" if either side reports active.
-                let isLogging = device.telemetry.logging_active || device.telemetry.bs_logging_active
+                // The rocket side is gated on rocket state (#137 follow-up) — see
+                // rocketLoggingActive on TelemetryData for why.
+                let isLogging = device.telemetry.rocketLoggingActive || device.telemetry.bs_logging_active
                 HStack {
                     Image(systemName: isLogging ? "stop.circle.fill" : "record.circle")
                     Text(isLogging ? "Stop Logging" : "Start Logging")

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,173 @@
+# Bench HIL tests
+
+Hardware-in-the-loop regression tests that exercise real firmware on real
+boards over BLE.  Run manually before flight days and on PRs that touch
+LoRa / base station / logging code.
+
+## `test_lora_log_capture.py` (issue #137)
+
+End-to-end test that verifies the BS captures a complete LoRa CSV across a
+simulated flight cycle.
+
+### What it does
+
+```
+   laptop ─ BLE ─ base station ─ LoRa ─ flight computer (SIM mode)
+```
+
+1. Connects to the BS via BLE
+2. Sends time-sync (cmd 9) so the new log uses a timestamped name
+3. Optionally clears existing `lora_*.csv` for a clean slate
+   (`--delete-existing`)
+4. Sends sim config (cmd 5) + sim start (cmd 6) — the BS relays both to
+   the flight computer via LoRa uplink
+5. The flight computer's `SensorCollectorSim` feeds synthetic GNSS / IMU /
+   pressure to the state machine, driving:
+   `READY → PRELAUNCH → POWERED → COASTING → DESCENT → LANDED → READY`
+6. The rocket transmits real LoRa packets the whole time; the BS receives
+   them and writes to SD
+7. After the cycle, downloads the newest `lora_*.csv` via BLE
+8. Asserts the file is complete, parseable, and shows the expected state
+   sequence
+
+### Hardware setup
+
+| Item                | Required        | Notes                              |
+|---------------------|-----------------|------------------------------------|
+| Base station        | Powered, on SD  | LoRa antenna connected             |
+| Flight computer     | Powered         | USB or 1-cell LiPo                 |
+| Distance            | <5 m            | bench-to-bench is fine             |
+| Laptop BLE          | Built-in or USB | tested on macOS + Linux            |
+
+No GPS antenna or external sensors needed — the sim path bypasses real
+sensors and provides synthetic data instead.
+
+### Software requirements
+
+```bash
+pip install bleak    # tested with bleak 0.21+
+```
+
+Python 3.10 or newer.
+
+### Two ways to run
+
+#### A. Fully scripted (Python drives everything)
+
+```bash
+# Auto-discover BS named "TinkerBaseStation":
+python3 tests/bench/test_lora_log_capture.py
+
+# Specific BS by MAC:
+python3 tests/bench/test_lora_log_capture.py --address AA:BB:CC:DD:EE:FF
+
+# Wipe old logs first (recommended for repeated runs):
+python3 tests/bench/test_lora_log_capture.py --delete-existing
+
+# Shorter sim (faster turnaround):
+python3 tests/bench/test_lora_log_capture.py --sim-burn 1.5 --sim-thrust 30
+```
+
+The Python script handles BLE pairing, time-sync, sim config, sim start,
+state-machine observation, log download, and assertions.  No iOS device
+needed.  Recommended for repeated runs and pre-flight regression checks.
+
+#### B. iOS-driven (you launch the sim from the app, Python just verifies)
+
+The Python script connects after the sim is done, grabs the resulting
+log, and asserts on it.  Use this when you want to:
+
+- Exercise the **same code path operators use in the field** (iOS app →
+  cmd 5/6 → BS → LoRa relay → rocket).  This catches the
+  iOS-side encoding bug that an all-Python test would miss.
+- Manually choose sim parameters via the polished iOS Simulation view
+  rather than CLI flags.
+- Verify a specific past log without re-running the sim (see `--file`).
+
+**Steps:**
+
+1. Power up the BS (SD inserted) and the flight computer.  Let both boot.
+2. Open the iOS app on your phone.
+3. Pair with the BS in the app's BLE scanner.  On connect the app
+   automatically sends time-sync (cmd 9) — confirm via the dashboard
+   that battery/RSSI fields populate.
+4. (Optional) From the Files view, delete any old `lora_*.csv` to
+   simplify the post-run check.  Equivalent to `--delete-existing`.
+5. Open the Simulation view (gear icon → Simulation, or the Sim tile on
+   the dashboard).
+6. Enter sim parameters and tap **Launch Sim**.  The app sends cmd 5
+   (config) + cmd 6 (start) via the BS LoRa uplink.
+7. Watch the dashboard.  The rocket state field should sweep:
+   `READY → PRELAUNCH → INFLIGHT → LANDED → READY`.  Total ~30-60 s
+   depending on burn / descent parameters.
+8. After the state shows READY again, **wait ~5 s** for the BS to flush
+   the LANDED-close fsync to disk.  The BS will auto-open a *second*
+   log file ("log B") for post-landing telemetry — that file stays
+   open until 5 min of LoRa silence elapses
+   (`LOG_SILENCE_TIMEOUT_MS = 5 * 60 * 1000`).  The iOS toggle button
+   will reflect that: it stays at "Stop Logging" until log B closes.
+   The Python verifier targets log A (the file active during INFLIGHT,
+   not the post-landing log B) via `Capture.inflight_active_file`.
+9. **Disconnect** the iOS app from the BS — either kill the app or
+   toggle airplane mode briefly.  The BS only accepts one BLE
+   connection at a time, so the Python verifier needs the slot free.
+10. Run the verifier:
+
+    ```bash
+    python3 tests/bench/test_lora_log_capture.py --skip-sim
+    ```
+
+    Pass = exit 0, prints `[pass] BS LoRa log captured the simulated
+    flight end-to-end` plus a row-count and peak-altitude summary.
+
+11. To re-verify a specific file (e.g. after the bench is gone and you
+    saved the log file separately, or when iterating on assertion
+    logic):
+
+    ```bash
+    python3 tests/bench/test_lora_log_capture.py --skip-sim \
+        --file lora_20260512_143000.csv
+    ```
+
+#### Help
+
+```bash
+python3 tests/bench/test_lora_log_capture.py --help
+```
+
+### What the assertions catch
+
+| Assertion                              | Bug it would have caught (#137 context) |
+|----------------------------------------|----------------------------------------|
+| Newest `lora_*.csv` exists             | "no log on disk after flight"          |
+| File size > 200 bytes                  | "empty file, only header"              |
+| State sequence has PRELAUNCH/INFLIGHT/LANDED | "Journey 75 pattern" (log opens at LANDED only) |
+| Peak `max_alt` > threshold             | rocket telemetry not actually captured |
+| No INFLIGHT inter-row gap > 5 s        | silence-close-during-INFLIGHT (Fix A regression) |
+
+### Limits / what this test doesn't cover
+
+- **SD card flakiness mid-session** — would need a glitching tool or a
+  flaky-by-design test card.  The current path catches "SD never worked
+  this session," not "SD wedged at minute 5."
+- **Multi-rocket BS state interactions** — only one flight computer in the
+  loop.  Multi-rocket regressions need a second rocket on the bench.
+- **LoRa range loss** — both boards are close together.  To simulate
+  long-range altitude dropouts, power-cycle the flight computer mid-sim
+  (manual, not scripted).
+- **GNSS lock semantics** — `SensorCollectorSim` provides a synthetic
+  `num_sats=4` immediately, so the READY→PRELAUNCH transition fires within
+  a few seconds.  Real-world GPS-cold-start regressions aren't caught here.
+
+### Exit codes
+
+- `0`   — all assertions passed
+- `3`   — BLE scan found no base station
+- `4`   — connected but received no telemetry within 10 s
+- `5-8` — state-machine timeout (PRELAUNCH / INFLIGHT / LANDED / READY)
+- `9`   — BS didn't respond to file-list request
+- `10`  — no `lora_*.csv` on the SD after the cycle
+- `11`  — newest log is suspiciously small
+- `12`  — file download timed out
+- `20+` — CSV content assertions failed (see stderr for which)
+- `130` — interrupted (Ctrl-C)

--- a/tests/bench/test_lora_log_capture.py
+++ b/tests/bench/test_lora_log_capture.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Bench HIL test for the BS LoRa CSV logging path (#137).
+
+Drives a simulated flight on real hardware end-to-end:
+
+    laptop ── BLE ── BS ── LoRa ── flight computer (in SIM mode)
+
+The flight computer's SensorCollectorSim provides synthetic GNSS / IMU /
+pressure that drive the rocket state machine through READY → PRELAUNCH →
+INFLIGHT → LANDED → READY, while the rocket transmits real LoRa packets
+on the operating frequency.  The BS receives them and writes lora_*.csv
+to the SD card.  After the cycle, the test downloads the newest LoRa log
+via BLE and asserts:
+
+    • the file exists with a header + non-trivial number of data rows
+    • the state column shows the expected sequence
+    • max_alt grew (the synthetic flight actually went up)
+    • there's no in-flight silence gap larger than the silence-close
+      threshold (which would indicate the #137 silence-during-INFLIGHT
+      regression had returned)
+
+This is a manual bench test — not run from CI.  Run it on hardware before
+every flight day, and on every PR that touches LoRa or BS logging code.
+
+Hardware setup:
+    1. BS powered, antenna connected, SD card inserted
+    2. Flight computer powered (USB or battery)
+    3. Both within LoRa range of each other (~1 m on the bench is plenty)
+    4. Laptop within BLE range of the BS
+    5. No other tinker base station advertising (or pass --address)
+
+Software requirements:
+    pip install bleak   # tested with bleak 0.21+
+    Python 3.10+
+
+Usage:
+    # Fully scripted: Python drives the sim end-to-end
+    python3 tests/bench/test_lora_log_capture.py
+
+    # Explicit BS by MAC (when multiple BS are advertising)
+    python3 tests/bench/test_lora_log_capture.py --address AA:BB:CC:DD:EE:FF
+
+    # Wipe old logs first (recommended for repeated runs)
+    python3 tests/bench/test_lora_log_capture.py --delete-existing
+
+    # Customise the sim profile
+    python3 tests/bench/test_lora_log_capture.py --sim-burn 1.5 --sim-thrust 30
+
+    # iOS-driven mode: skip the sim drive, just verify the newest log on the
+    # BS SD.  Workflow: drive the sim from the iOS Simulation view, wait for
+    # rocket to return to READY, disconnect iOS, then run this.
+    python3 tests/bench/test_lora_log_capture.py --skip-sim
+
+    # Verify a specific file (e.g. a recovered log from a past flight)
+    python3 tests/bench/test_lora_log_capture.py --skip-sim --file lora_20260512_143000.csv
+
+Exit code 0 = pass, non-zero = fail (with diagnostic output).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import io
+import json
+import re
+import struct
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+try:
+    from bleak import BleakClient, BleakScanner
+except ImportError:
+    sys.stderr.write(
+        "error: bleak not installed.  Run: pip install bleak\n"
+    )
+    sys.exit(2)
+
+
+# ----------------------------------------------------------------------------
+# BLE constants — must match tinkerrocket-idf/components/TR_BLE_To_APP/
+# ----------------------------------------------------------------------------
+SERVICE_UUID            = "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
+TELEMETRY_CHAR_UUID     = "beb5483e-36e1-4688-b7f5-ea07361b26a8"
+COMMAND_CHAR_UUID       = "cba1d466-344c-4be3-ab3f-189f80dd7518"
+FILE_OPS_CHAR_UUID      = "8d53dc1d-1db7-4cd3-868b-8a527460aa84"
+FILE_TRANSFER_CHAR_UUID = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+
+DEFAULT_BS_NAME = "TinkerBaseStation"
+
+# Command bytes (subset — full list in base_station/main/main.cpp BLE handler)
+CMD_FILE_LIST       = 0x02
+CMD_DELETE          = 0x03
+CMD_DOWNLOAD        = 0x04
+CMD_SIM_CONFIG      = 0x05
+CMD_SIM_START       = 0x06
+CMD_SIM_STOP        = 0x07
+CMD_TIME_SYNC       = 0x09
+
+
+# ----------------------------------------------------------------------------
+# Captured state
+# ----------------------------------------------------------------------------
+@dataclass
+class Capture:
+    """Aggregates everything we need to observe during the test."""
+    states_seen: list[str] = field(default_factory=list)
+    last_state: Optional[str] = None
+    last_bs_logging_active: Optional[bool] = None
+    last_active_file: Optional[str] = None
+    # The BS closes the flight log on the INFLIGHT→LANDED transition and
+    # then auto-opens a new file for any post-landing telemetry, so the
+    # "newest" file on disk after a sim is a tiny post-flight log without
+    # the actual flight content.  Capture the active_file while we're
+    # observing INFLIGHT so the assertion path can target the right log.
+    inflight_active_file: Optional[str] = None
+    last_max_alt: float = 0.0
+    last_landed_flag: bool = False
+    telemetry_count: int = 0
+
+    # Asynchronous file ops
+    file_list_event: asyncio.Event = field(default_factory=asyncio.Event)
+    file_list_json: Optional[str] = None
+    chunks: dict[int, bytes] = field(default_factory=dict)
+    download_complete: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def note_state(self, state: str) -> None:
+        if state and state != self.last_state:
+            self.states_seen.append(state)
+            self.last_state = state
+
+
+# ----------------------------------------------------------------------------
+# Notification handlers
+# ----------------------------------------------------------------------------
+def make_telemetry_handler(cap: Capture):
+    def handler(_char, data: bytearray):
+        cap.telemetry_count += 1
+        try:
+            obj = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return
+        state = obj.get("st")
+        if isinstance(state, str):
+            cap.note_state(state)
+        if "bslog" in obj:
+            cap.last_bs_logging_active = bool(obj["bslog"])
+        if "af" in obj and isinstance(obj["af"], str) and obj["af"]:
+            cap.last_active_file = obj["af"]
+            if cap.last_state == "INFLIGHT":
+                cap.inflight_active_file = obj["af"]
+        if "malt" in obj:
+            try:
+                cap.last_max_alt = float(obj["malt"])
+            except (TypeError, ValueError):
+                pass
+        if "land" in obj:
+            cap.last_landed_flag = bool(obj["land"])
+    return handler
+
+
+def make_file_ops_handler(cap: Capture):
+    def handler(_char, data: bytearray):
+        # Multiple kinds of payload arrive on this characteristic:
+        #   0xAA marker  → scan results (ignore)
+        #   0xCA marker  → mag-cal status (ignore)
+        #   otherwise    → file list JSON (UTF-8 array)
+        if len(data) == 0:
+            return
+        marker = data[0]
+        if marker in (0xAA, 0xCA):
+            return
+        try:
+            cap.file_list_json = data.decode("utf-8")
+            cap.file_list_event.set()
+        except UnicodeDecodeError:
+            pass
+    return handler
+
+
+def make_file_transfer_handler(cap: Capture):
+    def handler(_char, data: bytearray):
+        # Packet format: [offset(4)][length(2)][flags(1)][data(N)]
+        if len(data) < 7:
+            return
+        offset = int.from_bytes(data[0:4], "little")
+        length = int.from_bytes(data[4:6], "little")
+        eof = bool(data[6] & 0x01)
+        payload = bytes(data[7:7 + length])
+        cap.chunks[offset] = payload
+        if eof:
+            cap.download_complete.set()
+    return handler
+
+
+# ----------------------------------------------------------------------------
+# Command builders
+# ----------------------------------------------------------------------------
+def build_time_sync_payload() -> bytes:
+    """Cmd 9: [year_lo, year_hi, mo, d, h, mi, s] — matches BS handler at
+    main.cpp:3314."""
+    now = datetime.now(timezone.utc)
+    return bytes([
+        CMD_TIME_SYNC,
+        now.year & 0xFF, (now.year >> 8) & 0xFF,
+        now.month, now.day, now.hour, now.minute, now.second,
+    ])
+
+
+def build_sim_config(mass_g: float, thrust_n: float, burn_s: float,
+                     descent_mps: float) -> bytes:
+    """Cmd 5: 16 bytes of little-endian floats [mass_g, thrust_n, burn_s,
+    descent_mps].  See iOS SimulationView.swift launchSim() for the
+    canonical encoder."""
+    return bytes([CMD_SIM_CONFIG]) + struct.pack(
+        "<ffff", mass_g, thrust_n, burn_s, descent_mps
+    )
+
+
+# ----------------------------------------------------------------------------
+# Test driver
+# ----------------------------------------------------------------------------
+async def find_bs(name_filter: str, address: Optional[str], timeout_s: float):
+    if address:
+        print(f"[scan] looking up BS by address {address}...")
+        device = await BleakScanner.find_device_by_address(
+            address, timeout=timeout_s
+        )
+        return device
+    print(f"[scan] scanning for BLE peripheral matching '{name_filter}'...")
+    device = await BleakScanner.find_device_by_filter(
+        lambda _d, adv: (adv.local_name or "").startswith(name_filter),
+        timeout=timeout_s,
+    )
+    return device
+
+
+async def wait_for_state(cap: Capture, target: str,
+                         timeout_s: float, label: str) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if cap.last_state == target:
+            return True
+        await asyncio.sleep(0.2)
+    print(f"[fail] timeout waiting for {label} (state={cap.last_state}, "
+          f"seen={cap.states_seen})", file=sys.stderr)
+    return False
+
+
+async def run_test(args) -> int:
+    cap = Capture()
+
+    device = await find_bs(args.name, args.address, args.scan_timeout)
+    if device is None:
+        print("[fail] no base station found over BLE", file=sys.stderr)
+        return 3
+    print(f"[scan] found {device.name} @ {device.address}")
+
+    async with BleakClient(device) as client:
+        print("[ble]  connected; subscribing to characteristics")
+        await client.start_notify(
+            TELEMETRY_CHAR_UUID,    make_telemetry_handler(cap))
+        await client.start_notify(
+            FILE_OPS_CHAR_UUID,     make_file_ops_handler(cap))
+        await client.start_notify(
+            FILE_TRANSFER_CHAR_UUID, make_file_transfer_handler(cap))
+
+        # Wait for first telemetry — confirms BS is alive and our subscription
+        # is wired up.  Bail early if the BS is offline.
+        print("[ble]  waiting for first telemetry...")
+        deadline = time.monotonic() + 10.0
+        while cap.telemetry_count == 0 and time.monotonic() < deadline:
+            await asyncio.sleep(0.2)
+        if cap.telemetry_count == 0:
+            print("[fail] no telemetry received within 10 s — is the BS "
+                  "powered and within range?", file=sys.stderr)
+            return 4
+
+        if args.skip_sim:
+            # iOS-driven mode: the operator already ran the sim from the iOS
+            # Simulation view and the flight cycle is complete.  We're just
+            # the verifier — connect, request file list, download newest,
+            # assert.  Skip time-sync (iOS already sent it on its connect)
+            # and the full state-machine wait.
+            print("[ble]  --skip-sim: assuming iOS already drove the flight")
+            # Brief grace in case the operator triggered the script right at
+            # LANDED transition; the BS may still be flushing.
+            await asyncio.sleep(2.0)
+        else:
+            # Time-sync so the new log will be named lora_YYYYMMDD_HHMMSS.csv,
+            # making the "newest file" check unambiguous below.
+            print("[ble]  sending time-sync")
+            await client.write_gatt_char(
+                COMMAND_CHAR_UUID, build_time_sync_payload(), response=True)
+            await asyncio.sleep(1.0)
+
+            # Optionally clear any stale logs so the post-flight file list has
+            # exactly one new entry.  Off by default — the operator may want
+            # to preserve previous bench runs for comparison.
+            if args.delete_existing:
+                print("[ble]  deleting existing lora_*.csv before sim...")
+                await delete_all_lora_logs(client, cap)
+
+            # Configure + start sim.  The flight computer's SensorCollectorSim
+            # walks PRELAUNCH (5 s) → POWERED (burn_s) → COASTING → DESCENT →
+            # LANDED — total ~burn + descent_time seconds for the masses we use.
+            print(f"[sim]  config: mass={args.sim_mass}g thrust={args.sim_thrust}N "
+                  f"burn={args.sim_burn}s descent={args.sim_descent}m/s")
+            await client.write_gatt_char(
+                COMMAND_CHAR_UUID,
+                build_sim_config(args.sim_mass, args.sim_thrust,
+                                 args.sim_burn, args.sim_descent),
+                response=True,
+            )
+
+            # The iOS app waits 0.3-1.0 s between cfg and start (LoRa uplink
+            # retries take ~300 ms).  Match the BS-relay path.
+            await asyncio.sleep(1.0)
+
+            print("[sim]  starting sim")
+            await client.write_gatt_char(
+                COMMAND_CHAR_UUID, bytes([CMD_SIM_START]), response=True)
+
+            # Watch the state machine.  Timeouts are conservative — even a 10 s
+            # burn + 30 s descent should comfortably hit READY again within 90 s.
+            if not await wait_for_state(
+                    cap, "PRELAUNCH",  20, "READY → PRELAUNCH"): return 5
+            if not await wait_for_state(
+                    cap, "INFLIGHT",   30, "PRELAUNCH → INFLIGHT"): return 6
+            if not await wait_for_state(
+                    cap, "LANDED",     90, "INFLIGHT → LANDED"): return 7
+            # After landing, the BS closes log A on the LANDED transition
+            # and immediately auto-opens log B for any post-landing packets
+            # (intentional — captures recovery telemetry).  Log A is on
+            # disk; log B will close on its own once 5 min of silence
+            # elapses (LOG_SILENCE_TIMEOUT_MS, #137).
+            await asyncio.sleep(5.0)
+            if not await wait_for_state(
+                    cap, "READY",      30, "LANDED → READY (sim done)"): return 8
+
+            # Short grace so the LANDED-close fsync has finished and log A
+            # is visible in the BLE file listing.  We deliberately do NOT
+            # wait for log B's 5-min silence-close — we want the assertion
+            # to run against log A (the file with PRELAUNCH/INFLIGHT/LANDED
+            # rows).  The newest-by-name pick below selects log B if it's
+            # opened with a later timestamp, so we use --file to force log
+            # A when running back-to-back tests.
+            await asyncio.sleep(5.0)
+
+        # ---- File list ----
+        print("[ble]  requesting file list")
+        cap.file_list_event.clear()
+        cap.file_list_json = None
+        await client.write_gatt_char(
+            COMMAND_CHAR_UUID, bytes([CMD_FILE_LIST, 0]), response=True)
+        try:
+            await asyncio.wait_for(cap.file_list_event.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            print("[fail] no file list returned within 10 s", file=sys.stderr)
+            return 9
+
+        lora_files = parse_lora_files(cap.file_list_json or "[]")
+        if not lora_files:
+            print(f"[fail] no lora_*.csv on the BS SD after sim cycle "
+                  f"(file list: {cap.file_list_json})", file=sys.stderr)
+            return 10
+
+        # Pick which file to verify.  Preference order:
+        #   1. --file FILENAME (explicit override, useful with --skip-sim)
+        #   2. The active_file we captured during the simulated INFLIGHT.
+        #      This is "log A" — the file containing the actual flight.
+        #      "log B" (post-landing auto-restart) shows up with a later
+        #      timestamp and would mislead the max() heuristic.
+        #   3. Newest by filename — fallback when nothing else is known
+        #      (e.g. --skip-sim and the iOS-driven flow couldn't be
+        #      observed, or this is the very first run).
+        if args.file:
+            chosen_name = args.file
+        elif cap.inflight_active_file:
+            chosen_name = cap.inflight_active_file
+            print(f"[ble]  selecting flight log observed during INFLIGHT: "
+                  f"{chosen_name}")
+        else:
+            chosen_name = max(lora_files, key=lambda f: f["name"])["name"]
+        match = [f for f in lora_files if f["name"] == chosen_name]
+        if not match:
+            print(f"[fail] target log {chosen_name!r} not present on the "
+                  f"BS SD (found: {[f['name'] for f in lora_files]})",
+                  file=sys.stderr)
+            return 10
+        newest = match[0]
+        print(f"[ble]  selected log: {newest['name']} ({newest['size']} bytes)")
+
+        if newest["size"] < 200:
+            print(f"[fail] newest log is suspiciously small "
+                  f"({newest['size']} bytes — header is ~140 bytes alone)",
+                  file=sys.stderr)
+            return 11
+
+        # ---- Download ----
+        print(f"[ble]  downloading {newest['name']}...")
+        cap.chunks.clear()
+        cap.download_complete.clear()
+        await client.write_gatt_char(
+            COMMAND_CHAR_UUID,
+            bytes([CMD_DOWNLOAD]) + newest["name"].encode("utf-8"),
+            response=True,
+        )
+        try:
+            await asyncio.wait_for(
+                cap.download_complete.wait(), timeout=180.0)
+        except asyncio.TimeoutError:
+            print(f"[fail] download did not complete within 180 s "
+                  f"(got {sum(len(v) for v in cap.chunks.values())} / "
+                  f"{newest['size']} bytes)", file=sys.stderr)
+            return 12
+
+        body = assemble_chunks(cap.chunks)
+        if len(body) != newest["size"]:
+            print(f"[warn] downloaded {len(body)} bytes, file list said "
+                  f"{newest['size']} — possibly mid-write")
+        return assert_log_quality(body, args)
+
+
+async def delete_all_lora_logs(client, cap: Capture) -> None:
+    """Walk pages until empty, deleting every lora_*.csv we see."""
+    page = 0
+    while True:
+        cap.file_list_event.clear()
+        cap.file_list_json = None
+        await client.write_gatt_char(
+            COMMAND_CHAR_UUID, bytes([CMD_FILE_LIST, page]), response=True)
+        try:
+            await asyncio.wait_for(cap.file_list_event.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            return
+        files = parse_lora_files(cap.file_list_json or "[]")
+        if not files:
+            return
+        for f in files:
+            print(f"       delete {f['name']}")
+            await client.write_gatt_char(
+                COMMAND_CHAR_UUID,
+                bytes([CMD_DELETE]) + f["name"].encode("utf-8"),
+                response=True,
+            )
+            await asyncio.sleep(0.3)
+        # handleDeleteCommand auto-resends page 0, so we re-poll page 0
+        # each round — no need to advance `page`.
+
+
+def parse_lora_files(json_str: str) -> list[dict]:
+    try:
+        arr = json.loads(json_str)
+    except json.JSONDecodeError:
+        return []
+    return [f for f in arr
+            if isinstance(f, dict)
+            and isinstance(f.get("name"), str)
+            and f["name"].startswith("lora_")
+            and f["name"].endswith(".csv")]
+
+
+def assemble_chunks(chunks: dict[int, bytes]) -> bytes:
+    if not chunks:
+        return b""
+    sorted_offsets = sorted(chunks.keys())
+    out = bytearray()
+    for off in sorted_offsets:
+        if off != len(out):
+            # Gap or overlap — pad with zeros so the parser doesn't choke,
+            # but the assertion path will catch it via row count.
+            out.extend(b"\x00" * max(0, off - len(out)))
+        out[off:off + len(chunks[off])] = chunks[off]
+    return bytes(out)
+
+
+# ----------------------------------------------------------------------------
+# Log quality assertions
+# ----------------------------------------------------------------------------
+EXPECTED_TRANSITIONS = ["PRELAUNCH", "INFLIGHT", "LANDED"]
+
+
+def assert_log_quality(body: bytes, args) -> int:
+    text = body.decode("utf-8", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    if len(rows) < 2:
+        print("[fail] log has no data rows", file=sys.stderr)
+        return 20
+    header, data_rows = rows[0], rows[1:]
+    print(f"[csv]  header: {len(header)} columns, {len(data_rows)} data rows")
+
+    try:
+        state_col = header.index("state")
+        time_col  = header.index("time_ms")
+        malt_col  = header.index("max_alt")
+    except ValueError as e:
+        print(f"[fail] required CSV column missing: {e}", file=sys.stderr)
+        return 21
+
+    # State transition sequence
+    states = [r[state_col] for r in data_rows if len(r) > state_col]
+    transitions = [s for i, s in enumerate(states)
+                   if i == 0 or s != states[i - 1]]
+    print(f"[csv]  state sequence: {transitions}")
+    for target in EXPECTED_TRANSITIONS:
+        if target not in transitions:
+            print(f"[fail] state '{target}' not seen in log", file=sys.stderr)
+            return 22
+
+    # max_alt grew at some point (the synthetic flight actually went up).
+    # The "max_alt" column is sticky-max from the rocket — it should rise
+    # above the threshold during INFLIGHT.
+    max_alts = [float(r[malt_col]) for r in data_rows
+                if len(r) > malt_col and is_float(r[malt_col])]
+    if not max_alts or max(max_alts) < args.min_max_alt:
+        print(f"[fail] peak max_alt={max(max_alts) if max_alts else 0:.1f} m "
+              f"< {args.min_max_alt} m — flight didn't register altitude",
+              file=sys.stderr)
+        return 23
+    print(f"[csv]  peak max_alt: {max(max_alts):.1f} m")
+
+    # Silence-gap check.  Skip EVENT rows (state=='EVENT') because they don't
+    # have a time_ms aligned to the rocket clock the same way.  We're looking
+    # for #137 returning: a >5 s in-flight gap that would have silence-closed
+    # the log pre-fix.
+    inflight_rows = [r for r in data_rows
+                     if len(r) > state_col and r[state_col] == "INFLIGHT"]
+    times = []
+    for r in inflight_rows:
+        if len(r) > time_col and is_float(r[time_col]):
+            times.append(float(r[time_col]))
+    if len(times) >= 2:
+        gaps_ms = [b - a for a, b in zip(times, times[1:])]
+        worst_ms = max(gaps_ms)
+        print(f"[csv]  worst INFLIGHT inter-row gap: {worst_ms:.0f} ms")
+        # 5 s threshold — typical packet cadence is ~200-500 ms; the BS will
+        # certainly hold the log open for >5 s with the #137 fix in place.
+        if worst_ms > 5000:
+            print(f"[fail] INFLIGHT gap {worst_ms:.0f} ms > 5000 ms — "
+                  f"silence-close-during-INFLIGHT may have regressed",
+                  file=sys.stderr)
+            return 24
+
+    print("[pass] BS LoRa log captured the simulated flight end-to-end")
+    return 0
+
+
+def is_float(s: str) -> bool:
+    try:
+        float(s)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--name", default=DEFAULT_BS_NAME,
+                   help="BLE name prefix to scan for")
+    p.add_argument("--address", default=None,
+                   help="explicit BLE MAC address (skips scan)")
+    p.add_argument("--scan-timeout", type=float, default=15.0,
+                   help="BLE scan timeout in seconds")
+    p.add_argument("--sim-mass", type=float, default=500.0,
+                   help="sim mass in grams")
+    p.add_argument("--sim-thrust", type=float, default=20.0,
+                   help="sim motor thrust in N")
+    p.add_argument("--sim-burn", type=float, default=2.0,
+                   help="sim motor burn time in s")
+    p.add_argument("--sim-descent", type=float, default=5.0,
+                   help="sim descent rate in m/s")
+    p.add_argument("--min-max-alt", type=float, default=20.0,
+                   help="minimum acceptable peak altitude in m")
+    p.add_argument("--delete-existing", action="store_true",
+                   help="delete every lora_*.csv on the BS SD before the sim")
+    p.add_argument("--skip-sim", action="store_true",
+                   help="don't drive the sim — assume iOS already did the "
+                        "flight cycle.  Just connect, list files, download, "
+                        "and assert on the newest (or --file)")
+    p.add_argument("--file", default=None,
+                   help="explicit log filename to verify (default: newest "
+                        "lora_*.csv).  Useful with --skip-sim")
+    args = p.parse_args()
+    if args.file and not args.skip_sim:
+        p.error("--file only makes sense with --skip-sim "
+                "(without it we don't know which log this run produced)")
+
+    try:
+        rc = asyncio.run(run_test(args))
+    except KeyboardInterrupt:
+        rc = 130
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -201,6 +201,21 @@ target_include_directories(test_tr_flightlog_core PRIVATE
 target_link_libraries(test_tr_flightlog_core GTest::gtest_main)
 gtest_discover_tests(test_tr_flightlog_core)
 
+# ---------- test_bs_log_policy ----------
+# Host-side test for the base-station LoRa CSV logging policy helpers
+# (silence-close gating + sequential-filename parser).  Header lives under
+# projects/base_station/main/ so the test adds that to the include path
+# directly — the helpers are pure and don't need any IDF stubs beyond the
+# host_shim that other tests already use.  See test file + bs_log_policy.h
+# for the #137 backstory.
+add_executable(test_bs_log_policy test_bs_log_policy.cpp)
+target_include_directories(test_bs_log_policy PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_log_policy GTest::gtest_main)
+gtest_discover_tests(test_bs_log_policy)
+
 # ---------- test_tr_flightlog_wire_format ----------
 # Golden-file regression guard on the BLE wire formats iOS depends on.
 # Fixtures under tests_cpp/fixtures/ble_wire_format/ are the source of truth.

--- a/tests_cpp/test_bs_log_policy.cpp
+++ b/tests_cpp/test_bs_log_policy.cpp
@@ -1,0 +1,103 @@
+// test_bs_log_policy.cpp
+// Host-side gtest for the BS LoRa-logging policy helpers extracted from
+// projects/base_station/main/bs_log_policy.h (#137).
+//
+// Currently covers parseSequentialFilename() — the sscanf bug that
+// produced bogus `lora_9886.csv` filenames was the most concrete
+// regression risk from the 5/9/26 test flights.  Other policy decisions
+// (silence-timeout threshold, auto-start gating) live as simple inline
+// conditionals in main.cpp and would need an integration / bench test to
+// exercise meaningfully — that's what tests/bench/test_lora_log_capture.py
+// is for.
+
+#include <gtest/gtest.h>
+
+#include "bs_log_policy.h"
+
+// ---------------------------------------------------------------------------
+// parseSequentialFilename()
+// ---------------------------------------------------------------------------
+
+TEST(BSLogPolicyParseFilename, AcceptsValidSequentialNames)
+{
+    uint16_t n = 0xFFFF;
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_001.csv", n));
+    EXPECT_EQ(n, 1u);
+
+    n = 0xFFFF;
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_42.csv", n));
+    EXPECT_EQ(n, 42u);
+
+    n = 0xFFFF;
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_9886.csv", n));
+    EXPECT_EQ(n, 9886u);
+
+    n = 0xFFFF;
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_65535.csv", n));
+    EXPECT_EQ(n, 65535u);
+
+    n = 0xFFFF;
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_0.csv", n));
+    EXPECT_EQ(n, 0u);
+}
+
+TEST(BSLogPolicyParseFilename, RejectsTimestampedNames)
+{
+    // Regression for the core #137 sscanf bug.  Pre-fix:
+    //   sscanf("lora_20260509_164143.csv", "lora_%hu.csv", &n) == 1, n=9885
+    // This made findNextFileNumber inflate max+1 to 9886, producing
+    // `lora_9886.csv` on the next no-time-sync boot.
+    uint16_t n = 0xFFFF;
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_20260509_164143.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_20260509_144144.csv", n));
+    // _2 collision-suffix variant should also reject (it's still timestamped)
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_20260509_164143_2.csv", n));
+}
+
+TEST(BSLogPolicyParseFilename, RejectsUnrelatedNames)
+{
+    uint16_t n = 0xFFFF;
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "flight_20260509_144128.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora.csv", n));               // no number
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_001.txt", n));           // wrong extension
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_001", n));               // missing extension
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        "lora_001.csv.bak", n));       // trailing junk
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(
+        ".write_test", n));            // BS boot probe file
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename(nullptr, n));
+}
+
+TEST(BSLogPolicyParseFilename, RejectsNegativeSignAndNonDigits)
+{
+    // The parser walks digits explicitly (rather than letting sscanf %hu
+    // accept signs / whitespace and wrap), so any non-digit between
+    // "lora_" and ".csv" disqualifies the match.
+    uint16_t n = 0xFFFF;
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_-1.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_+1.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_ 1.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_1a.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_abc.csv", n));
+}
+
+TEST(BSLogPolicyParseFilename, RejectsOversized)
+{
+    // 6-digit run can't fit uint16 (max=65535) — and even values <=65535
+    // that happen to have 6 digits ("099999" hypothetically) are rejected
+    // because they'd have come from a sequence we never produce.  Real-
+    // world BS code writes %03u, so anything >5 digits is malformed.
+    uint16_t n = 0xFFFF;
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_99999.csv", n));
+    EXPECT_FALSE(bs_log_policy::parseSequentialFilename("lora_123456.csv", n));
+    // Boundary: 65535 is the highest uint16 (5 digits) — accepted.
+    EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_65535.csv", n));
+}

--- a/tinkerrocket-idf/projects/base_station/main/bs_log_policy.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_log_policy.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Base-station LoRa CSV logging policy helpers (#137).
+//
+// Pure functions extracted from main.cpp so the host-side gtest can drive
+// them without dragging in the LoRa radio, SD card, or BLE stack.  Anything
+// in here must remain free of ESP-IDF / FreeRTOS / hardware dependencies.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace bs_log_policy {
+
+// Strict parser for the sequential lora_NNN.csv filenames used when the BS
+// has no phone time-sync yet.  Returns true and sets `out_num` only when
+// `name` exactly matches that pattern with the entire string consumed.
+//
+// Pre-fix, findNextFileNumber() used a bare `sscanf("lora_%hu.csv", &num)`,
+// which sscanf will happily satisfy with partial matches:
+//
+//   sscanf("lora_20260509_164143.csv", "lora_%hu.csv", &num) -> 1, num=9885
+//
+// because `%hu` consumes the leading digits "20260509" (truncating to the
+// low 16 bits = 9885), and the trailing format mismatch on '.' is not
+// reflected in the return value.  The result was that any timestamped file
+// on the SD inflated max_num past every real sequential, so the next
+// no-time-sync boot produced silly names like `lora_9886.csv` even when the
+// card had only ever held `lora_001.csv` next to timestamped flights (#137).
+//
+// Walks digits explicitly (rather than letting sscanf %hu accept signs /
+// whitespace and wrap), so any non-digit between "lora_" and ".csv"
+// disqualifies the match.
+static inline bool parseSequentialFilename(const char* name, uint16_t& out_num)
+{
+    if (name == nullptr) return false;
+    const size_t len = strlen(name);
+    constexpr const char PREFIX[] = "lora_";
+    constexpr const char SUFFIX[] = ".csv";
+    constexpr size_t PREFIX_LEN = sizeof(PREFIX) - 1;
+    constexpr size_t SUFFIX_LEN = sizeof(SUFFIX) - 1;
+    if (len <= PREFIX_LEN + SUFFIX_LEN) return false;
+    if (memcmp(name, PREFIX, PREFIX_LEN) != 0) return false;
+    if (memcmp(name + len - SUFFIX_LEN, SUFFIX, SUFFIX_LEN) != 0) return false;
+    const size_t digits = len - PREFIX_LEN - SUFFIX_LEN;
+    if (digits == 0 || digits > 5) return false;
+    uint32_t value = 0;
+    for (size_t i = 0; i < digits; i++) {
+        const char c = name[PREFIX_LEN + i];
+        if (c < '0' || c > '9') return false;
+        value = value * 10 + (uint32_t)(c - '0');
+    }
+    if (value > 0xFFFFu) return false;  // doesn't fit uint16
+    out_num = (uint16_t)value;
+    return true;
+}
+
+} // namespace bs_log_policy

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -53,7 +53,13 @@ namespace config
     static constexpr int SD_D3   = 8;
 
     // --- LoRa CSV Logging ---
-    static constexpr uint32_t LOG_SILENCE_TIMEOUT_MS  = 30000;          // Close file after 30s of no packets
+    // Close the log after 5 min of no rocket packets.  Long enough to ride
+    // through the worst-case altitude RX dropout on an Estes-class flight
+    // (signal back during descent) and a typical high-power coast-to-apogee,
+    // short enough that bs_logging_active doesn't stick true forever after
+    // the rocket is powered off post-recovery.  Pre-#137 this was 30 s
+    // which closed mid-flight on any altitude-driven silence.
+    static constexpr uint32_t LOG_SILENCE_TIMEOUT_MS  = 5 * 60 * 1000;
     static constexpr uint32_t LOG_INFLIGHT_SAFETY_MS  = 20 * 60 * 1000; // Safety: close log 20 min after INFLIGHT entry if LANDED never seen (#107)
     static constexpr size_t   BLE_FILE_CHUNK_SIZE    = 170;     // Bytes per BLE download chunk
     static constexpr uint32_t BLE_CHUNK_DELAY_MS     = 15;      // Delay between BLE chunks (ms)

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>               // fsync() — periodic-flush SD commit (#107)
 
 #include "config.h"
+#include "bs_log_policy.h"        // parseSequentialFilename() (#137)
 
 #include <TR_LoRa_Comms.h>
 #include <TR_Sensor_Data_Converter.h>
@@ -401,8 +402,13 @@ static uint16_t findNextFileNumber()
     struct dirent* entry;
     while ((entry = readdir(dir)) != nullptr)
     {
+        // #137: use the strict parser so timestamped siblings (e.g.
+        // lora_20260509_164143.csv) don't get matched as "lora_NNN.csv"
+        // with the leading digits truncated to the low 16 bits (= 9885).
+        // Pre-fix, that quirk made the BS pick lora_9886.csv after every
+        // no-time-sync boot whose SD already held timestamped flights.
         uint16_t num = 0;
-        if (sscanf(entry->d_name, "lora_%hu.csv", &num) == 1)
+        if (bs_log_policy::parseSequentialFilename(entry->d_name, num))
         {
             if (num > max_num) max_num = num;
         }
@@ -3117,10 +3123,17 @@ static void loop_bs()
         stopLogging();
     }
 
-    // Silence timeout (safety net): close log if no packets for 30s
-    if (logging_active && (millis() - log_last_write_ms) >= config::LOG_SILENCE_TIMEOUT_MS)
+    // Silence timeout: close log if no packets for LOG_SILENCE_TIMEOUT_MS
+    // (5 min, #137).  Applies in every rocket state — pre-#137 this was 30 s
+    // which closed mid-flight on altitude-driven RX gaps near apogee, but
+    // bumping to 5 min handles even the worst-case descent silence on the
+    // Estes-class flights we test with while still flushing the log a
+    // reasonable interval after the rocket is powered off post-recovery.
+    if (logging_active &&
+        (millis() - log_last_write_ms) >= config::LOG_SILENCE_TIMEOUT_MS)
     {
-        ESP_LOGW(TAG, "[LOG] Silence timeout, closing log file");
+        ESP_LOGW(TAG, "[LOG] Silence timeout (state=%s), closing log file",
+                 rocketStateToString(last_rocket_state));
         stopLogging();
     }
 


### PR DESCRIPTION
Closes #137.

## Summary

After the 5/9 test flights captured a useful LoRa log on only one of four flights, root-cause analysis turned up three concrete issues. This PR addresses all three plus adds regression coverage.

**Fixes**

- **5-min silence-close** ([config.h](tinkerrocket-idf/projects/base_station/main/config.h)): `LOG_SILENCE_TIMEOUT_MS` bumped from 30 s → 5 min. Pre-fix the 30 s threshold was firing during INFLIGHT signal drops at altitude (rocket over horizon, antenna roll-off near apogee), closing the log before descent + landing could be captured. 5 min is comfortably longer than the worst-case Estes-class altitude silence and still tight enough that `bs_logging_active` flushes a reasonable interval after the rocket is powered off post-recovery.
- **Strict sequential-filename parser** ([bs_log_policy.h](tinkerrocket-idf/projects/base_station/main/bs_log_policy.h) + [main.cpp](tinkerrocket-idf/projects/base_station/main/main.cpp)): `findNextFileNumber()` used bare `sscanf("lora_%hu.csv", &num)` which happily matched timestamped names like `lora_20260509_164143.csv` and returned `num=9885` (low 16 bits of `20260509`). That produced bogus filenames like `lora_9886.csv` after every no-time-sync boot whose SD already held timestamped flights. New parser walks digits explicitly and requires the whole name to match.
- **iOS rocket-log indicator gated on state** ([TelemetryData.swift](TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) + [DashboardView.swift](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift)): added a `rocketLoggingActive` computed property that returns true only when `state == "INFLIGHT" && logging_active`. The raw `logging_active` flag from the OC's `isLoggingActive()` stays true during the end-flight queue drain (and can stick true indefinitely if `END_FLIGHT` is dropped over I2C), so the "Rocket Log" badge and "Stop Logging" button label were lit forever post-flight. Trust the rocket state instead — the OC's flight log only ever opens during INFLIGHT.

**Tests**

- [`tests_cpp/test_bs_log_policy.cpp`](tests_cpp/test_bs_log_policy.cpp) — 5 gtest cases for the strict filename parser. Pulled into `tests_cpp/CMakeLists.txt`. Runs in <1 ms in the existing gtest suite; covers timestamped names, non-digit chars, oversized values, and the negative-sign edge case.
- [`tests/bench/test_lora_log_capture.py`](tests/bench/test_lora_log_capture.py) — BLE-driven HIL flight sim. Connects to the BS, drives the flight computer's `SensorCollectorSim` through `READY → PRELAUNCH → INFLIGHT → LANDED → READY`, downloads the resulting log, and asserts on state-sequence + max-alt + no-mid-flight-gaps. Includes a `--skip-sim` flag for the iOS-driven workflow (operator launches the sim from the Simulation view, Python only verifies the result) and a `--file FILENAME` flag for re-verifying a specific past log. Captures the BS's `active_file` during INFLIGHT to target the correct log even when the post-LANDED auto-restart opens a second file.
- [`tests/bench/README.md`](tests/bench/README.md) — operator docs, hardware setup, exit-code reference.

## Test plan

- [x] gtests pass (`cd tests_cpp && cmake --build build && ctest -R BSLogPolicy`) — all 5 green
- [x] BS firmware compiles with the new header (`bs_log_policy.h`)
- [ ] **Bench HIL** — flash the updated BS, run `python3 tests/bench/test_lora_log_capture.py --delete-existing` (or `--skip-sim` with the iOS workflow), confirm exit 0
- [ ] **iOS check** — after a bench sim, the "Rocket Log" badge and "Stop Logging" button revert correctly once the rocket returns to READY (state-gated indicator no longer stuck lit)
- [ ] **Silence-close check** — power off the flight computer mid-test; the BS log should close ~5 min after the last received packet (visible as `[LOG] Silence timeout (state=...), closing log file` in the BS serial monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
