### PR TITLE
ble: voice callouts over BS relay + flag-bitfield MTU pack (#138)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -91,8 +91,9 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// Rockets seen via this device's LoRa relay (base station only)
     @Published var remoteRockets: [RemoteRocket] = []
 
-    // Flight voice announcer (set by DashboardView)
-    var flightAnnouncer: FlightAnnouncer?
+    // Flight voice announcer (set by DashboardView).  Typed as a protocol so
+    // dispatch tests can inject a spy without touching AVAudioSession.
+    var flightAnnouncer: (any TelemetryAnnouncer)?
 
     // MARK: - Internal state
 
@@ -122,12 +123,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
     // MARK: - Init
 
-    init(peripheral: CBPeripheral, name: String) {
+    init(peripheral: CBPeripheral?, name: String) {
         self.connectedDeviceName = name
         self.deviceType = BLEDeviceType.from(name: name)
         super.init()
         self.peripheral = peripheral
-        peripheral.delegate = self
+        peripheral?.delegate = self
     }
 
     // MARK: - Connection lifecycle (called by BLEFleet)
@@ -931,7 +932,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
     // MARK: - Telemetry parsing
 
-    private func parseTelemetryData(_ data: Data?) {
+    func parseTelemetryData(_ data: Data?) {
         guard let data = data else { return }
 
         // Config readback: "type":"config"
@@ -1006,8 +1007,8 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
             // If telemetry has a source_rocket_id, it's relayed via base station
             // → route to RemoteRocket instead of updating our own telemetry
-            if let rid = newTelemetry.source_rocket_id, rid > 0, isBaseStation,
-               let bsID = peripheral?.identifier {
+            if let rid = newTelemetry.source_rocket_id, rid > 0, isBaseStation {
+                let bsID = peripheral?.identifier ?? UUID()
                 let rocketID = UInt8(rid)
                 if let existing = remoteRockets.first(where: { $0.rocketID == rocketID }) {
                     existing.updateTelemetry(newTelemetry, unitName: newTelemetry.source_unit_name)
@@ -1022,9 +1023,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                     print("[BS] New remote rocket: rid=\(rocketID) name=\(remote.unitName)")
                     triggerAutoChannelSelectIfNeeded()
                 }
-                // Still update base station's own telemetry for BS-specific fields
-                // (battery, logging state) but don't overwrite rocket telemetry
                 self.telemetry = newTelemetry
+                // The relayed JSON carries the full rocket state (st/aapo/lnch/
+                // land/mspd/palt — see TR_BLE_To_APP.cpp).  Without this call
+                // voice callouts only fire when paired directly to the rocket,
+                // never during a real flight (phone↔BS↔LoRa↔rocket).  #138.
+                self.flightAnnouncer?.processTelemetry(newTelemetry)
                 return
             }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
@@ -10,7 +10,16 @@ import Foundation
 import AVFoundation
 import Combine
 
-class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
+/// Subset of `FlightAnnouncer` that `BLEDevice` calls during dispatch.
+/// Defined as a protocol so tests can substitute a lightweight spy without
+/// instantiating `AVSpeechSynthesizer` / `AVAudioSession`, and so the
+/// dispatch logic in `BLEDevice` can be exercised end-to-end.
+protocol TelemetryAnnouncer: AnyObject {
+    func processTelemetry(_ telemetry: TelemetryData)
+    func reset()
+}
+
+class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, TelemetryAnnouncer {
 
     @Published var isEnabled: Bool = false
 
@@ -208,6 +217,18 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
             return
         }
 
+        // Skip stale or syncing frames.  When the rocket goes silent
+        // mid-flight (powered off, out of range) the BS keeps forwarding the
+        // last-known telemetry with data_status=STALE and a growing `age`.
+        // Time-gated callouts (descent/altitude) would otherwise re-fire the
+        // same frozen reading every interval forever.  Skipping here also
+        // lets the currently-playing utterance finish naturally — we just
+        // don't queue a new one.
+        guard telemetry.data_status == .live else {
+            previousTelemetry = telemetry
+            return
+        }
+
         let prev = previousTelemetry
         let state = telemetry.state
 
@@ -222,7 +243,7 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
         }
 
         // --- Capture launch location on launch flag if not set ---
-        if (telemetry.launch_flag ?? false) && launchLocation == nil {
+        if telemetry.launch_flag && launchLocation == nil {
             if let lat = telemetry.latitude, let lon = telemetry.longitude,
                !lat.isNaN && !lon.isNaN {
                 launchLocation = (lat: lat, lon: lon)
@@ -230,7 +251,7 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
         }
 
         // --- INFLIGHT announcements (before apogee) ---
-        if state == "INFLIGHT" && !(telemetry.alt_apo ?? false) {
+        if state == "INFLIGHT" && !telemetry.alt_apo {
             checkBurnout(telemetry)
             // Only announce altitude after burnout — during powered flight there
             // is too much happening and the rapidly changing values aren't useful.
@@ -240,7 +261,7 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
         }
 
         // --- Apogee detection ---
-        if (telemetry.alt_apo ?? false) && !(prev?.alt_apo ?? false) && !apogeeAnnounced {
+        if telemetry.alt_apo && !(prev?.alt_apo ?? false) && !apogeeAnnounced {
             apogeeAnnounced = true
             let alt = telemetry.max_alt_m.map { String(format: "%.0f", $0) } ?? "unknown"
             announceImmediate("Apogee. \(alt) meters")
@@ -249,12 +270,12 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
         }
 
         // --- Descent callouts (after apogee, before landed) ---
-        if (telemetry.alt_apo ?? false) && !(telemetry.landed_flag ?? false) && state == "INFLIGHT" {
+        if telemetry.alt_apo && !telemetry.landed_flag && state == "INFLIGHT" {
             checkDescentCallout(telemetry)
         }
 
         // --- Landing detection ---
-        if (telemetry.landed_flag ?? false) && !(prev?.landed_flag ?? false) && !landedAnnounced {
+        if telemetry.landed_flag && !(prev?.landed_flag ?? false) && !landedAnnounced {
             landedAnnounced = true
             let distance = horizontalDistanceString(telemetry)
             announceImmediate("Landed. \(distance)")

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -16,8 +16,6 @@ struct TelemetryData: Codable {
     var gdop: Float?                  // GPS dilution of precision
     var num_sats: Int = 0             // Number of GPS satellites
     var state: String = "UNKNOWN"     // Rocket state
-    var camera_recording: Bool = false
-    var logging_active: Bool = false
     var active_file: String = ""
     var rx_kbs: Float?                // I2C RX rate kB/s
     var wr_kbs: Float?                // Flash write rate kB/s
@@ -82,20 +80,24 @@ struct TelemetryData: Codable {
     var bs_soc: Float?                // Base station SOC %
     var bs_voltage: Float?            // Base station voltage V
     var bs_current: Float?            // Base station current mA
-    var bs_logging_active: Bool = false // Base station CSV logging active
     // Seconds remaining until the BS silence-timeout closes the active log.
     // Sent only when bs_logging_active is true (BS omits the JSON key
     // otherwise) — nil here = no countdown to show.
     var bs_log_silence_remaining_s: UInt16?
 
-    // Flight event flags (optional for backward compat with old firmware)
-    var launch_flag: Bool?            // Launch detected
-    var vel_apo: Bool?                // Velocity apogee (vertical vel crossed zero)
-    var alt_apo: Bool?                // Altitude apogee (alt started decreasing)
-    var landed_flag: Bool?            // Landing detected
-
-    // Power rail state
-    var pwr_pin_on: Bool = false      // FlightComputer + sensors powered on
+    // Packed flight-status bits ("fs" JSON key, decoded in init).  Replaces
+    // 8 separate boolean keys to keep the BLE notify payload under MTU —
+    // see TR_BLE_To_APP.cpp:buildTelemetryJSON.  Bit layout must stay in
+    // sync with the firmware side.
+    var flight_status_bits: Int = 0
+    var launch_flag: Bool       { (flight_status_bits & 0x01) != 0 }
+    var vel_apo: Bool           { (flight_status_bits & 0x02) != 0 }
+    var alt_apo: Bool           { (flight_status_bits & 0x04) != 0 }
+    var landed_flag: Bool       { (flight_status_bits & 0x08) != 0 }
+    var pwr_pin_on: Bool        { (flight_status_bits & 0x10) != 0 }
+    var camera_recording: Bool  { (flight_status_bits & 0x20) != 0 }
+    var logging_active: Bool    { (flight_status_bits & 0x40) != 0 }
+    var bs_logging_active: Bool { (flight_status_bits & 0x80) != 0 }
 
     // Source rocket identity (base station relay only, nil for direct BLE)
     var source_rocket_id: Int?        // rocket_id from LoRa header
@@ -126,8 +128,6 @@ struct TelemetryData: Codable {
         case longitude = "lon"
         case num_sats = "nsat"
         case state = "st"
-        case camera_recording = "cam"
-        case logging_active = "log"
         case active_file = "af"
         case rx_kbs = "rxk"
         case wr_kbs = "wrk"
@@ -153,13 +153,10 @@ struct TelemetryData: Codable {
         case bs_soc = "bsoc"
         case bs_voltage = "bvol"
         case bs_current = "bcur"
-        case bs_logging_active = "bslog"
         case bs_log_silence_remaining_s = "slrm"
-        case launch_flag = "lnch"
-        case vel_apo = "vapo"
-        case alt_apo = "aapo"
-        case landed_flag = "land"
-        case pwr_pin_on = "pwr"
+        // Packed flight-status bitfield (replaces lnch/vapo/aapo/land/pwr/
+        // cam/log/bslog).  Bit layout mirrors TR_BLE_To_APP.cpp.
+        case flight_status_bits = "fs"
         case pyro_status_bits = "ps"  // packed bitfield: b0=ch1_armed, b1=ch1_cont, b2=ch1_fired, b3=ch2_armed, b4=ch2_cont, b5=ch2_fired
         case source_rocket_id = "rid"
         case source_unit_name = "run"
@@ -177,8 +174,6 @@ struct TelemetryData: Codable {
         longitude = try c.decodeIfPresent(Double.self, forKey: .longitude)
         num_sats = try c.decodeIfPresent(Int.self, forKey: .num_sats) ?? 0
         state = try c.decodeIfPresent(String.self, forKey: .state) ?? "UNKNOWN"
-        camera_recording = try c.decodeIfPresent(Bool.self, forKey: .camera_recording) ?? false
-        logging_active = try c.decodeIfPresent(Bool.self, forKey: .logging_active) ?? false
         active_file = try c.decodeIfPresent(String.self, forKey: .active_file) ?? ""
         rx_kbs = try c.decodeIfPresent(Float.self, forKey: .rx_kbs)
         wr_kbs = try c.decodeIfPresent(Float.self, forKey: .wr_kbs)
@@ -208,13 +203,8 @@ struct TelemetryData: Codable {
         bs_soc = try c.decodeIfPresent(Float.self, forKey: .bs_soc)
         bs_voltage = try c.decodeIfPresent(Float.self, forKey: .bs_voltage)
         bs_current = try c.decodeIfPresent(Float.self, forKey: .bs_current)
-        bs_logging_active = try c.decodeIfPresent(Bool.self, forKey: .bs_logging_active) ?? false
         bs_log_silence_remaining_s = try c.decodeIfPresent(UInt16.self, forKey: .bs_log_silence_remaining_s)
-        launch_flag = try c.decodeIfPresent(Bool.self, forKey: .launch_flag)
-        vel_apo = try c.decodeIfPresent(Bool.self, forKey: .vel_apo)
-        alt_apo = try c.decodeIfPresent(Bool.self, forKey: .alt_apo)
-        landed_flag = try c.decodeIfPresent(Bool.self, forKey: .landed_flag)
-        pwr_pin_on = try c.decodeIfPresent(Bool.self, forKey: .pwr_pin_on) ?? false
+        flight_status_bits = try c.decodeIfPresent(Int.self, forKey: .flight_status_bits) ?? 0
         pyro_status_bits = try c.decodeIfPresent(Int.self, forKey: .pyro_status_bits) ?? 0
         source_rocket_id = try c.decodeIfPresent(Int.self, forKey: .source_rocket_id)
         source_unit_name = try c.decodeIfPresent(String.self, forKey: .source_unit_name)

--- a/TinkerRocketApp/TinkerRocketAppTests/FlightAnnouncerDispatchTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/FlightAnnouncerDispatchTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Regression tests for #138: voice callouts must fire when telemetry arrives
+/// through a base-station LoRa relay, not just on direct rocket BLE.
+/// The original bug was an early `return` in the BS branch of
+/// `parseTelemetryData` that skipped the announcer entirely.
+final class FlightAnnouncerDispatchTests: XCTestCase {
+
+    /// Captures `processTelemetry` calls without touching AVFoundation, so the
+    /// test can run on any host without an audio session.
+    final class SpyAnnouncer: TelemetryAnnouncer {
+        var received: [TelemetryData] = []
+        var resetCount = 0
+        func processTelemetry(_ telemetry: TelemetryData) {
+            received.append(telemetry)
+        }
+        func reset() {
+            resetCount += 1
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Build a base-station BLEDevice with no peripheral.  The "TR-B-" prefix
+    /// causes `BLEDeviceType.from(name:)` to classify it as a base station.
+    private func makeBaseStation() -> BLEDevice {
+        BLEDevice(peripheral: nil, name: "TR-B-Test")
+    }
+
+    private func makeRocket() -> BLEDevice {
+        BLEDevice(peripheral: nil, name: "TR-R-Test")
+    }
+
+    /// JSON keys mirror TelemetryData.CodingKeys ("rid", "st", "aapo", etc.).
+    private func relayedJSON(rocketID: Int, state: String = "INFLIGHT") -> Data {
+        """
+        {"rid":\(rocketID),"run":"Atlas","st":"\(state)","palt":120.5,"mspd":85.0}
+        """.data(using: .utf8)!
+    }
+
+    private func directJSON(state: String = "INFLIGHT") -> Data {
+        """
+        {"st":"\(state)","palt":120.5,"mspd":85.0}
+        """.data(using: .utf8)!
+    }
+
+    // MARK: - Tests
+
+    /// Core regression: relayed telemetry must reach the announcer.
+    /// Before the fix this asserted 0 calls (the dispatch returned early).
+    func testRelayedTelemetry_TriggersAnnouncer() {
+        let bs = makeBaseStation()
+        let spy = SpyAnnouncer()
+        bs.flightAnnouncer = spy
+
+        bs.parseTelemetryData(relayedJSON(rocketID: 7))
+
+        XCTAssertEqual(spy.received.count, 1,
+                       "Relayed telemetry should invoke the announcer (#138)")
+        XCTAssertEqual(spy.received.first?.source_rocket_id, 7)
+        XCTAssertEqual(spy.received.first?.state, "INFLIGHT")
+        XCTAssertEqual(bs.remoteRockets.count, 1,
+                       "Relayed rocket should also be tracked in remoteRockets")
+    }
+
+    /// A full PRELAUNCH→INFLIGHT→LANDED sequence over the relay path should
+    /// produce one announcer call per frame, so edge-detection in the
+    /// announcer sees the transitions.
+    func testRelayedFlightSequence_AllFramesReachAnnouncer() {
+        let bs = makeBaseStation()
+        let spy = SpyAnnouncer()
+        bs.flightAnnouncer = spy
+
+        bs.parseTelemetryData(relayedJSON(rocketID: 7, state: "PRELAUNCH"))
+        bs.parseTelemetryData(relayedJSON(rocketID: 7, state: "INFLIGHT"))
+        bs.parseTelemetryData(relayedJSON(rocketID: 7, state: "LANDED"))
+
+        XCTAssertEqual(spy.received.count, 3)
+        XCTAssertEqual(spy.received.map(\.state),
+                       ["PRELAUNCH", "INFLIGHT", "LANDED"])
+    }
+
+    /// Direct-rocket path must keep working — guards against a fix that
+    /// breaks the case the bug report compared against.
+    func testDirectRocketTelemetry_TriggersAnnouncer() {
+        let rocket = makeRocket()
+        let spy = SpyAnnouncer()
+        rocket.flightAnnouncer = spy
+
+        rocket.parseTelemetryData(directJSON())
+
+        XCTAssertEqual(spy.received.count, 1)
+        XCTAssertNil(spy.received.first?.source_rocket_id)
+    }
+
+    /// A BS receiving a frame with no `rid` (e.g. its own heartbeat) must
+    /// still route through the announcer via the non-relay branch.
+    func testBaseStation_SelfTelemetry_TriggersAnnouncer() {
+        let bs = makeBaseStation()
+        let spy = SpyAnnouncer()
+        bs.flightAnnouncer = spy
+
+        bs.parseTelemetryData(directJSON())
+
+        XCTAssertEqual(spy.received.count, 1)
+        XCTAssertEqual(bs.remoteRockets.count, 0,
+                       "Non-relayed frames should not populate remoteRockets")
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -48,6 +48,52 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(telemetry.num_sats, 0)
     }
 
+    // MARK: - Flight status bitfield (#138 MTU pack)
+
+    /// "fs" packs 8 flags into one byte to keep the BLE notify under MTU.
+    /// Bit layout must match TR_BLE_To_APP.cpp:buildTelemetryJSON.
+    ///   b0=lnch b1=vapo b2=aapo b3=land
+    ///   b4=pwr  b5=cam  b6=log  b7=bslog
+    func testFlightStatusBits_AllBitsResolve() throws {
+        // 0xFF — every flag should resolve true.
+        let allSet = try JSONDecoder().decode(
+            TelemetryData.self, from: #"{"fs":255}"#.data(using: .utf8)!)
+        XCTAssertTrue(allSet.launch_flag)
+        XCTAssertTrue(allSet.vel_apo)
+        XCTAssertTrue(allSet.alt_apo)
+        XCTAssertTrue(allSet.landed_flag)
+        XCTAssertTrue(allSet.pwr_pin_on)
+        XCTAssertTrue(allSet.camera_recording)
+        XCTAssertTrue(allSet.logging_active)
+        XCTAssertTrue(allSet.bs_logging_active)
+
+        // 0x55 = 0b0101_0101 — even bits: lnch, aapo, pwr, log.
+        // Verifies each computed property reads from its assigned bit
+        // position (not e.g. an off-by-one bit-shift).
+        let evenSet = try JSONDecoder().decode(
+            TelemetryData.self, from: #"{"fs":85}"#.data(using: .utf8)!)
+        XCTAssertTrue(evenSet.launch_flag)
+        XCTAssertFalse(evenSet.vel_apo)
+        XCTAssertTrue(evenSet.alt_apo)
+        XCTAssertFalse(evenSet.landed_flag)
+        XCTAssertTrue(evenSet.pwr_pin_on)
+        XCTAssertFalse(evenSet.camera_recording)
+        XCTAssertTrue(evenSet.logging_active)
+        XCTAssertFalse(evenSet.bs_logging_active)
+    }
+
+    /// Missing "fs" key → all flags false (older firmware or BS-self frame
+    /// with no flight context).  Must not crash.
+    func testFlightStatusBits_MissingKey_AllFalse() throws {
+        let json = "{}".data(using: .utf8)!
+        let t = try JSONDecoder().decode(TelemetryData.self, from: json)
+        XCTAssertEqual(t.flight_status_bits, 0)
+        XCTAssertFalse(t.launch_flag)
+        XCTAssertFalse(t.alt_apo)
+        XCTAssertFalse(t.landed_flag)
+        XCTAssertFalse(t.bs_logging_active)
+    }
+
     // MARK: - Quaternion storage
 
     func testQuaternionToEuler_Identity() {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -949,18 +949,36 @@ void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
 
 String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
 {
-    // Use a pre-allocated char buffer to build JSON efficiently.
-    // Max telemetry JSON is well under 512 bytes.
-    char buf[512];
+    // Stack buffer for JSON construction.  Sized with comfortable headroom
+    // above the negotiated BLE MTU (typically 512, payload window 509) so
+    // a near-full frame still has slack — every add* lambda below does an
+    // upfront fit check and silently drops the field rather than memcpy'ing
+    // past the end.  Unchecked overflow here previously crashed the BS
+    // (cache-disabled MMU fault from corrupted stack) and silently dropped
+    // every telemetry update once size crept past 512.  See #138 / memory:
+    // "BLE telemetry JSON exceeding MTU silently drops all updates".
+    char buf[640];
     size_t pos = 0;
     bool first = true;
+    // Reserve trailing bytes for closing '}' + '\0'.
+    const size_t kReserve = 2;
 
     buf[pos++] = '{';
 
-    // Comma separator helper
+    // Returns true if `n` more bytes (plus the reserved tail) still fit.
+    auto room = [&](size_t n) -> bool {
+        return pos + n + kReserve <= sizeof(buf);
+    };
+
+    // Comma separator helper.  Bytes accounted for in each caller's fit check.
     auto sep = [&]() { if (!first) buf[pos++] = ','; first = false; };
 
-    // Append a key (quoted)
+    // Bytes appendKey will write for `key`: optional ',' + '"' + key + '":'
+    auto keyBytes = [&](const char* key) -> size_t {
+        return (first ? 0 : 1) + 2 + strlen(key) + 1;
+    };
+
+    // Append a key (quoted).  Assumes caller pre-checked space via `room()`.
     auto appendKey = [&](const char* key) {
         sep();
         buf[pos++] = '"';
@@ -971,9 +989,14 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
         buf[pos++] = ':';
     };
 
-    // Optional float — skips NaN values entirely to save BLE payload bytes
+    // Numeric max-width budget: floats/doubles at any reasonable precision
+    // and 32-bit ints both fit comfortably in 24 chars (incl. sign/decimal).
+    const size_t kNumMax = 24;
+
+    // Optional float — skips NaN values entirely to save BLE payload bytes.
     auto addFloat = [&](const char* key, float value, int decimals) {
         if (std::isnan(value)) return;
+        if (!room(keyBytes(key) + kNumMax)) return;
         appendKey(key);
         pos += snprintf(buf + pos, sizeof(buf) - pos, "%.*f", decimals, (double)value);
     };
@@ -981,60 +1004,51 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     // Optional double — skips NaN values
     auto addDouble = [&](const char* key, double value, int decimals) {
         if (std::isnan(value)) return;
+        if (!room(keyBytes(key) + kNumMax)) return;
         appendKey(key);
         pos += snprintf(buf + pos, sizeof(buf) - pos, "%.*f", decimals, value);
     };
 
-    // Always-present helpers
     auto addInt = [&](const char* key, int value) {
+        if (!room(keyBytes(key) + kNumMax)) return;
         appendKey(key);
         pos += snprintf(buf + pos, sizeof(buf) - pos, "%d", value);
     };
     auto addUint = [&](const char* key, uint32_t value) {
+        if (!room(keyBytes(key) + kNumMax)) return;
         appendKey(key);
         pos += snprintf(buf + pos, sizeof(buf) - pos, "%lu", (unsigned long)value);
     };
     auto addString = [&](const char* key, const char* value) {
+        size_t vlen = value ? strlen(value) : 0;
+        // 2 extra for the value's surrounding quotes.
+        if (!room(keyBytes(key) + 2 + vlen)) return;
         appendKey(key);
         buf[pos++] = '"';
         if (value) {
-            size_t vlen = strlen(value);
             memcpy(buf + pos, value, vlen);
             pos += vlen;
         }
         buf[pos++] = '"';
     };
-    auto addBool = [&](const char* key, bool value) {
-        appendKey(key);
-        const char* s = value ? "true" : "false";
-        size_t slen = strlen(s);
-        memcpy(buf + pos, s, slen);
-        pos += slen;
-    };
+    // (addBool removed — every bool now lives in the "fs" bitfield.)
 
     // Battery
     addFloat("soc", data.soc, 1);
     addFloat("cur", data.current, 1);
     addFloat("vol", data.voltage, 2);
 
-    // GPS
-    addDouble("lat", data.latitude, 7);
-    addDouble("lon", data.longitude, 7);
+    // GPS — 5 decimals = ~1.1 m precision, plenty for tracking and saves
+    // ~4 B/frame vs 7 decimals.  iOS decodes as Double regardless.
+    addDouble("lat", data.latitude, 5);
+    addDouble("lon", data.longitude, 5);
     addInt("nsat", data.num_sats);
 
     // State
     addString("st", data.state);
 
-    // Status flags
-    addBool("cam", data.camera_recording);
-    addBool("log", data.logging_active);
+    // Logging filename (camera/log/bslog flags now packed into "fs" below).
     addString("af", data.active_file);
-
-    // Flight event flags
-    addBool("lnch", data.launch_flag);
-    addBool("vapo", data.vel_u_apogee_flag);
-    addBool("aapo", data.alt_apogee_flag);
-    addBool("land", data.alt_landed_flag);
 
     // Data rates
     addFloat("rxk", data.rx_kbs, 1);
@@ -1066,12 +1080,14 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("gy", data.gyro_y, 1);
     addFloat("gz", data.gyro_z, 1);
 
-    // Roll command + quaternion
+    // Roll command + quaternion — quat at 3 decimals gives ~0.06° angle
+    // error in the derived Euler display, well under the dashboard's
+    // %.1f° formatting.  Saves ~4 B per frame vs 4 decimals.
     addFloat("rcmd", data.roll_cmd, 1);
-    addFloat("q0", data.q0, 4);
-    addFloat("q1", data.q1, 4);
-    addFloat("q2", data.q2, 4);
-    addFloat("q3", data.q3, 4);
+    addFloat("q0", data.q0, 3);
+    addFloat("q1", data.q1, 3);
+    addFloat("q2", data.q2, 3);
+    addFloat("q3", data.q3, 3);
 
     // LoRa signal quality (NaN on direct connection — will be omitted)
     addFloat("rssi", data.rssi, 0);
@@ -1081,7 +1097,6 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("bsoc", data.bs_soc, 1);
     addFloat("bvol", data.bs_voltage, 2);
     addFloat("bcur", data.bs_current, 0);
-    addBool("bslog", data.bs_logging_active);
     // Countdown to the silence-timeout close — only emitted while the log
     // is actually open (saves ~10 B per telemetry packet when idle).  iOS
     // renders this next to the Base Stn Log badge so the operator can see
@@ -1090,8 +1105,23 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
         addUint("slrm", data.bs_log_silence_remaining_s);
     }
 
-    // Power rail state
-    addBool("pwr", data.pwr_pin_on);
+    // Packed flight-status bits (saves ~90 B vs 8 separate JSON booleans).
+    // The pyro flags use the same trick via "ps" — same pattern.
+    //   b0  launch_flag           b4  pwr_pin_on
+    //   b1  vel_u_apogee_flag     b5  camera_recording
+    //   b2  alt_apogee_flag       b6  logging_active
+    //   b3  alt_landed_flag       b7  bs_logging_active
+    {
+        uint8_t fs = (data.launch_flag        ? 0x01 : 0)
+                   | (data.vel_u_apogee_flag  ? 0x02 : 0)
+                   | (data.alt_apogee_flag    ? 0x04 : 0)
+                   | (data.alt_landed_flag    ? 0x08 : 0)
+                   | (data.pwr_pin_on         ? 0x10 : 0)
+                   | (data.camera_recording   ? 0x20 : 0)
+                   | (data.logging_active     ? 0x40 : 0)
+                   | (data.bs_logging_active  ? 0x80 : 0);
+        addInt("fs", fs);
+    }
 
     // Pyro channel status — packed into single byte to minimize JSON size
     {


### PR DESCRIPTION
## Summary
- Fix voice callouts not firing during real flights when the phone is paired to the base station (closes #138). The BS-relay branch on iOS used to early-return before invoking `FlightAnnouncer`; it now dispatches the same as direct-rocket telemetry.
- Pack 8 telemetry booleans (`lnch`/`vapo`/`aapo`/`land`/`pwr`/`cam`/`log`/`bslog`) into a single `"fs"` byte mirroring the existing `"ps"` pyro pattern, and trim `lat`/`lon` to 5 dp and quaternion to 3 dp. ~98 B/frame savings — worst-case INFLIGHT frame goes from 517 B (over MTU, silently dropped) to ~419 B.
- Harden `buildTelemetryJSON()` against the underlying bug that caused the symptom: every `add*` lambda now precomputes its byte cost via a `room()` predicate and skips the field instead of `memcpy`'ing past the end of the stack buffer. The original unchecked overflow was crashing the BS with a cache-disabled MMU fault (Guru Meditation from corrupted return addresses in `__memcpy_aux`). Buffer also grew 512 → 640 B for additional headroom.
- `FlightAnnouncer` now skips stale/syncing telemetry — the BS keeps forwarding the last-known rocket state with `ds=1` after the rocket goes silent, and the time-gated descent callouts were re-firing the same frozen reading every 10 s forever.

## Test plan
- [x] `xcodebuild test -scheme TinkerRocketApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5'` — 39/39 pass locally, including 4 new `FlightAnnouncerDispatchTests` covering relayed → announcer fires, full PRELAUNCH/INFLIGHT/LANDED sequence over relay, direct rocket path, and BS self-telemetry; plus two new `TelemetryDataTests` cases verifying the `fs` bit-position mapping with `fs=255` (all bits) and `fs=85` (even bits — catches off-by-one).
- [x] `idf.py build` clean on both base_station and out_computer projects (shared TR_BLE_To_APP component).
- [x] Bench-tested: sim flight via BS relay produced expected callouts (burnout/apogee/descent/landed); after rocket power-off, the last callout no longer repeats forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
