### PR TITLE
detect: harden NSF_BURNOUT detector with sample hysteresis (#197)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -216,6 +216,14 @@ target_include_directories(test_bs_log_policy PRIVATE
 target_link_libraries(test_bs_log_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_log_policy)
 
+# ---------- test_burnout_detector (#197) ----------
+# Hysteresis-based burnout detector lives inline in
+# flight_computer/main/main.cpp; test reimplements the small state
+# machine and asserts behavior matches spec. See test file header.
+add_executable(test_burnout_detector test_burnout_detector.cpp)
+target_link_libraries(test_burnout_detector GTest::gtest_main)
+gtest_discover_tests(test_burnout_detector)
+
 # ---------- test_tr_flightlog_wire_format ----------
 # Golden-file regression guard on the BLE wire formats iOS depends on.
 # Fixtures under tests_cpp/fixtures/ble_wire_format/ are the source of truth.

--- a/tests_cpp/test_burnout_detector.cpp
+++ b/tests_cpp/test_burnout_detector.cpp
@@ -1,0 +1,149 @@
+// Tests for the burnout-detector hysteresis added in #197.
+//
+// The detector itself lives inline in the flight_computer main loop at
+// tinkerrocket-idf/projects/flight_computer/main/main.cpp:3860 (search
+// for "Burnout detection").  Extracting the logic to a shared component
+// is a deliberate follow-up — for now this test reimplements the small
+// state machine and verifies it matches the spec.  If main.cpp diverges
+// from this reference, this test will pass while the firmware is wrong;
+// the next refactor should consolidate to a single source of truth.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+namespace {
+
+// Mirror of config::BURNOUT_NEG_HYSTERESIS in
+// tinkerrocket-idf/projects/flight_computer/main/config.h.
+constexpr uint16_t BURNOUT_NEG_HYSTERESIS = 50;
+// 200 ms launch lockout — pre-existing, unchanged by #197.
+constexpr uint32_t LAUNCH_LOCKOUT_MS = 200;
+
+struct BurnoutDetector {
+    bool     detected  = false;
+    uint16_t neg_count = 0;
+    uint32_t fired_at_ms = 0;
+
+    // Mirror of the inline detector at main.cpp:3860.
+    void update(float body_ax, uint32_t t_since_launch_ms) {
+        if (detected) return;
+        if (t_since_launch_ms <= LAUNCH_LOCKOUT_MS) return;
+        if (body_ax < 0.0f) {
+            if (++neg_count >= BURNOUT_NEG_HYSTERESIS) {
+                detected = true;
+                fired_at_ms = t_since_launch_ms;
+            }
+        } else {
+            neg_count = 0;
+        }
+    }
+};
+
+} // namespace
+
+TEST(BurnoutDetector, SingleNegativeSample_DoesNotFire) {
+    BurnoutDetector kd;
+    kd.update(-5.0f, 300);  // negative, past lockout, single sample
+    EXPECT_FALSE(kd.detected);
+    EXPECT_EQ(kd.neg_count, 1);
+}
+
+TEST(BurnoutDetector, JustUnderHysteresis_DoesNotFire) {
+    BurnoutDetector kd;
+    for (int i = 0; i < BURNOUT_NEG_HYSTERESIS - 1; ++i) {
+        kd.update(-5.0f, 300 + i);
+    }
+    EXPECT_FALSE(kd.detected);
+    EXPECT_EQ(kd.neg_count, BURNOUT_NEG_HYSTERESIS - 1);
+}
+
+TEST(BurnoutDetector, ReachesHysteresis_Fires) {
+    BurnoutDetector kd;
+    for (int i = 0; i < BURNOUT_NEG_HYSTERESIS; ++i) {
+        kd.update(-5.0f, 300 + i);
+    }
+    EXPECT_TRUE(kd.detected);
+    EXPECT_EQ(kd.fired_at_ms, 300 + BURNOUT_NEG_HYSTERESIS - 1);
+}
+
+TEST(BurnoutDetector, PositiveSampleResetsCounter) {
+    BurnoutDetector kd;
+    // 49 negative samples — one short of latching.
+    for (int i = 0; i < BURNOUT_NEG_HYSTERESIS - 1; ++i) {
+        kd.update(-5.0f, 300 + i);
+    }
+    EXPECT_EQ(kd.neg_count, BURNOUT_NEG_HYSTERESIS - 1);
+    // One positive sample resets the counter.
+    kd.update(2.0f, 400);
+    EXPECT_EQ(kd.neg_count, 0);
+    EXPECT_FALSE(kd.detected);
+    // 49 more negatives still doesn't fire (need 50 in a row).
+    for (int i = 0; i < BURNOUT_NEG_HYSTERESIS - 1; ++i) {
+        kd.update(-5.0f, 401 + i);
+    }
+    EXPECT_FALSE(kd.detected);
+}
+
+TEST(BurnoutDetector, LaunchLockout_BlocksFiringEarly) {
+    BurnoutDetector kd;
+    // 200 negative samples within the launch lockout window: nothing fires.
+    for (int i = 0; i < 200; ++i) {
+        kd.update(-5.0f, i);  // t_since_launch_ms = 0..199, all <= 200
+    }
+    EXPECT_FALSE(kd.detected);
+    EXPECT_EQ(kd.neg_count, 0);
+}
+
+TEST(BurnoutDetector, LaunchLockout_BoundaryCondition) {
+    BurnoutDetector kd;
+    // At exactly t_since_launch_ms = 200, still locked out.
+    kd.update(-5.0f, 200);
+    EXPECT_EQ(kd.neg_count, 0);
+    // At t_since_launch_ms = 201, lockout cleared.
+    kd.update(-5.0f, 201);
+    EXPECT_EQ(kd.neg_count, 1);
+}
+
+TEST(BurnoutDetector, OnceLatched_StaysLatchedAcrossPositiveSamples) {
+    BurnoutDetector kd;
+    for (int i = 0; i < BURNOUT_NEG_HYSTERESIS; ++i) {
+        kd.update(-5.0f, 300 + i);
+    }
+    ASSERT_TRUE(kd.detected);
+    uint32_t latched_at = kd.fired_at_ms;
+    // Positive samples after latch should not un-fire.
+    kd.update(50.0f, 1000);
+    kd.update(-50.0f, 1001);
+    EXPECT_TRUE(kd.detected);
+    EXPECT_EQ(kd.fired_at_ms, latched_at);  // fire time unchanged
+}
+
+TEST(BurnoutDetector, NoSpuriousFireOnAlternatingSignal) {
+    // Heavy vibration alternates sign each sample — must never fire.
+    BurnoutDetector kd;
+    for (int i = 0; i < 1000; ++i) {
+        kd.update((i % 2 == 0) ? -10.0f : 10.0f, 300 + i);
+    }
+    EXPECT_FALSE(kd.detected);
+}
+
+TEST(BurnoutDetector, RIM66Profile_FiresAtRealCutoff) {
+    // RIM-66 5/17: body_ax was strongly positive (~75 m/s²) during boost
+    // T=1..3 s post-launch, then dropped to a sustained -7 m/s² through
+    // T=8 s. The detector should fire near T+3 s (close to the very
+    // first sustained-negative run, allowing for the hysteresis window).
+    BurnoutDetector kd;
+    // 1 kHz cadence: 2000 ms of boost (positive), then sustained negative.
+    uint32_t t = 250;  // past lockout
+    for (int i = 0; i < 2000; ++i, ++t) {
+        kd.update(75.0f, t);  // boost
+    }
+    ASSERT_FALSE(kd.detected);
+    // Motor cuts off — sustained negative.
+    for (int i = 0; i < 100; ++i, ++t) {
+        kd.update(-7.0f, t);
+    }
+    EXPECT_TRUE(kd.detected);
+    // Fire time should be at sample-50 of the negative run.
+    EXPECT_EQ(kd.fired_at_ms, 250 + 2000 + BURNOUT_NEG_HYSTERESIS - 1);
+}

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -233,6 +233,15 @@ struct config
     // Delay after burnout before engaging guidance (ms)
     static constexpr uint16_t PN_COAST_DELAY_MS = 0;
 
