### PR TITLE
ios: fall back to advertisementData when peripheral.name is nil

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -205,7 +205,16 @@ extension BLEFleet: CBCentralManagerDelegate {
                        didDiscover peripheral: CBPeripheral,
                        advertisementData: [String: Any],
                        rssi RSSI: NSNumber) {
-        let name = peripheral.name ?? "Unknown"
+        // peripheral.name is iOS-cached and is nil on a fresh-scan discovery
+        // until iOS has connected at least once or otherwise persisted the
+        // name (e.g. an active pair). After a firmware re-flash that wipes
+        // bond state, the cache is invalidated and peripheral.name comes
+        // back nil even though the device is advertising correctly — the
+        // name lives in the scan-response payload, surfaced through
+        // advertisementData[CBAdvertisementDataLocalNameKey]. Prefer that
+        // when present so the prefix filter works on first discovery.
+        let advertisedName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
+        let name = advertisedName ?? peripheral.name ?? "Unknown"
         print("Discovered: \(name) RSSI: \(RSSI)")
 
         // Only list Tinker devices (legacy "TinkerRocket"/"TinkerBaseStation" + new "TR-R-"/"TR-B-")


### PR DESCRIPTION
## Summary

`BLEFleet.swift`'s `didDiscover` callback filtered discovered peripherals by `peripheral.name.hasPrefix("TR-")`. But `peripheral.name` is **iOS-cached** — only populated after iOS has connected at least once and persisted the name. On a fresh scan against a never-bonded device (or one whose bond got wiped by a firmware re-flash), it comes back nil, the prefix check trips, and the device is silently dropped from the discovered list.

The fresh-scan name actually lives in the scan-response payload, surfaced via `advertisementData[CBAdvertisementDataLocalNameKey]`. The fix reads that first and only falls back to `peripheral.name` when it's missing.

## Repro that prompted this

During an IDF firmware re-flash session, OC's BLE bond state in NVS was invalidated. nRF Connect saw `TR-R-e150` normally; the TinkerRocket app saw nothing on its discovery list. Toggling Bluetooth on the iPhone didn't help (cache survives), and "Forget This Device" wasn't possible because the device wasn't in My Devices to begin with. The OC was broadcasting fine — the app's name filter just dropped the unnamed `CBPeripheral` and never showed it.

## Diff

```swift
// Before:
let name = peripheral.name ?? "Unknown"
guard name.hasPrefix("TR-") || name.contains("Tinker") else { return }

// After:
let advertisedName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
let name = advertisedName ?? peripheral.name ?? "Unknown"
guard name.hasPrefix("TR-") || name.contains("Tinker") else { return }
```

One file changed: [`TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift`](TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) — 10 lines (mostly comment).

## Test plan

- [ ] On an iPhone that's never paired with the rocket, opening the app and scanning shows `TR-R-e150` (the new advertisement-data path)
- [ ] After Forget Device + re-scan, the rocket is still discovered (validates that name-cache invalidation no longer hides it)
- [ ] On an iPhone that has bonded to the rocket before, behavior is unchanged (`peripheral.name` fallback still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
