### PR TITLE
profile: add recovery fields for landing prediction (#156)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -115,6 +115,22 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var pyro2TriggerMode: UInt8 = 0
     var pyro2TriggerValue: Float = 100.0
 
+    // MARK: Recovery (issue #156) — descent profile for landing-point
+    // prediction and drift-cast.  Stored per-airframe so different rockets
+    // can have different chute setups; DriftCastView reads these (with a
+    // global @AppStorage fallback when no profile is selected).
+    /// Drogue / no-chute descent rate, fps.  Used above mainDeployAltAglFt.
+    var drogueRateFps: Double = 60.0
+    /// Main chute descent rate, fps.  Used below mainDeployAltAglFt.
+    var mainRateFps: Double = 12.0
+    /// Altitude AGL at which the main pyro fires (drogue→main transition).
+    var mainDeployAltAglFt: Double = 700.0
+    /// Quadratic drag coefficient k (1/m) for the coast-to-apogee ballistic
+    /// propagation.  Default 5e-4 ≈ terminal velocity ~140 m/s, in the
+    /// ballpark for typical 54–65 mm airframes.  Operator can refine in
+    /// the rocket-edit UI.
+    var ballisticDragK: Double = 5e-4
+
     // MARK: Calibration (per physical airframe / board)
     var magCal: MagCalData? = nil
     var sensorCal: SensorCalData? = nil
@@ -122,5 +138,67 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     /// A profile with all firmware factory defaults and the given name.
     static func makeDefault(name: String) -> RocketProfile {
         RocketProfile(name: name)
+    }
+}
+
+// MARK: - Backward-compatible decoding
+//
+// The synthesized Decodable conformance treats missing JSON keys as a hard
+// decode failure even when the property has a default — so adding any new
+// field without a custom decoder would silently drop existing saved
+// profiles in RocketProfileStore.load() (it does `try? decoder.decode(...)`
+// and skips on nil).  This extension uses decodeIfPresent ?? default for
+// every field so old profiles upgrade gracefully and future additions only
+// need a single line here.
+extension RocketProfile {
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = RocketProfile(name: "")
+
+        id = try c.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        name = try c.decode(String.self, forKey: .name)
+        notes = try c.decodeIfPresent(String.self, forKey: .notes) ?? defaults.notes
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? defaults.createdAt
+        updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? defaults.updatedAt
+        lastUsedUnitID = try c.decodeIfPresent(String.self, forKey: .lastUsedUnitID)
+
+        soundsEnabled = try c.decodeIfPresent(Bool.self, forKey: .soundsEnabled) ?? defaults.soundsEnabled
+        servoControlEnabled = try c.decodeIfPresent(Bool.self, forKey: .servoControlEnabled) ?? defaults.servoControlEnabled
+        gainScheduleEnabled = try c.decodeIfPresent(Bool.self, forKey: .gainScheduleEnabled) ?? defaults.gainScheduleEnabled
+        useAngleControl = try c.decodeIfPresent(Bool.self, forKey: .useAngleControl) ?? defaults.useAngleControl
+        rollDelayMs = try c.decodeIfPresent(UInt16.self, forKey: .rollDelayMs) ?? defaults.rollDelayMs
+        guidanceEnabled = try c.decodeIfPresent(Bool.self, forKey: .guidanceEnabled) ?? defaults.guidanceEnabled
+        cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
+
+        servoBias1 = try c.decodeIfPresent(Int16.self, forKey: .servoBias1) ?? defaults.servoBias1
+        servoBias2 = try c.decodeIfPresent(Int16.self, forKey: .servoBias2) ?? defaults.servoBias2
+        servoBias3 = try c.decodeIfPresent(Int16.self, forKey: .servoBias3) ?? defaults.servoBias3
+        servoBias4 = try c.decodeIfPresent(Int16.self, forKey: .servoBias4) ?? defaults.servoBias4
+        servoHz = try c.decodeIfPresent(Int16.self, forKey: .servoHz) ?? defaults.servoHz
+        servoMinUs = try c.decodeIfPresent(Int16.self, forKey: .servoMinUs) ?? defaults.servoMinUs
+        servoMaxUs = try c.decodeIfPresent(Int16.self, forKey: .servoMaxUs) ?? defaults.servoMaxUs
+
+        pidKp = try c.decodeIfPresent(Float.self, forKey: .pidKp) ?? defaults.pidKp
+        pidKi = try c.decodeIfPresent(Float.self, forKey: .pidKi) ?? defaults.pidKi
+        pidKd = try c.decodeIfPresent(Float.self, forKey: .pidKd) ?? defaults.pidKd
+        pidMinCmd = try c.decodeIfPresent(Float.self, forKey: .pidMinCmd) ?? defaults.pidMinCmd
+        pidMaxCmd = try c.decodeIfPresent(Float.self, forKey: .pidMaxCmd) ?? defaults.pidMaxCmd
+
+        rollWaypoints = try c.decodeIfPresent([RollWaypoint].self, forKey: .rollWaypoints) ?? defaults.rollWaypoints
+
+        pyro1Enabled = try c.decodeIfPresent(Bool.self, forKey: .pyro1Enabled) ?? defaults.pyro1Enabled
+        pyro1TriggerMode = try c.decodeIfPresent(UInt8.self, forKey: .pyro1TriggerMode) ?? defaults.pyro1TriggerMode
+        pyro1TriggerValue = try c.decodeIfPresent(Float.self, forKey: .pyro1TriggerValue) ?? defaults.pyro1TriggerValue
+        pyro2Enabled = try c.decodeIfPresent(Bool.self, forKey: .pyro2Enabled) ?? defaults.pyro2Enabled
+        pyro2TriggerMode = try c.decodeIfPresent(UInt8.self, forKey: .pyro2TriggerMode) ?? defaults.pyro2TriggerMode
+        pyro2TriggerValue = try c.decodeIfPresent(Float.self, forKey: .pyro2TriggerValue) ?? defaults.pyro2TriggerValue
+
+        drogueRateFps = try c.decodeIfPresent(Double.self, forKey: .drogueRateFps) ?? defaults.drogueRateFps
+        mainRateFps = try c.decodeIfPresent(Double.self, forKey: .mainRateFps) ?? defaults.mainRateFps
+        mainDeployAltAglFt = try c.decodeIfPresent(Double.self, forKey: .mainDeployAltAglFt) ?? defaults.mainDeployAltAglFt
+        ballisticDragK = try c.decodeIfPresent(Double.self, forKey: .ballisticDragK) ?? defaults.ballisticDragK
+
+        magCal = try c.decodeIfPresent(MagCalData.self, forKey: .magCal)
+        sensorCal = try c.decodeIfPresent(SensorCalData.self, forKey: .sensorCal)
     }
 }

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketProfileStoreTests.swift
@@ -177,6 +177,11 @@ final class RocketProfileStoreTests: XCTestCase {
         ]
         p.pyro2Enabled = true
         p.pyro2TriggerValue = 213