+    // ### Burnout Detection ###
+    // Consecutive samples of negative body-X accel required to latch
+    // burnout_detected. The IMU runs at ~1 kHz so 50 samples ≈ 50 ms of
+    // sustained deceleration — long enough to filter vibration / sensor
+    // noise / wind gusts that briefly drop body_ax below zero during
+    // boost, short enough to catch real motor cutoff within one PN coast
+    // delay tick. See issue #197.
+    static constexpr uint16_t BURNOUT_NEG_HYSTERESIS = 50;
+
     // ### Ground Test ###
     // Attitude-hold gain: virtual accel command per unit tilt (m/s² per rad)
     // Higher = more aggressive correction.  Only affects direction test on ground.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -257,6 +257,10 @@ static TR_PID roll_rate_pid_standalone(config::KP, config::KI, config::KD,
 static bool guidance_enabled = config::GUIDANCE_ENABLED;
 static bool burnout_detected = false;
 static uint32_t burnout_time_ms = 0;
+// Consecutive-sample hysteresis for burnout detection (#197). Prevents
+// single-sample noise / vibration / wind dips from latching the flag
+// prematurely; require N consecutive negative body_ax samples first.
+static uint16_t burnout_neg_count = 0;
 static bool mach_locked_out = false;    // promoted from baro block for apogee voting
 static bool gps_new_for_kc = false;     // new GPS sample available for kinematic checks
 static bool guidance_active = false;
@@ -3793,6 +3797,7 @@ static void loop_fc()
                     roll_rate_pid_standalone.reset();
                     burnout_detected = false;
                     burnout_time_ms = 0;
