### PR TITLE
roll: per-WP mode (angle vs null-rate) + outer-loop rate cap

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -494,16 +494,23 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendCommand(25)
     }
 
-    func sendRollProfile(waypoints: [(time: Float, angle: Float)]) {
+    // Wire format matches firmware RollProfileData (packed): 1-byte
+    // num_waypoints + 3 pad bytes, then 8 entries of RollWaypoint where
+    // each entry is float time_s (4) + float angle_deg (4) + uint8_t mode (1)
+    // = 9 bytes per waypoint. Total payload = 1 + 3 + 8*9 = 76 bytes.
+    // mode: 0 = ROLL_SEG_ANGLE, 1 = ROLL_SEG_NULL_RATE.
+    func sendRollProfile(waypoints: [(time: Float, angle: Float, mode: UInt8)]) {
         var payload = Data()
         let n = UInt8(min(waypoints.count, 8))
         payload.append(n)
         payload.append(contentsOf: [0, 0, 0])
         for i in 0..<8 {
-            var t: Float = i < waypoints.count ? waypoints[i].time : 0.0
+            var t: Float = i < waypoints.count ? waypoints[i].time  : 0.0
             var a: Float = i < waypoints.count ? waypoints[i].angle : 0.0
+            let  m: UInt8 = i < waypoints.count ? waypoints[i].mode : 0
             payload.append(Data(bytes: &t, count: 4))
             payload.append(Data(bytes: &a, count: 4))
+            payload.append(m)
         }
         sendRawCommand(26, payload: payload)
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -64,9 +64,12 @@ struct SettingsView: View {
     @State private var sPidMinCmd = ""
     @State private var sPidMaxCmd = ""
 
-    // Roll profile waypoints — persisted as JSON string in @AppStorage
+    // Roll profile waypoints — persisted as JSON string in @AppStorage.
+    // mode is the segment mode for the segment STARTING at this waypoint:
+    //   0 = ROLL_SEG_ANGLE     -- interpolate angle to next waypoint
+    //   1 = ROLL_SEG_NULL_RATE -- hold rate=0; angle field ignored
     @AppStorage("rollProfileJSON") private var rollProfileJSON: String = "[]"
-    @State private var rollWaypoints: [(time: String, angle: String)] = []
+    @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
 
     // Roll control config
     @State private var sRollDelayMs = ""
@@ -344,46 +347,62 @@ struct SettingsView: View {
                             .foregroundColor(.secondary)
 
                         if useAngleControl {
-                            Text("Define (time, angle) waypoints for the cascaded angle controller. During flight, the target roll angle is interpolated between waypoints.")
+                            Text("Each waypoint defines the START of a segment. Pick the mode per waypoint: Angle interpolates the target roll angle to the next waypoint's angle; Null Rate holds zero roll rate (angle field ignored) for the duration of the segment.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
 
                             ForEach(rollWaypoints.indices, id: \.self) { i in
-                                HStack(spacing: 8) {
-                                    Text("WP \(i + 1)")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 40)
-                                    TextField("Time", text: Binding(
-                                        get: { rollWaypoints[i].time },
-                                        set: { rollWaypoints[i].time = $0 }
-                                    ))
-                                    .keyboardType(.decimalPad)
-                                    .multilineTextAlignment(.trailing)
-                                    .frame(width: 60)
-                                    .focused($focusedField, equals: .wpTime(i))
-                                    Text("s")
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 15)
-                                    TextField("Angle", text: Binding(
-                                        get: { rollWaypoints[i].angle },
-                                        set: { rollWaypoints[i].angle = $0 }
-                                    ))
-                                    .keyboardType(.numbersAndPunctuation)
-                                    .multilineTextAlignment(.trailing)
-                                    .frame(width: 60)
-                                    .focused($focusedField, equals: .wpAngle(i))
-                                    Text("\u{00B0}")
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 15)
-                                    Button(role: .destructive) {
-                                        rollWaypoints.remove(at: i)
-                                        applyRollProfile()
-                                    } label: {
-                                        Image(systemName: "minus.circle.fill")
-                                            .foregroundColor(.red)
+                                VStack(spacing: 4) {
+                                    HStack(spacing: 8) {
+                                        Text("WP \(i + 1)")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 40)
+                                        TextField("Time", text: Binding(
+                                            get: { rollWaypoints[i].time },
+                                            set: { rollWaypoints[i].time = $0 }
+                                        ))
+                                        .keyboardType(.decimalPad)
+                                        .multilineTextAlignment(.trailing)
+                                        .frame(width: 60)
+                                        .focused($focusedField, equals: .wpTime(i))
+                                        Text("s")
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 15)
+                                        TextField("Angle", text: Binding(
+                                            get: { rollWaypoints[i].angle },
+                                            set: { rollWaypoints[i].angle = $0 }
+                                        ))
+                                        .keyboardType(.numbersAndPunctuation)
+                                        .multilineTextAlignment(.trailing)
+                                        .frame(width: 60)
+                                        .focused($focusedField, equals: .wpAngle(i))
+                                        .disabled(rollWaypoints[i].mode == 1)
+                                        .foregroundColor(rollWaypoints[i].mode == 1 ? .secondary : .primary)
+                                        Text("\u{00B0}")
+                                            .foregroundColor(.secondary)
+                                            .frame(width: 15)
+                                        Button(role: .destructive) {
+                                            rollWaypoints.remove(at: i)
+                                            applyRollProfile()
+                                        } label: {
+                                            Image(systemName: "minus.circle.fill")
+                                                .foregroundColor(.red)
+                                        }
+                                        .buttonStyle(.borderless)
                                     }
-                                    .buttonStyle(.borderless)
+                                    Picker("Mode", selection: Binding(
+                                        get: { rollWaypoints[i].mode },
+                                        set: {
+                                            rollWaypoints[i].mode = $0
+                                            applyRollProfile()
+                                        }
+                                    )) {
+                                        Text("Angle").tag(UInt8(0))
+                                        Text("Null Rate").tag(UInt8(1))
+                                    }
+                                    .pickerStyle(.segmented)
+                                    .padding(.leading, 40)
                                 }
                             }
 
@@ -391,7 +410,7 @@ struct SettingsView: View {
                                 Button {
                                     let defaultTime = rollWaypoints.isEmpty ? "0.0" :
                                         String(format: "%.1f", (Double(rollWaypoints.last?.time ?? "0") ?? 0) + 1.0)
-                                    rollWaypoints.append((time: defaultTime, angle: "0"))
+                                    rollWaypoints.append((time: defaultTime, angle: "0", mode: 0))
                                     applyRollProfile()
                                 } label: {
                                     HStack {
@@ -643,11 +662,11 @@ struct SettingsView: View {
     }
 
     private func applyRollProfile() {
-        var waypoints: [(time: Float, angle: Float)] = []
+        var waypoints: [(time: Float, angle: Float, mode: UInt8)] = []
         for wp in rollWaypoints {
             let t = Float(wp.time) ?? 0.0
             let a = Float(wp.angle) ?? 0.0
-            waypoints.append((time: t, angle: a))
+            waypoints.append((time: t, angle: a, mode: wp.mode))
         }
         // Sort by time
         waypoints.sort { $0.time < $1.time }
@@ -664,13 +683,20 @@ struct SettingsView: View {
             rollWaypoints = []
             return
         }
-        rollWaypoints = decoded.map { pair in
-            (time: pair.count > 0 ? pair[0] : "0", angle: pair.count > 1 ? pair[1] : "0")
+        // Triples are [time, angle, mode]; tolerate older [time, angle] pairs
+        // by defaulting mode to "0" (ROLL_SEG_ANGLE) for backward compat.
+        rollWaypoints = decoded.map { entry in
+            let t = entry.count > 0 ? entry[0] : "0"
+            let a = entry.count > 1 ? entry[1] : "0"
+            let m = (entry.count > 2 ? UInt8(entry[2]) : nil) ?? 0
+            return (time: t, angle: a, mode: m)
         }
     }
 
     private func saveRollWaypointsToStorage() {
-        let encoded: [[String]] = rollWaypoints.map { [String($0.time), String($0.angle)] }
+        let encoded: [[String]] = rollWaypoints.map {
+            [String($0.time), String($0.angle), String($0.mode)]
+        }
         if let data = try? JSONEncoder().encode(encoded),
            let json = String(data: data, encoding: .utf8) {
             rollProfileJSON = json

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -202,7 +202,7 @@ private:
     volatile uint8_t pending_file_list_page_;
     String pending_delete_filename_;
     String pending_download_filename_;
-    uint8_t pending_payload_[72] = {};   // Raw payload for commands with data (max = RollProfileData 68 bytes)
+    uint8_t pending_payload_[80] = {};   // Raw payload for commands with data (max = RollProfileData 76 bytes)
     size_t  pending_payload_len_ = 0;
     String file_list_json_;              // Persistent storage for file list
     uint8_t* chunk_buffer_;              // Persistent storage for file chunks

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1319,20 +1319,30 @@ static_assert(sizeof(ServoReplayData) == 4, "ServoReplayData must be 4 bytes");
 // Max 8 waypoints: fits in single BLE MTU with header
 static constexpr uint8_t MAX_ROLL_WAYPOINTS = 8;
 
-typedef struct __attribute__((packed))
+// Per-waypoint segment mode: how the controller should behave during the
+// segment that STARTS at this waypoint (and ends at the next waypoint, or
+// holds indefinitely if this is the last waypoint).
+enum RollSegmentMode : uint8_t
 {
-    float time_s;       // seconds after launch
-    float angle_deg;    // target roll angle (deg)
-} RollWaypoint;
-static_assert(sizeof(RollWaypoint) == 8, "RollWaypoint must be 8 bytes");
+    ROLL_SEG_ANGLE     = 0,  // interpolate to next waypoint's angle (cascaded angle PID)
+    ROLL_SEG_NULL_RATE = 1,  // hold roll rate = 0 (rate-only inner PID); angle field ignored
+};
 
 typedef struct __attribute__((packed))
 {
-    uint8_t num_waypoints;      // 0 = no profile (rate-only mode)
-    uint8_t _pad[3];            // alignment padding
+    float   time_s;     // seconds after launch
+    float   angle_deg;  // target roll angle (deg) -- ignored when mode==ROLL_SEG_NULL_RATE
+    uint8_t mode;       // RollSegmentMode for the segment starting at this waypoint
+} RollWaypoint;
+static_assert(sizeof(RollWaypoint) == 9, "RollWaypoint must be 9 bytes");
+
+typedef struct __attribute__((packed))
+{
+    uint8_t      num_waypoints;             // 0 = no profile (rate-only mode)
+    uint8_t      _pad[3];                   // alignment padding
     RollWaypoint waypoints[MAX_ROLL_WAYPOINTS];
 } RollProfileData;
-static_assert(sizeof(RollProfileData) == 68, "RollProfileData must be 68 bytes");
+static_assert(sizeof(RollProfileData) == 76, "RollProfileData must be 76 bytes");
 
 // --- Roll Control Config (runtime-configurable from app) ---
 typedef struct __attribute__((packed))

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -263,13 +263,22 @@ void TR_ServoControl::controlAngle(float target_roll_deg,
                                    float actual_roll_deg,
                                    float roll_rate_dps,
                                    float velocity_ms,
-                                   float kp_angle) {
+                                   float kp_angle,
+                                   float rate_cap_dps) {
     // ── Outer loop: angle error → rate command ──
     // Wrap angle error to [-180, +180] degrees
     float angle_error = target_roll_deg - actual_roll_deg;
     while (angle_error > 180.0f)  angle_error -= 360.0f;
     while (angle_error < -180.0f) angle_error += 360.0f;
     float rate_cmd = kp_angle * angle_error;  // deg/s
+
+    // Cap the outer-loop rate command. With a 180 deg wrapped error and
+    // kp_angle=4, this would otherwise demand 720 dps -- a rate the inner
+    // loop can't deliver, which also drives integrator windup and direction
+    // whipsawing during spin recovery.
+    if (rate_cap_dps > 0.0f) {
+        rate_cmd = constrain(rate_cmd, -rate_cap_dps, rate_cap_dps);
+    }
 
     // ── Inner loop: PID on rate error with gain scheduling ──
     // roll_rate_dps is passed in negated (–gyro_x) to match servo sign

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -62,13 +62,18 @@ public:
     void controlWithGainSchedule(float roll_rate, float velocity_ms);
 
     // ── Cascaded angle → rate controller ──
-    // Outer loop: rate_cmd = kp_angle * (target_roll_deg - actual_roll_deg)
-    // Inner loop: PID on (rate_cmd - roll_rate_dps) with gain scheduling
+    // Outer loop: rate_cmd = clamp(kp_angle * (target - actual), ±rate_cap_dps)
+    // Inner loop: PID on (rate_cmd - roll_rate_dps) with gain scheduling.
+    // rate_cap_dps caps the outer-loop rate command to prevent a wrapped
+    // angle error from demanding rates the actuators can't track (which
+    // also causes the controller to whipsaw direction during spin recovery).
+    // Pass a large value (e.g. 10000) to effectively disable the cap.
     void controlAngle(float target_roll_deg,
                       float actual_roll_deg,
                       float roll_rate_dps,
                       float velocity_ms,
-                      float kp_angle);
+                      float kp_angle,
+                      float rate_cap_dps);
     void setAngleControlKpAngle(float kp) { kp_angle_ = kp; }
     float getAngleControlKpAngle() const { return kp_angle_; }
 

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -188,6 +188,13 @@ struct config
     static constexpr float KP_ANGLE = 4.0f;
     static constexpr bool USE_ANGLE_CONTROL = false;  // default; overridden at runtime via app
 
+    // Cascaded angle control: cap on outer-loop rate command (deg/s).
+    // Prevents a large wrapped angle error from demanding rates the inner
+    // loop / actuators cannot deliver, and keeps the inner-loop setpoint
+    // sane during spin-recovery so the controller doesn't whipsaw direction.
+    // Runtime-overridable via NVS key "rcap".
+    static constexpr float KP_ANGLE_RATE_CAP_DPS = 60.0f;
+
     // Roll control activation delay after launch (ms).  Keeps fins neutral
     // for this many ms after launch detection before engaging any roll control.
     static constexpr uint16_t ROLL_CONTROL_DELAY_MS = 0;  // default; overridden at runtime via app

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -232,6 +232,7 @@ static bool servo_enabled = false;
 static bool gain_sched_enabled = config::GAIN_SCHEDULE_ENABLED;
 static bool use_angle_control = config::USE_ANGLE_CONTROL;
 static uint16_t roll_delay_ms = config::ROLL_CONTROL_DELAY_MS;
+static float kp_angle_rate_cap_dps = config::KP_ANGLE_RATE_CAP_DPS;
 // --- Guidance (PN) state ---
 static TR_GuidancePN guidance;
 static TR_ControlMixer control_mixer;
@@ -799,43 +800,68 @@ static void servicePyroChannels(uint32_t now_ms)
 }
 
 // ── Roll profile interpolation ────────────────────────────────────────────────
-// Linearly interpolates between waypoints using time since launch.
-// Before the first waypoint → hold first angle.
-// After the last waypoint → hold last angle.
-// If no waypoints (rate-only mode) → return 0 (setpoint passed to rate PID).
-static float roll_profile_interpolate(float t_flight_s)
+// Returns the desired (angle, mode) for the current flight time.
+// Mode is the segment mode of the waypoint that STARTS the current segment.
+// Linear interpolation of angle between consecutive waypoints (ROLL_SEG_ANGLE
+// segments); ROLL_SEG_NULL_RATE segments instead null roll rate to 0 in the
+// inner loop and ignore the angle field. Before WP1 or after WPn we hold that
+// waypoint's mode and angle.
+// If no waypoints are loaded, defaults to NULL_RATE / 0 deg.
+struct RollProfileQuery
 {
+    float   angle_deg;
+    uint8_t mode;
+};
+
+static RollProfileQuery roll_profile_query(float t_flight_s)
+{
+    RollProfileQuery out{};
+    out.angle_deg = config::ROLL_RATE_SET_POINT;
+    out.mode      = ROLL_SEG_NULL_RATE;
+
     if (roll_profile.num_waypoints == 0)
     {
-        return config::ROLL_RATE_SET_POINT;  // no profile → default setpoint (typically 0)
+        return out;
     }
     const uint8_t n = roll_profile.num_waypoints;
 
-    // Before first waypoint: hold first angle
+    // Before first waypoint: hold first angle & mode
     if (t_flight_s <= roll_profile.waypoints[0].time_s)
     {
-        return roll_profile.waypoints[0].angle_deg;
+        out.angle_deg = roll_profile.waypoints[0].angle_deg;
+        out.mode      = roll_profile.waypoints[0].mode;
+        return out;
     }
-    // After last waypoint: hold last angle
+    // After last waypoint: hold last angle & mode
     if (t_flight_s >= roll_profile.waypoints[n - 1].time_s)
     {
-        return roll_profile.waypoints[n - 1].angle_deg;
+        out.angle_deg = roll_profile.waypoints[n - 1].angle_deg;
+        out.mode      = roll_profile.waypoints[n - 1].mode;
+        return out;
     }
-    // Linear interpolation between surrounding waypoints
+    // Inside profile -- find the segment [i, i+1)
     for (uint8_t i = 0; i < n - 1; ++i)
     {
         if (t_flight_s < roll_profile.waypoints[i + 1].time_s)
         {
-            float t0 = roll_profile.waypoints[i].time_s;
-            float t1 = roll_profile.waypoints[i + 1].time_s;
-            float a0 = roll_profile.waypoints[i].angle_deg;
-            float a1 = roll_profile.waypoints[i + 1].angle_deg;
-            if (t1 <= t0) return a0;  // guard against duplicate timestamps
-            float frac = (t_flight_s - t0) / (t1 - t0);
-            return a0 + frac * (a1 - a0);
+            const float t0 = roll_profile.waypoints[i].time_s;
+            const float t1 = roll_profile.waypoints[i + 1].time_s;
+            const float a0 = roll_profile.waypoints[i].angle_deg;
+            const float a1 = roll_profile.waypoints[i + 1].angle_deg;
+            out.mode = roll_profile.waypoints[i].mode;
+            if (t1 <= t0)
+            {
+                out.angle_deg = a0;  // guard against duplicate timestamps
+                return out;
+            }
+            const float frac = (t_flight_s - t0) / (t1 - t0);
+            out.angle_deg = a0 + frac * (a1 - a0);
+            return out;
         }
     }
-    return roll_profile.waypoints[n - 1].angle_deg;
+    out.angle_deg = roll_profile.waypoints[n - 1].angle_deg;
+    out.mode      = roll_profile.waypoints[n - 1].mode;
+    return out;
 }
 
 static inline void i2sSendWithStats(uint8_t type, const uint8_t *payload, size_t len)
@@ -1509,14 +1535,16 @@ static void setup_fc()
                       (double)kp, (double)ki, (double)kd,
                       (double)mincmd, (double)maxcmd);
     }
-    gain_sched_enabled = prefs.getBool("gs", config::GAIN_SCHEDULE_ENABLED);
-    use_angle_control  = prefs.getBool("ac", config::USE_ANGLE_CONTROL);
-    roll_delay_ms      = prefs.getUShort("rdly", config::ROLL_CONTROL_DELAY_MS);
-    guidance_enabled   = prefs.getBool("guid_en", config::GUIDANCE_ENABLED);
+    gain_sched_enabled      = prefs.getBool("gs", config::GAIN_SCHEDULE_ENABLED);
+    use_angle_control       = prefs.getBool("ac", config::USE_ANGLE_CONTROL);
+    roll_delay_ms           = prefs.getUShort("rdly", config::ROLL_CONTROL_DELAY_MS);
+    kp_angle_rate_cap_dps   = prefs.getFloat("rcap", config::KP_ANGLE_RATE_CAP_DPS);
+    guidance_enabled        = prefs.getBool("guid_en", config::GUIDANCE_ENABLED);
     prefs.end();
     ESP_LOGI(TAG, "Gain scheduling: %s", gain_sched_enabled ? "ON" : "OFF");
-    ESP_LOGI(TAG, "Angle control: %s  Roll delay: %u ms",
-                  use_angle_control ? "ON" : "OFF", (unsigned)roll_delay_ms);
+    ESP_LOGI(TAG, "Angle control: %s  Roll delay: %u ms  Rate cap: %.1f dps",
+                  use_angle_control ? "ON" : "OFF", (unsigned)roll_delay_ms,
+                  (double)kp_angle_rate_cap_dps);
 #if TR_GUIDANCE_AVAILABLE
     ESP_LOGI(TAG, "PN Guidance: %s (compiled in)", guidance_enabled ? "ON" : "OFF");
 #else
@@ -1612,9 +1640,10 @@ static void setup_fc()
             ESP_LOGI(TAG, "NVS roll profile: %d waypoints", roll_profile.num_waypoints);
             for (uint8_t i = 0; i < roll_profile.num_waypoints; ++i)
             {
-                ESP_LOGI(TAG, "  WP%d: t=%.1fs angle=%.1f°", i,
+                ESP_LOGI(TAG, "  WP%d: t=%.1fs angle=%.1f° mode=%s", i,
                               (double)roll_profile.waypoints[i].time_s,
-                              (double)roll_profile.waypoints[i].angle_deg);
+                              (double)roll_profile.waypoints[i].angle_deg,
+                              roll_profile.waypoints[i].mode == ROLL_SEG_NULL_RATE ? "NULL_RATE" : "ANGLE");
             }
         }
         else
@@ -3619,7 +3648,18 @@ static void loop_fc()
                             // --- Roll-only mode (powered flight or guidance disabled) ---
                             guidance_active = false;
 
-                            if (use_angle_control && ekf_initialized)
+                            // Decide per-segment whether to track angle or null rate.
+                            // Profile-mode lookup is only meaningful when angle
+                            // control is enabled and the EKF is initialized.
+                            const float t_flight = (float)(now_ms - launch_time_millis) / 1000.0f;
+                            const bool angle_mode_active = use_angle_control && ekf_initialized;
+                            RollProfileQuery seg = {0.0f, ROLL_SEG_NULL_RATE};
+                            if (angle_mode_active)
+                            {
+                                seg = roll_profile_query(t_flight);
+                            }
+
+                            if (angle_mode_active && seg.mode == ROLL_SEG_ANGLE)
                             {
                                 // Quaternion-based roll extraction (gimbal-lock-free).
                                 float quat[4];
@@ -3629,17 +3669,18 @@ static void loop_fc()
                                 float z_east  = 2.0f * (qy*qz - qw*qx);
                                 float actual_roll_deg = -atan2f(z_east, z_north) * (180.0f / (float)M_PI);
 
-                                float t_flight = (float)(now_ms - launch_time_millis) / 1000.0f;
-                                float target_roll_deg = roll_profile_interpolate(t_flight);
-
-                                servo_control.controlAngle(target_roll_deg,
+                                servo_control.controlAngle(seg.angle_deg,
                                                            actual_roll_deg,
                                                            -roll_rate_dps,
                                                            speed,
-                                                           config::KP_ANGLE);
+                                                           config::KP_ANGLE,
+                                                           kp_angle_rate_cap_dps);
                             }
                             else if (gain_sched_enabled)
                             {
+                                // Rate-null path (used when angle control is off,
+                                // OR when angle control is on but the current
+                                // profile segment selects ROLL_SEG_NULL_RATE).
                                 servo_control.controlWithGainSchedule(-roll_rate_dps, speed);
                             }
                             else


### PR DESCRIPTION
## Summary

- Adds a per-waypoint `mode` byte to the roll profile: `ROLL_SEG_ANGLE` (existing cascaded angle->rate behavior) or `ROLL_SEG_NULL_RATE` (hold rate=0 via the inner rate PID, ignoring the angle field). The mode applies to the segment **starting at** that waypoint.
- Caps the outer angle->rate command at `+/-60 dps` (override via NVS key `"rcap"`). Prevents a wrapped 180-deg error from demanding 720 dps that the inner loop cannot deliver, which on the 2026-05-17 RollyPolly flight drove windup and direction whipsawing during spin recovery (see #165 for context).
- iOS Settings UI gains a segmented `Angle / Null Rate` picker per waypoint; angle field disables when Null Rate is selected; changes self-apply.

## Motivation

On 2026-05-17 the rocket experienced a ~3000 dps roll perturbation at boost. The cascaded angle controller could not damp the spin because (a) the wrapped angle error periodically matched the spin direction, telling the inner loop to do nothing, and (b) the unclamped outer loop was demanding rates the actuators could not deliver. Splitting the profile so the early segment runs in null-rate damping mode and only switching to angle tracking after the disturbance settles is a much cleaner story. The rate cap protects against the second failure mode independently.

## Test plan

- [x] `idf.py build` clean on both `flight_computer` and `out_computer`
- [x] `xcodebuild` clean on the iOS app (iphonesimulator)
- [ ] Push profile from app with mixed modes (e.g. WP1 Null Rate at 0.5s, WP2/3/4 Angle stepping 0->90->0) and confirm the rocket logs each WP with the correct mode tag at boot
- [ ] Verify on-rocket logs print `Rate cap: 60.0 dps` line on boot
- [ ] One flight (intended profile: WP1 0.5s/0/NullRate, WP2 3.0s/0/Angle, WP3 4.0s/90/Angle, WP4 5.0s/0/Angle), confirm null-rate damps boost-induced spin and then angle segment tracks the 0->90->0 step

## Notes

- Wire format change: `RollWaypoint` 8 -> 9 bytes (packed), `RollProfileData` 68 -> 76 bytes. Existing NVS profiles get cleared on first boot via the existing size-mismatch handler. Re-push profile after flashing.
- Submodule `TR_GuidancePN` not touched.

Follow-up: issue for higher-fidelity simulation to exercise roll + guidance algorithms (filed separately).
