### PR TITLE
map: keep last rocket GPS on signal loss / BLE reconnect (#140)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -91,6 +91,20 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// Rockets seen via this device's LoRa relay (base station only)
     @Published var remoteRockets: [RemoteRocket] = []
 
+    /// Latched copy of the most recent usable rocket GPS fix (#140).
+    /// Stays populated when a telemetry packet arrives without fresh
+    /// GPS so the map marker doesn't blank — only a newer valid fix
+    /// replaces it.  Hydrated from the fleet's cache on the first
+    /// telemetry packet after a BLE reconnect so a brief disconnect
+    /// doesn't lose the last known position.
+    @Published var lastValidRocketFix: LastValidRocketFix?
+
+    /// Back-reference to the fleet so this device can read/write the
+    /// cross-session last-valid-fix cache.  Weak: the fleet owns this
+    /// device's lifetime via its `devices` array (didDisconnectPeripheral
+    /// removes us), and a strong link would form a retain cycle.
+    weak var fleet: BLEFleet?
+
     // Flight voice announcer (set by DashboardView).  Typed as a protocol so
     // dispatch tests can inject a spy without touching AVAudioSession.
     var flightAnnouncer: (any TelemetryAnnouncer)?
@@ -1024,6 +1038,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                     triggerAutoChannelSelectIfNeeded()
                 }
                 self.telemetry = newTelemetry
+                // Mirror the latched fix (#140).  Only assign when the
+                // cache returns a non-nil value so a GPS-less first
+                // packet for a newly-relayed rocket can't blank a fix
+                // this device just mirrored for a different rocketID.
+                if let fix = fleet?.recordRocketFix(from: newTelemetry, rocketID: rocketID) {
+                    self.lastValidRocketFix = fix
+                }
                 // The relayed JSON carries the full rocket state (st/aapo/lnch/
                 // land/mspd/palt — see TR_BLE_To_APP.cpp).  Without this call
                 // voice callouts only fire when paired directly to the rocket,
@@ -1042,6 +1063,15 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 }
             }
             self.telemetry = newTelemetry
