### PR TITLE
landing: non-blocking deferred camera stop + END_FLIGHT retry (#141)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -96,6 +96,12 @@ struct config
     static constexpr int8_t CAM_SHUTTER_PIN = 31;    // GoPro shutter pulse
     static constexpr uint16_t GOPRO_PULSE_MS = 120;
 
+    // Time to keep the camera rolling after LANDED before issuing the stop.
+    // Captures post-impact footage and, critically, removes the inline
+    // delay() that previously stalled the main loop on the LANDED edge
+    // (which saturated i2s_tx_queue and dropped END_FLIGHT; see #141).
+    static constexpr uint32_t CAMERA_STOP_DELAY_MS = 30000;  // 30 s
+
     // RunCam UART pins & settings
     static constexpr int8_t RUNCAM_RX_PIN = 31;      // FC receives from RunCam
     static constexpr int8_t RUNCAM_TX_PIN = 32;      // FC sends to RunCam

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -205,6 +205,16 @@ static bool landed_actions_done = false;
 static bool gopro_recording = false;
 static bool gopro_pulse_active = false;
 static uint32_t gopro_pulse_end_ms = 0;
+// Deferred camera-stop sequence (see cameraStop / serviceCameraStop).
+// Idle → DelayBeforeStop (30s post-LANDED) → for RunCam, RunCamToggleSent
+// (500ms after toggle, then power off) → Idle.
+enum class CameraStopPhase : uint8_t {
+    Idle,
+    DelayBeforeStop,
+    RunCamToggleSent,
+};
+static CameraStopPhase camera_stop_phase = CameraStopPhase::Idle;
+static uint32_t camera_stop_due_ms = 0;
 static uint8_t runtime_camera_type = config::CAMERA_TYPE;  // can be overridden via BLE
 static bool servo_enabled = false;
 static bool gain_sched_enabled = config::GAIN_SCHEDULE_ENABLED;
@@ -1013,24 +1023,65 @@ static void cameraStart(uint32_t now_ms)
     }
 }
 
-static void cameraStop(uint32_t now_ms)
+static inline void serviceCameraStop(uint32_t now_ms);
+
+// Queue a camera stop.  delay_ms = 0 (default) drives the first phase
+// inline so the GPIO/UART action happens in this call (e.g. user manual
+// stop).  delay_ms > 0 schedules — LANDED uses CAMERA_STOP_DELAY_MS to
+// capture post-impact footage and to avoid stalling the i2s_tx_queue
+// long enough to drop END_FLIGHT (#141).  Either way, the RunCam's 500 ms
+// toggle-to-power-off step runs non-blockingly via serviceCameraStop().
+static void cameraStop(uint32_t now_ms, uint32_t delay_ms = 0)
 {
-    if (!gopro_recording) return;  // not recording
-    if (runtime_camera_type == CAM_TYPE_GOPRO)
+    if (!gopro_recording) return;                            // not recording
+    if (camera_stop_phase != CameraStopPhase::Idle) return;  // already stopping
+    camera_stop_phase = CameraStopPhase::DelayBeforeStop;
+    camera_stop_due_ms = now_ms + delay_ms;
+    if (delay_ms > 0)
     {
-        startGoProPulse(now_ms);
-        ESP_LOGI(TAG, "Camera STOP (GoPro)");
+        ESP_LOGI(TAG, "Camera STOP scheduled in %lu ms",
+                 (unsigned long)delay_ms);
+        return;
     }
-    else if (runtime_camera_type == CAM_TYPE_RUNCAM)
+    // Execute first phase immediately so the user-visible stop is sync.
+    serviceCameraStop(now_ms);
+}
+
+static inline void serviceCameraStop(uint32_t now_ms)
+{
+    if (camera_stop_phase == CameraStopPhase::Idle) return;
+    if ((int32_t)(now_ms - camera_stop_due_ms) < 0) return;
+
+    if (camera_stop_phase == CameraStopPhase::DelayBeforeStop)
     {
-        // Send toggle to stop recording, then power off
-        sendRunCamToggle();
-        delay(500);  // let the stop command process
+        if (runtime_camera_type == CAM_TYPE_GOPRO)
+        {
+            startGoProPulse(now_ms);
+            ESP_LOGI(TAG, "Camera STOP (GoPro)");
+            gopro_recording = false;
+            camera_stop_phase = CameraStopPhase::Idle;
+        }
+        else if (runtime_camera_type == CAM_TYPE_RUNCAM)
+        {
+            sendRunCamToggle();
+            ESP_LOGI(TAG, "RunCam toggle sent — power-off in 500 ms");
+            camera_stop_phase = CameraStopPhase::RunCamToggleSent;
+            camera_stop_due_ms = now_ms + 500U;  // let the stop command process
+        }
+        else
+        {
+            gopro_recording = false;
+            camera_stop_phase = CameraStopPhase::Idle;
+        }
+    }
+    else  // RunCamToggleSent
+    {
         if (config::RUNCAM_PWR_PIN >= 0)
             digitalWrite(config::RUNCAM_PWR_PIN, LOW);
         ESP_LOGI(TAG, "Camera STOP (RunCam) — powered off");
+        gopro_recording = false;
+        camera_stop_phase = CameraStopPhase::Idle;
     }
-    gopro_recording = false;
 }
 
 static inline void startBootReadyChirp(uint32_t now_ms, uint32_t now_us)
