### PR TITLE
detect: reset landing sub-flag counters on apogee rising edge (#192)

### DIFF
--- a/Data_Analysis/sim_kinematic_checks.py
+++ b/Data_Analysis/sim_kinematic_checks.py
@@ -216,6 +216,10 @@ class KinematicChecks:
     ) -> None:
         self._now_ms = now_ms
 
+        # Snapshot apogee_flag so the rising-edge reset below sees the
+        # state *before* this tick's apogee voting fires (#192).
+        apogee_was_set = self.apogee_flag
+
         # ── CHANGED (1): Baro rate-gate at ingestion ──────────────────
         # Only the new_baro sample is judged. Once accepted (or substituted
         # with the last good value) all downstream paths — KF update,
@@ -456,6 +460,26 @@ class KinematicChecks:
 
                 if available >= 2 and passed >= 2 and passed >= (available - 1):
                     self.apogee_flag = True
+
+        # ── Apogee rising edge: reset landing sub-flag counters (#192) ──
+        # The 1 Hz sub-detectors above accumulate evidence regardless of
+        # flight state, so a rocket flying straight pre-apogee (low roll
+        # rate, ~0 m/s in EKF frame at burnout, ~1g during coast) latches
+        # gyro_quiet / gps_stationary / accel_1g before apogee. The
+        # master-vote apogee gate ([landing voting block above]) prevents
+        # a false LANDED, but the latched sub-flags carry pre-apogee
+        # history into the post-apogee vote — eroding the 3-of-4 margin.
+        # Zero the counters + flags at the transition so post-apogee
+        # voting reflects only post-apogee evidence.
+        if self.apogee_flag and not apogee_was_set:
+            self.baro_stable_count_ = 0
+            self.gyro_quiet_count_ = 0
+            self.gps_stationary_count_ = 0
+            self.accel_1g_count_ = 0
+            self.baro_stable_flag = False
+            self.gyro_quiet_flag = False
+            self.gps_stationary_flag = False
+            self.accel_1g_flag = False
 
         # TRKC.cpp:302 ─ Pre-apogee max speed
         speed = math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2)

