### PR TITLE
Add SI/imperial display-unit toggle to iOS app (#160)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
@@ -263,8 +263,8 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
         // --- Apogee detection ---
         if telemetry.alt_apo && !(prev?.alt_apo ?? false) && !apogeeAnnounced {
             apogeeAnnounced = true
-            let alt = telemetry.max_alt_m.map { String(format: "%.0f", $0) } ?? "unknown"
-            announceImmediate("Apogee. \(alt) meters")
+            let alt = telemetry.max_alt_m.map { UnitFormatter.spokenAltitude(Double($0)) } ?? "altitude unknown"
+            announceImmediate("Apogee. \(alt)")
             // First descent callout 5 seconds after apogee (not the full 10s interval)
             lastDescentAnnounceTime = Date().addingTimeInterval(-(Self.descentInterval - 5.0))
         }
@@ -318,8 +318,7 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
             maxSpeedStableCount += 1
             if maxSpeedStableCount >= Self.burnoutStableThreshold {
                 burnoutAnnounced = true
-                let speedStr = String(format: "%.0f", lastMaxSpeed)
-                announceImmediate("Burnout. Max speed \(speedStr) meters per second")
+                announceImmediate("Burnout. Max speed \(UnitFormatter.spokenSpeed(Double(lastMaxSpeed)))")
             }
         }
     }
@@ -330,14 +329,13 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
         guard let alt = telemetry.pressure_alt else { return }
 
         lastAltitudeAnnounceTime = now
-        let altStr = String(format: "%.0f", alt)
+        let altStr = UnitFormatter.spokenAltitude(Double(alt))
         // Only include climb rate after burnout — during powered flight the
         // rate changes too rapidly and isn't meaningful to announce.
         if burnoutAnnounced, let rate = telemetry.altitude_rate, abs(rate) > 1.0 {
-            let rateStr = String(format: "%.0f", abs(rate))
-            announce("\(altStr) meters, climbing \(rateStr) meters per second")
+            announce("\(altStr), climbing \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
         } else {
-            announce("\(altStr) meters")
+            announce(altStr)
         }
     }
 
@@ -348,12 +346,11 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
 
         lastDescentAnnounceTime = now
 
-        let altStr = String(format: "%.0f", alt)
+        let altStr = UnitFormatter.spokenAltitude(Double(alt))
         if let rate = telemetry.altitude_rate, abs(rate) > 1.0 {
-            let rateStr = String(format: "%.0f", abs(rate))
-            announce("\(altStr) meters, descending \(rateStr) meters per second")
+            announce("\(altStr), descending \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
         } else {
-            announce("\(altStr) meters")
+            announce(altStr)
         }
     }
 
@@ -368,7 +365,7 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
 
         let dist = haversineDistance(lat1: launch.lat, lon1: launch.lon,
                                      lat2: lat, lon2: lon)
