### PR TITLE
Per-rocket settings profiles + grouped settings UI (#132)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -35,8 +35,9 @@ final class ActiveRocketSyncer: ObservableObject {
         case failed(String)
     }
 
-    /// Mag cal is tied to a physical board, so it can't be blindly pushed.
-    enum MagCalAdvisory: Equatable {
+    /// Calibration is tied to a physical board, so it can't be blindly pushed.
+    /// Shared by mag cal and sensor cal.
+    enum CalAdvisory: Equatable {
         case none
         case missing                                   // no cal anywhere — run calibration
         case boardMismatch(savedOn: String, current: String)  // profile cal is for another board
@@ -44,7 +45,8 @@ final class ActiveRocketSyncer: ObservableObject {
     }
 
     @Published private(set) var syncState: SyncState = .idle
-    @Published private(set) var magCalAdvisory: MagCalAdvisory = .none
+    @Published private(set) var magCalAdvisory: CalAdvisory = .none
+    @Published private(set) var sensorCalAdvisory: CalAdvisory = .none
     /// A profile previously flown on the just-connected board, offered as a
     /// soft switch suggestion.  The user always confirms — never auto-applied.
     @Published private(set) var suggestedProfileId: UUID?
@@ -53,6 +55,7 @@ final class ActiveRocketSyncer: ObservableObject {
     private weak var store: RocketProfileStore?
     private var cancellables = Set<AnyCancellable>()
     private var magCalReadPending = false
+    private var sensorCalReadPending = false
 
     // MARK: - Lifecycle
 
@@ -79,11 +82,17 @@ final class ActiveRocketSyncer: ObservableObject {
             .sink { [weak self] _ in self?.onReadyToSync() }
             .store(in: &cancellables)
 
-        // Connect-time mag-cal READ reply (only honoured right after we ask).
+        // Connect-time cal READ replies (only honoured right after we ask).
         device.$magCalStatus
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in self?.handleMagCalStatus(status) }
+            .store(in: &cancellables)
+
+        device.$sensorCalStatus
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in self?.handleSensorCalStatus(status) }
             .store(in: &cancellables)
 
         // Re-push when the user switches the active profile mid-connection.
@@ -100,8 +109,10 @@ final class ActiveRocketSyncer: ObservableObject {
         device = nil
         store = nil
         magCalReadPending = false
+        sensorCalReadPending = false
         syncState = .idle
         magCalAdvisory = .none
+        sensorCalAdvisory = .none
         suggestedProfileId = nil
     }
 
@@ -157,6 +168,7 @@ final class ActiveRocketSyncer: ObservableObject {
             ch2Value: profile.pyro2TriggerValue)
 
         syncMagCal(profile: profile, device: device)
+        syncSensorCal(profile: profile, device: device)
 
         // Record which board this profile last flew on (soft pre-select).
         store.update(profile.id) { $0.lastUsedUnitID = device.unitID }
@@ -226,6 +238,55 @@ final class ActiveRocketSyncer: ObservableObject {
         magCalAdvisory = .none
     }
 
+    // MARK: - Sensor cal (gyro + high-g) — mirrors mag cal
+
+    enum SensorCalSyncAction: Equatable {
+        case push(SensorCalData)
+        case warnMismatch(savedOn: String, current: String)
+        case readRocket
+    }
+
+    static func sensorCalSyncAction(profileCal: SensorCalData?,
+                                    deviceUnitID: String) -> SensorCalSyncAction {
+        guard let cal = profileCal else { return .readRocket }
+        if cal.calibratedOnUnitID == deviceUnitID {
+            return .push(cal)
+        }
+        return .warnMismatch(savedOn: cal.calibratedOnUnitID, current: deviceUnitID)
+    }
+
+    private func syncSensorCal(profile: RocketProfile, device: BLEDevice) {
+        switch Self.sensorCalSyncAction(profileCal: profile.sensorCal,
+                                        deviceUnitID: device.unitID) {
+        case .push(let cal):
+            sensorCalAdvisory = .none
+            device.sendSensorCalApply(gyroX: cal.gyroX, gyroY: cal.gyroY, gyroZ: cal.gyroZ,
+                                      hgX: cal.hgX, hgY: cal.hgY, hgZ: cal.hgZ)
+        case .warnMismatch(let savedOn, let current):
+            sensorCalAdvisory = .boardMismatch(savedOn: savedOn, current: current)
+        case .readRocket:
+            sensorCalReadPending = true
+            device.sendSensorCalRead()
+        }
+    }
+
+    private func handleSensorCalStatus(_ status: SensorCalStatus) {
+        guard sensorCalReadPending else { return }
+        sensorCalReadPending = false
+        sensorCalAdvisory = status.valid ? .rocketHasUnsavedCal : .missing
+    }
+
+    func importRocketSensorCalIntoActiveProfile() {
+        guard let device, let store,
+              let profile = store.activeProfile,
+              let status = device.sensorCalStatus, status.valid
+        else { return }
+        store.update(profile.id) {
+            $0.sensorCal = SensorCalData(status: status, unitID: device.unitID)
+        }
+        sensorCalAdvisory = .none
+    }
+
     // MARK: - Suggestion
 
     private func computeSuggestion() {
@@ -252,6 +313,21 @@ extension MagCalData {
                   offsetZ: status.offsetZ,
                   fieldR_uT: status.fieldR_uT,
                   residualUT: status.residualUT,
+                  calibratedOnUnitID: unitID,
+                  calibratedAt: Date())
+    }
+}
+
+extension SensorCalData {
+    /// Snapshot a sensor cal readback into a savable profile cal, tagged with
+    /// the board it was captured on.
+    init(status: SensorCalStatus, unitID: String) {
+        self.init(gyroX: status.gyroX,
+                  gyroY: status.gyroY,
+                  gyroZ: status.gyroZ,
+                  hgX: status.hgX,
+                  hgY: status.hgY,
+                  hgZ: status.hgZ,
                   calibratedOnUnitID: unitID,
                   calibratedAt: Date())
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -1,0 +1,258 @@
+//
+//  ActiveRocketSyncer.swift
+//  TinkerRocketApp
+//
+//  Pushes the active rocket profile to the connected flight computer
+//  (issue #132).  The app is source-of-truth: on connect we push the whole
+//  active profile so the rocket always flies the profile's settings, never
+//  whatever happened to be in its NVS.  This is what fixes the
+//  "flew the wrong rocket's settings" problem.
+//
+//  Lifecycle: the dashboard calls attach(device:store:) when a rocket
+//  connects and detach() on disconnect.  While attached, the syncer also
+//  re-pushes when the user switches the active profile, and surfaces a
+//  mag-cal advisory (cal is board-specific — see MagCalData).
+//
+//  Why push the whole profile instead of diffing field-by-field: the config
+//  readback doesn't echo every field (servo biases 2-4, roll waypoints, and
+//  sounds aren't in it), so a reliable diff isn't possible.  Connects are
+//  infrequent (once per flying session), so a handful of idempotent writes
+//  is cheaper than the bugs a partial diff would invite.  Edits made while
+//  disconnected are saved to the profile and ride out on the next connect —
+//  that is the "offline queue" the design called for, for free.
+//
+
+import Foundation
+import Combine
+
+final class ActiveRocketSyncer: ObservableObject {
+
+    enum SyncState: Equatable {
+        case idle              // not connected, or base station
+        case noProfile         // connected to a rocket but no active profile
+        case syncing
+        case synced
+        case failed(String)
+    }
+
+    /// Mag cal is tied to a physical board, so it can't be blindly pushed.
+    enum MagCalAdvisory: Equatable {
+        case none
+        case missing                                   // no cal anywhere — run calibration
+        case boardMismatch(savedOn: String, current: String)  // profile cal is for another board
+        case rocketHasUnsavedCal                       // rocket carries a cal the profile doesn't
+    }
+
+    @Published private(set) var syncState: SyncState = .idle
+    @Published private(set) var magCalAdvisory: MagCalAdvisory = .none
+    /// A profile previously flown on the just-connected board, offered as a
+    /// soft switch suggestion.  The user always confirms — never auto-applied.
+    @Published private(set) var suggestedProfileId: UUID?
+
+    private weak var device: BLEDevice?
+    private weak var store: RocketProfileStore?
+    private var cancellables = Set<AnyCancellable>()
+    private var magCalReadPending = false
+
+    // MARK: - Lifecycle
+
+    func attach(device: BLEDevice, store: RocketProfileStore) {
+        detach()
+        self.device = device
+        self.store = store
+
+        guard !device.isBaseStation else {
+            // Base station is a read-only display of the active rocket; it
+            // never receives a profile push.
+            syncState = .idle
+            return
+        }
+
+        // Sync once, when the first config readback AND the hardware id are
+        // both in hand.  unitID arrives in a later readback message than the
+        // main config, and we need it for the mag-cal board check + the
+        // last-used binding, so wait for both.
+        device.$rocketConfig.combineLatest(device.$unitID)
+            .filter { cfg, uid in cfg != nil && !uid.isEmpty }
+            .first()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.onReadyToSync() }
+            .store(in: &cancellables)
+
+        // Connect-time mag-cal READ reply (only honoured right after we ask).
+        device.$magCalStatus
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in self?.handleMagCalStatus(status) }
+            .store(in: &cancellables)
+
+        // Re-push when the user switches the active profile mid-connection.
+        store.$activeId
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.handleActiveProfileSwitch() }
+            .store(in: &cancellables)
+    }
+
+    func detach() {
+        cancellables.removeAll()
+        device = nil
+        store = nil
+        magCalReadPending = false
+        syncState = .idle
+        magCalAdvisory = .none
+        suggestedProfileId = nil
+    }
+
+    // MARK: - Triggers
+
+    private func onReadyToSync() {
+        guard let device, !device.isBaseStation else { return }
+        computeSuggestion()
+        performSync()
+    }
+
+    private func handleActiveProfileSwitch() {
+        guard let device, device.isConnected, !device.isBaseStation else { return }
+        suggestedProfileId = nil   // user has chosen; drop the hint
+        performSync()
+    }
+
+    // MARK: - Sync
+
+    private func performSync() {
+        guard let device, let store, device.isConnected else {
+            syncState = .idle
+            return
+        }
+        guard let profile = store.activeProfile else {
+            syncState = .noProfile
+            return
+        }
+
+        syncState = .syncing
+
+        device.sendServoConfig(
+            biases: [profile.servoBias1, profile.servoBias2,
+                     profile.servoBias3, profile.servoBias4],
+            hz: profile.servoHz, minUs: profile.servoMinUs, maxUs: profile.servoMaxUs)
+        device.sendPIDConfig(
+            kp: profile.pidKp, ki: profile.pidKi, kd: profile.pidKd,
+            minCmd: profile.pidMinCmd, maxCmd: profile.pidMaxCmd)
+        device.sendServoControlConfig(enabled: profile.servoControlEnabled)
+        device.sendGainScheduleConfig(enabled: profile.gainScheduleEnabled)
+        device.sendRollControlConfig(useAngleControl: profile.useAngleControl,
+                                     rollDelayMs: profile.rollDelayMs)
+        device.sendRollProfile(waypoints: profile.rollWaypoints.map {
+            (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
+        })
+        device.sendGuidanceConfig(enabled: profile.guidanceEnabled)
+        device.sendCameraConfig(cameraType: profile.cameraType)
+        device.sendSoundConfig(enabled: profile.soundsEnabled)
+        device.sendPyroConfig(
+            ch1Enabled: profile.pyro1Enabled, ch1Mode: profile.pyro1TriggerMode,
+            ch1Value: profile.pyro1TriggerValue,
+            ch2Enabled: profile.pyro2Enabled, ch2Mode: profile.pyro2TriggerMode,
+            ch2Value: profile.pyro2TriggerValue)
+
+        syncMagCal(profile: profile, device: device)
+
+        // Record which board this profile last flew on (soft pre-select).
+        store.update(profile.id) { $0.lastUsedUnitID = device.unitID }
+
+        // Optimistic, like the rest of the app's config writes (no per-command
+        // ack on this link).  Hold "syncing" briefly so the badge is visible.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            guard let self, case .syncing = self.syncState else { return }
+            self.syncState = .synced
+        }
+    }
+
+    // MARK: - Mag cal
+
+    /// What to do with mag cal on connect, given the active profile's cal and
+    /// the connected board's id.  Pure so it can be unit-tested without a
+    /// peripheral (mirrors BLEDevice.autoApplyRefusalReason).
+    enum MagCalSyncAction: Equatable {
+        case push(MagCalData)                           // profile cal matches this board
+        case warnMismatch(savedOn: String, current: String)  // cal is for another board
+        case readRocket                                 // profile has none — query the rocket
+    }
+
+    static func magCalSyncAction(profileCal: MagCalData?,
+                                 deviceUnitID: String) -> MagCalSyncAction {
+        guard let cal = profileCal else { return .readRocket }
+        if cal.calibratedOnUnitID == deviceUnitID {
+            return .push(cal)
+        }
+        return .warnMismatch(savedOn: cal.calibratedOnUnitID, current: deviceUnitID)
+    }
+
+    private func syncMagCal(profile: RocketProfile, device: BLEDevice) {
+        switch Self.magCalSyncAction(profileCal: profile.magCal,
+                                     deviceUnitID: device.unitID) {
+        case .push(let cal):
+            magCalAdvisory = .none
+            device.sendMagCalApply(cx: cal.offsetX, cy: cal.offsetY, cz: cal.offsetZ,
+                                   fieldR_uT: cal.fieldR_uT, residualUT: cal.residualUT)
+        case .warnMismatch(let savedOn, let current):
+            magCalAdvisory = .boardMismatch(savedOn: savedOn, current: current)
+        case .readRocket:
+            // Ask the rocket whether it carries a cal so we can offer to import
+            // it (rather than silently overwriting either side).
+            magCalReadPending = true
+            device.sendMagCalRead()
+        }
+    }
+
+    private func handleMagCalStatus(_ status: MagCalStatus) {
+        guard magCalReadPending else { return }   // only our connect-time READ
+        magCalReadPending = false
+        magCalAdvisory = (status.subType == .applied) ? .rocketHasUnsavedCal : .missing
+    }
+
+    /// Import the rocket's currently-applied cal into the active profile, tagged
+    /// with this board's id.  Called from the UI when the user accepts the
+    /// `rocketHasUnsavedCal` advisory.
+    func importRocketCalIntoActiveProfile() {
+        guard let device, let store,
+              let profile = store.activeProfile,
+              let status = device.magCalStatus, status.subType == .applied
+        else { return }
+        store.update(profile.id) {
+            $0.magCal = MagCalData(status: status, unitID: device.unitID)
+        }
+        magCalAdvisory = .none
+    }
+
+    // MARK: - Suggestion
+
+    private func computeSuggestion() {
+        guard let device, let store else { return }
+        suggestedProfileId = Self.suggestedProfile(
+            in: store.profiles, active: store.activeId, unitID: device.unitID)
+    }
+
+    /// A profile previously flown on `unitID` other than the active one, or
+    /// nil if none.  Pure for testability.
+    static func suggestedProfile(in profiles: [RocketProfile],
+                                 active: UUID?, unitID: String) -> UUID? {
+        guard !unitID.isEmpty else { return nil }
+        return profiles.first { $0.lastUsedUnitID == unitID && $0.id != active }?.id
+    }
+}
+
+extension MagCalData {
+    /// Snapshot a cal status frame into a savable profile cal, tagged with the
+    /// board it was captured on.
+    init(status: MagCalStatus, unitID: String) {
+        self.init(offsetX: status.offsetX,
+                  offsetY: status.offsetY,
+                  offsetZ: status.offsetZ,
+                  fieldR_uT: status.fieldR_uT,
+                  residualUT: status.residualUT,
+                  calibratedOnUnitID: unitID,
+                  calibratedAt: Date())
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -57,6 +57,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     // disconnect so a stale REVIEW state doesn't bleed across sessions.
     @Published var magCalStatus: MagCalStatus?
 
+    /// Latest sensor (gyro + high-g) cal readback from the FC, received on
+    /// the file_ops characteristic behind a 0xCB discriminator (#132).
+    @Published var sensorCalStatus: SensorCalStatus?
+
     /// Set once per connected-session after the first-time-seen base station
     /// has auto-picked and pushed a quiet channel.  Gates the auto-pick so it
     /// only runs once per session; cleared on disconnect so that a BS reboot
@@ -176,6 +180,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // session doesn't show up on reconnect (issue #96).  The FC
         // republishes IDLE on reconnect anyway.
         magCalStatus = nil
+        sensorCalStatus = nil
         flightAnnouncer?.reset()
         UIApplication.shared.isIdleTimerDisabled = false
     }
@@ -591,6 +596,25 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// (subType=APPLIED if cal is present, IDLE otherwise).
     func sendMagCalRead() { sendCommand(56) }
 
+    /// Push a saved sensor cal (gyro zero-rate bias + high-g accel bias) into
+    /// the rocket's NVS (#132).  Wire format mirrors `SensorCalApplyData`:
+    /// int16 gyro x/y/z, float hg x/y/z (little-endian, packed, 18 bytes).
+    func sendSensorCalApply(gyroX: Int16, gyroY: Int16, gyroZ: Int16,
+                            hgX: Float, hgY: Float, hgZ: Float) {
+        var payload = Data()
+        var gx = gyroX; payload.append(Data(bytes: &gx, count: 2))
+        var gy = gyroY; payload.append(Data(bytes: &gy, count: 2))
+        var gz = gyroZ; payload.append(Data(bytes: &gz, count: 2))
+        var hx = hgX;   payload.append(Data(bytes: &hx, count: 4))
+        var hy = hgY;   payload.append(Data(bytes: &hy, count: 4))
+        var hz = hgZ;   payload.append(Data(bytes: &hz, count: 4))
+        sendRawCommand(57, payload: payload)
+    }
+
+    /// Ask the FC to publish its stored sensor cal; the reply lands on
+    /// `sensorCalStatus` (valid=false when the rocket has none).
+    func sendSensorCalRead() { sendCommand(58) }
+
     func sendToggleLogging() {
         sendCommand(23)
     }
@@ -989,7 +1013,8 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 // can never collide with it.
                 switch data.first {
                 case 0xAA: parseScanResult(data)
-                case 0xCA: parseMagCalStatus(data)   // issue #96
+                case 0xCA: parseMagCalStatus(data)     // issue #96
+                case 0xCB: parseSensorCalStatus(data)  // issue #132
                 default:   parseFileList(data)
                 }
             }
@@ -1166,6 +1191,20 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             return
         }
         magCalStatus = status