--- a/tests/unit/test_landing_subflag_reset.py
+++ b/tests/unit/test_landing_subflag_reset.py
@@ -1,0 +1,138 @@
+"""Regression test for issue #192.
+
+The landing sub-detectors in TR_KinematicChecks accumulate evidence at 1 Hz
+regardless of flight state, so a rocket flying straight pre-apogee (low roll
+rate, ~0 m/s in EKF frame at burnout, ~1g during coast) can latch
+gyro_quiet / gps_stationary / accel_1g before apogee. The master vote is
+gated on apogee_flag so this didn't (yet) cause a false LANDED, but the
+latched sub-flags carried pre-apogee history into the post-apogee vote.
+
+Fix: zero the sub-flag counters + flags on the apogee_flag rising edge so
+post-apogee voting reflects only post-apogee evidence.
+
+This test verifies the Python mirror in `sim_kinematic_checks.py`. The
+firmware mirror in tinkerrocket-idf/components/TR_KinematicChecks is
+covered by `tests_cpp/test_kinematic_checks.cpp::Landing_SubflagsResetOnApogeeRisingEdge`.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import sys
+
+# Pull in sim_kinematic_checks from the Data_Analysis directory.
+_SIM_DIR = Path(__file__).resolve().parent.parent.parent / "Data_Analysis"
+sys.path.insert(0, str(_SIM_DIR))
+
+from sim_kinematic_checks import KinematicChecks  # noqa: E402
+
+
+def _drive(kc, now_ms, **kw):
+    """Wrapper around kc.kinematic_checks() with sensible test defaults."""
+    defaults = dict(
+        pressure_altitude=30.0,
+        acc_mag=9.80665,
+        position=(0.0, 0.0, 30.0),
+        velocity=(0.0, 0.0, 0.0),
+        roll_rate=0.1,
+        new_baro=True,
+        gps_altitude=0.0,
+        new_gps=False,
+        pitch_rad=math.pi / 2,
+        burnout_detected=False,
+        baro_locked_out=False,
+        now_ms=now_ms,
+    )
+    defaults.update(kw)
+    kc.kinematic_checks(**defaults)
+
+
+def test_sub_flag_counters_reset_on_apogee_rising_edge():
+    kc = KinematicChecks()
+    # Bypass launch detection (covered by other tests) and force
+    # max_altitude so baro_stable's > 15 m gate is satisfied.
+    kc.launch_flag = True
+    kc.max_altitude = 50.0
+
+    # Seed KF at 30 m so alt_est tracks above 15 m (needed for vel/baro
+    # apogee detectors below).
+    for i in range(80):
+        _drive(kc, now_ms=i * 2)
+
+    # 6 s of "quiet coast" — should latch gyro_quiet, accel_1g, baro_stable.
+    for second in range(6):
+        base = 200 + second * 1000
+        for i in range(50):
+            _drive(kc, now_ms=base + i * 2)
+
+    # Pre-apogee: sub-flags latched, apogee_flag still False.
+    assert kc.gyro_quiet_flag is True, "quiet inputs should latch gyro_quiet_flag pre-apogee"
+    assert kc.accel_1g_flag is True,  "quiet inputs should latch accel_1g_flag pre-apogee"
+    assert kc.baro_stable_flag is True, "quiet inputs should latch baro_stable_flag pre-apogee"
+    assert kc.apogee_flag is False, "apogee_flag should still be False"
+
+    # Counters at their cap (LANDING_SLOW_COUNT_MAX = 8 in the sim).
+    assert kc.gyro_quiet_count_ >= 4
+    assert kc.accel_1g_count_ >= 4
+    assert kc.baro_stable_count_ >= 4
+
+    # Drive apogee-triggering inputs to flip apogee_flag inside the
+    # function (the rising edge our reset hooks on).
+    #   vel_pass: position[2] > 15 and velocity[2] < 0
+    #   baro_pass: alt_est > 15 and alt_est < max_altitude - 5 and d_alt < 20
+    #   pitch_pass: pitch_rad < -0.087
+    # APOGEE_COUNT_HI = 6 → need 6+ passing calls to latch sub-flags, then
+    # voting fires on the next call.
+    for i in range(20):
+        alt = 30.0 - i * 0.5
+        _drive(
+            kc,
+            now_ms=6500 + i * 2,
+            pressure_altitude=alt,
+            acc_mag=5.0,
+            position=(0.0, 0.0, alt),
+            velocity=(0.0, 0.0, -10.0),
+            pitch_rad=-0.5,
+            burnout_detected=True,
+        )
+
+    assert kc.apogee_flag is True, "apogee_flag should have transitioned"
+
+    # The rising edge in this loop triggers the reset: counters back to 0,
+    # flags back to False.
+    assert kc.gyro_quiet_count_ == 0, f"gyro_quiet_count_ not reset (got {kc.gyro_quiet_count_})"
+    assert kc.accel_1g_count_ == 0,   f"accel_1g_count_ not reset (got {kc.accel_1g_count_})"
+    assert kc.gps_stationary_count_ == 0
+    assert kc.baro_stable_count_ == 0
+    assert kc.gyro_quiet_flag is False, "gyro_quiet_flag should reset on apogee rising edge"
+    assert kc.accel_1g_flag is False
+    assert kc.gps_stationary_flag is False
+    assert kc.baro_stable_flag is False
+
+
+def test_apogee_flag_already_set_does_not_reset_counters():
+    """If apogee_flag is True at the start of the tick, no transition → no reset.
+
+    Guards against accidentally resetting on every post-apogee tick.
+    """
+    kc = KinematicChecks()
+    kc.launch_flag = True
+    kc.max_altitude = 50.0
+    kc.apogee_flag = True  # already set before this tick
+
+    # Drive a single quiet tick; counters should tick normally (or not at
+    # all if outside the 1 Hz window), but they MUST NOT be force-reset.
+    kc.gyro_quiet_count_ = 5
+    kc.gyro_quiet_flag = True
+    kc.accel_1g_count_ = 5
+    kc.accel_1g_flag = True
+
+    _drive(kc, now_ms=10000)
+
+    # Counters preserved (the 1-Hz block may or may not have ticked; the
+    # important thing is that the reset block did NOT zero them).
+    assert kc.gyro_quiet_count_ >= 4, (
+        f"gyro_quiet_count_ should not be reset when apogee was already set "
+        f"(got {kc.gyro_quiet_count_})"
+    )
+    assert kc.gyro_quiet_flag is True

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -318,3 +318,65 @@ TEST_F(KinematicChecksTest, Landing_FastPath_BriefSpike_CounterResets) {
     }
     EXPECT_FALSE(kc.alt_landed_flag);
 }
+
+// ── Test for issue #192: landing sub-flag counters reset on apogee rising edge ──
+TEST_F(KinematicChecksTest, Landing_SubflagsResetOnApogeeRisingEdge) {
+    // The 1 Hz landing sub-detectors (gyro_quiet, gps_stationary, accel_1g,
+    // baro_stable) tick regardless of flight state, so a rocket flying
+    // straight pre-apogee (low roll rate, ~1g coast) can latch their flags
+    // before apogee. The apogee-rising-edge code in kinematicChecks() must
+    // zero those counters + flags so post-apogee voting sees only post-
+    // apogee evidence. Verifies the observable: pre-latched flags reset
+    // when apogee_flag transitions False → True inside the function.
+
+    // Bypass launch detection (already covered by other tests) and force
+    // max_altitude so baro_stable's > 15 m gate is satisfied.
+    kc.launch_flag = true;
+    kc.max_altitude = 50.0f;
+
+    // Seed the KF at 30 m so alt_est tracks above 15 m (needed later for
+    // baro/vel apogee tests). 80 calls @ 2 ms = ~160 ms, plenty for the KF
+    // to converge.
+    for (int i = 0; i < 80; i++) {
+        setMockMillis(i * 2);
+        callFlight(30.0f, 9.81f, 0.0f, 0.1f);  // hold at 30 m, ~1g, quiet
+    }
+
+    // Drive 6 s of "quiet coast" (low gyro, ~1g, vel=0). With the 1 Hz
+    // sub-detector gate, gyro_quiet_count_ rises one tick/second; flag
+    // latches at count >= 4 (~T+4 s into quiet).
+    for (int second = 0; second < 6; second++) {
+        uint32_t base = 200 + second * 1000;
+        for (int i = 0; i < 50; i++) {
+            setMockMillis(base + i * 2);
+            callFlight(30.0f, 9.81f, 0.0f, 0.1f);  // quiet
+        }
+    }
+
+    ASSERT_TRUE(kc.gyro_quiet_flag) << "Quiet inputs should latch gyro_quiet_flag pre-apogee";
+    ASSERT_TRUE(kc.accel_1g_flag)  << "Quiet inputs should latch accel_1g_flag pre-apogee";
+    ASSERT_FALSE(kc.apogee_flag)   << "apogee_flag should still be false";
+
+    // Now drive apogee-triggering inputs to flip apogee_flag inside the
+    // function (this is the rising edge the reset hooks on).
+    //   vel_pass:   alt > 15 (pos[2]) && velocity[2] < 0
+    //   baro_pass:  alt_est > 15 && alt_est < max_altitude - 5 && d_alt_est < 20
+    //   pitch_pass: pitch_rad < -0.087  (5° below horizontal)
+    // APOGEE_COUNT_HI = 6 so 6+ consecutive passing calls latches each
+    // sub-flag; one more call after that fires the master vote.
+    for (int i = 0; i < 20; i++) {
+        setMockMillis(6500 + i * 2);
+        float alt = 30.0f - i * 0.5f;  // descending from 30 m
+        callFlight(alt, 5.0f, -10.0f, 0.1f,
+                   /*gps_alt=*/0.0f, /*new_gps=*/false,
+                   /*pitch_rad=*/-0.5f, /*burnout=*/true, /*baro_lockout=*/false);
+    }
+
+    EXPECT_TRUE(kc.apogee_flag)        << "apogee_flag should have transitioned to true";
+    EXPECT_FALSE(kc.gyro_quiet_flag)   << "gyro_quiet_flag should reset on apogee rising edge";
+    EXPECT_FALSE(kc.accel_1g_flag)     << "accel_1g_flag should reset on apogee rising edge";
+    EXPECT_FALSE(kc.gps_stationary_flag)
+        << "gps_stationary_flag should reset on apogee rising edge";
+    EXPECT_FALSE(kc.baro_stable_flag)
+        << "baro_stable_flag should reset on apogee rising edge";
+}

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -162,6 +162,9 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                                          bool  burnout_detected,
                                          bool  baro_locked_out)
 {
+    // Snapshot apogee_flag so the rising-edge reset below sees the
+    // state *before* this tick's apogee voting fires (#192).
+    const bool apogee_was_set = apogee_flag;
 
     // ### Baro rate-gate (#166) ###
     // Reject obvious spikes (ejection charges, sensor glitches) before they
@@ -470,6 +473,27 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
             }
         }
     } // end burnout gate
+
+    // ### Apogee rising edge: reset landing sub-flag counters (#192) ###
+    // The 1 Hz sub-detectors above accumulate evidence regardless of
+    // flight state, so a rocket flying straight pre-apogee (low roll
+    // rate, ~0 m/s in EKF frame, ~1g during coast) latches gyro_quiet /
+    // gps_stationary / accel_1g before apogee.  The apogee gate on the
+    // master vote prevents a false LANDED, but the latched sub-flags
+    // would carry pre-apogee history into the post-apogee vote and erode
+    // the 3-of-4 margin.  Zero counters + flags at the transition so
+    // post-apogee voting reflects only post-apogee evidence.
+    if (apogee_flag && !apogee_was_set)
+    {
+        baro_stable_count_    = 0;
+        gyro_quiet_count_     = 0;
+        gps_stationary_count_ = 0;
+        accel_1g_count_       = 0;
+        baro_stable_flag    = false;
+        gyro_quiet_flag     = false;
+        gps_stationary_flag = false;
+        accel_1g_flag       = false;
+    }
 
     // ### Pre-Apogee Max Speed ###
     float speed = sqrt(velocity[0]*velocity[0]+


### PR DESCRIPTION
## Summary

Closes #192. Fix surfaced by the flight_report voting timeline plot ([#184](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/189)) on RIM-66 5/17.

The 1 Hz landing sub-detectors (`baro_stable`, `gyro_quiet`, `gps_stationary`, `accel_1g`) accumulate evidence unconditionally. A rocket flying straight pre-apogee — low roll rate, ~1g during coast, ~0 m/s in EKF frame at burnout — latches them before apogee. The apogee gate on the master vote keeps `alt_landed_flag` from firing today, but the latched sub-flags carry pre-apogee history into the post-apogee vote and erode the 3-of-4 margin.

On RIM-66 (apogee 9.3 s, max 211 m/s):

| T (s) | gyro_x (dps) | counter |
|---|---|---|
| 0 | 0.09 | 0 (on pad) |
| 1 | -13.12 | 1 |
| 2 | 13.47 | 2 (launch at T+0.98 s) |
| 3 | -10.53 | 3 |
| 4 | -8.46 | **4 → flag latches** |
| 5-8 | ~-9 | 5..8 (capped) |
| 9 | 176.26 | 7 (tumble starts) |

So `gyro_quiet_flag` was True at master apogee fire (T+10.28 s) for entirely pre-flight reasons.

## Fix

Capture `apogee_flag` at the start of `kinematicChecks()`. After the apogee voting block, if it transitioned False → True this tick, zero the four landing sub-flag counters and flags. Mirrored in firmware (`TR_KinematicChecks.cpp`) and the Python sim (`sim_kinematic_checks.py`) so replay matches firmware.

The existing apogee gate on the master vote is unchanged; this just keeps the sub-flag state consistent with the gate's intent (landing votes reflect post-apogee evidence).

## Tests

- **`tests_cpp/test_kinematic_checks.cpp::Landing_SubflagsResetOnApogeeRisingEdge`** — drives 6 s of quiet inputs to latch `gyro_quiet` + `accel_1g` + `baro_stable`, then drives descending/burnout inputs that trip apogee voting. Asserts all four sub-flags reset.
- **`tests/unit/test_landing_subflag_reset.py`** — Python mirror plus a guard that already-True `apogee_flag` does not spuriously reset on every tick.

All 273 existing C++ tests still pass.

## Test plan

- [x] Local C++: `ctest --test-dir tests_cpp/build --output-on-failure` → 273/273 pass
- [x] Local Python: `pytest tests/unit/test_landing_subflag_reset.py -v` → 2/2 pass
- [ ] CI: C++ Unit Tests workflow green
- [ ] (Optional) Re-run the flight_report on the 5/17 set and confirm the RIM-66 landing-voting plot now shows gyro_quiet's band ending at apogee instead of continuing through descent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)