+                    burnout_neg_count = 0;
                     guidance_active = false;
                     // Reset and arm pyro channels on launch
                     pyro_apogee_detected = false;
@@ -3857,15 +3862,24 @@ static void loop_fc()
                         // Body-X accel (forward axis in FRD) goes negative when
                         // decelerating after motor burnout.  Wait at least 200ms
                         // after launch to avoid false triggers from vibration.
+                        // Require N consecutive negative samples (#197) so a
+                        // single vibration cycle or wind gust can't trip it.
                         if (!burnout_detected && t_since_launch_ms > 200)
                         {
                             float body_ax = ism6_latest_si.low_g_acc_x;
                             if (body_ax < 0.0f)
                             {
-                                burnout_detected = true;
-                                burnout_time_ms = now_ms;
-                                ESP_LOGI(TAG, "[GUID] Burnout detected at T+%lu ms",
-                                              (unsigned long)t_since_launch_ms);
+                                if (++burnout_neg_count >= config::BURNOUT_NEG_HYSTERESIS)
+                                {
+                                    burnout_detected = true;
+                                    burnout_time_ms = now_ms;
+                                    ESP_LOGI(TAG, "[GUID] Burnout detected at T+%lu ms",
+                                                  (unsigned long)t_since_launch_ms);
+                                }
+                            }
+                            else
+                            {
+                                burnout_neg_count = 0;
                             }
                         }
 
@@ -4123,6 +4137,7 @@ static void loop_fc()
                 roll_rate_pid_standalone.reset();
                 burnout_detected = false;
                 burnout_time_ms = 0;
+                burnout_neg_count = 0;
                 guidance_active = false;
                 reboot_recovery = false;
                 reboot_recovery_telem = false;


### PR DESCRIPTION
## Summary

Closes #197. Adds consecutive-sample hysteresis to the firmware burnout detector at [main.cpp:3860](tinkerrocket-idf/projects/flight_computer/main/main.cpp:3860).

## What changed

The detector previously fired on the first single sample where `body_ax < 0` after the 200 ms launch lockout. That's vulnerable to:
- Boost vibration cycles dipping the accel reading momentarily below zero
- Wind gusts decelerating the rocket briefly
- IMU bias drift wandering across zero
- Max-Q drag transients exceeding thrust for a sample

Replaces the single-sample threshold with the same hysteresis idiom the rest of TR_KinematicChecks already uses:

```cpp
if (body_ax < 0.0f) {
    if (++burnout_neg_count >= config::BURNOUT_NEG_HYSTERESIS) {
        burnout_detected = true;
        ...
    }
} else {
    burnout_neg_count = 0;
}
```

Threshold: `config::BURNOUT_NEG_HYSTERESIS = 50` samples ≈ 50 ms at 1 kHz IMU cadence. Long enough to reject vibration / brief gusts, short enough that real cutoff latches within one `PN_COAST_DELAY_MS` tick.

Counter is zeroed alongside `burnout_detected`/`burnout_time_ms` in both reset paths (launch detection at line 3795, sim-restart at line 4125).

## RIM-66 sanity check

Body-X accel data from 2026-05-17 RIM-66 shows the real cutoff was unambiguous — 75 m/s² boost dropping to a sustained −7.5 m/s² for 5.5 s. With the new hysteresis the detector still fires within ~50 ms of the first negative sample (the counter clears the threshold easily on sustained decel). Verified in test `RIM66Profile_FiresAtRealCutoff`.

## Tests

`tests_cpp/test_burnout_detector.cpp` — 9 new test cases:

- `SingleNegativeSample_DoesNotFire`
- `JustUnderHysteresis_DoesNotFire` (49 samples)
- `ReachesHysteresis_Fires` (exactly 50)
- `PositiveSampleResetsCounter` (49 neg + 1 pos + 49 neg → no fire)
- `LaunchLockout_BlocksFiringEarly`
- `LaunchLockout_BoundaryCondition` (200 ms exclusive)
- `OnceLatched_StaysLatchedAcrossPositiveSamples`
- `NoSpuriousFireOnAlternatingSignal` (vibration profile)
- `RIM66Profile_FiresAtRealCutoff` (mimics 5/17 RIM-66 trace)

Existing 273 C++ tests still pass. Suite now 282/282.

## Caveat

The detector logic lives inline in `main.cpp` and the test reimplements the state machine (with comments noting the duplication). Extracting to a shared header / component would be the right long-term move but is bigger than this PR — flagged in the test file header for the next person who touches this code.

## Relationship to #196

Once this lands, the iOS sidecar fix in [the companion PR for #196](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/196) can rely on `NSF_BURNOUT` as a trustworthy source of truth. That PR will read the flag from the binary log and replace the current peak-velocity proxy.

## Test plan

- [x] Local: `ctest --test-dir tests_cpp/build` → 282/282 pass
- [ ] CI green
