### PR TITLE
new PCB: 4-channel pyro + boot-twitch fix + GPS rail + GNSS auto-swap

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -161,11 +161,12 @@ final class ActiveRocketSyncer: ObservableObject {
         device.sendGuidanceConfig(enabled: profile.guidanceEnabled)
         device.sendCameraConfig(cameraType: profile.cameraType)
         device.sendSoundConfig(enabled: profile.soundsEnabled)
-        device.sendPyroConfig(
-            ch1Enabled: profile.pyro1Enabled, ch1Mode: profile.pyro1TriggerMode,
-            ch1Value: profile.pyro1TriggerValue,
-            ch2Enabled: profile.pyro2Enabled, ch2Mode: profile.pyro2TriggerMode,
-            ch2Value: profile.pyro2TriggerValue)
+        device.sendPyroConfig(channels: [
+            (profile.pyro1Enabled, profile.pyro1TriggerMode, profile.pyro1TriggerValue),
+            (profile.pyro2Enabled, profile.pyro2TriggerMode, profile.pyro2TriggerValue),
+            (profile.pyro3Enabled, profile.pyro3TriggerMode, profile.pyro3TriggerValue),
+            (profile.pyro4Enabled, profile.pyro4TriggerMode, profile.pyro4TriggerValue),
+        ])
 
         syncMagCal(profile: profile, device: device)
         syncSensorCal(profile: profile, device: device)

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -565,17 +565,17 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendRawCommand(33, payload: Data([cameraType]))
     }
 
-    func sendPyroConfig(ch1Enabled: Bool, ch1Mode: UInt8, ch1Value: Float,
-                        ch2Enabled: Bool, ch2Mode: UInt8, ch2Value: Float) {
+    /// 4-channel pyro config. Each tuple is (enabled, trigger_mode, trigger_value).
+    /// Wire layout (24 bytes): 4 × {u8 enabled, u8 mode, f32 value}.
+    func sendPyroConfig(channels: [(enabled: Bool, mode: UInt8, value: Float)]) {
+        precondition(channels.count == 4, "pyro config requires exactly 4 channels")
         var payload = Data()
-        payload.append(ch1Enabled ? 0x01 : 0x00)
-        payload.append(ch1Mode)
-        var v1 = ch1Value
-        payload.append(Data(bytes: &v1, count: 4))
-        payload.append(ch2Enabled ? 0x01 : 0x00)
-        payload.append(ch2Mode)
-        var v2 = ch2Value
-        payload.append(Data(bytes: &v2, count: 4))
+        for ch in channels {
+            payload.append(ch.enabled ? 0x01 : 0x00)
+            payload.append(ch.mode)
+            var v = ch.value
+            payload.append(Data(bytes: &v, count: 4))
+        }
         sendRawCommand(34, payload: payload)
     }
 
@@ -1093,13 +1093,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 cfg.pyro2Enabled = existing.pyro2Enabled
                 cfg.pyro2TriggerMode = existing.pyro2TriggerMode
                 cfg.pyro2TriggerValue = existing.pyro2TriggerValue
+                cfg.pyro3Enabled = existing.pyro3Enabled
+                cfg.pyro3TriggerMode = existing.pyro3TriggerMode
+                cfg.pyro3TriggerValue = existing.pyro3TriggerValue
+                cfg.pyro4Enabled = existing.pyro4Enabled
+                cfg.pyro4TriggerMode = existing.pyro4TriggerMode
+                cfg.pyro4TriggerValue = existing.pyro4TriggerValue
             }
             self.rocketConfig = cfg
             triggerAutoChannelSelectIfNeeded()
             return
         }
 