+            // Direct rocket connection — use this device's own rocketID
+            // (relayed-telemetry path above uses source_rocket_id instead).
+            // Skip when rocketID is unset so a BS-self packet (which falls
+            // through to here without a source_rocket_id) doesn't nil out
+            // a fix this device just mirrored from a relay packet.
+            if self.rocketID > 0,
+               let fix = fleet?.recordRocketFix(from: newTelemetry, rocketID: self.rocketID) {
+                self.lastValidRocketFix = fix
+            }
             self.flightAnnouncer?.processTelemetry(newTelemetry)
         } catch {
             print("Failed to parse telemetry: \(error)")

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -25,6 +25,13 @@ class BLEFleet: NSObject, ObservableObject {
     /// Which device the dashboard is currently showing.
     @Published var activeDeviceID: UUID?
 
+    /// Latest usable rocket GPS fix per rocketID.  Lives on the fleet
+    /// (not on a BLEDevice) because BLEFleet destroys+recreates a
+    /// BLEDevice on every BLE disconnect/reconnect — without an outer
+    /// cache, the map would blank every time the phone briefly loses
+    /// the base station.  In-memory only; cleared on app kill.  #140.
+    @Published var lastValidRocketFixes: [UInt8: LastValidRocketFix] = [:]
+
     /// Convenience: the active device, or nil.
     var activeDevice: BLEDevice? {
         guard let id = activeDeviceID else { return devices.first }
@@ -125,6 +132,24 @@ class BLEFleet: NSObject, ObservableObject {
     private func device(for peripheral: CBPeripheral) -> BLEDevice? {
         devices.first { $0.peripheral?.identifier == peripheral.identifier }
     }
+
+    // MARK: - Last-valid rocket fix cache (#140)
+
+    /// Called by BLEDevice on every telemetry packet.  Updates the
+    /// cached fix when the packet carries a usable GPS solution, and
+    /// returns the resulting fix (new or pre-existing) so the caller
+    /// can mirror it onto its own @Published property — including the
+    /// hydrate-on-reconnect case where a brand-new BLEDevice's first
+    /// packet has no GPS but a prior session cached one.
+    @discardableResult
+    func recordRocketFix(from telemetry: TelemetryData,
+                         rocketID: UInt8) -> LastValidRocketFix? {
+        if let fresh = LastValidRocketFix.fromTelemetry(telemetry, rocketID: rocketID) {
+            lastValidRocketFixes[rocketID] = fresh
+            return fresh
+        }
+        return lastValidRocketFixes[rocketID]
+    }
 }
 
 // MARK: - CBCentralManagerDelegate
@@ -196,6 +221,7 @@ extension BLEFleet: CBCentralManagerDelegate {
         reconnectAttempts = 0
 
         let device = BLEDevice(peripheral: peripheral, name: name)
+        device.fleet = self
         device.onConnect()
         devices.append(device)
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/LastValidRocketFix.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/LastValidRocketFix.swift
@@ -1,0 +1,56 @@
+//
+//  LastValidRocketFix.swift
+//  TinkerRocketApp
+//
+//  Latched copy of the most recent usable rocket GPS fix.  Issue #140:
+//  the BS keeps BLE-streaming to the phone even when its LoRa link to
+//  the rocket goes quiet or carries a packet with no fresh GPS — those
+//  packets land in iOS as a TelemetryData with lat/lon = nil, which
+//  blanks the map marker.  We keep a separate latched fix that only
+//  advances on a usable solution, so the marker stays parked on the
+//  last reported position until a better one arrives.
+//
+
+import Foundation
+import CoreLocation
+
+struct LastValidRocketFix: Equatable {
+    let rocketID: UInt8
+    let latitude: Double
+    let longitude: Double
+    let numSats: Int
+    let fixDate: Date
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    /// A 3D GNSS solution needs four satellites; below this the position
+    /// can wander by hundreds of metres and isn't worth latching onto as
+    /// the rocket's "last known" location.  Tunable — lower if recovery
+    /// flights routinely produce sparser fixes.
+    static let minSatsForValidFix = 4
+
+    /// Build a fix from a freshly parsed telemetry packet if its GPS
+    /// fields look usable.  Returns nil for packets missing GPS, sitting
+    /// at the (0, 0) origin, below the sat-count floor, or with no
+    /// known rocketID — those must not advance the cache.
+    static func fromTelemetry(_ telemetry: TelemetryData,
+                              rocketID: UInt8,
+                              now: Date = Date()) -> LastValidRocketFix? {
+        guard rocketID > 0,
+              let lat = telemetry.latitude,
+              let lon = telemetry.longitude,
+              !(lat == 0 && lon == 0),
+              telemetry.num_sats >= minSatsForValidFix else {
+            return nil
+        }
+        return LastValidRocketFix(
+            rocketID: rocketID,
+            latitude: lat,
+            longitude: lon,
+            numSats: telemetry.num_sats,
+            fixDate: now
+        )
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -13,6 +13,7 @@ import MapKit
 struct RocketMapView: UIViewRepresentable {
     @Binding var mapType: MKMapType
     var rocketCoordinate: CLLocationCoordinate2D?
+    var rocketSubtitle: String?
     @Binding var region: MKCoordinateRegion
 
     func makeUIView(context: Context) -> MKMapView {
@@ -35,6 +36,7 @@ struct RocketMapView: UIViewRepresentable {
             let annotation = MKPointAnnotation()
             annotation.coordinate = coordinate
             annotation.title = "TinkerRocket"
+            annotation.subtitle = rocketSubtitle
             mapView.addAnnotation(annotation)
         }
 
@@ -107,22 +109,27 @@ struct MapView: View {
     )
     @State private var hasInitializedRegion = false
 
+    /// Always reads from the latched last-valid fix (#140), not raw
+    /// telemetry — so a rocket-side GPS dropout or LoRa loss can't blank
+    /// the marker.  A fresh BLE reconnect hydrates this from the fleet
+    /// cache on the first telemetry packet.
     private var rocketCoordinate: CLLocationCoordinate2D? {
-        guard let lat = device.telemetry.latitude,
-              let lon = device.telemetry.longitude,
-              !(lat == 0 && lon == 0) else {
-            return nil
-        }
-        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        device.lastValidRocketFix?.coordinate
     }
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            RocketMapView(
-                mapType: $mapType,
-                rocketCoordinate: rocketCoordinate,
-                region: $region
-            )
+            // TimelineView so the "last fix Ns ago" subtitle keeps ticking
+            // even when telemetry has stopped arriving — without it the age
+            // would freeze at whatever it was on the most recent re-render.
+            TimelineView(.periodic(from: .now, by: 1.0)) { context in
+                RocketMapView(
+                    mapType: $mapType,
+                    rocketCoordinate: rocketCoordinate,
+                    rocketSubtitle: markerSubtitle(now: context.date),
+                    region: $region
+                )
+            }
             .ignoresSafeArea(edges: .bottom)
 
             // Floating control buttons
@@ -160,7 +167,7 @@ struct MapView: View {
         .navigationTitle("Rocket Map")
         .navigationBarTitleDisplayMode(.inline)
         .brandedToolbar()
-        .onChange(of: device.telemetry.latitude) { _ in
+        .onChange(of: device.lastValidRocketFix) { _ in
             if !hasInitializedRegion {
                 centerOnRocket()
                 hasInitializedRegion = true
@@ -177,6 +184,22 @@ struct MapView: View {
             center: coordinate,
             span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
         )
+    }
+
+    /// Callout text under the marker.  Shows sat count and the age of
+    /// the fix so a stale marker can't be mistaken for a live one.
+    private func markerSubtitle(now: Date) -> String? {
+        guard let fix = device.lastValidRocketFix else { return nil }
+        let age = max(0, Int(now.timeIntervalSince(fix.fixDate)))
+        return "\(fix.numSats) sats • \(formatAge(age)) ago"
+    }
+
+    /// Compact age string: bare seconds under a minute, M:SS or H:MM:SS
+    /// above.  Avoids the "0:05" noise of the longer formatter on very
+    /// fresh fixes where seconds is the only thing that matters.
+    private func formatAge(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        return formatElapsed(seconds: seconds)
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketAppTests/LastValidRocketFixTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/LastValidRocketFixTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Issue #140: the map must keep showing the last reported rocket
+/// position even when a fresh telemetry packet arrives without GPS
+/// (LoRa loss or BLE drop during flight).  These tests pin the
+/// validity check and the cache-preservation behaviour that make that
+/// possible.
+final class LastValidRocketFixTests: XCTestCase {
+
+    // MARK: - fromTelemetry validity
+
+    func testFromTelemetry_ValidFix_Returned() throws {
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.longitude = -118.4
+        t.num_sats = 8
+
+        let fix = try XCTUnwrap(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+        XCTAssertEqual(fix.latitude, 33.7, accuracy: 1e-9)
+        XCTAssertEqual(fix.longitude, -118.4, accuracy: 1e-9)
+        XCTAssertEqual(fix.numSats, 8)
+        XCTAssertEqual(fix.rocketID, 1)
+    }
+
+    func testFromTelemetry_MissingLat_Rejected() {
+        // The BS firmware omits NAN lat/lon from JSON to save MTU, so
+        // a real "no fix" packet arrives with latitude == nil.  Must
+        // not advance the cache — the whole point of issue #140.
+        var t = TelemetryData()
+        t.longitude = -118.4
+        t.num_sats = 8
+        XCTAssertNil(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+    }
+
+    func testFromTelemetry_MissingLon_Rejected() {
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.num_sats = 8
+        XCTAssertNil(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+    }
+
+    func testFromTelemetry_ZeroOrigin_Rejected() {
+        // (0, 0) is in the Gulf of Guinea — an unrealistic rocket
+        // position that almost always means "no fix" leaking through.
+        var t = TelemetryData()
+        t.latitude = 0
+        t.longitude = 0
+        t.num_sats = 8
+        XCTAssertNil(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+    }
+
+    func testFromTelemetry_TooFewSats_Rejected() {
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.longitude = -118.4
+        t.num_sats = 3
+        XCTAssertNil(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+    }
+
+    func testFromTelemetry_MinSatsBoundary_Accepted() {
+        // The 4-sat floor is the boundary — anything ≥ 4 must pass so
+        // a freshly acquired 3D fix can populate the cache.
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.longitude = -118.4
+        t.num_sats = LastValidRocketFix.minSatsForValidFix
+        XCTAssertNotNil(LastValidRocketFix.fromTelemetry(t, rocketID: 1))
+    }
+
+    func testFromTelemetry_ZeroRocketID_Rejected() {
+        // rocketID == 0 means "unknown rocket" (the default) — never
+        // cache against that key or all rockets share the same slot.
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.longitude = -118.4
+        t.num_sats = 8
+        XCTAssertNil(LastValidRocketFix.fromTelemetry(t, rocketID: 0))
+    }
+
+    // MARK: - BLEFleet.recordRocketFix cache behaviour
+
+    func testRecordRocketFix_ValidPacket_PopulatesCache() throws {
+        let fleet = BLEFleet()
+        var t = TelemetryData()
+        t.latitude = 33.7
+        t.longitude = -118.4
+        t.num_sats = 8
+
+        XCTAssertNotNil(fleet.recordRocketFix(from: t, rocketID: 1))
+        let cached = try XCTUnwrap(fleet.lastValidRocketFixes[1])
+        XCTAssertEqual(cached.latitude, 33.7, accuracy: 1e-9)
+    }
+
+    func testRecordRocketFix_InvalidPacketWithCached_PreservesCache() throws {
+        // THE bug fix for #140.  Once a valid fix is cached, an
+        // incoming GPS-less packet must not blow it away — the map
+        // must keep showing the last reported position.
+        let fleet = BLEFleet()
+        var valid = TelemetryData()
+        valid.latitude = 33.7
+        valid.longitude = -118.4
+        valid.num_sats = 8
+        fleet.recordRocketFix(from: valid, rocketID: 1)
+
+        let gpsless = TelemetryData()  // no lat/lon, no sats
+        let result = try XCTUnwrap(fleet.recordRocketFix(from: gpsless, rocketID: 1))
+        XCTAssertEqual(result.latitude, 33.7, accuracy: 1e-9,
+                       "Cache must survive a GPS-less packet")
+
+        let cached = try XCTUnwrap(fleet.lastValidRocketFixes[1])
+        XCTAssertEqual(cached.latitude, 33.7, accuracy: 1e-9)
+    }
+
+    func testRecordRocketFix_NewerValidReplacesOlder() throws {
+        // Newer always wins so a recovery-grade fix isn't stuck on a
+        // pre-launch one even if both meet the minimum quality bar.
+        let fleet = BLEFleet()
+        var first = TelemetryData()
+        first.latitude = 33.7
+        first.longitude = -118.4
+        first.num_sats = 4
+        fleet.recordRocketFix(from: first, rocketID: 1)
+
+        var second = TelemetryData()
+        second.latitude = 34.0
+        second.longitude = -118.5
+        second.num_sats = 10
+        fleet.recordRocketFix(from: second, rocketID: 1)
+
+        let cached = try XCTUnwrap(fleet.lastValidRocketFixes[1])
+        XCTAssertEqual(cached.latitude, 34.0, accuracy: 1e-9)
+        XCTAssertEqual(cached.numSats, 10)
+    }
+
+    func testRecordRocketFix_MultipleRockets_IndependentSlots() throws {
+        let fleet = BLEFleet()
+        var rocketA = TelemetryData()
+        rocketA.latitude = 33.7
+        rocketA.longitude = -118.4
+        rocketA.num_sats = 8
+        fleet.recordRocketFix(from: rocketA, rocketID: 1)
+
+        var rocketB = TelemetryData()
+        rocketB.latitude = 47.6
+        rocketB.longitude = -122.3
+        rocketB.num_sats = 6
+        fleet.recordRocketFix(from: rocketB, rocketID: 2)
+
+        let cachedA = try XCTUnwrap(fleet.lastValidRocketFixes[1])
+        let cachedB = try XCTUnwrap(fleet.lastValidRocketFixes[2])
+        XCTAssertEqual(cachedA.latitude, 33.7, accuracy: 1e-9)
+        XCTAssertEqual(cachedB.latitude, 47.6, accuracy: 1e-9)
+    }
+
+    func testRecordRocketFix_EmptyCacheAndInvalidPacket_StaysEmpty() {
+        let fleet = BLEFleet()
+        let gpsless = TelemetryData()
+
+        XCTAssertNil(fleet.recordRocketFix(from: gpsless, rocketID: 1))
+        XCTAssertNil(fleet.lastValidRocketFixes[1])
+    }
+}


### PR DESCRIPTION
## Summary
- Latch the last usable rocket GPS fix on `BLEFleet` (keyed by rocketID) so a LoRa dropout, a GPS-less relay packet, or a brief phone-to-BS BLE disconnect can't blank the map marker.
- `BLEDevice` mirrors the cache into `@Published var lastValidRocketFix`; the parse path only assigns when the helper returns non-nil, so a GPS-less first packet for a newly-seen rocketID can't clobber a fix the device just mirrored for a different one.
- `MapView` reads the latched fix and wraps the map in `TimelineView(.periodic(by: 1.0))` so the "N sats • Xs ago" callout subtitle ticks even when telemetry has stopped — a stale marker is visibly stale, not silently old.
- Validity threshold: `lat/lon present`, `!(0,0)`, `num_sats >= 4`, `rocketID > 0` (tunable via `LastValidRocketFix.minSatsForValidFix`).

Closes #140.

## Why the map was reverting to the default location
The BS keeps streaming telemetry to iOS over BLE even when its LoRa link to the rocket is patchy. `TR_BLE_To_APP.cpp` omits NAN `lat`/`lon` from the JSON to save MTU, so a packet with no fresh rocket fix decodes into a `TelemetryData` with `latitude = nil`. `BLEDevice` was overwriting `self.telemetry` wholesale on every packet, which nilled out the coordinates → `MapView`'s rocketCoordinate went nil → marker disappeared → on the next view-appear the `@State` region defaulted back to Cupertino. The cache lives on `BLEFleet` rather than `BLEDevice` because `didDisconnectPeripheral` destroys+recreates the BLEDevice on every BLE drop.

## Test plan
- [x] 12 new unit tests in `LastValidRocketFixTests.swift` (validity boundaries + cache preservation on GPS-less follow-ups + newer-replaces-older + multi-rocket independence).
- [x] Full app test suite green on iPhone 17 / iOS 26.5.
- [x] Build clean for the iOS simulator.
- [ ] **Field test at next flight** — bench testing doesn't exercise the rocket↔LoRa↔BS↔BLE↔iOS path the bug lives in; will validate that the marker parks on the last reported position when LoRa drops and that the age callout ticks up as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
