### PR TITLE
ios: source sidecar burnout_time_s from NSF_BURNOUT (#196)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -213,8 +213,8 @@ nonisolated class CSVGenerator {
         // Track flight summary stats
         var maxPressureAlt: Double?
         var maxSpeed: Double?
-        var maxSpeedTime_us: UInt32?
         var launchTime_us: UInt32?
+        var burnoutTime_us: UInt32?  // first NSF_BURNOUT flag latch (#196)
         var apogeeTime_us: UInt32?
 
         // Running indices for forward-fill (O(n+m) total)
@@ -287,9 +287,9 @@ nonisolated class CSVGenerator {
                 }
             }
 
-            // Track max 3D speed from EKF velocity (peak = burnout)
-            // Only update before apogee — IMU integration drifts after apogee
-            // so post-apogee speeds are unreliable.
+            // Track max 3D speed from EKF velocity for the max_speed_mps
+            // metric. Only update before apogee — IMU integration drifts
+            // after apogee so post-apogee speeds are unreliable.
             //
             // Gate on the master voted apogee_flag — a single per-detector
             // false positive (#142) previously gated off max-speed tracking
@@ -303,12 +303,26 @@ nonisolated class CSVGenerator {
                     let speed = sqrt(ns.e_vel * ns.e_vel + ns.n_vel * ns.n_vel + ns.u_vel * ns.u_vel)
                     if maxSpeed == nil || speed > maxSpeed! {
                         maxSpeed = speed
-                        maxSpeedTime_us = t
                     }
                 }
 
                 if ns.launch_flag && launchTime_us == nil {
                     launchTime_us = t
+                }
+
+                // burnout_time_s is the first NSF_BURNOUT flag latch (#196).
+                // Previously the sidecar used peak-velocity time as a
+                // burnout proxy ("peak = burnout"), but that diverges from
+                // the firmware's own decision by multiple seconds on flights
+                // where peak |v| comes later than motor cutoff (RIM-66 5/17
+                // had FW burnout at T+2.13s vs peak |v| at T+9.30s).
+                // Read the flag directly so the sidecar timing agrees with
+                // pyro / kinematic_checks / every other consumer of the bin.
+                // Legacy logs predating the burnout bit set in firmware
+                // decode as false → burnoutTime_us stays nil → JSON emits
+                // null rather than a wrong proxy value.
+                if ns.burnout_flag && burnoutTime_us == nil {
+                    burnoutTime_us = t
                 }
 
                 // Source apogee timestamp from the master voted flag — not