+    }
+
+    private func parseSensorCalStatus(_ data: Data) {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 20, bytes[0] == 0xCB else {
+            print("[SENSORCAL] malformed status (\(bytes.count) bytes)")
+            return
+        }
+        let payload = Array(bytes[1..<bytes.count])
+        guard let status = SensorCalStatus.decode(payload) else {
+            print("[SENSORCAL] decode failed (payload=\(payload.count) bytes)")
+            return
+        }
+        sensorCalStatus = status
     }
 
     private func parseScanResult(_ data: Data) {

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -565,6 +565,32 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// "finishes."
     func sendMagCalComputeFit() { sendCommand(54) }
 
+    // Issue #132 — rocket-profile auto-sync.  The app holds source-of-truth
+    // for mag cal as part of the active rocket profile.  APPLY pushes the
+    // saved cal back into FC NVS on connect; READ queries what's currently
+    // in NVS so the syncer can diff against the profile.  Both bypass the
+    // sampling / sphere-fit flow — APPLY is gated FC-side to READY.
+
+    /// Push a saved cal (hard-iron offsets + R/residual diagnostics) into
+    /// the rocket's NVS.  Wire format mirrors `MagCalApplyData` in
+    /// RocketComputerTypes.h: int16 cx, cy, cz, float R_uT, float res_uT
+    /// (little-endian, packed, 14 bytes total).
+    func sendMagCalApply(cx: Int16, cy: Int16, cz: Int16,
+                         fieldR_uT: Float, residualUT: Float) {
+        var payload = Data()
+        var cxv = cx;       payload.append(Data(bytes: &cxv, count: 2))
+        var cyv = cy;       payload.append(Data(bytes: &cyv, count: 2))
+        var czv = cz;       payload.append(Data(bytes: &czv, count: 2))
+        var rv  = fieldR_uT; payload.append(Data(bytes: &rv,  count: 4))
+        var sv  = residualUT; payload.append(Data(bytes: &sv,  count: 4))
+        sendRawCommand(55, payload: payload)
+    }
+
+    /// Ask the FC to publish a status frame built from current NVS values.
+    /// The reply lands on `magCalStatus` like any other cal status frame
+    /// (subType=APPLIED if cal is present, IDLE otherwise).
+    func sendMagCalRead() { sendCommand(56) }
+
     func sendToggleLogging() {
         sendCommand(23)
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -1,0 +1,109 @@
+//
+//  RocketProfile.swift
+//  TinkerRocketApp
+//
+//  Per-rocket settings profile (issue #132).  Each airframe gets its own
+//  profile of gains / biases / roll profile / camera / pyro / mag cal.
+//  Profiles live in the app (not on the flight computer) so the same set
+//  of settings can be applied to whichever physical computer is flying
+//  that airframe.  The app is source-of-truth: on connect the active
+//  profile is pushed to the rocket (see ActiveRocketSyncer).
+//
+//  Field defaults mirror RocketConfig (BLETypes.swift) and the firmware
+//  factory defaults, so a freshly-created profile matches an out-of-the-box
+//  rocket.  Keep them in sync if the firmware defaults change.
+//
+
+import Foundation
+
+/// Segment mode for a roll-profile waypoint.  Matches the firmware enum
+/// (ROLL_SEG_* in RocketComputerTypes.h): the mode applies to the segment
+/// *starting* at this waypoint.
+enum RollSegmentMode: UInt8, Codable, CaseIterable {
+    case angle    = 0   // interpolate target roll angle to the next waypoint
+    case nullRate = 1   // hold zero roll rate; the angle field is ignored
+}
+
+/// One roll-profile waypoint.  `id` gives SwiftUI stable identity in the
+/// editor; it is persisted but otherwise carries no wire meaning.
+struct RollWaypoint: Codable, Equatable, Identifiable {
+    var id: UUID = UUID()
+    var timeSeconds: Float
+    var angleDeg: Float
+    var mode: RollSegmentMode = .angle
+}
+
+/// Saved magnetometer hard-iron calibration, captured from a cal run and
+/// re-pushed to the rocket on connect.  Tagged with the hardware ID it was
+/// captured on: cal varies by physical airframe *and* by the specific
+/// flight-computer board, so applying a cal taken on a different board would
+/// make heading drift.  The syncer compares `calibratedOnUnitID` to the
+/// connected device and warns (instead of pushing) on a mismatch.
+struct MagCalData: Codable, Equatable {
+    var offsetX: Int16        // hard-iron offset, raw IIS2MDC LSB (0.15 µT/LSB)
+    var offsetY: Int16
+    var offsetZ: Int16
+    var fieldR_uT: Float      // fitted Earth-field magnitude when accepted
+    var residualUT: Float     // fit RMS residual when accepted
+    var calibratedOnUnitID: String   // hardware ID of the board cal ran on
+    var calibratedAt: Date
+}
+
+struct RocketProfile: Codable, Equatable, Identifiable {
+    // MARK: Identity / meta
+    var id: UUID = UUID()
+    var name: String
+    var notes: String = ""
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+    /// Hardware ID of the last flight computer this profile was applied to.
+    /// Drives a soft pre-select so connecting a known rocket lands on the
+    /// profile last flown on it.  The user always confirms — no auto-apply
+    /// without a selected active profile.
+    var lastUsedUnitID: String? = nil
+
+    // MARK: Rocket toggles
+    var soundsEnabled: Bool = false
+    var servoControlEnabled: Bool = true
+    var gainScheduleEnabled: Bool = true
+    var useAngleControl: Bool = false
+    var rollDelayMs: UInt16 = 0
+    var guidanceEnabled: Bool = false
+    var cameraType: UInt8 = 2          // 0=None, 1=GoPro, 2=RunCam
+
+    // MARK: Servo
+    var servoBias1: Int16 = 85
+    var servoBias2: Int16 = 0
+    var servoBias3: Int16 = 0
+    var servoBias4: Int16 = 0
+    var servoHz: Int16 = 333
+    var servoMinUs: Int16 = 1250
+    var servoMaxUs: Int16 = 1750
+
+    // MARK: PID
+    var pidKp: Float = 0.08
+    var pidKi: Float = 0.005
+    var pidKd: Float = 0.003
+    var pidMinCmd: Float = -10.0
+    var pidMaxCmd: Float = 10.0
+
+    // MARK: Roll profile
+    var rollWaypoints: [RollWaypoint] = []
+
+    // MARK: Pyro (per-airframe; auto-pushed on connect — arming stays a
+    // separate explicit action, never driven by the profile).
+    var pyro1Enabled: Bool = false
+    var pyro1TriggerMode: UInt8 = 0
+    var pyro1TriggerValue: Float = 1.0
+    var pyro2Enabled: Bool = false
+    var pyro2TriggerMode: UInt8 = 0
+    var pyro2TriggerValue: Float = 100.0
+
+    // MARK: Mag cal (per physical airframe)
+    var magCal: MagCalData? = nil
+
+    /// A profile with all firmware factory defaults and the given name.
+    static func makeDefault(name: String) -> RocketProfile {
+        RocketProfile(name: name)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -49,6 +49,22 @@ struct MagCalData: Codable, Equatable {
     var calibratedAt: Date
 }
 
+/// Saved on-pad sensor calibration (issue #132): gyro zero-rate bias (raw
+/// LSB) + high-g accel bias (m/s²).  Like mag cal it's board-specific, so
+/// it's tagged with the hardware ID it was captured on and only re-applied to
+/// a matching board.  The low-g accelerometer is the cal reference and isn't
+/// itself corrected, so there's nothing to store for it.
+struct SensorCalData: Codable, Equatable {
+    var gyroX: Int16
+    var gyroY: Int16
+    var gyroZ: Int16
+    var hgX: Float            // high-g accel bias, m/s²
+    var hgY: Float
+    var hgZ: Float
+    var calibratedOnUnitID: String
+    var calibratedAt: Date
+}
+
 struct RocketProfile: Codable, Equatable, Identifiable {
     // MARK: Identity / meta
     var id: UUID = UUID()
@@ -99,8 +115,9 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var pyro2TriggerMode: UInt8 = 0
     var pyro2TriggerValue: Float = 100.0
 
-    // MARK: Mag cal (per physical airframe)
+    // MARK: Calibration (per physical airframe / board)
     var magCal: MagCalData? = nil
+    var sensorCal: SensorCalData? = nil
 
     /// A profile with all firmware factory defaults and the given name.
     static func makeDefault(name: String) -> RocketProfile {

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift
@@ -1,0 +1,268 @@
+//
+//  RocketProfileStore.swift
+//  TinkerRocketApp
+//
+//  Owns the set of rocket profiles and the active selection (issue #132).
+//
+//  Persistence is one JSON file per profile under Application Support
+//  (RocketProfiles/<uuid>.json) plus the active id in UserDefaults.  One
+//  file per profile keeps each write small and means a single corrupt file
+//  can't take down the whole set — it's skipped on load and the rest
+//  survive.  The directory + UserDefaults are injectable so the store can
+//  be unit-tested against a temp dir without touching the real app state.
+//
+
+import Foundation
+import Combine
+
+final class RocketProfileStore: ObservableObject {
+    @Published private(set) var profiles: [RocketProfile] = []
+    @Published private(set) var activeId: UUID?
+
+    private let dir: URL
+    private let defaults: UserDefaults
+
+    private static let activeIdKey = "activeRocketProfileId"
+    private static let migratedKey = "rocketProfilesMigratedV1"
+
+    /// The active profile, or nil if none is selected (valid empty state —
+    /// the UI prompts the user to pick or create one).
+    var activeProfile: RocketProfile? {
+        guard let id = activeId else { return nil }
+        return profiles.first { $0.id == id }
+    }
+
+    init(directory: URL? = nil, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let directory {
+            self.dir = directory
+        } else {
+            let base = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                in: .userDomainMask)[0]
+            self.dir = base.appendingPathComponent("RocketProfiles", isDirectory: true)
+        }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        load()
+        migrateLegacyIfNeeded()
+        reconcileActiveId()
+    }
+
+    // MARK: - CRUD
+
+    /// Create a new profile with factory defaults.  Does not change the
+    /// active selection — the caller decides whether to activate it.
+    @discardableResult
+    func add(name: String) -> RocketProfile {
+        let profile = RocketProfile.makeDefault(name: dedupedName(name))
+        profiles.append(profile)
+        sortProfiles()
+        save(profile)
+        return profile
+    }
+
+    /// Deep-copy an existing profile under a new id + "(copy)" name.  The
+    /// mag cal is intentionally NOT copied: cal is tied to a physical board,
+    /// so a duplicate (likely for a different airframe) starts uncalibrated.
+    @discardableResult
+    func duplicate(_ id: UUID) -> RocketProfile? {
+        guard let src = profiles.first(where: { $0.id == id }) else { return nil }
+        var copy = src
+        copy.id = UUID()
+        copy.name = dedupedName("\(src.name) copy")
+        copy.createdAt = Date()
+        copy.updatedAt = Date()
+        copy.lastUsedUnitID = nil
+        copy.magCal = nil
+        profiles.append(copy)
+        sortProfiles()
+        save(copy)
+        return copy
+    }
+
+    func rename(_ id: UUID, to newName: String) {
+        update(id) { $0.name = newName }
+    }
+
+    func delete(_ id: UUID) {
+        profiles.removeAll { $0.id == id }
+        try? FileManager.default.removeItem(at: fileURL(id))
+        if activeId == id {
+            setActive(profiles.first?.id)
+        }
+    }
+
+    func setActive(_ id: UUID?) {
+        activeId = id
+        persistActiveId()
+    }
+
+    /// Mutate a profile in place, bump `updatedAt`, and persist it.  All
+    /// edits funnel through here so persistence + the timestamp can't be
+    /// forgotten at a call site.
+    func update(_ id: UUID, _ mutate: (inout RocketProfile) -> Void) {
+        guard let idx = profiles.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&profiles[idx])
+        profiles[idx].updatedAt = Date()
+        sortProfiles()
+        // Re-find: sort may have moved it.
+        if let p = profiles.first(where: { $0.id == id }) { save(p) }
+    }
+
+    // MARK: - Persistence
+
+    private func fileURL(_ id: UUID) -> URL {
+        dir.appendingPathComponent("\(id.uuidString).json")
+    }
+
+    private func load() {
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil)) ?? []
+        let decoder = JSONDecoder()
+        var loaded: [RocketProfile] = []
+        for url in urls where url.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: url),
+                  let profile = try? decoder.decode(RocketProfile.self, from: data)
+            else { continue }   // skip corrupt/foreign files — don't fail the set
+            loaded.append(profile)
+        }
+        profiles = loaded
+        sortProfiles()
+        if let s = defaults.string(forKey: Self.activeIdKey) {
+            activeId = UUID(uuidString: s)
+        }
+    }
+
+    private func save(_ profile: RocketProfile) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(profile) else { return }
+        try? data.write(to: fileURL(profile.id), options: .atomic)
+    }
+
+    private func persistActiveId() {
+        if let id = activeId {
+            defaults.set(id.uuidString, forKey: Self.activeIdKey)
+        } else {
+            defaults.removeObject(forKey: Self.activeIdKey)
+        }
+    }
+
+    private func sortProfiles() {
+        profiles.sort {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    /// Drop a dangling active id (e.g. its file was deleted out from under
+    /// us) so `activeProfile` never points at a profile that isn't loaded.
+    private func reconcileActiveId() {
+        if let id = activeId, !profiles.contains(where: { $0.id == id }) {
+            setActive(profiles.first?.id)
+        }
+    }
+
+    /// Make `name` unique among existing profiles by appending " 2", " 3", …
+    private func dedupedName(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.isEmpty ? "Rocket" : trimmed
+        let existing = Set(profiles.map { $0.name })
+        guard existing.contains(base) else { return base }
+        var n = 2
+        while existing.contains("\(base) \(n)") { n += 1 }
+        return "\(base) \(n)"
+    }
+
+    // MARK: - Legacy migration (#132)
+
+    /// On first launch after the profiles feature ships, fold the old global
+    /// `@AppStorage` settings into a single "Default" profile so existing
+    /// users don't lose their tuning.  Runs once (guarded by `migratedKey`).
+    /// Legacy keys are left in place as a one-release safety net; a later
+    /// change removes them.  Fresh installs (no legacy keys) migrate nothing
+    /// and start with an empty set.
+    private func migrateLegacyIfNeeded() {
+        guard !defaults.bool(forKey: Self.migratedKey) else { return }
+        defer { defaults.set(true, forKey: Self.migratedKey) }
+
+        // Only migrate if the user actually has legacy settings AND we don't
+        // already have profiles (a fresh install has neither).
+        guard profiles.isEmpty, hasLegacySettings() else { return }
+
+        var p = RocketProfile.makeDefault(name: "Default")
+
+        if defaults.object(forKey: "rocketSoundsEnabled") != nil {
+            p.soundsEnabled = defaults.bool(forKey: "rocketSoundsEnabled")
+        }
+        if defaults.object(forKey: "servoControlEnabled") != nil {
+            p.servoControlEnabled = defaults.bool(forKey: "servoControlEnabled")
+        }
+        if defaults.object(forKey: "gainScheduleEnabled") != nil {
+            p.gainScheduleEnabled = defaults.bool(forKey: "gainScheduleEnabled")
+        }
+        if defaults.object(forKey: "useAngleControl") != nil {
+            p.useAngleControl = defaults.bool(forKey: "useAngleControl")
+        }
+        if defaults.object(forKey: "guidanceEnabled") != nil {
+            p.guidanceEnabled = defaults.bool(forKey: "guidanceEnabled")
+        }
+        if defaults.object(forKey: "rollDelayMs") != nil {
+            p.rollDelayMs = UInt16(clamping: Int(defaults.double(forKey: "rollDelayMs")))
+        }
+        if defaults.object(forKey: "cameraType") != nil {
+            p.cameraType = UInt8(clamping: defaults.integer(forKey: "cameraType"))
+        }
+
+        if let v = legacyInt16("servoBias1") { p.servoBias1 = v }
+        if let v = legacyInt16("servoBias2") { p.servoBias2 = v }
+        if let v = legacyInt16("servoBias3") { p.servoBias3 = v }
+        if let v = legacyInt16("servoBias4") { p.servoBias4 = v }
+        if let v = legacyInt16("servoHz")    { p.servoHz    = v }
+        if let v = legacyInt16("servoMinUs") { p.servoMinUs = v }
+        if let v = legacyInt16("servoMaxUs") { p.servoMaxUs = v }
+
+        if let v = legacyFloat("pidKp")     { p.pidKp     = v }
+        if let v = legacyFloat("pidKi")     { p.pidKi     = v }
+        if let v = legacyFloat("pidKd")     { p.pidKd     = v }
+        if let v = legacyFloat("pidMinCmd") { p.pidMinCmd = v }
+        if let v = legacyFloat("pidMaxCmd") { p.pidMaxCmd = v }
+
+        p.rollWaypoints = legacyRollWaypoints()
+
+        profiles = [p]
+        save(p)
+        setActive(p.id)
+    }
+
+    private func hasLegacySettings() -> Bool {
+        let probe = ["pidKp", "servoBias1", "rollProfileJSON", "cameraType",
+                     "useAngleControl", "servoHz"]
+        return probe.contains { defaults.object(forKey: $0) != nil }
+    }
+
+    private func legacyInt16(_ key: String) -> Int16? {
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return Int16(clamping: Int(defaults.double(forKey: key).rounded()))
+    }
+
+    private func legacyFloat(_ key: String) -> Float? {
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return Float(defaults.double(forKey: key))
+    }
+
+    /// Decode the legacy `rollProfileJSON` blob — an array of [time, angle,
+    /// mode] string triples (older builds wrote [time, angle] pairs).
+    private func legacyRollWaypoints() -> [RollWaypoint] {
+        guard let json = defaults.string(forKey: "rollProfileJSON"),
+              let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([[String]].self, from: data)
+        else { return [] }
+        return decoded.map { entry in
+            let t = entry.count > 0 ? (Float(entry[0]) ?? 0) : 0
+            let a = entry.count > 1 ? (Float(entry[1]) ?? 0) : 0
+            let m = entry.count > 2 ? (UInt8(entry[2]) ?? 0) : 0
+            return RollWaypoint(timeSeconds: t, angleDeg: a,
+                                mode: RollSegmentMode(rawValue: m) ?? .angle)
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift
@@ -74,6 +74,7 @@ final class RocketProfileStore: ObservableObject {
         copy.updatedAt = Date()
         copy.lastUsedUnitID = nil
         copy.magCal = nil
+        copy.sensorCal = nil
         profiles.append(copy)
         sortProfiles()
         save(copy)

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorCalStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorCalStatus.swift
@@ -1,0 +1,50 @@
+//
+//  SensorCalStatus.swift
+//  TinkerRocketApp
+//
+//  Decoded form of the FC's SensorCalStatusData frame (issue #132): the
+//  gyro zero-rate bias + high-g accel bias currently stored in the rocket's
+//  NVS.  Arrives on the file_ops characteristic behind a 0xCB discriminator
+//  (sibling of the 0xCA mag-cal frame).  Wire layout mirrors
+//  SensorCalStatusData in RocketComputerTypes.h — keep both in sync.
+//
+//  Wire (19 bytes, little-endian, packed):
+//    [0]      uint8  valid       (1 if a cal is stored)
+//    [1..2]   int16  gyro_x      (raw gyro LSB)
+//    [3..4]   int16  gyro_y
+//    [5..6]   int16  gyro_z
+//    [7..10]  float  hg_x        (high-g accel bias, m/s²)
+//    [11..14] float  hg_y
+//    [15..18] float  hg_z
+//
+
+import Foundation
+
+struct SensorCalStatus: Equatable {
+    let valid: Bool
+    let gyroX: Int16
+    let gyroY: Int16
+    let gyroZ: Int16
+    let hgX: Float
+    let hgY: Float
+    let hgZ: Float
+
+    /// Decode the payload *after* the 0xCB discriminator byte.
+    static func decode(_ bytes: [UInt8]) -> SensorCalStatus? {
+        guard bytes.count >= 19 else { return nil }
+        func i16(_ o: Int) -> Int16 {
+            bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: o, as: Int16.self)
+            }
+        }
+        func f32(_ o: Int) -> Float {
+            bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: o, as: Float.self)
+            }
+        }
+        return SensorCalStatus(
+            valid: bytes[0] != 0,
+            gyroX: i16(1), gyroY: i16(3), gyroZ: i16(5),
+            hgX: f32(7), hgY: f32(11), hgZ: f32(15))
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/TinkerRocketAppApp.swift
+++ b/TinkerRocketApp/TinkerRocketApp/TinkerRocketAppApp.swift
@@ -9,13 +9,22 @@ import SwiftUI
 struct TinkerRocketAppApp: App {
     @AppStorage("hasOnboarded") private var hasOnboarded: Bool = false
 
+    // Per-rocket profiles (#132).  App-level so the picker, settings, and the
+    // connect-time syncer all share one source of truth.
+    @StateObject private var profileStore = RocketProfileStore()
+    @StateObject private var syncer = ActiveRocketSyncer()
+
     var body: some Scene {
         WindowGroup {
-            if hasOnboarded {
-                DashboardView()
-            } else {
-                OnboardingView()
+            Group {
+                if hasOnboarded {
+                    DashboardView()
+                } else {
+                    OnboardingView()
+                }
             }
+            .environmentObject(profileStore)
+            .environmentObject(syncer)
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -16,43 +16,54 @@ struct ActiveRocketHeader: View {
     @EnvironmentObject var syncer: ActiveRocketSyncer
 
     var body: some View {
-        NavigationLink(destination: RocketProfileView(device: device)) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 8) {
-                    Image("RocketIcon")
-                        .resizable().renderingMode(.template)
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 20, height: 20)
-                        .foregroundColor(.accentColor)
-                    Text(store.activeProfile?.name ?? "No rocket selected")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                    Spacer()
+        // On a base station the active rocket is read-only — the picker isn't
+        // reachable here (you change/manage rockets connected directly to a
+        // rocket).  So the header navigates only for a direct rocket link.
+        if device.isBaseStation {
+            card
+        } else {
+            NavigationLink(destination: RocketProfileView(device: device)) { card }
+                .buttonStyle(.plain)
+        }
+    }
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image("RocketIcon")
+                    .resizable().renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20, height: 20)
+                    .foregroundColor(.accentColor)
+                Text(store.activeProfile?.name ?? "No rocket selected")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+                if !device.isBaseStation {
                     Image(systemName: "chevron.right")
                         .font(.caption).foregroundColor(.secondary)
                 }
-
-                if let p = store.activeProfile {
-                    Text(keyline(p))
-                        .font(.caption).foregroundColor(.secondary)
-                } else {
-                    Text("Tap to pick or create a rocket.")
-                        .font(.caption).foregroundColor(.secondary)
-                }
-
-                if device.isBaseStation {
-                    Text("Settings are edited on the rocket.")
-                        .font(.caption2).foregroundColor(.secondary)
-                } else {
-                    SyncStatusRow(state: syncer.syncState)
-                }
             }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.secondarySystemBackground))
-            .cornerRadius(10)
+
+            if let p = store.activeProfile {
+                Text(keyline(p))
+                    .font(.caption).foregroundColor(.secondary)
+            } else if !device.isBaseStation {
+                Text("Tap to pick or create a rocket.")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+
+            if device.isBaseStation {
+                Text("Settings are edited on the rocket.")
+                    .font(.caption2).foregroundColor(.secondary)
+            } else {
+                SyncStatusRow(state: syncer.syncState)
+            }
         }
-        .buttonStyle(.plain)
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(10)
     }
 
     private func keyline(_ p: RocketProfile) -> String {

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -1,0 +1,66 @@
+//
+//  ActiveRocketHeader.swift
+//  TinkerRocketApp
+//
+//  Top-of-dashboard summary of the active rocket profile (issue #132):
+//  name + a few key settings + the connect-time sync status.  Tapping it
+//  opens the rocket picker.  On a base-station connection it's read-only and
+//  reminds the user that settings are edited on the rocket.
+//
+
+import SwiftUI
+
+struct ActiveRocketHeader: View {
+    @ObservedObject var device: BLEDevice
+    @EnvironmentObject var store: RocketProfileStore
+    @EnvironmentObject var syncer: ActiveRocketSyncer
+
+    var body: some View {
+        NavigationLink(destination: RocketProfileView(device: device)) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Image("RocketIcon")
+                        .resizable().renderingMode(.template)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(.accentColor)
+                    Text(store.activeProfile?.name ?? "No rocket selected")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption).foregroundColor(.secondary)
+                }
+
+                if let p = store.activeProfile {
+                    Text(keyline(p))
+                        .font(.caption).foregroundColor(.secondary)
+                } else {
+                    Text("Tap to pick or create a rocket.")
+                        .font(.caption).foregroundColor(.secondary)
+                }
+
+                if device.isBaseStation {
+                    Text("Settings are edited on the rocket.")
+                        .font(.caption2).foregroundColor(.secondary)
+                } else {
+                    SyncStatusRow(state: syncer.syncState)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(10)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func keyline(_ p: RocketProfile) -> String {
+        let mode = p.useAngleControl ? "Track Profile" : "Null Roll"
+        let cam: String = {
+            switch p.cameraType { case 1: return "GoPro"; case 2: return "RunCam"; default: return "No cam" }
+        }()
+        let cal = p.magCal == nil ? "Uncalibrated" : "Cal saved"
+        return "\(mode) \u{2022} \(cam) \u{2022} \(cal)"
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -60,7 +60,8 @@ struct ActiveRocketHeader: View {
         let cam: String = {
             switch p.cameraType { case 1: return "GoPro"; case 2: return "RunCam"; default: return "No cam" }
         }()
+        let pyro = (p.pyro1Enabled || p.pyro2Enabled) ? "Pyro on" : "Pyro off"
         let cal = p.magCal == nil ? "Uncalibrated" : "Cal saved"
-        return "\(mode) \u{2022} \(cam) \u{2022} \(cal)"
+        return "\(mode) \u{2022} \(cam) \u{2022} \(pyro) \u{2022} \(cal)"
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -29,6 +29,8 @@ struct DashboardView: View {
     @StateObject private var fleet = BLEFleet()
     @StateObject private var flightAnnouncer = FlightAnnouncer()
     @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject private var profileStore: RocketProfileStore
+    @EnvironmentObject private var syncer: ActiveRocketSyncer
     @State private var activeSheet: DashboardSheet?
     @State private var showProvisioning = false
 
@@ -132,12 +134,19 @@ struct DashboardView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if let device = fleet.activeDevice {
                         HStack(spacing: 16) {
-                            NavigationLink(destination: FileManagerView(device: device)) {
+                            // Rocket icon → pick / manage rocket profiles (#132).
+                            NavigationLink(destination: RocketProfileView(device: device)) {
                                 Image("RocketIcon")
                                     .resizable()
                                     .renderingMode(.template)
                                     .aspectRatio(contentMode: .fit)
                                     .frame(width: 22, height: 22)
+                            }
+
+                            // Book icon → stored flights on the rocket (where the
+                            // rocket icon used to go).
+                            NavigationLink(destination: FileManagerView(device: device)) {
+                                Image(systemName: "book.fill")
                             }
 
                             NavigationLink(destination: MapView(device: device)) {
@@ -174,10 +183,18 @@ struct DashboardView: View {
         .navigationViewStyle(.stack)
         .onAppear {
             fleet.activeDevice?.flightAnnouncer = flightAnnouncer
+            if fleet.isConnected, let dev = fleet.activeDevice {
+                syncer.attach(device: dev, store: profileStore)
+            }
         }
         .onChange(of: fleet.isConnected) { connected in
             if connected {
                 fleet.activeDevice?.flightAnnouncer = flightAnnouncer
+                if let dev = fleet.activeDevice {
+                    syncer.attach(device: dev, store: profileStore)
+                }
+            } else {
+                syncer.detach()
             }
             if !connected && !fleet.isScanning {
                 fleet.startScanning()
@@ -247,6 +264,9 @@ struct ConnectedDashboardView: View {
     @Binding var activeSheet: DashboardSheet?
 
     var body: some View {
+        // Active rocket profile summary + sync status (#132).
+        ActiveRocketHeader(device: device)
+
         // Device chip bar (multi-device) or simple status (single device)
         if fleet.devices.count > 1 {
             DeviceChipBar(fleet: fleet, activeDevice: device)
@@ -1450,6 +1470,7 @@ struct PyroChannelsView: View {
 
 struct PyroConfigSheet: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var store: RocketProfileStore
     let channel: Int
     @Environment(\.dismiss) var dismiss
 
@@ -1520,6 +1541,18 @@ struct PyroConfigSheet: View {
             ch1Enabled: cfg.pyro1Enabled, ch1Mode: cfg.pyro1TriggerMode, ch1Value: cfg.pyro1TriggerValue,
             ch2Enabled: cfg.pyro2Enabled, ch2Mode: cfg.pyro2TriggerMode, ch2Value: cfg.pyro2TriggerValue
         )
+        // Persist pyro config to the active rocket profile too (#132) so the
+        // connect-time syncer doesn't push a stale value back over this edit.
+        if let id = store.activeId {
+            store.update(id) {
+                $0.pyro1Enabled = cfg.pyro1Enabled
+                $0.pyro1TriggerMode = cfg.pyro1TriggerMode
+                $0.pyro1TriggerValue = cfg.pyro1TriggerValue
+                $0.pyro2Enabled = cfg.pyro2Enabled
+                $0.pyro2TriggerMode = cfg.pyro2TriggerMode
+                $0.pyro2TriggerValue = cfg.pyro2TriggerValue
+            }
+        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1767,6 +1767,9 @@ struct TestingControlsView: View {
 
 struct OnPadCalibrationView: View {
     @ObservedObject var device: BLEDevice
+    /// When embedded in a Form (e.g. the settings General tab) we drop the
+    /// card chrome + headline so it sits naturally as a row (#132).
+    var embedded: Bool = false
     @State private var calibrating = false
     @State private var showGravityWarning = false
     @State private var gravityMag: Float = 0.0
@@ -1774,8 +1777,10 @@ struct OnPadCalibrationView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("On Pad Calibration")
-                .font(.headline)
+            if !embedded {
+                Text("On Pad Calibration")
+                    .font(.headline)
+            }
 
             Button(action: {
                 calibrating = true
@@ -1820,10 +1825,10 @@ struct OnPadCalibrationView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
-        .padding()
+        .padding(embedded ? 0 : 16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.systemGray6))
-        .cornerRadius(10)
+        .background(embedded ? Color.clear : Color(.systemGray6))
+        .cornerRadius(embedded ? 0 : 10)
         .alert("Accelerometer Warning", isPresented: $showGravityWarning) {
             Button("OK", role: .cancel) { }
         } message: {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -135,12 +135,17 @@ struct DashboardView: View {
                     if let device = fleet.activeDevice {
                         HStack(spacing: 16) {
                             // Rocket icon → pick / manage rocket profiles (#132).
-                            NavigationLink(destination: RocketProfileView(device: device)) {
-                                Image("RocketIcon")
-                                    .resizable()
-                                    .renderingMode(.template)
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 22, height: 22)
+                            // Hidden on a base station: rocket selection is
+                            // read-only there (you manage rockets connected
+                            // directly to a rocket).
+                            if !device.isBaseStation {
+                                NavigationLink(destination: RocketProfileView(device: device)) {
+                                    Image("RocketIcon")
+                                        .resizable()
+                                        .renderingMode(.template)
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 22, height: 22)
+                                }
                             }
 
                             // Book icon → stored flights on the rocket (where the

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -388,9 +388,8 @@ struct ConnectedDashboardView: View {
 
             TestingControlsView(device: device, activeSheet: $activeSheet)
 
-            if !device.isBaseStation {
-                OnPadCalibrationView(device: device)
-            }
+            // Gyro/accel calibration lives in Settings → General → Calibration
+            // now (#132), so it's no longer shown on the dashboard.
 
             if !device.isBaseStation {
                 Button {
@@ -1816,7 +1815,7 @@ struct OnPadCalibrationView: View {
                             .tint(.white)
                     }
                     Image(systemName: "gyroscope")
-                    Text(calibrating ? "Calibrating..." : "Calibrate Sensors")
+                    Text(calibrating ? "Calibrating..." : "Calibrate Gyro and Accel")
                 }
                 .frame(maxWidth: .infinity)
                 .padding()

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1819,7 +1819,7 @@ struct OnPadCalibrationView: View {
                 .foregroundColor(.white)
                 .cornerRadius(10)
             }
-            .disabled(calibrating || !device.isConnected)
+            .disabled(calibrating || !device.isConnected || !device.telemetry.pwr_pin_on)
 
             Text("Place rocket on pad and keep still. Calibrates gyro bias and accelerometer offsets (~10 seconds).")
                 .font(.caption)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1767,6 +1767,7 @@ struct TestingControlsView: View {
 
 struct OnPadCalibrationView: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var store: RocketProfileStore
     /// When embedded in a Form (e.g. the settings General tab) we drop the
     /// card chrome + headline so it sits naturally as a row (#132).
     var embedded: Bool = false
@@ -1774,6 +1775,9 @@ struct OnPadCalibrationView: View {
     @State private var showGravityWarning = false
     @State private var gravityMag: Float = 0.0
     @State private var gravityError: Float = 0.0
+    /// Set when the user kicks off a cal so the next sensor-cal readback gets
+    /// snapshotted into the active profile (#132) — not arbitrary frames.
+    @State private var pendingCalSnapshot = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -1784,6 +1788,7 @@ struct OnPadCalibrationView: View {
 
             Button(action: {
                 calibrating = true
+                pendingCalSnapshot = true
                 device.sendCommand(21)
                 // Calibration takes ~10 seconds (1000 samples x 10ms)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 12.0) {
@@ -1833,6 +1838,14 @@ struct OnPadCalibrationView: View {
             Button("OK", role: .cancel) { }
         } message: {
             Text("Low-G accelerometer magnitude (\(String(format: "%.2f", gravityMag)) m/s²) differs from expected gravity (9.81 m/s²) by \(String(format: "%.1f", gravityError))%. Consider running a bench calibration before flight.")
+        }
+        // Snapshot the freshly-run sensor cal into the active profile (#132),
+        // tagged with this board's id so the syncer re-applies it on connect.
+        .onChange(of: device.sensorCalStatus) { newStatus in
+            guard pendingCalSnapshot, let s = newStatus, s.valid,
+                  !device.unitID.isEmpty, let id = store.activeId else { return }
+            pendingCalSnapshot = false
+            store.update(id) { $0.sensorCal = SensorCalData(status: s, unitID: device.unitID) }
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MagCalView.swift
@@ -22,6 +22,7 @@ import Combine
 
 struct MagCalView: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var store: RocketProfileStore
     @Environment(\.dismiss) var dismiss
 
     /// Latest status frame, or nil if the FC hasn't published one yet
@@ -48,6 +49,14 @@ struct MagCalView: View {
         }
         .navigationTitle("Mag Calibration")
         .navigationBarTitleDisplayMode(.inline)
+        // Snapshot a freshly-accepted cal into the active rocket profile (#132),
+        // tagged with this board's id so the syncer can re-apply it on connect
+        // and warn if a different board is later used.
+        .onChange(of: device.magCalStatus) { newStatus in
+            guard let s = newStatus, s.subType == .applied,
+                  !device.unitID.isEmpty, let id = store.activeId else { return }
+            store.update(id) { $0.magCal = MagCalData(status: s, unitID: device.unitID) }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 if status?.subType == .sampling || status?.subType == .review {

--- a/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
@@ -122,6 +122,7 @@ struct RocketProfileView: View {
             summaryRow("Camera", cameraLabel(active.cameraType))
             summaryRow("Gain scheduling", active.gainScheduleEnabled ? "On" : "Off")
             summaryRow("Mag cal", active.magCal == nil ? "Not saved" : "Saved")
+            summaryRow("Sensor cal", active.sensorCal == nil ? "Not saved" : "Saved")
 
             if let device, device.isConnected, !device.isBaseStation {
                 Button {
@@ -159,29 +160,34 @@ struct RocketProfileView: View {
                 }
             }
 
-            magCalAdvisoryRow
+            calAdvisoryView("magnetometer", advisory: syncer.magCalAdvisory) {
+                syncer.importRocketCalIntoActiveProfile()
+            }
+            calAdvisoryView("sensor", advisory: syncer.sensorCalAdvisory) {
+                syncer.importRocketSensorCalIntoActiveProfile()
+            }
         }
     }
 
     @ViewBuilder
-    private var magCalAdvisoryRow: some View {
-        switch syncer.magCalAdvisory {
+    private func calAdvisoryView(_ kind: String,
+                                 advisory adv: ActiveRocketSyncer.CalAdvisory,
+                                 onImport: @escaping () -> Void) -> some View {
+        switch adv {
         case .none:
             EmptyView()
         case .missing:
-            advisory("No magnetometer calibration saved. Run calibration in Settings for accurate heading.",
+            advisory("No \(kind) calibration saved. Run calibration in Settings.",
                      systemImage: "exclamationmark.triangle", color: .orange)
         case .boardMismatch(let savedOn, let current):
-            advisory("This profile's mag cal was done on board \(short(savedOn)). The connected board is \(short(current)) — re-run calibration so heading doesn't drift.",
+            advisory("This profile's \(kind) cal was done on board \(short(savedOn)). The connected board is \(short(current)) — re-run calibration.",
                      systemImage: "exclamationmark.triangle.fill", color: .orange)
         case .rocketHasUnsavedCal:
             VStack(alignment: .leading, spacing: 6) {
-                advisory("This rocket has a calibration the profile doesn't. Save it to the profile?",
+                advisory("This rocket has a \(kind) calibration the profile doesn't. Save it to the profile?",
                          systemImage: "square.and.arrow.down", color: .blue)
-                Button("Save Calibration to Profile") {
-                    syncer.importRocketCalIntoActiveProfile()
-                }
-                .buttonStyle(.bordered)
+                Button("Save \(kind.capitalized) Cal to Profile", action: onImport)
+                    .buttonStyle(.bordered)
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
@@ -1,0 +1,232 @@
+//
+//  RocketProfileView.swift
+//  TinkerRocketApp
+//
+//  Pick / manage rocket profiles (issue #132).  Each airframe is a saved
+//  profile; the active one is what the app pushes to a connected rocket.
+//  Reached from the dashboard rocket icon.  Settings for the active rocket
+//  are edited in SettingsView, presented from here.
+//
+
+import SwiftUI
+
+struct RocketProfileView: View {
+    /// The connected device, if any — drives the connect-time sync status,
+    /// mag-cal advisory, and "last flown as…" suggestion.
+    var device: BLEDevice?
+
+    @EnvironmentObject var store: RocketProfileStore
+    @EnvironmentObject var syncer: ActiveRocketSyncer
+
+    @State private var showingAdd = false
+    @State private var newName = ""
+    @State private var renamingId: UUID?
+    @State private var renameText = ""
+    @State private var showSettings = false
+
+    private var isConnectedRocket: Bool {
+        guard let device else { return false }
+        return device.isConnected && !device.isBaseStation
+    }
+
+    var body: some View {
+        List {
+            if isConnectedRocket { connectionSection }
+
+            Section(header: Text("Rockets")) {
+                ForEach(store.profiles) { profile in
+                    profileRow(profile)
+                }
+                Button {
+                    newName = ""
+                    showingAdd = true
+                } label: {
+                    Label("Add Rocket", systemImage: "plus")
+                }
+            }
+
+            if let active = store.activeProfile {
+                activeSection(active)
+            }
+        }
+        .navigationTitle("Rockets")
+        .alert("New Rocket", isPresented: $showingAdd) {
+            TextField("Name", text: $newName)
+            Button("Cancel", role: .cancel) {}
+            Button("Add") {
+                let p = store.add(name: newName)
+                store.setActive(p.id)
+            }
+        } message: {
+            Text("Name this airframe (e.g. \u{201C}Big Bertha\u{201D}).")
+        }
+        .alert("Rename Rocket", isPresented: Binding(
+            get: { renamingId != nil },
+            set: { if !$0 { renamingId = nil } })) {
+            TextField("Name", text: $renameText)
+            Button("Cancel", role: .cancel) { renamingId = nil }
+            Button("Save") {
+                if let id = renamingId { store.rename(id, to: renameText) }
+                renamingId = nil
+            }
+        }
+        .sheet(isPresented: $showSettings) {
+            if let device { SettingsView(device: device) }
+        }
+    }
+
+    // MARK: - Rows
+
+    private func profileRow(_ profile: RocketProfile) -> some View {
+        Button {
+            store.setActive(profile.id)
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(profile.name)
+                        .foregroundColor(.primary)
+                    if !profile.notes.isEmpty {
+                        Text(profile.notes)
+                            .font(.caption).foregroundColor(.secondary).lineLimit(1)
+                    }
+                }
+                Spacer()
+                if profile.id == store.activeId {
+                    Image(systemName: "checkmark.circle.fill").foregroundColor(.accentColor)
+                }
+            }
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) { store.delete(profile.id) } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .contextMenu {
+            Button { renamingId = profile.id; renameText = profile.name } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            Button { store.duplicate(profile.id) } label: {
+                Label("Duplicate", systemImage: "plus.square.on.square")
+            }
+            Button(role: .destructive) { store.delete(profile.id) } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    // MARK: - Active profile section
+
+    private func activeSection(_ active: RocketProfile) -> some View {
+        Section(header: Text("Active: \(active.name)")) {
+            summaryRow("Control mode", active.useAngleControl ? "Track Profile" : "Null Roll")
+            summaryRow("Camera", cameraLabel(active.cameraType))
+            summaryRow("Gain scheduling", active.gainScheduleEnabled ? "On" : "Off")
+            summaryRow("Mag cal", active.magCal == nil ? "Not saved" : "Saved")
+
+            if let device, device.isConnected, !device.isBaseStation {
+                Button {
+                    showSettings = true
+                } label: {
+                    Label("Edit Settings", systemImage: "slider.horizontal.3")
+                }
+            } else {
+                Label("Connect to a rocket to edit and apply settings",
+                      systemImage: "antenna.radiowaves.left.and.right.slash")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Connection-aware section
+
+    @ViewBuilder
+    private var connectionSection: some View {
+        Section {
+            SyncStatusRow(state: syncer.syncState)
+
+            if let suggestedId = syncer.suggestedProfileId,
+               let suggested = store.profiles.first(where: { $0.id == suggestedId }) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Last flown as \u{201C}\(suggested.name)\u{201D}")
+                            .font(.subheadline)
+                        Text("Switch to apply that profile?")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Button("Switch") { store.setActive(suggested.id) }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+
+            magCalAdvisoryRow
+        }
+    }
+
+    @ViewBuilder
+    private var magCalAdvisoryRow: some View {
+        switch syncer.magCalAdvisory {
+        case .none:
+            EmptyView()
+        case .missing:
+            advisory("No magnetometer calibration saved. Run calibration in Settings for accurate heading.",
+                     systemImage: "exclamationmark.triangle", color: .orange)
+        case .boardMismatch(let savedOn, let current):
+            advisory("This profile's mag cal was done on board \(short(savedOn)). The connected board is \(short(current)) — re-run calibration so heading doesn't drift.",
+                     systemImage: "exclamationmark.triangle.fill", color: .orange)
+        case .rocketHasUnsavedCal:
+            VStack(alignment: .leading, spacing: 6) {
+                advisory("This rocket has a calibration the profile doesn't. Save it to the profile?",
+                         systemImage: "square.and.arrow.down", color: .blue)
+                Button("Save Calibration to Profile") {
+                    syncer.importRocketCalIntoActiveProfile()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    // MARK: - Bits
+
+    private func summaryRow(_ label: String, _ value: String) -> some View {
+        HStack { Text(label); Spacer(); Text(value).foregroundColor(.secondary) }
+    }
+
+    private func advisory(_ text: String, systemImage: String, color: Color) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption).foregroundColor(color)
+    }
+
+    private func cameraLabel(_ t: UInt8) -> String {
+        switch t { case 1: return "GoPro"; case 2: return "RunCam"; default: return "None" }
+    }
+
+    /// Shorten a long hardware id for display.
+    private func short(_ id: String) -> String {
+        id.count > 8 ? "…" + id.suffix(6) : id
+    }
+}
+
+/// One-line sync state, reused by the dashboard header.
+struct SyncStatusRow: View {
+    let state: ActiveRocketSyncer.SyncState
+
+    var body: some View {
+        switch state {
+        case .idle:
+            EmptyView()
+        case .noProfile:
+            Label("No active rocket — pick one to apply settings", systemImage: "questionmark.circle")
+                .font(.caption).foregroundColor(.secondary)
+        case .syncing:
+            Label("Applying settings to rocket…", systemImage: "arrow.triangle.2.circlepath")
+                .font(.caption).foregroundColor(.secondary)
+        case .synced:
+            Label("Settings applied", systemImage: "checkmark.circle.fill")
+                .font(.caption).foregroundColor(.green)
+        case .failed(let reason):
+            Label(reason, systemImage: "xmark.circle.fill")
+                .font(.caption).foregroundColor(.red)
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
@@ -44,10 +44,6 @@ struct RocketProfileView: View {
                     Label("Add Rocket", systemImage: "plus")
                 }
             }
-
-            if let active = store.activeProfile {
-                activeSection(active)
-            }
         }
         .navigationTitle("Rockets")
         .alert("New Rocket", isPresented: $showingAdd) {
@@ -78,22 +74,42 @@ struct RocketProfileView: View {
     // MARK: - Rows
 
     private func profileRow(_ profile: RocketProfile) -> some View {
-        Button {
-            store.setActive(profile.id)
-        } label: {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(profile.name)
-                        .foregroundColor(.primary)
-                    if !profile.notes.isEmpty {
-                        Text(profile.notes)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1)
+        let selected = profile.id == store.activeId
+        return HStack(spacing: 12) {
+            // Rocket icon → make this the active rocket and open its settings.
+            Button {
+                store.setActive(profile.id)
+                showSettings = true
+            } label: {
+                Image("RocketIcon")
+                    .resizable().renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 26, height: 26)
+                    .foregroundColor(selected ? .blue : .secondary)
+            }
+            .buttonStyle(.borderless)
+
+            // Name → select (make active) without opening settings.
+            Button {
+                store.setActive(profile.id)
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(profile.name)
+                            .foregroundColor(selected ? .blue : .primary)
+                        if !profile.notes.isEmpty {
+                            Text(profile.notes)
+                                .font(.caption).foregroundColor(.secondary).lineLimit(1)
+                        }
                     }
+                    Spacer()
                 }
-                Spacer()
-                if profile.id == store.activeId {
-                    Image(systemName: "checkmark.circle.fill").foregroundColor(.accentColor)
-                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+
+            if selected {
+                Image(systemName: "checkmark.circle.fill").foregroundColor(.blue)
             }
         }
         .swipeActions(edge: .trailing) {
@@ -110,30 +126,6 @@ struct RocketProfileView: View {
             }
             Button(role: .destructive) { store.delete(profile.id) } label: {
                 Label("Delete", systemImage: "trash")
-            }
-        }
-    }
-
-    // MARK: - Active profile section
-
-    private func activeSection(_ active: RocketProfile) -> some View {
-        Section(header: Text("Active: \(active.name)")) {
-            summaryRow("Control mode", active.useAngleControl ? "Track Profile" : "Null Roll")
-            summaryRow("Camera", cameraLabel(active.cameraType))
-            summaryRow("Gain scheduling", active.gainScheduleEnabled ? "On" : "Off")
-            summaryRow("Mag cal", active.magCal == nil ? "Not saved" : "Saved")
-            summaryRow("Sensor cal", active.sensorCal == nil ? "Not saved" : "Saved")
-
-            if let device, device.isConnected, !device.isBaseStation {
-                Button {
-                    showSettings = true
-                } label: {
-                    Label("Edit Settings", systemImage: "slider.horizontal.3")
-                }
-            } else {
-                Label("Connect to a rocket to edit and apply settings",
-                      systemImage: "antenna.radiowaves.left.and.right.slash")
-                    .font(.caption).foregroundColor(.secondary)
             }
         }
     }
@@ -194,17 +186,9 @@ struct RocketProfileView: View {
 
     // MARK: - Bits
 
-    private func summaryRow(_ label: String, _ value: String) -> some View {
-        HStack { Text(label); Spacer(); Text(value).foregroundColor(.secondary) }
-    }
-
     private func advisory(_ text: String, systemImage: String, color: Color) -> some View {
         Label(text, systemImage: systemImage)
             .font(.caption).foregroundColor(color)
-    }
-
-    private func cameraLabel(_ t: UInt8) -> String {
-        switch t { case 1: return "GoPro"; case 2: return "RunCam"; default: return "None" }
     }
 
     /// Shorten a long hardware id for display.

--- a/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
@@ -76,24 +76,18 @@ struct RocketProfileView: View {
     private func profileRow(_ profile: RocketProfile) -> some View {
         let selected = profile.id == store.activeId
         return HStack(spacing: 12) {
-            // Rocket icon → make this the active rocket and open its settings.
+            // Tapping the icon or the name makes this the active rocket and
+            // opens its settings.
             Button {
                 store.setActive(profile.id)
                 showSettings = true
             } label: {
-                Image("RocketIcon")
-                    .resizable().renderingMode(.template)
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 26, height: 26)
-                    .foregroundColor(selected ? .blue : .secondary)
-            }
-            .buttonStyle(.borderless)
-
-            // Name → select (make active) without opening settings.
-            Button {
-                store.setActive(profile.id)
-            } label: {
-                HStack {
+                HStack(spacing: 12) {
+                    Image("RocketIcon")
+                        .resizable().renderingMode(.template)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 26, height: 26)
+                        .foregroundColor(selected ? .blue : .secondary)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(profile.name)
                             .foregroundColor(selected ? .blue : .primary)

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -58,10 +58,10 @@ struct SettingsView: View {
 
     // Settings are grouped into tabs (one panel at a time) on phone screens
     // (#132 / #147).  Switching a tab flushes the leaving tab's pending edit.
-    @State private var tab: SettingsTab = .flight
+    @State private var tab: SettingsTab = .control
     private enum SettingsTab: String, CaseIterable {
-        case flight = "Flight"
-        case airframe = "Airframe"
+        case control = "Control"
+        case camera = "Camera"
         case pyro = "Pyro"
         case general = "General"
     }
@@ -268,15 +268,15 @@ struct SettingsView: View {
         }
 
         switch tab {
-        case .flight:   flightSections
-        case .airframe: airframeSections
+        case .control:  controlSections
+        case .camera:   cameraSections
         case .pyro:     pyroSections
         case .general:  generalSections
         }
     }
 
     @ViewBuilder
-    private var flightSections: some View {
+    private var controlSections: some View {
         Section(header: configHeader("PID Gains", applied: pidApplied)) {
             stringRow("Kp", text: $sPidKp, field: .pidKp, decimal: true)
             stringRow("Ki", text: $sPidKi, field: .pidKi, decimal: true)
@@ -289,12 +289,11 @@ struct SettingsView: View {
             Text("Scales PID gains with (V_ref/V)\u{00B2}. Disable for fixed gains at all speeds.")
                 .font(.caption).foregroundColor(.secondary)
         }
-        rollControlSection
-    }
 
-    @ViewBuilder
-    private var airframeSections: some View {
         Section(header: configHeader("Servo", applied: servoApplied)) {
+            Toggle("Enable Servo Control", isOn: bind(\.servoControlEnabled) {
+                device.sendServoControlConfig(enabled: $0)
+            })
             stringRow("Servo 1", text: $sBias1, field: .bias1)
             stringRow("Servo 2", text: $sBias2, field: .bias2)
             stringRow("Servo 3", text: $sBias3, field: .bias3)
@@ -305,13 +304,20 @@ struct SettingsView: View {
             stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
             stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
         }
-        Section("Magnetometer") {
-            NavigationLink {
-                MagCalView(device: device)
-            } label: {
-                Label("Magnetometer Calibration", systemImage: "location.north.line")
+
+        rollControlSection
+    }
+
+    @ViewBuilder
+    private var cameraSections: some View {
+        Section("Camera") {
+            Picker("Camera Type", selection: cameraBinding) {
+                Text("None").tag(0)
+                Text("GoPro").tag(1)
+                Text("RunCam").tag(2)
             }
-            Text("Calibration is saved per rocket. Persists across reboots.")
+            .pickerStyle(.segmented)
+            Text(cameraHint(Int(profile.cameraType)))
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -368,21 +374,18 @@ struct SettingsView: View {
             Toggle("Enable Sounds", isOn: bind(\.soundsEnabled) {
                 device.sendSoundConfig(enabled: $0)
             })
-            Toggle("Enable Servo Control", isOn: bind(\.servoControlEnabled) {
-                device.sendServoControlConfig(enabled: $0)
-            })
             Text("Stored in the rocket profile. Persists across reboots.")
                 .font(.caption).foregroundColor(.secondary)
         }
 
-        Section("Camera") {
-            Picker("Camera Type", selection: cameraBinding) {
-                Text("None").tag(0)
-                Text("GoPro").tag(1)
-                Text("RunCam").tag(2)
+        Section("Calibration") {
+            NavigationLink {
+                MagCalView(device: device)
+            } label: {
+                Label("Magnetometer Calibration", systemImage: "location.north.line")
             }
-            .pickerStyle(.segmented)
-            Text(cameraHint(Int(profile.cameraType)))
+            OnPadCalibrationView(device: device, embedded: true)
+            Text("Mag cal is saved to this rocket's profile and re-applied on connect. Sensor (gyro/accel) calibration runs on the connected rocket — place it on the pad and keep still.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -209,6 +209,7 @@ struct SettingsView: View {
                 summaryRow("Camera", cameraLabel(p.cameraType))
                 summaryRow("Gain scheduling", p.gainScheduleEnabled ? "On" : "Off")
                 summaryRow("Mag cal", p.magCal == nil ? "Not saved" : "Saved")
+                summaryRow("Sensor cal", p.sensorCal == nil ? "Not saved" : "Saved")
             }
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -39,10 +39,15 @@ struct SettingsView: View {
     // Roll waypoints edited as strings; committed to the profile on change.
     @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
 
+    // Pyro trigger values edited as strings (seconds or meters by mode).
+    @State private var sPyro1Value = ""
+    @State private var sPyro2Value = ""
+
     // "Sent" feedback in section headers.
     @State private var servoApplied = false
     @State private var pidApplied = false
     @State private var rollControlApplied = false
+    @State private var pyroApplied = false
 
     // LoRa TX power (BS only) — hydrated from rocketConfig, debounced send.
     @State private var txPowerDbm: Int = 12
@@ -57,7 +62,7 @@ struct SettingsView: View {
     private enum SettingsTab: String, CaseIterable {
         case flight = "Flight"
         case airframe = "Airframe"
-        case camera = "Camera"
+        case pyro = "Pyro"
         case general = "General"
     }
 
@@ -88,9 +93,10 @@ struct SettingsView: View {
         case pidKp, pidKi, pidKd, pidMin, pidMax
         case rollDelay
         case wpTime(Int), wpAngle(Int)
+        case pyro1Value, pyro2Value
     }
 
-    private enum EditGroup { case servo, pid, rollControl, rollWaypoints }
+    private enum EditGroup { case servo, pid, rollControl, rollWaypoints, pyro }
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
@@ -98,6 +104,7 @@ struct SettingsView: View {
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay: return .rollControl
         case .wpTime, .wpAngle: return .rollWaypoints
+        case .pyro1Value, .pyro2Value: return .pyro
         case nil: return nil
         }
     }
@@ -108,6 +115,7 @@ struct SettingsView: View {
         case .pid: applyPIDConfig()
         case .rollControl: applyRollControlConfig()
         case .rollWaypoints: applyRollProfile()
+        case .pyro: applyPyroConfig()
         }
     }
 
@@ -262,7 +270,7 @@ struct SettingsView: View {
         switch tab {
         case .flight:   flightSections
         case .airframe: airframeSections
-        case .camera:   cameraSections
+        case .pyro:     pyroSections
         case .general:  generalSections
         }
     }
@@ -309,16 +317,43 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private var cameraSections: some View {
-        Section("Camera") {
-            Picker("Camera Type", selection: cameraBinding) {
-                Text("None").tag(0)
-                Text("GoPro").tag(1)
-                Text("RunCam").tag(2)
-            }
-            .pickerStyle(.segmented)
-            Text(cameraHint(Int(profile.cameraType)))
+    private var pyroSections: some View {
+        pyroChannelSection(1)
+        pyroChannelSection(2)
+        Section {
+            Text("Channels arm automatically at launch. Test continuity and test-fire from the rocket dashboard before flight.")
                 .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    private func pyroChannelSection(_ ch: Int) -> some View {
+        let enabled = (ch == 1) ? profile.pyro1Enabled : profile.pyro2Enabled
+        let mode = Int((ch == 1) ? profile.pyro1TriggerMode : profile.pyro2TriggerMode)
+        return Section(header: configHeader("Pyro Channel \(ch)", applied: pyroApplied)) {
+            Toggle("Enabled", isOn: pyroEnabledBinding(ch))
+            if enabled {
+                Picker("Trigger", selection: pyroModeBinding(ch)) {
+                    Text("Time after apogee").tag(0)
+                    Text("Altitude on descent").tag(1)
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    Text(mode == 0 ? "Delay" : "Altitude")
+                    Spacer()
+                    TextField(mode == 0 ? "0.0" : "0",
+                              text: (ch == 1) ? $sPyro1Value : $sPyro2Value)
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                        .focused($focusedField, equals: (ch == 1) ? .pyro1Value : .pyro2Value)
+                    Text(mode == 0 ? "s after apogee" : "m on descent")
+                        .foregroundColor(.secondary)
+                }
+                Text(mode == 0
+                    ? "Fires this many seconds after apogee is detected."
+                    : "Fires when the rocket descends through this altitude (AGL).")
+                    .font(.caption).foregroundColor(.secondary)
+            }
         }
     }
 
@@ -337,6 +372,17 @@ struct SettingsView: View {
                 device.sendServoControlConfig(enabled: $0)
             })
             Text("Stored in the rocket profile. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+
+        Section("Camera") {
+            Picker("Camera Type", selection: cameraBinding) {
+                Text("None").tag(0)
+                Text("GoPro").tag(1)
+                Text("RunCam").tag(2)
+            }
+            .pickerStyle(.segmented)
+            Text(cameraHint(Int(profile.cameraType)))
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -494,6 +540,32 @@ struct SettingsView: View {
             })
     }
 
+    // Pyro enable / mode apply immediately (like toggles); the trigger value
+    // commits on focus loss via the .pyro EditGroup.
+    private func pyroEnabledBinding(_ ch: Int) -> Binding<Bool> {
+        Binding(
+            get: { (ch == 1) ? profile.pyro1Enabled : profile.pyro2Enabled },
+            set: { newValue in
+                updateProfile {
+                    if ch == 1 { $0.pyro1Enabled = newValue } else { $0.pyro2Enabled = newValue }
+                }
+                applyPyroConfig()
+            })
+    }
+
+    private func pyroModeBinding(_ ch: Int) -> Binding<Int> {
+        Binding(
+            get: { Int((ch == 1) ? profile.pyro1TriggerMode : profile.pyro2TriggerMode) },
+            set: { newValue in
+                updateProfile {
+                    if ch == 1 { $0.pyro1TriggerMode = UInt8(newValue) }
+                    else { $0.pyro2TriggerMode = UInt8(newValue) }
+                }
+                reloadPyroValueStrings()   // reformat for the new unit (s vs m)
+                applyPyroConfig()
+            })
+    }
+
     // MARK: - String ↔ profile sync
 
     private func loadFromProfile() {
@@ -514,6 +586,18 @@ struct SettingsView: View {
         rollWaypoints = p.rollWaypoints.map {
             (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg), mode: $0.mode.rawValue)
         }
+        reloadPyroValueStrings()
+    }
+
+    private func reloadPyroValueStrings() {
+        let p = profile
+        sPyro1Value = formatPyro(p.pyro1TriggerValue, mode: p.pyro1TriggerMode)
+        sPyro2Value = formatPyro(p.pyro2TriggerValue, mode: p.pyro2TriggerMode)
+    }
+
+    /// Time-after-apogee shows one decimal (seconds); altitude shows whole metres.
+    private func formatPyro(_ v: Float, mode: UInt8) -> String {
+        String(format: mode == 0 ? "%.1f" : "%.0f", v)
     }
 
     private func formatInt(_ v: Double) -> String {
@@ -597,6 +681,32 @@ struct SettingsView: View {
             device.sendServoConfig(biases: [b1, b2, b3, b4], hz: hz, minUs: mn, maxUs: mx)
         }
         showApplied($servoApplied)
+    }
+
+    private func applyPyroConfig() {
+        let v1 = Float(sPyro1Value) ?? profile.pyro1TriggerValue
+        let v2 = Float(sPyro2Value) ?? profile.pyro2TriggerValue
+        updateProfile {
+            $0.pyro1TriggerValue = v1
+            $0.pyro2TriggerValue = v2
+        }
+        let p = profile
+        if device.isConnected {
+            device.sendPyroConfig(
+                ch1Enabled: p.pyro1Enabled, ch1Mode: p.pyro1TriggerMode, ch1Value: p.pyro1TriggerValue,
+                ch2Enabled: p.pyro2Enabled, ch2Mode: p.pyro2TriggerMode, ch2Value: p.pyro2TriggerValue)
+            // Mirror into rocketConfig so the dashboard pyro tiles update live.
+            if var cfg = device.rocketConfig {
+                cfg.pyro1Enabled = p.pyro1Enabled
+                cfg.pyro1TriggerMode = p.pyro1TriggerMode
+                cfg.pyro1TriggerValue = p.pyro1TriggerValue
+                cfg.pyro2Enabled = p.pyro2Enabled
+                cfg.pyro2TriggerMode = p.pyro2TriggerMode
+                cfg.pyro2TriggerValue = p.pyro2TriggerValue
+                device.rocketConfig = cfg
+            }
+        }
+        showApplied($pyroApplied)
     }
 
     private func applyPIDConfig() {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -51,6 +51,16 @@ struct SettingsView: View {
     @FocusState private var focusedField: EditField?
     @State private var lastFocusedField: EditField?
 
+    // Settings are grouped into tabs (one panel at a time) on phone screens
+    // (#132 / #147).  Switching a tab flushes the leaving tab's pending edit.
+    @State private var tab: SettingsTab = .flight
+    private enum SettingsTab: String, CaseIterable {
+        case flight = "Flight"
+        case airframe = "Airframe"
+        case camera = "Camera"
+        case general = "General"
+    }
+
     private var currentFreqMHz: Float { device.rocketConfig?.loraFreqMHz ?? 915.0 }
 
     private var isInitializing: Bool {
@@ -63,6 +73,12 @@ struct SettingsView: View {
     /// through `updateProfile`, which no-ops when there's no active id.
     private var profile: RocketProfile {
         store.activeProfile ?? RocketProfile.makeDefault(name: "")
+    }
+
+    /// Editing a rocket shows its name as the title; otherwise generic.
+    private var navTitle: String {
+        if !device.isBaseStation, let active = store.activeProfile { return active.name }
+        return "Settings"
     }
 
     // MARK: - Focus-driven self-apply (#144)
@@ -119,7 +135,7 @@ struct SettingsView: View {
                     rocketSettingsSections
                 }
             }
-            .navigationTitle("Settings")
+            .navigationTitle(navTitle)
             .overlay { if isInitializing { initializingOverlay } }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -136,6 +152,12 @@ struct SettingsView: View {
             }
             .onAppear { loadFromProfile() }
             .onChange(of: store.activeId) { _ in loadFromProfile() }
+            // Leaving a tab commits its pending text edit; reloading then snaps
+            // any unparseable input back to the last saved (valid) value.
+            .onChange(of: tab) { _ in
+                flushPendingEdits()
+                loadFromProfile()
+            }
             .onChange(of: focusedField) { handleFocusChange($0) }
             .onDisappear { flushPendingEdits() }
             .onReceive(device.$rocketConfig.compactMap { $0 }) { cfg in
@@ -230,39 +252,23 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var rocketSettingsSections: some View {
-        Section("Rocket") {
-            HStack {
-                Text("Active rocket")
-                Spacer()
-                Text(profile.name).foregroundColor(.secondary)
+        Section {
+            Picker("Group", selection: $tab) {
+                ForEach(SettingsTab.allCases, id: \.self) { Text($0.rawValue).tag($0) }
             }
-            Toggle("Enable Sounds", isOn: bind(\.soundsEnabled) {
-                device.sendSoundConfig(enabled: $0)
-            })
-            Toggle("Enable Servo Control", isOn: bind(\.servoControlEnabled) {
-                device.sendServoControlConfig(enabled: $0)
-            })
-            NavigationLink {
-                MagCalView(device: device)
-            } label: {
-                Label("Magnetometer Calibration", systemImage: "location.north.line")
-            }
-            Text("Stored in the rocket profile. Persists across reboots.")
-                .font(.caption).foregroundColor(.secondary)
+            .pickerStyle(.segmented)
         }
 
-        Section(header: configHeader("Servo", applied: servoApplied)) {
-            stringRow("Servo 1", text: $sBias1, field: .bias1)
-            stringRow("Servo 2", text: $sBias2, field: .bias2)
-            stringRow("Servo 3", text: $sBias3, field: .bias3)
-            stringRow("Servo 4", text: $sBias4, field: .bias4)
-            Text("Microsecond offset per servo to trim mechanical misalignment.")
-                .font(.caption).foregroundColor(.secondary)
-            stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
-            stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
-            stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
+        switch tab {
+        case .flight:   flightSections
+        case .airframe: airframeSections
+        case .camera:   cameraSections
+        case .general:  generalSections
         }
+    }
 
+    @ViewBuilder
+    private var flightSections: some View {
         Section(header: configHeader("PID Gains", applied: pidApplied)) {
             stringRow("Kp", text: $sPidKp, field: .pidKp, decimal: true)
             stringRow("Ki", text: $sPidKi, field: .pidKi, decimal: true)
@@ -275,7 +281,35 @@ struct SettingsView: View {
             Text("Scales PID gains with (V_ref/V)\u{00B2}. Disable for fixed gains at all speeds.")
                 .font(.caption).foregroundColor(.secondary)
         }
+        rollControlSection
+    }
 
+    @ViewBuilder
+    private var airframeSections: some View {
+        Section(header: configHeader("Servo", applied: servoApplied)) {
+            stringRow("Servo 1", text: $sBias1, field: .bias1)
+            stringRow("Servo 2", text: $sBias2, field: .bias2)
+            stringRow("Servo 3", text: $sBias3, field: .bias3)
+            stringRow("Servo 4", text: $sBias4, field: .bias4)
+            Text("Microsecond offset per servo to trim mechanical misalignment.")
+                .font(.caption).foregroundColor(.secondary)
+            stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
+            stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
+            stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
+        }
+        Section("Magnetometer") {
+            NavigationLink {
+                MagCalView(device: device)
+            } label: {
+                Label("Magnetometer Calibration", systemImage: "location.north.line")
+            }
+            Text("Calibration is saved per rocket. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var cameraSections: some View {
         Section("Camera") {
             Picker("Camera Type", selection: cameraBinding) {
                 Text("None").tag(0)
@@ -286,8 +320,25 @@ struct SettingsView: View {
             Text(cameraHint(Int(profile.cameraType)))
                 .font(.caption).foregroundColor(.secondary)
         }
+    }
 
-        rollControlSection
+    @ViewBuilder
+    private var generalSections: some View {
+        Section("Rocket") {
+            HStack {
+                Text("Active rocket")
+                Spacer()
+                Text(profile.name).foregroundColor(.secondary)
+            }
+            Toggle("Enable Sounds", isOn: bind(\.soundsEnabled) {
+                device.sendSoundConfig(enabled: $0)
+            })
+            Toggle("Enable Servo Control", isOn: bind(\.servoControlEnabled) {
+                device.sendServoControlConfig(enabled: $0)
+            })
+            Text("Stored in the rocket profile. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
     }
 
     @ViewBuilder

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -73,6 +73,13 @@ struct SettingsView: View {
             && device.telemetry.state == "INITIALIZATION"
     }
 
+    /// Calibrations run on the rocket, so they need it connected AND powered
+    /// on (its sensors aren't running otherwise).  Other settings stay
+    /// editable offline — only the cal rows are gated.
+    private var canCalibrate: Bool {
+        device.isConnected && !device.isBaseStation && device.telemetry.pwr_pin_on
+    }
+
     /// Convenience: the active profile, or a throwaway default so getters have
     /// something to read before a profile is selected.  Writes always go
     /// through `updateProfile`, which no-ops when there's no active id.
@@ -384,9 +391,15 @@ struct SettingsView: View {
             } label: {
                 Label("Magnetometer Calibration", systemImage: "location.north.line")
             }
+            .disabled(!canCalibrate)
             OnPadCalibrationView(device: device, embedded: true)
-            Text("Mag cal is saved to this rocket's profile and re-applied on connect. Sensor (gyro/accel) calibration runs on the connected rocket — place it on the pad and keep still.")
-                .font(.caption).foregroundColor(.secondary)
+            if canCalibrate {
+                Text("Mag and sensor cal are saved to this rocket's profile and re-applied on connect. Place the rocket on the pad and keep still while calibrating.")
+                    .font(.caption).foregroundColor(.secondary)
+            } else {
+                Label("Power on the rocket to run calibrations.", systemImage: "bolt.slash")
+                    .font(.caption).foregroundColor(.orange)
+            }
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -2,55 +2,26 @@
 //  SettingsView.swift
 //  TinkerRocketApp
 //
-//  Device settings: rocket computer configuration + LoRa radio settings.
-//  Rocket settings (sounds, etc.) are relayed via I2C to the FlightComputer.
-//  LoRa settings are sent to whichever device is currently connected via BLE.
+//  Per-rocket settings, edited against the ACTIVE rocket profile (issue
+//  #132).  The app is source-of-truth: edits are written to the profile and,
+//  when a rocket is connected, also pushed live so there's no
+//  disconnect/reconnect needed to apply.  On the next connect the
+//  ActiveRocketSyncer re-pushes the whole profile, so the rocket always
+//  matches the profile regardless of what was in its NVS.
+//
+//  LoRa frequency / TX power stay device/BS-side (not part of a profile) and
+//  are shown here read-only / BS-only as before.
 //
 
 import SwiftUI
 import Combine
 
-// MARK: - LoRa UI policy (issue #136)
-//
-// LoRa configuration is no longer user-editable from the app.  The base
-// station boots on the hardcoded rendezvous frequency, runs a noise scan
-// once it acquires the rocket, and uses the cmd-10 transactional flow to
-// move both ends onto the quietest channel — all without user
-// involvement.  This view shows only a read-only "Current frequency" so
-// the user can confirm both devices ended up on the same channel.
-// Hopping / preset / TX-power controls are gated behind a developer flag
-// in firmware (cmd 17 / cmd 10), not exposed here.
-
-// MARK: - SettingsView
-
 struct SettingsView: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var store: RocketProfileStore
     @Environment(\.dismiss) var dismiss
 
-    // Persisted selections — Rocket settings
-    @AppStorage("rocketSoundsEnabled")  private var soundsEnabled: Bool = false
-    @AppStorage("servoControlEnabled")  private var servoControlEnabled: Bool = true
-    @AppStorage("gainScheduleEnabled")  private var gainScheduleEnabled: Bool = true
-    @AppStorage("useAngleControl")      private var useAngleControl: Bool = false
-    @AppStorage("rollDelayMs")          private var rollDelayMs: Double = 0
-    @AppStorage("guidanceEnabled")      private var guidanceEnabled: Bool = false
-    @AppStorage("cameraType")           private var cameraType: Int = 2  // 0=None, 1=GoPro, 2=RunCam
-
-    // Persisted servo/PID values (synced from rocket on connect, updated on Apply)
-    @AppStorage("servoBias1")   private var storedBias1: Double = 85
-    @AppStorage("servoBias2")   private var storedBias2: Double = 0
-    @AppStorage("servoBias3")   private var storedBias3: Double = 0
-    @AppStorage("servoBias4")   private var storedBias4: Double = 0
-    @AppStorage("servoHz")      private var storedServoHz: Double = 333
-    @AppStorage("servoMinUs")   private var storedServoMinUs: Double = 1250
-    @AppStorage("servoMaxUs")   private var storedServoMaxUs: Double = 1750
-    @AppStorage("pidKp")        private var storedPidKp: Double = 0.08
-    @AppStorage("pidKi")        private var storedPidKi: Double = 0.005
-    @AppStorage("pidKd")        private var storedPidKd: Double = 0.003
-    @AppStorage("pidMinCmd")    private var storedPidMinCmd: Double = -10.0
-    @AppStorage("pidMaxCmd")    private var storedPidMaxCmd: Double = 10.0
-
-    // Editable string fields — no live parsing, parsed only on Apply
+    // Editable string fields — parsed on focus loss, not per keystroke.
     @State private var sBias1 = ""
     @State private var sBias2 = ""
     @State private var sBias3 = ""
@@ -63,52 +34,39 @@ struct SettingsView: View {
     @State private var sPidKd = ""
     @State private var sPidMinCmd = ""
     @State private var sPidMaxCmd = ""
-
-    // Roll profile waypoints — persisted as JSON string in @AppStorage.
-    // mode is the segment mode for the segment STARTING at this waypoint:
-    //   0 = ROLL_SEG_ANGLE     -- interpolate angle to next waypoint
-    //   1 = ROLL_SEG_NULL_RATE -- hold rate=0; angle field ignored
-    @AppStorage("rollProfileJSON") private var rollProfileJSON: String = "[]"
-    @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
-
-    // Roll control config
     @State private var sRollDelayMs = ""
 
-    // Config "Sent" feedback — transient checkmark in section headers.
+    // Roll waypoints edited as strings; committed to the profile on change.
+    @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
+
+    // "Sent" feedback in section headers.
     @State private var servoApplied = false
     @State private var pidApplied = false
     @State private var rollControlApplied = false
 
-    // LoRa TX power (base station only).  Hydrated from rocketConfig on
-    // readback; user edits are debounced so a rapid Stepper drag fires one
-    // Cmd 10 transaction at the final value instead of one per tick.
+    // LoRa TX power (BS only) — hydrated from rocketConfig, debounced send.
     @State private var txPowerDbm: Int = 12
     @State private var txPowerSendWork: DispatchWorkItem?
 
-    // Self-apply on focus loss (#144): editable config fields are sent to
-    // the rocket when keyboard focus leaves their section, so there's no
-    // separate "apply" button to forget.
     @FocusState private var focusedField: EditField?
     @State private var lastFocusedField: EditField?
 
-    /// Current active frequency for the connected device, read from the most
-    /// recent config readback.  Falls back to the factory default so the
-    /// read-only summary has something to show before the first readback
-    /// lands (typically the rendezvous freq, since BS boots there too).
-    private var currentFreqMHz: Float {
-        device.rocketConfig?.loraFreqMHz ?? 915.0
+    private var currentFreqMHz: Float { device.rocketConfig?.loraFreqMHz ?? 915.0 }
+
+    private var isInitializing: Bool {
+        device.isConnected && !device.isBaseStation
+            && device.telemetry.state == "INITIALIZATION"
     }
 
-    /// True when the connected rocket is still initializing (sensors/GPS starting up).
-    private var isInitializing: Bool {
-        device.isConnected
-        && !device.isBaseStation
-        && device.telemetry.state == "INITIALIZATION"
+    /// Convenience: the active profile, or a throwaway default so getters have
+    /// something to read before a profile is selected.  Writes always go
+    /// through `updateProfile`, which no-ops when there's no active id.
+    private var profile: RocketProfile {
+        store.activeProfile ?? RocketProfile.makeDefault(name: "")
     }
 
     // MARK: - Focus-driven self-apply (#144)
 
-    /// Identifies every editable config text field for @FocusState tracking.
     private enum EditField: Hashable {
         case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax
         case pidKp, pidKi, pidKd, pidMin, pidMax
@@ -116,351 +74,53 @@ struct SettingsView: View {
         case wpTime(Int), wpAngle(Int)
     }
 
-    /// Config groups — every field in a group is pushed together by one
-    /// `apply*` call when keyboard focus leaves the group.
-    private enum EditGroup {
-        case servo, pid, rollControl, rollWaypoints
-    }
+    private enum EditGroup { case servo, pid, rollControl, rollWaypoints }
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
-        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax:
-            return .servo
-        case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax:
-            return .pid
-        case .rollDelay:
-            return .rollControl
-        case .wpTime, .wpAngle:
-            return .rollWaypoints
-        case nil:
-            return nil
+        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax: return .servo
+        case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
+        case .rollDelay: return .rollControl
+        case .wpTime, .wpAngle: return .rollWaypoints
+        case nil: return nil
         }
     }
 
     private func applyGroup(_ g: EditGroup) {
         switch g {
-        case .servo:         applyServoConfig()
-        case .pid:           applyPIDConfig()
-        case .rollControl:   applyRollControlConfig()
+        case .servo: applyServoConfig()
+        case .pid: applyPIDConfig()
+        case .rollControl: applyRollControlConfig()
         case .rollWaypoints: applyRollProfile()
         }
     }
 
-    /// Push a group's config when keyboard focus leaves it — to another
-    /// group, or to nil when the keyboard dismisses.  This is what makes
-    /// every text field "apply on edit" with no separate button (#144).
     private func handleFocusChange(_ newField: EditField?) {
         let previous = lastFocusedField
         lastFocusedField = newField
-        if let leftGroup = group(of: previous),
-           leftGroup != group(of: newField) {
+        if let leftGroup = group(of: previous), leftGroup != group(of: newField) {
             applyGroup(leftGroup)
         }
     }
 
-    /// Flush a still-focused field if the view goes away before focus
-    /// cleared (e.g. nav-bar Done tapped with the keyboard still up).
     private func flushPendingEdits() {
-        if let g = group(of: lastFocusedField) {
-            applyGroup(g)
-        }
+        if let g = group(of: lastFocusedField) { applyGroup(g) }
         lastFocusedField = nil
     }
 
     var body: some View {
         NavigationView {
             Form {
-                // Network settings hidden in #136: both ends are forced to
-                // the firmware default network ID at boot so the BS and OC
-                // can't drift apart silently.  The text-field UI showed the
-                // app's @AppStorage "Network ID" — which had nothing to do
-                // with what the connected device actually used — and that
-                // confused users into thinking they were on the same
-                // network when in fact the OC's NVS still carried an old
-                // value while the BS had been reset to default.  The
-                // user-facing network-name flow returns alongside hopping
-                // in #150.
-
-                // Rocket computer settings (only when connected directly to rocket)
-                if !device.isBaseStation {
-                    Section("Rocket Settings") {
-                        Toggle("Enable Sounds", isOn: $soundsEnabled)
-                            .onChange(of: soundsEnabled) { newValue in
-                                device.sendSoundConfig(enabled: newValue)
-                            }
-                        Toggle("Enable Servo Control", isOn: $servoControlEnabled)
-                            .onChange(of: servoControlEnabled) { newValue in
-                                device.sendServoControlConfig(enabled: newValue)
-                            }
-                        // Hard-iron magnetometer cal entry (issue #96).  Only
-                        // shown for direct rocket connections — the cal flow
-                        // runs on the FC itself and the OC publishes status
-                        // back over the same BLE link.
-                        NavigationLink {
-                            MagCalView(device: device)
-                        } label: {
-                            Label("Magnetometer Calibration", systemImage: "location.north.line")
-                        }
-                        Text("Persists across reboots.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                }
-
-                // --- LoRa Frequency (read-only) ---
-                //
-                // Issue #136: the BS auto-acquires the rocket on the
-                // hardcoded rendezvous frequency, runs a noise scan, and
-                // moves both ends to the quietest channel via the
-                // existing cmd-10 transactional handshake.  Nothing here
-                // is user-editable.  We show the current channel so the
-                // user can confirm both devices ended up on the same
-                // frequency — if they don't match, the BS rolled back
-                // and both should be reading the rendezvous (915 MHz).
                 if device.isBaseStation {
-                    Section(header: Text("LoRa Frequency"),
-                            footer: Text("Base station picks the quietest channel automatically at boot. Both devices should report the same frequency.")) {
-                        HStack {
-                            Text("Current")
-                            Spacer()
-                            Text(String(format: "%.2f MHz", currentFreqMHz))
-                                .foregroundColor(.secondary)
-                                .font(.system(.body, design: .monospaced))
-                        }
-                    }
-
-                    // LoRa TX power — adjusts both BS and rocket via the
-                    // existing Cmd 10 transactional flow.  Stepper changes
-                    // are debounced; the BS firmware relays the new power
-                    // to the rocket, verifies a beacon on the new setting,
-                    // and rolls back if the rocket can't be heard.
-                    Section(header: Text("LoRa TX Power"),
-                            footer: txPowerFooter) {
-                        Stepper(value: $txPowerDbm, in: -9...22) {
-                            HStack {
-                                Text("Power")
-                                Spacer()
-                                Text("\(txPowerDbm) dBm")
-                                    .foregroundColor(.secondary)
-                                    .font(.system(.body, design: .monospaced))
-                            }
-                        }
-                        .disabled(device.autoApplyRefusalReason() != nil)
-                        .onChange(of: txPowerDbm) { newValue in
-                            scheduleTxPowerSend(newValue)
-                        }
-                    }
-                }
-
-                // --- Servo & PID Settings (rocket only) ---
-
-                if !device.isBaseStation {
-                    // Servo biases + timing share one config message, so
-                    // they live in one section that self-applies when focus
-                    // leaves any of its fields (#144).
-                    Section(header: configHeader("Servo", applied: servoApplied)) {
-                        stringRow("Servo 1", text: $sBias1, field: .bias1)
-                        stringRow("Servo 2", text: $sBias2, field: .bias2)
-                        stringRow("Servo 3", text: $sBias3, field: .bias3)
-                        stringRow("Servo 4", text: $sBias4, field: .bias4)
-                        Text("Microsecond offset per servo to trim mechanical misalignment.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
-                        stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
-                        stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
-                    }
-
-                    Section(header: configHeader("PID Gains", applied: pidApplied)) {
-                        stringRow("Kp", text: $sPidKp, field: .pidKp, decimal: true)
-                        stringRow("Ki", text: $sPidKi, field: .pidKi, decimal: true)
-                        stringRow("Kd", text: $sPidKd, field: .pidKd, decimal: true)
-                        stringRow("Min Cmd", text: $sPidMinCmd, field: .pidMin, unit: "deg")
-                        stringRow("Max Cmd", text: $sPidMaxCmd, field: .pidMax, unit: "deg")
-                        Toggle("Velocity Gain Scheduling", isOn: $gainScheduleEnabled)
-                            .onChange(of: gainScheduleEnabled) { newValue in
-                                device.sendGainScheduleConfig(enabled: newValue)
-                            }
-                        Text("Scales PID gains with (V_ref/V)\u{00B2}. Disable for fixed gains at all speeds.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    // Control Mode (PN guidance) picker hidden until PN
-                    // guidance is flight-validated (#144).  guidanceEnabled
-                    // @AppStorage + sendGuidanceConfig() plumbing kept intact.
-
-                    Section("Camera") {
-                        Picker("Camera Type", selection: $cameraType) {
-                            Text("None").tag(0)
-                            Text("GoPro").tag(1)
-                            Text("RunCam").tag(2)
-                        }
-                        .pickerStyle(.segmented)
-                        .onChange(of: cameraType) { newValue in
-                            device.sendCameraConfig(cameraType: UInt8(newValue))
-                        }
-                        Text(cameraType == 1
-                            ? "GoPro: controlled via GPIO pulse on shutter pin."
-                            : cameraType == 2
-                            ? "RunCam: controlled via UART serial command."
-                            : "No camera connected.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    // Roll Control + Roll Profile unified into one section
-                    // (#144).  The mode picker self-applies cmd 31 on change
-                    // — pre-#144 the "Use Roll Profile" toggle only flipped
-                    // local @AppStorage, so a user could load a profile that
-                    // the FC never activated.  The waypoint editor is only
-                    // shown in Track Profile mode.
-                    Section(header: configHeader("Roll Control", applied: rollControlApplied)) {
-                        Picker("Mode", selection: $useAngleControl) {
-                            Text("Null Roll").tag(false)
-                            Text("Track Profile").tag(true)
-                        }
-                        .pickerStyle(.segmented)
-                        .onChange(of: useAngleControl) { _ in
-                            applyRollControlConfig()
-                        }
-                        Text(useAngleControl
-                            ? "Cascaded angle control \u{2014} fins track the roll profile waypoints below."
-                            : "Rate-only control \u{2014} fins hold zero roll rate. No profile followed.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
-                        HStack {
-                            Text("Activation Delay")
-                            Spacer()
-                            TextField("0", text: $sRollDelayMs)
-                                .keyboardType(.numberPad)
-                                .multilineTextAlignment(.trailing)
-                                .frame(width: 80)
-                                .focused($focusedField, equals: .rollDelay)
-                            Text("ms")
-                                .foregroundColor(.secondary)
-                        }
-                        Text("Milliseconds after launch before any roll control activates. Keeps fins neutral during initial boost.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
-                        if useAngleControl {
-                            Text("Each waypoint defines the START of a segment. Pick the mode per waypoint: Angle interpolates the target roll angle to the next waypoint's angle; Null Rate holds zero roll rate (angle field ignored) for the duration of the segment.")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-
-                            ForEach(rollWaypoints.indices, id: \.self) { i in
-                                VStack(spacing: 4) {
-                                    HStack(spacing: 8) {
-                                        Text("WP \(i + 1)")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                            .frame(width: 40)
-                                        TextField("Time", text: Binding(
-                                            get: { rollWaypoints[i].time },
-                                            set: { rollWaypoints[i].time = $0 }
-                                        ))
-                                        .keyboardType(.decimalPad)
-                                        .multilineTextAlignment(.trailing)
-                                        .frame(width: 60)
-                                        .focused($focusedField, equals: .wpTime(i))
-                                        Text("s")
-                                            .foregroundColor(.secondary)
-                                            .frame(width: 15)
-                                        TextField("Angle", text: Binding(
-                                            get: { rollWaypoints[i].angle },
-                                            set: { rollWaypoints[i].angle = $0 }
-                                        ))
-                                        .keyboardType(.numbersAndPunctuation)
-                                        .multilineTextAlignment(.trailing)
-                                        .frame(width: 60)
-                                        .focused($focusedField, equals: .wpAngle(i))
-                                        .disabled(rollWaypoints[i].mode == 1)
-                                        .foregroundColor(rollWaypoints[i].mode == 1 ? .secondary : .primary)
-                                        Text("\u{00B0}")
-                                            .foregroundColor(.secondary)
-                                            .frame(width: 15)
-                                        Button(role: .destructive) {
-                                            rollWaypoints.remove(at: i)
-                                            applyRollProfile()
-                                        } label: {
-                                            Image(systemName: "minus.circle.fill")
-                                                .foregroundColor(.red)
-                                        }
-                                        .buttonStyle(.borderless)
-                                    }
-                                    Picker("Mode", selection: Binding(
-                                        get: { rollWaypoints[i].mode },
-                                        set: {
-                                            rollWaypoints[i].mode = $0
-                                            applyRollProfile()
-                                        }
-                                    )) {
-                                        Text("Angle").tag(UInt8(0))
-                                        Text("Null Rate").tag(UInt8(1))
-                                    }
-                                    .pickerStyle(.segmented)
-                                    .padding(.leading, 40)
-                                }
-                            }
-
-                            if rollWaypoints.count < 8 {
-                                Button {
-                                    let defaultTime = rollWaypoints.isEmpty ? "0.0" :
-                                        String(format: "%.1f", (Double(rollWaypoints.last?.time ?? "0") ?? 0) + 1.0)
-                                    rollWaypoints.append((time: defaultTime, angle: "0", mode: 0))
-                                    applyRollProfile()
-                                } label: {
-                                    HStack {
-                                        Image(systemName: "plus.circle.fill")
-                                        Text("Add Waypoint")
-                                    }
-                                }
-                            }
-
-                            Button(role: .destructive) {
-                                rollWaypoints.removeAll()
-                                saveRollWaypointsToStorage()
-                                device.sendRollProfileClear()
-                                showApplied($rollControlApplied)
-                            } label: {
-                                HStack {
-                                    Image(systemName: "trash")
-                                    Text("Clear Roll Profile")
-                                }
-                                .frame(maxWidth: .infinity)
-                            }
-                            .disabled(!device.isConnected)
-                        }
-
-                        Text("Persists across reboots.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+                    baseStationSections
+                } else if store.activeProfile == nil {
+                    noProfileSection
+                } else {
+                    rocketSettingsSections
                 }
             }
             .navigationTitle("Settings")
-            .overlay {
-                if isInitializing {
-                    ZStack {
-                        Color(.systemBackground).opacity(0.9)
-                            .ignoresSafeArea()
-                        VStack(spacing: 16) {
-                            ProgressView()
-                                .scaleEffect(1.5)
-                            Text("Initializing...")
-                                .font(.title2.bold())
-                            Text("Waiting for sensors to start up.\nSettings can be applied once ready.")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
-                        .padding()
-                    }
-                }
-            }
+            .overlay { if isInitializing { initializingOverlay } }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") { dismiss() }
@@ -474,61 +134,335 @@ struct SettingsView: View {
                     }
                 }
             }
-            .onAppear {
-                loadStringsFromStorage()
-                loadRollWaypointsFromStorage()
-            }
-            .onChange(of: focusedField) { newField in
-                handleFocusChange(newField)
-            }
-            .onDisappear {
-                flushPendingEdits()
-            }
-            // Sync settings from rocket config received on BLE connect
+            .onAppear { loadFromProfile() }
+            .onChange(of: store.activeId) { _ in loadFromProfile() }
+            .onChange(of: focusedField) { handleFocusChange($0) }
+            .onDisappear { flushPendingEdits() }
             .onReceive(device.$rocketConfig.compactMap { $0 }) { cfg in
-                storedBias1 = Double(cfg.servoBias1)
-                storedServoHz = Double(cfg.servoHz)
-                storedServoMinUs = Double(cfg.servoMinUs)
-                storedServoMaxUs = Double(cfg.servoMaxUs)
-                storedPidKp = Double(cfg.pidKp)
-                storedPidKi = Double(cfg.pidKi)
-                storedPidKd = Double(cfg.pidKd)
-                storedPidMinCmd = Double(cfg.pidMinCmd)
-                storedPidMaxCmd = Double(cfg.pidMaxCmd)
-                servoControlEnabled = cfg.servoEnabled
-                gainScheduleEnabled = cfg.gainScheduleEnabled
-                useAngleControl = cfg.useAngleControl
-                rollDelayMs = Double(cfg.rollDelayMs)
-                guidanceEnabled = cfg.guidanceEnabled
-                cameraType = Int(cfg.cameraType)
-                // LoRa state is displayed read-only via `currentFreqMHz`;
-                // SF / BW / CR / hop are still gated behind a developer
-                // flag (#136).  TX power is the one exception: the BS GUI
-                // exposes a Stepper, hydrated here from the readback.
-                if let pwr = cfg.loraTxPower {
-                    txPowerDbm = Int(pwr)
-                }
-                loadStringsFromStorage()
+                // Only LoRa TX power is hydrated from the rocket now — every
+                // other setting is owned by the profile (app is source of
+                // truth) so we no longer pull config back into local state.
+                if let pwr = cfg.loraTxPower { txPowerDbm = Int(pwr) }
             }
         }
     }
 
-    // MARK: - String ↔ Storage sync
+    // MARK: - Base station (read-only display)
 
-    private func loadStringsFromStorage() {
-        sBias1 = formatInt(storedBias1)
-        sBias2 = formatInt(storedBias2)
-        sBias3 = formatInt(storedBias3)
-        sBias4 = formatInt(storedBias4)
-        sServoHz = formatInt(storedServoHz)
-        sServoMinUs = formatInt(storedServoMinUs)
-        sServoMaxUs = formatInt(storedServoMaxUs)
-        sPidKp = formatDecimal(storedPidKp)
-        sPidKi = formatDecimal(storedPidKi)
-        sPidKd = formatDecimal(storedPidKd)
-        sPidMinCmd = formatDecimal(storedPidMinCmd)
-        sPidMaxCmd = formatDecimal(storedPidMaxCmd)
-        sRollDelayMs = formatInt(rollDelayMs)
+    @ViewBuilder
+    private var baseStationSections: some View {
+        Section(header: Text("Active Rocket")) {
+            HStack {
+                Image("RocketIcon")
+                    .resizable().renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20, height: 20)
+                    .foregroundColor(.accentColor)
+                Text(store.activeProfile?.name ?? "None selected")
+                    .fontWeight(.semibold)
+            }
+            Text("Settings are stored per rocket in the app. To change them, connect directly to the rocket computer over Bluetooth.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+
+        if let p = store.activeProfile {
+            Section(header: Text("Summary")) {
+                summaryRow("Control mode", p.useAngleControl ? "Track Profile" : "Null Roll")
+                summaryRow("Camera", cameraLabel(p.cameraType))
+                summaryRow("Gain scheduling", p.gainScheduleEnabled ? "On" : "Off")
+                summaryRow("Mag cal", p.magCal == nil ? "Not saved" : "Saved")
+            }
+        }
+
+        loRaSections
+    }
+
+    @ViewBuilder
+    private var loRaSections: some View {
+        Section(header: Text("LoRa Frequency"),
+                footer: Text("Base station picks the quietest channel automatically at boot. Both devices should report the same frequency.")) {
+            HStack {
+                Text("Current")
+                Spacer()
+                Text(String(format: "%.2f MHz", currentFreqMHz))
+                    .foregroundColor(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+        }
+
+        Section(header: Text("LoRa TX Power"), footer: txPowerFooter) {
+            Stepper(value: $txPowerDbm, in: -9...22) {
+                HStack {
+                    Text("Power")
+                    Spacer()
+                    Text("\(txPowerDbm) dBm")
+                        .foregroundColor(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
+            }
+            .disabled(device.autoApplyRefusalReason() != nil)
+            .onChange(of: txPowerDbm) { scheduleTxPowerSend($0) }
+        }
+    }
+
+    // MARK: - No active profile
+
+    private var noProfileSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("No rocket selected")
+                    .font(.headline)
+                Text("Pick or create a rocket from the rocket menu to edit its settings.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                NavigationLink {
+                    RocketProfileView(device: device)
+                } label: {
+                    Label("Choose Rocket", systemImage: "list.bullet")
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Rocket settings (profile-backed)
+
+    @ViewBuilder
+    private var rocketSettingsSections: some View {
+        Section("Rocket") {
+            HStack {
+                Text("Active rocket")
+                Spacer()
+                Text(profile.name).foregroundColor(.secondary)
+            }
+            Toggle("Enable Sounds", isOn: bind(\.soundsEnabled) {
+                device.sendSoundConfig(enabled: $0)
+            })
+            Toggle("Enable Servo Control", isOn: bind(\.servoControlEnabled) {
+                device.sendServoControlConfig(enabled: $0)
+            })
+            NavigationLink {
+                MagCalView(device: device)
+            } label: {
+                Label("Magnetometer Calibration", systemImage: "location.north.line")
+            }
+            Text("Stored in the rocket profile. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+
+        Section(header: configHeader("Servo", applied: servoApplied)) {
+            stringRow("Servo 1", text: $sBias1, field: .bias1)
+            stringRow("Servo 2", text: $sBias2, field: .bias2)
+            stringRow("Servo 3", text: $sBias3, field: .bias3)
+            stringRow("Servo 4", text: $sBias4, field: .bias4)
+            Text("Microsecond offset per servo to trim mechanical misalignment.")
+                .font(.caption).foregroundColor(.secondary)
+            stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
+            stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
+            stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
+        }
+
+        Section(header: configHeader("PID Gains", applied: pidApplied)) {
+            stringRow("Kp", text: $sPidKp, field: .pidKp, decimal: true)
+            stringRow("Ki", text: $sPidKi, field: .pidKi, decimal: true)
+            stringRow("Kd", text: $sPidKd, field: .pidKd, decimal: true)
+            stringRow("Min Cmd", text: $sPidMinCmd, field: .pidMin, unit: "deg")
+            stringRow("Max Cmd", text: $sPidMaxCmd, field: .pidMax, unit: "deg")
+            Toggle("Velocity Gain Scheduling", isOn: bind(\.gainScheduleEnabled) {
+                device.sendGainScheduleConfig(enabled: $0)
+            })
+            Text("Scales PID gains with (V_ref/V)\u{00B2}. Disable for fixed gains at all speeds.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+
+        Section("Camera") {
+            Picker("Camera Type", selection: cameraBinding) {
+                Text("None").tag(0)
+                Text("GoPro").tag(1)
+                Text("RunCam").tag(2)
+            }
+            .pickerStyle(.segmented)
+            Text(cameraHint(Int(profile.cameraType)))
+                .font(.caption).foregroundColor(.secondary)
+        }
+
+        rollControlSection
+    }
+
+    @ViewBuilder
+    private var rollControlSection: some View {
+        Section(header: configHeader("Roll Control", applied: rollControlApplied)) {
+            Picker("Mode", selection: angleControlBinding) {
+                Text("Null Roll").tag(false)
+                Text("Track Profile").tag(true)
+            }
+            .pickerStyle(.segmented)
+            Text(profile.useAngleControl
+                ? "Cascaded angle control \u{2014} fins track the roll profile waypoints below."
+                : "Rate-only control \u{2014} fins hold zero roll rate. No profile followed.")
+                .font(.caption).foregroundColor(.secondary)
+
+            HStack {
+                Text("Activation Delay")
+                Spacer()
+                TextField("0", text: $sRollDelayMs)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 80)
+                    .focused($focusedField, equals: .rollDelay)
+                Text("ms").foregroundColor(.secondary)
+            }
+            Text("Milliseconds after launch before any roll control activates. Keeps fins neutral during initial boost.")
+                .font(.caption).foregroundColor(.secondary)
+
+            if profile.useAngleControl {
+                rollWaypointEditor
+            }
+
+            Text("Stored in the rocket profile. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var rollWaypointEditor: some View {
+        Text("Each waypoint defines the START of a segment. Angle interpolates the target roll angle to the next waypoint; Null Rate holds zero roll rate (angle ignored) for the segment.")
+            .font(.caption).foregroundColor(.secondary)
+
+        ForEach(rollWaypoints.indices, id: \.self) { i in
+            VStack(spacing: 4) {
+                HStack(spacing: 8) {
+                    Text("WP \(i + 1)")
+                        .font(.caption).foregroundColor(.secondary).frame(width: 40)
+                    TextField("Time", text: Binding(
+                        get: { rollWaypoints[i].time },
+                        set: { rollWaypoints[i].time = $0 }))
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing).frame(width: 60)
+                        .focused($focusedField, equals: .wpTime(i))
+                    Text("s").foregroundColor(.secondary).frame(width: 15)
+                    TextField("Angle", text: Binding(
+                        get: { rollWaypoints[i].angle },
+                        set: { rollWaypoints[i].angle = $0 }))
+                        .keyboardType(.numbersAndPunctuation)
+                        .multilineTextAlignment(.trailing).frame(width: 60)
+                        .focused($focusedField, equals: .wpAngle(i))
+                        .disabled(rollWaypoints[i].mode == 1)
+                        .foregroundColor(rollWaypoints[i].mode == 1 ? .secondary : .primary)
+                    Text("\u{00B0}").foregroundColor(.secondary).frame(width: 15)
+                    Button(role: .destructive) {
+                        rollWaypoints.remove(at: i)
+                        applyRollProfile()
+                    } label: {
+                        Image(systemName: "minus.circle.fill").foregroundColor(.red)
+                    }
+                    .buttonStyle(.borderless)
+                }
+                Picker("Mode", selection: Binding(
+                    get: { rollWaypoints[i].mode },
+                    set: { rollWaypoints[i].mode = $0; applyRollProfile() })) {
+                    Text("Angle").tag(UInt8(0))
+                    Text("Null Rate").tag(UInt8(1))
+                }
+                .pickerStyle(.segmented)
+                .padding(.leading, 40)
+            }
+        }
+
+        if rollWaypoints.count < 8 {
+            Button {
+                let defaultTime = rollWaypoints.isEmpty ? "0.0" :
+                    String(format: "%.1f", (Double(rollWaypoints.last?.time ?? "0") ?? 0) + 1.0)
+                rollWaypoints.append((time: defaultTime, angle: "0", mode: 0))
+                applyRollProfile()
+            } label: {
+                HStack { Image(systemName: "plus.circle.fill"); Text("Add Waypoint") }
+            }
+        }
+
+        Button(role: .destructive) {
+            rollWaypoints.removeAll()
+            updateProfile { $0.rollWaypoints = [] }
+            if device.isConnected { device.sendRollProfileClear() }
+            showApplied($rollControlApplied)
+        } label: {
+            HStack { Image(systemName: "trash"); Text("Clear Roll Profile") }
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var initializingOverlay: some View {
+        ZStack {
+            Color(.systemBackground).opacity(0.9).ignoresSafeArea()
+            VStack(spacing: 16) {
+                ProgressView().scaleEffect(1.5)
+                Text("Initializing...").font(.title2.bold())
+                Text("Waiting for sensors to start up.\nSettings can be applied once ready.")
+                    .font(.subheadline).foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Profile bindings
+
+    private func updateProfile(_ mutate: (inout RocketProfile) -> Void) {
+        guard let id = store.activeId else { return }
+        store.update(id, mutate)
+    }
+
+    /// Binding into a profile field that persists the edit and, when a rocket
+    /// is connected, pushes it live via `push`.
+    private func bind<T>(_ kp: WritableKeyPath<RocketProfile, T>,
+                         push: @escaping (T) -> Void) -> Binding<T> {
+        Binding(
+            get: { profile[keyPath: kp] },
+            set: { newValue in
+                updateProfile { $0[keyPath: kp] = newValue }
+                if device.isConnected { push(newValue) }
+            })
+    }
+
+    private var cameraBinding: Binding<Int> {
+        Binding(
+            get: { Int(profile.cameraType) },
+            set: { newValue in
+                updateProfile { $0.cameraType = UInt8(clamping: newValue) }
+                if device.isConnected { device.sendCameraConfig(cameraType: UInt8(clamping: newValue)) }
+            })
+    }
+
+    private var angleControlBinding: Binding<Bool> {
+        Binding(
+            get: { profile.useAngleControl },
+            set: { newValue in
+                updateProfile { $0.useAngleControl = newValue }
+                applyRollControlConfig()
+            })
+    }
+
+    // MARK: - String ↔ profile sync
+
+    private func loadFromProfile() {
+        let p = profile
+        sBias1 = formatInt(Double(p.servoBias1))
+        sBias2 = formatInt(Double(p.servoBias2))
+        sBias3 = formatInt(Double(p.servoBias3))
+        sBias4 = formatInt(Double(p.servoBias4))
+        sServoHz = formatInt(Double(p.servoHz))
+        sServoMinUs = formatInt(Double(p.servoMinUs))
+        sServoMaxUs = formatInt(Double(p.servoMaxUs))
+        sPidKp = formatDecimal(Double(p.pidKp))
+        sPidKi = formatDecimal(Double(p.pidKi))
+        sPidKd = formatDecimal(Double(p.pidKd))
+        sPidMinCmd = formatDecimal(Double(p.pidMinCmd))
+        sPidMaxCmd = formatDecimal(Double(p.pidMaxCmd))
+        sRollDelayMs = formatInt(Double(p.rollDelayMs))
+        rollWaypoints = p.rollWaypoints.map {
+            (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg), mode: $0.mode.rawValue)
+        }
     }
 
     private func formatInt(_ v: Double) -> String {
@@ -536,23 +470,22 @@ struct SettingsView: View {
     }
 
     private func formatDecimal(_ v: Double) -> String {
-        // Show enough precision for PID gains (e.g. 0.005)
         let s = String(format: "%.6f", v)
-        // Trim trailing zeros but keep at least one decimal
         var trimmed = s
-        while trimmed.hasSuffix("0") && !trimmed.hasSuffix(".0") {
-            trimmed.removeLast()
-        }
+        while trimmed.hasSuffix("0") && !trimmed.hasSuffix(".0") { trimmed.removeLast() }
         return trimmed
     }
 
-    private func parseDouble(_ s: String, fallback: Double) -> Double {
-        Double(s) ?? fallback
+    private func trimFloat(_ v: Float) -> String {
+        v == v.rounded() ? String(Int(v)) : String(v)
     }
+
+    private func parseDouble(_ s: String, fallback: Double) -> Double { Double(s) ?? fallback }
 
     // MARK: - Helpers
 
-    private func stringRow(_ label: String, text: Binding<String>, field: EditField, unit: String? = nil, decimal: Bool = false) -> some View {
+    private func stringRow(_ label: String, text: Binding<String>, field: EditField,
+                           unit: String? = nil, decimal: Bool = false) -> some View {
         HStack {
             Text(label)
             Spacer()
@@ -567,86 +500,103 @@ struct SettingsView: View {
         }
     }
 
-    /// Section header with a transient "Sent" checkmark, shown for ~2 s
-    /// after the section's config is pushed to the rocket (#144).
     private func configHeader(_ title: String, applied: Bool) -> some View {
         HStack {
             Text(title)
             if applied {
                 Spacer()
                 Label("Sent", systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundColor(.green)
+                    .font(.caption).foregroundColor(.green)
             }
         }
     }
 
-    // MARK: - Apply actions
+    private func summaryRow(_ label: String, _ value: String) -> some View {
+        HStack { Text(label); Spacer(); Text(value).foregroundColor(.secondary) }
+    }
+
+    private func cameraLabel(_ t: UInt8) -> String {
+        switch t { case 1: return "GoPro"; case 2: return "RunCam"; default: return "None" }
+    }
+
+    private func cameraHint(_ t: Int) -> String {
+        switch t {
+        case 1: return "GoPro: controlled via GPIO pulse on shutter pin."
+        case 2: return "RunCam: controlled via UART serial command."
+        default: return "No camera connected."
+        }
+    }
+
+    // MARK: - Apply actions (write profile + push when connected)
 
     private func applyServoConfig() {
-        let b1 = parseDouble(sBias1, fallback: storedBias1)
-        let b2 = parseDouble(sBias2, fallback: storedBias2)
-        let b3 = parseDouble(sBias3, fallback: storedBias3)
-        let b4 = parseDouble(sBias4, fallback: storedBias4)
-        let hz = parseDouble(sServoHz, fallback: storedServoHz)
-        let mn = parseDouble(sServoMinUs, fallback: storedServoMinUs)
-        let mx = parseDouble(sServoMaxUs, fallback: storedServoMaxUs)
+        let b1 = Int16(clamping: Int(parseDouble(sBias1, fallback: Double(profile.servoBias1)).rounded()))
+        let b2 = Int16(clamping: Int(parseDouble(sBias2, fallback: Double(profile.servoBias2)).rounded()))
+        let b3 = Int16(clamping: Int(parseDouble(sBias3, fallback: Double(profile.servoBias3)).rounded()))
+        let b4 = Int16(clamping: Int(parseDouble(sBias4, fallback: Double(profile.servoBias4)).rounded()))
+        let hz = Int16(clamping: Int(parseDouble(sServoHz, fallback: Double(profile.servoHz)).rounded()))
+        let mn = Int16(clamping: Int(parseDouble(sServoMinUs, fallback: Double(profile.servoMinUs)).rounded()))
+        let mx = Int16(clamping: Int(parseDouble(sServoMaxUs, fallback: Double(profile.servoMaxUs)).rounded()))
 
-        // Persist parsed values
-        storedBias1 = b1; storedBias2 = b2; storedBias3 = b3; storedBias4 = b4
-        storedServoHz = hz; storedServoMinUs = mn; storedServoMaxUs = mx
-
-        device.sendServoConfig(
-            biases: [Int16(b1), Int16(b2), Int16(b3), Int16(b4)],
-            hz: Int16(hz),
-            minUs: Int16(mn),
-            maxUs: Int16(mx)
-        )
+        updateProfile {
+            $0.servoBias1 = b1; $0.servoBias2 = b2; $0.servoBias3 = b3; $0.servoBias4 = b4
+            $0.servoHz = hz; $0.servoMinUs = mn; $0.servoMaxUs = mx
+        }
+        if device.isConnected {
+            device.sendServoConfig(biases: [b1, b2, b3, b4], hz: hz, minUs: mn, maxUs: mx)
+        }
         showApplied($servoApplied)
     }
 
     private func applyPIDConfig() {
-        let kp = parseDouble(sPidKp, fallback: storedPidKp)
-        let ki = parseDouble(sPidKi, fallback: storedPidKi)
-        let kd = parseDouble(sPidKd, fallback: storedPidKd)
-        let mn = parseDouble(sPidMinCmd, fallback: storedPidMinCmd)
-        let mx = parseDouble(sPidMaxCmd, fallback: storedPidMaxCmd)
+        let kp = Float(parseDouble(sPidKp, fallback: Double(profile.pidKp)))
+        let ki = Float(parseDouble(sPidKi, fallback: Double(profile.pidKi)))
+        let kd = Float(parseDouble(sPidKd, fallback: Double(profile.pidKd)))
+        let mn = Float(parseDouble(sPidMinCmd, fallback: Double(profile.pidMinCmd)))
+        let mx = Float(parseDouble(sPidMaxCmd, fallback: Double(profile.pidMaxCmd)))
 
-        // Persist parsed values
-        storedPidKp = kp; storedPidKi = ki; storedPidKd = kd
-        storedPidMinCmd = mn; storedPidMaxCmd = mx
-
-        device.sendPIDConfig(
-            kp: Float(kp),
-            ki: Float(ki),
-            kd: Float(kd),
-            minCmd: Float(mn),
-            maxCmd: Float(mx)
-        )
+        updateProfile {
+            $0.pidKp = kp; $0.pidKi = ki; $0.pidKd = kd; $0.pidMinCmd = mn; $0.pidMaxCmd = mx
+        }
+        if device.isConnected {
+            device.sendPIDConfig(kp: kp, ki: ki, kd: kd, minCmd: mn, maxCmd: mx)
+        }
         showApplied($pidApplied)
     }
 
     private func applyRollControlConfig() {
-        let delayMs = UInt16(clamping: Int(Double(sRollDelayMs) ?? rollDelayMs))
-        rollDelayMs = Double(delayMs)
-        device.sendRollControlConfig(useAngleControl: useAngleControl, rollDelayMs: delayMs)
+        let delayMs = UInt16(clamping: Int(Double(sRollDelayMs) ?? Double(profile.rollDelayMs)))
+        let useAngle = profile.useAngleControl
+        updateProfile { $0.rollDelayMs = delayMs }
+        if device.isConnected {
+            device.sendRollControlConfig(useAngleControl: useAngle, rollDelayMs: delayMs)
+        }
+        showApplied($rollControlApplied)
+    }
+
+    private func applyRollProfile() {
+        let waypoints: [RollWaypoint] = rollWaypoints.map {
+            RollWaypoint(timeSeconds: Float($0.time) ?? 0,
+                         angleDeg: Float($0.angle) ?? 0,
+                         mode: RollSegmentMode(rawValue: $0.mode) ?? .angle)
+        }.sorted { $0.timeSeconds < $1.timeSeconds }
+
+        updateProfile { $0.rollWaypoints = waypoints }
+        if device.isConnected {
+            device.sendRollProfile(waypoints: waypoints.map {
+                (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
+            })
+        }
         showApplied($rollControlApplied)
     }
 
     // MARK: - LoRa TX power (base station only)
 
-    /// Debounce Stepper edits so a held +/- doesn't queue a Cmd 10 per
-    /// tick — the firmware refuses overlapping transactions and the LoRa
-    /// link is throughput-limited.  Skips the send if the new value
-    /// matches what the BS already reports, so hydration from rocketConfig
-    /// doesn't echo back as a no-op transaction.
     private func scheduleTxPowerSend(_ newValue: Int) {
         txPowerSendWork?.cancel()
         let work = DispatchWorkItem {
             let current = device.rocketConfig?.loraTxPower.map(Int.init) ?? Int.min
-            if newValue != current {
-                device.autoApplyTxPower(Int8(newValue))
-            }
+            if newValue != current { device.autoApplyTxPower(Int8(newValue)) }
         }
         txPowerSendWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
@@ -661,55 +611,9 @@ struct SettingsView: View {
         }
     }
 
-    private func applyRollProfile() {
-        var waypoints: [(time: Float, angle: Float, mode: UInt8)] = []
-        for wp in rollWaypoints {
-            let t = Float(wp.time) ?? 0.0
-            let a = Float(wp.angle) ?? 0.0
-            waypoints.append((time: t, angle: a, mode: wp.mode))
-        }
-        // Sort by time
-        waypoints.sort { $0.time < $1.time }
-        device.sendRollProfile(waypoints: waypoints)
-        saveRollWaypointsToStorage()
-        showApplied($rollControlApplied)
-    }
-
-    // MARK: - Roll Profile Persistence
-
-    private func loadRollWaypointsFromStorage() {
-        guard let data = rollProfileJSON.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode([[String]].self, from: data) else {
-            rollWaypoints = []
-            return
-        }
-        // Triples are [time, angle, mode]; tolerate older [time, angle] pairs
-        // by defaulting mode to "0" (ROLL_SEG_ANGLE) for backward compat.
-        rollWaypoints = decoded.map { entry in
-            let t = entry.count > 0 ? entry[0] : "0"
-            let a = entry.count > 1 ? entry[1] : "0"
-            let m = (entry.count > 2 ? UInt8(entry[2]) : nil) ?? 0
-            return (time: t, angle: a, mode: m)
-        }
-    }
-
-    private func saveRollWaypointsToStorage() {
-        let encoded: [[String]] = rollWaypoints.map {
-            [String($0.time), String($0.angle), String($0.mode)]
-        }
-        if let data = try? JSONEncoder().encode(encoded),
-           let json = String(data: data, encoding: .utf8) {
-            rollProfileJSON = json
-        }
-    }
-
     private func showApplied(_ flag: Binding<Bool>) {
-        // Only flash "Sent" when there's actually a rocket to send to —
-        // a false confirmation is the #144 anti-pattern in miniature.
         guard device.isConnected else { return }
         flag.wrappedValue = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            flag.wrappedValue = false
-        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { flag.wrappedValue = false }
     }
 }

--- a/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerTests.swift
@@ -1,0 +1,86 @@
+//
+//  ActiveRocketSyncerTests.swift
+//  TinkerRocketAppTests
+//
+//  Pure decision logic for the connect-time profile sync (issue #132):
+//  mag-cal push/warn/read and the soft profile suggestion.
+//
+
+import XCTest
+@testable import TinkerRocketApp
+
+final class ActiveRocketSyncerTests: XCTestCase {
+
+    private func cal(on unitID: String) -> MagCalData {
+        MagCalData(offsetX: 1, offsetY: 2, offsetZ: 3,
+                   fieldR_uT: 48, residualUT: 2,
+                   calibratedOnUnitID: unitID, calibratedAt: Date())
+    }
+
+    // MARK: - Mag cal action
+
+    func testNoProfileCalAsksRocket() {
+        let action = ActiveRocketSyncer.magCalSyncAction(profileCal: nil,
+                                                         deviceUnitID: "BOARD1")
+        XCTAssertEqual(action, .readRocket)
+    }
+
+    func testMatchingBoardPushesCal() {
+        let c = cal(on: "BOARD1")
+        let action = ActiveRocketSyncer.magCalSyncAction(profileCal: c,
+                                                         deviceUnitID: "BOARD1")
+        XCTAssertEqual(action, .push(c))
+    }
+
+    func testDifferentBoardWarns() {
+        let c = cal(on: "BOARD1")
+        let action = ActiveRocketSyncer.magCalSyncAction(profileCal: c,
+                                                         deviceUnitID: "BOARD2")
+        XCTAssertEqual(action, .warnMismatch(savedOn: "BOARD1", current: "BOARD2"))
+    }
+
+    // MARK: - Suggestion
+
+    func testSuggestionMatchesLastUsedBoard() {
+        var a = RocketProfile.makeDefault(name: "A"); a.lastUsedUnitID = "BOARD1"
+        var b = RocketProfile.makeDefault(name: "B"); b.lastUsedUnitID = "BOARD2"
+        let s = ActiveRocketSyncer.suggestedProfile(in: [a, b], active: nil, unitID: "BOARD2")
+        XCTAssertEqual(s, b.id)
+    }
+
+    func testNoSuggestionWhenActiveAlreadyMatches() {
+        var a = RocketProfile.makeDefault(name: "A"); a.lastUsedUnitID = "BOARD1"
+        // Active profile already the one flown on this board → nothing to suggest.
+        let s = ActiveRocketSyncer.suggestedProfile(in: [a], active: a.id, unitID: "BOARD1")
+        XCTAssertNil(s)
+    }
+
+    func testNoSuggestionForUnknownBoard() {
+        var a = RocketProfile.makeDefault(name: "A"); a.lastUsedUnitID = "BOARD1"
+        let s = ActiveRocketSyncer.suggestedProfile(in: [a], active: nil, unitID: "NEVER_SEEN")
+        XCTAssertNil(s)
+    }
+
+    func testNoSuggestionForEmptyUnitID() {
+        var a = RocketProfile.makeDefault(name: "A"); a.lastUsedUnitID = ""
+        let s = ActiveRocketSyncer.suggestedProfile(in: [a], active: nil, unitID: "")
+        XCTAssertNil(s)
+    }
+
+    // MARK: - MagCalData snapshot from a status frame
+
+    func testMagCalDataFromStatusTagsBoard() {
+        let status = MagCalStatus(
+            subType: .applied, coverageBins: 26, sampleCount: 1000,
+            instantaneousFieldUT: 48, offsetX: -4, offsetY: 5, offsetZ: -6,
+            fieldR_uT: 49.5, residualUT: 1.2, rejectCode: .ok, coverageMask: 0,
+            liveX_uT: 0, liveY_uT: 0, liveZ_uT: 0)
+        let data = MagCalData(status: status, unitID: "BOARD9")
+        XCTAssertEqual(data.offsetX, -4)
+        XCTAssertEqual(data.offsetY, 5)
+        XCTAssertEqual(data.offsetZ, -6)
+        XCTAssertEqual(data.fieldR_uT, 49.5, accuracy: 1e-4)
+        XCTAssertEqual(data.residualUT, 1.2, accuracy: 1e-4)
+        XCTAssertEqual(data.calibratedOnUnitID, "BOARD9")
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerTests.swift
@@ -39,6 +39,40 @@ final class ActiveRocketSyncerTests: XCTestCase {
         XCTAssertEqual(action, .warnMismatch(savedOn: "BOARD1", current: "BOARD2"))
     }
 
+    // MARK: - Sensor cal action
+
+    private func sensorCal(on unitID: String) -> SensorCalData {
+        SensorCalData(gyroX: 1, gyroY: 2, gyroZ: 3, hgX: 0.1, hgY: 0.2, hgZ: 0.3,
+                      calibratedOnUnitID: unitID, calibratedAt: Date())
+    }
+
+    func testNoProfileSensorCalAsksRocket() {
+        XCTAssertEqual(ActiveRocketSyncer.sensorCalSyncAction(profileCal: nil,
+                                                              deviceUnitID: "B1"), .readRocket)
+    }
+
+    func testMatchingBoardPushesSensorCal() {
+        let c = sensorCal(on: "B1")
+        XCTAssertEqual(ActiveRocketSyncer.sensorCalSyncAction(profileCal: c,
+                                                              deviceUnitID: "B1"), .push(c))
+    }
+
+    func testDifferentBoardWarnsSensorCal() {
+        let c = sensorCal(on: "B1")
+        XCTAssertEqual(ActiveRocketSyncer.sensorCalSyncAction(profileCal: c, deviceUnitID: "B2"),
+                       .warnMismatch(savedOn: "B1", current: "B2"))
+    }
+
+    func testSensorCalDataFromStatusTagsBoard() {
+        let status = SensorCalStatus(valid: true, gyroX: -3, gyroY: 4, gyroZ: -5,
+                                     hgX: 0.11, hgY: -0.22, hgZ: 9.7)
+        let data = SensorCalData(status: status, unitID: "B9")
+        XCTAssertEqual(data.gyroX, -3)
+        XCTAssertEqual(data.gyroZ, -5)
+        XCTAssertEqual(data.hgZ, 9.7, accuracy: 1e-4)
+        XCTAssertEqual(data.calibratedOnUnitID, "B9")
+    }
+
     // MARK: - Suggestion
 
     func testSuggestionMatchesLastUsedBoard() {

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
@@ -1,0 +1,236 @@
+//
+//  RocketProfileStoreTests.swift
+//  TinkerRocketAppTests
+//
+//  CRUD, persistence, legacy migration, and Codable round-trip for the
+//  per-rocket profile store (issue #132).
+//
+
+import XCTest
+@testable import TinkerRocketApp
+
+final class RocketProfileStoreTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProfileTests-\(UUID().uuidString)", isDirectory: true)
+        suiteName = "ProfileTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeStore() -> RocketProfileStore {
+        RocketProfileStore(directory: tempDir, defaults: defaults)
+    }
+
+    // MARK: - CRUD
+
+    func testAddCreatesProfileAndPersists() {
+        let store = makeStore()
+        XCTAssertTrue(store.profiles.isEmpty)
+
+        let p = store.add(name: "Big Bertha")
+        XCTAssertEqual(store.profiles.count, 1)
+        XCTAssertEqual(p.name, "Big Bertha")
+        // add() must not auto-activate.
+        XCTAssertNil(store.activeId)
+
+        // A fresh store over the same dir reloads it.
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.profiles.count, 1)
+        XCTAssertEqual(reloaded.profiles.first?.name, "Big Bertha")
+    }
+
+    func testAddDedupesNames() {
+        let store = makeStore()
+        store.add(name: "Arcas")
+        store.add(name: "Arcas")
+        store.add(name: "Arcas")
+        let names = store.profiles.map { $0.name }.sorted()
+        XCTAssertEqual(names, ["Arcas", "Arcas 2", "Arcas 3"])
+    }
+
+    func testDuplicateDropsMagCalAndRenames() {
+        let store = makeStore()
+        let src = store.add(name: "Source")
+        store.update(src.id) {
+            $0.pidKp = 0.42
+            $0.magCal = MagCalData(offsetX: 1, offsetY: 2, offsetZ: 3,
+                                   fieldR_uT: 48, residualUT: 2,
+                                   calibratedOnUnitID: "ABC123",
+                                   calibratedAt: Date())
+        }
+
+        let copy = store.duplicate(src.id)
+        XCTAssertNotNil(copy)
+        XCTAssertEqual(copy?.name, "Source copy")
+        XCTAssertEqual(copy?.pidKp, 0.42)          // tuning copied
+        XCTAssertNil(copy?.magCal)                  // cal NOT copied (board-specific)
+        XCTAssertNil(copy?.lastUsedUnitID)
+        XCTAssertNotEqual(copy?.id, src.id)
+        XCTAssertEqual(store.profiles.count, 2)
+    }
+
+    func testRenamePersists() {
+        let store = makeStore()
+        let p = store.add(name: "Old")
+        store.rename(p.id, to: "New")
+        XCTAssertEqual(store.profiles.first?.name, "New")
+        XCTAssertEqual(makeStore().profiles.first?.name, "New")
+    }
+
+    func testDeleteRemovesFileAndClearsActive() {
+        let store = makeStore()
+        let a = store.add(name: "A")
+        store.setActive(a.id)
+        XCTAssertEqual(store.activeId, a.id)
+
+        store.delete(a.id)
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertNil(store.activeId)
+        // The on-disk file is gone too.
+        XCTAssertTrue(makeStore().profiles.isEmpty)
+    }
+
+    func testDeleteActiveFallsBackToAnotherProfile() {
+        let store = makeStore()
+        let a = store.add(name: "A")
+        let b = store.add(name: "B")
+        store.setActive(a.id)
+        store.delete(a.id)
+        // Active falls back to a remaining profile rather than going nil.
+        XCTAssertEqual(store.activeId, b.id)
+    }
+
+    func testSetActivePersistsAcrossReload() {
+        let store = makeStore()
+        store.add(name: "A")
+        let b = store.add(name: "B")
+        store.setActive(b.id)
+
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.activeId, b.id)
+        XCTAssertEqual(reloaded.activeProfile?.name, "B")
+    }
+
+    func testUpdateBumpsTimestamp() {
+        let store = makeStore()
+        let p = store.add(name: "A")
+        let before = p.updatedAt
+        // Ensure a measurable delta.
+        Thread.sleep(forTimeInterval: 0.01)
+        store.update(p.id) { $0.cameraType = 1 }
+        let after = store.profiles.first!.updatedAt
+        XCTAssertGreaterThan(after, before)
+        XCTAssertEqual(store.profiles.first?.cameraType, 1)
+    }
+
+    // MARK: - Resilience
+
+    func testCorruptFileSkippedOnLoad() throws {
+        let store = makeStore()
+        store.add(name: "Good")
+        // Drop a garbage .json next to the real one.
+        let junk = tempDir.appendingPathComponent("\(UUID().uuidString).json")
+        try Data("not json".utf8).write(to: junk)
+
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.profiles.count, 1)
+        XCTAssertEqual(reloaded.profiles.first?.name, "Good")
+    }
+
+    func testDanglingActiveIdReconciled() {
+        let store = makeStore()
+        let a = store.add(name: "A")
+        store.setActive(a.id)
+        store.delete(a.id)
+        // Manually point active at a now-nonexistent id, then reload.
+        defaults.set(UUID().uuidString, forKey: "activeRocketProfileId")
+        let reloaded = makeStore()
+        XCTAssertNil(reloaded.activeId)
+    }
+
+    // MARK: - Codable round-trip
+
+    func testProfileCodableRoundTrip() throws {
+        var p = RocketProfile.makeDefault(name: "RT")
+        p.notes = "4in glass, J motors"
+        p.pidKp = 0.123
+        p.servoBias2 = -17
+        p.cameraType = 1
+        p.rollWaypoints = [
+            RollWaypoint(timeSeconds: 0, angleDeg: 0, mode: .nullRate),
+            RollWaypoint(timeSeconds: 2.5, angleDeg: 90, mode: .angle),
+        ]
+        p.pyro2Enabled = true
+        p.pyro2TriggerValue = 213
+        p.magCal = MagCalData(offsetX: -5, offsetY: 6, offsetZ: 7,
+                              fieldR_uT: 49.5, residualUT: 1.5,
+                              calibratedOnUnitID: "DEAD::BEEF",
+                              calibratedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let data = try JSONEncoder().encode(p)
+        let back = try JSONDecoder().decode(RocketProfile.self, from: data)
+        XCTAssertEqual(p, back)
+    }
+
+    // MARK: - Migration
+
+    private func seedLegacyDefaults() {
+        defaults.set(true, forKey: "rocketSoundsEnabled")
+        defaults.set(false, forKey: "servoControlEnabled")
+        defaults.set(1, forKey: "cameraType")
+        defaults.set(true, forKey: "useAngleControl")
+        defaults.set(150.0, forKey: "rollDelayMs")
+        defaults.set(90.0, forKey: "servoBias1")
+        defaults.set(0.111, forKey: "pidKp")
+        defaults.set(0.222, forKey: "pidKi")
+        let roll = "[[\"0.0\",\"0\",\"1\"],[\"2.0\",\"45\",\"0\"]]"
+        defaults.set(roll, forKey: "rollProfileJSON")
+    }
+
+    func testMigrationCreatesDefaultFromLegacyKeys() {
+        seedLegacyDefaults()
+        let store = makeStore()
+
+        XCTAssertEqual(store.profiles.count, 1)
+        let p = try! XCTUnwrap(store.activeProfile)
+        XCTAssertEqual(p.name, "Default")
+        XCTAssertTrue(p.soundsEnabled)
+        XCTAssertFalse(p.servoControlEnabled)
+        XCTAssertEqual(p.cameraType, 1)
+        XCTAssertTrue(p.useAngleControl)
+        XCTAssertEqual(p.rollDelayMs, 150)
+        XCTAssertEqual(p.servoBias1, 90)
+        XCTAssertEqual(p.pidKp, 0.111, accuracy: 1e-5)
+        XCTAssertEqual(p.pidKi, 0.222, accuracy: 1e-5)
+        XCTAssertEqual(p.rollWaypoints.count, 2)
+        XCTAssertEqual(p.rollWaypoints[0].mode, .nullRate)
+        XCTAssertEqual(p.rollWaypoints[1].angleDeg, 45)
+    }
+
+    func testMigrationRunsOnlyOnce() {
+        seedLegacyDefaults()
+        _ = makeStore()                 // first init migrates
+        // Tamper: add another legacy key + re-init. Should NOT re-migrate.
+        defaults.set(99.0, forKey: "servoBias2")
+        let second = makeStore()
+        XCTAssertEqual(second.profiles.count, 1)
+    }
+
+    func testNoMigrationOnFreshInstall() {
+        // No legacy keys seeded.
+        let store = makeStore()
+        XCTAssertTrue(store.profiles.isEmpty)
+        XCTAssertNil(store.activeId)
+        XCTAssertTrue(defaults.bool(forKey: "rocketProfilesMigratedV1"))
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
@@ -67,6 +67,10 @@ final class RocketProfileStoreTests: XCTestCase {
                                    fieldR_uT: 48, residualUT: 2,
                                    calibratedOnUnitID: "ABC123",
                                    calibratedAt: Date())
+            $0.sensorCal = SensorCalData(gyroX: 4, gyroY: 5, gyroZ: 6,
+                                         hgX: 0.1, hgY: 0.2, hgZ: 0.3,
+                                         calibratedOnUnitID: "ABC123",
+                                         calibratedAt: Date())
         }
 
         let copy = store.duplicate(src.id)
@@ -74,6 +78,7 @@ final class RocketProfileStoreTests: XCTestCase {
         XCTAssertEqual(copy?.name, "Source copy")
         XCTAssertEqual(copy?.pidKp, 0.42)          // tuning copied
         XCTAssertNil(copy?.magCal)                  // cal NOT copied (board-specific)
+        XCTAssertNil(copy?.sensorCal)               // sensor cal NOT copied either
         XCTAssertNil(copy?.lastUsedUnitID)
         XCTAssertNotEqual(copy?.id, src.id)
         XCTAssertEqual(store.profiles.count, 2)
@@ -176,6 +181,10 @@ final class RocketProfileStoreTests: XCTestCase {
                               fieldR_uT: 49.5, residualUT: 1.5,
                               calibratedOnUnitID: "DEAD::BEEF",
                               calibratedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        p.sensorCal = SensorCalData(gyroX: -8, gyroY: 9, gyroZ: -10,
+                                    hgX: 0.05, hgY: -0.06, hgZ: 9.81,
+                                    calibratedOnUnitID: "DEAD::BEEF",
+                                    calibratedAt: Date(timeIntervalSince1970: 1_700_000_500))
 
         let data = try JSONEncoder().encode(p)
         let back = try JSONDecoder().decode(RocketProfile.self, from: data)

--- a/tests/parse_flight.py
+++ b/tests/parse_flight.py
@@ -14,7 +14,7 @@ MSG_TYPES = {
     0xA2: ("ISM6HG256", 22),
     0xA3: ("BMP585", 12),
     0xA4: ("MMC5983MA", 16),
-    0xA5: ("NON_SENSOR", 43),
+    0xA5: ("NON_SENSOR", 44),
     0xA6: ("POWER", 10),
     0xA7: ("START_LOGGING", 0),
     0xA8: ("END_FLIGHT", 0),
@@ -79,9 +79,15 @@ def parse_mag(payload):
 
 def parse_nonsensor(payload):
     # Struct: uint32 time, i16*4 quat, i16 roll_cmd, i32*3 pos, i32*3 vel,
-    #         u8 flags, u8 rocket_state, i16 baro_alt_rate_dmps, u8 pyro_status
-    fields = struct.unpack('<I hhhh h iii iii BB h B', payload)
+    #         u8 flags, u8 rocket_state, i16 baro_alt_rate_dmps, u8 pyro_status,
+    #         u8 apogee_flags
+    # apogee_flags was appended in #142/#143 (frame grew 43 -> 44 bytes); old
+    # 43-byte logs are still decoded, with apogee_flags defaulting to 0.
+    has_apogee = len(payload) >= 44
+    fmt = '<I hhhh h iii iii BB h BB' if has_apogee else '<I hhhh h iii iii BB h B'
+    fields = struct.unpack(fmt, payload)
     pyro_status = fields[15]
+    apogee_flags = fields[16] if has_apogee else 0
     return {
         'time_us': fields[0],
         'q0': fields[1] / 10000.0, 'q1': fields[2] / 10000.0,
@@ -93,6 +99,11 @@ def parse_nonsensor(payload):
         'rocket_state': fields[13],
         'baro_alt_rate_ms': fields[14] / 10.0,
         'pyro_status': pyro_status,
+        'apogee_flags': apogee_flags,
+        # apogee_flags bits: 0=gps_apogee, 1=pitch_apogee, 2=apogee (voted master)
+        'gps_apogee': bool(apogee_flags & 0x01),
+        'pitch_apogee': bool(apogee_flags & 0x02),
+        'apogee_voted': bool(apogee_flags & 0x04),
         'guidance_enabled': bool(pyro_status & PSF_GUIDANCE_ENABLED),
     }
 
@@ -214,7 +225,7 @@ def parse_file(path):
             parsed = parse_baro(payload)
         elif msg_type == 0xA4 and msg_len == 16:
             parsed = parse_mag(payload)
-        elif msg_type == 0xA5 and msg_len == 43:
+        elif msg_type == 0xA5 and msg_len in (43, 44):
             parsed = parse_nonsensor(payload)
         elif msg_type == 0xA6 and msg_len == 10:
             parsed = parse_power(payload)

--- a/tests/trace_divergence.py
+++ b/tests/trace_divergence.py
@@ -57,11 +57,17 @@ def main():
 
     first_time = None
     for msg_type, msg_len, payload in frames:
-        if msg_type == 0xA5 and msg_len in (42, 43):  # NON_SENSOR (43=current, 42=legacy)
-            # Current: uint32 time + i16*4 quat + i16 roll_cmd + i32*3 pos + i32*3 vel
-            #          + u8 flags + u8 rocket_state + i16 baro_alt_rate_dmps + u8 pyro_status
-            # Legacy (42 bytes) is the same minus the trailing pyro_status byte.
-            fmt = '<I hhhh h iii iii BB h B' if msg_len == 43 else '<I hhhh h iii iii BB h'
+        if msg_type == 0xA5 and msg_len in (42, 43, 44):  # NON_SENSOR (44=current)
+            # Current (44): uint32 time + i16*4 quat + i16 roll_cmd + i32*3 pos
+            #   + i32*3 vel + u8 flags + u8 rocket_state + i16 baro_alt_rate_dmps
+            #   + u8 pyro_status + u8 apogee_flags  (apogee_flags added in #142/#143).
+            # 43 = same minus apogee_flags; 42 = also minus pyro_status (oldest).
+            if msg_len == 44:
+                fmt = '<I hhhh h iii iii BB h BB'
+            elif msg_len == 43:
+                fmt = '<I hhhh h iii iii BB h B'
+            else:
+                fmt = '<I hhhh h iii iii BB h'
             fields = struct.unpack(fmt, payload)
             t = fields[0]
             if first_time is None: first_time = t

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -888,6 +888,30 @@ void TR_BLE_To_APP::sendMagCalStatus(const uint8_t* status_bytes, size_t len)
     }
 }
 
+void TR_BLE_To_APP::sendSensorCalStatus(const uint8_t* status_bytes, size_t len)
+{
+    if (!device_connected_ || status_bytes == nullptr || len == 0) return;
+    // 0xCB marker + payload (sibling of mag cal's 0xCA).  Real payload is
+    // fixed at sizeof(SensorCalStatusData); cap defensively.
+    constexpr size_t MAX_PAYLOAD = 64;
+    if (len > MAX_PAYLOAD) len = MAX_PAYLOAD;
+
+    uint8_t buf[1 + MAX_PAYLOAD];
+    buf[0] = 0xCB;
+    memcpy(&buf[1], status_bytes, len);
+
+    int rc = notify_data(conn_handle_, file_ops_val_handle_, buf, 1 + len);
+    if (rc != 0)
+    {
+        static uint32_t fail_count = 0;
+        if ((fail_count++ % 32) == 0)
+        {
+            ESP_LOGW(BLE_TAG, "Sensor-cal status notify failed, rc=%d (count=%lu)",
+                     rc, (unsigned long)fail_count);
+        }
+    }
+}
+
 void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
                                    size_t len, bool eof)
 {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -169,6 +169,12 @@ public:
     // 0xAA / 0xCA, so all four payload kinds coexist on this channel.
     void sendMagCalStatus(const uint8_t* status_bytes, size_t len);
 
+    // Send a sensor (gyro + high-g) calibration readback frame on the
+    // file-ops characteristic (issue #132).  Format:
+    //   [0][0xCB marker] [1..19][SensorCalStatusData LE bytes]
+    // Sibling discriminator to mag cal's 0xCA.
+    void sendSensorCalStatus(const uint8_t* status_bytes, size_t len);
+
     // Get pending download filename (empty if none)
     // Clears the filename after reading
     String getDownloadFilename();

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -823,6 +823,36 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(MagCalApplyData) == 14,
               "MagCalApplyData must be 14 bytes");
 
+// Sensor cal payload (issue #132): gyro zero-rate bias in raw LSB (subtracted
+// from raw gyro) + high-g accel bias in m/s².  app→FC via SENSOR_CAL_APPLY_MSG.
+typedef struct __attribute__((packed))
+{
+    int16_t gyro_x;    // raw gyro LSB
+    int16_t gyro_y;
+    int16_t gyro_z;
+    float   hg_x;      // high-g accel bias, m/s²
+    float   hg_y;
+    float   hg_z;
+} SensorCalApplyData;
+static_assert(sizeof(SensorCalApplyData) == 18,
+              "SensorCalApplyData must be 18 bytes");
+
+// FC→OC/app sensor-cal readback: same fields plus a validity flag (0 when the
+// rocket has no stored sensor cal).  Rides the file_ops characteristic behind
+// a 0xCB discriminator, like mag cal's 0xCA frame.
+typedef struct __attribute__((packed))
+{
+    uint8_t valid;     // 1 if a sensor cal is stored in NVS, else 0
+    int16_t gyro_x;
+    int16_t gyro_y;
+    int16_t gyro_z;
+    float   hg_x;
+    float   hg_y;
+    float   hg_z;
+} SensorCalStatusData;
+static_assert(sizeof(SensorCalStatusData) == 19,
+              "SensorCalStatusData must be 19 bytes");
+
 // MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
 // int32_t in the same 18-bit signed centered-counts space as
 // mmc5983ma_centered_counts() returns.  Subtracted before scaling to µT.
@@ -1263,6 +1293,17 @@ static constexpr uint8_t MAG_CAL_COMPUTE_FIT  = 0xD9;  // OC→FC: run sphere fi
 static constexpr uint8_t MAG_CAL_APPLY_PENDING = 0xDA;  // OC→FC: payload follows as MAG_CAL_APPLY_MSG
 static constexpr uint8_t MAG_CAL_APPLY_MSG     = 0xDB;  // 14-byte MagCalApplyData payload
 static constexpr uint8_t MAG_CAL_READ          = 0xDC;  // OC→FC: publish current NVS cal as a status frame
+
+// --- App-driven sensor cal apply / read (issue #132 — rocket profiles) ---
+// The on-pad "Calibrate Sensors" routine produces a gyro zero-rate bias and
+// a high-g accel bias.  Mirroring mag cal, the app stores both per-rocket and
+// pushes them back on connect (APPLY) or reads what's stored (READ).  The
+// low-g accelerometer is the cal reference, not itself corrected, so there is
+// nothing to store for it.
+static constexpr uint8_t SENSOR_CAL_APPLY_PENDING = 0xDD;  // OC→FC: payload follows as SENSOR_CAL_APPLY_MSG
+static constexpr uint8_t SENSOR_CAL_APPLY_MSG     = 0xDE;  // 18-byte SensorCalApplyData payload
+static constexpr uint8_t SENSOR_CAL_READ          = 0xDF;  // OC→FC: publish current NVS sensor cal
+static constexpr uint8_t SENSOR_CAL_STATUS_MSG    = 0xE0;  // FC→OC: SensorCalStatusData
 
 static constexpr uint8_t LORA_MSG            = 0xF1;
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -807,6 +807,22 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(MagCalStatusData) == 32,
               "MagCalStatusData must be 32 bytes");
 
+// 14-byte payload for MAG_CAL_APPLY_MSG (issue #132).  Carries the hard-iron
+// offsets in IIS2MDC LSB units plus the R / residual diagnostics so NVS state
+// is bit-identical to what cmd 52 writes after a fresh cal — re-boot path is
+// the same regardless of whether cal came from the sphere fit or an app push.
+// No soft-iron / no MMC offsets: v1 behaviour matches MAG_CAL_ACCEPT.
+typedef struct __attribute__((packed))
+{
+    int16_t cx;        // raw IIS2MDC LSB
+    int16_t cy;
+    int16_t cz;
+    float   R_uT;      // fitted field magnitude when the cal was originally accepted
+    float   res_uT;    // fit RMS residual when the cal was originally accepted
+} MagCalApplyData;
+static_assert(sizeof(MagCalApplyData) == 14,
+              "MagCalApplyData must be 14 bytes");
+
 // MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
 // int32_t in the same 18-bit signed centered-counts space as
 // mmc5983ma_centered_counts() returns.  Subtracted before scaling to µT.
@@ -1238,6 +1254,15 @@ static constexpr uint8_t MAG_CAL_ACCEPT       = 0xD6;  // OC→FC: persist curre
 static constexpr uint8_t MAG_CAL_RETRY        = 0xD7;  // OC→FC: discard fit, restart sampling
 static constexpr uint8_t MAG_CAL_STATUS_MSG   = 0xD8;  // FC→OC: live progress / final result (MagCalStatusData)
 static constexpr uint8_t MAG_CAL_COMPUTE_FIT  = 0xD9;  // OC→FC: run sphere fit on current buffer, transition to REVIEW
+
+// --- App-driven mag cal apply / read (issue #132 — rocket profiles) ---
+// The iOS app holds source-of-truth for cal as part of a rocket profile.
+// On connect, the app pushes the saved cal back into FC NVS (APPLY) or
+// reads what's already there (READ).  Both bypass the cal flow entirely
+// — no sphere fit, no MAG_CALIBRATION state transition.
+static constexpr uint8_t MAG_CAL_APPLY_PENDING = 0xDA;  // OC→FC: payload follows as MAG_CAL_APPLY_MSG
+static constexpr uint8_t MAG_CAL_APPLY_MSG     = 0xDB;  // 14-byte MagCalApplyData payload
+static constexpr uint8_t MAG_CAL_READ          = 0xDC;  // OC→FC: publish current NVS cal as a status frame
 
 static constexpr uint8_t LORA_MSG            = 0xF1;
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -976,6 +976,45 @@ static inline void serviceBlueLedFlash(uint32_t now_ms)
     }
 }
 
+// Issue #132 — publish a one-shot status frame built from whatever the
+// "mag_cal" NVS namespace currently holds.  Used by MAG_CAL_APPLY (after
+// persisting a pushed cal) and MAG_CAL_READ (pure query) so the app sees
+// the FC's stored cal without waiting for the 5 Hz cadence — and without
+// needing the MagCalibrator object, which is in IDLE outside an active
+// cal flow.
+static void publishMagCalStatusFromNVS()
+{
+    MagCalStatusData s{};
+    s.time_us = (uint32_t)esp_timer_get_time();
+
+    Preferences p;
+    p.begin("mag_cal", true);  // read-only
+    const bool has_cal = p.isKey("ver") &&
+                        p.getUChar("ver", 0) == MAG_CAL_NVS_SCHEMA_VERSION &&
+                        p.getBool("done", false);
+    if (has_cal)
+    {
+        s.sub_type        = MAG_CAL_SUB_APPLIED;
+        s.offset_x        = (int16_t)p.getShort("cx", 0);
+        s.offset_y        = (int16_t)p.getShort("cy", 0);
+        s.offset_z        = (int16_t)p.getShort("cz", 0);
+        const float R     = p.getFloat("R_uT",   0.0f);
+        const float res   = p.getFloat("res_uT", 0.0f);
+        s.field_R_uT_x10  = (uint16_t)lroundf(R   * 10.0f);
+        s.residual_uT_x10 = (uint16_t)lroundf(res * 10.0f);
+        s.reject_code     = MAG_CAL_OK;
+    }
+    else
+    {
+        s.sub_type = MAG_CAL_SUB_IDLE;
+    }
+    p.end();
+
+    uint8_t buf[sizeof(MagCalStatusData)];
+    memcpy(buf, &s, sizeof(buf));
+    (void)enqueueI2STx(MAG_CAL_STATUS_MSG, buf, sizeof(buf));
+}
+
 static void piezoToggleCb(void *)
 {
     if (!piezo_wave_active)
@@ -2922,6 +2961,71 @@ static void loop_fc()
                     rocket_state = READY;
                     mag_calibrator.clear();
                 }
+            }
+            // Issue #132 — app pushes a saved cal from the active rocket profile
+            // back into FC NVS.  Bypasses the sampling / sphere-fit flow entirely
+            // but writes the same NVS keys as MAG_CAL_ACCEPT so the boot-time
+            // load path is identical.  Gated to READY (same as MAG_CAL_START) so
+            // the IIS2MDC OFFSET registers don't change mid-flight or mid-cal.
+            else if (out_pending_command == MAG_CAL_APPLY_PENDING)
+            {
+                if (rocket_state != READY)
+                {
+                    ESP_LOGW(TAG, "[MAGCAL] apply refused: state=%u (require READY)",
+                             (unsigned)rocket_state);
+                }
+                else
+                {
+                    delay(1);
+                    uint8_t cfg_payload[sizeof(MagCalApplyData)];
+                    size_t  cfg_len = 0;
+                    if (readConfigFrame(MAG_CAL_APPLY_MSG, sizeof(MagCalApplyData),
+                                        cfg_payload, sizeof(cfg_payload), cfg_len)
+                        && cfg_len >= sizeof(MagCalApplyData))
+                    {
+                        MagCalApplyData ap;
+                        memcpy(&ap, cfg_payload, sizeof(ap));
+
+                        if (sensor_collector.isIIS2MDCActive())
+                        {
+                            const bool ok = sensor_collector.setIIS2MDCHardIronOffset(ap.cx, ap.cy, ap.cz);
+                            ESP_LOGI(TAG, "[MAGCAL] APPLY IIS2MDC OFFSET (%d,%d,%d) %s",
+                                     (int)ap.cx, (int)ap.cy, (int)ap.cz, ok ? "OK" : "FAIL");
+                        }
+                        sensor_converter.setMMCOffset(0, 0, 0);
+
+                        prefs.begin("mag_cal", false);
+                        prefs.putUChar("ver",    MAG_CAL_NVS_SCHEMA_VERSION);
+                        prefs.putBool ("done",   true);
+                        prefs.putShort("cx",     ap.cx);
+                        prefs.putShort("cy",     ap.cy);
+                        prefs.putShort("cz",     ap.cz);
+                        prefs.putFloat("R_uT",   ap.R_uT);
+                        prefs.putFloat("res_uT", ap.res_uT);
+                        prefs.putInt  ("mmc_cx", 0);
+                        prefs.putInt  ("mmc_cy", 0);
+                        prefs.putInt  ("mmc_cz", 0);
+                        prefs.end();
+
+                        ESP_LOGI(TAG, "[MAGCAL] APPLY+saved: cx=%d cy=%d cz=%d R=%.2fµT res=%.2fµT",
+                                 (int)ap.cx, (int)ap.cy, (int)ap.cz,
+                                 (double)ap.R_uT, (double)ap.res_uT);
+
+                        publishMagCalStatusFromNVS();
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "[MAGCAL] APPLY payload read failed");
+                    }
+                }
+            }
+            // Issue #132 — pure NVS query.  No state side-effect; publishes one
+            // status frame so the app can diff against the active profile and
+            // decide push / pull / re-cal.
+            else if (out_pending_command == MAG_CAL_READ)
+            {
+                ESP_LOGI(TAG, "[MAGCAL] READ -> publish status from NVS");
+                publishMagCalStatusFromNVS();
             }
             else if (out_pending_command == GAIN_SCHED_ENABLE)
             {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -86,6 +86,12 @@ static bool    mag_cal_status_dirty   = false;  // true → publish on next tick
 static int16_t pending_mag_cx = 0, pending_mag_cy = 0, pending_mag_cz = 0;
 static bool    pending_mag_apply = false;
 
+// Gyro zero-rate bias restored from NVS (#132).  Applied to sensor_collector
+// after begin(), alongside the mag offsets, so a stored sensor cal survives
+// reboots without the app connected.
+static int16_t pending_gyro_cal_x = 0, pending_gyro_cal_y = 0, pending_gyro_cal_z = 0;
+static bool    pending_gyro_cal_apply = false;
+
 static ISM6HG256Data ism6hg256_data;
 static uint8_t ism6hg256_data_buffer[SIZE_OF_ISM6HG256_DATA];
 static BMP585Data bmp585_data;
@@ -1015,6 +1021,34 @@ static void publishMagCalStatusFromNVS()
     (void)enqueueI2STx(MAG_CAL_STATUS_MSG, buf, sizeof(buf));
 }
 
+// Issue #132 — publish the gyro + high-g sensor cal currently stored in NVS
+// (namespace "cal") so the app can snapshot it after a pad cal and diff it on
+// connect.  valid=0 when nothing is stored.
+static void publishSensorCalFromNVS()
+{
+    SensorCalStatusData s{};
+
+    Preferences p;
+    p.begin("cal", true);  // read-only
+    const bool has_hg = p.isKey("hgbx");
+    const bool has_gyro = p.isKey("gx");
+    if (has_hg || has_gyro)
+    {
+        s.valid  = 1;
+        s.gyro_x = (int16_t)p.getShort("gx", 0);
+        s.gyro_y = (int16_t)p.getShort("gy", 0);
+        s.gyro_z = (int16_t)p.getShort("gz", 0);
+        s.hg_x   = p.getFloat("hgbx", 0.0f);
+        s.hg_y   = p.getFloat("hgby", 0.0f);
+        s.hg_z   = p.getFloat("hgbz", 0.0f);
+    }
+    p.end();
+
+    uint8_t buf[sizeof(SensorCalStatusData)];
+    memcpy(buf, &s, sizeof(buf));
+    (void)enqueueI2STx(SENSOR_CAL_STATUS_MSG, buf, sizeof(buf));
+}
+
 static void piezoToggleCb(void *)
 {
     if (!piezo_wave_active)
@@ -1618,6 +1652,16 @@ static void setup_fc()
         ESP_LOGI(TAG, "NVS HG bias: %.3f, %.3f, %.3f m/s²",
                       (double)bx, (double)by, (double)bz);
     }
+    // Gyro zero-rate bias (#132) — applied after begin() (see below).
+    if (prefs.isKey("gx"))
+    {
+        pending_gyro_cal_x = (int16_t)prefs.getShort("gx", 0);
+        pending_gyro_cal_y = (int16_t)prefs.getShort("gy", 0);
+        pending_gyro_cal_z = (int16_t)prefs.getShort("gz", 0);
+        pending_gyro_cal_apply = true;
+        ESP_LOGI(TAG, "NVS gyro cal: %d, %d, %d (apply after begin)",
+                      (int)pending_gyro_cal_x, (int)pending_gyro_cal_y, (int)pending_gyro_cal_z);
+    }
     prefs.end();
 
     // Restore magnetometer hard-iron offset from NVS (namespace "mag_cal", issue #96).
@@ -1742,6 +1786,16 @@ static void setup_fc()
         ESP_LOGI(TAG, "IIS2MDC OFFSET applied: (%d,%d,%d) %s",
                  (int)pending_mag_cx, (int)pending_mag_cy, (int)pending_mag_cz,
                  ok ? "OK" : "FAILED");
+    }
+
+    // Apply restored gyro zero-rate bias now that begin() is done (#132).
+    if (pending_gyro_cal_apply)
+    {
+        sensor_collector_hw.gyro_cal_x = pending_gyro_cal_x;
+        sensor_collector_hw.gyro_cal_y = pending_gyro_cal_y;
+        sensor_collector_hw.gyro_cal_z = pending_gyro_cal_z;
+        ESP_LOGI(TAG, "Gyro cal applied: (%d,%d,%d)",
+                 (int)pending_gyro_cal_x, (int)pending_gyro_cal_y, (int)pending_gyro_cal_z);
     }
 
     out_status_query_data.ism6_low_g_fs_g = config::ISM6_LOW_G_FS_G;
@@ -2842,13 +2896,18 @@ static void loop_fc()
                 out_status_query_data.hg_bias_x_cmss = (int16_t)lroundf(sensor_collector.hg_bias_x * 100.0f);
                 out_status_query_data.hg_bias_y_cmss = (int16_t)lroundf(sensor_collector.hg_bias_y * 100.0f);
                 out_status_query_data.hg_bias_z_cmss = (int16_t)lroundf(sensor_collector.hg_bias_z * 100.0f);
-                // Persist to NVS
+                // Persist to NVS — high-g bias + gyro zero-rate bias (#132).
                 prefs.begin("cal", false);
                 prefs.putFloat("hgbx", sensor_collector.hg_bias_x);
                 prefs.putFloat("hgby", sensor_collector.hg_bias_y);
                 prefs.putFloat("hgbz", sensor_collector.hg_bias_z);
+                prefs.putShort("gx", sensor_collector_hw.gyro_cal_x);
+                prefs.putShort("gy", sensor_collector_hw.gyro_cal_y);
+                prefs.putShort("gz", sensor_collector_hw.gyro_cal_z);
                 prefs.end();
                 ESP_LOGI(TAG, "[CAL] Sensor calibration complete (saved to NVS)");
+                // Push the result up so the app can snapshot it into the profile.
+                publishSensorCalFromNVS();
             }
             // Issue #96 — magnetometer hard-iron cal: start / abort / accept / retry.
             // Entry is gated to READY only.  All transitions produce one
@@ -3026,6 +3085,60 @@ static void loop_fc()
             {
                 ESP_LOGI(TAG, "[MAGCAL] READ -> publish status from NVS");
                 publishMagCalStatusFromNVS();
+            }
+            // Issue #132 — app pushes a saved sensor cal (gyro + high-g) back
+            // into NVS and applies it.  Gated to READY like the pad cal.
+            else if (out_pending_command == SENSOR_CAL_APPLY_PENDING)
+            {
+                if (rocket_state != READY)
+                {
+                    ESP_LOGW(TAG, "[SENSORCAL] apply refused: state=%u (require READY)",
+                             (unsigned)rocket_state);
+                }
+                else
+                {
+                    delay(1);
+                    uint8_t cfg_payload[sizeof(SensorCalApplyData)];
+                    size_t  cfg_len = 0;
+                    if (readConfigFrame(SENSOR_CAL_APPLY_MSG, sizeof(SensorCalApplyData),
+                                        cfg_payload, sizeof(cfg_payload), cfg_len)
+                        && cfg_len >= sizeof(SensorCalApplyData))
+                    {
+                        SensorCalApplyData ap;
+                        memcpy(&ap, cfg_payload, sizeof(ap));
+
+                        sensor_collector_hw.gyro_cal_x = ap.gyro_x;
+                        sensor_collector_hw.gyro_cal_y = ap.gyro_y;
+                        sensor_collector_hw.gyro_cal_z = ap.gyro_z;
+                        sensor_converter.setHighGBias(ap.hg_x, ap.hg_y, ap.hg_z);
+                        out_status_query_data.hg_bias_x_cmss = (int16_t)lroundf(ap.hg_x * 100.0f);
+                        out_status_query_data.hg_bias_y_cmss = (int16_t)lroundf(ap.hg_y * 100.0f);
+                        out_status_query_data.hg_bias_z_cmss = (int16_t)lroundf(ap.hg_z * 100.0f);
+
+                        prefs.begin("cal", false);
+                        prefs.putFloat("hgbx", ap.hg_x);
+                        prefs.putFloat("hgby", ap.hg_y);
+                        prefs.putFloat("hgbz", ap.hg_z);
+                        prefs.putShort("gx", ap.gyro_x);
+                        prefs.putShort("gy", ap.gyro_y);
+                        prefs.putShort("gz", ap.gyro_z);
+                        prefs.end();
+
+                        ESP_LOGI(TAG, "[SENSORCAL] APPLY+saved: gyro=(%d,%d,%d) hg=(%.3f,%.3f,%.3f)",
+                                 (int)ap.gyro_x, (int)ap.gyro_y, (int)ap.gyro_z,
+                                 (double)ap.hg_x, (double)ap.hg_y, (double)ap.hg_z);
+                        publishSensorCalFromNVS();
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "[SENSORCAL] APPLY payload read failed");
+                    }
+                }
+            }
+            else if (out_pending_command == SENSOR_CAL_READ)
+            {
+                ESP_LOGI(TAG, "[SENSORCAL] READ -> publish status from NVS");
+                publishSensorCalFromNVS();
             }
             else if (out_pending_command == GAIN_SCHED_ENABLE)
             {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1057,7 +1057,8 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == ROLL_CTRL_CONFIG_PENDING ||
            cmd == PYRO_CONFIG_PENDING ||
            cmd == PYRO_CONT_TEST ||
-           cmd == PYRO_FIRE_TEST;
+           cmd == PYRO_FIRE_TEST ||
+           cmd == MAG_CAL_APPLY_PENDING;  // #132: app-pushed cal payload
 }
 
 // The FC reads exactly FC_COMBINED_READ_SIZE bytes per I2C poll.
@@ -4853,6 +4854,32 @@ static void loop_oc()
         {
             setPendingCommand(MAG_CAL_COMPUTE_FIT);
             ESP_LOGI("BLE", "Mag cal COMPUTE_FIT -> FlightComputer");
+        }
+        // Issue #132 — app pushes a saved cal back into FC NVS as part of the
+        // rocket-profile auto-sync on connect.  14-byte payload mirrors the
+        // values cmd 52 would have persisted after a fresh sphere fit.
+        else if (ble_cmd == 55)
+        {
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= sizeof(MagCalApplyData))
+            {
+                memcpy(pending_config_data, payload, sizeof(MagCalApplyData));
+                pending_config_data_len = sizeof(MagCalApplyData);
+                pending_config_msg_type = MAG_CAL_APPLY_MSG;
+                setPendingCommand(MAG_CAL_APPLY_PENDING);
+                ESP_LOGI("BLE", "Mag cal APPLY queued for FlightComputer");
+            }
+            else
+            {
+                ESP_LOGW("BLE", "Mag cal APPLY: payload too short (%u < %u)",
+                              (unsigned)plen, (unsigned)sizeof(MagCalApplyData));
+            }
+        }
+        else if (ble_cmd == 56)
+        {
+            setPendingCommand(MAG_CAL_READ);
+            ESP_LOGI("BLE", "Mag cal READ -> FlightComputer");
         }
     }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1058,7 +1058,8 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == PYRO_CONFIG_PENDING ||
            cmd == PYRO_CONT_TEST ||
            cmd == PYRO_FIRE_TEST ||
-           cmd == MAG_CAL_APPLY_PENDING;  // #132: app-pushed cal payload
+           cmd == MAG_CAL_APPLY_PENDING ||     // #132: app-pushed mag cal payload
+           cmd == SENSOR_CAL_APPLY_PENDING;    // #132: app-pushed sensor cal payload
 }
 
 // The FC reads exactly FC_COMBINED_READ_SIZE bytes per I2C poll.
@@ -1413,6 +1414,15 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         if (payload_len >= sizeof(MagCalStatusData))
         {
             ble_app.sendMagCalStatus(payload, sizeof(MagCalStatusData));
+        }
+    }
+    else if (type == SENSOR_CAL_STATUS_MSG)
+    {
+        // Issue #132: FC→OC sensor cal readback.  Forward to BLE on file-ops
+        // with a 0xCB discriminator (sibling of mag cal's 0xCA).
+        if (payload_len >= sizeof(SensorCalStatusData))
+        {
+            ble_app.sendSensorCalStatus(payload, sizeof(SensorCalStatusData));
         }
     }
     else if (type == GNSS_MSG)
@@ -4880,6 +4890,31 @@ static void loop_oc()
         {
             setPendingCommand(MAG_CAL_READ);
             ESP_LOGI("BLE", "Mag cal READ -> FlightComputer");
+        }
+        // Issue #132 — app pushes a saved sensor cal (gyro + high-g) back into
+        // FC NVS as part of the rocket-profile auto-sync on connect.
+        else if (ble_cmd == 57)
+        {
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= sizeof(SensorCalApplyData))
+            {
+                memcpy(pending_config_data, payload, sizeof(SensorCalApplyData));
+                pending_config_data_len = sizeof(SensorCalApplyData);
+                pending_config_msg_type = SENSOR_CAL_APPLY_MSG;
+                setPendingCommand(SENSOR_CAL_APPLY_PENDING);
+                ESP_LOGI("BLE", "Sensor cal APPLY queued for FlightComputer");
+            }
+            else
+            {
+                ESP_LOGW("BLE", "Sensor cal APPLY: payload too short (%u < %u)",
+                              (unsigned)plen, (unsigned)sizeof(SensorCalApplyData));
+            }
+        }
+        else if (ble_cmd == 58)
+        {
+            setPendingCommand(SENSOR_CAL_READ);
+            ESP_LOGI("BLE", "Sensor cal READ -> FlightComputer");
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the settings overhaul from #132 (Part 1 per-rocket profiles + Part 2 grouped UI / commit flow, which consolidated #147), plus per-rocket calibration.

- **Per-rocket profiles** — each airframe is a saved `RocketProfile` (gains, servo, roll profile, camera, pyro, mag cal, sensor cal). Stored in the app (one JSON file per profile under Application Support) with a global active id. One-time migration folds the old global `@AppStorage` keys into a "Default" profile.
- **App is source-of-truth** — `ActiveRocketSyncer` pushes the active profile to whichever flight computer connects (and on profile switch). Edits made offline ride out on the next connect. Fixes the global-overwrite class of bug behind #146.
- **Grouped settings UI** — `SettingsView` is now profile-backed with tabs (Control / Camera / Pyro / General), self-apply on tab switch (no Apply button, per #144), revert-to-last-valid on invalid input.
- **Navigation** — rocket icon → rocket picker; new book icon → on-rocket file list; an active-rocket header (name + key settings + pyro state + sync status) at the top of the dashboard.
- **Base station is read-only** — shows the active rocket + "settings are edited on the rocket"; rocket selection isn't changeable from the BS.
- **Per-rocket mag cal + sensor cal** — board-tagged, re-applied on connect, with a board-mismatch warning. Adds firmware commands to push/read mag cal and gyro+high-g sensor cal (the gyro bias now also persists across reboots on the FC). **Requires flashing both FC and OC.**
- **Pyro config** is per-rocket (Pyro settings tab); the dashboard pyro cards keep continuity/test-fire for the pad.

Also includes one tooling commit: updates `parse_flight.py` / `trace_divergence.py` for the 44-byte `NON_SENSOR` frame (apogee_flags from #142/#143) — they were silently skipping EKF records.

## Test plan

- [x] iOS app builds; unit tests pass (RocketProfileStore + ActiveRocketSyncer, 30 tests).
- [x] flight_computer + out_computer firmware build.
- [x] EKF math regression (`verify_sparse_ekf` f64 + f32) passes.
- [ ] Flash FC + OC; verify mag-cal and sensor-cal save to the profile and re-apply on connect (board-mismatch warning on a different board).
- [ ] Manual smoke test: create/rename/duplicate/delete rockets; pick active; per-rocket settings push on connect; BS shows read-only active rocket.

## Follow-ups found during testing (separate, not in this PR)

- #173 — BLE: retain `CBPeripheral` during `.connecting` (intermittent connect cancel).
- #174 — EKF: horizontal velocity diverges vs GNSS=0 on a sim flight.

Closes #132
