### PR TITLE
GNSS dynamic-model + EKF innovation-gate fixes (#174)

### DIFF
--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -398,11 +398,15 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
             }
         }
 
-        // Dynamic model: Airborne <4g (6)
+        // Dynamic model: Airborne <4g (DYN_MODEL_AIRBORNE4g = 8).
+        // NOTE (#174): value 6 is Airborne <1g, not <4g — the receiver then
+        // assumes <1g dynamics and drops the fix the instant the motor lights
+        // (>1g), not reacquiring until the rocket slows on descent, which
+        // starved the EKF of GNSS through the whole boost+coast.
         ok = false;
         for (i = 0; i < 8; i++)
         {
-            if (gnss.setVal8(UBLOX_CFG_NAVSPG_DYNMODEL, 6)) { ok = true; break; }
+            if (gnss.setVal8(UBLOX_CFG_NAVSPG_DYNMODEL, DYN_MODEL_AIRBORNE4g)) { ok = true; break; }
             ESP_LOGW(TAG, "Failed to set dynamic model");
             delay(150);
         }

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -786,22 +786,47 @@ void GpsInsEKF::measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]) {
     float S_inv[36];
     if (!invertMatrix6x6(S, S_inv)) return;  // singular S — skip update
 
-    // ── Gate 2: Chi-squared innovation test ──
-    // Reject GNSS measurement if innovation is statistically inconsistent
-    // with the current state + covariance.  Test statistic: y^T * S^-1 * y
-    // follows chi-squared with 6 DOF.  Threshold ≈ 22.46 corresponds to
-    // p = 0.001 (99.9% confidence), generous enough to avoid rejecting
-    // legitimate measurements during high dynamics.
+    // ── Gate 2: split position / velocity innovation tests (#174) ──
+    // A single 6-DOF NIS gate let a large innovation in one block — e.g.
+    // vertical velocity lagging during high-g boost — reject the ENTIRE
+    // pos+vel update, discarding the good horizontal-velocity correction so
+    // horizontal velocity dead-reckons and runs away.  Test the position
+    // (3-DOF) and velocity (3-DOF) blocks independently; on a trip de-weight
+    // only that block (inflate its R) rather than dropping the whole
+    // measurement.  The marginal precision of each block is the inverse of
+    // that block of S.  chi²(3, 0.001) ≈ 16.27.
     {
-        float nis = 0.0f; // Normalized Innovation Squared
-        for (int i = 0; i < 6; i++) {
-            float row_sum = 0.0f;
-            for (int j = 0; j < 6; j++)
-                row_sum += S_inv[i * 6 + j] * y[j];
-            nis += y[i] * row_sum;
+        static constexpr float CHI2_GATE_3DOF = 16.27f;
+        float Spp[9] = { S[0],  S[1],  S[2],  S[6],  S[7],  S[8],  S[12], S[13], S[14] };
+        float Svv[9] = { S[21], S[22], S[23], S[27], S[28], S[29], S[33], S[34], S[35] };
+        float Sinv3[9];
+        // Huber-style soft de-weight: when a block's NIS exceeds the gate,
+        // inflate that block's R by (NIS/gate) instead of rejecting it.  An
+        // inconsistent measurement is down-weighted in proportion to how far
+        // out it is (so a true outlier has near-zero influence) but never
+        // fully discarded — so the filter can still recover after it has
+        // drifted (e.g. a large reacquired-GNSS velocity innovation following
+        // a GNSS gap keeps pulling the estimate back).
+        float infl_pos = 1.0f, infl_vel = 1.0f;
+        if (invertMatrix3x3(Spp, Sinv3)) {
+            float nis = 0.0f;
+            for (int i=0;i<3;i++){ float r=0; for(int j=0;j<3;j++) r+=Sinv3[i*3+j]*y[j]; nis+=y[i]*r; }
+            if (nis > CHI2_GATE_3DOF) infl_pos = nis / CHI2_GATE_3DOF;
         }
-        static constexpr float CHI2_GATE_6DOF = 22.46f; // chi²(6, 0.001)
-        if (nis > CHI2_GATE_6DOF) return; // reject outlier measurement
+        if (invertMatrix3x3(Svv, Sinv3)) {
+            float nis = 0.0f;
+            for (int i=0;i<3;i++){ float r=0; for(int j=0;j<3;j++) r+=Sinv3[i*3+j]*y[3+j]; nis+=y[3+i]*r; }
+            if (nis > CHI2_GATE_3DOF) infl_vel = nis / CHI2_GATE_3DOF;
+        }
+        if (infl_pos > 1.0f || infl_vel > 1.0f) {
+            R_scaled[0][0]*=infl_pos; R_scaled[1][1]*=infl_pos; R_scaled[2][2]*=infl_pos;
+            R_scaled[3][3]*=infl_vel; R_scaled[4][4]*=infl_vel; R_scaled[5][5]*=infl_vel;
+            for (int i=0;i<6;i++) for (int j=0;j<6;j++) {
+                float s=0.0f; for (int k=0;k<15;k++) s+=H_P[i][k]*H_T[k][j];
+                S[i*6+j]=s+R_scaled[i][j];
+            }
+            if (!invertMatrix6x6(S, S_inv)) return;
+        }
     }
 
     float P_Ht[15][6]={};


### PR DESCRIPTION
## Summary

Fixes the EKF horizontal-velocity divergence in #174. Two independent root causes, two fixes:

1. **GNSS dynamic model (`gnss:` commit).** The u-blox dynModel was set to raw value `6` = `DYN_MODEL_AIRBORNE1g` (<1 g), while the comment/log claimed "<4g" (value `8`). Under <1 g the receiver drops the fix the instant the motor lights and doesn't reacquire until descent — confirmed on RIM-66 and Eagle Claw (sats/fix cliff to 0 at launch). This starved the EKF of GNSS through boost+coast. Fix: use `DYN_MODEL_AIRBORNE4g`.

2. **EKF innovation gate (`ekf:` commit).** The GNSS update used one 6-DOF chi-squared gate that rejected the *entire* pos+vel update when any axis was inconsistent. During high-g boost the vertical channel throws a large innovation, tripping the gate and discarding the GNSS velocity correction that pins horizontal velocity → it dead-reckons and runs away (replay: +225 m/s on a sim flight with perfect GNSS), with lockout (no recovery). Fix: split into independent position (3-DOF) and velocity (3-DOF) tests and, on a trip, **Huber soft de-weight** that block (inflate R by NIS/gate) instead of rejecting it.

## Validation (replay A/B)

- Bench sim (continuous good GNSS): horizontal velocity **+225 m/s → bounded ~0**.
- Real flight that lost GNSS through boost: now **recovers** toward GNSS on reacquisition instead of staying stuck.
- Outlier rejection retained (a true outlier is de-weighted to near-zero influence).
- FC firmware + binding compile.

Full analysis (GNSS plots, source analysis, A/B runs, both iterations) is on #174.

## ⚠️ Not yet flight-tested

The EKF change is **replay-validated but has not flown**. It's CI-tested (cpp-tests EKF suite) and bounded in replay, but the real-world check is the next flight. Merging puts it on `main`; flashing/flying remains a deliberate step.

## Deferred follow-ups (not blocking)

- Bench-sim apogee transient ~−10 m/s that recovers in ~3 s.
- Boost-phase accel-bias observability (gravity update gated off >1.5 g).

## Test plan

- [ ] Flash FC; confirm GNSS holds lock through boost (no cliff to 0 at launch).
- [ ] Flight-test the EKF gate change; confirm horizontal velocity stays bounded with GNSS present and recovers after any gap.

Closes #174
