### PR TITLE
log: snapshot rocket settings into per-flight log + .json

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -351,11 +351,20 @@ nonisolated class CSVGenerator {
             return Double(apogee - launch) / 1_000_000.0
         }()
 
+        // Decode the flight settings snapshot (#165), if present. The FC emits
+        // it a few times right after launch for redundancy; all copies are
+        // identical, so take the first one that decodes.
+        let flightSettings: FlightSettings? = frames
+            .first(where: { $0.type == MessageType.flightSettings.rawValue })
+            .flatMap { try? FlightSettingsData(from: $0.payload) }
+            .map { FlightSettings(from: $0) }
+
         return FlightSummary(
             max_altitude_m: maxPressureAlt,
             max_speed_mps: maxSpeed,
             burnout_time_s: burnoutTime,
-            apogee_time_s: apogeeTime
+            apogee_time_s: apogeeTime,
+            settings: flightSettings
         )
     }
 
@@ -624,6 +633,180 @@ nonisolated struct FlightSummary: Codable, Sendable {
     let burnout_time_s: Double?
     /// Time from launch to apogee (seconds). Apogee = first altitude or velocity apogee flag.
     let apogee_time_s: Double?
+    /// Runtime roll-control / IMU settings the FC flew with, snapshotted into
+    /// the log at launch (#165). nil for flights logged before the firmware
+    /// emitted the settings frame.
+    let settings: FlightSettings?
+}
+
+// MARK: - Flight Settings (#165)
+
+/// Round a float32 to `digits` significant figures so the JSON shows clean
+/// gains (e.g. 0.04, not 0.039999999105930) instead of float32→Double noise.
+private func sigFig(_ v: Float, _ digits: Int = 6) -> Double {
+    let d = Double(v)
+    if d == 0 || !d.isFinite { return d }
+    let mag = floor(log10(abs(d)))
+    let factor = pow(10.0, Double(digits - 1) - mag)
+    return (d * factor).rounded() / factor
+}
+
+/// Settings block written into the per-flight summary JSON. Mirrors every
+/// per-rocket setting editable in the app's settings UI (#165) plus the
+/// issue's IMU full-scale and outer-loop knobs.
+nonisolated struct FlightSettings: Codable, Sendable {
+    let fw_git_sha: String
+    let fw_dirty: Bool
+    let sounds_enabled: Bool
+    let roll_control: RollControlSettings
+    let servo: ServoSettings
+    let camera: CameraSettings
+    let pyro: PyroSettings
+    let imu: IMUSettings
+
+    init(from raw: FlightSettingsData) {
+        fw_git_sha = raw.fw_git_sha
+        fw_dirty = raw.fwDirty
+        sounds_enabled = raw.soundsEnabled
+        roll_control = RollControlSettings(from: raw)
+        servo = ServoSettings(from: raw)
+        camera = CameraSettings(type: CameraSettings.label(raw.camera_type))
+        pyro = PyroSettings(from: raw)
+        imu = IMUSettings(
+            gyro_fs_dps: Int(raw.ism6_gyro_fs_dps),
+            low_g_fs_g: Int(raw.ism6_low_g_fs_g),
+            high_g_fs_g: Int(raw.ism6_high_g_fs_g)
+        )
+    }
+}
+
+nonisolated struct RollControlSettings: Codable, Sendable {
+    /// "rate" (null-rate inner loop), "angle" (cascaded, single setpoint),
+    /// or "angle_profile" (cascaded, follows the waypoint profile).
+    let mode: String
+    let kp: Double
+    let ki: Double
+    let kd: Double
+    let d_lpf_hz: Double
+    let kp_angle: Double
+    let cmd_limit_min_deg: Double
+    let cmd_limit_max_deg: Double
+    let delay_ms: Int
+    let rate_cap_dps: Double
+    let roll_rate_set_point: Double
+    let guidance_enabled: Bool
+    let gain_schedule: GainScheduleSettings
+    let profile: [RollWaypointJSON]
+
+    init(from raw: FlightSettingsData) {
+        if raw.num_waypoints > 0 {
+            mode = "angle_profile"
+        } else if raw.useAngleControl {
+            mode = "angle"
+        } else {
+            mode = "rate"
+        }
+        kp = sigFig(raw.kp)
+        ki = sigFig(raw.ki)
+        kd = sigFig(raw.kd)
+        d_lpf_hz = sigFig(raw.d_lpf_hz)
+        kp_angle = sigFig(raw.kp_angle)
+        cmd_limit_min_deg = sigFig(raw.min_cmd_deg)
+        cmd_limit_max_deg = sigFig(raw.max_cmd_deg)
+        delay_ms = Int(raw.roll_delay_ms)
+        rate_cap_dps = sigFig(raw.kp_angle_rate_cap_dps)
+        roll_rate_set_point = sigFig(raw.roll_rate_set_point)
+        guidance_enabled = raw.guidanceEnabled
+        gain_schedule = GainScheduleSettings(
+            enabled: raw.gainScheduleEnabled,
+            v_ref: sigFig(raw.gs_v_ref),
+            v_min: sigFig(raw.gs_v_min),
+            scale_cap: sigFig(raw.gs_scale_cap)
+        )
+        profile = raw.waypoints.map {
+            RollWaypointJSON(
+                time_s: sigFig($0.time_s),
+                angle_deg: sigFig($0.angle_deg),
+                mode: $0.mode == 1 ? "null_rate" : "angle"
+            )
+        }
+    }
+}
+
+nonisolated struct GainScheduleSettings: Codable, Sendable {
+    let enabled: Bool
+    let v_ref: Double
+    let v_min: Double
+    let scale_cap: Double
+}
+
+nonisolated struct RollWaypointJSON: Codable, Sendable {
+    let time_s: Double
+    let angle_deg: Double
+    let mode: String   // "angle" or "null_rate"
+}
+
+nonisolated struct ServoSettings: Codable, Sendable {
+    let enabled: Bool
+    let bias_us: [Int]
+    let frequency_hz: Int
+    let min_pulse_us: Int
+    let max_pulse_us: Int
+
+    init(from raw: FlightSettingsData) {
+        enabled = raw.servoEnabled
+        bias_us = raw.servo_bias_us.map { Int($0) }
+        frequency_hz = Int(raw.servo_hz)
+        min_pulse_us = Int(raw.servo_min_us)
+        max_pulse_us = Int(raw.servo_max_us)
+    }
+}
+
+nonisolated struct CameraSettings: Codable, Sendable {
+    let type: String   // "none" | "gopro" | "runcam"
+
+    static func label(_ t: UInt8) -> String {
+        switch t {
+        case 1: return "gopro"
+        case 2: return "runcam"
+        default: return "none"
+        }
+    }
+}
+
+nonisolated struct PyroSettings: Codable, Sendable {
+    let ch1: PyroChannelSettings
+    let ch2: PyroChannelSettings
+
+    init(from raw: FlightSettingsData) {
+        ch1 = PyroChannelSettings(
+            enabled: raw.pyro1_enabled,
+            mode: raw.pyro1_trigger_mode,
+            value: raw.pyro1_trigger_value)
+        ch2 = PyroChannelSettings(
+            enabled: raw.pyro2_enabled,
+            mode: raw.pyro2_trigger_mode,
+            value: raw.pyro2_trigger_value)
+    }
+}
+
+nonisolated struct PyroChannelSettings: Codable, Sendable {
+    let enabled: Bool
+    /// "time_after_apogee" (value = seconds) or "altitude_on_descent" (value = meters AGL).
+    let trigger_mode: String
+    let trigger_value: Double
+
+    init(enabled: Bool, mode: UInt8, value: Float) {
+        self.enabled = enabled
+        self.trigger_mode = mode == 1 ? "altitude_on_descent" : "time_after_apogee"
+        self.trigger_value = sigFig(value)
+    }
+}
+
+nonisolated struct IMUSettings: Codable, Sendable {
+    let gyro_fs_dps: Int
+    let low_g_fs_g: Int
+    let high_g_fs_g: Int
 }
 
 // MARK: - CSV Errors

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -23,6 +23,7 @@ enum MessageType: UInt8 {
     case h3lis331 = 0xA9   // Legacy-only high-G accelerometer (10B)
     case cameraStart = 0xAA
     case cameraStop = 0xAB
+    case flightSettings = 0xE1  // FlightSettingsData (149B) — runtime settings snapshot at launch (#165)
     case lora = 0xF1
 }
 
