### PR TITLE
ios: branded launch screen with logo + app name

### DIFF
--- a/TinkerRocketApp/Info.plist
+++ b/TinkerRocketApp/Info.plist
@@ -2,15 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UILaunchScreen</key>
-	<dict>
-		<key>UIColorName</key>
-		<string>LaunchBackground</string>
-		<key>UIImageName</key>
-		<string>Small Tinkerbug Robotics Logo Vertical</string>
-		<key>UIImageRespectsSafeAreaInsets</key>
-		<true/>
-	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/TinkerRocketApp/Info.plist
+++ b/TinkerRocketApp/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+		<key>UIImageName</key>
+		<string>Small Tinkerbug Robotics Logo Vertical</string>
+		<key>UIImageRespectsSafeAreaInsets</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>

--- a/TinkerRocketApp/TinkerRocketApp.xcodeproj/project.pbxproj
+++ b/TinkerRocketApp/TinkerRocketApp.xcodeproj/project.pbxproj
@@ -381,7 +381,6 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "TinkerRocket uses your location to show the direction and distance to your rocket.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -417,7 +416,6 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "TinkerRocket uses your location to show the direction and distance to your rocket.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;

--- a/TinkerRocketApp/TinkerRocketApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/TinkerRocketApp/TinkerRocketApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TinkerRocketApp/TinkerRocketApp/LaunchScreen.storyboard
+++ b/TinkerRocketApp/TinkerRocketApp/LaunchScreen.storyboard
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vc1">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="scn1">
+            <objects>
+                <viewController id="vc1" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="vw1">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" image="Small Tinkerbug Robotics Logo Vertical" id="img1">
+                                <rect key="frame" x="136.5" y="311" width="120" height="130"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="cw1"/>
+                                    <constraint firstAttribute="height" constant="130" id="ch1"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="TinkerRocket" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl1">
+                                <rect key="frame" x="86.5" y="461" width="220" height="36"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl2">
+                                <rect key="frame" x="146.5" y="505" width="100" height="20"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="sa1"/>
+                        <color key="backgroundColor" name="LaunchBackground"/>
+                        <constraints>
+                            <constraint firstItem="img1" firstAttribute="centerX" secondItem="vw1" secondAttribute="centerX" id="c1"/>
+                            <constraint firstItem="img1" firstAttribute="centerY" secondItem="vw1" secondAttribute="centerY" constant="-50" id="c2"/>
+                            <constraint firstItem="lbl1" firstAttribute="centerX" secondItem="vw1" secondAttribute="centerX" id="c3"/>
+                            <constraint firstItem="lbl1" firstAttribute="top" secondItem="img1" secondAttribute="bottom" constant="20" id="c4"/>
+                            <constraint firstItem="lbl2" firstAttribute="centerX" secondItem="vw1" secondAttribute="centerX" id="c5"/>
+                            <constraint firstItem="lbl2" firstAttribute="top" secondItem="lbl1" secondAttribute="bottom" constant="8" id="c6"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fr1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="0.0" y="0.0"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="Small Tinkerbug Robotics Logo Vertical" width="106" height="115"/>
+        <namedColor name="LaunchBackground">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>


### PR DESCRIPTION
## Summary

- Replace the auto-generated blank launch screen with a `LaunchScreen.storyboard`: Tinkerbug logo centered (nudged up ~50pt), bold "TinkerRocket" below it, and a smaller gray "Loading..." below that.
- Background uses a new `LaunchBackground` color asset forced white in both appearances (the logo art has thin black legs that would vanish on a dark splash), with explicit dark text colors so labels stay legible.
- Initial commit used the Info.plist `UILaunchScreen` image-dict approach; follow-up swapped to a storyboard once we wanted text labels (the dict supports image only).
- The file-system-synchronized project group picks up `LaunchScreen.storyboard` automatically; the only pbxproj change is dropping `INFOPLIST_KEY_UILaunchScreen_Generation`.

## Test plan

- [x] Local Xcode build clean; `LaunchScreen.storyboardc` is in the app bundle, `UILaunchStoryboardName=LaunchScreen` in the compiled Info.plist, `LaunchBackground` + logo present in `Assets.car`.
- [x] On-device: splash renders with logo and labels (visually confirmed).
