### PR TITLE
log: BS silence-close countdown + HH:MM:SS elapsed-time display

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -83,6 +83,10 @@ struct TelemetryData: Codable {
     var bs_voltage: Float?            // Base station voltage V
     var bs_current: Float?            // Base station current mA
     var bs_logging_active: Bool = false // Base station CSV logging active
+    // Seconds remaining until the BS silence-timeout closes the active log.
+    // Sent only when bs_logging_active is true (BS omits the JSON key
+    // otherwise) — nil here = no countdown to show.
+    var bs_log_silence_remaining_s: UInt16?
 
     // Flight event flags (optional for backward compat with old firmware)
     var launch_flag: Bool?            // Launch detected
@@ -150,6 +154,7 @@ struct TelemetryData: Codable {
         case bs_voltage = "bvol"
         case bs_current = "bcur"
         case bs_logging_active = "bslog"
+        case bs_log_silence_remaining_s = "slrm"
         case launch_flag = "lnch"
         case vel_apo = "vapo"
         case alt_apo = "aapo"
@@ -204,6 +209,7 @@ struct TelemetryData: Codable {
         bs_voltage = try c.decodeIfPresent(Float.self, forKey: .bs_voltage)
         bs_current = try c.decodeIfPresent(Float.self, forKey: .bs_current)
         bs_logging_active = try c.decodeIfPresent(Bool.self, forKey: .bs_logging_active) ?? false
+        bs_log_silence_remaining_s = try c.decodeIfPresent(UInt16.self, forKey: .bs_log_silence_remaining_s)
         launch_flag = try c.decodeIfPresent(Bool.self, forKey: .launch_flag)
         vel_apo = try c.decodeIfPresent(Bool.self, forKey: .vel_apo)
         alt_apo = try c.decodeIfPresent(Bool.self, forKey: .alt_apo)
@@ -372,4 +378,26 @@ struct TelemetryData: Codable {
     var rocketLoggingActive: Bool {
         return logging_active && state == "INFLIGHT"
     }
+}
+
+/// Format an elapsed-time interval as H:MM:SS (or M:SS when under an hour).
+/// Used in place of bare seconds so multi-minute waits read as durations
+/// the operator can scan at a glance — e.g. "4:32" remaining on the BS
+/// silence-close, or "1:03:15" since the last received packet during a
+/// long stale stretch.  Negative or implausibly large values clamp to 0.
+func formatElapsed(seconds: Int) -> String {
+    let s = max(0, seconds)
+    let h = s / 3600
+    let m = (s % 3600) / 60
+    let sec = s % 60
+    if h > 0 {
+        return String(format: "%d:%02d:%02d", h, m, sec)
+    }
+    return String(format: "%d:%02d", m, sec)
+}
+
+/// Convenience: same as the Int version but for milliseconds, rounded to
+/// the nearest second.  Avoids divisor noise at the call site.
+func formatElapsed(ms: UInt32) -> String {
+    return formatElapsed(seconds: Int((ms + 500) / 1000))
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -569,7 +569,7 @@ struct TelemetryStatusBanner: View {
     private var subtitle: String {
         switch status {
         case .syncing: return "Base station hasn't received any telemetry yet. Power on the rocket and wait for the link to sync."
-        case .stale:   return String(format: "Last packet %.1f s ago. Showing cached values.", Double(ageMs) / 1000.0)
+        case .stale:   return "Last packet \(formatElapsed(ms: ageMs)) ago. Showing cached values."
         case .live:    return ""
         }
     }
@@ -992,6 +992,25 @@ struct StatusFlagsView: View {
                 Text("File: \(telemetry.active_file)")
                     .font(.caption)
                     .foregroundColor(.secondary)
+            }
+
+            // BS silence-close countdown.  Only rendered when the base
+            // station reports a remaining-seconds value, which the BS only
+            // sends while bs_logging_active=true (see TR_BLE_To_APP.cpp).
+            // Color tracks urgency: > 60 s green, 11..60 s orange, ≤ 10 s
+            // red so the operator can spot an imminent close at a glance.
+            if isBaseStation,
+               telemetry.bs_logging_active,
+               let remaining = telemetry.bs_log_silence_remaining_s {
+                let secs = Int(remaining)
+                let color: Color = secs > 60 ? .green : (secs > 10 ? .orange : .red)
+                HStack(spacing: 6) {
+                    Image(systemName: "timer")
+                        .foregroundColor(color)
+                    Text("Auto-close in \(formatElapsed(seconds: secs))")
+                        .font(.caption)
+                        .foregroundColor(color)
+                }
             }
         }
         .padding()

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1082,6 +1082,13 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("bvol", data.bs_voltage, 2);
     addFloat("bcur", data.bs_current, 0);
     addBool("bslog", data.bs_logging_active);
+    // Countdown to the silence-timeout close — only emitted while the log
+    // is actually open (saves ~10 B per telemetry packet when idle).  iOS
+    // renders this next to the Base Stn Log badge so the operator can see
+    // the auto-close approaching during a long quiet stretch.
+    if (data.bs_logging_active && data.bs_log_silence_remaining_s != 0xFFFF) {
+        addUint("slrm", data.bs_log_silence_remaining_s);
+    }
 
     // Power rail state
     addBool("pwr", data.pwr_pin_on);

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -68,6 +68,12 @@ public:
         float bs_voltage;       // Base station battery voltage V
         float bs_current;       // Base station battery current mA (NaN if no sensor)
         bool  bs_logging_active;// Base station CSV logging active
+        // Seconds until the silence-timeout closes the current BS log,
+        // when bs_logging_active is true.  Counts down from
+        // LOG_SILENCE_TIMEOUT_MS/1000 (300 s today) on every RX and decreases
+        // as the BS goes longer without a packet.  Omitted from the BLE
+        // payload when bs_logging_active is false (0xFFFF sentinel).
+        uint16_t bs_log_silence_remaining_s;
 
         // Flight event flags (from FlightComputer state machine)
         bool launch_flag;       // Launch detected

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -861,6 +861,23 @@ static void buildBLETelemetry(const LoRaDataSI& lora, float rssi, float snr,
 
     // Base station's own CSV logging state (shown as separate indicator)
     out.bs_logging_active = logging_active;
+    // Seconds remaining until silence-timeout fires (#137 follow-up).  When
+    // the log is open, iOS renders a countdown next to the Base Stn Log
+    // badge so the operator can see the auto-close approaching during long
+    // post-flight idles.  We sit-clamp at 0 rather than going negative
+    // because the close runs out of band with this packet build.
+    if (logging_active)
+    {
+        const uint32_t age_ms   = millis() - log_last_write_ms;
+        const uint32_t remain_ms = (age_ms >= config::LOG_SILENCE_TIMEOUT_MS)
+                                 ? 0
+                                 : (config::LOG_SILENCE_TIMEOUT_MS - age_ms);
+        out.bs_log_silence_remaining_s = (uint16_t)(remain_ms / 1000U);
+    }
+    else
+    {
+        out.bs_log_silence_remaining_s = 0xFFFF;  // sentinel — omit from JSON
+    }
 
     // Data rates -- not applicable for base station
     out.rx_kbs = NAN;


### PR DESCRIPTION
Two small UX improvements to the iOS dashboard after the #137 follow-up flight tests.

## Summary

**1. BS silence-close countdown** ([main.cpp](tinkerrocket-idf/projects/base_station/main/main.cpp), [TR_BLE_To_APP](tinkerrocket-idf/components/TR_BLE_To_APP), [DashboardView.swift](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift))

The BS now computes and ships `bs_log_silence_remaining_s` (key `"slrm"` in the BLE JSON):

```
remaining = LOG_SILENCE_TIMEOUT_MS - (millis() - log_last_write_ms)
```

clamped to 0 and converted to seconds. The field is **omitted from the payload entirely** when the log is closed so we don't burn ~10 bytes per telemetry packet on a value that would be meaningless — important given the 512 B MTU pressure on this JSON (see [feedback_ble_json_size.md](https://github.com/Tinkerbug-Robotics/TinkerRocket) memory).

iOS renders it as a timer row under the Base Stn Log badge with traffic-light coloring:
- green (`> 60 s`)
- orange (`> 10 s`)
- red (`≤ 10 s`)

Operator can spot an imminent auto-close at a glance during long post-flight stretches.

**2. HH:MM:SS elapsed-time display** ([TelemetryData.swift](TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift), [DashboardView.swift](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift))

The "Last packet 47.3 s ago" stale banner now reads:
- `Last packet 0:47 ago` (under an hour)
- `Last packet 1:03:15 ago` (over an hour)

via a small `formatElapsed(seconds:)` / `formatElapsed(ms:)` helper on `TelemetryData.swift`. The countdown UI from change #1 uses the same helper, so a 4:32 BS auto-close and a 0:47 stale duration read consistently.

## Test plan

- [x] Host gtests still pass (`test_bs_log_policy` re-run, 5/5 green — change doesn't touch policy)
- [x] Diff inspected: BS field defaults to 0xFFFF sentinel when log is closed, JSON encoder omits the key in that case
- [ ] **Bench HIL** — flash BS + iOS, start a sim, watch the countdown tick down on the dashboard while INFLIGHT (resets on each RX) and stay sticky after LANDED when the rocket goes quiet
- [ ] **Stale banner check** — disconnect the rocket briefly while connected via BS, confirm the "Last packet X:XX ago" formatting kicks in

## Notes

- Backward compatible: old iOS app builds will see the `"slrm"` key and ignore it (Codable `decodeIfPresent`). New iOS app builds against old BS firmware will get `bs_log_silence_remaining_s = nil`, hiding the countdown row.
- Field name `slrm` is 4 chars — same envelope cost as `"bvol"`, `"bsoc"`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
