### PR TITLE
ios: power-on busy indicator while OC flushes log

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -245,7 +245,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     func beginPowerOn() {
         poweringOn = true
         poweringOnTimer?.invalidate()
-        poweringOnTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: false) { [weak self] _ in
+        // 3 min: after cmd 8 the OC blocks its main loop (no telemetry sent)
+        // while it flushes and recovers the on-NAND flight log, which can run
+        // up to ~90s on a large/unclean log.  The watchdog must outlast that
+        // worst case so it only fires on a genuinely-dropped command, not a
+        // slow-but-normal recovery.
+        poweringOnTimer = Timer.scheduledTimer(withTimeInterval: 180.0, repeats: false) { [weak self] _ in
             DispatchQueue.main.async { self?.clearPoweringOn() }
         }
         sendPowerToggle()

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -44,6 +44,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var downloadStates: [String: DownloadState] = [:]
     @Published var simLaunched = false
     @Published var groundTestActive = false
+    // #159: drives the Power On button's busy state.  The OC can spend
+    // seconds-to-tens-of-seconds flushing the flight log before it acts on
+    // cmd 8, during which the press otherwise looks lost.
+    @Published var poweringOn = false
     @Published var connectedRSSI: Int?
     @Published var rocketConfig: RocketConfig?
 
@@ -124,6 +128,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     private var downloadCompletionHandler: ((URL?) -> Void)?
     private var downloadStallTimer: Timer?
     private var rssiTimer: Timer?
+    private var poweringOnTimer: Timer?
 
     // CoreBluetooth objects (peripheral is set by BLEFleet on connect)
     var peripheral: CBPeripheral?
@@ -169,6 +174,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         currentPage = 0
         hasMoreFiles = false
         clearSimBanner()
+        clearPoweringOn()
         rocketConfig = nil
         // Reset so the next reconnect (including after a BS reboot) triggers
         // another auto-pick.  Any pending scan-and-apply is also dropped —
@@ -227,6 +233,28 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
     func sendPowerToggle() {
         sendCommand(8)
+    }
+
+    /// Power-on press handler (#159).  Lights the button's busy state and
+    /// arms a watchdog before sending the toggle.  `poweringOn` clears on the
+    /// first `pwr_pin_on` telemetry frame (see telemetry decode) or on
+    /// disconnect; the watchdog is a backstop so a silently-dropped command
+    /// can't leave the button spinning forever.  Cmd 8 is a toggle, so the
+    /// button stays disabled while busy to prevent a double-press from
+    /// powering the rocket back off.
+    func beginPowerOn() {
+        poweringOn = true
+        poweringOnTimer?.invalidate()
+        poweringOnTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async { self?.clearPoweringOn() }
+        }
+        sendPowerToggle()
+    }
+
+    func clearPoweringOn() {
+        poweringOnTimer?.invalidate()
+        poweringOnTimer = nil
+        poweringOn = false
     }
 
     func sendRawCommand(_ command: UInt8, payload: Data = Data()) {
@@ -1142,6 +1170,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 }
             }
             self.telemetry = newTelemetry
+            // #159: the rocket has finished flushing and powered on — drop the
+            // Power On button's busy state.  Guarded so we don't republish on
+            // every frame while already powered on.
+            if newTelemetry.pwr_pin_on && self.poweringOn {
+                self.clearPoweringOn()
+            }
             // Direct rocket connection — use this device's own rocketID
             // (relayed-telemetry path above uses source_rocket_id instead).
             // Skip when rocketID is unset so a BS-self packet (which falls

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -305,19 +305,26 @@ struct ConnectedDashboardView: View {
             BatteryView(telemetry: device.telemetry, isBaseStation: false)
 
             Button {
-                device.sendPowerToggle()
+                device.beginPowerOn()
             } label: {
                 HStack {
-                    Image(systemName: "bolt.fill")
-                    Text("Power On")
+                    if device.poweringOn {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        Text("Powering on…")
+                    } else {
+                        Image(systemName: "bolt.fill")
+                        Text("Power On")
+                    }
                 }
                 .font(.system(.title2, design: .default).weight(.semibold))
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.green)
+                .background(device.poweringOn ? Color.gray : Color.green)
                 .foregroundColor(.white)
                 .cornerRadius(10)
             }
+            .disabled(device.poweringOn)
         } else {
             // --- Powered ON (or base station): full telemetry dashboard ---
 


### PR DESCRIPTION
## Summary

- Add a `poweringOn` flag on `BLEDevice` that drives the Power On button into a spinner + "Powering on..." label, greyed and disabled, while the OC is busy flushing the flight log and recovering on-NAND data after cmd 8.
- Clears on the first `pwr_pin_on=true` telemetry frame, on disconnect, or after a 3-minute watchdog (sized to outlast worst-case log recovery, ~30-90s, so a slow-but-normal boot does not reset the button).
- Button stays disabled while busy to prevent a double-press from toggling power back off (cmd 8 is a toggle).

## Test plan

- [x] Local Xcode build clean (iOS simulator, Debug).
- [ ] On-device: with a rocket powered off, tap Power On; button shows spinner + "Powering on..." until telemetry reports `pwr_pin_on=true`.
- [ ] Verify the watchdog does not fire mid-recovery on a worst-case log.

Closes #159