-        // Pyro config readback: "type":"config_pyro"
+        // Pyro config readback: "type":"config_pyro" (4 channels)
         if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            dict["type"] as? String == "config_pyro" {
             var cfg = self.rocketConfig ?? RocketConfig()
@@ -1109,6 +1115,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             cfg.pyro2Enabled = dict["p2e"] as? Bool ?? cfg.pyro2Enabled
             cfg.pyro2TriggerMode = UInt8(dict["p2m"] as? Int ?? Int(cfg.pyro2TriggerMode))
             cfg.pyro2TriggerValue = parseFloat(dict["p2v"]) ?? cfg.pyro2TriggerValue
+            cfg.pyro3Enabled = dict["p3e"] as? Bool ?? cfg.pyro3Enabled
+            cfg.pyro3TriggerMode = UInt8(dict["p3m"] as? Int ?? Int(cfg.pyro3TriggerMode))
+            cfg.pyro3TriggerValue = parseFloat(dict["p3v"]) ?? cfg.pyro3TriggerValue
+            cfg.pyro4Enabled = dict["p4e"] as? Bool ?? cfg.pyro4Enabled
+            cfg.pyro4TriggerMode = UInt8(dict["p4m"] as? Int ?? Int(cfg.pyro4TriggerMode))
+            cfg.pyro4TriggerValue = parseFloat(dict["p4v"]) ?? cfg.pyro4TriggerValue
             self.rocketConfig = cfg
             return
         }

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -112,4 +112,10 @@ struct RocketConfig {
     var pyro2Enabled: Bool = false
     var pyro2TriggerMode: UInt8 = 0
     var pyro2TriggerValue: Float = 100.0
+    var pyro3Enabled: Bool = false
+    var pyro3TriggerMode: UInt8 = 0
+    var pyro3TriggerValue: Float = 0.0
+    var pyro4Enabled: Bool = false
+    var pyro4TriggerMode: UInt8 = 0
+    var pyro4TriggerValue: Float = 0.0
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -529,11 +529,15 @@ nonisolated class CSVGenerator {
         columns.append("Apogee Flag (Master)")
         columns.append("Launch Flag")
 
-        // Pyro status bits (appended in #34 wire format; legacy files emit 0s)
+        // Pyro status bits — 4 channels (legacy files emit 0s for ch3/4)
         columns.append("Pyro 1 Continuity")
         columns.append("Pyro 2 Continuity")
+        columns.append("Pyro 3 Continuity")
+        columns.append("Pyro 4 Continuity")
         columns.append("Pyro 1 Fired")
         columns.append("Pyro 2 Fired")
+        columns.append("Pyro 3 Fired")
+        columns.append("Pyro 4 Fired")
         columns.append("Reboot Recovery")
         columns.append("FC Guidance Enabled")
 
@@ -623,11 +627,15 @@ nonisolated class CSVGenerator {
         values.append(nonSensor.map { $0.apogee_flag ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.launch_flag ? "1" : "0" } ?? "")
 
-        // Pyro status bits
+        // Pyro status bits (4 channels)
         values.append(nonSensor.map { $0.pyro1_continuity ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.pyro2_continuity ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro3_continuity ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro4_continuity ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.pyro1_fired ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.pyro2_fired ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro3_fired ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.pyro4_fired ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.reboot_recovery ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.guidance_enabled ? "1" : "0" } ?? "")
 
@@ -791,16 +799,22 @@ nonisolated struct CameraSettings: Codable, Sendable {
 nonisolated struct PyroSettings: Codable, Sendable {
     let ch1: PyroChannelSettings
     let ch2: PyroChannelSettings
+    let ch3: PyroChannelSettings
+    let ch4: PyroChannelSettings
 
     init(from raw: FlightSettingsData) {
-        ch1 = PyroChannelSettings(
-            enabled: raw.pyro1_enabled,
-            mode: raw.pyro1_trigger_mode,
-            value: raw.pyro1_trigger_value)
-        ch2 = PyroChannelSettings(
-            enabled: raw.pyro2_enabled,
-            mode: raw.pyro2_trigger_mode,
-            value: raw.pyro2_trigger_value)
+        ch1 = PyroChannelSettings(enabled: raw.pyro_enabled[0],
+                                  mode: raw.pyro_trigger_mode[0],
+                                  value: raw.pyro_trigger_value[0])
+        ch2 = PyroChannelSettings(enabled: raw.pyro_enabled[1],
+                                  mode: raw.pyro_trigger_mode[1],
+                                  value: raw.pyro_trigger_value[1])
+        ch3 = PyroChannelSettings(enabled: raw.pyro_enabled[2],
+                                  mode: raw.pyro_trigger_mode[2],
+                                  value: raw.pyro_trigger_value[2])
+        ch4 = PyroChannelSettings(enabled: raw.pyro_enabled[3],
+                                  mode: raw.pyro_trigger_mode[3],
+                                  value: raw.pyro_trigger_value[3])
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -107,13 +107,20 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var rollWaypoints: [RollWaypoint] = []
 
     // MARK: Pyro (per-airframe; auto-pushed on connect — arming stays a
-    // separate explicit action, never driven by the profile).
+    // separate explicit action, never driven by the profile). New PCB
+    // has 4 channels sharing a single ARM FET.
     var pyro1Enabled: Bool = false
     var pyro1TriggerMode: UInt8 = 0
     var pyro1TriggerValue: Float = 1.0
     var pyro2Enabled: Bool = false
     var pyro2TriggerMode: UInt8 = 0
     var pyro2TriggerValue: Float = 100.0
+    var pyro3Enabled: Bool = false
+    var pyro3TriggerMode: UInt8 = 0
+    var pyro3TriggerValue: Float = 0.0
+    var pyro4Enabled: Bool = false
+    var pyro4TriggerMode: UInt8 = 0
+    var pyro4TriggerValue: Float = 0.0
 
     // MARK: Recovery (issue #156) — descent profile for landing-point
     // prediction and drift-cast.  Stored per-airframe so different rockets
@@ -192,6 +199,12 @@ extension RocketProfile {
         pyro2Enabled = try c.decodeIfPresent(Bool.self, forKey: .pyro2Enabled) ?? defaults.pyro2Enabled
         pyro2TriggerMode = try c.decodeIfPresent(UInt8.self, forKey: .pyro2TriggerMode) ?? defaults.pyro2TriggerMode
         pyro2TriggerValue = try c.decodeIfPresent(Float.self, forKey: .pyro2TriggerValue) ?? defaults.pyro2TriggerValue
+        pyro3Enabled = try c.decodeIfPresent(Bool.self, forKey: .pyro3Enabled) ?? defaults.pyro3Enabled
+        pyro3TriggerMode = try c.decodeIfPresent(UInt8.self, forKey: .pyro3TriggerMode) ?? defaults.pyro3TriggerMode
+        pyro3TriggerValue = try c.decodeIfPresent(Float.self, forKey: .pyro3TriggerValue) ?? defaults.pyro3TriggerValue
+        pyro4Enabled = try c.decodeIfPresent(Bool.self, forKey: .pyro4Enabled) ?? defaults.pyro4Enabled
+        pyro4TriggerMode = try c.decodeIfPresent(UInt8.self, forKey: .pyro4TriggerMode) ?? defaults.pyro4TriggerMode
+        pyro4TriggerValue = try c.decodeIfPresent(Float.self, forKey: .pyro4TriggerValue) ?? defaults.pyro4TriggerValue
 
         drogueRateFps = try c.decodeIfPresent(Double.self, forKey: .drogueRateFps) ?? defaults.drogueRateFps
         mainRateFps = try c.decodeIfPresent(Double.self, forKey: .mainRateFps) ?? defaults.mainRateFps

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -356,8 +356,12 @@ nonisolated class SensorConverter {
             // Legacy wire format never carried pyro_status — leave unset.
             pyro1_continuity: false,
             pyro2_continuity: false,
+            pyro3_continuity: false,
+            pyro4_continuity: false,
             pyro1_fired: false,
             pyro2_fired: false,
+            pyro3_fired: false,
+            pyro4_fired: false,
             reboot_recovery: false,
             guidance_enabled: false
         )
@@ -400,26 +404,32 @@ nonisolated class SensorConverter {
         let launch_flag = (raw.flags & NSF_LAUNCH) != 0
         let burnout_flag = (raw.flags & NSF_BURNOUT) != 0
 
-        // Apogee detector outputs + master vote (appended in #142/#143).
-        let NSF2_GPS_APOGEE: UInt8    = (1 << 0)
-        let NSF2_PITCH_APOGEE: UInt8  = (1 << 1)
-        let NSF2_MASTER_APOGEE: UInt8 = (1 << 2)
+        // Apogee detector outputs + master vote + relocated reboot/guidance bits.
+        let NSF2_GPS_APOGEE: UInt8       = (1 << 0)
+        let NSF2_PITCH_APOGEE: UInt8     = (1 << 1)
+        let NSF2_MASTER_APOGEE: UInt8    = (1 << 2)
+        let NSF2_REBOOT_RECOVERY: UInt8  = (1 << 3)
+        let NSF2_GUIDANCE_ENABLED: UInt8 = (1 << 4)
         let gps_apogee_flag   = (raw.apogee_flags & NSF2_GPS_APOGEE) != 0
         let pitch_apogee_flag = (raw.apogee_flags & NSF2_PITCH_APOGEE) != 0
         let apogee_flag       = (raw.apogee_flags & NSF2_MASTER_APOGEE) != 0
+        let reboot_recovery   = (raw.apogee_flags & NSF2_REBOOT_RECOVERY) != 0
+        let guidance_enabled  = (raw.apogee_flags & NSF2_GUIDANCE_ENABLED) != 0
 
         let rocket_state = RocketState(rawValue: raw.rocket_state) ?? .initialization
 
         // dm/s -> m/s
         let altitude_rate = Double(raw.baro_alt_rate_dmps) * 0.1
 
-        // Pyro status byte — mirror the C++ PSF_ masks in RocketComputerTypes.h
-        let PSF_CH1_CONT: UInt8         = (1 << 0)
-        let PSF_CH2_CONT: UInt8         = (1 << 1)
-        let PSF_CH1_FIRED: UInt8        = (1 << 2)
-        let PSF_CH2_FIRED: UInt8        = (1 << 3)
-        let PSF_REBOOT_RECOVERY: UInt8  = (1 << 4)
-        let PSF_GUIDANCE_ENABLED: UInt8 = (1 << 5)
+        // Pyro status byte — 4 channels × (cont, fired). Mirror C++ PSF_* masks.
+        let PSF_CH1_CONT: UInt8  = (1 << 0)
+        let PSF_CH1_FIRED: UInt8 = (1 << 1)
+        let PSF_CH2_CONT: UInt8  = (1 << 2)
+        let PSF_CH2_FIRED: UInt8 = (1 << 3)
+        let PSF_CH3_CONT: UInt8  = (1 << 4)
+        let PSF_CH3_FIRED: UInt8 = (1 << 5)
+        let PSF_CH4_CONT: UInt8  = (1 << 6)
+        let PSF_CH4_FIRED: UInt8 = (1 << 7)
 
         return NonSensorDataSI(
             time_us: raw.time_us,
@@ -445,10 +455,14 @@ nonisolated class SensorConverter {
             rocket_state: rocket_state,
             pyro1_continuity: (raw.pyro_status & PSF_CH1_CONT) != 0,
             pyro2_continuity: (raw.pyro_status & PSF_CH2_CONT) != 0,
+            pyro3_continuity: (raw.pyro_status & PSF_CH3_CONT) != 0,
+            pyro4_continuity: (raw.pyro_status & PSF_CH4_CONT) != 0,
             pyro1_fired:      (raw.pyro_status & PSF_CH1_FIRED) != 0,
             pyro2_fired:      (raw.pyro_status & PSF_CH2_FIRED) != 0,
-            reboot_recovery:  (raw.pyro_status & PSF_REBOOT_RECOVERY) != 0,
-            guidance_enabled: (raw.pyro_status & PSF_GUIDANCE_ENABLED) != 0
+            pyro3_fired:      (raw.pyro_status & PSF_CH3_FIRED) != 0,
+            pyro4_fired:      (raw.pyro_status & PSF_CH4_FIRED) != 0,
+            reboot_recovery:  reboot_recovery,
+            guidance_enabled: guidance_enabled
         )
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -119,12 +119,10 @@ nonisolated struct FlightSettingsData {
 
     let camera_type: UInt8
 
-    let pyro1_enabled: Bool
-    let pyro1_trigger_mode: UInt8   // 0 = time-after-apogee, 1 = altitude-on-descent
-    let pyro1_trigger_value: Float
-    let pyro2_enabled: Bool
-    let pyro2_trigger_mode: UInt8
-    let pyro2_trigger_value: Float
+    // 4 pyro channels (new PCB). Arrays indexed 0..3 → channels 1..4.
+    let pyro_enabled: [Bool]
+    let pyro_trigger_mode: [UInt8]   // 0 = time-after-apogee, 1 = altitude-on-descent
+    let pyro_trigger_value: [Float]
 
     let fw_git_sha: String
     let num_waypoints: UInt8
@@ -138,8 +136,8 @@ nonisolated struct FlightSettingsData {
     var soundsEnabled: Bool { flags & (1 << FlightSettingsData.fSounds) != 0 }
 
     init(from data: Data) throws {
-        guard data.count >= 176 else {
-            throw ParseError.invalidSize(expected: 176, got: data.count)
+        guard data.count >= 188 else {
+            throw ParseError.invalidSize(expected: 188, got: data.count)
         }
 
         var offset = 0
@@ -181,27 +179,33 @@ nonisolated struct FlightSettingsData {
 
         camera_type = data.readUInt8(at: &offset)   // offset 75
 
-        // PyroConfigData (offset 76, 12 bytes)
-        pyro1_enabled = data.readUInt8(at: &offset) != 0
-        pyro1_trigger_mode = data.readUInt8(at: &offset)
-        pyro1_trigger_value = data.readFloat32LE(at: &offset)
-        pyro2_enabled = data.readUInt8(at: &offset) != 0
-        pyro2_trigger_mode = data.readUInt8(at: &offset)
-        pyro2_trigger_value = data.readFloat32LE(at: &offset)
+        // PyroConfigData (offset 76, 24 bytes — 4 channels)
+        var en: [Bool]   = []
+        var mode: [UInt8] = []
+        var val: [Float]  = []
+        en.reserveCapacity(4); mode.reserveCapacity(4); val.reserveCapacity(4)
+        for _ in 0..<4 {
+            en.append(data.readUInt8(at: &offset) != 0)
+            mode.append(data.readUInt8(at: &offset))
+            val.append(data.readFloat32LE(at: &offset))
+        }
+        pyro_enabled = en
+        pyro_trigger_mode = mode
+        pyro_trigger_value = val
 
-        // fw_git_sha: 12-byte NUL-terminated char array (offset 88..99)
+        // fw_git_sha: 12-byte NUL-terminated char array (offset 100..111)
         let shaBytes = data.subdata(in: offset..<(offset + 12))
         fw_git_sha = String(bytes: shaBytes.prefix(while: { $0 != 0 }), encoding: .utf8) ?? ""
         offset += 12
 
-        // roll_profile: RollProfileData @ offset 100
-        let nRaw = data.readUInt8(at: &offset)      // num_waypoints (offset 100)
+        // roll_profile: RollProfileData @ offset 112
+        let nRaw = data.readUInt8(at: &offset)      // num_waypoints (offset 112)
         offset += 3                                  // _pad[3]
         let n = min(Int(nRaw), 8)
         num_waypoints = UInt8(n)
         var wps: [RollWaypointRaw] = []
         wps.reserveCapacity(n)
-        for _ in 0..<n {                             // waypoints @ offset 104, 9 bytes each
+        for _ in 0..<n {                             // waypoints @ offset 116, 9 bytes each
             let t = data.readFloat32LE(at: &offset)
             let a = data.readFloat32LE(at: &offset)
             let m = data.readUInt8(at: &offset)
@@ -409,19 +413,23 @@ nonisolated struct NonSensorData {
     // KF-filtered barometric altitude rate (dm/s = 0.1 m/s)
     let baro_alt_rate_dmps: Int16
 
-    // Pyro channel status bitfield (appended in #34):
-    //   bit 0 PSF_CH1_CONT  — ch1 continuity
-    //   bit 1 PSF_CH2_CONT
-    //   bit 2 PSF_CH1_FIRED
+    // Pyro channel status bitfield — reclaimed for 4 channels (new PCB):
+    //   bit 0 PSF_CH1_CONT
+    //   bit 1 PSF_CH1_FIRED
+    //   bit 2 PSF_CH2_CONT
     //   bit 3 PSF_CH2_FIRED
-    //   bit 4 PSF_REBOOT_RECOVERY  — mid-flight reboot recovery occurred
-    //   bit 5 PSF_GUIDANCE_ENABLED — FC's live guidance_enabled config
+    //   bit 4 PSF_CH3_CONT
+    //   bit 5 PSF_CH3_FIRED
+    //   bit 6 PSF_CH4_CONT
+    //   bit 7 PSF_CH4_FIRED
     let pyro_status: UInt8
 
-    // Apogee detector outputs + master vote (appended in #142/#143):
+    // Apogee detector outputs + master vote + relocated reboot/guidance bits:
     //   bit 0 NSF2_GPS_APOGEE
     //   bit 1 NSF2_PITCH_APOGEE
     //   bit 2 NSF2_MASTER_APOGEE  — voted result driving pyro logic
+    //   bit 3 NSF2_REBOOT_RECOVERY  — moved from pyro_status bit 4
+    //   bit 4 NSF2_GUIDANCE_ENABLED — moved from pyro_status bit 5
     // Older logs (43-byte struct) decode this field as 0.
     let apogee_flags: UInt8
 
@@ -718,12 +726,16 @@ nonisolated struct NonSensorDataSI {
 
     let rocket_state: RocketState
 
-    // Derived from NonSensorData.pyro_status (raw byte is kept here so
-    // downstream consumers can inspect individual bits as needed).
+    // Derived from NonSensorData.pyro_status (4 channels, new PCB).
+    // reboot_recovery and guidance_enabled were relocated to apogee_flags.
     let pyro1_continuity: Bool
     let pyro2_continuity: Bool
+    let pyro3_continuity: Bool
+    let pyro4_continuity: Bool
     let pyro1_fired: Bool
     let pyro2_fired: Bool
+    let pyro3_fired: Bool
+    let pyro4_fired: Bool
     let reboot_recovery: Bool
     let guidance_enabled: Bool
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -110,14 +110,29 @@ struct TelemetryData: Codable {
     var data_status: DataStatus = .live
     var data_age_ms: UInt32 = 0      // only meaningful when .stale
 
-    // Pyro channel status (packed bitfield from "ps" JSON key, decoded in init)
+    // Pyro channel status (packed bitfield from "ps" JSON key, decoded in init).
+    // New PCB: bit 0 = global armed (single shared ARM FET), then per-channel
+    // (cont, fired) pairs for channels 1..4. 9 bits total.
     var pyro_status_bits: Int = 0
-    var pyro1_armed: Bool { (pyro_status_bits & 0x01) != 0 }
-    var pyro1_cont: Bool  { (pyro_status_bits & 0x02) != 0 }
-    var pyro1_fired: Bool { (pyro_status_bits & 0x04) != 0 }
-    var pyro2_armed: Bool { (pyro_status_bits & 0x08) != 0 }
-    var pyro2_cont: Bool  { (pyro_status_bits & 0x10) != 0 }
-    var pyro2_fired: Bool { (pyro_status_bits & 0x20) != 0 }
+    var pyro_armed: Bool { (pyro_status_bits & 0x001) != 0 }
+    var pyro1_cont:  Bool { (pyro_status_bits & 0x002) != 0 }
+    var pyro1_fired: Bool { (pyro_status_bits & 0x004) != 0 }
+    var pyro2_cont:  Bool { (pyro_status_bits & 0x008) != 0 }
+    var pyro2_fired: Bool { (pyro_status_bits & 0x010) != 0 }
+    var pyro3_cont:  Bool { (pyro_status_bits & 0x020) != 0 }
+    var pyro3_fired: Bool { (pyro_status_bits & 0x040) != 0 }
+    var pyro4_cont:  Bool { (pyro_status_bits & 0x080) != 0 }
+    var pyro4_fired: Bool { (pyro_status_bits & 0x100) != 0 }
+    func pyroCont(channel: Int) -> Bool {
+        switch channel { case 1: return pyro1_cont; case 2: return pyro2_cont
+                          case 3: return pyro3_cont; case 4: return pyro4_cont
+                          default: return false }
+    }
+    func pyroFired(channel: Int) -> Bool {
+        switch channel { case 1: return pyro1_fired; case 2: return pyro2_fired
+                          case 3: return pyro3_fired; case 4: return pyro4_fired
+                          default: return false }
+    }
 
     // Short JSON keys → Swift property names (saves ~150 bytes in BLE payload)
     enum CodingKeys: String, CodingKey {
@@ -157,7 +172,7 @@ struct TelemetryData: Codable {
         // Packed flight-status bitfield (replaces lnch/vapo/aapo/land/pwr/
         // cam/log/bslog).  Bit layout mirrors TR_BLE_To_APP.cpp.
         case flight_status_bits = "fs"
-        case pyro_status_bits = "ps"  // packed bitfield: b0=ch1_armed, b1=ch1_cont, b2=ch1_fired, b3=ch2_armed, b4=ch2_cont, b5=ch2_fired
+        case pyro_status_bits = "ps"  // packed bitfield: b0=armed (global), then (cont,fired) per channel 1..4
         case source_rocket_id = "rid"
         case source_unit_name = "run"
         case data_status = "ds"        // #95

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -71,7 +71,8 @@ struct ActiveRocketHeader: View {
         let cam: String = {
             switch p.cameraType { case 1: return "GoPro"; case 2: return "RunCam"; default: return "No cam" }
         }()
-        let pyro = (p.pyro1Enabled || p.pyro2Enabled) ? "Pyro on" : "Pyro off"
+        let anyPyro = p.pyro1Enabled || p.pyro2Enabled || p.pyro3Enabled || p.pyro4Enabled
+        let pyro = anyPyro ? "Pyro on" : "Pyro off"
         let cal = p.magCal == nil ? "Uncalibrated" : "Cal saved"
         return "\(mode) \u{2022} \(cam) \u{2022} \(pyro) \u{2022} \(cal)"
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1381,26 +1381,17 @@ struct PyroChannelsView: View {
             Text("Pyro Channels")
                 .font(.headline)
 
-            HStack(spacing: 10) {
-                pyroTile(
-                    channel: 1,
-                    enabled: device.rocketConfig?.pyro1Enabled ?? false,
-                    armed: device.telemetry.pyro1_armed,
-                    continuity: device.telemetry.pyro1_cont,
-                    fired: device.telemetry.pyro1_fired,
-                    mode: device.rocketConfig?.pyro1TriggerMode ?? 0,
-                    value: device.rocketConfig?.pyro1TriggerValue ?? 0
-                )
-
-                pyroTile(
-                    channel: 2,
-                    enabled: device.rocketConfig?.pyro2Enabled ?? false,
-                    armed: device.telemetry.pyro2_armed,
-                    continuity: device.telemetry.pyro2_cont,
-                    fired: device.telemetry.pyro2_fired,
-                    mode: device.rocketConfig?.pyro2TriggerMode ?? 0,
-                    value: device.rocketConfig?.pyro2TriggerValue ?? 0
-                )
+            // 2x2 grid for the 4 channels. The global "armed" bit (single
+            // shared ARM FET) drives the cont badge visibility for every tile.
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    pyroTileForChannel(1)
+                    pyroTileForChannel(2)
+                }
+                HStack(spacing: 10) {
+                    pyroTileForChannel(3)
+                    pyroTileForChannel(4)
+                }
             }
         }
         .padding()
@@ -1416,6 +1407,30 @@ struct PyroChannelsView: View {
         )) { item in
             PyroTestView(device: device, channel: item.value)
         }
+    }
+
+    /// Pull the right enabled/mode/value for the channel from rocketConfig.
+    private func pyroChannelConfig(_ ch: Int) -> (enabled: Bool, mode: UInt8, value: Float) {
+        guard let cfg = device.rocketConfig else { return (false, 0, 0) }
+        switch ch {
+        case 1: return (cfg.pyro1Enabled, cfg.pyro1TriggerMode, cfg.pyro1TriggerValue)
+        case 2: return (cfg.pyro2Enabled, cfg.pyro2TriggerMode, cfg.pyro2TriggerValue)
+        case 3: return (cfg.pyro3Enabled, cfg.pyro3TriggerMode, cfg.pyro3TriggerValue)
+        case 4: return (cfg.pyro4Enabled, cfg.pyro4TriggerMode, cfg.pyro4TriggerValue)
+        default: return (false, 0, 0)
+        }
+    }
+
+    private func pyroTileForChannel(_ ch: Int) -> some View {
+        let cfg = pyroChannelConfig(ch)
+        return pyroTile(
+            channel: ch,
+            enabled: cfg.enabled,
+            armed: device.telemetry.pyro_armed,
+            continuity: device.telemetry.pyroCont(channel: ch),
+            fired: device.telemetry.pyroFired(channel: ch),
+            mode: cfg.mode,
+            value: cfg.value)
     }
 
     func pyroTile(channel: Int, enabled: Bool, armed: Bool,
@@ -1546,14 +1561,24 @@ struct PyroConfigSheet: View {
 
     func loadCurrent() {
         guard let cfg = device.rocketConfig else { return }
-        if channel == 1 {
+        switch channel {
+        case 1:
             enabled = cfg.pyro1Enabled
             triggerMode = Int(cfg.pyro1TriggerMode)
             triggerValue = formatTriggerValue(cfg.pyro1TriggerValue, mode: triggerMode)
-        } else {
+        case 2:
             enabled = cfg.pyro2Enabled
             triggerMode = Int(cfg.pyro2TriggerMode)
             triggerValue = formatTriggerValue(cfg.pyro2TriggerValue, mode: triggerMode)
+        case 3:
+            enabled = cfg.pyro3Enabled
+            triggerMode = Int(cfg.pyro3TriggerMode)
+            triggerValue = formatTriggerValue(cfg.pyro3TriggerValue, mode: triggerMode)
+        case 4:
+            enabled = cfg.pyro4Enabled
+            triggerMode = Int(cfg.pyro4TriggerMode)
+            triggerValue = formatTriggerValue(cfg.pyro4TriggerValue, mode: triggerMode)
+        default: break
         }
     }
 
@@ -1573,20 +1598,32 @@ struct PyroConfigSheet: View {
     func saveAndSend() {
         let val = parseTriggerValue(triggerValue, mode: triggerMode)
         guard var cfg = device.rocketConfig else { return }
-        if channel == 1 {
+        switch channel {
+        case 1:
             cfg.pyro1Enabled = enabled
             cfg.pyro1TriggerMode = UInt8(triggerMode)
             cfg.pyro1TriggerValue = val
-        } else {
+        case 2:
             cfg.pyro2Enabled = enabled
             cfg.pyro2TriggerMode = UInt8(triggerMode)
             cfg.pyro2TriggerValue = val
+        case 3:
+            cfg.pyro3Enabled = enabled
+            cfg.pyro3TriggerMode = UInt8(triggerMode)
+            cfg.pyro3TriggerValue = val
+        case 4:
+            cfg.pyro4Enabled = enabled
+            cfg.pyro4TriggerMode = UInt8(triggerMode)
+            cfg.pyro4TriggerValue = val
+        default: return
         }
         device.rocketConfig = cfg
-        device.sendPyroConfig(
-            ch1Enabled: cfg.pyro1Enabled, ch1Mode: cfg.pyro1TriggerMode, ch1Value: cfg.pyro1TriggerValue,
-            ch2Enabled: cfg.pyro2Enabled, ch2Mode: cfg.pyro2TriggerMode, ch2Value: cfg.pyro2TriggerValue
-        )
+        device.sendPyroConfig(channels: [
+            (cfg.pyro1Enabled, cfg.pyro1TriggerMode, cfg.pyro1TriggerValue),
+            (cfg.pyro2Enabled, cfg.pyro2TriggerMode, cfg.pyro2TriggerValue),
+            (cfg.pyro3Enabled, cfg.pyro3TriggerMode, cfg.pyro3TriggerValue),
+            (cfg.pyro4Enabled, cfg.pyro4TriggerMode, cfg.pyro4TriggerValue),
+        ])
         // Persist pyro config to the active rocket profile too (#132) so the
         // connect-time syncer doesn't push a stale value back over this edit.
         if let id = store.activeId {
@@ -1597,6 +1634,12 @@ struct PyroConfigSheet: View {
                 $0.pyro2Enabled = cfg.pyro2Enabled
                 $0.pyro2TriggerMode = cfg.pyro2TriggerMode
                 $0.pyro2TriggerValue = cfg.pyro2TriggerValue
+                $0.pyro3Enabled = cfg.pyro3Enabled
+                $0.pyro3TriggerMode = cfg.pyro3TriggerMode
+                $0.pyro3TriggerValue = cfg.pyro3TriggerValue
+                $0.pyro4Enabled = cfg.pyro4Enabled
+                $0.pyro4TriggerMode = cfg.pyro4TriggerMode
+                $0.pyro4TriggerValue = cfg.pyro4TriggerValue
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
@@ -60,7 +60,7 @@ struct PyroTestView: View {
     @State private var camera = SlowMoCameraManager()
 
     private var continuity: Bool {
-        channel == 1 ? device.telemetry.pyro1_cont : device.telemetry.pyro2_cont
+        device.telemetry.pyroCont(channel: channel)
     }
 
     var body: some View {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -46,8 +46,7 @@ struct SettingsView: View {
     @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
 
     // Pyro trigger values edited as strings (seconds or meters by mode).
-    @State private var sPyro1Value = ""
-    @State private var sPyro2Value = ""
+    @State private var sPyroValue: [String] = ["", "", "", ""]
 
     // "Sent" feedback in section headers.
     @State private var servoApplied = false
@@ -106,7 +105,7 @@ struct SettingsView: View {
         case pidKp, pidKi, pidKd, pidMin, pidMax
         case rollDelay
         case wpTime(Int), wpAngle(Int)
-        case pyro1Value, pyro2Value
+        case pyroValue(Int)   // ch index 0..3
     }
 
     private enum EditGroup { case servo, pid, rollControl, rollWaypoints, pyro }
@@ -117,7 +116,7 @@ struct SettingsView: View {
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay: return .rollControl
         case .wpTime, .wpAngle: return .rollWaypoints
-        case .pyro1Value, .pyro2Value: return .pyro
+        case .pyroValue: return .pyro
         case nil: return nil
         }
     }
@@ -344,15 +343,18 @@ struct SettingsView: View {
     private var pyroSections: some View {
         pyroChannelSection(1)
         pyroChannelSection(2)
+        pyroChannelSection(3)
+        pyroChannelSection(4)
         Section {
-            Text("Channels arm automatically at launch. Test continuity and test-fire from the rocket dashboard before flight.")
+            Text("Single shared arm FET arms momentarily for each fire pulse. Test continuity and test-fire from the rocket dashboard before flight.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }
 
     private func pyroChannelSection(_ ch: Int) -> some View {
-        let enabled = (ch == 1) ? profile.pyro1Enabled : profile.pyro2Enabled
-        let mode = Int((ch == 1) ? profile.pyro1TriggerMode : profile.pyro2TriggerMode)
+        let enabled = pyroChannelEnabled(ch)
+        let mode = Int(pyroChannelTriggerMode(ch))
+        let idx = ch - 1
         return Section(header: configHeader("Pyro Channel \(ch)", applied: pyroApplied)) {
             Toggle("Enabled", isOn: pyroEnabledBinding(ch))
             if enabled {
@@ -364,12 +366,11 @@ struct SettingsView: View {
                 HStack {
                     Text(mode == 0 ? "Delay" : "Altitude")
                     Spacer()
-                    TextField(mode == 0 ? "0.0" : "0",
-                              text: (ch == 1) ? $sPyro1Value : $sPyro2Value)
+                    TextField(mode == 0 ? "0.0" : "0", text: $sPyroValue[idx])
                         .keyboardType(.decimalPad)
                         .multilineTextAlignment(.trailing)
                         .frame(width: 80)
-                        .focused($focusedField, equals: (ch == 1) ? .pyro1Value : .pyro2Value)
+                        .focused($focusedField, equals: .pyroValue(idx))
                     Text(mode == 0 ? "s after apogee" : "\(UnitFormatter.altitudeUnit(unitSystem)) on descent")
                         .foregroundColor(.secondary)
                 }
@@ -378,6 +379,68 @@ struct SettingsView: View {
                     : "Fires when the rocket descends through this altitude (AGL).")
                     .font(.caption).foregroundColor(.secondary)
             }
+        }
+    }
+
+    // MARK: - Per-channel profile accessors (centralise the 4-channel switch)
+
+    private func pyroChannelEnabled(_ ch: Int) -> Bool {
+        switch ch {
+        case 1: return profile.pyro1Enabled
+        case 2: return profile.pyro2Enabled
+        case 3: return profile.pyro3Enabled
+        case 4: return profile.pyro4Enabled
+        default: return false
+        }
+    }
+
+    private func pyroChannelTriggerMode(_ ch: Int) -> UInt8 {
+        switch ch {
+        case 1: return profile.pyro1TriggerMode
+        case 2: return profile.pyro2TriggerMode
+        case 3: return profile.pyro3TriggerMode
+        case 4: return profile.pyro4TriggerMode
+        default: return 0
+        }
+    }
+
+    private func pyroChannelTriggerValue(_ ch: Int) -> Float {
+        switch ch {
+        case 1: return profile.pyro1TriggerValue
+        case 2: return profile.pyro2TriggerValue
+        case 3: return profile.pyro3TriggerValue
+        case 4: return profile.pyro4TriggerValue
+        default: return 0
+        }
+    }
+
+    private func setPyroEnabled(_ ch: Int, in p: inout RocketProfile, _ value: Bool) {
+        switch ch {
+        case 1: p.pyro1Enabled = value
+        case 2: p.pyro2Enabled = value
+        case 3: p.pyro3Enabled = value
+        case 4: p.pyro4Enabled = value
+        default: break
+        }
+    }
+
+    private func setPyroMode(_ ch: Int, in p: inout RocketProfile, _ value: UInt8) {
+        switch ch {
+        case 1: p.pyro1TriggerMode = value
+        case 2: p.pyro2TriggerMode = value
+        case 3: p.pyro3TriggerMode = value
+        case 4: p.pyro4TriggerMode = value
+        default: break
+        }
+    }
+
+    private func setPyroValue(_ ch: Int, in p: inout RocketProfile, _ value: Float) {
+        switch ch {
+        case 1: p.pyro1TriggerValue = value
+        case 2: p.pyro2TriggerValue = value
+        case 3: p.pyro3TriggerValue = value
+        case 4: p.pyro4TriggerValue = value
+        default: break
         }
     }
 
@@ -571,23 +634,18 @@ struct SettingsView: View {
     // commits on focus loss via the .pyro EditGroup.
     private func pyroEnabledBinding(_ ch: Int) -> Binding<Bool> {
         Binding(
-            get: { (ch == 1) ? profile.pyro1Enabled : profile.pyro2Enabled },
+            get: { pyroChannelEnabled(ch) },
             set: { newValue in
-                updateProfile {
-                    if ch == 1 { $0.pyro1Enabled = newValue } else { $0.pyro2Enabled = newValue }
-                }
+                updateProfile { setPyroEnabled(ch, in: &$0, newValue) }
                 applyPyroConfig()
             })
     }
 
     private func pyroModeBinding(_ ch: Int) -> Binding<Int> {
         Binding(
-            get: { Int((ch == 1) ? profile.pyro1TriggerMode : profile.pyro2TriggerMode) },
+            get: { Int(pyroChannelTriggerMode(ch)) },
             set: { newValue in
-                updateProfile {
-                    if ch == 1 { $0.pyro1TriggerMode = UInt8(newValue) }
-                    else { $0.pyro2TriggerMode = UInt8(newValue) }
-                }
+                updateProfile { setPyroMode(ch, in: &$0, UInt8(newValue)) }
                 reloadPyroValueStrings()   // reformat for the new unit (s vs m)
                 applyPyroConfig()
             })
@@ -617,9 +675,10 @@ struct SettingsView: View {
     }
 
     private func reloadPyroValueStrings() {
-        let p = profile
-        sPyro1Value = formatPyro(p.pyro1TriggerValue, mode: p.pyro1TriggerMode)
-        sPyro2Value = formatPyro(p.pyro2TriggerValue, mode: p.pyro2TriggerMode)
+        for ch in 1...4 {
+            sPyroValue[ch - 1] = formatPyro(pyroChannelTriggerValue(ch),
+                                             mode: pyroChannelTriggerMode(ch))
+        }
     }
 
     /// Time-after-apogee shows one decimal (seconds); altitude is stored in
@@ -722,17 +781,25 @@ struct SettingsView: View {
     }
 
     private func applyPyroConfig() {
-        let v1 = parsePyroValue(sPyro1Value, mode: profile.pyro1TriggerMode, fallback: profile.pyro1TriggerValue)
-        let v2 = parsePyroValue(sPyro2Value, mode: profile.pyro2TriggerMode, fallback: profile.pyro2TriggerValue)
+        // Parse all four text fields back to canonical units, then push.
+        var parsed: [Float] = [0, 0, 0, 0]
+        for ch in 1...4 {
+            parsed[ch - 1] = parsePyroValue(
+                sPyroValue[ch - 1],
+                mode: pyroChannelTriggerMode(ch),
+                fallback: pyroChannelTriggerValue(ch))
+        }
         updateProfile {
-            $0.pyro1TriggerValue = v1
-            $0.pyro2TriggerValue = v2
+            for ch in 1...4 { setPyroValue(ch, in: &$0, parsed[ch - 1]) }
         }
         let p = profile
         if device.isConnected {
-            device.sendPyroConfig(
-                ch1Enabled: p.pyro1Enabled, ch1Mode: p.pyro1TriggerMode, ch1Value: p.pyro1TriggerValue,
-                ch2Enabled: p.pyro2Enabled, ch2Mode: p.pyro2TriggerMode, ch2Value: p.pyro2TriggerValue)
+            device.sendPyroConfig(channels: [
+                (p.pyro1Enabled, p.pyro1TriggerMode, p.pyro1TriggerValue),
+                (p.pyro2Enabled, p.pyro2TriggerMode, p.pyro2TriggerValue),
+                (p.pyro3Enabled, p.pyro3TriggerMode, p.pyro3TriggerValue),
+                (p.pyro4Enabled, p.pyro4TriggerMode, p.pyro4TriggerValue),
+            ])
             // Mirror into rocketConfig so the dashboard pyro tiles update live.
             if var cfg = device.rocketConfig {
                 cfg.pyro1Enabled = p.pyro1Enabled
@@ -741,6 +808,12 @@ struct SettingsView: View {
                 cfg.pyro2Enabled = p.pyro2Enabled
                 cfg.pyro2TriggerMode = p.pyro2TriggerMode
                 cfg.pyro2TriggerValue = p.pyro2TriggerValue
+                cfg.pyro3Enabled = p.pyro3Enabled
+                cfg.pyro3TriggerMode = p.pyro3TriggerMode
+                cfg.pyro3TriggerValue = p.pyro3TriggerValue
+                cfg.pyro4Enabled = p.pyro4Enabled
+                cfg.pyro4TriggerMode = p.pyro4TriggerMode
+                cfg.pyro4TriggerValue = p.pyro4TriggerValue
                 device.rocketConfig = cfg
             }
         }

--- a/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
@@ -179,9 +179,10 @@ final class MessageParserTests: XCTestCase {
     private func leI16(_ v: Int16) -> [UInt8] { leU16(UInt16(bitPattern: v)) }
     private func leF32(_ v: Float) -> [UInt8] { leU32(v.bitPattern) }
 
-    /// Build a known 176-byte FlightSettingsData payload and verify the decode
-    /// + JSON mapping. Offsets here must match the C++ struct (locked by the
-    /// FlightSettingsData_Layout test in tests_cpp).
+    /// Build a known 188-byte FlightSettingsData payload (post 4-channel
+    /// pyro layout) and verify the decode + JSON mapping. Offsets here must
+    /// match the C++ struct (locked by the FlightSettingsData_Layout test
+    /// in tests_cpp).
     func testFlightSettingsDecode() throws {
         var p: [UInt8] = []
         p += leU32(123456)        // time_us @0
@@ -211,15 +212,17 @@ final class MessageParserTests: XCTestCase {
         p.append(2)               // camera_type @75 (runcam)
         p.append(1); p.append(0); p += leF32(1.5)   // pyro ch1 @76: enabled, time mode, 1.5 s
         p.append(1); p.append(1); p += leF32(100)    // pyro ch2 @82: enabled, altitude mode, 100 m
-        let sha = Array("abc1234".utf8)              // fw_git_sha @88 (12 bytes)
+        p.append(0); p.append(0); p += leF32(0)      // pyro ch3 @88: disabled
+        p.append(1); p.append(0); p += leF32(2.5)    // pyro ch4 @94: enabled, time mode, 2.5 s
+        let sha = Array("abc1234".utf8)              // fw_git_sha @100 (12 bytes)
         p += sha + [UInt8](repeating: 0, count: 12 - sha.count)
-        p.append(2)               // num_waypoints @100
-        p += [0, 0, 0]            // _pad @101
-        p += leF32(0.5); p += leF32(0); p.append(1)      // wp0 @104: 0.5 s, 0°, null_rate
+        p.append(2)               // num_waypoints @112
+        p += [0, 0, 0]            // _pad @113
+        p += leF32(0.5); p += leF32(0); p.append(1)      // wp0 @116: 0.5 s, 0°, null_rate
         p += leF32(1.0); p += leF32(180); p.append(0)    // wp1: 1.0 s, 180°, angle
         p += [UInt8](repeating: 0, count: 6 * 9)         // remaining 6 zero waypoint slots
 
-        XCTAssertEqual(p.count, 176)
+        XCTAssertEqual(p.count, 188)
 
         let raw = try FlightSettingsData(from: Data(p))
         XCTAssertEqual(raw.time_us, 123456)
@@ -251,12 +254,12 @@ final class MessageParserTests: XCTestCase {
         XCTAssertEqual(raw.servo_min_us, 1250)
         XCTAssertEqual(raw.servo_max_us, 1750)
         XCTAssertEqual(raw.camera_type, 2)
-        XCTAssertTrue(raw.pyro1_enabled)
-        XCTAssertEqual(raw.pyro1_trigger_mode, 0)
-        XCTAssertEqual(raw.pyro1_trigger_value, 1.5, accuracy: 1e-4)
-        XCTAssertTrue(raw.pyro2_enabled)
-        XCTAssertEqual(raw.pyro2_trigger_mode, 1)
-        XCTAssertEqual(raw.pyro2_trigger_value, 100, accuracy: 1e-4)
+        XCTAssertEqual(raw.pyro_enabled,        [true, true, false, true])
+        XCTAssertEqual(raw.pyro_trigger_mode,   [0, 1, 0, 0])
+        XCTAssertEqual(raw.pyro_trigger_value[0], 1.5, accuracy: 1e-4)
+        XCTAssertEqual(raw.pyro_trigger_value[1], 100, accuracy: 1e-4)
+        XCTAssertEqual(raw.pyro_trigger_value[2], 0,   accuracy: 1e-4)
+        XCTAssertEqual(raw.pyro_trigger_value[3], 2.5, accuracy: 1e-4)
         XCTAssertEqual(raw.fw_git_sha, "abc1234")
         XCTAssertEqual(raw.num_waypoints, 2)
         XCTAssertEqual(raw.waypoints.count, 2)
@@ -280,9 +283,12 @@ final class MessageParserTests: XCTestCase {
         XCTAssertEqual(s.pyro.ch1.trigger_mode, "time_after_apogee")
         XCTAssertEqual(s.pyro.ch1.trigger_value, 1.5, accuracy: 1e-6)
         XCTAssertEqual(s.pyro.ch2.trigger_mode, "altitude_on_descent")
+        XCTAssertFalse(s.pyro.ch3.enabled)
+        XCTAssertTrue(s.pyro.ch4.enabled)
+        XCTAssertEqual(s.pyro.ch4.trigger_value, 2.5, accuracy: 1e-6)
         XCTAssertEqual(s.imu.gyro_fs_dps, 4000)
 
         // Undersized payload is rejected.
-        XCTAssertThrowsError(try FlightSettingsData(from: Data(p.prefix(175))))
+        XCTAssertThrowsError(try FlightSettingsData(from: Data(p.prefix(187))))
     }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -31,34 +31,55 @@ TEST(RocketComputerTypes, KnownSizes) {
 }
 
 TEST(RocketComputerTypes, NSF_FlagBits_NoOverlap) {
-    // All NonSensorData flag bits must be distinct
+    // bits 0-6 used; bit 7 reserved post per-fire-arming refactor.
     uint8_t all = NSF_ALT_LANDED | NSF_ALT_APOGEE | NSF_VEL_APOGEE |
                   NSF_LAUNCH | NSF_BURNOUT | NSF_GUIDANCE |
-                  NSF_PYRO1_ARMED | NSF_PYRO2_ARMED;
-    EXPECT_EQ(all, 0xFF); // all 8 bits used, none overlapping
+                  NSF_PYRO_ARMED;
+    EXPECT_EQ(all, 0x7F);
+    EXPECT_EQ(__builtin_popcount(NSF_PYRO_ARMED), 1);
+    EXPECT_EQ(NSF_PYRO_ARMED, 1u << 6);
 }
 
 TEST(RocketComputerTypes, NSF2_ApogeeFlagBits_NoOverlap) {
-    // apogee_flags byte (#142/#143) — three bits in use today.
-    uint8_t all = NSF2_GPS_APOGEE | NSF2_PITCH_APOGEE | NSF2_MASTER_APOGEE;
-    EXPECT_EQ(all, 0x07);
-    EXPECT_EQ(__builtin_popcount(NSF2_GPS_APOGEE),    1);
-    EXPECT_EQ(__builtin_popcount(NSF2_PITCH_APOGEE),  1);
-    EXPECT_EQ(__builtin_popcount(NSF2_MASTER_APOGEE), 1);
+    // apogee_flags byte: 3 apogee detector bits + 2 relocated signals
+    // (reboot_recovery, guidance_enabled) that used to live in pyro_status.
+    uint8_t all = NSF2_GPS_APOGEE | NSF2_PITCH_APOGEE | NSF2_MASTER_APOGEE |
+                  NSF2_REBOOT_RECOVERY | NSF2_GUIDANCE_ENABLED;
+    EXPECT_EQ(all, 0x1F);  // bits 0-4 used
+    EXPECT_EQ(__builtin_popcount(NSF2_GPS_APOGEE),       1);
+    EXPECT_EQ(__builtin_popcount(NSF2_PITCH_APOGEE),     1);
+    EXPECT_EQ(__builtin_popcount(NSF2_MASTER_APOGEE),    1);
+    EXPECT_EQ(__builtin_popcount(NSF2_REBOOT_RECOVERY),  1);
+    EXPECT_EQ(__builtin_popcount(NSF2_GUIDANCE_ENABLED), 1);
 }
 
 TEST(RocketComputerTypes, PSF_FlagBits_NoOverlap) {
-    uint8_t all = PSF_CH1_CONT | PSF_CH2_CONT | PSF_CH1_FIRED | PSF_CH2_FIRED |
-                  PSF_REBOOT_RECOVERY | PSF_GUIDANCE_ENABLED;
-    // Bits 0-5 used, no overlap
-    EXPECT_EQ(all, 0x3F);
-    // Each is a single bit
-    EXPECT_EQ(__builtin_popcount(PSF_CH1_CONT),         1);
-    EXPECT_EQ(__builtin_popcount(PSF_CH2_CONT),         1);
-    EXPECT_EQ(__builtin_popcount(PSF_CH1_FIRED),        1);
-    EXPECT_EQ(__builtin_popcount(PSF_CH2_FIRED),        1);
-    EXPECT_EQ(__builtin_popcount(PSF_REBOOT_RECOVERY),  1);
-    EXPECT_EQ(__builtin_popcount(PSF_GUIDANCE_ENABLED), 1);
+    // pyro_status is now exclusively pyro: 4 channels × (cont, fired).
+    uint8_t all = PSF_CH1_CONT | PSF_CH1_FIRED |
+                  PSF_CH2_CONT | PSF_CH2_FIRED |
+                  PSF_CH3_CONT | PSF_CH3_FIRED |
+                  PSF_CH4_CONT | PSF_CH4_FIRED;
+    EXPECT_EQ(all, 0xFF);  // all 8 bits used, none overlapping
+    EXPECT_EQ(__builtin_popcount(PSF_CH1_CONT),  1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH1_FIRED), 1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH2_CONT),  1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH2_FIRED), 1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH3_CONT),  1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH3_FIRED), 1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH4_CONT),  1);
+    EXPECT_EQ(__builtin_popcount(PSF_CH4_FIRED), 1);
+}
+
+TEST(RocketComputerTypes, PyroConfigData_FourChannelLayout) {
+    // 4 channels × (1 enabled + 1 mode + 4 value) = 24 bytes.
+    EXPECT_EQ(sizeof(PyroConfigData), 24u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch1_enabled),       0u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch1_trigger_mode),  1u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch1_trigger_value), 2u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch2_enabled),       6u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch3_enabled),       12u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch4_enabled),       18u);
+    EXPECT_EQ(offsetof(PyroConfigData, ch4_trigger_value), 20u);
 }
 
 TEST(RocketComputerTypes, MaxPayload_CoversAllTypes) {
@@ -768,7 +789,7 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
 // by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
 // here so a struct edit can't silently desync the cross-language decode.
 TEST(RocketComputerTypes, FlightSettingsData_Layout) {
-    EXPECT_EQ(sizeof(FlightSettingsData), 176u);
+    EXPECT_EQ(sizeof(FlightSettingsData), 188u);  // +12 vs pre-4ch pyro
     EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
 
     EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
@@ -789,16 +810,19 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
     EXPECT_EQ(offsetof(FlightSettingsData, servo_max_us),       73u);
     EXPECT_EQ(offsetof(FlightSettingsData, camera_type),        75u);
     EXPECT_EQ(offsetof(FlightSettingsData, pyro),               76u);
-    EXPECT_EQ(offsetof(FlightSettingsData, fw_git_sha),         88u);
-    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile),       100u);
+    EXPECT_EQ(offsetof(FlightSettingsData, fw_git_sha),         100u);  // 76 + 24
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile),       112u);
 
     // Embedded PyroConfigData reaches the right absolute offsets.
     EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch1_trigger_value), 78u);
     EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch2_enabled),       82u);
     EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch2_trigger_value), 84u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch3_enabled),       88u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch4_enabled),       94u);
+    EXPECT_EQ(offsetof(FlightSettingsData, pyro) + offsetof(PyroConfigData, ch4_trigger_value), 96u);
 
-    // Roll profile waypoints start (RollProfileData @ 100, after num+pad).
-    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile) + offsetof(RollProfileData, waypoints), 104u);
+    // Roll profile waypoints start (RollProfileData @ 112, after num+pad).
+    EXPECT_EQ(offsetof(FlightSettingsData, roll_profile) + offsetof(RollProfileData, waypoints), 116u);
 }
 
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1147,15 +1147,20 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
         addInt("fs", fs);
     }
 
-    // Pyro channel status — packed into single byte to minimize JSON size
+    // Pyro channel status — 9 bits packed into one JSON int. New-PCB
+    // layout: bit 0 = global armed (single ARM FET), then per-channel
+    // (cont, fired) pairs for channels 1..4. Omitted when all zero.
     {
-        uint8_t ps = (data.pyro1_armed ? 0x01 : 0)
-                   | (data.pyro1_cont  ? 0x02 : 0)
-                   | (data.pyro1_fired ? 0x04 : 0)
-                   | (data.pyro2_armed ? 0x08 : 0)
-                   | (data.pyro2_cont  ? 0x10 : 0)
-                   | (data.pyro2_fired ? 0x20 : 0);
-        if (ps != 0) { addInt("ps", ps); }
+        uint32_t ps = data.pyro_armed ? 0x001u : 0u;
+        if (data.pyro_cont[0])  ps |= 0x002u;
+        if (data.pyro_fired[0]) ps |= 0x004u;
+        if (data.pyro_cont[1])  ps |= 0x008u;
+        if (data.pyro_fired[1]) ps |= 0x010u;
+        if (data.pyro_cont[2])  ps |= 0x020u;
+        if (data.pyro_fired[2]) ps |= 0x040u;
+        if (data.pyro_cont[3])  ps |= 0x080u;
+        if (data.pyro_fired[3]) ps |= 0x100u;
+        if (ps != 0) { addInt("ps", (int)ps); }
     }
 
     // Source rocket identity (base station relay only)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -84,13 +84,12 @@ public:
         // Power rail state
         bool pwr_pin_on;        // true = FlightComputer + sensors powered on
 
-        // Pyro channel status
-        bool pyro1_armed;
-        bool pyro1_cont;        // true = continuity OK (load present)
-        bool pyro1_fired;
-        bool pyro2_armed;
-        bool pyro2_cont;
-        bool pyro2_fired;
+        // Pyro channel status — new PCB shares one ARM FET across 4
+        // channels, so "armed" is a single global bit mirroring the live
+        // ARM-pin state (HIGH only during a cont test or fire pulse).
+        bool pyro_armed;
+        bool pyro_cont[4];      // true = continuity OK (load present, closed)
+        bool pyro_fired[4];
 
         // Source rocket identity (base station only — for multi-rocket demux)
         uint8_t source_rocket_id;       // 0 = not set (direct connection)

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -175,7 +175,8 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         return false;
     };
 
-    // Bootstrap from preferred UART rate first, then fall back as needed.
+    // Bootstrap from preferred UART rate first (warm-boot fast path: module
+    // already configured at preferred_baud from a previous run).
     ESP_LOGI(TAG, "Bootstrap try %lu baud", (unsigned long)bootstrap_baud);
     uartBegin(bootstrap_baud, GNSS_RX, GNSS_TX);
     delay(80);
@@ -186,7 +187,50 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         active_tx = GNSS_TX;
     }
 
-    // Keep trying until we can talk UBX at some baud.
+    // Fast cold-boot orientation probe: u-blox modules power up at 9600 baud
+    // (factory default). A ~650 ms listen at 9600 on each orientation finds
+    // which way the RX/TX is wired and short-circuits the slow ~30 s
+    // baud-cycle scan on the wrong orientation. Works for both schematic-
+    // labeled boards (default orientation) and rev's where RX/TX are swapped.
+    if (connected_baud == 0U)
+    {
+        uint8_t probe_rx = GNSS_RX;
+        uint8_t probe_tx = GNSS_TX;
+        bool    detected = false;
+        bool    swapped  = false;
+
+        if (hasSerialActivity(GNSS_RX, GNSS_TX, 9600U))
+        {
+            detected = true;
+        }
+        else if ((GNSS_RX != GNSS_TX) && hasSerialActivity(GNSS_TX, GNSS_RX, 9600U))
+        {
+            detected = true;
+            swapped  = true;
+            probe_rx = GNSS_TX;
+            probe_tx = GNSS_RX;
+        }
+
+        if (detected)
+        {
+            if (swapped)
+            {
+                ESP_LOGW(TAG, "Quick probe: activity at 9600 on swapped RX/TX "
+                              "(RX=%d TX=%d)", probe_rx, probe_tx);
+            }
+            uint32_t probe_found = 0U;
+            if (scanAndConnectPins(probe_rx, probe_tx, probe_found))
+            {
+                connected_baud = probe_found;
+                // active_rx/tx set inside scanAndConnectPins
+            }
+        }
+    }
+
+    // Fall-back full-scan loop. Stays as a safety net for the case where
+    // the quick orientation probe fails (e.g. module powered on at a
+    // non-default baud and the activity probe at 9600 saw nothing, or the
+    // initial UBX handshake never completes despite serial activity).
     uint8_t scan_attempt = 0;
     while ((connected_baud == 0U) && !scanAndConnect(connected_baud))
     {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -969,24 +969,29 @@ static constexpr uint8_t NSF_VEL_APOGEE   = (1u << 2);
 static constexpr uint8_t NSF_LAUNCH       = (1u << 3);
 static constexpr uint8_t NSF_BURNOUT      = (1u << 4);
 static constexpr uint8_t NSF_GUIDANCE     = (1u << 5);
-static constexpr uint8_t NSF_PYRO1_ARMED  = (1u << 6);
-static constexpr uint8_t NSF_PYRO2_ARMED  = (1u << 7);
+// New-PCB pyro: single shared arming FET drives all four channels, so
+// only one global "armed" bit is reported. Live-mirrors the ARM pin.
+static constexpr uint8_t NSF_PYRO_ARMED   = (1u << 6);
+// bit 7 reserved
 
 // NonSensorData.apogee_flags bit masks (appended in #142/#143).
-static constexpr uint8_t NSF2_GPS_APOGEE     = (1u << 0);
-static constexpr uint8_t NSF2_PITCH_APOGEE   = (1u << 1);
-static constexpr uint8_t NSF2_MASTER_APOGEE  = (1u << 2);
+static constexpr uint8_t NSF2_GPS_APOGEE       = (1u << 0);
+static constexpr uint8_t NSF2_PITCH_APOGEE     = (1u << 1);
+static constexpr uint8_t NSF2_MASTER_APOGEE    = (1u << 2);
+// Relocated from pyro_status when that byte was reclaimed for the
+// 4-channel pyro layout.
+static constexpr uint8_t NSF2_REBOOT_RECOVERY  = (1u << 3);  // mid-flight reboot recovery occurred
+static constexpr uint8_t NSF2_GUIDANCE_ENABLED = (1u << 4);  // FC's live guidance_enabled config
 
-// Pyro status byte bit masks
+// Pyro status byte — 4 channels × (continuity, fired) = exactly 8 bits.
 static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);
-static constexpr uint8_t PSF_CH2_CONT  = (1u << 1);
-static constexpr uint8_t PSF_CH1_FIRED = (1u << 2);
+static constexpr uint8_t PSF_CH1_FIRED = (1u << 1);
+static constexpr uint8_t PSF_CH2_CONT  = (1u << 2);
 static constexpr uint8_t PSF_CH2_FIRED = (1u << 3);
-static constexpr uint8_t PSF_REBOOT_RECOVERY = (1u << 4);  // mid-flight reboot recovery occurred
-// Reuse of this byte for a non-pyro signal: the FlightComputer's live
-// guidance_enabled config. OutComputer uses this as the source of truth
-// to avoid iOS/OUT/FC NVS caches silently diverging.
-static constexpr uint8_t PSF_GUIDANCE_ENABLED = (1u << 5);
+static constexpr uint8_t PSF_CH3_CONT  = (1u << 4);
+static constexpr uint8_t PSF_CH3_FIRED = (1u << 5);
+static constexpr uint8_t PSF_CH4_CONT  = (1u << 6);
+static constexpr uint8_t PSF_CH4_FIRED = (1u << 7);
 
 typedef struct
 {
@@ -1330,7 +1335,7 @@ enum PyroTriggerMode : uint8_t {
     PYRO_TRIGGER_ALTITUDE_ON_DESCENT  = 1,
 };
 
-// Pyro channel configuration (both channels, 12 bytes)
+// Pyro channel configuration — 4 channels × (enabled, mode, value) = 24 bytes
 typedef struct __attribute__((packed))
 {
     uint8_t  ch1_enabled;       // 0 = disabled, 1 = enabled
@@ -1339,8 +1344,14 @@ typedef struct __attribute__((packed))
     uint8_t  ch2_enabled;
     uint8_t  ch2_trigger_mode;
     float    ch2_trigger_value;
+    uint8_t  ch3_enabled;
+    uint8_t  ch3_trigger_mode;
+    float    ch3_trigger_value;
+    uint8_t  ch4_enabled;
+    uint8_t  ch4_trigger_mode;
+    float    ch4_trigger_value;
 } PyroConfigData;
-static_assert(sizeof(PyroConfigData) == 12, "PyroConfigData must be 12 bytes");
+static_assert(sizeof(PyroConfigData) == 24, "PyroConfigData must be 24 bytes");
 
 // Packed config data structures for BLE → I2C relay
 typedef struct __attribute__((packed))
@@ -1488,7 +1499,7 @@ struct __attribute__((packed)) FlightSettingsData
     // Camera (0 = none, 1 = GoPro, 2 = RunCam)
     uint8_t  camera_type;
 
-    // Pyro channel config (both channels)
+    // Pyro channel config (all four channels)
     PyroConfigData pyro;
 
     // Firmware identity: git short SHA, NUL-terminated ("unknown" if no git)
@@ -1497,7 +1508,7 @@ struct __attribute__((packed)) FlightSettingsData
     // Active roll profile (num_waypoints == 0 → rate-only)
     RollProfileData roll_profile;
 };
-static_assert(sizeof(FlightSettingsData) == 176, "FlightSettingsData layout check");
+static_assert(sizeof(FlightSettingsData) == 188, "FlightSettingsData layout check");
 
 // --- Guidance Telemetry Data (sent at ~10 Hz during coast) ---
 typedef struct __attribute__((packed))
@@ -1532,7 +1543,7 @@ static_assert(sizeof(GuidanceTelemData) == 15, "GuidanceTelemData must be 15 byt
 struct __attribute__((packed)) FlightSnapshotData
 {
     static constexpr uint32_t MAGIC   = 0xF1A75A7E;  // distinct from old NVS magic (0xF1A7C0DE)
-    static constexpr uint8_t  VERSION = 1;           // bumped from old NVS struct on format change
+    static constexpr uint8_t  VERSION = 2;           // v2: 4-channel pyro layout, no per-channel ARM
 
     // --- Header ---
     uint32_t magic;
@@ -1546,11 +1557,15 @@ struct __attribute__((packed)) FlightSnapshotData
     uint32_t burnout_elapsed_ms;
 
     // --- Pyro state (safety-critical) ---
+    // "Armed" is no longer snapshotted: with per-fire arming, the ARM
+    // pin is only HIGH momentarily, and a reboot leaves it LOW anyway.
+    // On recovery we re-fire any unfired channel whose trigger condition
+    // is still satisfied.
     uint8_t  pyro_apogee_detected;
-    uint8_t  pyro1_armed;
     uint8_t  pyro1_fired;
-    uint8_t  pyro2_armed;
     uint8_t  pyro2_fired;
+    uint8_t  pyro3_fired;
+    uint8_t  pyro4_fired;
     uint8_t  pad2[3];
 
     // --- Flight references ---

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -37,11 +37,7 @@ struct config
     // ### Sensors to use ###
     static constexpr bool USE_BMP585 = true;
     static constexpr bool USE_MMC5983MA = true;
-    // BENCH-ONLY: GNSS bootstrap blocks the init thread cycling through
-    // baud rates when the receiver is unpowered/unresponsive — preventing
-    // the FC from ever reaching READY. Flip to true before merging — the
-    // flight build needs GNSS.
-    static constexpr bool USE_GNSS = false;
+    static constexpr bool USE_GNSS = true;
     static constexpr bool USE_ISM6HG256 = true;
     // When USE_MMC5983MA is true, the magnetometer slot first probes for
     // an IIS2MDC over I2C; if not detected, the MMC5983MA SPI path runs.

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -13,8 +13,14 @@ struct config
     static constexpr uint32_t SPI_SPEED = 10'000'000; // 10 MHz
 
     // ### GNSS Serial Pins ###
-    static constexpr uint8_t GNSS_RX = 3;  // 3
-    static constexpr uint8_t GNSS_TX = 4;
+    // New PCB has the schematic-labeled RX/TX swapped at the GPS module.
+    // Driver auto-detects the swap as a fallback, but starting with the
+    // wrong orientation costs ~30 s of baud-cycling on every boot.
+    // Pre-swap here so the first probe matches the wiring.
+    //   FC GPIO 4 -> GPS module TX (FC receives)
+    //   FC GPIO 3 -> GPS module RX (FC transmits)
+    static constexpr uint8_t GNSS_RX = 4;
+    static constexpr uint8_t GNSS_TX = 3;
     // Optional GNSS control pins. Set to -1 if not wired.
     static constexpr int8_t GNSS_RESET_N = -1;
     static constexpr int8_t GNSS_SAFEBOOT_N = -1;

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -13,14 +13,11 @@ struct config
     static constexpr uint32_t SPI_SPEED = 10'000'000; // 10 MHz
 
     // ### GNSS Serial Pins ###
-    // New PCB has the schematic-labeled RX/TX swapped at the GPS module.
-    // Driver auto-detects the swap as a fallback, but starting with the
-    // wrong orientation costs ~30 s of baud-cycling on every boot.
-    // Pre-swap here so the first probe matches the wiring.
-    //   FC GPIO 4 -> GPS module TX (FC receives)
-    //   FC GPIO 3 -> GPS module RX (FC transmits)
-    static constexpr uint8_t GNSS_RX = 4;
-    static constexpr uint8_t GNSS_TX = 3;
+    // Schematic-labeled wiring. The driver auto-detects the RX/TX swap on
+    // boards where the labeling is reversed (current rocket-computer rev
+    // has them swapped) via a fast 9600-baud activity probe at boot.
+    static constexpr uint8_t GNSS_RX = 3;
+    static constexpr uint8_t GNSS_TX = 4;
     // Optional GNSS control pins. Set to -1 if not wired.
     static constexpr int8_t GNSS_RESET_N = -1;
     static constexpr int8_t GNSS_SAFEBOOT_N = -1;

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -109,13 +109,22 @@ struct config
     static constexpr uint32_t RUNCAM_BAUD = 115200;
 
     // ### Pyro Channel Pins ###
-    static constexpr uint8_t PYRO1_ARM_PIN  = 14;
-    static constexpr uint8_t PYRO1_FIRE_PIN = 15;
-    static constexpr uint8_t PYRO1_CONT_PIN = 16;
-    static constexpr uint8_t PYRO2_ARM_PIN  = 22;
-    static constexpr uint8_t PYRO2_FIRE_PIN = 18;
-    static constexpr uint8_t PYRO2_CONT_PIN = 19;
-    static constexpr uint32_t PYRO_FIRE_DURATION_MS = 500;
+    // New PCB: one shared arming FET feeds all four squib drivers.
+    // ARM is raised only momentarily — for the PRELAUNCH continuity
+    // check and again during a fire pulse — never latched in flight.
+    static constexpr uint8_t PYRO_ARM_PIN   = 14;
+    static constexpr uint8_t PYRO1_CONT_PIN = 15;
+    static constexpr uint8_t PYRO1_FIRE_PIN = 16;
+    static constexpr uint8_t PYRO2_CONT_PIN = 18;
+    static constexpr uint8_t PYRO2_FIRE_PIN = 19;
+    static constexpr uint8_t PYRO3_CONT_PIN = 38;
+    static constexpr uint8_t PYRO3_FIRE_PIN = 34;
+    static constexpr uint8_t PYRO4_CONT_PIN = 51;
+    static constexpr uint8_t PYRO4_FIRE_PIN = 50;
+    static constexpr uint32_t PYRO_FIRE_DURATION_MS    = 500;
+    // Time between raising ARM and reading CONT / pulsing FIRE, giving
+    // the upstream arming FET its turn-on settle margin.
+    static constexpr uint32_t PYRO_ARM_SETTLE_MS       = 10;
 
     // ### Servo Controls (placeholder pins) ###
     // Set these to valid GPIOs for your board.

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -37,7 +37,11 @@ struct config
     // ### Sensors to use ###
     static constexpr bool USE_BMP585 = true;
     static constexpr bool USE_MMC5983MA = true;
-    static constexpr bool USE_GNSS = true;
+    // BENCH-ONLY: GNSS bootstrap blocks the init thread cycling through
+    // baud rates when the receiver is unpowered/unresponsive — preventing
+    // the FC from ever reaching READY. Flip to true before merging — the
+    // flight build needs GNSS.
+    static constexpr bool USE_GNSS = false;
     static constexpr bool USE_ISM6HG256 = true;
     // When USE_MMC5983MA is true, the magnetometer slot first probes for
     // an IIS2MDC over I2C; if not detected, the MMC5983MA SPI path runs.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -319,10 +319,10 @@ static bool          pyro_arm_pin_state   = false;   // last value driven onto P
 static bool          pyro_apogee_detected = false;
 static uint32_t      pyro_apogee_time_ms  = 0;
 
-// PRELAUNCH-edge continuity diagnostic — momentary ARM, read all 4 CONT, disarm.
-enum class PyroPrelaunchPhase : uint8_t { Idle, Settle, Done };
-static PyroPrelaunchPhase pyro_prelaunch_phase   = PyroPrelaunchPhase::Idle;
-static uint32_t           pyro_prelaunch_next_ms = 0;
+// PRELAUNCH-edge continuity check: on the new PCB the CONT divider is fed
+// from VPP (always on) and is independent of the shared ARM rail, so we
+// just sample the four CONT pins directly — no ARM pulse, no settle delay,
+// no state machine.
 // --- Inflight reboot recovery ---
 // Snapshot of critical flight state, sent to OC over I2S at 10 Hz during
 // INFLIGHT and stored in OC's MRAM.  On unexpected reboot (brownout,
@@ -741,33 +741,17 @@ static void pyroSafeAll()
         pyro_ch[i].phase_start_ms = 0;
     }
     pyroSetArmLocked(false);
-    pyro_prelaunch_phase   = PyroPrelaunchPhase::Idle;
-    pyro_prelaunch_next_ms = 0;
     portEXIT_CRITICAL(&pyro_spinlock);
     ESP_LOGI(TAG, "[PYRO] All channels safed");
 }
 
-// PRELAUNCH continuity test: raise ARM, wait settle, read all 4 CONT, lower
-// ARM. Non-blocking — pyroPrelaunchContTest() schedules and
-// servicePyroPrelaunchDiag() advances on each main-loop tick.
-static void pyroPrelaunchContTest(uint32_t now_ms)
+// PRELAUNCH continuity check. Sample all four CONT pins directly and cache
+// the result. Synchronous — no ARM pulse, no settle delay, no state machine.
+// The new PCB feeds the CONT divider from VPP (always on), so ARM is not
+// part of the cont sense path.
+static void pyroPrelaunchContTest(uint32_t /*now_ms*/)
 {
-    if (pyro_prelaunch_phase != PyroPrelaunchPhase::Idle) return;
-    portENTER_CRITICAL(&pyro_spinlock);
-    pyroSetArmLocked(true);
-    portEXIT_CRITICAL(&pyro_spinlock);
-    pyro_prelaunch_phase   = PyroPrelaunchPhase::Settle;
-    pyro_prelaunch_next_ms = now_ms + config::PYRO_ARM_SETTLE_MS;
-    ESP_LOGI(TAG, "[PYRO] Prelaunch CONT test: ARM raised, settle %u ms",
-             (unsigned)config::PYRO_ARM_SETTLE_MS);
-}
-
-static void servicePyroPrelaunchDiag(uint32_t now_ms)
-{
-    if (pyro_prelaunch_phase != PyroPrelaunchPhase::Settle) return;
-    if ((int32_t)(now_ms - pyro_prelaunch_next_ms) < 0) return;
-
-    int raw[4];
+    int  raw[4];
     bool cont[4];
     for (int i = 0; i < 4; ++i) {
         raw[i]  = gpio_get_level((gpio_num_t)PYRO_CONT_PINS[i]);
@@ -778,11 +762,7 @@ static void servicePyroPrelaunchDiag(uint32_t now_ms)
         pyro_ch[i].cont       = cont[i];
         pyro_ch[i].cont_known = true;
     }
-    // Drop ARM unless another consumer (fire state or a CONT-TEST request)
-    // is keeping it up; servicePyroChannels() will reassert if needed.
-    pyroSetArmLocked(false);
     portEXIT_CRITICAL(&pyro_spinlock);
-    pyro_prelaunch_phase = PyroPrelaunchPhase::Done;
     ESP_LOGI(TAG, "[PYRO] Prelaunch CONT: ch1 raw=%d cont=%d  ch2 raw=%d cont=%d  ch3 raw=%d cont=%d  ch4 raw=%d cont=%d",
              raw[0], cont[0], raw[1], cont[1], raw[2], cont[2], raw[3], cont[3]);
 }
@@ -3366,7 +3346,10 @@ static void loop_fc()
             }
             else if (out_pending_command == PYRO_CONT_TEST)
             {
-                // Momentary arm → read continuity → disarm (ground test only)
+                // Direct CONT read — no ARM pulse needed on the new PCB
+                // (CONT divider fed from VPP, independent of the ARM rail).
+                // Still rejected in flight to be conservative with the
+                // app's "ground tests are pad-only" UX guarantee.
                 if (rocket_state == INFLIGHT) {
                     ESP_LOGW(TAG, "[PYRO CONT TEST] Rejected — INFLIGHT");
                 } else {
@@ -3383,23 +3366,14 @@ static void loop_fc()
                         ESP_LOGW(TAG, "[PYRO CONT TEST] Invalid channel %u", ch);
                     } else {
                         const int idx = ch - 1;
-                        const gpio_num_t arm_pin  = (gpio_num_t)config::PYRO_ARM_PIN;
                         const gpio_num_t cont_pin = (gpio_num_t)PYRO_CONT_PINS[idx];
 
-                        // Defensive reclaim — peripheral defaults can re-grab
-                        // the ESP32-P4 IO MUX between boot and the test.
-                        esp_gpio_revoke(1ULL << arm_pin);
+                        // Defensive CONT-pad reclaim — peripheral defaults
+                        // can re-grab the ESP32-P4 IO MUX between boot and
+                        // the test. (The ARM pad was set up safely at boot
+                        // via safePyroOutputInit; we don't touch it here.)
                         esp_gpio_revoke(1ULL << cont_pin);
-                        gpio_reset_pin(arm_pin);
                         gpio_reset_pin(cont_pin);
-
-                        gpio_config_t arm_cfg = {};
-                        arm_cfg.pin_bit_mask = 1ULL << arm_pin;
-                        arm_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
-                        arm_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-                        arm_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-                        gpio_config(&arm_cfg);
-
                         gpio_config_t cont_cfg = {};
                         cont_cfg.pin_bit_mask = 1ULL << cont_pin;
                         cont_cfg.mode         = GPIO_MODE_INPUT;
@@ -3407,18 +3381,8 @@ static void loop_fc()
                         cont_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
                         gpio_config(&cont_cfg);
 
-                        // Force GPIO matrix output to GPIO function on ARM pin
-                        esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
-                        gpio_iomux_out(arm_pin, 1, false);
-
-                        portENTER_CRITICAL(&pyro_spinlock);
-                        pyroSetArmLocked(true);
-                        portEXIT_CRITICAL(&pyro_spinlock);
-                        delay(100);  // generous settle for ground-test path
                         int raw = gpio_get_level(cont_pin);
                         portENTER_CRITICAL(&pyro_spinlock);
-                        pyroSetArmLocked(false);
-                        // Cache the result so the live-telemetry path surfaces it
                         pyro_ch[idx].cont       = pyroContFromRaw(raw);
                         pyro_ch[idx].cont_known = true;
                         portEXIT_CRITICAL(&pyro_spinlock);
@@ -3669,11 +3633,6 @@ static void loop_fc()
         pressure_alt_rate_mps = kinematics.d_alt_est_;
         max_alt_m = kinematics.max_altitude;
         max_speed_mps = kinematics.max_speed;
-
-        // Progress the PRELAUNCH continuity diagnostic. Must run every
-        // iteration regardless of state/test path so the state machine
-        // started at READY→PRELAUNCH finishes promptly.
-        servicePyroPrelaunchDiag(now_ms);
 
         if (ground_test_active)
         {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -22,8 +22,10 @@
 #include <driver/gpio.h>
 #include <driver/uart.h>
 #include <esp_private/esp_gpio_reserve.h>
+#include <esp_private/gpio.h>      // gpio_func_sel
 #include <rom/gpio.h>              // esp_rom_gpio_connect_out_signal
 #include <soc/gpio_sig_map.h>      // SIG_GPIO_OUT_IDX
+#include <soc/io_mux_reg.h>        // PIN_FUNC_GPIO
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 #include <nvs_flash.h>
@@ -644,12 +646,45 @@ static inline float pyroChValue(int ch_idx)
 // spot.)
 static inline bool pyroContFromRaw(int raw) { return raw == 0; }
 
+// Reset a pyro OUTPUT pad to a known LOW-driven state WITHOUT going through
+// gpio_reset_pin(), which briefly enables the internal pull-up (~50 kΩ) as
+// part of its `GPIO_MODE_DISABLE` config. On the new pyro PCB the gate
+// drivers are DTC123J-style pre-biased NPNs (internal 2.2 kΩ base resistor
+// + 47 kΩ B-E pull-down): a 50 kΩ pull-up on the GPIO biases the base well
+// above Vbe for the microseconds-long window between gpio_reset_pin's
+// pull-up config and our subsequent pull-up-disable config — long enough to
+// momentarily turn on the ARM / FIRE MOSFETs and twitch the squib rail at
+// boot. This sequence pre-loads GPIO_OUT to 0, detaches any peripheral
+// output signal, selects plain-GPIO function on the IO MUX, and only then
+// enables output drive — so the pad goes from high-Z directly to driving 0
+// with no pull-up window.
+static void safePyroOutputInit(gpio_num_t pin)
+{
+    // 1. Pre-load output register to 0. No-op until output is enabled.
+    gpio_set_level(pin, 0);
+    // 2. Detach any peripheral output signal routed to this pad (e.g.,
+    //    SPI2 default on pins 14-19 after spi_bus_initialize()).
+    esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);
+    // 3. Force IO MUX function back to plain GPIO.
+    gpio_func_sel(pin, PIN_FUNC_GPIO);
+    // 4. Now enable output drive with no pulls. Pad transitions from high-Z
+    //    straight to driving 0 (because step 1 staged a 0 in GPIO_OUT).
+    gpio_config_t cfg = {};
+    cfg.pin_bit_mask = 1ULL << pin;
+    cfg.mode         = GPIO_MODE_OUTPUT;
+    cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+    cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    cfg.intr_type    = GPIO_INTR_DISABLE;
+    gpio_config(&cfg);
+    // Belt + suspenders.
+    gpio_set_level(pin, 0);
+}
+
 static void initPyroPins()
 {
-    // Drive PYRO_ARM and the four FIRE pins as outputs, start LOW (safe).
-    // gpio_reset_pin() reclaims the IO MUX from any peripheral default —
-    // mandatory on ESP32-P4 because several of these pins (14-19) default
-    // to SPI2/SPI3 IO MUX. CONT inputs get the same reset for parity.
+    // PYRO_ARM and the four FIRE pins: safe-driven outputs at LOW. The
+    // safePyroOutputInit() helper avoids gpio_reset_pin's pull-up trap that
+    // would otherwise glitch the gate drivers at boot.
     const gpio_num_t output_pins[] = {
         (gpio_num_t)config::PYRO_ARM_PIN,
         (gpio_num_t)config::PYRO1_FIRE_PIN,
@@ -658,18 +693,14 @@ static void initPyroPins()
         (gpio_num_t)config::PYRO4_FIRE_PIN,
     };
     for (gpio_num_t pin : output_pins) {
-        gpio_reset_pin(pin);
-        gpio_config_t cfg = {};
-        cfg.pin_bit_mask = 1ULL << pin;
-        cfg.mode         = GPIO_MODE_OUTPUT;
-        cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-        cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-        gpio_config(&cfg);
-        gpio_set_level(pin, 0);
+        safePyroOutputInit(pin);
     }
     pyro_arm_pin_state = false;
 
-    // CONTINUITY pins: input (external pull-up on PCB).
+    // CONTINUITY pins: input (external pull on PCB). gpio_reset_pin() is
+    // safe here — the input pad has no gate driver downstream, just the
+    // CONT divider, so a brief internal pull-up doesn't drive anything
+    // dangerous. The subsequent gpio_config() clears it.
     for (uint8_t pin : PYRO_CONT_PINS) {
         gpio_reset_pin((gpio_num_t)pin);
         gpio_config_t cfg = {};

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3755,15 +3755,10 @@ static void loop_fc()
             }
             case READY:
             {
-                // BENCH-ONLY: GNSS-fix requirement bypassed so pyro can be
-                // tested on the bench without a working GPS module. REVERT
-                // before merging — `gnss_ready` must gate this transition
-                // in any flight build.
-                const bool gnss_ready = true;
-                // const bool gnss_ready = gnss_started &&
-                //                         (now_ms > valid_gnss_start_millis + 3000U) &&
-                //                         have_gnss_si &&
-                //                         (gnss_latest_si.num_sats >= 4U);
+                const bool gnss_ready = gnss_started &&
+                                        (now_ms > valid_gnss_start_millis + 3000U) &&
+                                        have_gnss_si &&
+                                        (gnss_latest_si.num_sats >= 4U);
                 if (out_ready && gnss_ready)
                 {
                     rocket_state = PRELAUNCH;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -290,18 +290,37 @@ static bool blue_led_flash_active = false;
 static uint32_t blue_led_flash_end_ms = 0;
 
 // --- Pyro channel state ---
-// Spinlock protects all pyro state flags and GPIO operations.
-// Must be held when reading or writing armed/fired flags or toggling ARM/FIRE pins.
+// New PCB: single PYRO_ARM_PIN drives all four channels' upstream FET.
+// Per-channel fire is a [ArmSettle → Firing → Done] state machine —
+// ARM goes HIGH only while at least one channel sits in ArmSettle or
+// Firing (or a CONT-TEST is running), then drops LOW once everyone is
+// back to Idle/Done. Spinlock protects all pyro state and GPIO ops.
 static portMUX_TYPE pyro_spinlock = portMUX_INITIALIZER_UNLOCKED;
-static PyroConfigData pyro_config = {};  // zeroed = both disabled
-static bool pyro1_armed = false;
-static bool pyro1_fired = false;
-static uint32_t pyro1_fire_start_ms = 0;
-static bool pyro2_armed = false;
-static bool pyro2_fired = false;
-static uint32_t pyro2_fire_start_ms = 0;
-static bool pyro_apogee_detected = false;
-static uint32_t pyro_apogee_time_ms = 0;
+static PyroConfigData pyro_config = {};  // zeroed = all four disabled
+
+enum class PyroChState : uint8_t {
+    Idle,       // no fire requested
+    ArmSettle,  // ARM raised by this channel; waiting PYRO_ARM_SETTLE_MS
+    Firing,     // FIRE pin HIGH; waiting PYRO_FIRE_DURATION_MS
+    Done,       // fired; latched, prevents re-fire this flight
+};
+
+struct PyroChRuntime {
+    PyroChState state          = PyroChState::Idle;
+    uint32_t    phase_start_ms = 0;     // millis when current state began
+    bool        cont_known     = false; // true after first cont read post-power-on
+    bool        cont           = false; // last reading: true = closed (load present)
+};
+
+static PyroChRuntime pyro_ch[4] = {};
+static bool          pyro_arm_pin_state   = false;   // last value driven onto PYRO_ARM_PIN
+static bool          pyro_apogee_detected = false;
+static uint32_t      pyro_apogee_time_ms  = 0;
+
+// PRELAUNCH-edge continuity diagnostic — momentary ARM, read all 4 CONT, disarm.
+enum class PyroPrelaunchPhase : uint8_t { Idle, Settle, Done };
+static PyroPrelaunchPhase pyro_prelaunch_phase   = PyroPrelaunchPhase::Idle;
+static uint32_t           pyro_prelaunch_next_ms = 0;
 // --- Inflight reboot recovery ---
 // Snapshot of critical flight state, sent to OC over I2S at 10 Hz during
 // INFLIGHT and stored in OC's MRAM.  On unexpected reboot (brownout,
@@ -347,10 +366,10 @@ static void buildFlightSnapshot(FlightSnapshotData& snap, uint32_t now_ms, uint8
 
     portENTER_CRITICAL(&pyro_spinlock);
     snap.pyro_apogee_detected = pyro_apogee_detected ? 1 : 0;
-    snap.pyro1_armed          = pyro1_armed          ? 1 : 0;
-    snap.pyro1_fired          = pyro1_fired          ? 1 : 0;
-    snap.pyro2_armed          = pyro2_armed          ? 1 : 0;
-    snap.pyro2_fired          = pyro2_fired          ? 1 : 0;
+    snap.pyro1_fired = (pyro_ch[0].state == PyroChState::Done) ? 1 : 0;
+    snap.pyro2_fired = (pyro_ch[1].state == PyroChState::Done) ? 1 : 0;
+    snap.pyro3_fired = (pyro_ch[2].state == PyroChState::Done) ? 1 : 0;
+    snap.pyro4_fired = (pyro_ch[3].state == PyroChState::Done) ? 1 : 0;
     portEXIT_CRITICAL(&pyro_spinlock);
 
     snap.ground_pressure_pa = ground_pressure_pa;
@@ -575,16 +594,70 @@ static bool readConfigFrame(uint8_t expected_type,
 
 // ── Pyro channel helpers ─────────────────────────────────────────────────────
 
+// Per-channel pin lookups (indexed 0..3).
+static const uint8_t PYRO_FIRE_PINS[4] = {
+    config::PYRO1_FIRE_PIN, config::PYRO2_FIRE_PIN,
+    config::PYRO3_FIRE_PIN, config::PYRO4_FIRE_PIN,
+};
+static const uint8_t PYRO_CONT_PINS[4] = {
+    config::PYRO1_CONT_PIN, config::PYRO2_CONT_PIN,
+    config::PYRO3_CONT_PIN, config::PYRO4_CONT_PIN,
+};
+
+// Per-channel config accessors so the loop body stays uniform.
+static inline bool pyroChEnabled(int ch_idx)
+{
+    switch (ch_idx) {
+        case 0: return pyro_config.ch1_enabled;
+        case 1: return pyro_config.ch2_enabled;
+        case 2: return pyro_config.ch3_enabled;
+        case 3: return pyro_config.ch4_enabled;
+    }
+    return false;
+}
+static inline uint8_t pyroChMode(int ch_idx)
+{
+    switch (ch_idx) {
+        case 0: return pyro_config.ch1_trigger_mode;
+        case 1: return pyro_config.ch2_trigger_mode;
+        case 2: return pyro_config.ch3_trigger_mode;
+        case 3: return pyro_config.ch4_trigger_mode;
+    }
+    return 0;
+}
+static inline float pyroChValue(int ch_idx)
+{
+    switch (ch_idx) {
+        case 0: return pyro_config.ch1_trigger_value;
+        case 1: return pyro_config.ch2_trigger_value;
+        case 2: return pyro_config.ch3_trigger_value;
+        case 3: return pyro_config.ch4_trigger_value;
+    }
+    return 0.0f;
+}
+
+// New PCB inverts continuity sense vs the old board: with the shared
+// arming FET enabled, the channel's CONT line idles HIGH when the squib
+// loop is OPEN and gets pulled LOW when a load (closed circuit) is
+// present. Old PCB had the opposite polarity. (TODO: verify on bench
+// once a populated rev-A board is in hand — if wrong, flip this one
+// spot.)
+static inline bool pyroContFromRaw(int raw) { return raw == 0; }
+
 static void initPyroPins()
 {
-    // ARM and FIRE pins: output, start LOW (safe)
-    // gpio_reset_pin() forces IO MUX back to GPIO function — required on
-    // ESP32-P4 because SPI2 default pins (14-16) overlap with pyro pins,
-    // and spi_bus_initialize() may claim them at the IO MUX level.
-    for (auto pin : {(gpio_num_t)config::PYRO1_ARM_PIN,
-                     (gpio_num_t)config::PYRO1_FIRE_PIN,
-                     (gpio_num_t)config::PYRO2_ARM_PIN,
-                     (gpio_num_t)config::PYRO2_FIRE_PIN}) {
+    // Drive PYRO_ARM and the four FIRE pins as outputs, start LOW (safe).
+    // gpio_reset_pin() reclaims the IO MUX from any peripheral default —
+    // mandatory on ESP32-P4 because several of these pins (14-19) default
+    // to SPI2/SPI3 IO MUX. CONT inputs get the same reset for parity.
+    const gpio_num_t output_pins[] = {
+        (gpio_num_t)config::PYRO_ARM_PIN,
+        (gpio_num_t)config::PYRO1_FIRE_PIN,
+        (gpio_num_t)config::PYRO2_FIRE_PIN,
+        (gpio_num_t)config::PYRO3_FIRE_PIN,
+        (gpio_num_t)config::PYRO4_FIRE_PIN,
+    };
+    for (gpio_num_t pin : output_pins) {
         gpio_reset_pin(pin);
         gpio_config_t cfg = {};
         cfg.pin_bit_mask = 1ULL << pin;
@@ -594,10 +667,11 @@ static void initPyroPins()
         gpio_config(&cfg);
         gpio_set_level(pin, 0);
     }
-    // CONTINUITY pins: input (external 10k pullup on PCB)
-    for (auto pin : {(gpio_num_t)config::PYRO1_CONT_PIN,
-                     (gpio_num_t)config::PYRO2_CONT_PIN}) {
-        gpio_reset_pin(pin);
+    pyro_arm_pin_state = false;
+
+    // CONTINUITY pins: input (external pull-up on PCB).
+    for (uint8_t pin : PYRO_CONT_PINS) {
+        gpio_reset_pin((gpio_num_t)pin);
         gpio_config_t cfg = {};
         cfg.pin_bit_mask = 1ULL << pin;
         cfg.mode         = GPIO_MODE_INPUT;
@@ -605,146 +679,82 @@ static void initPyroPins()
         cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
         gpio_config(&cfg);
     }
-    ESP_LOGI(TAG, "[PYRO] Pins initialized (safe)");
+    ESP_LOGI(TAG, "[PYRO] Pins initialized (safe, 4 channels, single ARM)");
+}
+
+// Caller MUST hold pyro_spinlock.
+static void pyroSetArmLocked(bool want_high)
+{
+    if (pyro_arm_pin_state == want_high) return;
+    gpio_set_level((gpio_num_t)config::PYRO_ARM_PIN, want_high ? 1 : 0);
+    pyro_arm_pin_state = want_high;
 }
 
 static void pyroSafeAll()
 {
     portENTER_CRITICAL(&pyro_spinlock);
-    gpio_set_level((gpio_num_t)config::PYRO1_FIRE_PIN, 0);
-    gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 0);
-    gpio_set_level((gpio_num_t)config::PYRO2_FIRE_PIN, 0);
-    gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 0);
-    pyro1_armed = false;
-    pyro2_armed = false;
+    for (int i = 0; i < 4; ++i) {
+        gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 0);
+        pyro_ch[i].state          = PyroChState::Idle;
+        pyro_ch[i].phase_start_ms = 0;
+    }
+    pyroSetArmLocked(false);
+    pyro_prelaunch_phase   = PyroPrelaunchPhase::Idle;
+    pyro_prelaunch_next_ms = 0;
     portEXIT_CRITICAL(&pyro_spinlock);
     ESP_LOGI(TAG, "[PYRO] All channels safed");
 }
 
-// Non-blocking pyro arming + continuity diagnostic.
-//
-// The original pyroArmEnabled() called delay(10) six times on CH1 (1 settle
-// + 5 readback re-reads) plus delayMicroseconds(500) on CH2, blocking the FC
-// main loop for ~60 ms inside the PRELAUNCH→INFLIGHT transition. That stall
-// opened a ~62 ms gap in the sensor stream right at boost ignition.
-//
-// Two entry points share the same state machine:
-//   pyroPrelaunchContTest() — READY→PRELAUNCH: momentary arm + full
-//     diagnostic readback + disarm. Verifies wiring on the pad without
-//     leaving the squib hot during the launch wait.
-//   pyroArmEnabled()        — PRELAUNCH→INFLIGHT: latch ARM=1, mark armed,
-//     do one deferred readback ~10 ms later for sanity. Re-read loop is
-//     skipped — that already ran on the pad.
-//
-// servicePyroArmDiag() advances the state machine each main-loop iteration.
-enum class PyroArmDiagPhase : uint8_t {
-    Idle,
-    Ch1Settle,      // ARM=1 set, waiting 10 ms for VN5E160 settle
-    Ch1ReadRepeat,  // PRELAUNCH only: 5 additional CONT re-reads at 10 ms intervals
-    Ch2Settle,      // ARM=1 set, waiting 10 ms for VN5E160 settle
-};
-static PyroArmDiagPhase  pyro_diag_phase     = PyroArmDiagPhase::Idle;
-static bool              pyro_diag_prelaunch = false;
-static uint8_t           pyro_diag_ch1_reads = 0;
-static constexpr uint8_t PYRO_DIAG_CH1_TOTAL_READS = 6;  // 1 initial + 5 re-reads (preserved)
-static uint32_t          pyro_diag_next_ms   = 0;
-
-static void pyroDiagAdvanceToCh2OrFinish(uint32_t now_ms)
+// PRELAUNCH continuity test: raise ARM, wait settle, read all 4 CONT, lower
+// ARM. Non-blocking — pyroPrelaunchContTest() schedules and
+// servicePyroPrelaunchDiag() advances on each main-loop tick.
+static void pyroPrelaunchContTest(uint32_t now_ms)
 {
-    if (pyro_config.ch2_enabled) {
-        portENTER_CRITICAL(&pyro_spinlock);
-        gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 1);
-        if (!pyro_diag_prelaunch) pyro2_armed = true;
-        portEXIT_CRITICAL(&pyro_spinlock);
-        pyro_diag_phase   = PyroArmDiagPhase::Ch2Settle;
-        pyro_diag_next_ms = now_ms + 10;
-    } else {
-        pyro_diag_phase = PyroArmDiagPhase::Idle;
-    }
+    if (pyro_prelaunch_phase != PyroPrelaunchPhase::Idle) return;
+    portENTER_CRITICAL(&pyro_spinlock);
+    pyroSetArmLocked(true);
+    portEXIT_CRITICAL(&pyro_spinlock);
+    pyro_prelaunch_phase   = PyroPrelaunchPhase::Settle;
+    pyro_prelaunch_next_ms = now_ms + config::PYRO_ARM_SETTLE_MS;
+    ESP_LOGI(TAG, "[PYRO] Prelaunch CONT test: ARM raised, settle %u ms",
+             (unsigned)config::PYRO_ARM_SETTLE_MS);
 }
 
-static void pyroDiagStart(uint32_t now_ms, bool is_prelaunch)
+static void servicePyroPrelaunchDiag(uint32_t now_ms)
 {
-    if (pyro_diag_phase != PyroArmDiagPhase::Idle) return;
-    pyro_diag_prelaunch = is_prelaunch;
-    pyro_diag_ch1_reads = 0;
-    if (pyro_config.ch1_enabled) {
-        portENTER_CRITICAL(&pyro_spinlock);
-        gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 1);
-        if (!is_prelaunch) pyro1_armed = true;
-        portEXIT_CRITICAL(&pyro_spinlock);
-        pyro_diag_phase   = PyroArmDiagPhase::Ch1Settle;
-        pyro_diag_next_ms = now_ms + 10;
-    } else {
-        pyroDiagAdvanceToCh2OrFinish(now_ms);
+    if (pyro_prelaunch_phase != PyroPrelaunchPhase::Settle) return;
+    if ((int32_t)(now_ms - pyro_prelaunch_next_ms) < 0) return;
+
+    int raw[4];
+    bool cont[4];
+    for (int i = 0; i < 4; ++i) {
+        raw[i]  = gpio_get_level((gpio_num_t)PYRO_CONT_PINS[i]);
+        cont[i] = pyroContFromRaw(raw[i]);
     }
+    portENTER_CRITICAL(&pyro_spinlock);
+    for (int i = 0; i < 4; ++i) {
+        pyro_ch[i].cont       = cont[i];
+        pyro_ch[i].cont_known = true;
+    }
+    // Drop ARM unless another consumer (fire state or a CONT-TEST request)
+    // is keeping it up; servicePyroChannels() will reassert if needed.
+    pyroSetArmLocked(false);
+    portEXIT_CRITICAL(&pyro_spinlock);
+    pyro_prelaunch_phase = PyroPrelaunchPhase::Done;
+    ESP_LOGI(TAG, "[PYRO] Prelaunch CONT: ch1 raw=%d cont=%d  ch2 raw=%d cont=%d  ch3 raw=%d cont=%d  ch4 raw=%d cont=%d",
+             raw[0], cont[0], raw[1], cont[1], raw[2], cont[2], raw[3], cont[3]);
 }
 
-static void pyroPrelaunchContTest(uint32_t now_ms) { pyroDiagStart(now_ms, /*is_prelaunch=*/true);  }
-static void pyroArmEnabled       (uint32_t now_ms) { pyroDiagStart(now_ms, /*is_prelaunch=*/false); }
-
-static void servicePyroArmDiag(uint32_t now_ms)
-{
-    if (pyro_diag_phase == PyroArmDiagPhase::Idle) return;
-    if ((int32_t)(now_ms - pyro_diag_next_ms) < 0) return;
-
-    switch (pyro_diag_phase) {
-        case PyroArmDiagPhase::Ch1Settle: {
-            int arm_rb   = gpio_get_level((gpio_num_t)config::PYRO1_ARM_PIN);
-            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN);
-            ESP_LOGI(TAG, "[PYRO] CH1 %s: ARM_PIN=%d rb=%d  CONT_PIN=%d raw=%d  mode=%u val=%.1f",
-                     pyro_diag_prelaunch ? "cont-test" : "armed",
-                     config::PYRO1_ARM_PIN, arm_rb,
-                     config::PYRO1_CONT_PIN, cont_raw,
-                     pyro_config.ch1_trigger_mode, (double)pyro_config.ch1_trigger_value);
-            pyro_diag_ch1_reads = 1;
-            if (pyro_diag_prelaunch) {
-                pyro_diag_phase   = PyroArmDiagPhase::Ch1ReadRepeat;
-                pyro_diag_next_ms = now_ms + 10;
-            } else {
-                pyroDiagAdvanceToCh2OrFinish(now_ms);
-            }
-            break;
-        }
-        case PyroArmDiagPhase::Ch1ReadRepeat: {
-            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN);
-            ESP_LOGI(TAG, "[PYRO] CH1 CONT re-read[%u]: %d",
-                     (unsigned)(pyro_diag_ch1_reads - 1), cont_raw);
-            pyro_diag_ch1_reads++;
-            if (pyro_diag_ch1_reads >= PYRO_DIAG_CH1_TOTAL_READS) {
-                portENTER_CRITICAL(&pyro_spinlock);
-                gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 0);
-                portEXIT_CRITICAL(&pyro_spinlock);
-                pyroDiagAdvanceToCh2OrFinish(now_ms);
-            } else {
-                pyro_diag_next_ms = now_ms + 10;
-            }
-            break;
-        }
-        case PyroArmDiagPhase::Ch2Settle: {
-            int cont_raw = gpio_get_level((gpio_num_t)config::PYRO2_CONT_PIN);
-            ESP_LOGI(TAG, "[PYRO] CH2 %s (mode=%u val=%.1f) CONT_PIN=%d raw=%d",
-                     pyro_diag_prelaunch ? "cont-test" : "armed",
-                     pyro_config.ch2_trigger_mode, (double)pyro_config.ch2_trigger_value,
-                     config::PYRO2_CONT_PIN, cont_raw);
-            if (pyro_diag_prelaunch) {
-                portENTER_CRITICAL(&pyro_spinlock);
-                gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 0);
-                portEXIT_CRITICAL(&pyro_spinlock);
-            }
-            pyro_diag_phase = PyroArmDiagPhase::Idle;
-            break;
-        }
-        default: break;
-    }
-}
-
+// Called each main-loop tick during INFLIGHT (and benign elsewhere — no
+// channel will leave Idle until an enabled trigger fires). Drives the
+// per-channel ArmSettle → Firing → Done state machine and computes the
+// global ARM-pin level from the union of all channel demands.
 static void servicePyroChannels(uint32_t now_ms)
 {
     // Detect apogee (N-1 of N voting in TR_KinematicChecks)
     if (!pyro_apogee_detected && kinematics.apogee_flag) {
         pyro_apogee_detected = true;
-        pyro_apogee_time_ms = now_ms;
+        pyro_apogee_time_ms  = now_ms;
         ESP_LOGI(TAG, "[PYRO] Apogee detected at t=%lu ms (vel=%d baro=%d gps=%d pitch=%d)",
                  (unsigned long)now_ms,
                  kinematics.vel_u_apogee_flag,
@@ -753,73 +763,82 @@ static void servicePyroChannels(uint32_t now_ms)
                  kinematics.pitch_apogee_flag);
     }
 
+    bool just_fired[4]  = { false, false, false, false };
+    bool pulse_done[4]  = { false, false, false, false };
+
     portENTER_CRITICAL(&pyro_spinlock);
 
-    // --- Channel 1 fire logic ---
-    if (pyro1_armed && !pyro1_fired && pyro_config.ch1_enabled) {
-        bool should_fire = false;
-        if (pyro_config.ch1_trigger_mode == PYRO_TRIGGER_TIME_AFTER_APOGEE
-            && pyro_apogee_detected) {
-            float elapsed_s = (float)(now_ms - pyro_apogee_time_ms) / 1000.0f;
-            if (elapsed_s >= pyro_config.ch1_trigger_value) should_fire = true;
-        } else if (pyro_config.ch1_trigger_mode == PYRO_TRIGGER_ALTITUDE_ON_DESCENT
-                   && pyro_apogee_detected) {
-            if (pressure_alt_m <= pyro_config.ch1_trigger_value
-                && pressure_alt_rate_mps < 0.0f) should_fire = true;
+    for (int i = 0; i < 4; ++i) {
+        PyroChRuntime& ch = pyro_ch[i];
+
+        // Idle → ArmSettle when trigger satisfied
+        if (ch.state == PyroChState::Idle && pyroChEnabled(i)) {
+            bool should_fire = false;
+            const uint8_t mode = pyroChMode(i);
+            const float   val  = pyroChValue(i);
+            if (pyro_apogee_detected && mode == PYRO_TRIGGER_TIME_AFTER_APOGEE) {
+                const float elapsed_s = (float)(now_ms - pyro_apogee_time_ms) / 1000.0f;
+                if (elapsed_s >= val) should_fire = true;
+            } else if (pyro_apogee_detected && mode == PYRO_TRIGGER_ALTITUDE_ON_DESCENT) {
+                if (pressure_alt_m <= val && pressure_alt_rate_mps < 0.0f) should_fire = true;
+            }
+            if (should_fire) {
+                ch.state          = PyroChState::ArmSettle;
+                ch.phase_start_ms = now_ms;
+            }
         }
-        if (should_fire) {
-            gpio_set_level((gpio_num_t)config::PYRO1_FIRE_PIN, 1);
-            pyro1_fire_start_ms = now_ms;
-            pyro1_fired = true;
+
+        // ArmSettle → Firing once the settle elapses
+        if (ch.state == PyroChState::ArmSettle &&
+            (now_ms - ch.phase_start_ms) >= config::PYRO_ARM_SETTLE_MS) {
+            gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 1);
+            ch.state          = PyroChState::Firing;
+            ch.phase_start_ms = now_ms;
+            just_fired[i]     = true;
         }
-    }
-    // Channel 1 fire pulse timeout
-    bool ch1_pulse_done = false;
-    if (pyro1_fired && pyro1_fire_start_ms > 0 &&
-        (now_ms - pyro1_fire_start_ms) >= config::PYRO_FIRE_DURATION_MS) {
-        gpio_set_level((gpio_num_t)config::PYRO1_FIRE_PIN, 0);
-        pyro1_fire_start_ms = 0;
-        ch1_pulse_done = true;
+
+        // Firing → Done after pulse width
+        if (ch.state == PyroChState::Firing &&
+            (now_ms - ch.phase_start_ms) >= config::PYRO_FIRE_DURATION_MS) {
+            gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 0);
+            ch.state          = PyroChState::Done;
+            ch.phase_start_ms = 0;
+            pulse_done[i]     = true;
+        }
     }
 
-    // --- Channel 2 fire logic ---
-    if (pyro2_armed && !pyro2_fired && pyro_config.ch2_enabled) {
-        bool should_fire = false;
-        if (pyro_config.ch2_trigger_mode == PYRO_TRIGGER_TIME_AFTER_APOGEE
-            && pyro_apogee_detected) {
-            float elapsed_s = (float)(now_ms - pyro_apogee_time_ms) / 1000.0f;
-            if (elapsed_s >= pyro_config.ch2_trigger_value) should_fire = true;
-        } else if (pyro_config.ch2_trigger_mode == PYRO_TRIGGER_ALTITUDE_ON_DESCENT
-                   && pyro_apogee_detected) {
-            if (pressure_alt_m <= pyro_config.ch2_trigger_value
-                && pressure_alt_rate_mps < 0.0f) should_fire = true;
+    // While ARM is HIGH (only during a channel's fire window in flight),
+    // refresh its CONT bit. ARM=LOW leaves CONT floating, so the cached
+    // value from the last test stands.
+    if (pyro_arm_pin_state) {
+        for (int i = 0; i < 4; ++i) {
+            if (pyro_ch[i].state == PyroChState::ArmSettle ||
+                pyro_ch[i].state == PyroChState::Firing) {
+                pyro_ch[i].cont       = pyroContFromRaw(
+                                          gpio_get_level((gpio_num_t)PYRO_CONT_PINS[i]));
+                pyro_ch[i].cont_known = true;
+            }
         }
-        if (should_fire) {
-            gpio_set_level((gpio_num_t)config::PYRO2_FIRE_PIN, 1);
-            pyro2_fire_start_ms = now_ms;
-            pyro2_fired = true;
-        }
-    }
-    // Channel 2 fire pulse timeout
-    bool ch2_pulse_done = false;
-    if (pyro2_fired && pyro2_fire_start_ms > 0 &&
-        (now_ms - pyro2_fire_start_ms) >= config::PYRO_FIRE_DURATION_MS) {
-        gpio_set_level((gpio_num_t)config::PYRO2_FIRE_PIN, 0);
-        pyro2_fire_start_ms = 0;
-        ch2_pulse_done = true;
     }
 
-    // Snapshot fire events for logging outside critical section
-    bool ch1_just_fired = pyro1_fired && pyro1_fire_start_ms == now_ms;
-    bool ch2_just_fired = pyro2_fired && pyro2_fire_start_ms == now_ms;
+    // Compute ARM demand: any channel mid-fire keeps the pin HIGH.
+    bool any_demand = false;
+    for (int i = 0; i < 4; ++i) {
+        if (pyro_ch[i].state == PyroChState::ArmSettle ||
+            pyro_ch[i].state == PyroChState::Firing) {
+            any_demand = true;
+            break;
+        }
+    }
+    pyroSetArmLocked(any_demand);
 
     portEXIT_CRITICAL(&pyro_spinlock);
 
-    // Log outside critical section (ESP_LOG can block)
-    if (ch1_just_fired) ESP_LOGW(TAG, "[PYRO] CH1 FIRED at alt=%.1f m", (double)pressure_alt_m);
-    if (ch2_just_fired) ESP_LOGW(TAG, "[PYRO] CH2 FIRED at alt=%.1f m", (double)pressure_alt_m);
-    if (ch1_pulse_done) ESP_LOGI(TAG, "[PYRO] CH1 fire pulse complete");
-    if (ch2_pulse_done) ESP_LOGI(TAG, "[PYRO] CH2 fire pulse complete");
+    for (int i = 0; i < 4; ++i) {
+        if (just_fired[i]) ESP_LOGW(TAG, "[PYRO] CH%d FIRED at alt=%.1f m",
+                                    i + 1, (double)pressure_alt_m);
+        if (pulse_done[i]) ESP_LOGI(TAG, "[PYRO] CH%d fire pulse complete", i + 1);
+    }
 }
 
 // ── Roll profile interpolation ────────────────────────────────────────────────
@@ -1836,13 +1855,14 @@ static void setup_fc()
     size_t pyro_cfg_sz = prefs.getBytesLength("cfg");
     if (pyro_cfg_sz == sizeof(PyroConfigData)) {
         prefs.getBytes("cfg", &pyro_config, sizeof(pyro_config));
-        ESP_LOGI(TAG, "NVS pyro: ch1_en=%u mode=%u val=%.1f  ch2_en=%u mode=%u val=%.1f",
-                 pyro_config.ch1_enabled, pyro_config.ch1_trigger_mode,
-                 (double)pyro_config.ch1_trigger_value,
-                 pyro_config.ch2_enabled, pyro_config.ch2_trigger_mode,
-                 (double)pyro_config.ch2_trigger_value);
+        ESP_LOGI(TAG, "NVS pyro: ch1=%u/%u/%.1f  ch2=%u/%u/%.1f  ch3=%u/%u/%.1f  ch4=%u/%u/%.1f",
+                 pyro_config.ch1_enabled, pyro_config.ch1_trigger_mode, (double)pyro_config.ch1_trigger_value,
+                 pyro_config.ch2_enabled, pyro_config.ch2_trigger_mode, (double)pyro_config.ch2_trigger_value,
+                 pyro_config.ch3_enabled, pyro_config.ch3_trigger_mode, (double)pyro_config.ch3_trigger_value,
+                 pyro_config.ch4_enabled, pyro_config.ch4_trigger_mode, (double)pyro_config.ch4_trigger_value);
     } else {
-        ESP_LOGI(TAG, "NVS pyro: none (both disabled)");
+        ESP_LOGI(TAG, "NVS pyro: none (all four disabled) — stored=%u bytes, expected=%u",
+                 (unsigned)pyro_cfg_sz, (unsigned)sizeof(PyroConfigData));
     }
     prefs.end();
 
@@ -2098,32 +2118,24 @@ static void setup_fc()
                 burnout_time_ms = launch_time_millis + snap.burnout_elapsed_ms;
             }
 
-            // Restore pyro state (safety-critical: no double-fire, no missed fire)
+            // Restore pyro state (safety-critical: no double-fire, no missed fire).
+            // With per-fire arming, ARM is never persistent — any channel
+            // whose trigger condition is still met will re-arm and fire via
+            // servicePyroChannels(). We only need to lock in fired channels
+            // so they aren't re-fired.
             portENTER_CRITICAL(&pyro_spinlock);
-            pyro1_fired = snap.pyro1_fired;
-            pyro2_fired = snap.pyro2_fired;
-            pyro1_fire_start_ms = 0;
-            pyro2_fire_start_ms = 0;
+            const uint8_t fired_snap[4] = { snap.pyro1_fired, snap.pyro2_fired,
+                                            snap.pyro3_fired, snap.pyro4_fired };
+            for (int i = 0; i < 4; ++i) {
+                pyro_ch[i].state          = fired_snap[i] ? PyroChState::Done : PyroChState::Idle;
+                pyro_ch[i].phase_start_ms = 0;
+            }
             portEXIT_CRITICAL(&pyro_spinlock);
 
-            // Re-arm unfired pyro channels (GPIO ARM pins reset on reboot)
-            if (snap.pyro1_armed && !snap.pyro1_fired && pyro_config.ch1_enabled) {
-                portENTER_CRITICAL(&pyro_spinlock);
-                gpio_set_level((gpio_num_t)config::PYRO1_ARM_PIN, 1);
-                pyro1_armed = true;
-                portEXIT_CRITICAL(&pyro_spinlock);
-                ESP_LOGW(TAG, "[RECOVERY] CH1 re-armed");
-            }
-            if (snap.pyro2_armed && !snap.pyro2_fired && pyro_config.ch2_enabled) {
-                portENTER_CRITICAL(&pyro_spinlock);
-                gpio_set_level((gpio_num_t)config::PYRO2_ARM_PIN, 1);
-                pyro2_armed = true;
-                portEXIT_CRITICAL(&pyro_spinlock);
-                ESP_LOGW(TAG, "[RECOVERY] CH2 re-armed");
-            }
-
-            ESP_LOGW(TAG, "[RECOVERY] Pyro: apogee=%d ch1_armed=%d ch1_fired=%d ch2_armed=%d ch2_fired=%d",
-                     pyro_apogee_detected, pyro1_armed, pyro1_fired, pyro2_armed, pyro2_fired);
+            ESP_LOGW(TAG, "[RECOVERY] Pyro: apogee=%d fired=[%d,%d,%d,%d]",
+                     pyro_apogee_detected,
+                     snap.pyro1_fired, snap.pyro2_fired,
+                     snap.pyro3_fired, snap.pyro4_fired);
 
             // Restore flight references
             ground_pressure_pa = snap.ground_pressure_pa;
@@ -3293,7 +3305,7 @@ static void loop_fc()
             else if (out_pending_command == PYRO_CONFIG_PENDING)
             {
                 delay(1);
-                uint8_t cfg_payload[12];
+                uint8_t cfg_payload[sizeof(PyroConfigData)];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(PYRO_CONFIG_MSG, sizeof(PyroConfigData),
                                     cfg_payload, sizeof(cfg_payload), cfg_len)
@@ -3303,11 +3315,11 @@ static void loop_fc()
                     prefs.begin("pyro", false);
                     prefs.putBytes("cfg", &pyro_config, sizeof(pyro_config));
                     prefs.end();
-                    ESP_LOGI(TAG, "[PYRO CFG] ch1: en=%u mode=%u val=%.1f  ch2: en=%u mode=%u val=%.1f",
-                             pyro_config.ch1_enabled, pyro_config.ch1_trigger_mode,
-                             (double)pyro_config.ch1_trigger_value,
-                             pyro_config.ch2_enabled, pyro_config.ch2_trigger_mode,
-                             (double)pyro_config.ch2_trigger_value);
+                    ESP_LOGI(TAG, "[PYRO CFG] ch1=%u/%u/%.1f  ch2=%u/%u/%.1f  ch3=%u/%u/%.1f  ch4=%u/%u/%.1f",
+                             pyro_config.ch1_enabled, pyro_config.ch1_trigger_mode, (double)pyro_config.ch1_trigger_value,
+                             pyro_config.ch2_enabled, pyro_config.ch2_trigger_mode, (double)pyro_config.ch2_trigger_value,
+                             pyro_config.ch3_enabled, pyro_config.ch3_trigger_mode, (double)pyro_config.ch3_trigger_value,
+                             pyro_config.ch4_enabled, pyro_config.ch4_trigger_mode, (double)pyro_config.ch4_trigger_value);
                 }
             }
             else if (out_pending_command == PYRO_CONT_TEST)
@@ -3325,53 +3337,52 @@ static void loop_fc()
                         && cfg_len >= 1) {
                         ch = cfg_payload[0];
                     }
-                    gpio_num_t arm_pin  = (ch == 2) ? (gpio_num_t)config::PYRO2_ARM_PIN
-                                                    : (gpio_num_t)config::PYRO1_ARM_PIN;
-                    gpio_num_t cont_pin = (ch == 2) ? (gpio_num_t)config::PYRO2_CONT_PIN
-                                                    : (gpio_num_t)config::PYRO1_CONT_PIN;
-                    uint8_t cont_bit    = (ch == 2) ? PSF_CH2_CONT : PSF_CH1_CONT;
+                    if (ch < 1 || ch > 4) {
+                        ESP_LOGW(TAG, "[PYRO CONT TEST] Invalid channel %u", ch);
+                    } else {
+                        const int idx = ch - 1;
+                        const gpio_num_t arm_pin  = (gpio_num_t)config::PYRO_ARM_PIN;
+                        const gpio_num_t cont_pin = (gpio_num_t)PYRO_CONT_PINS[idx];
 
-                    // Reclaim pins from SPI2 (ESP32-P4 default SPI2 pins
-                    // overlap with pyro pins 14-16).
-                    esp_gpio_revoke(1ULL << arm_pin);
-                    esp_gpio_revoke(1ULL << cont_pin);
-                    gpio_reset_pin(arm_pin);
-                    gpio_reset_pin(cont_pin);
+                        // Defensive reclaim — peripheral defaults can re-grab
+                        // the ESP32-P4 IO MUX between boot and the test.
+                        esp_gpio_revoke(1ULL << arm_pin);
+                        esp_gpio_revoke(1ULL << cont_pin);
+                        gpio_reset_pin(arm_pin);
+                        gpio_reset_pin(cont_pin);
 
-                    gpio_config_t arm_cfg = {};
-                    arm_cfg.pin_bit_mask = 1ULL << arm_pin;
-                    arm_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
-                    arm_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-                    arm_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-                    gpio_config(&arm_cfg);
+                        gpio_config_t arm_cfg = {};
+                        arm_cfg.pin_bit_mask = 1ULL << arm_pin;
+                        arm_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
+                        arm_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+                        arm_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+                        gpio_config(&arm_cfg);
 
-                    gpio_config_t cont_cfg = {};
-                    cont_cfg.pin_bit_mask = 1ULL << cont_pin;
-                    cont_cfg.mode         = GPIO_MODE_INPUT;
-                    cont_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-                    cont_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-                    gpio_config(&cont_cfg);
+                        gpio_config_t cont_cfg = {};
+                        cont_cfg.pin_bit_mask = 1ULL << cont_pin;
+                        cont_cfg.mode         = GPIO_MODE_INPUT;
+                        cont_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+                        cont_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+                        gpio_config(&cont_cfg);
 
-                    // Force GPIO matrix output to simple GPIO signal,
-                    // overriding SPI2 peripheral signal on this pin.
-                    esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
-                    gpio_iomux_out(arm_pin, 1, false);
+                        // Force GPIO matrix output to GPIO function on ARM pin
+                        esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
+                        gpio_iomux_out(arm_pin, 1, false);
 
-                    // Arm, settle, read continuity, disarm (under spinlock for GPIO safety)
-                    portENTER_CRITICAL(&pyro_spinlock);
-                    gpio_set_level(arm_pin, 1);
-                    portEXIT_CRITICAL(&pyro_spinlock);
-                    delay(100);
-                    int raw = gpio_get_level(cont_pin);
-                    portENTER_CRITICAL(&pyro_spinlock);
-                    gpio_set_level(arm_pin, 0);
-                    portEXIT_CRITICAL(&pyro_spinlock);
-
-                    // Continuity: 1 = load connected, 0 = open (verified with Arduino test)
-                    non_sensor_data.pyro_status &= ~cont_bit;
-                    if (raw == 1) non_sensor_data.pyro_status |= cont_bit;
-                    ESP_LOGI(TAG, "[PYRO CONT TEST] CH%u raw=%d status=0x%02X",
-                             ch, raw, non_sensor_data.pyro_status);
+                        portENTER_CRITICAL(&pyro_spinlock);
+                        pyroSetArmLocked(true);
+                        portEXIT_CRITICAL(&pyro_spinlock);
+                        delay(100);  // generous settle for ground-test path
+                        int raw = gpio_get_level(cont_pin);
+                        portENTER_CRITICAL(&pyro_spinlock);
+                        pyroSetArmLocked(false);
+                        // Cache the result so the live-telemetry path surfaces it
+                        pyro_ch[idx].cont       = pyroContFromRaw(raw);
+                        pyro_ch[idx].cont_known = true;
+                        portEXIT_CRITICAL(&pyro_spinlock);
+                        ESP_LOGI(TAG, "[PYRO CONT TEST] CH%u raw=%d cont=%d",
+                                 ch, raw, pyroContFromRaw(raw) ? 1 : 0);
+                    }
                 }
             }
             else if (out_pending_command == PYRO_FIRE_TEST)
@@ -3389,46 +3400,52 @@ static void loop_fc()
                         && cfg_len >= 1) {
                         ch = cfg_payload[0];
                     }
-                    gpio_num_t arm_pin  = (ch == 2) ? (gpio_num_t)config::PYRO2_ARM_PIN
-                                                    : (gpio_num_t)config::PYRO1_ARM_PIN;
-                    gpio_num_t fire_pin = (ch == 2) ? (gpio_num_t)config::PYRO2_FIRE_PIN
-                                                    : (gpio_num_t)config::PYRO1_FIRE_PIN;
-                    uint8_t fired_bit   = (ch == 2) ? PSF_CH2_FIRED : PSF_CH1_FIRED;
+                    if (ch < 1 || ch > 4) {
+                        ESP_LOGW(TAG, "[PYRO FIRE TEST] Invalid channel %u", ch);
+                    } else {
+                        const int idx = ch - 1;
+                        const gpio_num_t arm_pin  = (gpio_num_t)config::PYRO_ARM_PIN;
+                        const gpio_num_t fire_pin = (gpio_num_t)PYRO_FIRE_PINS[idx];
 
-                    // Reclaim pins from SPI2
-                    esp_gpio_revoke(1ULL << arm_pin);
-                    esp_gpio_revoke(1ULL << fire_pin);
-                    gpio_reset_pin(arm_pin);
-                    gpio_reset_pin(fire_pin);
+                        esp_gpio_revoke(1ULL << arm_pin);
+                        esp_gpio_revoke(1ULL << fire_pin);
+                        gpio_reset_pin(arm_pin);
+                        gpio_reset_pin(fire_pin);
 
-                    gpio_config_t pin_cfg = {};
-                    pin_cfg.pin_bit_mask = (1ULL << arm_pin) | (1ULL << fire_pin);
-                    pin_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
-                    pin_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-                    pin_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-                    gpio_config(&pin_cfg);
+                        gpio_config_t pin_cfg = {};
+                        pin_cfg.pin_bit_mask = (1ULL << arm_pin) | (1ULL << fire_pin);
+                        pin_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
+                        pin_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+                        pin_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+                        gpio_config(&pin_cfg);
 
-                    esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
-                    gpio_iomux_out(arm_pin, 1, false);
-                    esp_rom_gpio_connect_out_signal(fire_pin, SIG_GPIO_OUT_IDX, false, false);
-                    gpio_iomux_out(fire_pin, 1, false);
+                        esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
+                        gpio_iomux_out(arm_pin, 1, false);
+                        esp_rom_gpio_connect_out_signal(fire_pin, SIG_GPIO_OUT_IDX, false, false);
+                        gpio_iomux_out(fire_pin, 1, false);
 
-                    // Arm → fire pulse → disarm
-                    portENTER_CRITICAL(&pyro_spinlock);
-                    gpio_set_level(arm_pin, 1);
-                    gpio_set_level(fire_pin, 1);
-                    portEXIT_CRITICAL(&pyro_spinlock);
+                        // ARM → settle → FIRE pulse → disarm (synchronous; ground only)
+                        portENTER_CRITICAL(&pyro_spinlock);
+                        pyroSetArmLocked(true);
+                        portEXIT_CRITICAL(&pyro_spinlock);
+                        delay(config::PYRO_ARM_SETTLE_MS);
+                        portENTER_CRITICAL(&pyro_spinlock);
+                        gpio_set_level(fire_pin, 1);
+                        portEXIT_CRITICAL(&pyro_spinlock);
 
-                    delay(config::PYRO_FIRE_DURATION_MS);
+                        delay(config::PYRO_FIRE_DURATION_MS);
 
-                    portENTER_CRITICAL(&pyro_spinlock);
-                    gpio_set_level(fire_pin, 0);
-                    gpio_set_level(arm_pin, 0);
-                    portEXIT_CRITICAL(&pyro_spinlock);
+                        portENTER_CRITICAL(&pyro_spinlock);
+                        gpio_set_level(fire_pin, 0);
+                        pyroSetArmLocked(false);
+                        // Mark the channel as Done so telemetry shows fired
+                        pyro_ch[idx].state          = PyroChState::Done;
+                        pyro_ch[idx].phase_start_ms = 0;
+                        portEXIT_CRITICAL(&pyro_spinlock);
 
-                    non_sensor_data.pyro_status |= fired_bit;
-                    ESP_LOGI(TAG, "[PYRO FIRE TEST] CH%u fired for %u ms",
-                             ch, (unsigned)config::PYRO_FIRE_DURATION_MS);
+                        ESP_LOGI(TAG, "[PYRO FIRE TEST] CH%u fired for %u ms",
+                                 ch, (unsigned)config::PYRO_FIRE_DURATION_MS);
+                    }
                 }
             }
             else if (out_pending_command == SERVO_TEST_PENDING)
@@ -3611,10 +3628,10 @@ static void loop_fc()
         max_alt_m = kinematics.max_altitude;
         max_speed_mps = kinematics.max_speed;
 
-        // Progress any in-flight pyro arming/continuity diagnostic. Must run
-        // every iteration regardless of state/test path so the state machine
-        // started at READY→PRELAUNCH or PRELAUNCH→INFLIGHT finishes promptly.
-        servicePyroArmDiag(now_ms);
+        // Progress the PRELAUNCH continuity diagnostic. Must run every
+        // iteration regardless of state/test path so the state machine
+        // started at READY→PRELAUNCH finishes promptly.
+        servicePyroPrelaunchDiag(now_ms);
 
         if (ground_test_active)
         {
@@ -3799,16 +3816,16 @@ static void loop_fc()
                     burnout_time_ms = 0;
                     burnout_neg_count = 0;
                     guidance_active = false;
-                    // Reset and arm pyro channels on launch
+                    // Reset pyro channels on launch. ARM stays LOW until a
+                    // channel's trigger fires (per-fire arming on new PCB).
                     pyro_apogee_detected = false;
-                    pyro_apogee_time_ms = 0;
+                    pyro_apogee_time_ms  = 0;
                     portENTER_CRITICAL(&pyro_spinlock);
-                    pyro1_fired = false;
-                    pyro2_fired = false;
-                    pyro1_fire_start_ms = 0;
-                    pyro2_fire_start_ms = 0;
+                    for (int i = 0; i < 4; ++i) {
+                        pyro_ch[i].state          = PyroChState::Idle;
+                        pyro_ch[i].phase_start_ms = 0;
+                    }
                     portEXIT_CRITICAL(&pyro_spinlock);
-                    pyroArmEnabled(now_ms);
                     ESP_LOGI(TAG, "[STATE] PRELAUNCH -> INFLIGHT (ground_p=%.0f)",
                                   (double)ground_pressure_pa);
                 }
@@ -4207,46 +4224,43 @@ static void loop_fc()
         if (kinematics.launch_flag || (rocket_state == INFLIGHT)) non_sensor_data.flags |= NSF_LAUNCH;
         if (burnout_detected) non_sensor_data.flags |= NSF_BURNOUT;
         if (guidance_active)  non_sensor_data.flags |= NSF_GUIDANCE;
-        // Apogee detector outputs + master vote (#142/#143).
+        // Apogee detector outputs + master vote (#142/#143) plus relocated
+        // reboot-recovery and guidance-enabled bits (formerly in pyro_status,
+        // moved when pyro_status was reclaimed for 4-channel state).
         non_sensor_data.apogee_flags = 0;
         if (kinematics.gps_apogee_flag)   non_sensor_data.apogee_flags |= NSF2_GPS_APOGEE;
         if (kinematics.pitch_apogee_flag) non_sensor_data.apogee_flags |= NSF2_PITCH_APOGEE;
         if (kinematics.apogee_flag)       non_sensor_data.apogee_flags |= NSF2_MASTER_APOGEE;
-        // Snapshot pyro state under spinlock for telemetry
+        if (reboot_recovery_telem)        non_sensor_data.apogee_flags |= NSF2_REBOOT_RECOVERY;
+        if (guidance_enabled)             non_sensor_data.apogee_flags |= NSF2_GUIDANCE_ENABLED;
+        // Snapshot pyro state under spinlock for telemetry. With per-fire
+        // arming the global "armed" bit just mirrors the live PYRO_ARM pin.
+        bool arm_now;
+        bool cont_known[4], cont_state[4], fired[4];
         portENTER_CRITICAL(&pyro_spinlock);
-        bool p1_armed = pyro1_armed;
-        bool p2_armed = pyro2_armed;
-        bool p1_fired = pyro1_fired;
-        bool p2_fired = pyro2_fired;
+        arm_now = pyro_arm_pin_state;
+        for (int i = 0; i < 4; ++i) {
+            cont_known[i] = pyro_ch[i].cont_known;
+            cont_state[i] = pyro_ch[i].cont;
+            fired[i]      = (pyro_ch[i].state == PyroChState::Done);
+        }
         portEXIT_CRITICAL(&pyro_spinlock);
-        if (p1_armed) non_sensor_data.flags |= NSF_PYRO1_ARMED;
-        if (p2_armed) non_sensor_data.flags |= NSF_PYRO2_ARMED;
+        if (arm_now) non_sensor_data.flags |= NSF_PYRO_ARMED;
         non_sensor_data.rocket_state = (uint8_t)rocket_state;
-        // Pyro continuity: when armed (INFLIGHT), read live from GPIO.
-        // When not armed, preserve bits set by PYRO_CONT_TEST command.
-        // Continuity: GPIO 1 = load connected, 0 = open (verified with Arduino test).
+        // 4-channel pyro status byte: bit pairs (cont, fired) per channel.
+        // CONT bits reflect the last known reading (set during a CONT test
+        // or while ARM is asserted mid-fire). Channels never measured stay
+        // 0 — iOS UI surfaces "unknown" until the prelaunch test runs.
         {
-            uint8_t ps = non_sensor_data.pyro_status;
-            // Clear armed-channel cont bits, then re-read live
-            if (p1_armed) {
-                ps &= ~PSF_CH1_CONT;
-                if (gpio_get_level((gpio_num_t)config::PYRO1_CONT_PIN) == 1)
-                    ps |= PSF_CH1_CONT;
+            uint8_t ps = 0;
+            static constexpr uint8_t CONT_BITS[4]  = {
+                PSF_CH1_CONT, PSF_CH2_CONT, PSF_CH3_CONT, PSF_CH4_CONT };
+            static constexpr uint8_t FIRED_BITS[4] = {
+                PSF_CH1_FIRED, PSF_CH2_FIRED, PSF_CH3_FIRED, PSF_CH4_FIRED };
+            for (int i = 0; i < 4; ++i) {
+                if (cont_known[i] && cont_state[i]) ps |= CONT_BITS[i];
+                if (fired[i])                       ps |= FIRED_BITS[i];
             }
-            if (p2_armed) {
-                ps &= ~PSF_CH2_CONT;
-                if (gpio_get_level((gpio_num_t)config::PYRO2_CONT_PIN) == 1)
-                    ps |= PSF_CH2_CONT;
-            }
-            // Update fired bits
-            if (p1_fired) ps |= PSF_CH1_FIRED;
-            if (p2_fired) ps |= PSF_CH2_FIRED;
-            if (reboot_recovery_telem) ps |= PSF_REBOOT_RECOVERY;
-            // Always report the live guidance_enabled config so the
-            // OutComputer can use it as the authoritative source of truth
-            // (prevents iOS/OUT/FC NVS caches from silently diverging).
-            ps &= ~PSF_GUIDANCE_ENABLED;
-            if (guidance_enabled) ps |= PSF_GUIDANCE_ENABLED;
             non_sensor_data.pyro_status = ps;
         }
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -682,9 +682,20 @@ static void safePyroOutputInit(gpio_num_t pin)
 
 static void initPyroPins()
 {
-    // PYRO_ARM and the four FIRE pins: safe-driven outputs at LOW. The
-    // safePyroOutputInit() helper avoids gpio_reset_pin's pull-up trap that
-    // would otherwise glitch the gate drivers at boot.
+    // ========================================================================
+    // SAFETY-CRITICAL: do NOT replace safePyroOutputInit() with
+    // gpio_reset_pin() for any of the OUTPUT pins below. The IDF's
+    // gpio_reset_pin() transiently enables the internal ~50 kΩ pull-up,
+    // which biases the DTC123J gate-driver NPN base above Vbe long enough
+    // to twitch the ARM and FIRE MOSFETs — confirmed on bench, the pyro
+    // rail flashes on every FC boot.
+    //
+    // If you add new pyro output pins, they MUST go through
+    // safePyroOutputInit(). The CONT input pads are fine on gpio_reset_pin()
+    // because they have no gate driver downstream.
+    // See project_pyro_safe_init_required.md in the agent memory and
+    // commit 421dd63 for the bench observation.
+    // ========================================================================
     const gpio_num_t output_pins[] = {
         (gpio_num_t)config::PYRO_ARM_PIN,
         (gpio_num_t)config::PYRO1_FIRE_PIN,

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3754,10 +3754,15 @@ static void loop_fc()
             }
             case READY:
             {
-                const bool gnss_ready = gnss_started &&
-                                        (now_ms > valid_gnss_start_millis + 3000U) &&
-                                        have_gnss_si &&
-                                        (gnss_latest_si.num_sats >= 4U);
+                // BENCH-ONLY: GNSS-fix requirement bypassed so pyro can be
+                // tested on the bench without a working GPS module. REVERT
+                // before merging — `gnss_ready` must gate this transition
+                // in any flight build.
+                const bool gnss_ready = true;
+                // const bool gnss_ready = gnss_started &&
+                //                         (now_ms > valid_gnss_start_millis + 3000U) &&
+                //                         have_gnss_si &&
+                //                         (gnss_latest_si.num_sats >= 4U);
                 if (out_ready && gnss_ready)
                 {
                     rocket_state = PRELAUNCH;

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -13,6 +13,9 @@ struct config
 
     // --- Power rail switch ---
     static constexpr int PWR_PIN = 6;
+    // New PCB: dedicated GPS enable rail. Toggled in lockstep with PWR_PIN
+    // so the GNSS module powers up alongside the FlightComputer.
+    static constexpr int GPS_PWR_PIN = 33;
 
     // --- Power Monitoring ---
     static constexpr int PWR_SDA = 7;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4420,10 +4420,7 @@ static void loop_oc()
                 // same time so the receiver can start its cold-start
                 // acquisition concurrently with FC boot.
                 digitalWrite(config::PWR_PIN, HIGH);
-                // BENCH-ONLY: GPS rail intentionally kept LOW so pyro can
-                // be exercised on the bench without a usable GNSS module.
-                // REVERT before merging — should be HIGH here in flight build.
-                // digitalWrite(config::GPS_PWR_PIN, HIGH);
+                digitalWrite(config::GPS_PWR_PIN, HIGH);
                 vTaskDelay(pdMS_TO_TICKS(500));  // Allow power rail to stabilize
                 vTaskDelay(1);  // feed watchdog before long init
                 initPeripherals();  // Initialize SPI, NAND, LoRa, I2C

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -544,13 +544,10 @@ static bool    cfg_use_angle_ctrl = false;
 static uint16_t cfg_roll_delay_ms  = 0;
 static bool    cfg_guidance_en  = false;
 static uint8_t cfg_camera_type  = CAM_TYPE_RUNCAM;  // default: RunCam
-// Pyro config cache
-static bool    cfg_pyro1_enabled = false;
-static uint8_t cfg_pyro1_trigger_mode = 0;
-static float   cfg_pyro1_trigger_value = 0.0f;
-static bool    cfg_pyro2_enabled = false;
-static uint8_t cfg_pyro2_trigger_mode = 0;
-static float   cfg_pyro2_trigger_value = 0.0f;
+// Pyro config cache (4 channels on new PCB)
+static bool    cfg_pyro_enabled[4]      = { false, false, false, false };
+static uint8_t cfg_pyro_trigger_mode[4] = { 0, 0, 0, 0 };
+static float   cfg_pyro_trigger_value[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 // Device identity (loaded from NVS "identity" namespace)
 static char    unit_id_hex[9] = {0};           // last 4 bytes of MAC as "a1b2c3d4"
@@ -1485,7 +1482,7 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             // access during BLE file downloads and tripped the task watchdog
             // on CPU 1 when the I2S Parse backlog got large.
             cfg_guidance_en =
-                (latest_non_sensor.pyro_status & PSF_GUIDANCE_ENABLED) != 0;
+                (latest_non_sensor.apogee_flags & NSF2_GUIDANCE_ENABLED) != 0;
         }
     }
     else if (type == POWER_MSG)
@@ -2042,14 +2039,16 @@ static void sendCurrentConfig()
 
     delay(50);  // let BLE stack drain before next notification
 
-    // Message 2: pyro config ("config_pyro" type)
+    // Message 2: pyro config ("config_pyro" type) — 4 channels
     String p = "{\"type\":\"config_pyro\"";
-    p += ",\"p1e\":"; p += cfg_pyro1_enabled ? "true" : "false";
-    p += ",\"p1m\":"; p += itos(cfg_pyro1_trigger_mode);
-    p += ",\"p1v\":"; p += fmtf(cfg_pyro1_trigger_value, 1);
-    p += ",\"p2e\":"; p += cfg_pyro2_enabled ? "true" : "false";
-    p += ",\"p2m\":"; p += itos(cfg_pyro2_trigger_mode);
-    p += ",\"p2v\":"; p += fmtf(cfg_pyro2_trigger_value, 1);
+    static const char* PE_KEYS[4] = { "p1e", "p2e", "p3e", "p4e" };
+    static const char* PM_KEYS[4] = { "p1m", "p2m", "p3m", "p4m" };
+    static const char* PV_KEYS[4] = { "p1v", "p2v", "p3v", "p4v" };
+    for (int i = 0; i < 4; ++i) {
+        p += ",\""; p += PE_KEYS[i]; p += "\":"; p += cfg_pyro_enabled[i]      ? "true" : "false";
+        p += ",\""; p += PM_KEYS[i]; p += "\":"; p += itos(cfg_pyro_trigger_mode[i]);
+        p += ",\""; p += PV_KEYS[i]; p += "\":"; p += fmtf(cfg_pyro_trigger_value[i], 1);
+    }
     p += "}";
     ble_app.sendConfigJSON(p);
     ESP_LOGI("CFG", "Sent pyro config readback (%u bytes)", (unsigned)p.length());
@@ -3325,14 +3324,20 @@ static void printStats()
     ble_telem.alt_apogee_flag   = nsFlagSet(latest_non_sensor.flags, NSF_ALT_APOGEE);
     ble_telem.alt_landed_flag   = nsFlagSet(latest_non_sensor.flags, NSF_ALT_LANDED);
     ble_telem.pwr_pin_on        = pwr_pin_on;
-    // Pyro channel status from NonSensorData
-    ble_telem.pyro1_armed = nsFlagSet(latest_non_sensor.flags, NSF_PYRO1_ARMED);
-    ble_telem.pyro2_armed = nsFlagSet(latest_non_sensor.flags, NSF_PYRO2_ARMED);
-    uint8_t ps = latest_non_sensor.pyro_status;
-    ble_telem.pyro1_cont  = (ps & PSF_CH1_CONT) != 0;
-    ble_telem.pyro2_cont  = (ps & PSF_CH2_CONT) != 0;
-    ble_telem.pyro1_fired = (ps & PSF_CH1_FIRED) != 0;
-    ble_telem.pyro2_fired = (ps & PSF_CH2_FIRED) != 0;
+    // Pyro channel status from NonSensorData (single shared armed bit
+    // mirrors the live ARM pin; 4 per-channel cont/fired bits).
+    ble_telem.pyro_armed = nsFlagSet(latest_non_sensor.flags, NSF_PYRO_ARMED);
+    {
+        const uint8_t ps = latest_non_sensor.pyro_status;
+        ble_telem.pyro_cont[0]  = (ps & PSF_CH1_CONT)  != 0;
+        ble_telem.pyro_fired[0] = (ps & PSF_CH1_FIRED) != 0;
+        ble_telem.pyro_cont[1]  = (ps & PSF_CH2_CONT)  != 0;
+        ble_telem.pyro_fired[1] = (ps & PSF_CH2_FIRED) != 0;
+        ble_telem.pyro_cont[2]  = (ps & PSF_CH3_CONT)  != 0;
+        ble_telem.pyro_fired[2] = (ps & PSF_CH3_FIRED) != 0;
+        ble_telem.pyro_cont[3]  = (ps & PSF_CH4_CONT)  != 0;
+        ble_telem.pyro_fired[3] = (ps & PSF_CH4_FIRED) != 0;
+    }
 
     static uint32_t telem_send_count = 0;
     static uint32_t telem_skip_count = 0;
@@ -3624,23 +3629,30 @@ void initPeripherals()
                  cfg_camera_type == CAM_TYPE_GOPRO ? "GoPro" :
                  cfg_camera_type == CAM_TYPE_RUNCAM ? "RunCam" : "None");
 
-        // Load cached pyro config from NVS
+        // Load cached pyro config from NVS (4 channels)
         prefs.begin("pyro", true);
         size_t pyro_sz = prefs.getBytesLength("cfg");
         if (pyro_sz == sizeof(PyroConfigData)) {
             PyroConfigData pcfg;
             prefs.getBytes("cfg", &pcfg, sizeof(pcfg));
-            cfg_pyro1_enabled       = pcfg.ch1_enabled;
-            cfg_pyro1_trigger_mode  = pcfg.ch1_trigger_mode;
-            cfg_pyro1_trigger_value = pcfg.ch1_trigger_value;
-            cfg_pyro2_enabled       = pcfg.ch2_enabled;
-            cfg_pyro2_trigger_mode  = pcfg.ch2_trigger_mode;
-            cfg_pyro2_trigger_value = pcfg.ch2_trigger_value;
+            const uint8_t en[4]   = { pcfg.ch1_enabled,      pcfg.ch2_enabled,
+                                      pcfg.ch3_enabled,      pcfg.ch4_enabled };
+            const uint8_t mode[4] = { pcfg.ch1_trigger_mode, pcfg.ch2_trigger_mode,
+                                      pcfg.ch3_trigger_mode, pcfg.ch4_trigger_mode };
+            const float   val[4]  = { pcfg.ch1_trigger_value, pcfg.ch2_trigger_value,
+                                      pcfg.ch3_trigger_value, pcfg.ch4_trigger_value };
+            for (int i = 0; i < 4; ++i) {
+                cfg_pyro_enabled[i]       = en[i];
+                cfg_pyro_trigger_mode[i]  = mode[i];
+                cfg_pyro_trigger_value[i] = val[i];
+            }
         }
         prefs.end();
-        ESP_LOGI("CFG", "NVS Pyro: ch1=%u/%u/%.1f ch2=%u/%u/%.1f",
-                 cfg_pyro1_enabled, cfg_pyro1_trigger_mode, (double)cfg_pyro1_trigger_value,
-                 cfg_pyro2_enabled, cfg_pyro2_trigger_mode, (double)cfg_pyro2_trigger_value);
+        ESP_LOGI("CFG", "NVS Pyro: ch1=%u/%u/%.1f  ch2=%u/%u/%.1f  ch3=%u/%u/%.1f  ch4=%u/%u/%.1f",
+                 cfg_pyro_enabled[0], cfg_pyro_trigger_mode[0], (double)cfg_pyro_trigger_value[0],
+                 cfg_pyro_enabled[1], cfg_pyro_trigger_mode[1], (double)cfg_pyro_trigger_value[1],
+                 cfg_pyro_enabled[2], cfg_pyro_trigger_mode[2], (double)cfg_pyro_trigger_value[2],
+                 cfg_pyro_enabled[3], cfg_pyro_trigger_mode[3], (double)cfg_pyro_trigger_value[3]);
     }
 
     if (config::USE_LORA_RADIO)
@@ -4724,18 +4736,23 @@ static void loop_oc()
         }
         else if (ble_cmd == 34)
         {
-            // Pyro config: [ch1_en:1][ch1_mode:1][ch1_val:4f][ch2_en:1][ch2_mode:1][ch2_val:4f] = 12 bytes
+            // Pyro config: 4 × {enabled:1, mode:1, value:4f} = 24 bytes
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
             if (plen >= sizeof(PyroConfigData)) {
                 PyroConfigData pcfg;
                 memcpy(&pcfg, payload, sizeof(pcfg));
-                cfg_pyro1_enabled       = pcfg.ch1_enabled;
-                cfg_pyro1_trigger_mode  = pcfg.ch1_trigger_mode;
-                cfg_pyro1_trigger_value = pcfg.ch1_trigger_value;
-                cfg_pyro2_enabled       = pcfg.ch2_enabled;
-                cfg_pyro2_trigger_mode  = pcfg.ch2_trigger_mode;
-                cfg_pyro2_trigger_value = pcfg.ch2_trigger_value;
+                const uint8_t en[4]   = { pcfg.ch1_enabled,      pcfg.ch2_enabled,
+                                          pcfg.ch3_enabled,      pcfg.ch4_enabled };
+                const uint8_t mode[4] = { pcfg.ch1_trigger_mode, pcfg.ch2_trigger_mode,
+                                          pcfg.ch3_trigger_mode, pcfg.ch4_trigger_mode };
+                const float   val[4]  = { pcfg.ch1_trigger_value, pcfg.ch2_trigger_value,
+                                          pcfg.ch3_trigger_value, pcfg.ch4_trigger_value };
+                for (int i = 0; i < 4; ++i) {
+                    cfg_pyro_enabled[i]       = en[i];
+                    cfg_pyro_trigger_mode[i]  = mode[i];
+                    cfg_pyro_trigger_value[i] = val[i];
+                }
                 // Queue for FC via I2C
                 memcpy(pending_config_data, &pcfg, sizeof(pcfg));
                 pending_config_data_len = sizeof(pcfg);
@@ -4746,9 +4763,11 @@ static void loop_oc()
                 prefs.begin("pyro", false);
                 size_t written = prefs.putBytes("cfg", &pcfg, sizeof(pcfg));
                 prefs.end();
-                ESP_LOGI("BLE", "Pyro config: ch1=%u/%u/%.1f ch2=%u/%u/%.1f (NVS wrote %u bytes)",
+                ESP_LOGI("BLE", "Pyro config: ch1=%u/%u/%.1f  ch2=%u/%u/%.1f  ch3=%u/%u/%.1f  ch4=%u/%u/%.1f (NVS wrote %u bytes)",
                          pcfg.ch1_enabled, pcfg.ch1_trigger_mode, (double)pcfg.ch1_trigger_value,
                          pcfg.ch2_enabled, pcfg.ch2_trigger_mode, (double)pcfg.ch2_trigger_value,
+                         pcfg.ch3_enabled, pcfg.ch3_trigger_mode, (double)pcfg.ch3_trigger_value,
+                         pcfg.ch4_enabled, pcfg.ch4_trigger_mode, (double)pcfg.ch4_trigger_value,
                          (unsigned)written);
             } else {
                 ESP_LOGW("BLE", "Pyro config: payload too short (%u < %u)",
@@ -4757,28 +4776,35 @@ static void loop_oc()
         }
         else if (ble_cmd == 35)
         {
-            // Pyro continuity test — 1 byte payload: channel (1 or 2)
+            // Pyro continuity test — 1 byte payload: channel (1..4)
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
             uint8_t ch = (plen >= 1) ? payload[0] : 0;
-            // Pack channel into config data so FC knows which channel
-            pending_config_data[0] = ch;
-            pending_config_data_len = 1;
-            pending_config_msg_type = PYRO_CONT_TEST;
-            setPendingCommand(PYRO_CONT_TEST);
-            ESP_LOGI("BLE", "Pyro continuity test CH%u", ch);
+            if (ch < 1 || ch > 4) {
+                ESP_LOGW("BLE", "Pyro continuity test: invalid channel %u", ch);
+            } else {
+                pending_config_data[0] = ch;
+                pending_config_data_len = 1;
+                pending_config_msg_type = PYRO_CONT_TEST;
+                setPendingCommand(PYRO_CONT_TEST);
+                ESP_LOGI("BLE", "Pyro continuity test CH%u", ch);
+            }
         }
         else if (ble_cmd == 36)
         {
-            // Pyro test fire — 1 byte payload: channel (1 or 2)
+            // Pyro test fire — 1 byte payload: channel (1..4)
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
             uint8_t ch = (plen >= 1) ? payload[0] : 0;
-            pending_config_data[0] = ch;
-            pending_config_data_len = 1;
-            pending_config_msg_type = PYRO_FIRE_TEST;
-            setPendingCommand(PYRO_FIRE_TEST);
-            ESP_LOGI("BLE", "Pyro test fire CH%u", ch);
+            if (ch < 1 || ch > 4) {
+                ESP_LOGW("BLE", "Pyro test fire: invalid channel %u", ch);
+            } else {
+                pending_config_data[0] = ch;
+                pending_config_data_len = 1;
+                pending_config_msg_type = PYRO_FIRE_TEST;
+                setPendingCommand(PYRO_FIRE_TEST);
+                ESP_LOGI("BLE", "Pyro test fire CH%u", ch);
+            }
         }
         // ---- Device Identity Commands ----
         else if (ble_cmd == 40)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4420,7 +4420,10 @@ static void loop_oc()
                 // same time so the receiver can start its cold-start
                 // acquisition concurrently with FC boot.
                 digitalWrite(config::PWR_PIN, HIGH);
-                digitalWrite(config::GPS_PWR_PIN, HIGH);
+                // BENCH-ONLY: GPS rail intentionally kept LOW so pyro can
+                // be exercised on the bench without a usable GNSS module.
+                // REVERT before merging — should be HIGH here in flight build.
+                // digitalWrite(config::GPS_PWR_PIN, HIGH);
                 vTaskDelay(pdMS_TO_TICKS(500));  // Allow power rail to stabilize
                 vTaskDelay(1);  // feed watchdog before long init
                 initPeripherals();  // Initialize SPI, NAND, LoRa, I2C

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3787,6 +3787,8 @@ static void setup_oc()
 
     pinMode(config::PWR_PIN, OUTPUT);
     digitalWrite(config::PWR_PIN, LOW);   // Start with power rail OFF
+    pinMode(config::GPS_PWR_PIN, OUTPUT);
+    digitalWrite(config::GPS_PWR_PIN, LOW);  // GPS enable rail off at boot
     pwr_pin_on = false;
 
     ESP_LOGI("OC", "Starting OutComputer (low-power mode)...");
@@ -4413,8 +4415,12 @@ static void loop_oc()
                 // full CPU speed and no auto light-sleep during init.
                 exitLowPowerMode();
 
-                // Power on the FlightComputer + sensors
+                // Power on the FlightComputer + sensors. New PCB also gates
+                // the GNSS rail off a separate enable that comes up at the
+                // same time so the receiver can start its cold-start
+                // acquisition concurrently with FC boot.
                 digitalWrite(config::PWR_PIN, HIGH);
+                digitalWrite(config::GPS_PWR_PIN, HIGH);
                 vTaskDelay(pdMS_TO_TICKS(500));  // Allow power rail to stabilize
                 vTaskDelay(1);  // feed watchdog before long init
                 initPeripherals();  // Initialize SPI, NAND, LoRa, I2C
@@ -4456,6 +4462,7 @@ static void loop_oc()
                 // hardware quirk exercises the same recovery path.
                 ESP_LOGI("PWR", "Power off: resetting OC for clean idle state (#9)...");
                 digitalWrite(config::PWR_PIN, LOW);
+                digitalWrite(config::GPS_PWR_PIN, LOW);  // drop GNSS rail in lockstep
 
                 // Drive every signal that goes from the OC to the switched-
                 // rail peripherals (LoRa, NAND, MRAM) LOW so back-feed current

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
@@ -1,5 +1,4 @@
 idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
-    REQUIRES esp_adc esp_driver_gpio
 )

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
+    REQUIRES esp_adc esp_driver_gpio
 )

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
@@ -29,7 +29,7 @@
  *   a   toggle shared ARM (latching, affects ALL channels)
  *   f   pulse FIRE 500 ms on active channel (only if armed)
  *   F   pulse FIRE 2 s    on active channel (only if armed)
- *   c   read continuity on active channel (meaningful only when ARMed)
+ *   c   read continuity on active channel
  *   C   momentary continuity test (arm 200 ms, read, disarm)
  *   r   read continuity raw on ALL channels (compare)
  *   j   jam FIRE high indefinitely on active channel (must be armed)
@@ -151,7 +151,7 @@ static void print_state()
            ch[active].name, PYRO_ARM_PIN, global_arm ? 1 : 0);
     for (auto& c : ch) {
         int raw = gpio_get_level(c.cont);
-        printf("  %s  CONT raw=%d -> cont=%d  FIRE(GPIO%d) rb=%d  (cont meaningful only when ARM=1)\n",
+        printf("  %s  CONT raw=%d -> cont=%d  FIRE(GPIO%d) rb=%d\n",
                c.name, raw, cont_from_raw(raw) ? 1 : 0,
                c.fire, gpio_get_level(c.fire));
     }
@@ -193,8 +193,8 @@ static void cmd_cont_raw()
 {
     auto& c = ch[active];
     int raw = gpio_get_level(c.cont);
-    printf("[%s] CONT raw=%d -> cont=%d  (ARM=%d — only meaningful when ARM=1)\n",
-           c.name, raw, cont_from_raw(raw) ? 1 : 0, global_arm ? 1 : 0);
+    printf("[%s] CONT raw=%d -> cont=%d\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0);
 }
 
 static void cmd_cont_momentary()

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
@@ -44,11 +44,6 @@
 #include <unistd.h>
 #include <driver/gpio.h>
 #include <esp_log.h>
-#include <esp_adc/adc_oneshot.h>
-// ESP32-P4 in IDF 5.3.2 has no ADC calibration scheme yet (per
-// components/esp_adc/esp32p4/include/adc_cali_schemes.h), so we skip cali
-// entirely and approximate mV from raw counts using the nominal 12-bit /
-// 12 dB atten range. Rough — but plenty for "is this 2.2 V or 3.3 V?".
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -72,73 +67,8 @@ static PyroChannel ch[4] = {
 static int  active     = 0;      // 0..3
 static bool global_arm = false;  // mirrors PYRO_ARM_PIN level
 
-// ADC handles for the two CONT pins that are ADC-capable on ESP32-P4:
-//   PYRO2_CONT = GPIO 18 -> ADC1 channel 2
-//   PYRO4_CONT = GPIO 51 -> ADC2 channel 2
-// PYRO1_CONT (GPIO 15) and PYRO3_CONT (GPIO 38) have no ADC mapping; those
-// channels stay on digital reads only.
-static adc_oneshot_unit_handle_t adc1_h = nullptr;
-static adc_oneshot_unit_handle_t adc2_h = nullptr;
-
-struct ChannelAdc {
-    adc_oneshot_unit_handle_t* unit;  // nullptr if no ADC on this channel
-    adc_channel_t              channel;
-};
-static ChannelAdc adc_map[4] = {
-    { nullptr,  (adc_channel_t)0 },   // PYRO1 GPIO15: no ADC
-    { &adc1_h,  ADC_CHANNEL_2 },      // PYRO2 GPIO18: ADC1 ch2
-    { nullptr,  (adc_channel_t)0 },   // PYRO3 GPIO38: no ADC
-    { &adc2_h,  ADC_CHANNEL_2 },      // PYRO4 GPIO51: ADC2 ch2
-};
-static inline bool has_adc(int i) { return adc_map[i].unit != nullptr; }
-
-// 12-bit ADC, ADC_ATTEN_DB_12 → ~0-3100 mV linear range. Real chip has some
-// non-linearity at the rails; for our "2.2 V vs 3.3 V" question this is fine.
-static inline int adc_raw_to_mv_rough(int raw) { return (raw * 3100) / 4095; }
-
-// New-PCB inverted continuity (digital sense): raw 0 = closed (load present).
+// New-PCB inverted continuity: raw 0 = closed (load present).
 static inline bool cont_from_raw(int raw) { return raw == 0; }
-
-// ADC-based continuity threshold. With the current divider (R29 50k pull-up,
-// R85 100k isolation) and VPP ~3.3 V, expect ~3.3 V open and ~2.2 V with a
-// shorted load. Threshold at 2.7 V (mid-band) — tune empirically once we see
-// real numbers.
-static constexpr int CONT_THRESHOLD_MV = 2700;
-static inline bool cont_from_mv(int mv) { return mv > 0 && mv < CONT_THRESHOLD_MV; }
-
-// Returns true if ADC read succeeded. Populates raw_out (0..4095) and
-// mv_out (rough mV from the linear approximation above).
-static bool read_adc_mv(int i, int* raw_out, int* mv_out)
-{
-    *raw_out = 0;
-    *mv_out  = 0;
-    if (!has_adc(i)) return false;
-    if (adc_oneshot_read(*adc_map[i].unit, adc_map[i].channel, raw_out) != ESP_OK) {
-        return false;
-    }
-    *mv_out = adc_raw_to_mv_rough(*raw_out);
-    return true;
-}
-
-// Print a uniform CONT line for one channel, automatically picking digital
-// or ADC read based on the pin's capability.
-static void print_cont_for(int i, const char* prefix = "  ", const char* suffix = "")
-{
-    if (has_adc(i)) {
-        int raw = 0, mv = 0;
-        bool ok = read_adc_mv(i, &raw, &mv);
-        if (ok) {
-            printf("%s%s  ADC raw=%4d (%4d mV) -> cont=%d%s\n",
-                   prefix, ch[i].name, raw, mv, cont_from_mv(mv) ? 1 : 0, suffix);
-        } else {
-            printf("%s%s  ADC read FAILED%s\n", prefix, ch[i].name, suffix);
-        }
-    } else {
-        int raw = gpio_get_level(ch[i].cont);
-        printf("%s%s  CONT raw=%d -> cont=%d%s\n",
-               prefix, ch[i].name, raw, cont_from_raw(raw) ? 1 : 0, suffix);
-    }
-}
 
 static void init_pins()
 {
@@ -159,8 +89,7 @@ static void init_pins()
         gpio_set_level(PYRO_ARM_PIN, 0);
     }
 
-    for (int i = 0; i < 4; ++i) {
-        auto& c = ch[i];
+    for (auto& c : ch) {
         gpio_reset_pin(c.fire);
         gpio_reset_pin(c.cont);
 
@@ -172,37 +101,15 @@ static void init_pins()
         gpio_config(&out_cfg);
         gpio_set_level(c.fire, 0);
 
-        // CONT: only configure as a digital input on channels without ADC.
-        // ADC-capable channels (2 and 4) get their pad set up by
-        // adc_oneshot_config_channel() in init_adc().
-        if (!has_adc(i)) {
-            gpio_config_t in_cfg = {};
-            in_cfg.pin_bit_mask  = 1ULL << c.cont;
-            in_cfg.mode          = GPIO_MODE_INPUT;
-            in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;
-            in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
-            gpio_config(&in_cfg);
-        }
+        gpio_config_t in_cfg = {};
+        in_cfg.pin_bit_mask  = 1ULL << c.cont;
+        in_cfg.mode          = GPIO_MODE_INPUT;
+        in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;   // PCB has external pull on CONT
+        in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
+        gpio_config(&in_cfg);
     }
 
     global_arm = false;
-}
-
-static void init_adc()
-{
-    adc_oneshot_unit_init_cfg_t init1 = {};
-    init1.unit_id = ADC_UNIT_1;
-    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init1, &adc1_h));
-
-    adc_oneshot_unit_init_cfg_t init2 = {};
-    init2.unit_id = ADC_UNIT_2;
-    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init2, &adc2_h));
-
-    adc_oneshot_chan_cfg_t chan = {};
-    chan.atten    = ADC_ATTEN_DB_12;          // ~0-3.1 V input range
-    chan.bitwidth = ADC_BITWIDTH_DEFAULT;     // 12-bit on ESP32-P4
-    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_h, ADC_CHANNEL_2, &chan));
-    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc2_h, ADC_CHANNEL_2, &chan));
 }
 
 static void set_arm(bool on)
@@ -220,16 +127,12 @@ static void disarm_all()
 static void print_help()
 {
     printf("\n=== Pyro Channel Debug (new PCB, shared ARM) ===\n");
-    printf("  CONT readings: digital on ch1/ch3 (GPIO 15/38, no ADC).\n");
-    printf("  Analog (ADC1/ADC2) on ch2 (GPIO18) and ch4 (GPIO51) -\n");
-    printf("  use those to validate the divider topology.\n");
-    printf("\n");
     printf("  ?   help\n");
     printf("  s   show state\n");
-    printf("  1   select channel 1 (CONT=15 FIRE=16, digital)\n");
-    printf("  2   select channel 2 (CONT=18 FIRE=19, ADC1)\n");
-    printf("  3   select channel 3 (CONT=38 FIRE=34, digital)\n");
-    printf("  4   select channel 4 (CONT=51 FIRE=50, ADC2)\n");
+    printf("  1   select channel 1 (CONT=15 FIRE=16)\n");
+    printf("  2   select channel 2 (CONT=18 FIRE=19)\n");
+    printf("  3   select channel 3 (CONT=38 FIRE=34)\n");
+    printf("  4   select channel 4 (CONT=51 FIRE=50)\n");
     printf("  a   toggle shared ARM (pin 14, affects ALL channels)\n");
     printf("  f   pulse FIRE 500 ms on active channel (must be armed)\n");
     printf("  F   pulse FIRE 2 s    on active channel (must be armed)\n");
@@ -246,13 +149,13 @@ static void print_state()
 {
     printf("\nactive: %s   ARM(GPIO%d)=%d\n",
            ch[active].name, PYRO_ARM_PIN, global_arm ? 1 : 0);
-    for (int i = 0; i < 4; ++i) {
-        char suffix[64];
-        snprintf(suffix, sizeof(suffix), "  FIRE(GPIO%d) rb=%d",
-                 ch[i].fire, gpio_get_level(ch[i].fire));
-        print_cont_for(i, "  ", suffix);
+    for (auto& c : ch) {
+        int raw = gpio_get_level(c.cont);
+        printf("  %s  CONT raw=%d -> cont=%d  FIRE(GPIO%d) rb=%d  (cont meaningful only when ARM=1)\n",
+               c.name, raw, cont_from_raw(raw) ? 1 : 0,
+               c.fire, gpio_get_level(c.fire));
     }
-    printf("  (cont meaningful only when ARM=1)\n\n");
+    printf("\n");
 }
 
 static void cmd_toggle_arm()
@@ -262,7 +165,11 @@ static void cmd_toggle_arm()
            global_arm ? 1 : 0, PYRO_ARM_PIN, gpio_get_level(PYRO_ARM_PIN));
     if (global_arm) {
         vTaskDelay(pdMS_TO_TICKS(50));
-        for (int i = 0; i < 4; ++i) print_cont_for(i);
+        for (auto& c : ch) {
+            int raw = gpio_get_level(c.cont);
+            printf("  %s  CONT raw=%d -> cont=%d\n",
+                   c.name, raw, cont_from_raw(raw) ? 1 : 0);
+        }
     }
 }
 
@@ -277,38 +184,41 @@ static void cmd_fire(uint32_t ms)
     gpio_set_level(c.fire, 1);
     vTaskDelay(pdMS_TO_TICKS(ms));
     gpio_set_level(c.fire, 0);
-    printf("[%s] FIRE done.\n", c.name);
-    print_cont_for(active);
+    int raw = gpio_get_level(c.cont);
+    printf("[%s] FIRE done. CONT raw=%d -> cont=%d\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0);
 }
 
 static void cmd_cont_raw()
 {
-    char suffix[40];
-    snprintf(suffix, sizeof(suffix), "  (ARM=%d)", global_arm ? 1 : 0);
-    print_cont_for(active, "[active] ", suffix);
+    auto& c = ch[active];
+    int raw = gpio_get_level(c.cont);
+    printf("[%s] CONT raw=%d -> cont=%d  (ARM=%d — only meaningful when ARM=1)\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0, global_arm ? 1 : 0);
 }
 
 static void cmd_cont_momentary()
 {
+    auto& c = ch[active];
     bool was_armed = global_arm;
     if (!was_armed) {
         set_arm(true);
         vTaskDelay(pdMS_TO_TICKS(200));
     }
-    printf("[%s] momentary cont test:\n", ch[active].name);
-    print_cont_for(active, "  ");
+    int raw = gpio_get_level(c.cont);
     if (!was_armed) set_arm(false);
-    printf("  (new PCB: digital raw 0 = closed; ADC mV < %d -> closed)\n",
-           CONT_THRESHOLD_MV);
+    printf("[%s] momentary CONT raw=%d -> cont=%d  "
+           "(new PCB: raw 0 = closed/load present, raw 1 = open)\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0);
 }
 
 static void cmd_read_all()
 {
     printf("ARM=%d  (pin %d)\n", global_arm ? 1 : 0, PYRO_ARM_PIN);
-    for (int i = 0; i < 4; ++i) {
-        char suffix[40];
-        snprintf(suffix, sizeof(suffix), "  FIRE rb=%d", gpio_get_level(ch[i].fire));
-        print_cont_for(i, "  ", suffix);
+    for (auto& c : ch) {
+        int raw = gpio_get_level(c.cont);
+        printf("  %s  CONT raw=%d -> cont=%d  FIRE rb=%d\n",
+               c.name, raw, cont_from_raw(raw) ? 1 : 0, gpio_get_level(c.fire));
     }
 }
 
@@ -386,7 +296,6 @@ extern "C" void app_main()
     vTaskDelay(pdMS_TO_TICKS(500));
 
     init_pins();
-    init_adc();
 
     // Non-blocking stdin so we can poll without freezing the task.
     int flags = fcntl(fileno(stdin), F_GETFL, 0);

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
@@ -44,6 +44,11 @@
 #include <unistd.h>
 #include <driver/gpio.h>
 #include <esp_log.h>
+#include <esp_adc/adc_oneshot.h>
+// ESP32-P4 in IDF 5.3.2 has no ADC calibration scheme yet (per
+// components/esp_adc/esp32p4/include/adc_cali_schemes.h), so we skip cali
+// entirely and approximate mV from raw counts using the nominal 12-bit /
+// 12 dB atten range. Rough — but plenty for "is this 2.2 V or 3.3 V?".
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -67,8 +72,73 @@ static PyroChannel ch[4] = {
 static int  active     = 0;      // 0..3
 static bool global_arm = false;  // mirrors PYRO_ARM_PIN level
 
-// New-PCB inverted continuity: raw 0 = closed (load present).
+// ADC handles for the two CONT pins that are ADC-capable on ESP32-P4:
+//   PYRO2_CONT = GPIO 18 -> ADC1 channel 2
+//   PYRO4_CONT = GPIO 51 -> ADC2 channel 2
+// PYRO1_CONT (GPIO 15) and PYRO3_CONT (GPIO 38) have no ADC mapping; those
+// channels stay on digital reads only.
+static adc_oneshot_unit_handle_t adc1_h = nullptr;
+static adc_oneshot_unit_handle_t adc2_h = nullptr;
+
+struct ChannelAdc {
+    adc_oneshot_unit_handle_t* unit;  // nullptr if no ADC on this channel
+    adc_channel_t              channel;
+};
+static ChannelAdc adc_map[4] = {
+    { nullptr,  (adc_channel_t)0 },   // PYRO1 GPIO15: no ADC
+    { &adc1_h,  ADC_CHANNEL_2 },      // PYRO2 GPIO18: ADC1 ch2
+    { nullptr,  (adc_channel_t)0 },   // PYRO3 GPIO38: no ADC
+    { &adc2_h,  ADC_CHANNEL_2 },      // PYRO4 GPIO51: ADC2 ch2
+};
+static inline bool has_adc(int i) { return adc_map[i].unit != nullptr; }
+
+// 12-bit ADC, ADC_ATTEN_DB_12 → ~0-3100 mV linear range. Real chip has some
+// non-linearity at the rails; for our "2.2 V vs 3.3 V" question this is fine.
+static inline int adc_raw_to_mv_rough(int raw) { return (raw * 3100) / 4095; }
+
+// New-PCB inverted continuity (digital sense): raw 0 = closed (load present).
 static inline bool cont_from_raw(int raw) { return raw == 0; }
+
+// ADC-based continuity threshold. With the current divider (R29 50k pull-up,
+// R85 100k isolation) and VPP ~3.3 V, expect ~3.3 V open and ~2.2 V with a
+// shorted load. Threshold at 2.7 V (mid-band) — tune empirically once we see
+// real numbers.
+static constexpr int CONT_THRESHOLD_MV = 2700;
+static inline bool cont_from_mv(int mv) { return mv > 0 && mv < CONT_THRESHOLD_MV; }
+
+// Returns true if ADC read succeeded. Populates raw_out (0..4095) and
+// mv_out (rough mV from the linear approximation above).
+static bool read_adc_mv(int i, int* raw_out, int* mv_out)
+{
+    *raw_out = 0;
+    *mv_out  = 0;
+    if (!has_adc(i)) return false;
+    if (adc_oneshot_read(*adc_map[i].unit, adc_map[i].channel, raw_out) != ESP_OK) {
+        return false;
+    }
+    *mv_out = adc_raw_to_mv_rough(*raw_out);
+    return true;
+}
+
+// Print a uniform CONT line for one channel, automatically picking digital
+// or ADC read based on the pin's capability.
+static void print_cont_for(int i, const char* prefix = "  ", const char* suffix = "")
+{
+    if (has_adc(i)) {
+        int raw = 0, mv = 0;
+        bool ok = read_adc_mv(i, &raw, &mv);
+        if (ok) {
+            printf("%s%s  ADC raw=%4d (%4d mV) -> cont=%d%s\n",
+                   prefix, ch[i].name, raw, mv, cont_from_mv(mv) ? 1 : 0, suffix);
+        } else {
+            printf("%s%s  ADC read FAILED%s\n", prefix, ch[i].name, suffix);
+        }
+    } else {
+        int raw = gpio_get_level(ch[i].cont);
+        printf("%s%s  CONT raw=%d -> cont=%d%s\n",
+               prefix, ch[i].name, raw, cont_from_raw(raw) ? 1 : 0, suffix);
+    }
+}
 
 static void init_pins()
 {
@@ -89,7 +159,8 @@ static void init_pins()
         gpio_set_level(PYRO_ARM_PIN, 0);
     }
 
-    for (auto& c : ch) {
+    for (int i = 0; i < 4; ++i) {
+        auto& c = ch[i];
         gpio_reset_pin(c.fire);
         gpio_reset_pin(c.cont);
 
@@ -101,15 +172,37 @@ static void init_pins()
         gpio_config(&out_cfg);
         gpio_set_level(c.fire, 0);
 
-        gpio_config_t in_cfg = {};
-        in_cfg.pin_bit_mask  = 1ULL << c.cont;
-        in_cfg.mode          = GPIO_MODE_INPUT;
-        in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;   // PCB has external pull on CONT
-        in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
-        gpio_config(&in_cfg);
+        // CONT: only configure as a digital input on channels without ADC.
+        // ADC-capable channels (2 and 4) get their pad set up by
+        // adc_oneshot_config_channel() in init_adc().
+        if (!has_adc(i)) {
+            gpio_config_t in_cfg = {};
+            in_cfg.pin_bit_mask  = 1ULL << c.cont;
+            in_cfg.mode          = GPIO_MODE_INPUT;
+            in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;
+            in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
+            gpio_config(&in_cfg);
+        }
     }
 
     global_arm = false;
+}
+
+static void init_adc()
+{
+    adc_oneshot_unit_init_cfg_t init1 = {};
+    init1.unit_id = ADC_UNIT_1;
+    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init1, &adc1_h));
+
+    adc_oneshot_unit_init_cfg_t init2 = {};
+    init2.unit_id = ADC_UNIT_2;
+    ESP_ERROR_CHECK(adc_oneshot_new_unit(&init2, &adc2_h));
+
+    adc_oneshot_chan_cfg_t chan = {};
+    chan.atten    = ADC_ATTEN_DB_12;          // ~0-3.1 V input range
+    chan.bitwidth = ADC_BITWIDTH_DEFAULT;     // 12-bit on ESP32-P4
+    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc1_h, ADC_CHANNEL_2, &chan));
+    ESP_ERROR_CHECK(adc_oneshot_config_channel(adc2_h, ADC_CHANNEL_2, &chan));
 }
 
 static void set_arm(bool on)
@@ -127,12 +220,16 @@ static void disarm_all()
 static void print_help()
 {
     printf("\n=== Pyro Channel Debug (new PCB, shared ARM) ===\n");
+    printf("  CONT readings: digital on ch1/ch3 (GPIO 15/38, no ADC).\n");
+    printf("  Analog (ADC1/ADC2) on ch2 (GPIO18) and ch4 (GPIO51) -\n");
+    printf("  use those to validate the divider topology.\n");
+    printf("\n");
     printf("  ?   help\n");
     printf("  s   show state\n");
-    printf("  1   select channel 1 (CONT=15 FIRE=16)\n");
-    printf("  2   select channel 2 (CONT=18 FIRE=19)\n");
-    printf("  3   select channel 3 (CONT=38 FIRE=34)\n");
-    printf("  4   select channel 4 (CONT=51 FIRE=50)\n");
+    printf("  1   select channel 1 (CONT=15 FIRE=16, digital)\n");
+    printf("  2   select channel 2 (CONT=18 FIRE=19, ADC1)\n");
+    printf("  3   select channel 3 (CONT=38 FIRE=34, digital)\n");
+    printf("  4   select channel 4 (CONT=51 FIRE=50, ADC2)\n");
     printf("  a   toggle shared ARM (pin 14, affects ALL channels)\n");
     printf("  f   pulse FIRE 500 ms on active channel (must be armed)\n");
     printf("  F   pulse FIRE 2 s    on active channel (must be armed)\n");
@@ -149,13 +246,13 @@ static void print_state()
 {
     printf("\nactive: %s   ARM(GPIO%d)=%d\n",
            ch[active].name, PYRO_ARM_PIN, global_arm ? 1 : 0);
-    for (auto& c : ch) {
-        int raw = gpio_get_level(c.cont);
-        printf("  %s  CONT raw=%d -> cont=%d  FIRE(GPIO%d) rb=%d  (cont meaningful only when ARM=1)\n",
-               c.name, raw, cont_from_raw(raw) ? 1 : 0,
-               c.fire, gpio_get_level(c.fire));
+    for (int i = 0; i < 4; ++i) {
+        char suffix[64];
+        snprintf(suffix, sizeof(suffix), "  FIRE(GPIO%d) rb=%d",
+                 ch[i].fire, gpio_get_level(ch[i].fire));
+        print_cont_for(i, "  ", suffix);
     }
-    printf("\n");
+    printf("  (cont meaningful only when ARM=1)\n\n");
 }
 
 static void cmd_toggle_arm()
@@ -165,11 +262,7 @@ static void cmd_toggle_arm()
            global_arm ? 1 : 0, PYRO_ARM_PIN, gpio_get_level(PYRO_ARM_PIN));
     if (global_arm) {
         vTaskDelay(pdMS_TO_TICKS(50));
-        for (auto& c : ch) {
-            int raw = gpio_get_level(c.cont);
-            printf("  %s  CONT raw=%d -> cont=%d\n",
-                   c.name, raw, cont_from_raw(raw) ? 1 : 0);
-        }
+        for (int i = 0; i < 4; ++i) print_cont_for(i);
     }
 }
 
@@ -184,41 +277,38 @@ static void cmd_fire(uint32_t ms)
     gpio_set_level(c.fire, 1);
     vTaskDelay(pdMS_TO_TICKS(ms));
     gpio_set_level(c.fire, 0);
-    int raw = gpio_get_level(c.cont);
-    printf("[%s] FIRE done. CONT raw=%d -> cont=%d\n",
-           c.name, raw, cont_from_raw(raw) ? 1 : 0);
+    printf("[%s] FIRE done.\n", c.name);
+    print_cont_for(active);
 }
 
 static void cmd_cont_raw()
 {
-    auto& c = ch[active];
-    int raw = gpio_get_level(c.cont);
-    printf("[%s] CONT raw=%d -> cont=%d  (ARM=%d — only meaningful when ARM=1)\n",
-           c.name, raw, cont_from_raw(raw) ? 1 : 0, global_arm ? 1 : 0);
+    char suffix[40];
+    snprintf(suffix, sizeof(suffix), "  (ARM=%d)", global_arm ? 1 : 0);
+    print_cont_for(active, "[active] ", suffix);
 }
 
 static void cmd_cont_momentary()
 {
-    auto& c = ch[active];
     bool was_armed = global_arm;
     if (!was_armed) {
         set_arm(true);
         vTaskDelay(pdMS_TO_TICKS(200));
     }
-    int raw = gpio_get_level(c.cont);
+    printf("[%s] momentary cont test:\n", ch[active].name);
+    print_cont_for(active, "  ");
     if (!was_armed) set_arm(false);
-    printf("[%s] momentary CONT raw=%d -> cont=%d  "
-           "(new PCB: raw 0 = closed/load present, raw 1 = open)\n",
-           c.name, raw, cont_from_raw(raw) ? 1 : 0);
+    printf("  (new PCB: digital raw 0 = closed; ADC mV < %d -> closed)\n",
+           CONT_THRESHOLD_MV);
 }
 
 static void cmd_read_all()
 {
     printf("ARM=%d  (pin %d)\n", global_arm ? 1 : 0, PYRO_ARM_PIN);
-    for (auto& c : ch) {
-        int raw = gpio_get_level(c.cont);
-        printf("  %s  CONT raw=%d -> cont=%d  FIRE rb=%d\n",
-               c.name, raw, cont_from_raw(raw) ? 1 : 0, gpio_get_level(c.fire));
+    for (int i = 0; i < 4; ++i) {
+        char suffix[40];
+        snprintf(suffix, sizeof(suffix), "  FIRE rb=%d", gpio_get_level(ch[i].fire));
+        print_cont_for(i, "  ", suffix);
     }
 }
 
@@ -296,6 +386,7 @@ extern "C" void app_main()
     vTaskDelay(pdMS_TO_TICKS(500));
 
     init_pins();
+    init_adc();
 
     // Non-blocking stdin so we can poll without freezing the task.
     int flags = fcntl(fileno(stdin), F_GETFL, 0);

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
@@ -1,15 +1,23 @@
 /**
  * Pyro Channel Interactive Debug Tool — ESP32-P4
  *
- * Manual single-channel debug REPL over USB Serial JTAG. Lets you walk the
- * chain (ARM → P-FET → VN5E160 VCC → FIRE → OUTPUT → load → STATUS) one
- * step at a time while probing with a multimeter.
+ * Manual debug REPL over USB Serial JTAG for the new rocket-computer PCB.
+ * One shared ARM FET feeds four squib drivers; per-channel CONT/FIRE.
+ * Walk the chain (ARM → upstream FET → channel FIRE → load → CONT readback)
+ * one step at a time while probing with a multimeter.
  *
- * Channels:
- *   1: ARM=14  FIRE=15  CONT=16
- *   2: ARM=22  FIRE=18  CONT=19
- *   3: ARM=37  FIRE=38  CONT=34
- *   4: ARM=49  FIRE=50  CONT=51
+ * Pins (new PCB):
+ *   PYRO_ARM = 14   (shared by all four channels)
+ *   Channel 1: CONT=15  FIRE=16
+ *   Channel 2: CONT=18  FIRE=19
+ *   Channel 3: CONT=38  FIRE=34
+ *   Channel 4: CONT=51  FIRE=50
+ *
+ * Continuity polarity (new PCB, inverted vs old board): raw GPIO 0 = closed
+ * (load present), raw 1 = open. The "cont" line in printouts shows the
+ * logical bit (1 = good continuity); the raw GPIO level is also shown so
+ * you can verify on the multimeter. TODO: confirm polarity on bench before
+ * trusting.
  *
  * Commands (one char, no Enter needed):
  *   ?   help
@@ -18,14 +26,15 @@
  *   2   select channel 2
  *   3   select channel 3
  *   4   select channel 4
- *   a   toggle ARM on active channel (latching)
- *   f   pulse FIRE 500 ms (only if armed)
- *   F   pulse FIRE 2 s    (only if armed)
- *   c   read continuity (raw GPIO level — meaningful only when ARMed)
+ *   a   toggle shared ARM (latching, affects ALL channels)
+ *   f   pulse FIRE 500 ms on active channel (only if armed)
+ *   F   pulse FIRE 2 s    on active channel (only if armed)
+ *   c   read continuity on active channel (meaningful only when ARMed)
  *   C   momentary continuity test (arm 200 ms, read, disarm)
- *   r   read continuity raw on BOTH channels (compare)
- *   j   jam FIRE high indefinitely (must be armed — for DC probing)
- *   d   disarm everything + release jammed FIRE (safety)
+ *   r   read continuity raw on ALL channels (compare)
+ *   j   jam FIRE high indefinitely on active channel (must be armed)
+ *   b   blink FIRE @ 1 Hz for 30 s on active channel (multimeter swing test)
+ *   d   disarm + release jammed FIRE pins (safety)
  */
 
 #include <cstdio>
@@ -40,163 +49,192 @@
 
 static const char* TAG = "PYRO_DBG";
 
+static constexpr gpio_num_t PYRO_ARM_PIN = GPIO_NUM_14;
+
 struct PyroChannel {
     const char*  name;
-    gpio_num_t   arm;
     gpio_num_t   fire;
     gpio_num_t   cont;
-    bool         armed;
 };
 
 static PyroChannel ch[4] = {
-    { "PYRO1", GPIO_NUM_14, GPIO_NUM_15, GPIO_NUM_16, false },
-    { "PYRO2", GPIO_NUM_22, GPIO_NUM_18, GPIO_NUM_19, false },
-    { "PYRO3", GPIO_NUM_37, GPIO_NUM_38, GPIO_NUM_34, false },
-    { "PYRO4", GPIO_NUM_49, GPIO_NUM_50, GPIO_NUM_51, false },
+    { "PYRO1", GPIO_NUM_16, GPIO_NUM_15 },
+    { "PYRO2", GPIO_NUM_19, GPIO_NUM_18 },
+    { "PYRO3", GPIO_NUM_34, GPIO_NUM_38 },
+    { "PYRO4", GPIO_NUM_50, GPIO_NUM_51 },
 };
 
-static int active = 0;  // 0..3
+static int  active     = 0;      // 0..3
+static bool global_arm = false;  // mirrors PYRO_ARM_PIN level
 
-static void init_channel(PyroChannel& c)
+// New-PCB inverted continuity: raw 0 = closed (load present).
+static inline bool cont_from_raw(int raw) { return raw == 0; }
+
+static void init_pins()
 {
     // gpio_reset_pin() forces IO MUX back to GPIO function — required on
-    // ESP32-P4 because SPI2 default pins (14-16) and SPI3 default pins (17-19)
-    // overlap with pyro pins. Without this, gpio_config() silently no-ops
-    // because the pad is stuck in its peripheral default function.
-    for (gpio_num_t pin : {c.arm, c.fire, c.cont}) {
-        gpio_reset_pin(pin);
+    // ESP32-P4 because pins 14-19 default to SPI2/SPI3 IO MUX. Without it,
+    // gpio_config() silently no-ops because the pad is stuck in its
+    // peripheral default function.
+    gpio_reset_pin(PYRO_ARM_PIN);
+    {
+        gpio_config_t cfg = {};
+        cfg.pin_bit_mask = 1ULL << PYRO_ARM_PIN;
+        // INPUT_OUTPUT lets gpio_get_level() read back the actual pad state —
+        // useful for "I set it high but multimeter shows 0V" diagnostics.
+        cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
+        cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+        cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+        gpio_config(&cfg);
+        gpio_set_level(PYRO_ARM_PIN, 0);
     }
 
-    // INPUT_OUTPUT mode so gpio_get_level() reads back the actual pad state —
-    // useful for diagnosing "I set it high but multimeter shows 0V" mysteries.
-    gpio_config_t out_cfg = {};
-    out_cfg.pin_bit_mask = (1ULL << c.arm) | (1ULL << c.fire);
-    out_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
-    out_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-    out_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    gpio_config(&out_cfg);
-    gpio_set_level(c.arm,  0);
-    gpio_set_level(c.fire, 0);
+    for (auto& c : ch) {
+        gpio_reset_pin(c.fire);
+        gpio_reset_pin(c.cont);
 
-    gpio_config_t in_cfg = {};
-    in_cfg.pin_bit_mask  = 1ULL << c.cont;
-    in_cfg.mode          = GPIO_MODE_INPUT;
-    in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;   // PCB has 10k pullup to 3V3
-    in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
-    gpio_config(&in_cfg);
+        gpio_config_t out_cfg = {};
+        out_cfg.pin_bit_mask = 1ULL << c.fire;
+        out_cfg.mode         = GPIO_MODE_INPUT_OUTPUT;
+        out_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+        out_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+        gpio_config(&out_cfg);
+        gpio_set_level(c.fire, 0);
 
-    c.armed = false;
+        gpio_config_t in_cfg = {};
+        in_cfg.pin_bit_mask  = 1ULL << c.cont;
+        in_cfg.mode          = GPIO_MODE_INPUT;
+        in_cfg.pull_up_en    = GPIO_PULLUP_DISABLE;   // PCB has external pull on CONT
+        in_cfg.pull_down_en  = GPIO_PULLDOWN_DISABLE;
+        gpio_config(&in_cfg);
+    }
+
+    global_arm = false;
+}
+
+static void set_arm(bool on)
+{
+    gpio_set_level(PYRO_ARM_PIN, on ? 1 : 0);
+    global_arm = on;
 }
 
 static void disarm_all()
 {
-    for (auto& c : ch) {
-        gpio_set_level(c.fire, 0);
-        gpio_set_level(c.arm,  0);
-        c.armed = false;
-    }
+    for (auto& c : ch) gpio_set_level(c.fire, 0);
+    set_arm(false);
 }
 
 static void print_help()
 {
-    printf("\n=== Pyro Channel Debug ===\n");
+    printf("\n=== Pyro Channel Debug (new PCB, shared ARM) ===\n");
     printf("  ?   help\n");
     printf("  s   show state\n");
-    printf("  1   select channel 1 (ARM=14 FIRE=15 CONT=16)\n");
-    printf("  2   select channel 2 (ARM=22 FIRE=18 CONT=19)\n");
-    printf("  3   select channel 3 (ARM=37 FIRE=38 CONT=34)\n");
-    printf("  4   select channel 4 (ARM=49 FIRE=50 CONT=51)\n");
-    printf("  a   toggle ARM on active channel\n");
-    printf("  f   pulse FIRE 500 ms (must be armed)\n");
-    printf("  F   pulse FIRE 2 s    (must be armed)\n");
-    printf("  c   read continuity raw (active channel)\n");
+    printf("  1   select channel 1 (CONT=15 FIRE=16)\n");
+    printf("  2   select channel 2 (CONT=18 FIRE=19)\n");
+    printf("  3   select channel 3 (CONT=38 FIRE=34)\n");
+    printf("  4   select channel 4 (CONT=51 FIRE=50)\n");
+    printf("  a   toggle shared ARM (pin 14, affects ALL channels)\n");
+    printf("  f   pulse FIRE 500 ms on active channel (must be armed)\n");
+    printf("  F   pulse FIRE 2 s    on active channel (must be armed)\n");
+    printf("  c   read continuity on active channel\n");
     printf("  C   momentary continuity test (arm 200 ms, read, disarm)\n");
     printf("  r   read continuity raw on ALL channels\n");
-    printf("  j   jam FIRE high indefinitely (must be armed — for DC probing)\n");
-    printf("  b   blink FIRE at 1 Hz for 30 s (must be armed — for multimeter swing test)\n");
-    printf("  d   disarm everything + release jammed FIRE\n");
-    printf("============================\n");
+    printf("  j   jam FIRE high indefinitely on active channel\n");
+    printf("  b   blink FIRE @ 1 Hz for 30 s on active channel\n");
+    printf("  d   disarm + release jammed FIRE pins\n");
+    printf("================================================\n");
 }
 
 static void print_state()
 {
-    printf("\nactive: %s\n", ch[active].name);
+    printf("\nactive: %s   ARM(GPIO%d)=%d\n",
+           ch[active].name, PYRO_ARM_PIN, global_arm ? 1 : 0);
     for (auto& c : ch) {
-        int cont = gpio_get_level(c.cont);
-        printf("  %s  ARM=%d  CONT=%d  (cont meaningful only when ARM=1)\n",
-               c.name, c.armed ? 1 : 0, cont);
+        int raw = gpio_get_level(c.cont);
+        printf("  %s  CONT raw=%d -> cont=%d  FIRE(GPIO%d) rb=%d  (cont meaningful only when ARM=1)\n",
+               c.name, raw, cont_from_raw(raw) ? 1 : 0,
+               c.fire, gpio_get_level(c.fire));
     }
     printf("\n");
 }
 
 static void cmd_toggle_arm()
 {
-    auto& c = ch[active];
-    c.armed = !c.armed;
-    gpio_set_level(c.arm, c.armed ? 1 : 0);
-    printf("[%s] ARM=%d\n", c.name, c.armed ? 1 : 0);
-    if (c.armed) {
+    set_arm(!global_arm);
+    printf("ARM=%d  (pin %d readback=%d)\n",
+           global_arm ? 1 : 0, PYRO_ARM_PIN, gpio_get_level(PYRO_ARM_PIN));
+    if (global_arm) {
         vTaskDelay(pdMS_TO_TICKS(50));
-        printf("[%s] CONT=%d (after arm settle)\n", c.name, gpio_get_level(c.cont));
+        for (auto& c : ch) {
+            int raw = gpio_get_level(c.cont);
+            printf("  %s  CONT raw=%d -> cont=%d\n",
+                   c.name, raw, cont_from_raw(raw) ? 1 : 0);
+        }
     }
 }
 
 static void cmd_fire(uint32_t ms)
 {
     auto& c = ch[active];
-    if (!c.armed) {
-        printf("[%s] REFUSED — not armed (press 'a' first)\n", c.name);
+    if (!global_arm) {
+        printf("[%s] REFUSED — ARM not asserted (press 'a' first)\n", c.name);
         return;
     }
     printf("[%s] FIRE %lu ms...\n", c.name, (unsigned long)ms);
     gpio_set_level(c.fire, 1);
     vTaskDelay(pdMS_TO_TICKS(ms));
     gpio_set_level(c.fire, 0);
-    printf("[%s] FIRE done. CONT=%d\n", c.name, gpio_get_level(c.cont));
+    int raw = gpio_get_level(c.cont);
+    printf("[%s] FIRE done. CONT raw=%d -> cont=%d\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0);
 }
 
 static void cmd_cont_raw()
 {
     auto& c = ch[active];
-    printf("[%s] CONT=%d  (ARM=%d — only meaningful when ARM=1)\n",
-           c.name, gpio_get_level(c.cont), c.armed ? 1 : 0);
+    int raw = gpio_get_level(c.cont);
+    printf("[%s] CONT raw=%d -> cont=%d  (ARM=%d — only meaningful when ARM=1)\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0, global_arm ? 1 : 0);
 }
 
 static void cmd_cont_momentary()
 {
     auto& c = ch[active];
-    bool was_armed = c.armed;
+    bool was_armed = global_arm;
     if (!was_armed) {
-        gpio_set_level(c.arm, 1);
+        set_arm(true);
         vTaskDelay(pdMS_TO_TICKS(200));
     }
-    int v = gpio_get_level(c.cont);
-    if (!was_armed) {
-        gpio_set_level(c.arm, 0);
-    }
-    printf("[%s] momentary CONT=%d  (1=load, 0=open per VN5E160 STATUS)\n", c.name, v);
+    int raw = gpio_get_level(c.cont);
+    if (!was_armed) set_arm(false);
+    printf("[%s] momentary CONT raw=%d -> cont=%d  "
+           "(new PCB: raw 0 = closed/load present, raw 1 = open)\n",
+           c.name, raw, cont_from_raw(raw) ? 1 : 0);
 }
 
-static void cmd_read_both()
+static void cmd_read_all()
 {
+    printf("ARM=%d  (pin %d)\n", global_arm ? 1 : 0, PYRO_ARM_PIN);
     for (auto& c : ch) {
-        printf("  %s  ARM=%d  CONT=%d\n", c.name, c.armed ? 1 : 0, gpio_get_level(c.cont));
+        int raw = gpio_get_level(c.cont);
+        printf("  %s  CONT raw=%d -> cont=%d  FIRE rb=%d\n",
+               c.name, raw, cont_from_raw(raw) ? 1 : 0, gpio_get_level(c.fire));
     }
 }
 
 static void cmd_jam_fire()
 {
     auto& c = ch[active];
-    if (!c.armed) {
-        printf("[%s] REFUSED — not armed (press 'a' first)\n", c.name);
+    if (!global_arm) {
+        printf("[%s] REFUSED — ARM not asserted (press 'a' first)\n", c.name);
         return;
     }
     gpio_set_level(c.fire, 1);
     vTaskDelay(pdMS_TO_TICKS(5));
-    int arm_rb  = gpio_get_level(c.arm);
+    int arm_rb  = gpio_get_level(PYRO_ARM_PIN);
     int fire_rb = gpio_get_level(c.fire);
     printf("[%s] FIRE JAMMED — readback ARM(GPIO%d)=%d  FIRE(GPIO%d)=%d  (1 = pad reads high)\n",
-           c.name, c.arm, arm_rb, c.fire, fire_rb);
+           c.name, PYRO_ARM_PIN, arm_rb, c.fire, fire_rb);
     printf("       Probe with multimeter now. Press 'd' to release.\n");
 }
 
@@ -206,8 +244,8 @@ static volatile bool blink_running = false;
 static void cmd_blink_fire()
 {
     auto& c = ch[active];
-    if (!c.armed) {
-        printf("[%s] REFUSED — not armed (press 'a' first)\n", c.name);
+    if (!global_arm) {
+        printf("[%s] REFUSED — ARM not asserted (press 'a' first)\n", c.name);
         return;
     }
     printf("[%s] BLINKING FIRE @ 1 Hz for 30 s — watch the multimeter, expect 0V<->~3V swing\n", c.name);
@@ -237,7 +275,7 @@ static void handle(char k)
         case 'F':                      cmd_fire(2000); break;
         case 'c':                      cmd_cont_raw(); break;
         case 'C':                      cmd_cont_momentary(); break;
-        case 'r': case 'R':            cmd_read_both(); break;
+        case 'r': case 'R':            cmd_read_all(); break;
         case 'j': case 'J':            cmd_jam_fire(); break;
         case 'b': case 'B':            cmd_blink_fire(); break;
         case 'd': case 'D':
@@ -254,10 +292,10 @@ static void handle(char k)
 
 extern "C" void app_main()
 {
-    ESP_LOGI(TAG, "=== Pyro Channel Interactive Debug ===");
+    ESP_LOGI(TAG, "=== Pyro Channel Interactive Debug (new PCB) ===");
     vTaskDelay(pdMS_TO_TICKS(500));
 
-    for (auto& c : ch) init_channel(c);
+    init_pins();
 
     // Non-blocking stdin so we can poll without freezing the task.
     int flags = fcntl(fileno(stdin), F_GETFL, 0);


### PR DESCRIPTION
## Summary
- **4-channel pyro firmware** for the new rocket-computer PCB: single shared ARM FET (GPIO 14), per-channel CONT/FIRE on (15/16) (18/19) (38/34) (51/50). Per-fire arming — ARM only HIGH during a fire pulse or prelaunch cont check, never latched in flight. Spans FC driver, OC config relay, BLE wire format (`PyroConfigData` 12→24 B, `FlightSettingsData` 176→188 B, `ps` JSON bitfield 6→9 bits), and full iOS app (Settings, Dashboard, RocketProfile, CSV/JSON export).
- **Bench-verified safety fix for fire-on-boot.** `gpio_reset_pin()` on the pyro output pads enables the internal pull-up for ~µs, briefly biasing the DTC123J gate-driver NPN bases above Vbe and twitching the FETs. Replaced with `safePyroOutputInit()` that detaches peripheral signal + selects GPIO function + enables output drive with no pull-up window. Confirmed on bench — pyros no longer twitch at boot.
- **GPS rail + GNSS bring-up speed-ups for new PCB**: OC drives GPIO 33 HIGH to enable the GPS rail in lockstep with the FC rail. Driver-side fast RX/TX-swap detection via a 9600-baud activity probe — cuts cold-boot GNSS lock from ~35 s to ~2-3 s on the swapped-wiring rev-A board, no per-board config needed (auto-works on old PCBs too).

## What stays bench / what's flight-ready

- All pyro firmware, GPS firmware, magnetometer, BLE telemetry, iOS app — flight-correct end state
- Fire-on-boot fix verified on bench
- Continuity reads on PYRO1 verified after a separate D2-removal hardware rework
- Real-squib fire still browns out the FC on this PCB rev — root-caused as a missing dedicated PYRO_BUS supercap topology; design proposal + part recommendations captured in #202. Not blocking this PR — firmware is correct, hardware needs the next PCB rev.
- D2 polarity bug on the CONT divider documented in conversation; next-rev PCB needs the diode footprint reversed across all four pyro channels. Workaround on rev-A: desolder D2 per channel.

## Note on `02c59f2 BENCH-ONLY` commit

The branch includes a commit titled `BENCH-ONLY (DO NOT MERGE)` added mid-development for hardware bring-up. **All three of its changes are subsequently overridden** by later commits in this same branch:
- `d800162` restored GPS power-on
- `7c214b1` restored `USE_GNSS=true` and the `gnss_ready` gate

End state is flight-correct. Squash merge is recommended — the squashed commit reflects only the final state, and the "DO NOT MERGE" tag from the journey goes away.

## Test plan
- [x] 274/274 C++ unit tests pass (`tests_cpp/build/`), including new `PyroConfigData` 4-channel layout, `FlightSettingsData` 188-byte layout, NSF/PSF bit relocations
- [x] iOS unit tests pass on iPhone 17 simulator including the updated `testFlightSettingsDecode` for the new 188-byte payload
- [x] FC firmware builds clean on ESP-IDF 5.3.2 (ESP32-P4)
- [x] OC firmware builds clean on ESP-IDF 5.3.2 (ESP32-S3)
- [x] iOS app + tests build clean (Xcode 26.5)
- [x] Bench verified on rev-A rocket-computer PCB: no fire-on-boot, GPS lock <5 s, prelaunch CONT test fires correctly, BLE telemetry reports 4-channel pyro state

## Related
See #202 for the pyro brownout investigation and proposed PYRO_BUS hardware fix for the next PCB rev (not closed by this PR — hardware-pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