@@ -64,6 +65,150 @@ nonisolated struct OutStatusQueryData {
     var imuRotationDeg: Double { Double(ism6_rot_z_cdeg) / 100.0 }
     /// Magnetometer rotation in degrees
     var magRotationDeg: Double { Double(mmc_rot_z_cdeg) / 100.0 }
+}
+
+// MARK: - Flight Settings Snapshot (176 bytes) — runtime config at launch (#165)
+
+/// One roll-profile waypoint as stored in the flight settings frame.
+nonisolated struct RollWaypointRaw {
+    let time_s: Float
+    let angle_deg: Float
+    let mode: UInt8       // 0 = ROLL_SEG_ANGLE, 1 = ROLL_SEG_NULL_RATE
+}
+
+/// Decoded FlightSettingsData wire frame. Layout mirrors the packed C++
+/// struct in RocketComputerTypes.h byte-for-byte (verified by offset).
+nonisolated struct FlightSettingsData {
+    // flags bit positions (match FlightSettingsData::F_* in firmware)
+    static let fUseAngleControl: UInt8 = 0
+    static let fGainSchedule: UInt8    = 1
+    static let fGuidance: UInt8        = 2
+    static let fServoEnabled: UInt8    = 3
+    static let fFwDirty: UInt8         = 4
+    static let fSounds: UInt8          = 5
+
+    let time_us: UInt32
+    let version: UInt8
+    let flags: UInt8
+    let roll_delay_ms: UInt16
+
+    let kp: Float
+    let ki: Float
+    let kd: Float
+    let d_lpf_hz: Float
+    let min_cmd_deg: Float
+    let max_cmd_deg: Float
+
+    let kp_angle: Float
+    let kp_angle_rate_cap_dps: Float
+
+    let gs_v_ref: Float
+    let gs_v_min: Float
+    let gs_scale_cap: Float
+
+    let roll_rate_set_point: Float
+
+    let ism6_low_g_fs_g: UInt8
+    let ism6_high_g_fs_g: UInt16
+    let ism6_gyro_fs_dps: UInt16
+
+    let servo_bias_us: [Int16]   // 4 entries
+    let servo_hz: Int16
+    let servo_min_us: Int16
+    let servo_max_us: Int16
+
+    let camera_type: UInt8
+
+    let pyro1_enabled: Bool
+    let pyro1_trigger_mode: UInt8   // 0 = time-after-apogee, 1 = altitude-on-descent
+    let pyro1_trigger_value: Float
+    let pyro2_enabled: Bool
+    let pyro2_trigger_mode: UInt8
+    let pyro2_trigger_value: Float
+
+    let fw_git_sha: String
+    let num_waypoints: UInt8
+    let waypoints: [RollWaypointRaw]
+
+    var useAngleControl: Bool { flags & (1 << FlightSettingsData.fUseAngleControl) != 0 }
+    var gainScheduleEnabled: Bool { flags & (1 << FlightSettingsData.fGainSchedule) != 0 }
+    var guidanceEnabled: Bool { flags & (1 << FlightSettingsData.fGuidance) != 0 }
+    var servoEnabled: Bool { flags & (1 << FlightSettingsData.fServoEnabled) != 0 }
+    var fwDirty: Bool { flags & (1 << FlightSettingsData.fFwDirty) != 0 }
+    var soundsEnabled: Bool { flags & (1 << FlightSettingsData.fSounds) != 0 }
+
+    init(from data: Data) throws {
+        guard data.count >= 176 else {
+            throw ParseError.invalidSize(expected: 176, got: data.count)
+        }
+
+        var offset = 0
+        time_us = data.readUInt32LE(at: &offset)
+        version = data.readUInt8(at: &offset)
+        flags = data.readUInt8(at: &offset)
+        roll_delay_ms = data.readUInt16LE(at: &offset)
+
+        kp = data.readFloat32LE(at: &offset)
+        ki = data.readFloat32LE(at: &offset)
+        kd = data.readFloat32LE(at: &offset)
+        d_lpf_hz = data.readFloat32LE(at: &offset)
+        min_cmd_deg = data.readFloat32LE(at: &offset)
+        max_cmd_deg = data.readFloat32LE(at: &offset)
+
+        kp_angle = data.readFloat32LE(at: &offset)
+        kp_angle_rate_cap_dps = data.readFloat32LE(at: &offset)
+
+        gs_v_ref = data.readFloat32LE(at: &offset)
+        gs_v_min = data.readFloat32LE(at: &offset)
+        gs_scale_cap = data.readFloat32LE(at: &offset)
+
+        roll_rate_set_point = data.readFloat32LE(at: &offset)
+
+        ism6_low_g_fs_g = data.readUInt8(at: &offset)
+        ism6_high_g_fs_g = data.readUInt16LE(at: &offset)
+        ism6_gyro_fs_dps = data.readUInt16LE(at: &offset)
+
+        // Servo trim + timing (offset 61)
+        servo_bias_us = [
+            data.readInt16LE(at: &offset),
+            data.readInt16LE(at: &offset),
+            data.readInt16LE(at: &offset),
+            data.readInt16LE(at: &offset),
+        ]
+        servo_hz = data.readInt16LE(at: &offset)
+        servo_min_us = data.readInt16LE(at: &offset)
+        servo_max_us = data.readInt16LE(at: &offset)
+
+        camera_type = data.readUInt8(at: &offset)   // offset 75
+
+        // PyroConfigData (offset 76, 12 bytes)
+        pyro1_enabled = data.readUInt8(at: &offset) != 0
+        pyro1_trigger_mode = data.readUInt8(at: &offset)
+        pyro1_trigger_value = data.readFloat32LE(at: &offset)
+        pyro2_enabled = data.readUInt8(at: &offset) != 0
+        pyro2_trigger_mode = data.readUInt8(at: &offset)
+        pyro2_trigger_value = data.readFloat32LE(at: &offset)
+
+        // fw_git_sha: 12-byte NUL-terminated char array (offset 88..99)
+        let shaBytes = data.subdata(in: offset..<(offset + 12))
+        fw_git_sha = String(bytes: shaBytes.prefix(while: { $0 != 0 }), encoding: .utf8) ?? ""
+        offset += 12
+
+        // roll_profile: RollProfileData @ offset 100
+        let nRaw = data.readUInt8(at: &offset)      // num_waypoints (offset 100)
+        offset += 3                                  // _pad[3]
+        let n = min(Int(nRaw), 8)
+        num_waypoints = UInt8(n)
+        var wps: [RollWaypointRaw] = []
+        wps.reserveCapacity(n)
+        for _ in 0..<n {                             // waypoints @ offset 104, 9 bytes each
+            let t = data.readFloat32LE(at: &offset)
+            let a = data.readFloat32LE(at: &offset)
+            let m = data.readUInt8(at: &offset)
+            wps.append(RollWaypointRaw(time_s: t, angle_deg: a, mode: m))
+        }
+        waypoints = wps
+    }
 }
 
 // MARK: - Raw Packed Data Structures