-        return String(format: "%.0f meters away", dist)
+        return UnitFormatter.spokenDistance(dist) + " away"
     }
 
     /// Haversine formula: returns distance in meters between two GPS coordinates

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -248,43 +248,52 @@ struct TelemetryData: Codable {
 
     var maxAltDisplay: String {
         if let max_alt_m = max_alt_m {
-            return String(format: "%.1f m", max_alt_m)
+            return UnitFormatter.altitude(Double(max_alt_m))
         }
         return "N/A"
     }
 
     var maxSpeedDisplay: String {
         if let max_speed_mps = max_speed_mps {
-            return String(format: "%.1f m/s", max_speed_mps)
+            return UnitFormatter.speed(Double(max_speed_mps))
         }
         return "N/A"
     }
 
     var pressureAltDisplay: String {
         if let alt = pressure_alt {
-            return String(format: "%.1f m", alt)
+            return UnitFormatter.altitude(Double(alt))
         }
         return "N/A"
     }
 
     var altitudeRateDisplay: String {
         if let rate = altitude_rate {
-            return String(format: "%.1f m/s", rate)
+            return UnitFormatter.speed(Double(rate))
         }
         return "N/A"
     }
 
-    // IMU display helpers
+    // IMU display helpers.  Values are converted to the display unit (m/s² or
+    // g); the unit label is shown separately by the IMU row.
     var lowGDisplay: String {
         if let x = low_g_x, let y = low_g_y, let z = low_g_z {
-            return String(format: "%.2f  %.2f  %.2f", x, y, z)
+            let s = UnitSystem.current
+            return String(format: "%.2f  %.2f  %.2f",
+                          UnitFormatter.accelerationValue(Double(x), system: s),
+                          UnitFormatter.accelerationValue(Double(y), system: s),
+                          UnitFormatter.accelerationValue(Double(z), system: s))
         }
         return "N/A"
     }
 
     var highGDisplay: String {
         if let x = high_g_x, let y = high_g_y, let z = high_g_z {
-            return String(format: "%.1f  %.1f  %.1f", x, y, z)
+            let s = UnitSystem.current
+            return String(format: "%.1f  %.1f  %.1f",
+                          UnitFormatter.accelerationValue(Double(x), system: s),
+                          UnitFormatter.accelerationValue(Double(y), system: s),
+                          UnitFormatter.accelerationValue(Double(z), system: s))
         }
         return "N/A"
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift
@@ -1,0 +1,198 @@
+//
+//  UnitFormatter.swift
+//  TinkerRocketApp
+//
+//  Centralized display-unit formatting (#160).  All telemetry, .bin/.csv
+//  logs, and the wire protocol stay SI (canonical) — these helpers convert
+//  at render time per the user's chosen UnitSystem, so logged data is never
+//  altered and analysis scripts are unaffected.
+//
+//  Methods default to UnitSystem.current so non-View code (FlightAnnouncer,
+//  TelemetryData computed props) can format too.  Views pass their
+//  @AppStorage("unitSystem") value so the UI re-renders when the toggle flips.
+//
+
+import Foundation
+
+enum UnitSystem: String, CaseIterable, Identifiable {
+    case metric
+    case imperial
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .metric:   return "Metric (SI)"
+        case .imperial: return "Imperial"
+        }
+    }
+
+    /// Persisted choice, readable from non-View code.  Shares the
+    /// "unitSystem" UserDefaults key with the @AppStorage in SettingsView.
+    static var current: UnitSystem {
+        UnitSystem(rawValue: UserDefaults.standard.string(forKey: "unitSystem") ?? "") ?? .metric
+    }
+}
+
+// Exact conversion factors.
+private let feetPerMeter = 1.0 / 0.3048
+private let feetPerMile = 5280.0
+private let standardGravity = 9.80665   // m/s² per g
+
+enum UnitFormatter {
+
+    // MARK: - Altitude
+    //
+    // Never switches to miles: rocket apogees routinely exceed 5280 ft and
+    // "1.2 mi" is useless for altitude.  Horizontal distances use distance().
+
+    static func altitude(_ meters: Double, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:
+            return meters >= 1000
+                ? String(format: "%.2f km", meters / 1000.0)
+                : String(format: "%.0f m", meters)
+        case .imperial:
+            return String(format: "%.0f ft", meters * feetPerMeter)
+        }
+    }
+
+    // MARK: - Horizontal distance (promotes to km / mi when large)
+
+    static func distance(_ meters: Double, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:
+            return meters >= 1000
+                ? String(format: "%.1f km", meters / 1000.0)
+                : String(format: "%.0f m", meters)
+        case .imperial:
+            let feet = meters * feetPerMeter
+            return feet >= feetPerMile
+                ? String(format: "%.2f mi", feet / feetPerMile)
+                : String(format: "%.0f ft", feet)
+        }
+    }
+
+    // MARK: - Speed
+
+    static func speed(_ mps: Double, decimals: Int = 1, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return String(format: "%.\(decimals)f m/s", mps)
+        case .imperial: return String(format: "%.\(decimals)f ft/s", mps * feetPerMeter)
+        }
+    }
+
+    static func speedUnit(_ system: UnitSystem = .current) -> String {
+        system == .metric ? "m/s" : "ft/s"
+    }
+
+    // MARK: - Acceleration (g in imperial)
+
+    static func acceleration(_ mps2: Double, decimals: Int = 2, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return String(format: "%.\(decimals)f m/s\u{00B2}", mps2)
+        case .imperial: return String(format: "%.\(decimals)f g", mps2 / standardGravity)
+        }
+    }
+
+    /// Unit suffix only — for table headers / IMU row labels that format the
+    /// triplet of axis values separately.
+    static func accelerationUnit(_ system: UnitSystem = .current) -> String {
+        system == .metric ? "m/s\u{00B2}" : "g"
+    }
+
+    /// Scale an acceleration triplet into the display unit (m/s² or g) without
+    /// formatting — callers lay out the three axes themselves.
+    static func accelerationValue(_ mps2: Double, system: UnitSystem = .current) -> Double {
+        system == .metric ? mps2 : mps2 / standardGravity
+    }
+
+    // MARK: - Temperature
+
+    static func temperature(_ celsius: Double, decimals: Int = 1, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return String(format: "%.\(decimals)f \u{00B0}C", celsius)
+        case .imperial: return String(format: "%.\(decimals)f \u{00B0}F", celsius * 9.0 / 5.0 + 32.0)
+        }
+    }
+
+    // MARK: - Spoken (FlightAnnouncer voice callouts)
+
+    static func spokenAltitude(_ meters: Double, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return "\(Int(meters.rounded())) meters"
+        case .imperial: return "\(Int((meters * feetPerMeter).rounded())) feet"
+        }
+    }
+
+    static func spokenSpeed(_ mps: Double, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return "\(Int(mps.rounded())) meters per second"
+        case .imperial: return "\(Int((mps * feetPerMeter).rounded())) feet per second"
+        }
+    }
+
+    static func spokenDistance(_ meters: Double, system: UnitSystem = .current) -> String {
+        switch system {
+        case .metric:   return "\(Int(meters.rounded())) meters"
+        case .imperial: return "\(Int((meters * feetPerMeter).rounded())) feet"
+        }
+    }
+
+    // MARK: - Raw numeric conversions (charts, input fields)
+
+    static func metersToDisplay(_ meters: Double, system: UnitSystem = .current) -> Double {
+        system == .metric ? meters : meters * feetPerMeter
+    }
+
+    static func displayToMeters(_ value: Double, system: UnitSystem = .current) -> Double {
+        system == .metric ? value : value / feetPerMeter
+    }
+
+    static func mpsToDisplay(_ mps: Double, system: UnitSystem = .current) -> Double {
+        system == .metric ? mps : mps * feetPerMeter
+    }
+
+    static func displayToMps(_ value: Double, system: UnitSystem = .current) -> Double {
+        system == .metric ? value : value / feetPerMeter
+    }
+
+    // MARK: - CSV column conversion (FlightChartView)
+    //
+    // Logs are canonical SI; the chart converts at render time keyed on the
+    // trailing "(unit)" token in the column header.  Non-convertible columns
+    // (deg, deg/s, uT, Pa, mA, V, %, ms, flags) pass through unchanged.
+
+    /// Returns the display label + converted values for a plotted CSV column.
+    static func convertSeries(column: String, values: [Double],
+                              system: UnitSystem = .current) -> (label: String, values: [Double]) {
+        guard system == .imperial else { return (column, values) }
+
+        switch columnUnit(column) {
+        case "m":
+            return (relabel(column, to: "ft"), values.map { $0 * feetPerMeter })
+        case "m/s":
+            return (relabel(column, to: "ft/s"), values.map { $0 * feetPerMeter })
+        case "m/s2":
+            return (relabel(column, to: "g"), values.map { $0 / standardGravity })
+        case "C":
+            return (relabel(column, to: "\u{00B0}F"), values.map { $0 * 9.0 / 5.0 + 32.0 })
+        default:
+            return (column, values)
+        }
+    }
+
+    /// Extract the unit token inside the trailing "(...)" of a column header.
+    private static func columnUnit(_ column: String) -> String? {
+        guard let open = column.lastIndex(of: "("),
+              let close = column.lastIndex(of: ")"),
+              open < close else { return nil }
+        return String(column[column.index(after: open)..<close])
+    }
+
+    /// Replace the trailing "(unit)" of a column header with a new unit.
+    private static func relabel(_ column: String, to unit: String) -> String {
+        guard let open = column.lastIndex(of: "(") else { return column }
+        return String(column[..<open]) + "(\(unit))"
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift
@@ -57,6 +57,12 @@ enum UnitFormatter {
         }
     }
 