@@ -3428,13 +3479,17 @@ static void loop_fc()
                     guidance_active = false;
                     reboot_recovery = false;
                     reboot_recovery_telem = false;
-                    cameraStop(now_ms);
-                    if (!end_flight_sent)
+                    cameraStop(now_ms, (uint32_t)config::CAMERA_STOP_DELAY_MS);
+                }
+                // Retry END_FLIGHT until enqueue succeeds.  The one-shot
+                // cleanup above is latched, but i2s_tx_queue can transiently
+                // saturate around LANDED entry and a single failed enqueue
+                // would otherwise lose END_FLIGHT forever (#141).
+                if (!end_flight_sent)
+                {
+                    if (enqueueI2STx(END_FLIGHT, nullptr, 0))
                     {
-                        if (enqueueI2STx(END_FLIGHT, nullptr, 0))
-                        {
-                            end_flight_sent = true;
-                        }
+                        end_flight_sent = true;
                     }
                 }
                 break;
@@ -3631,6 +3686,7 @@ static void loop_fc()
     serviceHeartbeatBeep(now_ms_for_sound);
     serviceBlueLedFlash(now_ms_for_sound);
     serviceGoProPulse(now_ms_for_sound);
+    serviceCameraStop(now_ms_for_sound);
 
     // --- Periodic poll-task timing diagnostics (once per second) ---
     {


### PR DESCRIPTION
## Summary

Fixes #141.  On the Roly Poly 5/9/26 flight (`flight_recovered_9.bin`)
the rocket reached LANDED at T+83.8 s but kept recording for ~524 s
past landing.  The OC never received END_FLIGHT, so the NAND log was
never finalized (file name prefix `flight_recovered_` is the
boot-recovery path; a properly closed flight would be `flight_NNN.bin`).

### Root cause

`cameraStop()` had an inline `delay(500)` for the RunCam stop sequence
([main.cpp:1028 pre-fix](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1028)).
The LANDED handler called it synchronously before enqueueing
END_FLIGHT, so:

1. State transitions to LANDED at T+83.8 s
2. `cameraStop()` blocks the FC main loop for 500 ms
3. Sensor tasks keep enqueueing into the 512-deep `i2s_tx_queue` at
   ~2 kHz, saturating it
4. `enqueueI2STx(END_FLIGHT, ...)` returns false
   (`xQueueSend(..., 0)` is non-blocking)
5. `landed_actions_done` was latched to `true` **before** the enqueue
   attempt, so the retry never ran on subsequent loop iterations
6. OC never finalized → keeps writing post-landing data until power-off

## Fix

1. **Non-blocking deferred camera stop.**  New `CameraStopPhase`
   state machine driven by `serviceCameraStop()` on the main loop.
   - LANDED: `cameraStop(now_ms, CAMERA_STOP_DELAY_MS)` defers the
     stop **30 s** so the camera captures post-impact footage.
   - Manual stop (BLE cmd): `cameraStop(now_ms)` executes the first
     phase inline so the user-visible action is synchronous.
   - RunCam's 500 ms toggle-to-power-off runs as a non-blocking state
     transition (`RunCamToggleSent → Idle`).

2. **END_FLIGHT retry moved outside the `landed_actions_done` latch.**
   One-shot cleanup (pyroSafeAll, clearFlightSnapshot, servo stow,
   guidance reset, etc.) stays latched.  END_FLIGHT now retries every
   loop until enqueue succeeds — defensive against any future code
   path that could saturate the queue around the LANDED edge.

## Test plan

- [x] FC firmware builds clean on ESP32-P4
- [x] Existing cpp test suite (261 tests) passes
- [ ] Bench sim flight (`tests/bench/test_lora_log_capture.py`) — confirm
      LANDED transition completes, OC finalizes within ~30 s of LANDED
      edge, camera stops ~30 s after LANDED
- [ ] Real flight — confirm log is finalized normally (filename
      `flight_NNN.bin`, not `flight_recovered_*.bin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
