### PR TITLE
fc: non-blocking pyro arm + PRELAUNCH continuity test

### DIFF
--- a/Data_Analysis/replay_flight_ekf.py
+++ b/Data_Analysis/replay_flight_ekf.py
@@ -123,6 +123,7 @@ def replay(binary_file, plot_dir=None):
     baro_ref_pa = None
     baro_samples_for_ref = []
     baro_alt_offset = 0.0  # offset to align baro (pad=0) with GNSS altitude frame
+    baro_alt_offset_set = False
 
     # Recording arrays
     log_time_us = []
@@ -199,8 +200,9 @@ def replay(binary_file, plot_dir=None):
                 continue
 
             # Defer baro offset until we have a valid GNSS fix
-            if baro_alt_offset == 0.0 and latest_gnss is not None:
+            if not baro_alt_offset_set and latest_gnss is not None:
                 baro_alt_offset = latest_gnss["alt_m"]
+                baro_alt_offset_set = True
                 print(f"  Baro alt offset: {baro_alt_offset:.1f}m "
                       f"(from GNSS at t={t_rel:.1f}s)")
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -597,38 +597,121 @@ static void pyroSafeAll()
     ESP_LOGI(TAG, "[PYRO] All channels safed");
 }
 
-static void pyroArmEnabled()
+// Non-blocking pyro arming + continuity diagnostic.
+//
+// The original pyroArmEnabled() called delay(10) six times on CH1 (1 settle
+// + 5 readback re-reads) plus delayMicroseconds(500) on CH2, blocking the FC
+// main loop for ~60 ms inside the PRELAUNCH→INFLIGHT transition. That stall
+// opened a ~62 ms gap in the sensor stream right at boost ignition.
+//
+// Two entry points share the same state machine:
+//   pyroPrelaunchContTest() — READY→PRELAUNCH: momentary arm + full
+//     diagnostic readback + disarm. Verifies wiring on the pad without
+//     leaving the squib hot during the launch wait.
+//   pyroArmEnabled()        — PRELAUNCH→INFLIGHT: latch ARM=1, mark armed,
+//     do one deferred readback ~10 ms later for sanity. Re-read loop is
+//     skipped — that already ran on the pad.
+//
+// servicePyroArmDiag() advances the state machine each main-loop iteration.
+enum class PyroArmDiagPhase : uint8_t {
+    Idle,
+    Ch1Settle,      // ARM=1 set, waiting 10 ms for VN5E160 settle
+    Ch1ReadRepeat,  // PRELAUNCH only: 5 additional CONT re-reads at 10 ms intervals
+    Ch2Settle,      // ARM=1 set, waiting 10 ms for VN5E160 settle
+};
+static PyroArmDiagPhase  pyro_diag_phase     = PyroArmDiagPhase::Idle;
+static bool              pyro_diag_prelaunch = false;
+static uint8_t           pyro_diag_ch1_reads = 0;
+static constexpr uint8_t PYRO_DIAG_CH1_TOTAL_READS = 6;  // 1 initial + 5 re-reads (preserved)
+static uint32_t          pyro_diag_next_ms   = 0;
+
+static void pyroDiagAdvanceToCh2OrFinish(uint32_t now_ms)
 {
-    if (pyro_config.ch1_enabled) {
-        portENTER_CRITICAL(&pyro_spinlock);
-        gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 1);
-        pyro1_armed = true;
-        portEXIT_CRITICAL(&pyro_spinlock);
-        // Verify ARM pin actually went HIGH and read continuity
-        delay(10);  // 10ms settle for VN5E160 power-up
-        int arm_rb = gpio_get_level((gpio_num_t)config::PYRO1_ARM_PIN);
-        int cont_raw = gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN);
-        ESP_LOGI(TAG, "[PYRO] CH1 armed: ARM_PIN=%d rb=%d  CONT_PIN=%d raw=%d  mode=%u val=%.1f",
-                 config::PYRO1_ARM_PIN, arm_rb,
-                 config::PYRO1_CONT_PIN, cont_raw,
-                 pyro_config.ch1_trigger_mode, (double)pyro_config.ch1_trigger_value);
-        // Re-read CONT 5 more times to check for transient
-        for (int i = 0; i < 5; i++) {
-            delay(10);
-            ESP_LOGI(TAG, "[PYRO] CH1 CONT re-read[%d]: %d", i,
-                     gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN));
-        }
-    }
     if (pyro_config.ch2_enabled) {
         portENTER_CRITICAL(&pyro_spinlock);
         gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 1);
-        pyro2_armed = true;
+        if (!pyro_diag_prelaunch) pyro2_armed = true;
         portEXIT_CRITICAL(&pyro_spinlock);