+    /// Base altitude unit label ("m" / "ft") for input-field suffixes like
+    /// "ft on descent" — no km/mi promotion.
+    static func altitudeUnit(_ system: UnitSystem = .current) -> String {
+        system == .metric ? "m" : "ft"
+    }
+
     // MARK: - Horizontal distance (promotes to km / mi when large)
 
     static func distance(_ meters: Double, system: UnitSystem = .current) -> String {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -31,6 +31,7 @@ struct DashboardView: View {
     @StateObject private var locationManager = LocationManager()
     @EnvironmentObject private var profileStore: RocketProfileStore
     @EnvironmentObject private var syncer: ActiveRocketSyncer
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
     @State private var activeSheet: DashboardSheet?
     @State private var showProvisioning = false
 
@@ -47,6 +48,18 @@ struct DashboardView: View {
         guard flightAnnouncer.isEnabled else { return .gray }
         if flightAnnouncer.lastSessionError != nil { return .red }
         return flightAnnouncer.audioSessionActive ? .green : .orange
+    }
+
+    /// App-wide display-unit picker (#160).  Lives on the front screen so it's
+    /// reachable whether or not a rocket is connected; the choice is global.
+    private var unitsMenu: some View {
+        Menu {
+            Picker("Display Units", selection: $unitSystem) {
+                ForEach(UnitSystem.allCases) { Text($0.label).tag($0) }
+            }
+        } label: {
+            Image(systemName: "ruler")
+        }
     }
 
     var body: some View {
@@ -122,12 +135,15 @@ struct DashboardView: View {
             .navigationTitle(fleet.isConnected ? "" : "TinkerRocket")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    if fleet.isConnected {
-                        Button {
-                            fleet.disconnectAll()
-                        } label: {
-                            Image(systemName: "chevron.backward")
+                    HStack(spacing: 16) {
+                        if fleet.isConnected {
+                            Button {
+                                fleet.disconnectAll()
+                            } label: {
+                                Image(systemName: "chevron.backward")
+                            }
                         }
+                        unitsMenu
                     }
                 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1347,6 +1347,7 @@ struct RocketDirectionView: View {
 
 struct PyroChannelsView: View {
     @ObservedObject var device: BLEDevice
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
     @State private var showPyroSheet = false
     @State private var editingChannel: Int = 1
     @State private var contTestChannel: Int = 0   // 0 = none, 1 = CH1, 2 = CH2
@@ -1469,9 +1470,10 @@ struct PyroChannelsView: View {
     func triggerDescription(mode: UInt8, value: Float) -> String {
         if mode == 0 {
             return String(format: "%.1fs after apogee", value)
-        } else {
-            return String(format: "%.0fm on descent", value)
         }
+        // Altitude on descent: stored in meters, shown in the display unit.
+        let alt = UnitFormatter.metersToDisplay(Double(value), system: unitSystem)
+        return String(format: "%.0f%@ on descent", alt, UnitFormatter.altitudeUnit(unitSystem))
     }
 }
 
@@ -1480,6 +1482,7 @@ struct PyroConfigSheet: View {
     @EnvironmentObject var store: RocketProfileStore
     let channel: Int
     @Environment(\.dismiss) var dismiss
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     @State private var enabled: Bool = false
     @State private var triggerMode: Int = 0  // 0=time, 1=altitude
@@ -1496,7 +1499,7 @@ struct PyroConfigSheet: View {
                 }
 
                 HStack {
-                    Text(triggerMode == 0 ? "Delay (s)" : "Altitude (m)")
+                    Text(triggerMode == 0 ? "Delay (s)" : "Altitude (\(UnitFormatter.altitudeUnit(unitSystem)))")
                     Spacer()
                     TextField("Value", text: $triggerValue)
                         .keyboardType(.decimalPad)
@@ -1523,16 +1526,29 @@ struct PyroConfigSheet: View {
         if channel == 1 {
             enabled = cfg.pyro1Enabled
             triggerMode = Int(cfg.pyro1TriggerMode)
-            triggerValue = String(format: triggerMode == 0 ? "%.1f" : "%.0f", cfg.pyro1TriggerValue)
+            triggerValue = formatTriggerValue(cfg.pyro1TriggerValue, mode: triggerMode)
         } else {
             enabled = cfg.pyro2Enabled
             triggerMode = Int(cfg.pyro2TriggerMode)
-            triggerValue = String(format: triggerMode == 0 ? "%.1f" : "%.0f", cfg.pyro2TriggerValue)
+            triggerValue = formatTriggerValue(cfg.pyro2TriggerValue, mode: triggerMode)
         }
     }
 
+    /// Time stays in seconds; altitude is stored in meters but shown/edited
+    /// in the display unit.
+    private func formatTriggerValue(_ v: Float, mode: Int) -> String {
+        if mode == 0 { return String(format: "%.1f", v) }
+        return String(format: "%.0f", UnitFormatter.metersToDisplay(Double(v), system: unitSystem))
+    }
+
+    private func parseTriggerValue(_ s: String, mode: Int) -> Float {
+        let entered = Float(s) ?? 0
+        if mode == 0 { return entered }
+        return Float(UnitFormatter.displayToMeters(Double(entered), system: unitSystem))
+    }
+
     func saveAndSend() {
-        let val = Float(triggerValue) ?? 0
+        let val = parseTriggerValue(triggerValue, mode: triggerMode)
         guard var cfg = device.rocketConfig else { return }
         if channel == 1 {
             cfg.pyro1Enabled = enabled

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -904,13 +904,13 @@ struct IMUView: View {
 
             IMURow(label: "Low-G", unit: "m/s\u{00B2}",
                    x: telemetry.low_g_x, y: telemetry.low_g_y, z: telemetry.low_g_z,
-                   decimals: 2)
+                   decimals: 2, isAcceleration: true)
 
             // High-G only available on direct rocket connection (not via LoRa)
             if !isBaseStation {
                 IMURow(label: "High-G", unit: "m/s\u{00B2}",
                        x: telemetry.high_g_x, y: telemetry.high_g_y, z: telemetry.high_g_z,
-                       decimals: 1)
+                       decimals: 1, isAcceleration: true)
             }
 
             IMURow(label: "Gyro", unit: "\u{00B0}/s",
@@ -931,10 +931,20 @@ struct IMURow: View {
     let y: Float?
     let z: Float?
     let decimals: Int
+    // Acceleration rows convert to g in imperial; gyro (°/s) stays as-is.
+    var isAcceleration: Bool = false
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
+
+    private var displayUnit: String {
+        isAcceleration ? UnitFormatter.accelerationUnit(unitSystem) : unit
+    }
 
     private func fmt(_ val: Float?) -> String {
         guard let v = val else { return "—" }
-        return String(format: "%.\(decimals)f", v)
+        let value = isAcceleration
+            ? UnitFormatter.accelerationValue(Double(v), system: unitSystem)
+            : Double(v)
+        return String(format: "%.\(decimals)f", value)
     }
 
     var body: some View {
@@ -942,7 +952,7 @@ struct IMURow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(label)
                     .font(.caption)
-                Text(unit)
+                Text(displayUnit)
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -1292,6 +1302,7 @@ struct StatusBadge: View {
 struct RocketDirectionView: View {
     let telemetry: TelemetryData
     @ObservedObject var locationManager: LocationManager
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     var body: some View {
         if let rocketLat = telemetry.latitude,
@@ -1320,7 +1331,7 @@ struct RocketDirectionView: View {
                     .rotationEffect(.degrees(arrowAngle))
                     .animation(.easeOut(duration: 0.3), value: arrowAngle)
 
-                Text(formatDistance(dist))
+                Text(UnitFormatter.distance(dist, system: unitSystem))
                     .font(.title2)
                     .fontWeight(.semibold)
             }
@@ -1328,14 +1339,6 @@ struct RocketDirectionView: View {
             .frame(maxWidth: .infinity)
             .background(Color(.systemGray6))
             .cornerRadius(10)
-        }
-    }
-
-    private func formatDistance(_ meters: Double) -> String {
-        if meters >= 1000 {
-            return String(format: "%.1f km", meters / 1000.0)
-        } else {
-            return String(format: "%.0f m", meters)
         }
     }
 }
@@ -1775,6 +1778,7 @@ struct OnPadCalibrationView: View {
     /// When embedded in a Form (e.g. the settings General tab) we drop the
     /// card chrome + headline so it sits naturally as a row (#132).
     var embedded: Bool = false
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
     @State private var calibrating = false
     @State private var showGravityWarning = false
     @State private var gravityMag: Float = 0.0
@@ -1841,7 +1845,7 @@ struct OnPadCalibrationView: View {
         .alert("Accelerometer Warning", isPresented: $showGravityWarning) {
             Button("OK", role: .cancel) { }
         } message: {
-            Text("Low-G accelerometer magnitude (\(String(format: "%.2f", gravityMag)) m/s²) differs from expected gravity (9.81 m/s²) by \(String(format: "%.1f", gravityError))%. Consider running a bench calibration before flight.")
+            Text("Low-G accelerometer magnitude (\(UnitFormatter.acceleration(Double(gravityMag), system: unitSystem))) differs from expected gravity (\(UnitFormatter.acceleration(9.80665, system: unitSystem))) by \(String(format: "%.1f", gravityError))%. Consider running a bench calibration before flight.")
         }
         // Snapshot the freshly-run sensor cal into the active profile (#132),
         // tagged with this board's id so the syncer re-applies it on connect.
@@ -1883,6 +1887,7 @@ struct SignalStrengthView: View {
     let bleRSSI: Int?
     let isBaseStation: Bool
     var locationManager: LocationManager? = nil
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     var body: some View {
         VStack(spacing: 10) {
@@ -1917,12 +1922,12 @@ struct SignalStrengthView: View {
                         if let phoneAlt = locMgr.userAltitude,
                            let rocketAlt = telemetry.gnss_alt ?? telemetry.pressure_alt {
                             let altDiff = Double(rocketAlt) - phoneAlt
-                            Text("\(formatDistance(abs(altDiff))) \(altDiff >= 0 ? "Up" : "Down")")
+                            Text("\(UnitFormatter.altitude(abs(altDiff), system: unitSystem)) \(altDiff >= 0 ? "Up" : "Down")")
                                 .font(.system(.caption, design: .monospaced))
                                 .foregroundColor(.primary)
                         }
 
-                        Text("\(formatDistance(dist)) Away")
+                        Text("\(UnitFormatter.distance(dist, system: unitSystem)) Away")
                             .font(.system(.caption, design: .monospaced))
                             .foregroundColor(.primary)
 
@@ -1963,14 +1968,6 @@ struct SignalStrengthView: View {
         .frame(maxWidth: .infinity)
         .background(Color(.systemGray6))
         .cornerRadius(10)
-    }
-
-    private func formatDistance(_ meters: Double) -> String {
-        if meters >= 1000 {
-            return String(format: "%.1f km", meters / 1000.0)
-        } else {
-            return String(format: "%.0f m", meters)
-        }
     }
 
     // MARK: - LoRa RSSI mapping (-130 to -30 dBm)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -181,6 +181,7 @@ struct DriftCastMapView: UIViewRepresentable {
 /// Supports interactive rotation/zoom via allowsCameraControl.
 struct Trajectory3DView: UIViewRepresentable {
     var result: GuidanceResult?
+    var unitSystem: UnitSystem
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
@@ -197,10 +198,10 @@ struct Trajectory3DView: UIViewRepresentable {
             return
         }
         // Only rebuild if result changed
-        let hash = "\(r.guidanceLat),\(r.guidanceLon),\(r.apogeeFt)"
+        let hash = "\(r.guidanceLat),\(r.guidanceLon),\(r.apogeeFt),\(unitSystem.rawValue)"
         if context.coordinator.lastHash != hash {
             context.coordinator.lastHash = hash
-            let (scene, groundNode, extent) = Self.buildScene(for: r)
+            let (scene, groundNode, extent) = Self.buildScene(for: r, unitSystem: unitSystem)
             scnView.scene = scene
             // Explicitly set the point of view so camera control works
             scnView.pointOfView = scene.rootNode.childNode(
@@ -274,7 +275,7 @@ struct Trajectory3DView: UIViewRepresentable {
 
     /// Build the 3D scene. Returns the scene, the ground node (for texture update),
     /// and the extent (for satellite fetch region).
-    static func buildScene(for r: GuidanceResult) -> (SCNScene, SCNNode, Float) {
+    static func buildScene(for r: GuidanceResult, unitSystem: UnitSystem) -> (SCNScene, SCNNode, Float) {
         let scene = SCNScene()
         let root = scene.rootNode
         let refLat = r.launchLat
@@ -360,7 +361,7 @@ struct Trajectory3DView: UIViewRepresentable {
         Self.addLabel(to: root, text: "Guidance",
                      position: SCNVector3(guidancePos.x, guidancePos.y + Float(markerSize) * 2.5, guidancePos.z),
                      color: UIColor(red: 0.30, green: 0.67, blue: 0.97, alpha: 1), scale: labelScale)
-        let altLabel = String(format: "%.0f ft AGL", r.apogeeFt)
+        let altLabel = UnitFormatter.altitude(ftToM(r.apogeeFt), system: unitSystem) + " AGL"
         Self.addLabel(to: root, text: altLabel,
                      position: SCNVector3(guidancePos.x, guidancePos.y + Float(markerSize) * 1.0, guidancePos.z),
                      color: UIColor(white: 0.7, alpha: 1), scale: labelScale * 0.7)
@@ -527,6 +528,11 @@ struct DriftCastView: View {
     @ObservedObject var device: BLEDevice
     @Environment(\.dismiss) var dismiss
 
+    // Display units (#160).  DriftCast is feet/knots-native (winds-aloft
+    // convention); only the result readouts respect this toggle — the wind
+    // profile table and ft/fps inputs stay as-is.
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
+
     // Map state
     @State private var mapType: MKMapType = .hybrid
     @State private var mapRegion = MKCoordinateRegion(
@@ -648,8 +654,8 @@ struct DriftCastView: View {
                 Button("OK") { }
             } message: {
                 if let r = result {
-                    Text(String(format: "Guidance point sent to unit:\n%.6f, %.6f\nAltitude: %.0f ft AGL",
-                                r.guidanceLat, r.guidanceLon, r.apogeeFt))
+                    Text(String(format: "Guidance point sent to unit:\n%.6f, %.6f\nAltitude: ", r.guidanceLat, r.guidanceLon)
+                         + UnitFormatter.altitude(ftToM(r.apogeeFt), system: unitSystem) + " AGL")
                 }
             }
             .alert("Send to Unit?", isPresented: $showSendConfirm) {
@@ -657,9 +663,9 @@ struct DriftCastView: View {
                 Button("Cancel", role: .cancel) { }
             } message: {
                 if let r = result {
-                    Text(String(format: "Send guidance point (%.6f, %.6f) at %.0f ft AGL to %@?",
-                                r.guidanceLat, r.guidanceLon, r.apogeeFt,
-                                device.connectedDeviceName))
+                    Text(String(format: "Send guidance point (%.6f, %.6f) at ", r.guidanceLat, r.guidanceLon)
+                         + UnitFormatter.altitude(ftToM(r.apogeeFt), system: unitSystem)
+                         + String(format: " AGL to %@?", device.connectedDeviceName))
                 }
             }
         }
@@ -698,7 +704,7 @@ struct DriftCastView: View {
 
             // Map view: 2D or 3D
             if show3D {
-                Trajectory3DView(result: result)
+                Trajectory3DView(result: result, unitSystem: unitSystem)
                     .frame(height: 350)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .padding(.horizontal)
@@ -830,11 +836,11 @@ struct DriftCastView: View {
             resultRow("Descent time",
                       String(format: "%.0f s (%.1f min)", r.totalDescentTimeS, r.totalDescentTimeS / 60))
             resultRow("Total drift",
-                      String(format: "%.0f m", r.totalDriftM))
+                      UnitFormatter.distance(r.totalDriftM, system: unitSystem))
             resultRow("Verification error",
-                      String(format: "%.1f m", r.landingErrorM))
+                      UnitFormatter.distance(r.landingErrorM, system: unitSystem))
             resultRow("Ground elev",
-                      String(format: "%.0f ft ASL", r.windProfile.groundElevFt))
+                      UnitFormatter.altitude(ftToM(r.windProfile.groundElevFt), system: unitSystem) + " ASL")
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightChartView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightChartView.swift
@@ -12,6 +12,8 @@ import Charts
 struct FlightChartView: View {
     let flight: CachedFlight
 
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
+
     @State private var csvData: FlightCSVData?
     @State private var isLoading = true
     @State private var errorMessage: String?
@@ -143,6 +145,9 @@ struct FlightChartView: View {
         }
         .onChange(of: selectedColumns) { newSelection in
             updateChartSeries(for: newSelection)
+        }
+        .onChange(of: unitSystem) { _ in
+            updateChartSeries(for: selectedColumns)
         }
         .task {
             await loadCSV()
@@ -392,7 +397,10 @@ struct FlightChartView: View {
             }
 
             guard !cleanX.isEmpty else { return nil }
-            return FullColumnData(id: columnName, x: cleanX, y: cleanY)
+            // Convert values + relabel the series for the chosen unit system.
+            // Logs are canonical SI; conversion happens only at render time.
+            let converted = UnitFormatter.convertSeries(column: columnName, values: cleanY, system: unitSystem)
+            return FullColumnData(id: converted.label, x: cleanX, y: converted.values)
         }
 
         fullSeriesData = newFullData

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightDetailView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightDetailView.swift
@@ -12,6 +12,7 @@ struct FlightDetailView: View {
     var onDelete: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
     @State private var showDeleteConfirm = false
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     var body: some View {
         List {
@@ -124,11 +125,7 @@ struct FlightDetailView: View {
     // MARK: - Formatting Helpers
 
     private func formatAltitude(_ meters: Double) -> String {
-        if meters >= 1000 {
-            return String(format: "%.2f km", meters / 1000.0)
-        } else {
-            return String(format: "%.0f m", meters)
-        }
+        UnitFormatter.altitude(meters, system: unitSystem)
     }
 
     /// ISA speed of sound at a given altitude (meters).
@@ -143,9 +140,8 @@ struct FlightDetailView: View {
         let a = altM > 0 ? speedOfSound(atAltitudeM: altM) : 343.0
         if mps >= a {
             return String(format: "Mach %.1f", mps / a)
-        } else {
-            return String(format: "%.0f m/s", mps)
         }
+        return UnitFormatter.speed(mps, decimals: 0, system: unitSystem)
     }
 
     private func formatTime(_ seconds: Double) -> String {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
@@ -51,6 +51,7 @@ struct FlightLogsView: View {
 
 struct FlightLogRow: View {
     let flight: CachedFlight
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     var body: some View {
         HStack(spacing: 12) {
@@ -122,11 +123,7 @@ struct FlightLogRow: View {
     }
 
     private func formatAltitude(_ meters: Double) -> String {
-        if meters >= 1000 {
-            return String(format: "%.2f km", meters / 1000.0)
-        } else {
-            return String(format: "%.0f m", meters)
-        }
+        UnitFormatter.altitude(meters, system: unitSystem)
     }
 
     /// ISA speed of sound at a given altitude (meters).
@@ -141,9 +138,8 @@ struct FlightLogRow: View {
         let a = altM > 0 ? speedOfSound(atAltitudeM: altM) : 343.0
         if mps >= a {
             return String(format: "Mach %.1f", mps / a)
-        } else {
-            return String(format: "%.0f m/s", mps)
         }
+        return UnitFormatter.speed(mps, decimals: 0, system: unitSystem)
     }
 
     private func formatFileSize(_ bytes: UInt64) -> String {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightTrajectoryView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightTrajectoryView.swift
@@ -97,6 +97,7 @@ struct FlightMapView: UIViewRepresentable {
     let launchPoint: TrackPoint?
     let apogeePoint: TrackPoint?
     let landingPoint: TrackPoint?
+    let unitSystem: UnitSystem
 
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -106,7 +107,7 @@ struct FlightMapView: UIViewRepresentable {
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        let hash = "\(trackPoints.count),\(trackPoints.first?.lat ?? 0),\(trackPoints.last?.lat ?? 0)"
+        let hash = "\(trackPoints.count),\(trackPoints.first?.lat ?? 0),\(trackPoints.last?.lat ?? 0),\(unitSystem.rawValue)"
         guard hash != context.coordinator.lastHash else { return }
         context.coordinator.lastHash = hash
         context.coordinator.trackPoints = trackPoints
@@ -124,7 +125,7 @@ struct FlightMapView: UIViewRepresentable {
         if let pt = apogeePoint {
             let ann = MKPointAnnotation()
             ann.coordinate = CLLocationCoordinate2D(latitude: pt.lat, longitude: pt.lon)
-            ann.title = String(format: "Apogee · %.0f ft", pt.altAglFt)
+            ann.title = "Apogee · " + UnitFormatter.altitude(ftToM(pt.altAglFt), system: unitSystem)
             ann.subtitle = "apogee"
             mapView.addAnnotation(ann)
         }
@@ -224,6 +225,7 @@ struct FlightScene3DView: UIViewRepresentable {
     let launchPoint: TrackPoint?
     let apogeePoint: TrackPoint?
     let landingPoint: TrackPoint?
+    let unitSystem: UnitSystem
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
@@ -239,13 +241,14 @@ struct FlightScene3DView: UIViewRepresentable {
             scnView.scene = nil
             return
         }
-        let hash = "\(trackPoints.count),\(trackPoints.first?.lat ?? 0),\(trackPoints.last?.lat ?? 0)"
+        let hash = "\(trackPoints.count),\(trackPoints.first?.lat ?? 0),\(trackPoints.last?.lat ?? 0),\(unitSystem.rawValue)"
         if context.coordinator.lastHash != hash {
             context.coordinator.lastHash = hash
             let scenePts = downsample(trackPoints, maxCount: 500)
             let (scene, groundNode, extent) = Self.buildScene(
                 trackPoints: scenePts,
-                launchPoint: launchPoint, apogeePoint: apogeePoint, landingPoint: landingPoint
+                launchPoint: launchPoint, apogeePoint: apogeePoint, landingPoint: landingPoint,
+                unitSystem: unitSystem
             )
             scnView.scene = scene
             scnView.pointOfView = scene.rootNode.childNode(
@@ -315,7 +318,8 @@ struct FlightScene3DView: UIViewRepresentable {
 
     static func buildScene(
         trackPoints: [TrackPoint],
-        launchPoint: TrackPoint?, apogeePoint: TrackPoint?, landingPoint: TrackPoint?
+        launchPoint: TrackPoint?, apogeePoint: TrackPoint?, landingPoint: TrackPoint?,
+        unitSystem: UnitSystem
     ) -> (SCNScene, SCNNode, Float) {
         let scene = SCNScene()
         let root = scene.rootNode
@@ -440,7 +444,8 @@ struct FlightScene3DView: UIViewRepresentable {
                  position: SCNVector3(apogeePos.x, apogeePos.y + Float(markerSize) * 2.5, apogeePos.z),
                  color: UIColor(red: 0.30, green: 0.67, blue: 0.97, alpha: 1), scale: labelScale)
         if let ap = apogeePoint {
-            let altLabel = String(format: "%.0f ft AGL", ap.altAglFt - (launchPoint?.altAglFt ?? 0))
+            let aglM = ftToM(ap.altAglFt - (launchPoint?.altAglFt ?? 0))
+            let altLabel = UnitFormatter.altitude(aglM, system: unitSystem) + " AGL"
             addLabel(to: root, text: altLabel,
                      position: SCNVector3(apogeePos.x, apogeePos.y + Float(markerSize) * 1.0, apogeePos.z),
                      color: UIColor(white: 0.7, alpha: 1), scale: labelScale * 0.7)
@@ -603,6 +608,7 @@ struct FlightScene3DView: UIViewRepresentable {
 
 struct FlightTrajectoryView: View {
     let flight: CachedFlight
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     @State private var trackPoints: [TrackPoint] = []
     @State private var launchPoint: TrackPoint?
@@ -666,7 +672,8 @@ struct FlightTrajectoryView: View {
                         trackPoints: trackPoints,
                         launchPoint: launchPoint,
                         apogeePoint: apogeePoint,
-                        landingPoint: landingPoint
+                        landingPoint: landingPoint,
+                        unitSystem: unitSystem
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .padding(.horizontal)
@@ -675,7 +682,8 @@ struct FlightTrajectoryView: View {
                         trackPoints: trackPoints,
                         launchPoint: launchPoint,
                         apogeePoint: apogeePoint,
-                        landingPoint: landingPoint
+                        landingPoint: landingPoint,
+                        unitSystem: unitSystem
                     )
                     .cornerRadius(12)
                     .padding(.horizontal)
@@ -701,7 +709,7 @@ struct FlightTrajectoryView: View {
 
         return HStack(spacing: 20) {
             VStack(spacing: 2) {
-                Text(String(format: "%.0f ft", maxAlt))
+                Text(UnitFormatter.altitude(ftToM(maxAlt), system: unitSystem))
                     .font(.system(.caption, design: .monospaced).bold())
                 Text("Max Alt")
                     .font(.caption2)

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -21,8 +21,10 @@ struct SettingsView: View {
     @EnvironmentObject var store: RocketProfileStore
     @Environment(\.dismiss) var dismiss
 
-    // App-wide display-unit preference (#160).  Display-layer only — logs,
-    // exports, and the wire protocol stay SI.
+    // App-wide display-unit preference (#160).  The picker lives on the
+    // dashboard (front screen); this is read here only to show/edit the pyro
+    // "altitude on descent" field in the chosen unit.  Display-layer only —
+    // logs, exports, and the wire protocol stay SI.
     @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     // Editable string fields — parsed on focus loss, not per keystroke.
@@ -146,7 +148,6 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
-                unitsSection
                 if device.isBaseStation {
                     baseStationSections
                 } else if store.activeProfile == nil {
@@ -190,18 +191,6 @@ struct SettingsView: View {
                 // truth) so we no longer pull config back into local state.
                 if let pwr = cfg.loraTxPower { txPowerDbm = Int(pwr) }
             }
-        }
-    }
-
-    // MARK: - Display units (app-wide, #160)
-
-    private var unitsSection: some View {
-        Section(header: Text("Display Units"),
-                footer: Text("Switches displayed altitude, speed, and acceleration units app-wide. Flight logs and exports always stay metric (SI).")) {
-            Picker("Units", selection: $unitSystem) {
-                ForEach(UnitSystem.allCases) { Text($0.label).tag($0) }
-            }
-            .pickerStyle(.segmented)
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -179,6 +179,10 @@ struct SettingsView: View {
                 loadFromProfile()
             }
             .onChange(of: focusedField) { handleFocusChange($0) }
+            // Flipping the unit picker reformats the altitude pyro field from
+            // the canonical (metres) profile value into the new unit.  Reload
+            // (not flush) so a mid-edit value isn't re-parsed in the wrong unit.
+            .onChange(of: unitSystem) { _ in reloadPyroValueStrings() }
             .onDisappear { flushPendingEdits() }
             .onReceive(device.$rocketConfig.compactMap { $0 }) { cfg in
                 // Only LoRa TX power is hydrated from the rocket now — every
@@ -377,7 +381,7 @@ struct SettingsView: View {
                         .multilineTextAlignment(.trailing)
                         .frame(width: 80)
                         .focused($focusedField, equals: (ch == 1) ? .pyro1Value : .pyro2Value)
-                    Text(mode == 0 ? "s after apogee" : "m on descent")
+                    Text(mode == 0 ? "s after apogee" : "\(UnitFormatter.altitudeUnit(unitSystem)) on descent")
                         .foregroundColor(.secondary)
                 }
                 Text(mode == 0
@@ -629,9 +633,20 @@ struct SettingsView: View {
         sPyro2Value = formatPyro(p.pyro2TriggerValue, mode: p.pyro2TriggerMode)
     }
 
-    /// Time-after-apogee shows one decimal (seconds); altitude shows whole metres.
+    /// Time-after-apogee shows one decimal (seconds); altitude is stored in
+    /// metres but shown in the display unit, whole numbers (#160).
     private func formatPyro(_ v: Float, mode: UInt8) -> String {
-        String(format: mode == 0 ? "%.1f" : "%.0f", v)
+        if mode == 0 { return String(format: "%.1f", v) }
+        return String(format: "%.0f", UnitFormatter.metersToDisplay(Double(v), system: unitSystem))
+    }
+
+    /// Inverse of `formatPyro`: parse an entered value back to canonical units
+    /// — seconds for time mode, metres for altitude mode (entered in the
+    /// display unit).
+    private func parsePyroValue(_ s: String, mode: UInt8, fallback: Float) -> Float {
+        guard let entered = Float(s) else { return fallback }
+        if mode == 0 { return entered }
+        return Float(UnitFormatter.displayToMeters(Double(entered), system: unitSystem))
     }
 
     private func formatInt(_ v: Double) -> String {
@@ -718,8 +733,8 @@ struct SettingsView: View {
     }
 
     private func applyPyroConfig() {
-        let v1 = Float(sPyro1Value) ?? profile.pyro1TriggerValue
-        let v2 = Float(sPyro2Value) ?? profile.pyro2TriggerValue
+        let v1 = parsePyroValue(sPyro1Value, mode: profile.pyro1TriggerMode, fallback: profile.pyro1TriggerValue)
+        let v2 = parsePyroValue(sPyro2Value, mode: profile.pyro2TriggerMode, fallback: profile.pyro2TriggerValue)
         updateProfile {
             $0.pyro1TriggerValue = v1
             $0.pyro2TriggerValue = v2

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -21,6 +21,10 @@ struct SettingsView: View {
     @EnvironmentObject var store: RocketProfileStore
     @Environment(\.dismiss) var dismiss
 
+    // App-wide display-unit preference (#160).  Display-layer only — logs,
+    // exports, and the wire protocol stay SI.
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
+
     // Editable string fields — parsed on focus loss, not per keystroke.
     @State private var sBias1 = ""
     @State private var sBias2 = ""
@@ -142,6 +146,7 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
+                unitsSection
                 if device.isBaseStation {
                     baseStationSections
                 } else if store.activeProfile == nil {
@@ -181,6 +186,18 @@ struct SettingsView: View {
                 // truth) so we no longer pull config back into local state.
                 if let pwr = cfg.loraTxPower { txPowerDbm = Int(pwr) }
             }
+        }
+    }
+
+    // MARK: - Display units (app-wide, #160)
+
+    private var unitsSection: some View {
+        Section(header: Text("Display Units"),
+                footer: Text("Switches displayed altitude, speed, and acceleration units app-wide. Flight logs and exports always stay metric (SI).")) {
+            Picker("Units", selection: $unitSystem) {
+                ForEach(UnitSystem.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/SimulationView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SimulationView.swift
@@ -19,6 +19,12 @@ struct SimulationView: View {
     @AppStorage("simBurnTimeSeconds") private var burnTimeSeconds: String = "1.5"
     @AppStorage("simDescentRateMps") private var descentRateMps: String = "5.0"
 
+    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
+    // Editable descent-rate text in the current display unit (m/s or ft/s).
+    // The persisted store above stays canonical m/s; this is synced on appear
+    // and whenever the unit system changes, and committed back on edit.
+    @State private var descentRateText: String = ""
+
     /// Whether all input fields parse to valid positive numbers
     private var inputsValid: Bool {
         guard let m = Float(massGrams), m > 0,
@@ -37,7 +43,9 @@ struct SimulationView: View {
                     parameterRow(label: "Mass", value: $massGrams, unit: "g", placeholder: "grams")
                     parameterRow(label: "Thrust", value: $thrustNewtons, unit: "N", placeholder: "newtons")
                     parameterRow(label: "Burn Time", value: $burnTimeSeconds, unit: "s", placeholder: "seconds")
-                    parameterRow(label: "Descent Rate", value: $descentRateMps, unit: "m/s", placeholder: "m/s")
+                    parameterRow(label: "Descent Rate", value: $descentRateText,
+                                 unit: UnitFormatter.speedUnit(unitSystem),
+                                 placeholder: UnitFormatter.speedUnit(unitSystem))
                 }
 
                 Section("Estimated Performance") {
@@ -77,7 +85,33 @@ struct SimulationView: View {
                     Button("Done") { dismiss() }
                 }
             }
+            .onAppear { syncDescentRateText() }
+            .onChange(of: descentRateText) { _ in commitDescentRate() }
+            .onChange(of: unitSystem) { _ in syncDescentRateText() }
         }
+    }
+
+    // MARK: - Descent-rate unit sync (#160)
+
+    /// Load the editable text from the canonical m/s store, in the current unit.
+    private func syncDescentRateText() {
+        guard let mps = Double(descentRateMps) else { descentRateText = descentRateMps; return }
+        descentRateText = formatRate(UnitFormatter.mpsToDisplay(mps, system: unitSystem))
+    }
+
+    /// Commit the editable text back to the canonical m/s store.  Invalid /
+    /// empty input clears the store so `inputsValid` fails, as before.
+    private func commitDescentRate() {
+        guard let display = Double(descentRateText) else { descentRateMps = ""; return }
+        descentRateMps = String(UnitFormatter.displayToMps(display, system: unitSystem))
+    }
+
+    /// Trim a converted rate to at most 2 decimals with no trailing zeros.
+    private func formatRate(_ value: Double) -> String {
+        var s = String(format: "%.2f", value)
+        while s.hasSuffix("0") { s.removeLast() }
+        if s.hasSuffix(".") { s.removeLast() }
+        return s
     }
 
     // MARK: - UI Helpers
@@ -92,7 +126,8 @@ struct SimulationView: View {
                 .frame(width: 80)
             Text(unit)
                 .foregroundColor(.secondary)
-                .frame(width: 20, alignment: .leading)
+                .fixedSize()
+                .frame(minWidth: 28, alignment: .leading)
         }
     }
 
@@ -192,8 +227,8 @@ struct SimulationView: View {
         let totalTime = time + descentTime
 
         return (
-            maxSpeed: String(format: "%.0f m/s", maxSpeed),
-            maxAlt: String(format: "%.0f m", maxAlt),
+            maxSpeed: UnitFormatter.speed(Double(maxSpeed), decimals: 0, system: unitSystem),
+            maxAlt: UnitFormatter.altitude(Double(maxAlt), system: unitSystem),
             flightTime: String(format: "%.0f s", totalTime)
         )
     }

--- a/TinkerRocketApp/TinkerRocketAppTests/UnitFormatterTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/UnitFormatterTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Conversions are display-layer only (#160); these lock down the math and
+/// the unit labels for both systems so a future refactor can't silently
+/// change what the user sees.
+final class UnitFormatterTests: XCTestCase {
+
+    // MARK: - Altitude (never promotes to miles)
+
+    func testAltitudeMetric() {
+        XCTAssertEqual(UnitFormatter.altitude(500, system: .metric), "500 m")
+        XCTAssertEqual(UnitFormatter.altitude(1000, system: .metric), "1.00 km")
+        XCTAssertEqual(UnitFormatter.altitude(2540, system: .metric), "2.54 km")
+    }
+
+    func testAltitudeImperial() {
+        // 500 m * 3.28084 = 1640.4 ft
+        XCTAssertEqual(UnitFormatter.altitude(500, system: .imperial), "1640 ft")
+        // 3000 m = 9842 ft — stays in feet, never miles
+        XCTAssertEqual(UnitFormatter.altitude(3000, system: .imperial), "9843 ft")
+    }
+
+    // MARK: - Distance (promotes to km / mi)
+
+    func testDistanceMetric() {
+        XCTAssertEqual(UnitFormatter.distance(500, system: .metric), "500 m")
+        XCTAssertEqual(UnitFormatter.distance(2000, system: .metric), "2.0 km")
+    }
+
+    func testDistanceImperial() {
+        // 500 m = 1640 ft, below the 5280 ft mile threshold
+        XCTAssertEqual(UnitFormatter.distance(500, system: .imperial), "1640 ft")
+        // 2000 m = 6561.7 ft → 1.24 mi
+        XCTAssertEqual(UnitFormatter.distance(2000, system: .imperial), "1.24 mi")
+    }
+
+    // MARK: - Speed
+
+    func testSpeed() {
+        XCTAssertEqual(UnitFormatter.speed(10, decimals: 1, system: .metric), "10.0 m/s")
+        // 10 m/s * 3.28084 = 32.8 ft/s
+        XCTAssertEqual(UnitFormatter.speed(10, decimals: 1, system: .imperial), "32.8 ft/s")
+        XCTAssertEqual(UnitFormatter.speed(100, decimals: 0, system: .imperial), "328 ft/s")
+    }
+
+    // MARK: - Acceleration (g in imperial)
+
+    func testAcceleration() {
+        XCTAssertEqual(UnitFormatter.acceleration(9.80665, decimals: 2, system: .metric), "9.81 m/s\u{00B2}")
+        XCTAssertEqual(UnitFormatter.acceleration(9.80665, decimals: 2, system: .imperial), "1.00 g")
+        XCTAssertEqual(UnitFormatter.acceleration(98.0665, decimals: 1, system: .imperial), "10.0 g")
+    }
+
+    func testAccelerationUnitAndValue() {
+        XCTAssertEqual(UnitFormatter.accelerationUnit(.metric), "m/s\u{00B2}")
+        XCTAssertEqual(UnitFormatter.accelerationUnit(.imperial), "g")
+        XCTAssertEqual(UnitFormatter.accelerationValue(9.80665, system: .metric), 9.80665, accuracy: 1e-6)
+        XCTAssertEqual(UnitFormatter.accelerationValue(9.80665, system: .imperial), 1.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Temperature
+
+    func testTemperature() {
+        XCTAssertEqual(UnitFormatter.temperature(0, decimals: 1, system: .metric), "0.0 \u{00B0}C")
+        XCTAssertEqual(UnitFormatter.temperature(0, decimals: 1, system: .imperial), "32.0 \u{00B0}F")
+        XCTAssertEqual(UnitFormatter.temperature(100, decimals: 1, system: .imperial), "212.0 \u{00B0}F")
+    }
+
+    // MARK: - Spoken (voice)
+
+    func testSpoken() {
+        XCTAssertEqual(UnitFormatter.spokenAltitude(1000, system: .metric), "1000 meters")
+        XCTAssertEqual(UnitFormatter.spokenAltitude(1000, system: .imperial), "3281 feet")
+        XCTAssertEqual(UnitFormatter.spokenSpeed(10, system: .metric), "10 meters per second")
+        XCTAssertEqual(UnitFormatter.spokenSpeed(10, system: .imperial), "33 feet per second")
+        XCTAssertEqual(UnitFormatter.spokenDistance(300, system: .imperial), "984 feet")
+    }
+
+    // MARK: - Chart column conversion
+
+    func testConvertSeriesMetricPassthrough() {
+        let (label, values) = UnitFormatter.convertSeries(
+            column: "Pressure Altitude (m)", values: [1, 2, 3], system: .metric)
+        XCTAssertEqual(label, "Pressure Altitude (m)")
+        XCTAssertEqual(values, [1, 2, 3])
+    }
+
+    func testConvertSeriesImperialLength() {
+        let (label, values) = UnitFormatter.convertSeries(
+            column: "Pressure Altitude (m)", values: [100], system: .imperial)
+        XCTAssertEqual(label, "Pressure Altitude (ft)")
+        XCTAssertEqual(values[0], 328.084, accuracy: 1e-2)
+    }
+
+    func testConvertSeriesImperialSpeed() {
+        let (label, values) = UnitFormatter.convertSeries(
+            column: "Velocity Up (m/s)", values: [10], system: .imperial)
+        XCTAssertEqual(label, "Velocity Up (ft/s)")
+        XCTAssertEqual(values[0], 32.8084, accuracy: 1e-3)
+    }
+
+    func testConvertSeriesImperialAccel() {
+        let (label, values) = UnitFormatter.convertSeries(
+            column: "Low-G Acceleration X (m/s2)", values: [9.80665], system: .imperial)
+        XCTAssertEqual(label, "Low-G Acceleration X (g)")
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+    }
+
+    func testConvertSeriesImperialTemperature() {
+        let (label, values) = UnitFormatter.convertSeries(
+            column: "Barometer Temperature (C)", values: [0, 100], system: .imperial)
+        XCTAssertEqual(label, "Barometer Temperature (\u{00B0}F)")
+        XCTAssertEqual(values[0], 32, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 212, accuracy: 1e-6)
+    }
+
+    func testConvertSeriesNonConvertibleColumns() {
+        // Angles, percent, voltage etc. must pass through untouched in imperial.
+        for col in ["Roll (deg)", "Gyro X (deg/s)", "State of Charge (%)",
+                    "Voltage (V)", "Magnetic Field X (uT)", "Pressure (Pa)"] {
+            let (label, values) = UnitFormatter.convertSeries(
+                column: col, values: [42], system: .imperial)
+            XCTAssertEqual(label, col, "\(col) should not be relabeled")
+            XCTAssertEqual(values, [42], "\(col) values should be unchanged")
+        }
+    }
+
+    // MARK: - UnitSystem persistence
+
+    func testUnitSystemRawValues() {
+        XCTAssertEqual(UnitSystem(rawValue: "metric"), .metric)
+        XCTAssertEqual(UnitSystem(rawValue: "imperial"), .imperial)
+        XCTAssertEqual(UnitSystem(rawValue: "garbage"), nil)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/UnitFormatterTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/UnitFormatterTests.swift
@@ -126,6 +126,27 @@ final class UnitFormatterTests: XCTestCase {
         }
     }
 
+    // MARK: - Base unit label + raw conversions (pyro / input fields)
+
+    func testAltitudeUnit() {
+        XCTAssertEqual(UnitFormatter.altitudeUnit(.metric), "m")
+        XCTAssertEqual(UnitFormatter.altitudeUnit(.imperial), "ft")
+    }
+
+    func testMetersDisplayRoundTrip() {
+        // Metric is identity.
+        XCTAssertEqual(UnitFormatter.metersToDisplay(150, system: .metric), 150, accuracy: 1e-9)
+        XCTAssertEqual(UnitFormatter.displayToMeters(150, system: .metric), 150, accuracy: 1e-9)
+
+        // Imperial: 150 m -> 492.13 ft; entering 500 ft -> 152.4 m.
+        XCTAssertEqual(UnitFormatter.metersToDisplay(150, system: .imperial), 492.126, accuracy: 1e-2)
+        XCTAssertEqual(UnitFormatter.displayToMeters(500, system: .imperial), 152.4, accuracy: 1e-3)
+
+        // A pyro altitude entered in feet then redisplayed must round-trip.
+        let stored = UnitFormatter.displayToMeters(500, system: .imperial)
+        XCTAssertEqual(UnitFormatter.metersToDisplay(stored, system: .imperial), 500, accuracy: 1e-6)
+    }
+
     // MARK: - UnitSystem persistence
 
     func testUnitSystemRawValues() {


### PR DESCRIPTION
## Summary

App-wide SI / imperial display-unit toggle for the iOS app. This is a **display-layer change only** — flight logs, `.bin`/CSV/JSON exports, and the BLE wire protocol all stay canonical SI; conversion happens at render time. **No firmware (FC/OC) changes.**

- New `UnitSystem` enum + centralized `UnitFormatter` (altitude, distance, speed, acceleration, temperature, and spoken voice variants). Imperial maps to ft, ft/s, g, and degrees F.
- App-level **Units** menu on the dashboard front screen (ruler icon), reachable whether or not a rocket is connected.
- Routed every meter-native display site through the formatter: live telemetry tiles, IMU accel rows, gravity-check text, flight detail/logs (Mach fallback preserved), and `FlightAnnouncer` voice callouts.
- Fixed the trajectory **map / 3D / stats** that showed feet while everything else used meters.
- Flight **chart** rescales plotted values and relabels the legend per the chosen unit (keyed on each column's trailing `(unit)` token); non-convertible columns pass through.
- **DriftCast**: result readouts (apogee, total drift, ground elevation) follow the toggle; the winds-aloft table and ft/fps inputs stay aviation-standard.
- **Pyro "altitude on descent"** displays/edits in the chosen unit across the dashboard tile, edit sheet, and Settings; stored canonically in metres so the value sent to firmware is unchanged.
- `SimulationView` outputs + descent-rate input convert; canonical m/s storage so live decimal entry isn't broken.

MagCal intentionally stays in m/s2 (calibration guidance references standard gravity).

## Tests

- New `UnitFormatterTests` cover every quantity, the spoken variants, the chart column relabel/passthrough, and the metres-to-feet round-trip the pyro path relies on.
- Full existing test suite passes on the iOS simulator.

## Test plan

- [ ] Toggle the front-screen **Units** menu (ruler icon) between Metric / Imperial and confirm altitude, speed, acceleration, the map, the flight chart, DriftCast results, and voice callouts all switch.
- [ ] Pyro altitude round-trip: set it in ft, confirm it reads back correctly, and verify the rocket still deploys at the same actual altitude (firmware still receives metres).
- [ ] Confirm `.bin` / CSV / JSON exports remain SI.

Closes #160.

Generated with [Claude Code](https://claude.com/claude-code)
