### PR TITLE
detect: apogee + landing voting with un-latching sub-flags

### DIFF
--- a/Data_Analysis/replay_kinematic_checks.py
+++ b/Data_Analysis/replay_kinematic_checks.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Replay a binary flight log through the Python port of TR_KinematicChecks.
+
+Drives ``sim_kinematic_checks.KinematicChecks`` with sensor + EKF data
+read from a .bin file and reports when each detection flag fires vs when
+the firmware (logged in NonSensor) fired it.
+
+Usage:
+    python replay_kinematic_checks.py <binary> [<binary>...] [--plot DIR]
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from plot_flight_data_mini import parse_binary_file
+from sim_kinematic_checks import KinematicChecks, G_MS2
+
+
+NSF_BURNOUT = 1 << 4
+
+BARO_MACH_LOCKOUT_ON  = 260.0
+BARO_MACH_LOCKOUT_OFF = 240.0
+
+LOW_G_FS_G = 16.0
+LOW_G_SAT_THRESH_MS2 = (LOW_G_FS_G - 0.5) * G_MS2
+
+
+def pressure_to_altitude_firmware(p_pa: float, p_ground: float) -> float:
+    return 44330.0 * (1.0 - (p_pa / p_ground) ** (1.0 / 5.255))
+
+
+def accel_norm_firmware(low_xyz, high_xyz) -> float:
+    ax_l, ay_l, az_l = low_xyz
+    near_sat = (abs(ax_l) > LOW_G_SAT_THRESH_MS2
+                or abs(ay_l) > LOW_G_SAT_THRESH_MS2
+                or abs(az_l) > LOW_G_SAT_THRESH_MS2)
+    ax, ay, az = high_xyz if near_sat else low_xyz
+    return math.sqrt(ax*ax + ay*ay + az*az)
+
+
+def estimate_ground_pressure(baro_recs, nonsensor_recs) -> float:
+    if not baro_recs or not nonsensor_recs:
+        return 101325.0
+
+    launch_us = None
+    for r in nonsensor_recs:
+        if r["launch"]:
+            launch_us = r["time_us"]
+            break
+
+    cutoff_us = launch_us if launch_us is not None else baro_recs[-1]["time_us"]
+    pre = [r["pressure_pa"] for r in baro_recs if r["time_us"] < cutoff_us]
+    if not pre:
+        pre = [r["pressure_pa"] for r in baro_recs[:50]]
+    return sum(pre) / len(pre)
+
+
+def build_events(records):
+    events = []
+    for r in records["ISM6HG256"]: events.append((r["time_us"], "imu",  r))
+    for r in records["BMP585"]:    events.append((r["time_us"], "baro", r))
+    for r in records["GNSS"]:      events.append((r["time_us"], "gnss", r))
+    for r in records["NonSensor"]: events.append((r["time_us"], "ns",   r))
+    events.sort(key=lambda e: (e[0], 0 if e[1] != "imu" else 1))
+    return events
+
+
+def logged_flag_times(nonsensor_recs, t0_us):
+    out = {}
+    for r in nonsensor_recs:
+        flags_byte = r["flags"]
+        burnout = bool(flags_byte & NSF_BURNOUT)
+        for name, val in (
+            ("launch",       r["launch"]),
+            ("burnout",      burnout),
+            ("vel_apogee",   r["vel_apogee"]),
+            ("alt_apogee",   r["alt_apogee"]),
+            ("gps_apogee",   r["gps_apogee"]),
+            ("pitch_apogee", r["pitch_apogee"]),
+            ("apogee_flag",  r["apogee_flag"]),
+            ("alt_landed",   r["alt_landed"]),
+        ):
+            if val and name not in out:
+                out[name] = (r["time_us"] - t0_us) / 1e6
+    return out
+
+
+def replay(binary_path: str) -> dict:
+    records, stats, _config = parse_binary_file(binary_path)
+
+    if not records["ISM6HG256"]:
+        print(f"  {binary_path}: no IMU samples — skipping")
+        return {}
+
+    t0_us = records["ISM6HG256"][0]["time_us"]
+    ground_pa = estimate_ground_pressure(records["BMP585"], records["NonSensor"])
+
+    print(f"\n=== {Path(binary_path).name} ===")
+    print(f"  IMU={len(records['ISM6HG256']):,}  Baro={len(records['BMP585']):,}  "
+          f"GNSS={len(records['GNSS']):,}  NS={len(records['NonSensor']):,}")
+    print(f"  ground pressure (pre-launch avg): {ground_pa:.1f} Pa")
+
+    kc = KinematicChecks()
+
+    latest_palt: float = 0.0
+    latest_acc_mag: float = 0.0
+    latest_pos = (0.0, 0.0, 0.0)
+    latest_vel = (0.0, 0.0, 0.0)
+    latest_roll_rate: float = 0.0
+    latest_gps_alt: float = 0.0
+    latest_pitch_rad: float = math.pi / 2
+    burnout: bool = False
+    mach_locked_out: bool = False
+
+    new_baro = False
+    new_gps = False
+
+    sim_fires: dict[str, float] = {}
+    # Time-series capture for plotting.
+    raw_palt_t, raw_palt_v = [], []
+    sim_alt_t, sim_alt_v = [], []
+    baro_reject_t: list[float] = []
+    # Per-tick pass states (used to draw "condition true" bands).
+    pass_t: list[float] = []
+    pass_vel: list[bool] = []
+    pass_baro: list[bool] = []
+    pass_pitch: list[bool] = []
+    gps_pass_t: list[float] = []
+    gps_pass_v: list[bool] = []
+
+    def _snap_edges(now_s: float, prev_rejects: int):
+        for name, val in (
+            ("launch_flag",       kc.launch_flag),
+            ("vel_u_apogee_flag", kc.vel_u_apogee_flag),
+            ("alt_apogee_flag",   kc.alt_apogee_flag),
+            ("gps_apogee_flag",   kc.gps_apogee_flag),
+            ("pitch_apogee_flag", kc.pitch_apogee_flag),
+            ("apogee_flag",       kc.apogee_flag),
+            ("alt_landed_flag",   kc.alt_landed_flag),
+        ):
+            if val and name not in sim_fires:
+                sim_fires[name] = now_s
+        if kc._consec_baro_rejects > prev_rejects:
+            baro_reject_t.append(now_s)
+
+    for t_us, kind, r in build_events(records):
+        now_ms = (t_us - t0_us) // 1000
+
+        if kind == "baro":
+            latest_palt = pressure_to_altitude_firmware(r["pressure_pa"], ground_pa)
+            raw_palt_t.append((t_us - t0_us) / 1e6)
+            raw_palt_v.append(latest_palt)
+            new_baro = True
+            continue
+
+        if kind == "gnss":
+            latest_gps_alt = float(r["alt_m"])
+            new_gps = True
+            # Record GPS pass-state at GPS sample time (separate axis since
+            # GPS is much slower than IMU and shouldn't be smeared along it).
+            gps_pass_t.append((t_us - t0_us) / 1e6)
+            continue
+
+        if kind == "ns":
+            latest_pos = (r["e_pos"], r["n_pos"], r["u_pos"])
+            latest_vel = (r["e_vel"], r["n_vel"], r["u_vel"])
+            latest_pitch_rad = math.radians(r["pitch"])
+            burnout = bool(r["flags"] & NSF_BURNOUT)
+            speed = math.sqrt(r["e_vel"]**2 + r["n_vel"]**2 + r["u_vel"]**2)
+            if not mach_locked_out and speed > BARO_MACH_LOCKOUT_ON:
+                mach_locked_out = True
+            elif mach_locked_out and speed < BARO_MACH_LOCKOUT_OFF:
+                mach_locked_out = False
+            continue
+
+        # imu — main-loop tick
+        latest_low_xyz  = (r["low_acc_x"],  r["low_acc_y"],  r["low_acc_z"])
+        latest_high_xyz = (r["high_acc_x"], r["high_acc_y"], r["high_acc_z"])
+        latest_acc_mag = accel_norm_firmware(latest_low_xyz, latest_high_xyz)
+        latest_roll_rate = r["gyro_x"]
+
+        prev_rejects = kc._consec_baro_rejects
+
+        kc.kinematic_checks(
+            pressure_altitude=latest_palt,
+            acc_mag=latest_acc_mag,
+            position=latest_pos,
+            velocity=latest_vel,
+            roll_rate=latest_roll_rate,
+            new_baro=new_baro,
+            gps_altitude=latest_gps_alt,
+            new_gps=new_gps,
+            pitch_rad=latest_pitch_rad,
+            burnout_detected=burnout,
+            baro_locked_out=mach_locked_out,
+            now_ms=now_ms,
+        )
+        new_baro = False
+        new_gps = False
+
+        now_s = now_ms / 1000.0
+        sim_alt_t.append(now_s)
+        sim_alt_v.append(kc.alt_est)
+        pass_t.append(now_s)
+        pass_vel.append(kc.last_vel_pass)
+        pass_baro.append(kc.last_baro_pass)
+        pass_pitch.append(kc.last_pitch_pass)
+        # GPS pass is sticky between samples; record current value at the
+        # GPS time we noted above. Aligning lengths:
+        if len(gps_pass_t) > len(gps_pass_v):
+            gps_pass_v.append(kc.last_gps_pass)
+        _snap_edges(now_s, prev_rejects)
+
+    logged = logged_flag_times(records["NonSensor"], t0_us)
+
+    rows = [
+        ("launch",       "launch_flag"),
+        ("burnout",      None),
+        ("vel_apogee",   "vel_u_apogee_flag"),
+        ("alt_apogee",   "alt_apogee_flag"),
+        ("gps_apogee",   "gps_apogee_flag"),
+        ("pitch_apogee", "pitch_apogee_flag"),
+        ("apogee_flag",  "apogee_flag"),
+        ("alt_landed",   "alt_landed_flag"),
+    ]
+    print(f"  {'flag':<14} {'logged':>10} {'sim':>10}   Δ (s)")
+    print(f"  {'─'*14} {'─'*10} {'─'*10}   {'─'*7}")
+    for logged_name, sim_name in rows:
+        l = logged.get(logged_name)
+        s = sim_fires.get(sim_name) if sim_name else None
+        l_str = f"{l:10.3f}" if l is not None else f"{'—':>10}"
+        s_str = f"{s:10.3f}" if s is not None else f"{'—':>10}"
+        if l is not None and s is not None:
+            d_str = f"{s - l:+7.3f}"
+        else:
+            d_str = "      —"
+        print(f"  {logged_name:<14} {l_str} {s_str}   {d_str}")
+    print(f"  max_alt (sim): {kc.max_altitude:.1f} m   max_speed (sim): {kc.max_speed:.1f} m/s   "
+          f"baro rejects: {len(baro_reject_t)}")
+
+    # Compress per-tick pass arrays into contiguous (t_start, t_end) periods.
+    def periods(times, states):
+        out = []
+        in_run = False
+        run_start = 0.0
+        prev_t = 0.0
+        for t, s in zip(times, states):
+            if s and not in_run:
+                in_run = True
+                run_start = t
+            elif not s and in_run:
+                in_run = False
+                out.append((run_start, prev_t))
+            prev_t = t
+        if in_run:
+            out.append((run_start, prev_t))
+        return out
+
+    # Rocket name = parent directory (works for 5/17 layout).
+    rocket_label = Path(binary_path).parent.name.strip() or Path(binary_path).stem
+
+    return {
+        "name":      rocket_label,
+        "filename":  Path(binary_path).name,
+        "sim_fires": sim_fires,
+        "logged":    logged,
+        "raw_palt":  (raw_palt_t, raw_palt_v),
+        "sim_alt":   (sim_alt_t, sim_alt_v),
+        "baro_reject_t": baro_reject_t,
+        "vel_periods":   periods(pass_t, pass_vel),
+        "baro_periods":  periods(pass_t, pass_baro),
+        "pitch_periods": periods(pass_t, pass_pitch),
+        "gps_periods":   periods(gps_pass_t, gps_pass_v),
+        "kc":        kc,
+    }
+
+
+def plot_flights(results, out_path: str | None = None, show: bool = False) -> None:
+    import matplotlib.pyplot as plt
+    from matplotlib.gridspec import GridSpec
+
+    n = len(results)
+    cols = 2
+    rows = (n + 1) // 2
+
+    # Each "cell" is two stacked panes: altitude on top, condition-true
+    # strip below. Use GridSpec with height ratios so the strip is short.
+    fig = plt.figure(figsize=(15, 5.5 * rows))
+    outer = GridSpec(rows, cols, figure=fig, hspace=0.4, wspace=0.22)
+
+    det_style = {
+        "vel":   ("Vel",   "tab:blue"),
+        "baro":  ("Baro",  "tab:green"),
+        "gps":   ("GPS",   "tab:orange"),
+        "pitch": ("Pitch", "tab:purple"),
+    }
+    fire_marker = {"vel": "s", "baro": "^", "gps": "o", "pitch": "*"}
+    flag_for_det = {
+        "vel":   "vel_u_apogee_flag",
+        "baro":  "alt_apogee_flag",
+        "gps":   "gps_apogee_flag",
+        "pitch": "pitch_apogee_flag",
+    }
+
+    for idx, res in enumerate(results):
+        if not res:
+            continue
+        row, col = idx // cols, idx % cols
+        sub = outer[row, col].subgridspec(2, 1, height_ratios=[3, 1], hspace=0.05)
+        ax_alt = fig.add_subplot(sub[0])
+        ax_pass = fig.add_subplot(sub[1], sharex=ax_alt)
+
+        # ── Altitude pane ───────────────────────────────────────────
+        t_raw, v_raw = res["raw_palt"]
+        t_sim, v_sim = res["sim_alt"]
+        ax_alt.plot(t_raw, v_raw, color="lightgray", lw=0.6, label="raw palt")
+        ax_alt.plot(t_sim, v_sim, color="black",     lw=0.9, label="KF alt_est")
+
+        # True apogee = peak of raw palt.
+        if v_raw:
+            peak_idx = max(range(len(v_raw)), key=lambda i: v_raw[i])
+            ax_alt.axvline(t_raw[peak_idx], color="dimgray", ls=":", lw=0.8,
+                           label=f"true apogee {t_raw[peak_idx]:.2f}s")
+
+        # Sub-detector first-fire markers (when count crossed HI threshold).
+        for det_key, flag_name in flag_for_det.items():
+            t = res["sim_fires"].get(flag_name)
+            if t is None:
+                continue
+            i = min(range(len(t_sim)), key=lambda j: abs(t_sim[j] - t))
+            y = v_sim[i]
+            label, color = det_style[det_key]
+            ax_alt.scatter([t], [y], color=color, marker=fire_marker[det_key],
+                           s=80, zorder=5, edgecolor="black", linewidth=0.6,
+                           label=f"{label} fire {t:.2f}s")
+
+        # Master apogee fire.
+        t_master = res["sim_fires"].get("apogee_flag")
+        if t_master is not None:
+            ax_alt.axvline(t_master, color="red", lw=1.2, alpha=0.7,
+                           label=f"master {t_master:.2f}s")
+
+        # Baro rejects at bottom of altitude pane (just inside ylim floor).
+        ALT_FLOOR = -50.0
+        if res["baro_reject_t"]:
+            ax_alt.scatter(res["baro_reject_t"],
+                           [ALT_FLOOR + 5] * len(res["baro_reject_t"]),
+                           color="red", marker="x", s=14, alpha=0.4,
+                           label=f"baro reject ({len(res['baro_reject_t'])})")
+
+        ax_alt.set_title(f"{res['name']}   ({res['filename']})", fontsize=10)
+        ax_alt.set_ylabel("altitude (m)")
+        ax_alt.set_ylim(bottom=ALT_FLOOR)
+        ax_alt.grid(True, alpha=0.3)
+        ax_alt.legend(fontsize=7, loc="best", ncol=2)
+        plt.setp(ax_alt.get_xticklabels(), visible=False)
+
+        # ── Pass-state pane ─────────────────────────────────────────
+        # One row per detector at fixed Y. Draw each contiguous period
+        # where the test condition was true as a horizontal bar.
+        det_rows = [
+            ("vel",   res["vel_periods"]),
+            ("baro",  res["baro_periods"]),
+            ("gps",   res["gps_periods"]),
+            ("pitch", res["pitch_periods"]),
+        ]
+        for y_idx, (det_key, periods) in enumerate(det_rows):
+            label, color = det_style[det_key]
+            y = len(det_rows) - 1 - y_idx
+            for (t0, t1) in periods:
+                ax_pass.hlines(y, t0, max(t1, t0 + 0.001), color=color,
+                               lw=8, alpha=0.7)
+            ax_pass.text(-0.01, y, label, transform=ax_pass.get_yaxis_transform(),
+                         ha="right", va="center", fontsize=8, color=color)
+
+        ax_pass.set_yticks([])
+        ax_pass.set_ylim(-0.7, len(det_rows) - 0.3)
+        ax_pass.set_xlabel("t (s)")
+        ax_pass.set_ylabel("condition\ntrue", fontsize=8)
+        ax_pass.grid(True, axis="x", alpha=0.3)
+
+        # Shared X range trimmed to action window.
+        if t_raw:
+            t_end = (res["sim_fires"].get("apogee_flag") or t_raw[-1]) + 3.0
+            ax_alt.set_xlim(-0.5, min(t_end, t_raw[-1]))
+
+    fig.suptitle("Apogee sub-detector firings & pass-conditions — sim_kinematic_checks",
+                 fontsize=12, y=0.995)
+    fig.tight_layout()
+    if out_path:
+        fig.savefig(out_path, dpi=140)
+        print(f"\nPlot saved to: {out_path}")
+    if show:
+        plt.show()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("binary", nargs="+", help="One or more flight .bin files")
+    ap.add_argument("--plot", help="Save per-flight plot to this path")
+    ap.add_argument("--show", action="store_true",
+                    help="Open interactive matplotlib window (zoom/pan)")
+    args = ap.parse_args()
+
+    results = [replay(p) for p in args.binary]
+
+    if args.plot or args.show:
+        plot_flights(results, args.plot, args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/Data_Analysis/sim_kinematic_checks.py
+++ b/Data_Analysis/sim_kinematic_checks.py
@@ -1,0 +1,525 @@
+"""Python port of TR_KinematicChecks.cpp for offline replay.
+
+Line-for-line mirror of tinkerrocket-idf/components/TR_KinematicChecks/
+TR_KinematicChecks.{cpp,h}, with experimental detection changes flagged
+as ``CHANGED:`` to keep the diff visible for back-porting to C++.
+
+Active experiments (all behind no flag — edit to disable):
+  1. Baro rate-gate at ingestion (reject |Δpalt|/dt > 300 m/s, with a
+     consecutive-reject safety valve so a wedged sensor reseeds).
+  2. GPS max-altitude spike-reject window removed (boost-phase GPS
+     dropouts on big flights leave a 500 m+ post-recovery jump that
+     the 100 m window permanently rejected — Eagle Claw 5/17 was
+     silently no-vote because of this).
+  3. Apogee block gated on ``launch_flag && burnout_detected`` (was
+     burnout only; defensive against pre-launch noise).
+  4. Sub-detector flags are leaky-counter hysteresis rather than
+     single-write latches, so a false-positive sample can un-vote
+     once the underlying condition reverses. Master ``apogee_flag``
+     still latches once true.
+
+Run replay_kinematic_checks.py after editing to validate against
+known flights before porting any change back to C++ source.
+
+C++ line references appear as ``# TRKC.cpp:NN`` for cross-reference.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+# TRKC.cpp:10-13 (anonymous namespace constants for landing fast path)
+LANDING_IMPACT_G       = 15.0
+LANDING_IMPACT_ALT_M   = 20.0
+LANDING_IMPACT_COUNT   = 5
+G_MS2                  = 9.80665
+
+# CHANGED (1): Baro rate-gate.
+# 300 m/s headroom above max plausible rocket dynamic (~200 m/s peak
+# ascent or terminal). Ejection spikes are O(10–100 km/s) so they're
+# rejected by 2+ orders of magnitude. self-scales with dt: at a 1 s
+# dropout the allowed Δ is 300 m, at 5 ms it's 1.5 m.
+MAX_BARO_RATE_MS = 300.0
+# After this many consecutive rejects the gate accepts the next sample
+# unconditionally and reseeds — prevents a permanently wedged sensor
+# from leaving us baro-blind for the rest of the flight.
+MAX_CONSEC_BARO_REJECTS = 10
+
+# CHANGED (4): Apogee sub-detector hysteresis thresholds.
+# Each test runs a leaky counter (+1 on pass, -1 on miss, clamped).
+# Flag latches true at HI, un-latches at zero. The HI thresholds are
+# chosen to preserve the original C++ time-to-fire behaviour:
+#   Baro/Pitch/Vel run at kinematicChecks rate (~1 kHz), so HI=6 →
+#     ~6 ms to fire (same as the original ``apogee_count > 5``).
+#   GPS runs at GNSS rate (~5 Hz), so HI=4 → ~800 ms to fire (same
+#     as the original ``gps_apogee_count_ > 3``).
+APOGEE_COUNT_MAX     = 10
+APOGEE_COUNT_HI      = 6        # baro/pitch/vel latch-on threshold
+GPS_APOGEE_COUNT_MAX = 8
+GPS_APOGEE_COUNT_HI  = 4
+
+# CHANGED (5): Landing sub-detector hysteresis thresholds.
+# Slow detectors evaluated at 1 Hz inside the existing landing_check_dt
+# gate. HI=4 → ~4 s to fire (matches the original ``landing_checks > 4``).
+LANDING_SLOW_COUNT_MAX = 8
+LANDING_SLOW_COUNT_HI  = 4
+
+# Landing sub-detector thresholds.
+# Lower bound is −50 m, not 0, because ground-pressure drift across a
+# 60-90 s flight can put a settled palt several m below the pre-launch
+# reference (Roly Poly GTV 5/9 settled at palt ≈ −8 m). The rate-gate
+# upstream filters deep spikes, so this is just a defensive backstop.
+BARO_STABLE_PALT_MIN     = -50.0
+BARO_STABLE_PALT_MAX     = 50.0
+BARO_STABLE_DELTA_MAX    = 2.0     # |Δpalt| over 1 s
+BARO_STABLE_MAX_ALT_MIN  = 15.0    # rocket must have flown
+GYRO_QUIET_DPS           = 20.0    # |roll_rate| < this
+GPS_STATIONARY_SPEED_MS  = 1.0     # |velocity| < this (EKF proxy)
+ACCEL_1G_TOLERANCE       = 2.94    # |acc_mag − 1g| < this (≈ 0.3 g)
+
+
+def _constrain(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+@dataclass
+class KinematicChecks:
+    """Mirror of TR_KinematicChecks (public + private fields)."""
+
+    # ── Public output flags / values ──────────────────────────────────
+    launch_flag: bool = False
+    alt_landed_flag: bool = False
+    alt_apogee_flag: bool = False      # Test 2: baro altitude decreasing
+    vel_u_apogee_flag: bool = False    # Test 1: EKF velocity negative
+    gps_apogee_flag: bool = False      # Test 3: GPS altitude decreasing
+    pitch_apogee_flag: bool = False    # Test 4: pitch below horizontal
+    apogee_flag: bool = False          # Voted master
+    # Landing sub-detector flags (#166) — exposed for diagnostics/logging.
+    impact_flag: bool = False          # one-shot: high-G ground impact
+    baro_stable_flag: bool = False     # palt low and stable
+    gyro_quiet_flag: bool = False      # roll-rate quiescent
+    gps_stationary_flag: bool = False  # EKF speed near zero (GPS fresh)
+    accel_1g_flag: bool = False        # acc_mag near 1 g
+    max_altitude: float = 0.0
+    max_speed: float = 0.0
+    alt_est: float = 0.0
+    d_alt_est_: float = 0.0
+
+    # ── Private state ─────────────────────────────────────────────────
+    launch_count: int = 0
+    landing_check_time: int = 0
+    landing_look_back_alt: float = 0.0
+    landing_check_dt: int = 1000
+    apogee_count: int = 0             # Baro test counter (now leaky)
+    landing_checks: int = 0
+    impact_seen_count: int = 0
+
+    # CHANGED (4): new per-detector counters for un-latching hysteresis.
+    vel_apogee_count_: int = 0
+    pitch_apogee_count_: int = 0
+
+    # CHANGED (5): landing sub-detector counters.
+    baro_stable_count_: int = 0
+    gyro_quiet_count_: int = 0
+    gps_stationary_count_: int = 0
+    accel_1g_count_: int = 0
+
+    max_gps_altitude_: float = 0.0
+    gps_apogee_count_: int = 0
+    gps_available_: bool = False
+    last_gps_time_ms_: int = 0
+
+    # CHANGED (1): baro rate-gate state.
+    _baro_gate_init: bool = False
+    _palt_accepted: float = 0.0
+    _last_baro_gate_ms: int = 0
+    _consec_baro_rejects: int = 0
+
+    # Per-tick pass-state outputs (exposed for replay/plot — not in C++).
+    last_vel_pass: bool = False
+    last_baro_pass: bool = False
+    last_gps_pass: bool = False    # only meaningful on new_gps ticks
+    last_pitch_pass: bool = False
+
+    # KF state
+    kf_init_: bool = False
+    P00_: float = 10.0
+    P01_: float = 0.0
+    P10_: float = 0.0
+    P11_: float = 10.0
+    last_ms_: int = 0
+
+    # KF tunables (TRKC.cpp:49-55)
+    R_: float  = 1.0
+    Qz_: float = 0.05
+    Qv_: float = 5.0
+
+    _now_ms: int = field(default=0, repr=False)
+
+    def reset(self) -> None:
+        """TRKC.cpp:58 reset()."""
+        self.launch_flag = False
+        self.alt_landed_flag = False
+        self.alt_apogee_flag = False
+        self.vel_u_apogee_flag = False
+        self.gps_apogee_flag = False
+        self.pitch_apogee_flag = False
+        self.apogee_flag = False
+        self.launch_count = 0
+        self.max_altitude = 0.0
+        self.max_speed = 0.0
+        self.landing_check_time = 0
+        self.landing_look_back_alt = 0.0
+        self.apogee_count = 0
+        self.landing_checks = 0
+        self.impact_seen_count = 0
+        self.vel_apogee_count_ = 0
+        self.pitch_apogee_count_ = 0
+        self.impact_flag = False
+        self.baro_stable_flag = False
+        self.gyro_quiet_flag = False
+        self.gps_stationary_flag = False
+        self.accel_1g_flag = False
+        self.baro_stable_count_ = 0
+        self.gyro_quiet_count_ = 0
+        self.gps_stationary_count_ = 0
+        self.accel_1g_count_ = 0
+        self.max_gps_altitude_ = 0.0
+        self.gps_apogee_count_ = 0
+        self.gps_available_ = False
+        self.last_gps_time_ms_ = 0
+        self._baro_gate_init = False
+        self._palt_accepted = 0.0
+        self._last_baro_gate_ms = 0
+        self._consec_baro_rejects = 0
+        self.kf_init_ = False
+        self.alt_est = 0.0
+        self.d_alt_est_ = 0.0
+        self.P00_ = 10.0; self.P01_ = 0.0; self.P10_ = 0.0; self.P11_ = 10.0
+
+    # TRKC.cpp:86
+    def kinematic_checks(
+        self,
+        pressure_altitude: float,
+        acc_mag: float,
+        position: tuple[float, float, float],
+        velocity: tuple[float, float, float],
+        roll_rate: float,
+        new_baro: bool,
+        gps_altitude: float,
+        new_gps: bool,
+        pitch_rad: float,
+        burnout_detected: bool,
+        baro_locked_out: bool,
+        now_ms: int,
+    ) -> None:
+        self._now_ms = now_ms
+
+        # ── CHANGED (1): Baro rate-gate at ingestion ──────────────────
+        # Only the new_baro sample is judged. Once accepted (or substituted
+        # with the last good value) all downstream paths — KF update,
+        # landing checks, baro apogee test — see the gated value.
+        if new_baro:
+            if self._baro_gate_init:
+                dt = max(0.001, (now_ms - self._last_baro_gate_ms) * 0.001)
+                rate = abs(pressure_altitude - self._palt_accepted) / dt
+                if (rate > MAX_BARO_RATE_MS
+                        and self._consec_baro_rejects < MAX_CONSEC_BARO_REJECTS):
+                    # Spike: don't pass to KF, hold last good for downstream.
+                    self._consec_baro_rejects += 1
+                    new_baro = False
+                    pressure_altitude = self._palt_accepted
+                else:
+                    # Accept (either truly OK, or reseed after wedge).
+                    self._consec_baro_rejects = 0
+                    self._palt_accepted = pressure_altitude
+                    self._last_baro_gate_ms = now_ms
+            else:
+                self._palt_accepted = pressure_altitude
+                self._last_baro_gate_ms = now_ms
+                self._baro_gate_init = True
+        else:
+            pressure_altitude = self._palt_accepted
+
+        # TRKC.cpp:105 KF predict (every call) / update (when new_baro).
+        self._update_alt_kf(pressure_altitude, new_baro)
+
+        # TRKC.cpp:112 ─ Launch detection
+        if not self.launch_flag:
+            if acc_mag > 20.0:
+                self.launch_count += 1
+                if self.launch_count > 50 and self.d_alt_est_ > 1.0:
+                    self.launch_flag = True
+            else:
+                self.launch_count = 0
+
+        # TRKC.cpp:133 ─ max_altitude with 50 m spike-reject window
+        if self.max_altitude == 0.0 or abs(self.alt_est - self.max_altitude) < 50.0:
+            self.max_altitude = max(self.max_altitude, self.alt_est)
+
+        # ── CHANGED (5): Landing voting system (#166) ────────────────
+        # Fast path: high-G impact gated on apogee + ground proximity.
+        # One-shot latch — once a real impact is detected, the flag stays
+        # true so it can participate in voting alongside slower detectors.
+        # Defensive ``palt > -10`` lower bound mirrors the rate-gate intent.
+        if (self.apogee_flag
+                and pressure_altitude > -10.0
+                and pressure_altitude < LANDING_IMPACT_ALT_M
+                and acc_mag > LANDING_IMPACT_G * G_MS2):
+            self.impact_seen_count += 1
+            if self.impact_seen_count >= LANDING_IMPACT_COUNT:
+                self.impact_flag = True
+        else:
+            self.impact_seen_count = 0
+
+        # Slow detectors evaluated at 1 Hz inside the existing time-gate.
+        # Each is a leaky-counter sub-flag like the apogee tests.
+        if self._now_ms > self.landing_check_time + self.landing_check_dt:
+            landing_alt_change = abs(pressure_altitude - self.landing_look_back_alt)
+            self.landing_look_back_alt = pressure_altitude
+            self.landing_check_time = self._now_ms
+
+            # Sub 1: Baro-stable (was the original slow path; +lower bound)
+            baro_stable_pass = (BARO_STABLE_PALT_MIN <= pressure_altitude <= BARO_STABLE_PALT_MAX
+                                and landing_alt_change < BARO_STABLE_DELTA_MAX
+                                and self.max_altitude > BARO_STABLE_MAX_ALT_MIN)
+            if baro_stable_pass:
+                self.baro_stable_count_ = min(LANDING_SLOW_COUNT_MAX,
+                                              self.baro_stable_count_ + 1)
+            else:
+                self.baro_stable_count_ = max(0, self.baro_stable_count_ - 1)
+            if self.baro_stable_count_ >= LANDING_SLOW_COUNT_HI:
+                self.baro_stable_flag = True
+            elif self.baro_stable_count_ == 0:
+                self.baro_stable_flag = False
+
+            # Sub 2: Gyro-quiet (roll_rate; future: generalize to all axes)
+            gyro_quiet_pass = abs(roll_rate) < GYRO_QUIET_DPS
+            if gyro_quiet_pass:
+                self.gyro_quiet_count_ = min(LANDING_SLOW_COUNT_MAX,
+                                             self.gyro_quiet_count_ + 1)
+            else:
+                self.gyro_quiet_count_ = max(0, self.gyro_quiet_count_ - 1)
+            if self.gyro_quiet_count_ >= LANDING_SLOW_COUNT_HI:
+                self.gyro_quiet_flag = True
+            elif self.gyro_quiet_count_ == 0:
+                self.gyro_quiet_flag = False
+
+            # Sub 3: GPS-stationary (EKF speed magnitude as proxy)
+            if (self.gps_available_
+                    and (self._now_ms - self.last_gps_time_ms_) < 5000):
+                speed = math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2)
+                gps_stationary_pass = speed < GPS_STATIONARY_SPEED_MS
+                if gps_stationary_pass:
+                    self.gps_stationary_count_ = min(LANDING_SLOW_COUNT_MAX,
+                                                     self.gps_stationary_count_ + 1)
+                else:
+                    self.gps_stationary_count_ = max(0, self.gps_stationary_count_ - 1)
+                if self.gps_stationary_count_ >= LANDING_SLOW_COUNT_HI:
+                    self.gps_stationary_flag = True
+                elif self.gps_stationary_count_ == 0:
+                    self.gps_stationary_flag = False
+
+            # Sub 4: Accel-1g floor
+            accel_1g_pass = abs(acc_mag - G_MS2) < ACCEL_1G_TOLERANCE
+            if accel_1g_pass:
+                self.accel_1g_count_ = min(LANDING_SLOW_COUNT_MAX,
+                                           self.accel_1g_count_ + 1)
+            else:
+                self.accel_1g_count_ = max(0, self.accel_1g_count_ - 1)
+            if self.accel_1g_count_ >= LANDING_SLOW_COUNT_HI:
+                self.accel_1g_flag = True
+            elif self.accel_1g_count_ == 0:
+                self.accel_1g_flag = False
+
+        # Voting: impact alone fires master; otherwise N-1 of N over the
+        # slow detectors (GPS excluded if stale). Master latches once true.
+        # Gated on apogee_flag — pre-flight a static rocket trips
+        # gyro_quiet + gps_stationary + accel_1g, which would otherwise
+        # be 3 of 4 votes and fire landed on the pad.
+        if not self.alt_landed_flag and self.apogee_flag:
+            if self.impact_flag:
+                self.alt_landed_flag = True
+            else:
+                available = 0
+                passed = 0
+
+                available += 1
+                if self.baro_stable_flag: passed += 1
+
+                available += 1
+                if self.gyro_quiet_flag: passed += 1
+
+                if (self.gps_available_
+                        and (self._now_ms - self.last_gps_time_ms_) < 5000):
+                    available += 1
+                    if self.gps_stationary_flag: passed += 1
+
+                available += 1
+                if self.accel_1g_flag: passed += 1
+
+                if available >= 2 and passed >= 2 and passed >= (available - 1):
+                    self.alt_landed_flag = True
+
+        # TRKC.cpp:189 ─ GPS max altitude tracking (post-launch)
+        # CHANGED (2): no spike-reject window. The 100 m gate left
+        # Eagle Claw silently no-voting because GPS dropped out
+        # through boost and re-acquired at +500 m past the gate.
+        if new_gps and self.launch_flag:
+            self.gps_available_ = True
+            self.last_gps_time_ms_ = self._now_ms
+            self.max_gps_altitude_ = max(self.max_gps_altitude_, gps_altitude)
+
+        # Per-tick pass states default false (overwritten if apogee block runs).
+        self.last_vel_pass = False
+        self.last_baro_pass = False
+        self.last_pitch_pass = False
+        # last_gps_pass is only updated on new_gps ticks; keep prior value.
+
+        # TRKC.cpp:209 ─ Apogee detection
+        # CHANGED (3): added launch_flag gate (was burnout only).
+        if self.launch_flag and burnout_detected:
+            # ─ Test 1: Velocity (CHANGED (4): leaky counter) ─
+            vel_pass = position[2] > 15.0 and velocity[2] < 0.0
+            self.last_vel_pass = vel_pass
+            if vel_pass:
+                self.vel_apogee_count_ = min(APOGEE_COUNT_MAX,
+                                              self.vel_apogee_count_ + 1)
+            else:
+                self.vel_apogee_count_ = max(0, self.vel_apogee_count_ - 1)
+            if self.vel_apogee_count_ >= APOGEE_COUNT_HI:
+                self.vel_u_apogee_flag = True
+            elif self.vel_apogee_count_ == 0:
+                self.vel_u_apogee_flag = False
+
+            # ─ Test 2: Baro (CHANGED (4): leaky counter; same HI=6) ─
+            baro_pass = (self.alt_est > 15.0
+                         and self.alt_est < self.max_altitude - 5.0
+                         and self.d_alt_est_ < 20.0)
+            self.last_baro_pass = baro_pass
+            if baro_pass:
+                self.apogee_count = min(APOGEE_COUNT_MAX, self.apogee_count + 1)
+            else:
+                self.apogee_count = max(0, self.apogee_count - 1)
+            if self.apogee_count >= APOGEE_COUNT_HI:
+                self.alt_apogee_flag = True
+            elif self.apogee_count == 0:
+                self.alt_apogee_flag = False
+
+            # ─ Test 3: GPS (CHANGED (4): leaky counter; same HI=4) ─
+            if new_gps and self.gps_available_ and gps_altitude > 15.0:
+                gps_pass = gps_altitude < self.max_gps_altitude_ - 10.0
+                self.last_gps_pass = gps_pass
+                if gps_pass:
+                    self.gps_apogee_count_ = min(GPS_APOGEE_COUNT_MAX,
+                                                  self.gps_apogee_count_ + 1)
+                else:
+                    self.gps_apogee_count_ = max(0, self.gps_apogee_count_ - 1)
+                if self.gps_apogee_count_ >= GPS_APOGEE_COUNT_HI:
+                    self.gps_apogee_flag = True
+                elif self.gps_apogee_count_ == 0:
+                    self.gps_apogee_flag = False
+
+            # ─ Test 4: Pitch (CHANGED (4): leaky counter) ─
+            pitch_pass = pitch_rad < -0.087
+            self.last_pitch_pass = pitch_pass
+            if pitch_pass:
+                self.pitch_apogee_count_ = min(APOGEE_COUNT_MAX,
+                                                self.pitch_apogee_count_ + 1)
+            else:
+                self.pitch_apogee_count_ = max(0, self.pitch_apogee_count_ - 1)
+            if self.pitch_apogee_count_ >= APOGEE_COUNT_HI:
+                self.pitch_apogee_flag = True
+            elif self.pitch_apogee_count_ == 0:
+                self.pitch_apogee_flag = False
+
+            # N-1 of N voting (TRKC.cpp:264) — master still latches once true.
+            if not self.apogee_flag:
+                available = 0
+                passed = 0
+
+                available += 1
+                if self.vel_u_apogee_flag: passed += 1
+
+                if not baro_locked_out:
+                    available += 1
+                    if self.alt_apogee_flag: passed += 1
+
+                if (self.gps_available_
+                        and (self._now_ms - self.last_gps_time_ms_) < 5000):
+                    available += 1
+                    if self.gps_apogee_flag: passed += 1
+
+                available += 1
+                if self.pitch_apogee_flag: passed += 1
+
+                if available >= 2 and passed >= 2 and passed >= (available - 1):
+                    self.apogee_flag = True
+
+        # TRKC.cpp:302 ─ Pre-apogee max speed
+        speed = math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2)
+        if not self.apogee_flag and speed > self.max_speed:
+            self.max_speed = speed
+
+    # TRKC.cpp:328 ─ 1D CV Kalman filter (unchanged)
+    def _update_alt_kf(self, z_meas: float, new_measurement: bool) -> float:
+        now = self._now_ms
+        dt = 0.02
+        if self.kf_init_:
+            dms = now - self.last_ms_
+            dt = _constrain(dms * 0.001, 0.0005, 0.200)
+        self.last_ms_ = now
+
+        if not self.kf_init_:
+            self.alt_est = z_meas
+            self.d_alt_est_ = 0.0
+            self.kf_init_ = True
+            return self.alt_est
+
+        z_pred  = self.alt_est + self.d_alt_est_ * dt
+        vz_pred = self.d_alt_est_
+
+        F00, F01 = 1.0, dt
+        F10, F11 = 0.0, 1.0
+
+        P00p = F00*self.P00_ + F01*self.P10_
+        P01p = F00*self.P01_ + F01*self.P11_
+        P10p = F10*self.P00_ + F11*self.P10_
+        P11p = F10*self.P01_ + F11*self.P11_
+
+        P00pp = P00p*F00 + P01p*F01
+        P01pp = P00p*F10 + P01p*F11
+        P10pp = P10p*F00 + P11p*F01
+        P11pp = P10p*F10 + P11p*F11
+
+        P00pp += self.Qz_ * dt
+        P11pp += self.Qv_ * dt
+
+        if new_measurement:
+            S  = P00pp + self.R_
+            K0 = P00pp / S
+            K1 = P10pp / S
+
+            innov = z_meas - z_pred
+            self.alt_est    = z_pred  + K0 * innov
+            self.d_alt_est_ = vz_pred + K1 * innov
+
+            P00n = (1.0 - K0) * P00pp
+            P01n = (1.0 - K0) * P01pp
+            P10n = P10pp - K1 * P00pp
+            P11n = P11pp - K1 * P01pp
+
+            self.P00_ = P00n
+            self.P11_ = P11n
+            self.P01_ = 0.5 * (P01n + P10n)
+            self.P10_ = self.P01_
+        else:
+            self.alt_est    = z_pred
+            self.d_alt_est_ = vz_pred
+            self.P00_ = P00pp
+            self.P11_ = P11pp
+            self.P01_ = 0.5 * (P01pp + P10pp)
+            self.P10_ = self.P01_
+
+        return self.alt_est

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -153,8 +153,12 @@ TEST_F(KinematicChecksTest, Landing_StableAlt) {
     ASSERT_TRUE(kc.launch_flag);
     ASSERT_GT(kc.max_altitude, 15.0f);
 
-    // Now simulate landed: alt < 50, stable, low roll rate
-    // Landing needs 5 consecutive 1-second checks
+    // Landing voting is gated on apogee_flag (#166) — set it the same
+    // way Landing_FastPath_ImpactTriggers does.
+    kc.apogee_flag = true;
+
+    // Now simulate landed: alt < 50, stable, low roll rate, accel ~1g.
+    // Voting needs the slow detectors to accumulate over ~4 s.
     for (int second = 0; second < 7; second++) {
         uint32_t base = 1000 + second * 1000;
         // Call many times within each second (landing_check_dt = 1000ms)
@@ -230,6 +234,9 @@ TEST_F(KinematicChecksTest, Landing_RollRate15dps_StillPasses) {
     }
     ASSERT_TRUE(kc.launch_flag);
     ASSERT_GT(kc.max_altitude, 15.0f);
+
+    // Landing voting is gated on apogee_flag (#166).
+    kc.apogee_flag = true;
 
     for (int second = 0; second < 7; second++) {
         uint32_t base = 1000 + second * 1000;

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -11,6 +11,45 @@ constexpr float    LANDING_IMPACT_G       = 15.0f;
 constexpr float    LANDING_IMPACT_ALT_M   = 20.0f;
 constexpr uint16_t LANDING_IMPACT_COUNT   = 5;       // ~5 ms at 1 kHz
 constexpr float    G_MS2                  = 9.80665f;
+
+// Baro rate-gate (#166): rejects |Δpalt|/dt above any plausible rocket
+// dynamic. Self-scales with dt so legitimate large changes after a sensor
+// dropout still pass.  Ejection spikes are O(10-100 km/s), max plausible
+// rocket dynamic is ~200 m/s, so 300 m/s gives wide headroom both ways.
+constexpr float    MAX_BARO_RATE_MS         = 300.0f;
+// After this many consecutive rejects the gate accepts the next sample
+// unconditionally and reseeds, preventing a permanently wedged sensor
+// from blinding the detector for the rest of the flight.
+constexpr uint8_t  MAX_CONSEC_BARO_REJECTS  = 10;
+
+// Apogee sub-detector leaky-counter thresholds (#166).
+// Each test runs +1 on pass / -1 on miss (clamped) so a single false
+// positive can un-vote once conditions reverse, instead of latching for
+// the rest of the flight. HI thresholds preserve original first-fire
+// timing: ~6 ms at 1 kHz for baro/pitch/vel, ~800 ms at 5 Hz for GPS.
+constexpr uint8_t  APOGEE_COUNT_MAX         = 10;
+constexpr uint8_t  APOGEE_COUNT_HI          = 6;
+constexpr uint8_t  GPS_APOGEE_COUNT_MAX     = 8;
+constexpr uint8_t  GPS_APOGEE_COUNT_HI      = 4;
+
+// Landing slow-detector hysteresis (#166). Slow detectors evaluate inside
+// the 1 Hz landing_check_dt gate, so HI=4 → 4 s to fire (matches the
+// original ``landing_checks > 4`` first-fire timing).
+constexpr uint8_t  LANDING_SLOW_COUNT_MAX   = 8;
+constexpr uint8_t  LANDING_SLOW_COUNT_HI    = 4;
+
+// Landing sub-detector thresholds.
+// Lower bound is -50 m, not 0, because ground-pressure drift across a
+// 60-90 s flight can leave a settled palt several m below the pre-launch
+// reference (Roly Poly GTV 5/9 settled at palt ≈ -8 m). The rate-gate
+// upstream filters deep spikes, so this is just a defensive backstop.
+constexpr float    BARO_STABLE_PALT_MIN     = -50.0f;
+constexpr float    BARO_STABLE_PALT_MAX     = 50.0f;
+constexpr float    BARO_STABLE_DELTA_MAX    = 2.0f;     // |Δpalt| over 1 s
+constexpr float    BARO_STABLE_MAX_ALT_MIN  = 15.0f;    // rocket must have flown
+constexpr float    GYRO_QUIET_DPS           = 20.0f;
+constexpr float    GPS_STATIONARY_SPEED_MS  = 1.0f;     // EKF speed proxy
+constexpr float    ACCEL_1G_TOLERANCE_MS2   = 2.94f;    // ≈ 0.3 g
 }
 
 TR_KinematicChecks::TR_KinematicChecks()
@@ -29,12 +68,26 @@ TR_KinematicChecks::TR_KinematicChecks()
     landing_look_back_alt = 0.0;
     landing_check_dt = 1000;
     apogee_count = 0;
-    landing_checks = 0;
+    vel_apogee_count_ = 0;
+    pitch_apogee_count_ = 0;
     impact_seen_count = 0;
+    impact_flag = false;
+    baro_stable_flag = false;
+    gyro_quiet_flag = false;
+    gps_stationary_flag = false;
+    accel_1g_flag = false;
+    baro_stable_count_ = 0;
+    gyro_quiet_count_ = 0;
+    gps_stationary_count_ = 0;
+    accel_1g_count_ = 0;
     max_gps_altitude_ = 0.0f;
     gps_apogee_count_ = 0;
     gps_available_ = false;
     last_gps_time_ms_ = 0;
+    baro_gate_init_ = false;
+    palt_accepted_ = 0.0f;
+    last_baro_gate_ms_ = 0;
+    consec_baro_rejects_ = 0;
 
     // KF init
     kf_init_ = false;
@@ -70,12 +123,26 @@ void TR_KinematicChecks::reset()
     landing_check_time = 0;
     landing_look_back_alt = 0.0;
     apogee_count = 0;
-    landing_checks = 0;
+    vel_apogee_count_ = 0;
+    pitch_apogee_count_ = 0;
     impact_seen_count = 0;
+    impact_flag = false;
+    baro_stable_flag = false;
+    gyro_quiet_flag = false;
+    gps_stationary_flag = false;
+    accel_1g_flag = false;
+    baro_stable_count_ = 0;
+    gyro_quiet_count_ = 0;
+    gps_stationary_count_ = 0;
+    accel_1g_count_ = 0;
     max_gps_altitude_ = 0.0f;
     gps_apogee_count_ = 0;
     gps_available_ = false;
     last_gps_time_ms_ = 0;
+    baro_gate_init_ = false;
+    palt_accepted_ = 0.0f;
+    last_baro_gate_ms_ = 0;
+    consec_baro_rejects_ = 0;
     kf_init_ = false;
     alt_est = 0.0f;
     d_alt_est_ = 0.0f;
@@ -95,6 +162,45 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                                          bool  burnout_detected,
                                          bool  baro_locked_out)
 {
+
+    // ### Baro rate-gate (#166) ###
+    // Reject obvious spikes (ejection charges, sensor glitches) before they
+    // poison the KF or trip the landing fast path.  The rate test self-scales
+    // with dt so a single missed sample doesn't make the next legitimate
+    // reading look like a spike.  After MAX_CONSEC_BARO_REJECTS in a row the
+    // next sample is accepted unconditionally so a wedged sensor reseeds.
+    if (new_baro)
+    {
+        if (baro_gate_init_)
+        {
+            uint32_t dms = millis() - last_baro_gate_ms_;
+            float dt = (dms < 1u) ? 0.001f : (dms * 0.001f);
+            float rate = fabs(pressure_altitude - palt_accepted_) / dt;
+            if (rate > MAX_BARO_RATE_MS &&
+                consec_baro_rejects_ < MAX_CONSEC_BARO_REJECTS)
+            {
+                consec_baro_rejects_++;
+                new_baro = false;
+                pressure_altitude = palt_accepted_;
+            }
+            else
+            {
+                consec_baro_rejects_ = 0;
+                palt_accepted_ = pressure_altitude;
+                last_baro_gate_ms_ = millis();
+            }
+        }
+        else
+        {
+            palt_accepted_ = pressure_altitude;
+            last_baro_gate_ms_ = millis();
+            baro_gate_init_ = true;
+        }
+    }
+    else if (baro_gate_init_)
+    {
+        pressure_altitude = palt_accepted_;
+    }
 
     // ### Altitude ###
 
@@ -134,51 +240,29 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         max_altitude = std::max(max_altitude, alt_est);
     }
 
-    // ### Check for Landing ###
+    // ================================================================
+    // ### Landing Detection: 5 sub-detectors + N-1 voting (#166) ###
+    // Fast path (impact) fires master immediately on unambiguous high-G
+    // ground contact.  Slow path requires 3 of the 4 settle-state
+    // detectors (Baro-stable, Gyro-quiet, GPS-stationary, Accel-1g) to
+    // agree — independent signals so a single noise source can't drive
+    // a false landed.  Master ``alt_landed_flag`` latches once true.
+    // ================================================================
 
-    if (millis() > landing_check_time + landing_check_dt)
-    {
-        float landing_altitude_change = fabs(pressure_altitude - landing_look_back_alt);
-        landing_look_back_alt = pressure_altitude;
-        landing_check_time = millis();
-
-        // Checking landing declaration criteria.
-        // roll_rate threshold: 20 dps tolerates wind-induced body roll on a
-        // landed rocket (RolyPoly 5/3/26 saw 5-22 dps wobbles post-touchdown);
-        // anything below 50 dps is clearly not in flight.
-        if (pressure_altitude < 50.0      // Low current altitude
-         && landing_altitude_change < 2.0 // Less than 2 m change
-         && max_altitude > 15.0           // Max altitude was more than 15 m
-         && fabs(roll_rate) < 20.0)       // Gyro is stable (no longer in flight)
-        {
-            landing_checks++;
-        }
-        else
-        {
-            landing_checks = 0;
-        }
-        // Once the criteria is true for multiple times in a row
-        // indicate we have landed (5 consecutive 1-second checks = 5s)
-        if (landing_checks > 4)
-        {
-            alt_landed_flag = true;
-        }
-    }
-
-    // ### Impact-detected fast path ###
-    // High-energy ground impact is unambiguous: descent tumbling tops out
-    // around 12 g, and a hard landing is several hundred g for ~100 ms.
-    // This runs every call (gyro rate, ~1 kHz) so we don't have to wait
-    // 5 s for the slow path to accumulate when impact already gave us a
-    // definitive ground signal. See issue #113.
+    // --- Fast path: high-G impact, gated on apogee + ground proximity.
+    // The baro rate-gate upstream already filters glitch spikes, but the
+    // defensive ``palt > -10`` lower bound mirrors the gate's intent so
+    // this path is robust even if the gate is bypassed in future.
+    // One-shot latch — impact_flag stays true once a real impact fires.
     if (apogee_flag
+     && pressure_altitude > -10.0f
      && pressure_altitude < LANDING_IMPACT_ALT_M
      && acc_mag > LANDING_IMPACT_G * G_MS2)
     {
         impact_seen_count++;
         if (impact_seen_count >= LANDING_IMPACT_COUNT)
         {
-            alt_landed_flag = true;
+            impact_flag = true;
         }
     }
     else
@@ -186,80 +270,168 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         impact_seen_count = 0;
     }
 
+    // --- Slow detectors: evaluated at 1 Hz inside the existing time gate.
+    if (millis() > landing_check_time + landing_check_dt)
+    {
+        float landing_altitude_change = fabs(pressure_altitude - landing_look_back_alt);
+        landing_look_back_alt = pressure_altitude;
+        landing_check_time = millis();
+
+        // Sub 1: Baro-stable (was the original slow path; +lower bound)
+        const bool baro_stable_pass = (pressure_altitude >= BARO_STABLE_PALT_MIN
+                                       && pressure_altitude <= BARO_STABLE_PALT_MAX
+                                       && landing_altitude_change < BARO_STABLE_DELTA_MAX
+                                       && max_altitude > BARO_STABLE_MAX_ALT_MIN);
+        if (baro_stable_pass) {
+            if (baro_stable_count_ < LANDING_SLOW_COUNT_MAX) baro_stable_count_++;
+        } else {
+            if (baro_stable_count_ > 0) baro_stable_count_--;
+        }
+        if (baro_stable_count_ >= LANDING_SLOW_COUNT_HI) baro_stable_flag = true;
+        else if (baro_stable_count_ == 0)                baro_stable_flag = false;
+
+        // Sub 2: Gyro-quiet — roll_rate (future: generalize to all axes).
+        const bool gyro_quiet_pass = (fabs(roll_rate) < GYRO_QUIET_DPS);
+        if (gyro_quiet_pass) {
+            if (gyro_quiet_count_ < LANDING_SLOW_COUNT_MAX) gyro_quiet_count_++;
+        } else {
+            if (gyro_quiet_count_ > 0) gyro_quiet_count_--;
+        }
+        if (gyro_quiet_count_ >= LANDING_SLOW_COUNT_HI) gyro_quiet_flag = true;
+        else if (gyro_quiet_count_ == 0)                gyro_quiet_flag = false;
+
+        // Sub 3: GPS-stationary — EKF speed proxy; excluded if GPS stale.
+        if (gps_available_ && (millis() - last_gps_time_ms_) < 5000)
+        {
+            const float speed = sqrt(velocity[0]*velocity[0] +
+                                     velocity[1]*velocity[1] +
+                                     velocity[2]*velocity[2]);
+            const bool gps_stationary_pass = (speed < GPS_STATIONARY_SPEED_MS);
+            if (gps_stationary_pass) {
+                if (gps_stationary_count_ < LANDING_SLOW_COUNT_MAX) gps_stationary_count_++;
+            } else {
+                if (gps_stationary_count_ > 0) gps_stationary_count_--;
+            }
+            if (gps_stationary_count_ >= LANDING_SLOW_COUNT_HI) gps_stationary_flag = true;
+            else if (gps_stationary_count_ == 0)                gps_stationary_flag = false;
+        }
+
+        // Sub 4: Accel-1g floor.
+        const bool accel_1g_pass = (fabs(acc_mag - G_MS2) < ACCEL_1G_TOLERANCE_MS2);
+        if (accel_1g_pass) {
+            if (accel_1g_count_ < LANDING_SLOW_COUNT_MAX) accel_1g_count_++;
+        } else {
+            if (accel_1g_count_ > 0) accel_1g_count_--;
+        }
+        if (accel_1g_count_ >= LANDING_SLOW_COUNT_HI) accel_1g_flag = true;
+        else if (accel_1g_count_ == 0)                accel_1g_flag = false;
+    }
+
+    // --- Voting: impact alone fires; otherwise N-1 of N over slow flags.
+    // Gated on apogee_flag — a static rocket on the pad trips gyro_quiet,
+    // gps_stationary, and accel_1g (3 of 4 votes), which would otherwise
+    // fire landed pre-flight (caught on bench 2026-05-18).
+    if (!alt_landed_flag && apogee_flag)
+    {
+        if (impact_flag)
+        {
+            alt_landed_flag = true;
+        }
+        else
+        {
+            uint8_t available = 0;
+            uint8_t passed = 0;
+
+            available++; if (baro_stable_flag) passed++;
+            available++; if (gyro_quiet_flag)  passed++;
+            if (gps_available_ && (millis() - last_gps_time_ms_) < 5000)
+            {
+                available++; if (gps_stationary_flag) passed++;
+            }
+            available++; if (accel_1g_flag) passed++;
+
+            if (available >= 2 && passed >= 2 && passed >= (available - 1))
+            {
+                alt_landed_flag = true;
+            }
+        }
+    }
+
     // ### GPS altitude tracking ###
     // Track max GPS altitude from launch onwards (raw MSL — relative
     // tracking means absolute value doesn't matter).
+    // #166: the 100 m spike-reject window was removed.  On big flights where
+    // GPS lost lock through boost (Eagle Claw 5/17/26), the post-recovery
+    // sample legitimately differs from the pad fix by hundreds of metres,
+    // and the gate permanently rejected those updates — leaving the GPS
+    // apogee detector silent for the entire flight.  Boost-phase dropout is
+    // common, so the gate did more harm than good.
     if (new_gps && launch_flag)
     {
         gps_available_ = true;
         last_gps_time_ms_ = millis();
-
-        // Spike rejection: 100m window (wider than baro's 50m for GPS noise)
-        if (max_gps_altitude_ == 0.0f ||
-            fabs(gps_altitude - max_gps_altitude_) < 100.0f) {
-            max_gps_altitude_ = fmax(max_gps_altitude_, gps_altitude);
-        }
+        max_gps_altitude_ = fmax(max_gps_altitude_, gps_altitude);
     }
 
     // ================================================================
-    // ### Apogee Detection (gated on burnout) ###
-    // Four independent tests with N-1 of N voting.
-    // No apogee flag can latch before motor burnout is confirmed.
+    // ### Apogee Detection (gated on launch + burnout) ###
+    // Four independent tests, each a leaky counter with hysteresis so a
+    // single bad sample (EKF wobble, baro glitch, momentary attitude
+    // excursion) doesn't latch a vote for the rest of the flight (#166).
+    // N-1 of N voting on the sub-flags; master apogee_flag still latches
+    // once true.
     // ================================================================
-    if (burnout_detected)
+    if (launch_flag && burnout_detected)
     {
         // --- Test 1: Velocity (EKF vertical velocity negative) ---
-        if (launch_flag && position[2] > 15.0f && velocity[2] < 0.0f)
-        {
-            vel_u_apogee_flag = true;
+        const bool vel_pass = (position[2] > 15.0f && velocity[2] < 0.0f);
+        if (vel_pass) {
+            if (vel_apogee_count_ < APOGEE_COUNT_MAX) vel_apogee_count_++;
+        } else {
+            if (vel_apogee_count_ > 0) vel_apogee_count_--;
         }
+        if (vel_apogee_count_ >= APOGEE_COUNT_HI)      vel_u_apogee_flag = true;
+        else if (vel_apogee_count_ == 0)               vel_u_apogee_flag = false;
 
         // --- Test 2: Baro altitude (filtered altitude decreasing) ---
         // Uses KF-smoothed alt_est rather than raw pressure_altitude — boost
         // noise on the raw signal was previously tripping this test during
-        // ascent (#142).  Velocity gate (d_alt_est_ < 20 m/s) keeps the
-        // counter at 0 across the whole boost-coast band where vertical
-        // velocity is far above the apogee neighborhood, regardless of any
-        // remaining noise on the filtered altitude.
-        if (alt_est > 15.0f &&
-            alt_est < max_altitude - 5.0f &&
-            d_alt_est_ < 20.0f)
-        {
-            apogee_count++;
+        // ascent (#142). Velocity gate (d_alt_est_ < 20 m/s) is preserved.
+        const bool baro_pass = (alt_est > 15.0f &&
+                                alt_est < max_altitude - 5.0f &&
+                                d_alt_est_ < 20.0f);
+        if (baro_pass) {
+            if (apogee_count < APOGEE_COUNT_MAX) apogee_count++;
+        } else {
+            if (apogee_count > 0) apogee_count--;
         }
-        else
-        {
-            apogee_count = 0;
-        }
-        if (apogee_count > 5)
-        {
-            alt_apogee_flag = true;
-        }
+        if (apogee_count >= APOGEE_COUNT_HI)            alt_apogee_flag = true;
+        else if (apogee_count == 0)                     alt_apogee_flag = false;
 
         // --- Test 3: GPS altitude (GPS altitude decreasing) ---
         if (new_gps && gps_available_ && gps_altitude > 15.0f)
         {
-            if (gps_altitude < max_gps_altitude_ - 10.0f)
-            {
-                gps_apogee_count_++;
+            const bool gps_pass = (gps_altitude < max_gps_altitude_ - 10.0f);
+            if (gps_pass) {
+                if (gps_apogee_count_ < GPS_APOGEE_COUNT_MAX) gps_apogee_count_++;
+            } else {
+                if (gps_apogee_count_ > 0) gps_apogee_count_--;
             }
-            else
-            {
-                gps_apogee_count_ = 0;
-            }
-            if (gps_apogee_count_ > 3)
-            {
-                gps_apogee_flag = true;
-            }
+            if (gps_apogee_count_ >= GPS_APOGEE_COUNT_HI) gps_apogee_flag = true;
+            else if (gps_apogee_count_ == 0)              gps_apogee_flag = false;
         }
 
         // --- Test 4: Pitch below horizontal ---
         // NED convention: +90° = nose up, 0° = horizontal, negative = past horizontal.
         // -5° threshold avoids false trigger from coast oscillation.
-        if (pitch_rad < -0.087f)
-        {
-            pitch_apogee_flag = true;
+        const bool pitch_pass = (pitch_rad < -0.087f);
+        if (pitch_pass) {
+            if (pitch_apogee_count_ < APOGEE_COUNT_MAX) pitch_apogee_count_++;
+        } else {
+            if (pitch_apogee_count_ > 0) pitch_apogee_count_--;
         }
+        if (pitch_apogee_count_ >= APOGEE_COUNT_HI)     pitch_apogee_flag = true;
+        else if (pitch_apogee_count_ == 0)              pitch_apogee_flag = false;
 
         // --- Dynamic N-1 of N voting ---
         if (!apogee_flag)

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -26,12 +26,18 @@ public:
                          bool  baro_locked_out = false);
 
     bool launch_flag;
-    bool alt_landed_flag;
+    bool alt_landed_flag;       // Voted master landed
     bool alt_apogee_flag;       // Test 2: baro altitude decreasing
     bool vel_u_apogee_flag;     // Test 1: EKF velocity negative
     bool gps_apogee_flag;       // Test 3: GPS altitude decreasing
     bool pitch_apogee_flag;     // Test 4: pitch below horizontal
     bool apogee_flag;           // Combined voted result
+    // Landing sub-detector flags (#166) — exposed for diagnostics/logging.
+    bool impact_flag;           // High-G ground impact (one-shot latch)
+    bool baro_stable_flag;      // palt low and stable
+    bool gyro_quiet_flag;       // roll-rate quiescent
+    bool gps_stationary_flag;   // EKF speed near zero (GPS fresh)
+    bool accel_1g_flag;         // acc_mag near 1 g
     float max_altitude;
     float max_speed;
     float alt_est;    // Filtered altitude (m)
@@ -43,15 +49,28 @@ private:
     uint32_t landing_check_time;
     float landing_look_back_alt;
     uint32_t landing_check_dt;
-    uint8_t apogee_count;
-    uint16_t landing_checks;
+    uint8_t apogee_count;          // baro apogee leaky counter
+    uint8_t vel_apogee_count_;     // velocity apogee leaky counter
+    uint8_t pitch_apogee_count_;   // pitch apogee leaky counter
     uint16_t impact_seen_count;
+    // Landing sub-detector leaky counters (#166).
+    uint8_t baro_stable_count_;
+    uint8_t gyro_quiet_count_;
+    uint8_t gps_stationary_count_;
+    uint8_t accel_1g_count_;
 
     // GPS apogee test state
     float max_gps_altitude_;
     uint8_t gps_apogee_count_;
     bool gps_available_;
     uint32_t last_gps_time_ms_;
+
+    // Baro rate-gate state (rejects ejection / sensor spikes before they
+    // reach the KF or the landing fast path).
+    bool     baro_gate_init_;
+    float    palt_accepted_;
+    uint32_t last_baro_gate_ms_;
+    uint8_t  consec_baro_rejects_;
     
     // 1D CV Kalman filter for altitude & rate
     bool kf_init_;


### PR DESCRIPTION
## Summary

Fixes the apogee + landing detection bugs surfaced by the 5/17/26 flight data ([#166](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/166)). Four apogee sub-detectors and five landing sub-detectors, each a leaky-counter with hysteresis so a single false-positive sample doesn't latch a stale vote for the rest of the flight. N-1 of N voting on both sides; master flags still latch once true.

**Apogee changes:**
- Baro rate-gate at ingestion (`|Δpalt|/dt > 300 m/s` → reject; consecutive-reject reseed valve). Self-scales with `dt` so dropouts still pass. Filters ejection spikes (O(10–100 km/s)) without touching real rocket dynamics (max ~200 m/s).
- GPS `max_gps_altitude_` spike-reject window removed — Eagle Claw 5/17 lost GPS through boost and re-acquired at +500 m, which the 100 m gate permanently rejected.
- Apogee block now gated on `launch_flag && burnout_detected` (was burnout only).
- Sub-detectors (Vel, Baro, GPS, Pitch) converted to leaky-counter hysteresis. HI thresholds preserve original first-fire timing.

**Landing changes (new 5-detector voting):**
- Impact one-shot (apogee + ground proximity + 15 g) still fires master immediately for unambiguous hard landings.
- Slow detectors at 1 Hz: **Baro-stable**, **Gyro-quiet**, **GPS-stationary**, **Accel-1g**.
- Master = `impact OR (N-1 of N voting)`; voting gated on `apogee_flag` (a static rocket on the pad trips 3 of 4 slow detectors — caught on bench).
- Baro-stable lower bound is −50 m (not 0) to accept normal post-flight ground-pressure drift; rate-gate upstream filters deep spikes.

**Tooling added** (`Data_Analysis/`):
- `sim_kinematic_checks.py` — 1:1 Python mirror of `TR_KinematicChecks.{h,cpp}` with line-ref comments. Keep in sync when changing detection logic.
- `replay_kinematic_checks.py` — driver that parses a flight `.bin`, feeds the sim, compares to logged firmware flags. Useful for iterating logic changes against the back-catalog of real flights before flashing.

## Validation

Sim matches firmware to within ms on every flag across 11 binaries (1 bench + 5/3 + 5/9 + 5/17). Headline results:

| Flight                         | Apogee Δ vs logged | Landing change |
|--------------------------------|--------------------|----------------|
| Bench 5/18 (201 m)             | −2 ms              | sim 52.06 ↔ fw 52.02 |
| 5/3 RIM-66 (132 m)             | n/a (legacy log)   | impact 25.29 s (was 31.12 s, old slow path) |
| 5/3 RolyPoly (271 m)           | n/a (legacy log)   | impact 28.64 s (was 34.60 s, old slow path) |
| 5/9 Journey 75 (339 m)         | n/a (legacy log)   | 36.52 ↔ 36.52 |
| 5/9 Roly Poly GTV (#142)       | apogee 11.43 s (was 2.88 s false) | 87.28 ↔ 82.75 |
| 5/17 Eagle Claw (499 m)        | +5 ms              | no fire (was 15.06 s false; rocket still in motion at log end) |
| 5/17 V2 (93 m)                 | +6 ms              | 17.11 s (was 7.65 s false; real slow path) |
| 5/17 RollyPolly (87 m)         | +4 ms              | no fire (was 7.22 s false; rocket still in motion) |
| 5/17 RIM-66 (727 m)            | +6 ms              | settle at log edge |

The 5/9 Roly Poly GTV is the original [#142](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/142) boost-phase Baro false-positive — that bug is eliminated. All three 5/17 landing false-trips (Eagle Claw, V2, RollyPolly) are eliminated. Both 5/3 landings fire ~6 s earlier than the old slow path via the impact one-shot.

## Test plan

- [x] `idf.py build` clean on FC firmware (local — FC is excluded from CI's firmware-build matrix). Binary size 0x86e20 (+560 bytes vs main).
- [x] Sim replay matches logged firmware on all 11 binaries within ms.
- [x] Bench test on real hardware (`flight_20260518_211535`, 201 m flight): apogee at 10.23 s, landed at 52.02 s, INFLIGHT→LANDED state transition at 54.02 s, no pre-flight misfire.
- [ ] Wait for CI.

Closes [#166](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/166).
