### PR TITLE
fc: fix fresh-worktree build (target detection + guidance stub dispatch)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
@@ -14,6 +14,9 @@ else()
     list(APPEND EXCLUDE_COMPONENTS TR_GuidancePN)
     add_compile_definitions(TR_GUIDANCE_AVAILABLE=0)
 endif()
+# NB: main/CMakeLists.txt runs the same EXISTS check to decide whether to
+# list TR_GuidancePN or TR_GuidancePN_Stub in its REQUIRES. Kept in sync
+# by hand — both checks must agree.
 
 # Exclude BLE and LoRa components not used by FlightComputer
 list(APPEND EXCLUDE_COMPONENTS TR_BLE_To_APP TR_LoRa_Comms TR_INA230)

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -1,3 +1,13 @@
+# Pick the real TR_GuidancePN submodule when it's checked out, otherwise
+# the local no-op stub. Project CMakeLists.txt does the matching
+# EXCLUDE_COMPONENTS dance so only one of the two is actually in the
+# build. Both expose `TR_GuidancePN.h`, so main.cpp compiles unchanged.
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../../components/TR_GuidancePN/TR_GuidancePN.cpp")
+    set(_guidance_req "TR_GuidancePN")
+else()
+    set(_guidance_req "TR_GuidancePN_Stub")
+endif()
+
 idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
@@ -14,7 +24,7 @@ idf_component_register(
         TR_KinematicChecks
         TR_MagCalibrator
         TR_ServoControl_ledc_mult
-        TR_GuidancePN
+        ${_guidance_req}
         TR_ControlMixer
         TR_GNSSReceiverUBlox_Serial
         TR_IMU_Int_V2

--- a/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
@@ -1,8 +1,4 @@
-CONFIG_IDF_TARGET="esp32s3"
-
-# Arduino-as-component
-CONFIG_AUTOSTART_ARDUINO=y
-CONFIG_ARDUINO_LOOP_STACK_SIZE=16384
+CONFIG_IDF_TARGET="esp32p4"
 
 # No power management — runs at full speed
 CONFIG_PM_ENABLE=n
@@ -23,5 +19,3 @@ CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
-
-# Prevent Arduino min/max macros from conflicting with std::min/std::max

--- a/tinkerrocket-idf/tools/build.sh
+++ b/tinkerrocket-idf/tools/build.sh
@@ -39,10 +39,15 @@ fi
 
 cd "$PROJECT_DIR"
 
-# Set target if not already done
+# Set target if not already done. Read the desired target from
+# sdkconfig.defaults so each project picks its own chip (OC/BS=esp32s3,
+# FC=esp32p4) without idf.py silently defaulting to esp32s3 and producing
+# a binary for the wrong target.
 if [ ! -f "sdkconfig" ]; then
-    echo "First build — setting target to esp32s3..."
-    idf.py set-target esp32s3
+    TARGET="$(grep -E '^CONFIG_IDF_TARGET=' sdkconfig.defaults 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/' | head -1)"
+    TARGET="${TARGET:-esp32s3}"
+    echo "First build — setting target to ${TARGET}..."
+    idf.py set-target "${TARGET}"
 fi
 
 case "$COMMAND" in


### PR DESCRIPTION
## Summary

Three pre-existing footguns that surface on fresh worktrees / fresh clones, all in the FC build path. Discovered while attempting the IDF 5.5 upgrade (#88) — independent of that upgrade and worth landing on their own.

- **`tools/build.sh` hardcoded `idf.py set-target esp32s3`** for first builds, so a fresh-checkout `./build.sh flight_computer build` quietly produced an esp32s3 binary that won't flash to the P4 board (`A fatal error occurred: This chip is ESP32-P4, not ESP32-S3`). Now reads `CONFIG_IDF_TARGET` from `sdkconfig.defaults` and falls back to `esp32s3` if absent.
- **FC `sdkconfig.defaults` claimed `CONFIG_IDF_TARGET="esp32s3"`** (FC is actually P4). `CONFIG_AUTOSTART_ARDUINO=y` and `CONFIG_ARDUINO_LOOP_STACK_SIZE` were also dead kconfig — arduino-esp32 isn't pulled into FC, main.cpp has zero Arduino includes, so these symbols were silently dropped during sdkconfig generation. Cleaned up.
- **TR_GuidancePN dual-mode dispatch was broken**: project CMakeLists already excluded one of the two components based on submodule presence, but `main/CMakeLists.txt` listed `TR_GuidancePN` literally in `REQUIRES`. Without the private submodule initialized, that REQUIRES went unresolved and FC build failed with `TR_GuidancePN.h: No such file or directory`. `main` now mirrors the same `EXISTS` check and swaps in `TR_GuidancePN_Stub` when the submodule isn't checked out.

## Verified locally

- FC stub path (no submodule): esp32p4 build OK
- FC real path (submodule init): esp32p4 build OK
- OC: esp32s3 build OK (target-detect regression check)
- BS: esp32s3 build OK (target-detect regression check)

## Test plan

- [ ] From a fresh clone or `git worktree add` without `git submodule update --init`, `./tools/build.sh flight_computer build` builds successfully against the stub and produces an esp32p4 binary
- [ ] With submodule initialized, same command builds against the real guidance code
- [ ] `./tools/build.sh out_computer build` and `./tools/build.sh base_station build` still produce esp32s3 binaries (no regression)
- [ ] Flashing FC works end-to-end (`./tools/build.sh flight_computer fm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