+        // Recovery fields (#156) — non-default to prove they survive round-trip.
+        p.drogueRateFps = 55.0
+        p.mainRateFps = 14.0
+        p.mainDeployAltAglFt = 600.0
+        p.ballisticDragK = 0.00072
         p.magCal = MagCalData(offsetX: -5, offsetY: 6, offsetZ: 7,
                               fieldR_uT: 49.5, residualUT: 1.5,
                               calibratedOnUnitID: "DEAD::BEEF",
@@ -189,6 +194,43 @@ final class RocketProfileStoreTests: XCTestCase {
         let data = try JSONEncoder().encode(p)
         let back = try JSONDecoder().decode(RocketProfile.self, from: data)
         XCTAssertEqual(p, back)
+    }
+
+    /// Pre-#156 profile JSON (no recovery fields) must still load — the
+    /// store does `try? decode(...)` and silently drops failures, so a
+    /// regression here would erase saved profiles on app upgrade.
+    func testLegacyProfileMissingRecoveryFieldsLoads() throws {
+        let legacyJSON = """
+        {
+          "id": "11111111-2222-3333-4444-555555555555",
+          "name": "Legacy",
+          "createdAt": 1700000000.0,
+          "updatedAt": 1700000000.0,
+          "notes": "from before recovery fields",
+          "soundsEnabled": false,
+          "servoControlEnabled": true,
+          "gainScheduleEnabled": true,
+          "useAngleControl": false,
+          "rollDelayMs": 0,
+          "guidanceEnabled": false,
+          "cameraType": 2,
+          "servoBias1": 85, "servoBias2": 0, "servoBias3": 0, "servoBias4": 0,
+          "servoHz": 333, "servoMinUs": 1250, "servoMaxUs": 1750,
+          "pidKp": 0.08, "pidKi": 0.005, "pidKd": 0.003,
+          "pidMinCmd": -10.0, "pidMaxCmd": 10.0,
+          "rollWaypoints": [],
+          "pyro1Enabled": false, "pyro1TriggerMode": 0, "pyro1TriggerValue": 1.0,
+          "pyro2Enabled": false, "pyro2TriggerMode": 0, "pyro2TriggerValue": 100.0
+        }
+        """
+        let data = legacyJSON.data(using: .utf8)!
+        let p = try JSONDecoder().decode(RocketProfile.self, from: data)
+        XCTAssertEqual(p.name, "Legacy")
+        // Missing keys must fall back to RocketProfile's defaults.
+        XCTAssertEqual(p.drogueRateFps, 60.0)
+        XCTAssertEqual(p.mainRateFps, 12.0)
+        XCTAssertEqual(p.mainDeployAltAglFt, 700.0)
+        XCTAssertEqual(p.ballisticDragK, 5e-4)
     }
 
     // MARK: - Migration


### PR DESCRIPTION
## Summary
Adds four per-airframe fields to `RocketProfile` so the upcoming `LandingPredictor` and `DriftCastView` can read recovery parameters per rocket (the global `@AppStorage` values that #132 left in `DriftCastView` will stop being the only source):

- `drogueRateFps` — descent rate above the main-pyro altitude (default 60)
- `mainRateFps` — descent rate below the main-pyro altitude (default 12)
- `mainDeployAltAglFt` — altitude AGL where the main pyro fires (default 700)
- `ballisticDragK` — quadratic drag coefficient for the ascent ballistic propagator (default 5e-4, ≈ terminal velocity 140 m/s)

The synthesized `Decodable` conformance throws on missing JSON keys even when the property has a default, and `RocketProfileStore.load()` silently drops profiles that fail to decode — so a custom `init(from:)` is added in an extension that uses `decodeIfPresent ?? defaults` for every field. Old saved profiles upgrade cleanly with defaults; future field additions only need one line each.

## Tests
- `testProfileCodableRoundTrip` extended to cover the new fields
- `testLegacyProfileMissingRecoveryFieldsLoads` (new) — guard against the regression where adding a field would erase user profiles on app upgrade

Both pass; all 15 `RocketProfileStoreTests` green.

## Test plan
- [ ] `xcodebuild ... -only-testing:TinkerRocketAppTests/RocketProfileStoreTests test` passes
- [ ] Existing saved profiles still load after app upgrade (covered by the new test)

Part of #156. Consumed by the follow-up PR `feat/landing-predictor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