--- a/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
@@ -169,4 +169,120 @@ final class MessageParserTests: XCTestCase {
         let crc2 = calculateCRC16(data)
         XCTAssertEqual(crc, crc2)
     }
+
+    // MARK: - Flight Settings Snapshot (#165)
+
+    private func leU16(_ v: UInt16) -> [UInt8] { [UInt8(v & 0xFF), UInt8(v >> 8)] }
+    private func leU32(_ v: UInt32) -> [UInt8] {
+        [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)]
+    }
+    private func leI16(_ v: Int16) -> [UInt8] { leU16(UInt16(bitPattern: v)) }
+    private func leF32(_ v: Float) -> [UInt8] { leU32(v.bitPattern) }
+
+    /// Build a known 176-byte FlightSettingsData payload and verify the decode
+    /// + JSON mapping. Offsets here must match the C++ struct (locked by the
+    /// FlightSettingsData_Layout test in tests_cpp).
+    func testFlightSettingsDecode() throws {
+        var p: [UInt8] = []
+        p += leU32(123456)        // time_us @0
+        p.append(1)               // version @4
+        let flags: UInt8 = (1 << 0) | (1 << 1) | (1 << 3) | (1 << 5)  // angle, gainSched, servo, sounds
+        p.append(flags)           // flags @5
+        p += leU16(500)           // roll_delay_ms @6
+        p += leF32(0.02)          // kp @8
+        p += leF32(0.0005)        // ki @12
+        p += leF32(0.0003)        // kd @16
+        p += leF32(10)            // d_lpf_hz @20
+        p += leF32(-20)           // min_cmd_deg @24
+        p += leF32(20)            // max_cmd_deg @28
+        p += leF32(4.0)           // kp_angle @32
+        p += leF32(60)            // kp_angle_rate_cap_dps @36
+        p += leF32(50)            // gs_v_ref @40
+        p += leF32(25)            // gs_v_min @44
+        p += leF32(3)             // gs_scale_cap @48
+        p += leF32(0)             // roll_rate_set_point @52
+        p.append(16)              // ism6_low_g_fs_g @56
+        p += leU16(256)           // ism6_high_g_fs_g @57
+        p += leU16(4000)          // ism6_gyro_fs_dps @59
+        p += leI16(85); p += leI16(-3); p += leI16(0); p += leI16(12)  // servo_bias_us @61
+        p += leI16(333)           // servo_hz @69
+        p += leI16(1250)          // servo_min_us @71
+        p += leI16(1750)          // servo_max_us @73
+        p.append(2)               // camera_type @75 (runcam)
+        p.append(1); p.append(0); p += leF32(1.5)   // pyro ch1 @76: enabled, time mode, 1.5 s
+        p.append(1); p.append(1); p += leF32(100)    // pyro ch2 @82: enabled, altitude mode, 100 m
+        let sha = Array("abc1234".utf8)              // fw_git_sha @88 (12 bytes)
+        p += sha + [UInt8](repeating: 0, count: 12 - sha.count)
+        p.append(2)               // num_waypoints @100
+        p += [0, 0, 0]            // _pad @101
+        p += leF32(0.5); p += leF32(0); p.append(1)      // wp0 @104: 0.5 s, 0°, null_rate
+        p += leF32(1.0); p += leF32(180); p.append(0)    // wp1: 1.0 s, 180°, angle
+        p += [UInt8](repeating: 0, count: 6 * 9)         // remaining 6 zero waypoint slots
+
+        XCTAssertEqual(p.count, 176)
+
+        let raw = try FlightSettingsData(from: Data(p))
+        XCTAssertEqual(raw.time_us, 123456)
+        XCTAssertEqual(raw.version, 1)
+        XCTAssertTrue(raw.useAngleControl)
+        XCTAssertTrue(raw.gainScheduleEnabled)
+        XCTAssertFalse(raw.guidanceEnabled)
+        XCTAssertTrue(raw.servoEnabled)
+        XCTAssertTrue(raw.soundsEnabled)
+        XCTAssertFalse(raw.fwDirty)
+        XCTAssertEqual(raw.roll_delay_ms, 500)
+        XCTAssertEqual(raw.kp, 0.02, accuracy: 1e-6)
+        XCTAssertEqual(raw.ki, 0.0005, accuracy: 1e-7)
+        XCTAssertEqual(raw.kd, 0.0003, accuracy: 1e-7)
+        XCTAssertEqual(raw.d_lpf_hz, 10, accuracy: 1e-4)
+        XCTAssertEqual(raw.min_cmd_deg, -20, accuracy: 1e-4)
+        XCTAssertEqual(raw.max_cmd_deg, 20, accuracy: 1e-4)
+        XCTAssertEqual(raw.kp_angle, 4.0, accuracy: 1e-4)
+        XCTAssertEqual(raw.kp_angle_rate_cap_dps, 60, accuracy: 1e-4)
+        XCTAssertEqual(raw.gs_v_ref, 50, accuracy: 1e-4)
+        XCTAssertEqual(raw.gs_v_min, 25, accuracy: 1e-4)
+        XCTAssertEqual(raw.gs_scale_cap, 3, accuracy: 1e-4)
+        XCTAssertEqual(raw.roll_rate_set_point, 0, accuracy: 1e-4)
+        XCTAssertEqual(raw.ism6_low_g_fs_g, 16)
+        XCTAssertEqual(raw.ism6_high_g_fs_g, 256)
+        XCTAssertEqual(raw.ism6_gyro_fs_dps, 4000)
+        XCTAssertEqual(raw.servo_bias_us, [85, -3, 0, 12])
+        XCTAssertEqual(raw.servo_hz, 333)
+        XCTAssertEqual(raw.servo_min_us, 1250)
+        XCTAssertEqual(raw.servo_max_us, 1750)
+        XCTAssertEqual(raw.camera_type, 2)
+        XCTAssertTrue(raw.pyro1_enabled)
+        XCTAssertEqual(raw.pyro1_trigger_mode, 0)
+        XCTAssertEqual(raw.pyro1_trigger_value, 1.5, accuracy: 1e-4)
+        XCTAssertTrue(raw.pyro2_enabled)
+        XCTAssertEqual(raw.pyro2_trigger_mode, 1)
+        XCTAssertEqual(raw.pyro2_trigger_value, 100, accuracy: 1e-4)
+        XCTAssertEqual(raw.fw_git_sha, "abc1234")
+        XCTAssertEqual(raw.num_waypoints, 2)
+        XCTAssertEqual(raw.waypoints.count, 2)
+        XCTAssertEqual(raw.waypoints[0].time_s, 0.5, accuracy: 1e-4)
+        XCTAssertEqual(raw.waypoints[0].mode, 1)
+        XCTAssertEqual(raw.waypoints[1].angle_deg, 180, accuracy: 1e-4)
+        XCTAssertEqual(raw.waypoints[1].mode, 0)
+
+        // JSON model mapping
+        let s = FlightSettings(from: raw)
+        XCTAssertEqual(s.fw_git_sha, "abc1234")
+        XCTAssertTrue(s.sounds_enabled)
+        XCTAssertEqual(s.roll_control.mode, "angle_profile")   // num_waypoints > 0
+        XCTAssertEqual(s.roll_control.kp, 0.02, accuracy: 1e-9)
+        XCTAssertEqual(s.roll_control.cmd_limit_min_deg, -20, accuracy: 1e-9)
+        XCTAssertEqual(s.roll_control.profile.count, 2)
+        XCTAssertEqual(s.roll_control.profile[0].mode, "null_rate")
+        XCTAssertEqual(s.servo.bias_us, [85, -3, 0, 12])
+        XCTAssertEqual(s.servo.frequency_hz, 333)
+        XCTAssertEqual(s.camera.type, "runcam")
+        XCTAssertEqual(s.pyro.ch1.trigger_mode, "time_after_apogee")
+        XCTAssertEqual(s.pyro.ch1.trigger_value, 1.5, accuracy: 1e-6)
+        XCTAssertEqual(s.pyro.ch2.trigger_mode, "altitude_on_descent")
+        XCTAssertEqual(s.imu.gyro_fs_dps, 4000)
+
+        // Undersized payload is rejected.
+        XCTAssertThrowsError(try FlightSettingsData(from: Data(p.prefix(175))))
+    }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -762,3 +762,51 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
     // SF12 at sensitivity (-20 dB) must also pass.
     EXPECT_GE(-20.0f, loraMinValidSnrDb(12));
 }