@@ -341,7 +355,7 @@ nonisolated class CSVGenerator {
 
         // Compute event times relative to launch (seconds)
         let burnoutTime: Double? = {
-            guard let launch = launchTime_us, let burnout = maxSpeedTime_us,
+            guard let launch = launchTime_us, let burnout = burnoutTime_us,
                   burnout > launch else { return nil }
             return Double(burnout - launch) / 1_000_000.0
         }()

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -345,7 +345,10 @@ nonisolated class SensorConverter {
             alt_apogee_flag: raw.alt_apogee_flag,
             vel_u_apogee_flag: raw.vel_u_apogee_flag,
             launch_flag: raw.launch_flag,
-            // Legacy wire format never carried the extra apogee detectors.
+            // Legacy wire format never carried NSF_BURNOUT or the extra
+            // apogee detectors. Sidecar burnout_time_s will be null on
+            // these flights (#196).
+            burnout_flag: false,
             gps_apogee_flag: false,
             pitch_apogee_flag: false,
             apogee_flag: false,
@@ -383,16 +386,19 @@ nonisolated class SensorConverter {
         let n_vel = Double(raw.n_vel) * 0.01
         let u_vel = Double(raw.u_vel) * 0.01
 
-        // Extract flags (bitfield)
+        // Extract flags (bitfield).  Mirror the C++ NSF_* masks in
+        // tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h.
         let NSF_ALT_LANDED: UInt8   = (1 << 0)
         let NSF_ALT_APOGEE: UInt8   = (1 << 1)
         let NSF_VEL_APOGEE: UInt8   = (1 << 2)
         let NSF_LAUNCH: UInt8       = (1 << 3)
+        let NSF_BURNOUT: UInt8      = (1 << 4)   // #196: source of truth for burnout_time_s
 
         let alt_landed_flag = (raw.flags & NSF_ALT_LANDED) != 0
         let alt_apogee_flag = (raw.flags & NSF_ALT_APOGEE) != 0
         let vel_u_apogee_flag = (raw.flags & NSF_VEL_APOGEE) != 0
         let launch_flag = (raw.flags & NSF_LAUNCH) != 0
+        let burnout_flag = (raw.flags & NSF_BURNOUT) != 0
 
         // Apogee detector outputs + master vote (appended in #142/#143).
         let NSF2_GPS_APOGEE: UInt8    = (1 << 0)
@@ -432,6 +438,7 @@ nonisolated class SensorConverter {
             alt_apogee_flag: alt_apogee_flag,
             vel_u_apogee_flag: vel_u_apogee_flag,
             launch_flag: launch_flag,
+            burnout_flag: burnout_flag,
             gps_apogee_flag: gps_apogee_flag,
             pitch_apogee_flag: pitch_apogee_flag,
             apogee_flag: apogee_flag,

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -704,6 +704,10 @@ nonisolated struct NonSensorDataSI {
     let alt_apogee_flag: Bool
     let vel_u_apogee_flag: Bool
     let launch_flag: Bool
+    // Firmware-set burnout flag (NSF_BURNOUT, bit 4). Source of truth for
+    // burnout_time_s in the .json sidecar (#196). Pre-existing logs that
+    // predate the firmware setting this bit decode as false.
+    let burnout_flag: Bool
 
     // Per #142/#143: full apogee detector set + master voted result.
     // Decoded from NonSensorData.apogee_flags; legacy 43-byte logs decode all

--- a/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
@@ -60,6 +60,25 @@ private func makeGNSS(
     return try GNSSData(from: d)
 }
 
+private func makeNonSensor(
+    timeUs: UInt32 = 0,
+    flags: UInt8 = 0,
+    rocketState: UInt8 = 0,
+    pyroStatus: UInt8 = 0,
+    apogeeFlags: UInt8 = 0
+) throws -> NonSensorData {
+    var d = Data()
+    d.appendLE(timeUs)
+    // q0..q3 + roll_cmd (5 × Int16 = 10 bytes)
+    for _ in 0..<5 { d.appendLE(Int16(0)) }
+    // e/n/u_pos + e/n/u_vel (6 × Int32 = 24 bytes)
+    for _ in 0..<6 { d.appendLE(Int32(0)) }
+    d.append(contentsOf: [flags, rocketState])
+    d.appendLE(Int16(0))           // baro_alt_rate_dmps
+    d.append(contentsOf: [pyroStatus, apogeeFlags])
+    return try NonSensorData(from: d)
+}
+
 final class SensorConverterTests: XCTestCase {
 
     let converter = SensorConverter()
@@ -127,5 +146,37 @@ final class SensorConverterTests: XCTestCase {
         XCTAssertEqual(si.mag_x, 0.0, accuracy: 0.01)
         XCTAssertEqual(si.mag_y, 0.0, accuracy: 0.01)
         XCTAssertEqual(si.mag_z, 0.0, accuracy: 0.01)
+    }
+
+    // MARK: - NonSensor flag extraction (#196)
+
+    func testNonSensor_BurnoutFlag_FalseWhenBitClear() throws {
+        // No NSF_BURNOUT bit set
+        let raw = try makeNonSensor(flags: 0b0000_0000)
+        let si = converter.convertNonSensor(raw)
+        XCTAssertFalse(si.burnout_flag,
+                       "burnout_flag should be false when NSF_BURNOUT bit is clear")
+    }
+
+    func testNonSensor_BurnoutFlag_TrueWhenBitSet() throws {
+        // NSF_BURNOUT is bit 4 (1 << 4 = 0x10)
+        let raw = try makeNonSensor(flags: 1 << 4)
+        let si = converter.convertNonSensor(raw)
+        XCTAssertTrue(si.burnout_flag,
+                      "burnout_flag should be true when NSF_BURNOUT bit is set")
+    }
+
+    func testNonSensor_BurnoutFlag_IndependentOfOtherFlags() throws {
+        // All other NSF_* bits set, NSF_BURNOUT clear
+        let otherBits: UInt8 = (1<<0) | (1<<1) | (1<<2) | (1<<3) | (1<<5) | (1<<6) | (1<<7)
+        let raw = try makeNonSensor(flags: otherBits)
+        let si = converter.convertNonSensor(raw)
+        XCTAssertFalse(si.burnout_flag,
+                       "burnout_flag must not be set by neighboring flag bits")
+        // Sanity: the bits we DID set should be reflected.
+        XCTAssertTrue(si.alt_landed_flag)
+        XCTAssertTrue(si.alt_apogee_flag)
+        XCTAssertTrue(si.vel_u_apogee_flag)
+        XCTAssertTrue(si.launch_flag)
     }
 }


### PR DESCRIPTION
## Summary

Closes #196. The `.json` sidecar's `burnout_time_s` was being computed as the moment of peak EKF |velocity| pre-apogee — a proxy that conflates "motor cutoff" with "peak speed." On three of four 2026-05-17 flights this proxy diverged from the firmware's own `NSF_BURNOUT` flag by 2–7 seconds.

| Flight | iOS sidecar | FW NSF_BURNOUT (rel to launch) | gap |
|---|---|---|---|
| V2 | 0.79 s | 0.82 s | −0.03 s |
| RollyPolly_54mm | 2.72 s | 0.78 s | +1.94 s |
| Eagle Claw | 3.43 s | 1.31 s | +2.11 s |
| RIM-66_65mm | **9.30 s** | 2.13 s | **+7.17 s** |

## Verification on RIM-66

Body-X accel from the binary confirms the firmware flag is correct: 75 m/s² boost dropped to a **sustained −7.5 m/s² for 5.5 s starting at T+3.10s** — unambiguous motor cutoff. iOS's 9.30s was peak EKF |velocity|, which occurred 7 s later due to horizontal drift after the motor stopped pushing.

## The fix

Three small Swift edits.

1. **[SensorConverter.swift:386-396](TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift:386)** — extract `NSF_BURNOUT = 1<<4` from `NonSensorData.flags`. Mirrors the existing `NSF_*` extraction block.
2. **[SensorTypes.swift:706](TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift:706)** — add `burnout_flag: Bool` to `NonSensorDataSI`. The legacy constructor (BLE wire-format path) defaults this to `false`.
3. **[CSVGenerator.swift:290-307](TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift:290)** — replace `maxSpeedTime_us` tracking with a direct read of `ns.burnout_flag`. `max_speed_mps` stays — that metric is real and independent.

Legacy logs predating the firmware setting `NSF_BURNOUT` decode `burnout_time_s` as `null` rather than emitting the old proxy value.

## Tests

`SensorConverterTests.swift` gets a `makeNonSensor` byte-packing helper + 3 new cases:
- `testNonSensor_BurnoutFlag_FalseWhenBitClear`
- `testNonSensor_BurnoutFlag_TrueWhenBitSet` (NSF_BURNOUT bit set)
- `testNonSensor_BurnoutFlag_IndependentOfOtherFlags` (all 7 other NSF_* bits set, NSF_BURNOUT clear)

## Companion PR

[#198](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/198) hardens the firmware's `NSF_BURNOUT` detector with consecutive-sample hysteresis so the flag itself is robust before this PR starts relying on it as the source of truth.

## Test plan

- [ ] CI: iOS Tests workflow green on this PR (the new XCTest cases run)
- [ ] Once landed, regenerate one of the 5/17 reports and confirm the headline summary's burnout value agrees with the per-module sections (currently they disagree by seconds — see issue #196)
