### PR TITLE
settings: add BS LoRa TX-power control with rocket sync

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -353,6 +353,27 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         return true
     }
 
+    /// Relay a new LoRa TX-power value to every tracked rocket and apply
+    /// the same power to this base station.  Keeps freq/SF/BW/CR from the
+    /// current base-station config — only TX power changes.  Reuses the
+    /// transactional Cmd 10 path: the BS relays on OLD, switches to NEW
+    /// power, and rolls back if no rocket beacon is heard within the verify
+    /// window.  Refuses unless `autoApplyRefusalReason()` returns nil.
+    @discardableResult
+    func autoApplyTxPower(_ txPower: Int8) -> Bool {
+        if let refusal = autoApplyRefusalReason() {
+            print("[TXPWR] Auto-apply refused: \(refusal.rawValue)")
+            return false
+        }
+        guard let cfg = rocketConfig,
+              let freq = cfg.loraFreqMHz,
+              let bw = cfg.loraBwKHz,
+              let sf = cfg.loraSF,
+              let cr = cfg.loraCR else { return false }
+        sendLoRaConfig(freqMHz: freq, bwKHz: bw, sf: sf, cr: cr, txPower: txPower)
+        return true
+    }
+
     func sendLoRaConfig(freqMHz: Float, bwKHz: Float, sf: UInt8, cr: UInt8, txPower: Int8) {
         var payload = Data()
         var freq = freqMHz

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -76,6 +76,12 @@ struct SettingsView: View {
     @State private var pidApplied = false
     @State private var rollControlApplied = false
 
+    // LoRa TX power (base station only).  Hydrated from rocketConfig on
+    // readback; user edits are debounced so a rapid Stepper drag fires one
+    // Cmd 10 transaction at the final value instead of one per tick.
+    @State private var txPowerDbm: Int = 12
+    @State private var txPowerSendWork: DispatchWorkItem?
+
     // Self-apply on focus loss (#144): editable config fields are sent to
     // the rocket when keyboard focus leaves their section, so there's no
     // separate "apply" button to forget.
@@ -218,6 +224,28 @@ struct SettingsView: View {
                             Text(String(format: "%.2f MHz", currentFreqMHz))
                                 .foregroundColor(.secondary)
                                 .font(.system(.body, design: .monospaced))
+                        }
+                    }
+
+                    // LoRa TX power — adjusts both BS and rocket via the
+                    // existing Cmd 10 transactional flow.  Stepper changes
+                    // are debounced; the BS firmware relays the new power
+                    // to the rocket, verifies a beacon on the new setting,
+                    // and rolls back if the rocket can't be heard.
+                    Section(header: Text("LoRa TX Power"),
+                            footer: txPowerFooter) {
+                        Stepper(value: $txPowerDbm, in: -9...22) {
+                            HStack {
+                                Text("Power")
+                                Spacer()
+                                Text("\(txPowerDbm) dBm")
+                                    .foregroundColor(.secondary)
+                                    .font(.system(.body, design: .monospaced))
+                            }
+                        }
+                        .disabled(device.autoApplyRefusalReason() != nil)
+                        .onChange(of: txPowerDbm) { newValue in
+                            scheduleTxPowerSend(newValue)
                         }
                     }
                 }
@@ -455,8 +483,12 @@ struct SettingsView: View {
                 guidanceEnabled = cfg.guidanceEnabled
                 cameraType = Int(cfg.cameraType)
                 // LoRa state is displayed read-only via `currentFreqMHz`;
-                // no per-field bindings to sync since the user can't edit
-                // the preset/TX-power/hop fields here anymore (#136).
+                // SF / BW / CR / hop are still gated behind a developer
+                // flag (#136).  TX power is the one exception: the BS GUI
+                // exposes a Stepper, hydrated here from the readback.
+                if let pwr = cfg.loraTxPower {
+                    txPowerDbm = Int(pwr)
+                }
                 loadStringsFromStorage()
             }
         }
@@ -580,6 +612,34 @@ struct SettingsView: View {
         rollDelayMs = Double(delayMs)
         device.sendRollControlConfig(useAngleControl: useAngleControl, rollDelayMs: delayMs)
         showApplied($rollControlApplied)
+    }
+
+    // MARK: - LoRa TX power (base station only)
+
+    /// Debounce Stepper edits so a held +/- doesn't queue a Cmd 10 per
+    /// tick — the firmware refuses overlapping transactions and the LoRa
+    /// link is throughput-limited.  Skips the send if the new value
+    /// matches what the BS already reports, so hydration from rocketConfig
+    /// doesn't echo back as a no-op transaction.
+    private func scheduleTxPowerSend(_ newValue: Int) {
+        txPowerSendWork?.cancel()
+        let work = DispatchWorkItem {
+            let current = device.rocketConfig?.loraTxPower.map(Int.init) ?? Int.min
+            if newValue != current {
+                device.autoApplyTxPower(Int8(newValue))
+            }
+        }
+        txPowerSendWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
+    }
+
+    @ViewBuilder
+    private var txPowerFooter: some View {
+        if let refusal = device.autoApplyRefusalReason() {
+            Text(refusal.rawValue).foregroundColor(.orange)
+        } else {
+            Text("Sets transmit power on both the base station and the rocket. The base station relays the change over LoRa, verifies the rocket joined the new setting, and rolls both sides back if it can't be reached.")
+        }
     }
 
     private func applyRollProfile() {


### PR DESCRIPTION
## Summary
- Adds a Stepper in iOS Settings → Base Station section to adjust LoRa TX power (-9..+22 dBm).
- Uses the existing transactional Cmd 10 flow: BS relays new power to all rockets, verifies a beacon on NEW, and rolls both sides back if the rocket cannot be heard.
- Reuses `autoApplyRefusalReason()` gating — the Stepper is disabled until a config readback lands and a rocket beacons within the freshness window.

No firmware changes needed: `tx_power` was already in the Cmd 10 payload at `base_station/main/main.cpp:1289` and `out_computer/main/main.cpp:2248`; both ends already persist `txpwr` to NVS on commit. This PR just exposes the control in the UI.

## Test plan
- [ ] Unit tests pass locally (`AutoApplyRefusalTests` — covers the shared gate).
- [ ] Hardware: connect to BS over BLE, open Settings, bump the TX Power Stepper. Confirm BS serial log shows `[TXN] Start` then `[TXN] COMMIT`, and rocket log shows `UPLINK LoRa reconfigured + saved: ... N dBm`.
- [ ] Hardware: power the rocket off, bump Stepper. Confirm UI shows "No rocket has beaconed recently…" and the change is refused.
- [ ] Hardware: with rocket at fringe range, lower power until verify fails. Confirm both sides roll back to the previous setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