+
+// --- Flight settings snapshot (#165) ---
+// The settings frame is decoded by the iOS app (SensorTypes.swift) and built
+// by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
+// here so a struct edit can't silently desync the cross-language decode.
+TEST(RocketComputerTypes, FlightSettingsData_Layout) {
+    EXPECT_EQ(sizeof(FlightSettingsData), 176u);
+    EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
+
+    EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
+    EXPECT_EQ(offsetof(FlightSettingsData, version),            4u);
+    EXPECT_EQ(offsetof(FlightSettingsData, flags),              5u);
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_delay_ms),      6u);
+    EXPECT_EQ(offsetof(FlightSettingsData, kp),                 8u);
+    EXPECT_EQ(offsetof(FlightSettingsData, min_cmd_deg),        24u);
+    EXPECT_EQ(offsetof(FlightSettingsData, kp_angle),           32u);
+    EXPECT_EQ(offsetof(FlightSettingsData, gs_v_ref),           40u);
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_rate_set_point), 52u);
+    EXPECT_EQ(offsetof(FlightSettingsData, ism6_low_g_fs_g),    56u);
+    EXPECT_EQ(offsetof(FlightSettingsData, ism6_high_g_fs_g),   57u);
+    EXPECT_EQ(offsetof(FlightSettingsData, ism6_gyro_fs_dps),   59u);
+    EXPECT_EQ(offsetof(FlightSettingsData, servo_bias_us),      61u);
+    EXPECT_EQ(offsetof(FlightSettingsData, servo_hz),           69u);
+    EXPECT_EQ(offsetof(FlightSettingsData, servo_min_us),       71u);
+    EXPECT_EQ(offsetof(FlightSettingsData, servo_max_us),       73u);
+    EXPECT_EQ(offsetof(FlightSettingsData, camera_type),        75u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro),               76u);
+    EXPECT_EQ(offsetof(FlightSettingsData, fw_git_sha),         88u);
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile),       100u);
+
+    // Embedded PyroConfigData reaches the right absolute offsets.
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch1_trigger_value), 78u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch2_enabled),       82u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch2_trigger_value), 84u);
+
+    // Roll profile waypoints start (RollProfileData @ 100, after num+pad).
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile) + offsetof(RollProfileData, waypoints), 104u);
+}
+
+TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
+    uint8_t all = (uint8_t)((1u << FlightSettingsData::F_USE_ANGLE_CONTROL) |
+                            (1u << FlightSettingsData::F_GAIN_SCHEDULE) |
+                            (1u << FlightSettingsData::F_GUIDANCE) |
+                            (1u << FlightSettingsData::F_SERVO_ENABLED) |
+                            (1u << FlightSettingsData::F_FW_DIRTY) |
+                            (1u << FlightSettingsData::F_SOUNDS));
+    EXPECT_EQ(all, 0x3Fu);  // bits 0-5, no overlap
+}

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1305,6 +1305,11 @@ static constexpr uint8_t SENSOR_CAL_APPLY_MSG     = 0xDE;  // 18-byte SensorCalA
 static constexpr uint8_t SENSOR_CAL_READ          = 0xDF;  // OC→FC: publish current NVS sensor cal
 static constexpr uint8_t SENSOR_CAL_STATUS_MSG    = 0xE0;  // FC→OC: SensorCalStatusData
 