-        delayMicroseconds(500);
-        int cont_raw = gpio_get_level((gpio_num_t)config::PYRO2_CONT_PIN);
-        ESP_LOGI(TAG, "[PYRO] CH2 armed (mode=%u val=%.1f) CONT_PIN=%d raw=%d",
-                 pyro_config.ch2_trigger_mode, (double)pyro_config.ch2_trigger_value,
-                 config::PYRO2_CONT_PIN, cont_raw);
+        pyro_diag_phase   = PyroArmDiagPhase::Ch2Settle;
+        pyro_diag_next_ms = now_ms + 10;
+    } else {
+        pyro_diag_phase = PyroArmDiagPhase::Idle;
+    }
+}
+
+static void pyroDiagStart(uint32_t now_ms, bool is_prelaunch)
+{
+    if (pyro_diag_phase != PyroArmDiagPhase::Idle) return;
+    pyro_diag_prelaunch = is_prelaunch;
+    pyro_diag_ch1_reads = 0;
+    if (pyro_config.ch1_enabled) {
+        portENTER_CRITICAL(&pyro_spinlock);
+        gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 1);
+        if (!is_prelaunch) pyro1_armed = true;
+        portEXIT_CRITICAL(&pyro_spinlock);
+        pyro_diag_phase   = PyroArmDiagPhase::Ch1Settle;
+        pyro_diag_next_ms = now_ms + 10;
+    } else {
+        pyroDiagAdvanceToCh2OrFinish(now_ms);
+    }
+}
+
+static void pyroPrelaunchContTest(uint32_t now_ms) { pyroDiagStart(now_ms, /*is_prelaunch=*/true);  }
+static void pyroArmEnabled       (uint32_t now_ms) { pyroDiagStart(now_ms, /*is_prelaunch=*/false); }
+
+static void servicePyroArmDiag(uint32_t now_ms)
+{
+    if (pyro_diag_phase == PyroArmDiagPhase::Idle) return;
+    if ((int32_t)(now_ms - pyro_diag_next_ms) < 0) return;
+
+    switch (pyro_diag_phase) {
+        case PyroArmDiagPhase::Ch1Settle: {
+            int arm_rb   = gpio_get_level((gpio_num_t)config::PYRO1_ARM_PIN);
+            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN);
+            ESP_LOGI(TAG, "[PYRO] CH1 %s: ARM_PIN=%d rb=%d  CONT_PIN=%d raw=%d  mode=%u val=%.1f",
+                     pyro_diag_prelaunch ? "cont-test" : "armed",
+                     config::PYRO1_ARM_PIN, arm_rb,
+                     config::PYRO1_CONT_PIN, cont_raw,
+                     pyro_config.ch1_trigger_mode, (double)pyro_config.ch1_trigger_value);
+            pyro_diag_ch1_reads = 1;
+            if (pyro_diag_prelaunch) {
+                pyro_diag_phase   = PyroArmDiagPhase::Ch1ReadRepeat;
+                pyro_diag_next_ms = now_ms + 10;
+            } else {
+                pyroDiagAdvanceToCh2OrFinish(now_ms);
+            }
+            break;
+        }
+        case PyroArmDiagPhase::Ch1ReadRepeat: {
+            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN);
+            ESP_LOGI(TAG, "[PYRO] CH1 CONT re-read[%u]: %d",
+                     (unsigned)(pyro_diag_ch1_reads - 1), cont_raw);
+            pyro_diag_ch1_reads++;
+            if (pyro_diag_ch1_reads >= PYRO_DIAG_CH1_TOTAL_READS) {
+                portENTER_CRITICAL(&pyro_spinlock);
+                gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 0);
+                portEXIT_CRITICAL(&pyro_spinlock);
+                pyroDiagAdvanceToCh2OrFinish(now_ms);
+            } else {
+                pyro_diag_next_ms = now_ms + 10;
+            }
+            break;
+        }
+        case PyroArmDiagPhase::Ch2Settle: {
+            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO2_CONT_PIN);
+            ESP_LOGI(TAG, "[PYRO] CH2 %s (mode=%u val=%.1f) CONT_PIN=%d raw=%d",
+                     pyro_diag_prelaunch ? "cont-test" : "armed",
+                     pyro_config.ch2_trigger_mode, (double)pyro_config.ch2_trigger_value,
+                     config::PYRO2_CONT_PIN, cont_raw);
+            if (pyro_diag_prelaunch) {
+                portENTER_CRITICAL(&pyro_spinlock);
+                gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 0);
+                portEXIT_CRITICAL(&pyro_spinlock);
+            }
+            pyro_diag_phase = PyroArmDiagPhase::Idle;
+            break;
+        }
+        default: break;
     }
 }
 
