### PR TITLE
ci: trigger C++ Unit Tests on tests/test_data changes

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -6,11 +6,13 @@ on:
       - 'tinkerrocket-idf/components/**'
       - 'tests_cpp/**'
       - 'tests/integration/**'
+      - 'tests/test_data/**'   # integration tests are parametrized over these fixtures
   pull_request:
     paths:
       - 'tinkerrocket-idf/components/**'
       - 'tests_cpp/**'
       - 'tests/integration/**'
+      - 'tests/test_data/**'   # integration tests are parametrized over these fixtures
 
 # TR_GuidancePN is a private submodule. When the repo secret
 # TR_GUIDANCEPN_TOKEN is set (this org, trusted branches), we recurse

--- a/tests/test_data/README.md
+++ b/tests/test_data/README.md
@@ -1,0 +1,26 @@
+# Test-data fixtures
+
+Binary flight logs (`flight_*.bin`) used as parametric inputs by:
+
+- `tests/integration/test_bin_replay.py` — board-variant invariants
+  (CRC pass rate, timestamp monotonicity, sensor frame rates, IMU gap
+  thresholds, board-specific magnetometer expectations).
+- `tests/test_flight_report.py` — smoke test for the flight_report suite
+  (`Data_Analysis/flight_report/`).
+
+Each `.bin` must be accompanied by a sidecar JSON declaring which PCB
+revision produced the capture:
+
+```json
+{ "board": "old" }   # MMC5983MA over SPI; no IIS2MDC frames expected
+{ "board": "new" }   # IIS2MDC over I2C; no MMC5983MA frames expected
+```
+
+Naming: `<binfile-stem>.meta.json` (e.g., `flight_20260520_173339.meta.json`).
+See `tests/integration/conftest.py:117` for the convention. Without a
+`.meta.json`, `board_variant()` falls back to `BOARD_OLD` so the
+integration tests will fail on a new-PCB capture.
+
+Note: `<binfile-stem>.json` (no `.meta` infix) is the iOS app's flight
+summary file (apogee/burnout/max altitude/max speed) — written by
+TinkerRocketApp and intentionally not consulted by the integration tests.


### PR DESCRIPTION
## Summary

`tests/integration/test_bin_replay.py` is parametrized over `.bin` fixtures in `tests/test_data/`, but the `C++ Unit Tests` workflow path filter only included `tests/integration/**`. That gap let PR #189 land a fixture without its `.meta.json` sidecar undetected — the failure only surfaced on the next PR that happened to touch `tests_cpp/**` (PR #193, just merged).

Add `tests/test_data/**` to both push and pull_request triggers so changes there exercise the integration suite from now on.

Also clears the stale red on `main`: this PR's CI on `cpp-tests.yml` itself will run, the bench-integration job will pick up the `meta.json` that's now on main (PR #194), and pass.

## Test plan

- [ ] CI green on this PR