+// FC→OC over I2S, emitted once at the PRELAUNCH→INFLIGHT transition. A
+// snapshot of the active roll-control / IMU settings so the per-flight .bin
+// (and the .json the app derives from it) records what actually flew (#165).
+static constexpr uint8_t FLIGHT_SETTINGS_MSG = 0xE1;
+
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
 // Camera types
@@ -1419,6 +1424,81 @@ typedef struct __attribute__((packed))
 } RollControlConfigData;
 static_assert(sizeof(RollControlConfigData) == 4, "RollControlConfigData must be 4 bytes");
 
+// --- Flight settings snapshot (#165) ---
+// One-shot snapshot of the rocket's runtime settings, emitted FC→OC over I2S
+// at the PRELAUNCH→INFLIGHT transition and logged into the per-flight .bin.
+// The iOS app decodes it into the flight summary .json so post-flight analysis
+// can reconstruct the exact loop that flew, instead of guessing from config.h
+// defaults (the original confusion in #165 — wrong Kp sent reconstruction off
+// by 5x).  Covers every per-rocket setting editable in the app's settings UI
+// (PID, gain schedule, servo trim/timing, roll control + profile, camera,
+// pyro, sounds) plus the issue's IMU full-scale and outer-loop knobs.  Read at
+// the snapshot point from the live servo_control values, the runtime override
+// globals, config:: constants, pyro_config, and the active roll_profile.
+// time_us is first so the generic frame parser's "timestamp = first 4 payload
+// bytes" convention still holds.
+struct __attribute__((packed)) FlightSettingsData
+{
+    static constexpr uint8_t VERSION = 1;
+
+    // flags bit positions
+    static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only
+    static constexpr uint8_t F_GAIN_SCHEDULE     = 1;  // gain scheduling enabled
+    static constexpr uint8_t F_GUIDANCE          = 2;  // PN guidance enabled
+    static constexpr uint8_t F_SERVO_ENABLED     = 3;  // servo/roll control enabled at all
+    static constexpr uint8_t F_FW_DIRTY          = 4;  // build had uncommitted changes
+    static constexpr uint8_t F_SOUNDS            = 5;  // piezo sounds enabled
+
+    uint32_t time_us;            // micros() at snapshot
+    uint8_t  version;            // = VERSION
+    uint8_t  flags;              // see F_* bit positions above
+    uint16_t roll_delay_ms;      // roll-control activation delay after launch (ms)
+
+    // Inner rate PID — gain-schedule base gains (what the loop uses at V_ref)
+    float    kp;
+    float    ki;
+    float    kd;
+    float    d_lpf_hz;           // D-term low-pass cutoff (Hz; 0 = disabled)
+    float    min_cmd_deg;        // fin command lower limit (deg)
+    float    max_cmd_deg;        // fin command upper limit (deg)
+
+    // Outer (cascaded angle) loop
+    float    kp_angle;
+    float    kp_angle_rate_cap_dps;
+
+    // Gain schedule (meaningful only when F_GAIN_SCHEDULE set)
+    float    gs_v_ref;           // reference speed (m/s)
+    float    gs_v_min;           // min speed clamp (m/s)
+    float    gs_scale_cap;       // max gain scale factor
+
+    // Rate-only setpoint (deg/s)
+    float    roll_rate_set_point;
+
+    // IMU full-scale (mirror of OutStatusQueryData)
+    uint8_t  ism6_low_g_fs_g;    // e.g. 16
+    uint16_t ism6_high_g_fs_g;   // e.g. 256
+    uint16_t ism6_gyro_fs_dps;   // e.g. 4000
+
+    // Servo trim + timing (app "Servo" settings)
+    int16_t  servo_bias_us[4];   // per-servo µs trim offset
+    int16_t  servo_hz;           // PWM frequency
+    int16_t  servo_min_us;       // min pulse width (µs)
+    int16_t  servo_max_us;       // max pulse width (µs)
+
+    // Camera (0 = none, 1 = GoPro, 2 = RunCam)
+    uint8_t  camera_type;
+
+    // Pyro channel config (both channels)
+    PyroConfigData pyro;
+
+    // Firmware identity: git short SHA, NUL-terminated ("unknown" if no git)
+    char     fw_git_sha[12];
+
+    // Active roll profile (num_waypoints == 0 → rate-only)
+    RollProfileData roll_profile;
+};
+static_assert(sizeof(FlightSettingsData) == 176, "FlightSettingsData layout check");
+
 // --- Guidance Telemetry Data (sent at ~10 Hz during coast) ---
 typedef struct __attribute__((packed))
 {
@@ -1531,6 +1611,12 @@ static constexpr size_t M_SENSOR = (M1234 > M567 ? M1234 : M567);
 
 static constexpr size_t M_SENSOR_OR_PROFILE = (M_SENSOR > P8 ? M_SENSOR : P8);
 static constexpr size_t MAX_PAYLOAD = (M_SENSOR_OR_PROFILE > P9 ? M_SENSOR_OR_PROFILE : P9);
+
+// The flight settings snapshot (#165) rides the same I2S frame path, so it
+// must also fit one payload.  Checked here since MAX_PAYLOAD is defined below
+// the struct.
+static_assert(sizeof(FlightSettingsData) <= MAX_PAYLOAD,
+              "FlightSettingsData must fit one I2S frame");
 
 // Frame: [0xAA][0x55][0xAA][0x55] + type + length + payload + CRC16
 static constexpr size_t MAX_FRAME = 4 + 1 + 1 + MAX_PAYLOAD + 2;

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -243,7 +243,7 @@ void TR_ServoControl::controlWithGainSchedule(float roll_rate, float velocity_ms
         float v_ratio = gain_schedule_v_ref / v;
         float scale = v_ratio * v_ratio;
         // Cap the scale factor so servo saturates at ~50 deg/s error, not gyro noise
-        scale = std::min(scale, 3.0f);
+        scale = std::min(scale, GAIN_SCHEDULE_SCALE_CAP);
 
         // Reset I-term when gain scale changes significantly to prevent
         // accumulated integral from spiking the output after a step change in Ki.

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -54,10 +54,31 @@ public:
     // Reset PID internal state (for replay / test sessions)
     void resetPID();
 
+    // Max gain-schedule scale factor. Caps (V_ref/V)² so servos saturate on
+    // real ~50 deg/s errors at low speed, not on gyro noise.
+    static constexpr float GAIN_SCHEDULE_SCALE_CAP = 3.0f;
+
     // Gain scheduling configuration
     void enableGainSchedule(float v_ref, float v_min);
     void disableGainSchedule();
     bool isGainScheduleEnabled() const { return gain_schedule_enabled; }
+
+    // Live PID gains / limits — base (pre-gain-schedule) values, i.e. what
+    // was loaded from NVS or config and pushed via setPIDGains/setPIDLimits.
+    // Used to snapshot the flown settings into the flight log (#165).
+    float getKp() const { return kp_base; }
+    float getKi() const { return ki_base; }
+    float getKd() const { return kd_base; }
+    float getMinCmd() const { return min_cmd; }
+    float getMaxCmd() const { return max_cmd; }
+
+    // Live servo trim / timing — for the flight settings snapshot (#165).
+    int getServoBiasUs(int servoIndex) const {
+        return (servoIndex >= 0 && servoIndex < 4) ? servo_bias_us_[servoIndex] : 0;
+    }
+    int getServoHz() const { return servo_hz; }
+    int getServoMinUs() const { return servo_min_us; }
+    int getServoMaxUs() const { return servo_max_us; }
     // update PWM outputs with velocity-based gain scaling
     void controlWithGainSchedule(float roll_rate, float velocity_ms);
 

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -23,3 +23,27 @@ idf_component_register(
         nvs_flash
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)
+
+# Record the firmware revision in each flight's settings snapshot (#165).
+# Captured at CMake configure time; reconfigure (touch this file or clean
+# build) to refresh.  git describe is unusable here (repo has no tags), so
+# use the raw short SHA plus a dirty flag for uncommitted tracked changes.
+execute_process(
+    COMMAND git -C ${CMAKE_CURRENT_LIST_DIR} rev-parse --short HEAD
+    OUTPUT_VARIABLE FW_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+if(NOT FW_GIT_SHA)
+    set(FW_GIT_SHA "unknown")
+endif()
+execute_process(
+    COMMAND git -C ${CMAKE_CURRENT_LIST_DIR} diff --quiet HEAD --
+    RESULT_VARIABLE FW_GIT_DIFF_RC)
+if(FW_GIT_DIFF_RC EQUAL 1)
+    set(FW_GIT_DIRTY 1)
+else()
+    set(FW_GIT_DIRTY 0)
+endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    FW_GIT_SHA="${FW_GIT_SHA}"
+    FW_GIT_DIRTY=${FW_GIT_DIRTY})

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -33,6 +33,16 @@
 #include <CRC32.h>
 static const char* TAG = "FC";
 
+// Firmware revision recorded in the flight settings snapshot (#165).
+// Injected by CMake (git rev-parse / git diff); fall back when building
+// outside the IDF build (e.g. host tests) so main.cpp stays compilable.
+#ifndef FW_GIT_SHA
+#define FW_GIT_SHA "unknown"
+#endif
+#ifndef FW_GIT_DIRTY
+#define FW_GIT_DIRTY 0
+#endif
+
 // EKF timeUpdate()/measUpdate() allocate ~7.5 KB of temporary 15x15 matrices
 // on the stack.  The FreeRTOS task in app_main() is created with 16 KB.
 
@@ -304,6 +314,9 @@ static bool     reboot_recovery = false;      // true during servo settle period
 static bool     reboot_recovery_telem = false; // true for rest of flight (telemetry flag)
 static uint32_t servo_settle_end_ms = 0;      // hold servos neutral until this time
 static uint32_t last_snapshot_ms = 0;         // rate-limit NVS writes to 10 Hz
+// Resend the flight settings snapshot (#165) on the first few INFLIGHT ticks
+// so a single dropped I2S frame at launch doesn't lose the record.
+static uint8_t  settings_emit_count = 0;
 
 static uint32_t computeSnapshotCRC(const FlightSnapshotData& snap)
 {
@@ -928,6 +941,79 @@ static inline bool enqueueI2STx(uint8_t type, const uint8_t *payload, size_t len
 
     i2s_tx_enqueue_drop++;
     return false;
+}
+
+// Build a snapshot of the active roll-control / IMU settings (#165).  Reads
+// the live PID gains from servo_control (these can be NVS- or BLE-overridden),
+// the runtime override globals, the config:: defaults for the compile-time-only
+// knobs, and the active roll profile.  Logged once at flight-start so the
+// per-flight .json records exactly what flew.
+static void buildFlightSettings(FlightSettingsData& s)
+{
+    memset(&s, 0, sizeof(s));
+    s.time_us = micros();
+    s.version = FlightSettingsData::VERSION;
+
+    uint8_t flags = 0;
+    if (use_angle_control)  flags |= (uint8_t)(1u << FlightSettingsData::F_USE_ANGLE_CONTROL);
+    if (gain_sched_enabled) flags |= (uint8_t)(1u << FlightSettingsData::F_GAIN_SCHEDULE);
+    if (guidance_enabled)   flags |= (uint8_t)(1u << FlightSettingsData::F_GUIDANCE);
+    if (servo_enabled)      flags |= (uint8_t)(1u << FlightSettingsData::F_SERVO_ENABLED);
+    if (FW_GIT_DIRTY)       flags |= (uint8_t)(1u << FlightSettingsData::F_FW_DIRTY);
+    if (enable_sounds)      flags |= (uint8_t)(1u << FlightSettingsData::F_SOUNDS);
+    s.flags = flags;
+    s.roll_delay_ms = roll_delay_ms;
+
+    // Inner rate PID — live base gains (NVS/BLE-overridable, so read from
+    // servo_control rather than config:: which is only the boot default).
+    s.kp          = servo_control.getKp();
+    s.ki          = servo_control.getKi();
+    s.kd          = servo_control.getKd();
+    s.d_lpf_hz    = config::D_FILTER_CUTOFF_HZ;
+    s.min_cmd_deg = servo_control.getMinCmd();
+    s.max_cmd_deg = servo_control.getMaxCmd();
+
+    // Outer (cascaded angle) loop.  kp_angle is compile-time only.
+    s.kp_angle              = config::KP_ANGLE;
+    s.kp_angle_rate_cap_dps = kp_angle_rate_cap_dps;
+
+    // Gain schedule.  v_ref/v_min are compile-time only; the cap is owned by
+    // TR_ServoControl.
+    s.gs_v_ref     = config::GAIN_SCHEDULE_V_REF;
+    s.gs_v_min     = config::GAIN_SCHEDULE_V_MIN;
+    s.gs_scale_cap = TR_ServoControl::GAIN_SCHEDULE_SCALE_CAP;
+
+    s.roll_rate_set_point = config::ROLL_RATE_SET_POINT;
+
+    s.ism6_low_g_fs_g  = config::ISM6_LOW_G_FS_G;
+    s.ism6_high_g_fs_g = config::ISM6_HIGH_G_FS_G;
+    s.ism6_gyro_fs_dps = config::ISM6_GYRO_FS_DPS;
+
+    // Servo trim + timing (live values from servo_control).
+    for (int i = 0; i < 4; ++i) {
+        s.servo_bias_us[i] = (int16_t)servo_control.getServoBiasUs(i);
+    }
+    s.servo_hz     = (int16_t)servo_control.getServoHz();
+    s.servo_min_us = (int16_t)servo_control.getServoMinUs();
+    s.servo_max_us = (int16_t)servo_control.getServoMaxUs();
+
+    s.camera_type = runtime_camera_type;
+    s.pyro        = pyro_config;
+
+    // fw_git_sha buffer was zeroed by memset above, so strncpy of at most
+    // size-1 chars leaves it NUL-terminated.
+    strncpy(s.fw_git_sha, FW_GIT_SHA, sizeof(s.fw_git_sha) - 1);
+
+    s.roll_profile = roll_profile;
+}
+
+static void sendFlightSettings()
+{
+    FlightSettingsData s;
+    buildFlightSettings(s);
+    (void)enqueueI2STx(FLIGHT_SETTINGS_MSG,
+                       reinterpret_cast<const uint8_t*>(&s),
+                       sizeof(s));
 }
 
 static SemaphoreHandle_t i2c_bus_mutex = nullptr;
@@ -3735,6 +3821,15 @@ static void loop_fc()
                 if (now_ms - last_snapshot_ms >= 100U) {
                     last_snapshot_ms = now_ms;
                     saveFlightSnapshot(now_ms);
+
+                    // Emit the flight settings snapshot (#165) on the first
+                    // few ticks after launch.  Resent for redundancy against a
+                    // dropped frame; values are stable in flight so all copies
+                    // are identical and the app reads the first one.
+                    if (settings_emit_count < 3) {
+                        sendFlightSettings();
+                        settings_emit_count++;
+                    }
                 }
 
                 // Servo settling after reboot recovery — hold neutral until EKF stabilizes

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1232,6 +1232,7 @@ static bool isKnownMessageType(uint8_t type)
         case SNAPSHOT_MSG:           // FC→OC over I2S during INFLIGHT
         case GET_FLIGHT_SNAPSHOT:    // FC→OC over I2C at boot recovery
         case MAG_CAL_STATUS_MSG:     // FC→OC over I2S — issue #96
+        case FLIGHT_SETTINGS_MSG:    // FC→OC over I2S at flight-start — issue #165
             return true;
         default:
             return false;


### PR DESCRIPTION
## Summary
- Flight computer emits a FlightSettingsData frame into the per-flight .bin at the PRELAUNCH to INFLIGHT transition (resent a few times for drop tolerance). The OutComputer whitelists it so it gets logged, and the iOS CSVGenerator decodes it into a nested settings block in the flight summary .json.
- Captures every per-rocket setting editable in the app settings UI (PID + gain schedule, servo trim/timing, roll mode/delay/profile, camera, pyro, sounds) plus the IMU full-scale, outer-loop knobs, and the firmware git sha.
- Wire layout is locked by a host C++ offset/size test (tests_cpp) and a Swift decode roundtrip test.

## Test plan
- [x] tests_cpp suite green (272/272) including the FlightSettingsData layout test
- [x] Swift CSV pipeline type-checks; decode roundtrip test added
- [x] flight_computer and out_computer build clean under ESP-IDF
- [ ] Flash the FC, fly, and confirm the settings block in the per-flight .json

Closes #165

Generated with Claude Code