@@ -3192,6 +3275,11 @@ static void loop_fc()
         max_alt_m = kinematics.max_altitude;
         max_speed_mps = kinematics.max_speed;
 
+        // Progress any in-flight pyro arming/continuity diagnostic. Must run
+        // every iteration regardless of state/test path so the state machine
+        // started at READY→PRELAUNCH or PRELAUNCH→INFLIGHT finishes promptly.
+        servicePyroArmDiag(now_ms);
+
         if (ground_test_active)
         {
             // Ground test behavior depends on control mode:
@@ -3322,6 +3410,9 @@ static void loop_fc()
                     rocket_state = PRELAUNCH;
                     prelaunch_time_millis = now_ms;
                     // Camera is manually controlled via app — no auto-start on prelaunch
+                    // Verify pyro continuity on the pad via momentary arm-disarm.
+                    // Non-blocking — runs over the next ~60 ms of main loop ticks.
+                    pyroPrelaunchContTest(now_ms);
                     ESP_LOGI(TAG, "[STATE] READY -> PRELAUNCH");
                 }
                 break;
@@ -3380,7 +3471,7 @@ static void loop_fc()
                     pyro1_fire_start_ms = 0;
                     pyro2_fire_start_ms = 0;
                     portEXIT_CRITICAL(&pyro_spinlock);
-                    pyroArmEnabled();
+                    pyroArmEnabled(now_ms);
                     ESP_LOGI(TAG, "[STATE] PRELAUNCH -> INFLIGHT (ground_p=%.0f)",
                                   (double)ground_pressure_pa);
                 }


### PR DESCRIPTION
## Summary

`pyroArmEnabled()` blocked the FC main loop for ~60 ms via `delay(10) × 6` (one VN5E160 settle + five CONT readback re-reads) inside the PRELAUNCH→INFLIGHT state transition. That stall opened a synchronized ~62 ms gap across all FC sensors (ISM6, BMP, MMC, NonSensor) at launch detection — the worst possible moment for sample loss (peak accel, fastest dynamics).

Refactored into a phase-based state machine driven from the main loop, with two entry points:

- **`READY→PRELAUNCH`** kicks off `pyroPrelaunchContTest()` — momentary arm → 6× CONT read at 10 ms intervals → disarm. Verifies wiring on the pad without leaving the squib hot during the launch wait.
- **`PRELAUNCH→INFLIGHT`** kicks off `pyroArmEnabled(now_ms)` — latches `ARM=1` and the `pyroN_armed` flags instantly, defers a single CONT readback for one main-loop tick. Re-read loop is skipped (already ran on the pad).

`servicePyroArmDiag(now_ms)` advances the state machine each `loop_fc()` iteration, placed before the rocket_state switch so it runs regardless of state path (ground test / servo test / normal flight).

Also includes a small tooling fix: `replay_flight_ekf.py` was using `baro_alt_offset == 0.0` as both initial value and "unset" sentinel — on a sim flight where the pad GNSS altitude is exactly 0, the "Baro alt offset" debug line printed on every baro sample (30k lines on a 1 min log).

## Verification

Sim flight comparison (`flight_20260515_120202.bin`, post-fix vs `flight_20260515_104816.bin`, pre-fix):

| Sensor | Pre-fix max dt | Post-fix max dt | Δ |
|---|---|---|---|
| ISM6HG256 | 61.7 ms | 21.9 ms | **−39.8 ms** |
| BMP585 | 62.2 ms | 22.3 ms | **−39.9 ms** |
| MMC5983MA | 62.6 ms | 22.4 ms | **−40.2 ms** |
| NonSensor | 62.6 ms | 22.2 ms | **−40.4 ms** |

- Global gaps over 5 ms threshold: **104 → 2** (both remaining are mid-flight, unrelated to arming path).
- INFLIGHT gap rate (`analyze_gaps_detailed.py`): **1.8 → 0.2 gaps/s**.
- No launch-edge synchronized stall; first INFLIGHT gap is at T+9 s, not T+0 s.
- EKF replay tracked peak altitude within 0.3 m of GNSS truth (200.9 m vs 201.2 m).

## Test plan

- [x] `idf.py build` clean on FC firmware (local — FC is excluded from CI's firmware-build matrix)
- [x] `python3 -m pytest tests/unit/` — 3/3 pass
- [x] `python3 -m pytest tests/integration/` against post-fix sim bin — 6/6 pass (CRC, monotonic timestamps, IMU rate, baro rate, no large IMU gaps, mag/board variant)
- [x] `analyze_gaps.py` / `analyze_gaps_detailed.py` / `replay_flight_ekf.py` on post-fix sim flight show the launch-edge gap eliminated
- [ ] Live bench test of READY→PRELAUNCH continuity diagnostic with a real squib (or dummy load) to confirm the deferred-readback path matches the original diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
