### PR TITLE
oc: instrument MRAM ring usage + flight_report log_buffer module

### DIFF
--- a/Data_Analysis/flight_report/modules/log_buffer.py
+++ b/Data_Analysis/flight_report/modules/log_buffer.py
@@ -1,0 +1,171 @@
+"""Log-buffer module — MRAM ring high-water + smaller-chip viability.
+
+Reads the LogBufferStats frames (msg 0xE2) that the OutComputer emits into
+the flight log at ~1 Hz while a session is open.  Each frame is a snapshot
+of the runtime ring capacity, current fill, peak fill since boot, overrun
+count, and drop-oldest bytes.
+
+The point of this module is to answer "is the 128 KB MR25H10 over-
+provisioned?".  We report:
+
+  * Peak ring fill in bytes and as a percent of the configured ring size.
+  * Whether the ring ever overran or dropped tail bytes (i.e. data loss).
+  * A viability table for common smaller / cheaper alternatives, marking
+    each "would have fit" or "would have dropped data".
+
+For pre-instrumentation flight logs (no LogBufferStats frames present),
+the module emits a single warning and otherwise renders nothing — so the
+report still renders for old captures.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from ..flight import Flight
+from ..registry import AnalysisResult
+
+
+# Alternative chip sizes (bytes) we want to evaluate against the peak ring
+# fill.  Names are deliberately short — the table cell width is the limit.
+_ALTERNATIVES = [
+    ("MR25H10 (current, 1 Mbit MRAM)",        131072),
+    ("CY15B102Q-class (1 Mbit FRAM)",         131072),
+    ("MR25H40 / 256-Kbit FRAM",                32768),
+    ("512-Kbit FRAM (e.g. FM25V05)",           65536),
+    ("128-Kbit FRAM (e.g. FM25V01)",           16384),
+]
+
+
+def _peak_fill_pct(peak: int, capacity: int) -> Optional[float]:
+    if capacity <= 0:
+        return None
+    return 100.0 * peak / capacity
+
+
+def _viability_text(peak: int, capacity: int) -> str:
+    """One-line-per-row 'would this chip have fit?' table."""
+    lines = [
+        f"Ring capacity (configured):  {capacity:>8,} bytes ({capacity / 1024.0:.1f} KB)",
+        f"Ring peak fill (this flight):{peak:>8,} bytes ({peak / 1024.0:.1f} KB)",
+        "",
+        "Alternative chip viability (would it have held the observed peak?):",
+        "",
+        f"  {'Part':<38} {'Capacity':>10}  Verdict",
+        f"  {'-' * 38} {'-' * 10}  {'-' * 28}",
+    ]
+    for name, size_bytes in _ALTERNATIVES:
+        if peak <= size_bytes:
+            verdict = f"OK ({peak / size_bytes * 100.0:5.1f}% used)"
+        else:
+            verdict = f"DROP — peak exceeds capacity by {peak - size_bytes:,} B"
+        lines.append(f"  {name:<38} {size_bytes:>8,} B  {verdict}")
+    return "\n".join(lines)
+
+
+def _plot_ring_fill(samples, capacity: int):
+    """Time-series of ring_fill vs time with ring_highwater + capacity ceiling."""
+    if not samples:
+        return None
+    t0_us = samples[0]["time_us"]
+    t_s = [(s["time_us"] - t0_us) / 1e6 for s in samples]
+    fill = [s["ring_fill"] for s in samples]
+    hi = [s["ring_highwater"] for s in samples]
+
+    fig, ax = plt.subplots(figsize=(11, 4))
+    ax.fill_between(t_s, 0, fill, color="tab:blue", alpha=0.25,
+                    label="ring fill (instantaneous)")
+    ax.plot(t_s, fill, color="tab:blue", linewidth=1.0)
+    ax.plot(t_s, hi, color="tab:red", linewidth=1.5,
+            label="ring high-water (cumulative peak)")
+    if capacity > 0:
+        ax.axhline(capacity, color="black", linestyle="--", linewidth=1.0,
+                   label=f"ring capacity ({capacity / 1024.0:.0f} KB)")
+    ax.set_xlabel("Time since first LogBufferStats sample (s)")
+    ax.set_ylabel("Bytes")
+    ax.set_title("Log-buffer ring fill")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper left", fontsize=9)
+    fig.tight_layout()
+    return fig
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="log_buffer", title="Log Buffer (MRAM)")
+    samples = flight.records.get("LogBufferStats", [])
+
+    if not samples:
+        # Old / pre-instrumentation flight — just say so, don't error.
+        result.warnings.append(
+            "No LogBufferStats frames in this log — flight predates the "
+            "LOG_BUFFER_STATS_MSG (0xE2) instrumentation. Re-fly with current "
+            "firmware to capture ring high-water data."
+        )
+        return result
+
+    # All samples should report the same ring_size (set once at begin()).  If
+    # they differ, surface a warning — likely cause is a parser misalignment.
+    capacities = {s["ring_size"] for s in samples}
+    if len(capacities) != 1:
+        result.warnings.append(
+            f"Inconsistent ring_size across {len(samples)} samples: {sorted(capacities)}. "
+            "Suspect parser corruption or mid-flight config change."
+        )
+    capacity = max(capacities) if capacities else 0
+
+    # ring_highwater is monotonic since boot, so the *max* over samples is the
+    # session peak.  ring_overruns / ring_drop_oldest_bytes likewise.
+    peak_fill = max(s["ring_highwater"] for s in samples)
+    final_overruns = samples[-1]["ring_overruns"]
+    final_drop_oldest = samples[-1]["ring_drop_oldest_bytes"]
+    final_bad_sof = samples[-1]["ring_bad_sof_clears"]
+    initial_overruns = samples[0]["ring_overruns"]
+    initial_drop_oldest = samples[0]["ring_drop_oldest_bytes"]
+    # In-flight deltas tell you whether overrun/drop happened *during this
+    # session* vs. carried over from a prior session on the same boot.
+    overruns_this_session = max(0, final_overruns - initial_overruns)
+    drop_oldest_this_session = max(0, final_drop_oldest - initial_drop_oldest)
+
+    pct = _peak_fill_pct(peak_fill, capacity) or 0.0
+
+    result.metrics = {
+        "samples":                       len(samples),
+        "ring_capacity_bytes":           capacity,
+        "ring_capacity_kb":              round(capacity / 1024.0, 1),
+        "peak_fill_bytes":               peak_fill,
+        "peak_fill_kb":                  round(peak_fill / 1024.0, 1),
+        "peak_fill_pct":                 round(pct, 1),
+        "ring_overruns_in_session":      overruns_this_session,
+        "ring_drop_oldest_bytes_session":drop_oldest_this_session,
+        "ring_bad_sof_clears_final":     final_bad_sof,
+    }
+
+    if overruns_this_session > 0:
+        result.warnings.append(
+            f"{overruns_this_session} ring overrun(s) during this session — "
+            "writer outpaced flush; some frames were dropped."
+        )
+    if drop_oldest_this_session > 0:
+        result.warnings.append(
+            f"{drop_oldest_this_session:,} bytes dropped from ring tail "
+            "(drop-oldest path) — ring undersized for this load."
+        )
+    if pct >= 90.0:
+        result.warnings.append(
+            f"Ring peak fill {pct:.1f}% — within 10% of capacity. "
+            "Smaller chip would be risky."
+        )
+    elif pct >= 70.0:
+        result.warnings.append(
+            f"Ring peak fill {pct:.1f}% — moderate headroom. "
+            "Halving the chip would leave little margin."
+        )
+
+    result.text = _viability_text(peak_fill, capacity)
+    fig = _plot_ring_fill(samples, capacity)
+    if fig is not None:
+        result.figures.append(fig)
+
+    return result

--- a/Data_Analysis/flight_report/registry.py
+++ b/Data_Analysis/flight_report/registry.py
@@ -38,6 +38,7 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn]]:
         kinematic_checks,
         roll_pid,
         lora,
+        log_buffer,
         timestamps,
     )
 
@@ -52,6 +53,7 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn]]:
         ("kinematic_checks",  kinematic_checks.analyze),
         ("roll_pid",          roll_pid.analyze),
         ("lora",              lora.analyze),
+        ("log_buffer",        log_buffer.analyze),
     ]
 
 

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -60,16 +60,17 @@ MMC_UT_PER_COUNT = (8.0 * 100.0) / 131072.0  # ≈ 0.006104
 # ------------------------------------
 
 # ---------- Message type IDs (Mini) ----------
-MSG_OUT_STATUS_QUERY = 0xA0
-MSG_GNSS             = 0xA1
-MSG_ISM6HG256        = 0xA2
-MSG_BMP585           = 0xA3
-MSG_MMC5983MA        = 0xA4
-MSG_NON_SENSOR       = 0xA5
-MSG_POWER            = 0xA6
-MSG_START_LOGGING    = 0xA7
-MSG_END_FLIGHT       = 0xA8
-MSG_LORA             = 0xF1
+MSG_OUT_STATUS_QUERY  = 0xA0
+MSG_GNSS              = 0xA1
+MSG_ISM6HG256         = 0xA2
+MSG_BMP585            = 0xA3
+MSG_MMC5983MA         = 0xA4
+MSG_NON_SENSOR        = 0xA5
+MSG_POWER             = 0xA6
+MSG_START_LOGGING     = 0xA7
+MSG_END_FLIGHT        = 0xA8
+MSG_LOG_BUFFER_STATS  = 0xE2  # OC self-emitted ring-buffer snapshot (~1 Hz)
+MSG_LORA              = 0xF1
 
 MSG_NAMES = {
     MSG_OUT_STATUS_QUERY: "OUT_STATUS_QUERY",
@@ -81,21 +82,23 @@ MSG_NAMES = {
     MSG_POWER:            "POWER",
     MSG_START_LOGGING:    "StartLogging",
     MSG_END_FLIGHT:       "EndFlight",
+    MSG_LOG_BUFFER_STATS: "LogBufferStats",
     MSG_LORA:             "LoRa",
 }
 
 # Expected payload sizes for validation
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY: 16,   # OutStatusQueryData
-    MSG_GNSS:             42,
-    MSG_ISM6HG256:        22,
-    MSG_BMP585:           12,
-    MSG_MMC5983MA:        16,
-    MSG_NON_SENSOR:       None,  # 42 (legacy) or 43 (with pyro_status byte)
-    MSG_POWER:            10,
-    MSG_START_LOGGING:    None,  # variable / no payload
-    MSG_END_FLIGHT:       None,
-    MSG_LORA:             49,
+    MSG_OUT_STATUS_QUERY:  16,   # OutStatusQueryData
+    MSG_GNSS:              42,
+    MSG_ISM6HG256:         22,
+    MSG_BMP585:            12,
+    MSG_MMC5983MA:         16,
+    MSG_NON_SENSOR:        None,  # 42 (legacy) or 43 (with pyro_status byte)
+    MSG_POWER:             10,
+    MSG_START_LOGGING:     None,  # variable / no payload
+    MSG_END_FLIGHT:        None,
+    MSG_LOG_BUFFER_STATS:  28,    # LogBufferStatsData
+    MSG_LORA:              49,
 }
 
 # Struct formats (little-endian, packed)
@@ -115,6 +118,8 @@ FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'  # +pyro_status byte (#34)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'  # +apogee_flags byte (#142/#143)
 # OutStatusQueryData: 16 bytes
 FMT_STATUS_QUERY = '<B H H hh B hhh'
+# LogBufferStatsData: 28 bytes (time_us + 6× uint32 ring counters)
+FMT_LOG_BUFFER_STATS = '<I IIIIII'
 
 SYNC = b'\xAA\x55\xAA\x55'
 
@@ -223,12 +228,13 @@ def parse_binary_file(filepath):
 
     file_size = len(data)
     records = {
-        "GNSS":       [],
-        "ISM6HG256":  [],
-        "BMP585":     [],
-        "MMC5983MA":  [],
-        "NonSensor":  [],
-        "POWER":      [],
+        "GNSS":           [],
+        "ISM6HG256":      [],
+        "BMP585":         [],
+        "MMC5983MA":      [],
+        "NonSensor":      [],
+        "POWER":          [],
+        "LogBufferStats": [],
     }
 
     config = {
@@ -436,6 +442,20 @@ def parse_binary_file(filepath):
                         "current":  decode_current(fields[2]),
                         "soc":      decode_soc(fields[3]),
                     })
+
+            elif msg_type == MSG_LOG_BUFFER_STATS:
+                # OC self-emitted ring snapshot, ~1 Hz while logging.
+                # See LogBufferStatsData in RocketComputerTypes.h.
+                fields = struct.unpack(FMT_LOG_BUFFER_STATS, payload)
+                records["LogBufferStats"].append({
+                    "time_us":                fields[0],
+                    "ring_size":              fields[1],
+                    "ring_fill":              fields[2],
+                    "ring_highwater":         fields[3],
+                    "ring_overruns":          fields[4],
+                    "ring_drop_oldest_bytes": fields[5],
+                    "ring_bad_sof_clears":    fields[6],
+                })
 
         except struct.error:
             pass

--- a/tests/test_flight_report.py
+++ b/tests/test_flight_report.py
@@ -27,6 +27,7 @@ REQUIRED_SECTIONS = [
     'id="kinematic_checks"',
     'id="roll_pid"',
     'id="lora"',
+    'id="log_buffer"',
     'id="settings"',
     'id="parser"',
 ]

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -327,6 +327,7 @@ void TR_LogToFlash::service()
 
 void TR_LogToFlash::getStats(TR_LogToFlashStats& out) const
 {
+    out.ring_size = ring_size_;
     out.ring_fill = rb_count;
     out.ring_highwater = rb_highwater;
     out.ring_overruns = rb_overruns;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -55,6 +55,11 @@ struct TR_LogToFlashConfig
 
 struct TR_LogToFlashStats
 {
+    // Ring capacity in bytes (MRAM region when MRAM is wired, else RAM ring).
+    // Reported alongside ring_fill / ring_highwater so callers can derive the
+    // actual utilization without knowing which backing is active — useful for
+    // deciding whether the current 1 Mbit MRAM is over-provisioned.
+    uint32_t ring_size = 0;
     uint32_t ring_fill = 0;
     uint32_t ring_highwater = 0;
     uint32_t ring_overruns = 0;

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1315,6 +1315,14 @@ static constexpr uint8_t SENSOR_CAL_STATUS_MSG    = 0xE0;  // FC→OC: SensorCal
 // (and the .json the app derives from it) records what actually flew (#165).
 static constexpr uint8_t FLIGHT_SETTINGS_MSG = 0xE1;
 
+// OC→self, emitted into the log once per stats interval (~1 Hz) while a
+// session is open.  Carries the runtime ring-buffer capacity and peak-fill
+// metrics so post-flight analysis can judge how much MRAM the flight
+// actually used and whether a smaller / cheaper chip would have fit
+// (the MR25H10 is 128 KB; payload here lets us compare against the real
+// high-water mark per flight).  See LogBufferStatsData.
+static constexpr uint8_t LOG_BUFFER_STATS_MSG = 0xE2;
+
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
 // Camera types
@@ -1509,6 +1517,30 @@ struct __attribute__((packed)) FlightSettingsData
     RollProfileData roll_profile;
 };
 static_assert(sizeof(FlightSettingsData) == 188, "FlightSettingsData layout check");
+
+// --- Log Buffer Stats Data (OC self-emitted, ~1 Hz while logging) -----------
+// Snapshot of the OC's ring-buffer health written into the flight log so the
+// per-flight .bin records exactly how much MRAM the session actually used.
+// This is the data point we need to decide if the current 1 Mbit MR25H10
+// (128 KB) is over-provisioned and we can drop to a smaller / cheaper part.
+//
+// All counters are cumulative since boot (the OC doesn't reset between
+// sessions in normal operation); analysis tooling pulls the *last* sample
+// before close to get the per-flight peak.
+typedef struct __attribute__((packed))
+{
+    uint32_t time_us;                  // micros() at emit
+    uint32_t ring_size;                // ring capacity in bytes
+                                       //   (MRAM region size when MRAM is wired,
+                                       //    else RAM fallback ring size)
+    uint32_t ring_fill;                // current bytes resident in ring at emit
+    uint32_t ring_highwater;           // peak ring fill since boot
+    uint32_t ring_overruns;            // count of overrun events since boot
+    uint32_t ring_drop_oldest_bytes;   // cumulative bytes dropped from tail since boot
+    uint32_t ring_bad_sof_clears;      // ring-clear events from corrupt-tail recovery
+} LogBufferStatsData;
+static_assert(sizeof(LogBufferStatsData) == 28,
+              "LogBufferStatsData must be 28 bytes");
 
 // --- Guidance Telemetry Data (sent at ~10 Hz during coast) ---
 typedef struct __attribute__((packed))

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3070,8 +3070,38 @@ static void printStats()
     prev_msg_count_end_flight = msg_count_end_flight;
     prev_msg_count_unknown = msg_count_unknown;
 
+    // Persist a LogBufferStats snapshot once per stats interval (~1 Hz) into
+    // the flight log so post-flight tooling can read the per-flight peak
+    // without needing VERBOSE_DEBUG serial captures.  Cheap (28 B payload +
+    // 8 B frame overhead = 36 B/s) and enqueueFrame() internally drops the
+    // frame when no session/file is open, so off-session traffic is zero.
+    {
+        LogBufferStatsData lbs = {};
+        lbs.time_us = (uint32_t)esp_timer_get_time();
+        lbs.ring_size = s.ring_size;
+        lbs.ring_fill = s.ring_fill;
+        lbs.ring_highwater = s.ring_highwater;
+        lbs.ring_overruns = s.ring_overruns;
+        lbs.ring_drop_oldest_bytes = s.ring_drop_oldest_bytes;
+        lbs.ring_bad_sof_clears = s.ring_bad_sof_clears;
+
+        uint8_t lbs_frame[MAX_FRAME];
+        size_t  lbs_frame_len = 0;
+        if (TR_I2C_Interface::packMessage(LOG_BUFFER_STATS_MSG,
+                                           (const uint8_t*)&lbs,
+                                           sizeof(lbs),
+                                           lbs_frame, sizeof(lbs_frame),
+                                           lbs_frame_len))
+        {
+            (void)logger.enqueueFrame(lbs_frame, lbs_frame_len);
+        }
+    }
+
     if (config::VERBOSE_DEBUG)
     {
+    // Denominator is s.ring_size (the runtime ring capacity) — used to show
+    // 64 KB when the RAM-only fallback ring is in use even with MRAM wired,
+    // which obscured the real headroom on the 128 KB MR25H10.
     ESP_LOGI("OC", "RX %.1f KB/s | WR %.1f KB/s | frames rx/drop/bad=%lu/%lu/%lu | RING=%lu/%lu (hi=%lu)",
                   (double)rx_kbs,
                   (double)wr_kbs,
@@ -3079,7 +3109,7 @@ static void printStats()
                   (unsigned long)s.frames_dropped,
                   (unsigned long)frames_bad_crc,
                   (unsigned long)s.ring_fill,
-                  (unsigned long)config::RAM_RING_SIZE,
+                  (unsigned long)s.ring_size,
                   (unsigned long)s.ring_highwater);
     ESP_LOGI("OC", "RING interval peak/overrun/drop_oldest_bytes/bad_sof=%lu/%lu/%lu/%lu (bad_sof_total=%lu)",
                   (unsigned long)interval_ring_fill_peak,


### PR DESCRIPTION
## Summary

Instrument the OutComputer MRAM ring buffer so each flight log carries its own peak-fill / overrun / drop-bytes record, and add a flight_report module that surfaces those numbers alongside a smaller-chip viability table. Motivated by the MR25H10 (1 Mbit MRAM, 128 KB) being the most expensive part on the OC — before swapping to a cheaper / smaller chip we need real per-flight peaks.

- **Firmware (`b440c57`)**: new `LOG_BUFFER_STATS_MSG = 0xE2` frame (28-byte payload) emitted into the log at the existing ~1 Hz stats cadence while a session is open. `TR_LogToFlashStats` gains `ring_size` so the existing `VERBOSE_DEBUG` `RING=` line stops misreporting capacity as `RAM_RING_SIZE` (64 KB) when the 128 KB MRAM ring is actually backing it. Off-session cost is zero — `enqueueFrame()` drops the frame when no log file is open.
- **Analysis (`5d17047`)**: `plot_flight_data_mini.py` learns the new message type; new `flight_report` module `log_buffer` reports peak fill in bytes / KB / % of capacity, in-session overruns + drop-oldest bytes, a "would this smaller chip have fit" table covering 128 KB / 64 KB / 32 KB / 16 KB MRAM + FRAM alternatives, and a time-series fill+high-water plot. Pre-instrumentation logs render a single warning instead of erroring.

## Test plan

- [x] OC firmware builds clean (ESP-IDF 5.3.2, esp32s3)
- [x] FC firmware builds clean (ESP-IDF 5.3.2, esp32p4)
- [x] `tests/test_flight_report.py` — 3/3 pass (golden flight predates the instrumentation; module renders gracefully)
- [x] Synthetic LBS frame round-trips through `parse_binary_file` correctly (all 7 fields)
- [ ] Real flight: capture LBS frames, open report, confirm viability table + figure render with non-zero numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)