### PR TITLE
fc: TR_ISM6HG256 to native IDF SPI (drop Arduino SPIClass shim)

### DIFF
--- a/tinkerrocket-idf/components/TR_ISM6HG256/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/CMakeLists.txt
@@ -1,2 +1,4 @@
-idf_component_register(SRCS "TR_ISM6HG256.cpp" "ism6hg256x_reg.c" INCLUDE_DIRS "." REQUIRES TR_Compat)
+idf_component_register(SRCS "TR_ISM6HG256.cpp" "ism6hg256x_reg.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver esp_rom)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.cpp
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.cpp
@@ -1,9 +1,16 @@
 #include <TR_ISM6HG256.h>
+#include <cstring>
+#include <esp_log.h>
+#include <esp_rom_sys.h>
 
-TR_ISM6HG256::TR_ISM6HG256(SPIClass *spi, int cs_pin, uint32_t spi_speed)
-    : dev_spi(spi),
-      cs_pin(cs_pin),
-      spi_speed(spi_speed),
+static const char* ISM6_TAG = "TR_ISM6HG256";
+
+// ---------------- Ctor / Dtor ----------------
+
+TR_ISM6HG256::TR_ISM6HG256(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz)
+    : host_(host),
+      cs_pin_(cs_pin),
+      clock_hz_(clock_hz),
       acc_is_enabled(0),
       acc_hg_is_enabled(0),
       gyro_is_enabled(0),
@@ -16,12 +23,57 @@ TR_ISM6HG256::TR_ISM6HG256(SPIClass *spi, int cs_pin, uint32_t spi_speed)
     reg_ctx.handle = (void *)this;
 }
 
+TR_ISM6HG256::~TR_ISM6HG256()
+{
+    if (spi_dev_) {
+        spi_bus_remove_device(spi_dev_);
+        spi_dev_ = nullptr;
+    }
+}
+
+// ---------------- IDF setup helpers ----------------
+
+void TR_ISM6HG256::configureCsPin_()
+{
+    gpio_config_t io = {};
+    io.pin_bit_mask  = 1ULL << cs_pin_;
+    io.mode          = GPIO_MODE_OUTPUT;
+    io.pull_up_en    = GPIO_PULLUP_DISABLE;
+    io.pull_down_en  = GPIO_PULLDOWN_DISABLE;
+    io.intr_type     = GPIO_INTR_DISABLE;
+    gpio_config(&io);
+    csDeselect_();
+}
+
+bool TR_ISM6HG256::ensureSpiDevice_()
+{
+    if (spi_dev_) return true;
+
+    spi_device_interface_config_t devcfg = {};
+    devcfg.clock_speed_hz = clock_hz_;
+    devcfg.mode           = 0;          // SPI_MODE0 (ST convention)
+    devcfg.spics_io_num   = -1;         // CS driven manually by this wrapper
+    devcfg.queue_size     = 1;
+    devcfg.command_bits   = 8;          // reg byte goes in t.cmd
+
+    esp_err_t err = spi_bus_add_device(host_, &devcfg, &spi_dev_);
+    if (err != ESP_OK) {
+        ESP_LOGE(ISM6_TAG, "spi_bus_add_device failed: %s", esp_err_to_name(err));
+        spi_dev_ = nullptr;
+        return false;
+    }
+    return true;
+}
+
+// ---------------- Public API ----------------
+
 TR_ISM6HG256Status TR_ISM6HG256::begin()
 {
     uint8_t whoami = 0U;
 
-    pinMode(cs_pin, OUTPUT);
-    digitalWrite(cs_pin, HIGH);
+    configureCsPin_();
+
+    if (!ensureSpiDevice_()) return TR_ISM6HG256_ERROR;
 
     if (ReadWhoAmI(&whoami) != TR_ISM6HG256_OK) return TR_ISM6HG256_ERROR;
     if (whoami != ISM6HG256X_ID) return TR_ISM6HG256_ERROR;
@@ -312,29 +364,34 @@ TR_ISM6HG256Status TR_ISM6HG256::Set_G_OutputDataRate_When_Disabled(float Odr)
 
 uint8_t TR_ISM6HG256::IO_Read(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToRead)
 {
-    dev_spi->beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE0));
-    digitalWrite(cs_pin, LOW);
-    dev_spi->transfer(RegisterAddr | 0x80);
-    // Bulk transfer: fill buffer with 0x00 (MOSI) and read MISO in-place.
-    // ESP32 SPI driver can use DMA for this, much faster than byte-by-byte.
-    memset(pBuffer, 0x00, NumByteToRead);
-    dev_spi->transfer(pBuffer, NumByteToRead);
-    digitalWrite(cs_pin, HIGH);
-    dev_spi->endTransaction();
-    return 0;
+    if (!spi_dev_ || !pBuffer || NumByteToRead == 0) return 1;
+
+    spi_transaction_t t = {};
+    t.cmd       = static_cast<uint16_t>(RegisterAddr | 0x80);  // ST: bit7=1 for read, auto-increment via IF_INC
+    t.length    = NumByteToRead * 8;
+    t.rx_buffer = pBuffer;
+
+    csSelect_();
+    esp_err_t err = spi_device_polling_transmit(spi_dev_, &t);
+    csDeselect_();
+
+    return (err == ESP_OK) ? 0 : 1;
 }
 
 uint8_t TR_ISM6HG256::IO_Write(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
 {
-    dev_spi->beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE0));
-    digitalWrite(cs_pin, LOW);
-    dev_spi->transfer(RegisterAddr);
-    for (uint16_t i = 0; i < NumByteToWrite; i++) {
-        dev_spi->transfer(pBuffer[i]);
-    }
-    digitalWrite(cs_pin, HIGH);
-    dev_spi->endTransaction();
-    return 0;
+    if (!spi_dev_ || !pBuffer || NumByteToWrite == 0) return 1;
+
+    spi_transaction_t t = {};
+    t.cmd       = static_cast<uint16_t>(RegisterAddr & 0x7F);  // ST: bit7=0 for write
+    t.length    = NumByteToWrite * 8;
+    t.tx_buffer = pBuffer;
+
+    csSelect_();
+    esp_err_t err = spi_device_polling_transmit(spi_dev_, &t);
+    csDeselect_();
+
+    return (err == ESP_OK) ? 0 : 1;
 }
 
 int32_t TR_ISM6HG256::io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite)

--- a/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.cpp
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.cpp
@@ -49,6 +49,11 @@ bool TR_ISM6HG256::ensureSpiDevice_()
 {
     if (spi_dev_) return true;
 
+    // Configure CS as a GPIO output and idle HIGH first — the SPI master
+    // does not own this pin (spics_io_num=-1) so we drive it ourselves.
+    // Idempotent across the lazy-init path triggered by ReadWhoAmI().
+    configureCsPin_();
+
     spi_device_interface_config_t devcfg = {};
     devcfg.clock_speed_hz = clock_hz_;
     devcfg.mode           = 0;          // SPI_MODE0 (ST convention)
@@ -71,8 +76,9 @@ TR_ISM6HG256Status TR_ISM6HG256::begin()
 {
     uint8_t whoami = 0U;
 
-    configureCsPin_();
-
+    // CS + SPI device are configured here on the cold path (no prior
+    // ReadWhoAmI), or skipped (idempotent) if SensorCollector probed
+    // already.
     if (!ensureSpiDevice_()) return TR_ISM6HG256_ERROR;
 
     if (ReadWhoAmI(&whoami) != TR_ISM6HG256_OK) return TR_ISM6HG256_ERROR;
@@ -364,7 +370,10 @@ TR_ISM6HG256Status TR_ISM6HG256::Set_G_OutputDataRate_When_Disabled(float Odr)
 
 uint8_t TR_ISM6HG256::IO_Read(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToRead)
 {
-    if (!spi_dev_ || !pBuffer || NumByteToRead == 0) return 1;
+    if (!pBuffer || NumByteToRead == 0) return 1;
+    // SensorCollector calls ReadWhoAmI() before begin() to fail-fast on a
+    // missing chip — initialise the SPI device lazily so that path works.
+    if (!ensureSpiDevice_()) return 1;
 
     spi_transaction_t t = {};
     t.cmd       = static_cast<uint16_t>(RegisterAddr | 0x80);  // ST: bit7=1 for read, auto-increment via IF_INC
@@ -380,7 +389,8 @@ uint8_t TR_ISM6HG256::IO_Read(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t N
 
 uint8_t TR_ISM6HG256::IO_Write(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
 {
-    if (!spi_dev_ || !pBuffer || NumByteToWrite == 0) return 1;
+    if (!pBuffer || NumByteToWrite == 0) return 1;
+    if (!ensureSpiDevice_()) return 1;
 
     spi_transaction_t t = {};
     t.cmd       = static_cast<uint16_t>(RegisterAddr & 0x7F);  // ST: bit7=0 for write

--- a/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.h
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/TR_ISM6HG256.h
@@ -1,7 +1,9 @@
 #ifndef TR_ISM6HG256_H
 #define TR_ISM6HG256_H
 
-#include <compat.h>
+#include <cstdint>
+#include <driver/spi_master.h>
+#include <driver/gpio.h>
 #include "ism6hg256x_reg.h"
 
 typedef enum {
@@ -18,7 +20,13 @@ typedef struct {
 class TR_ISM6HG256
 {
 public:
-    TR_ISM6HG256(SPIClass *spi, int cs_pin, uint32_t spi_speed = 2000000);
+    // ESP-IDF native constructor.  The SPI bus identified by `host` must be
+    // initialised (spi_bus_initialize) before begin() is called.  CS is
+    // driven manually by the wrapper via the GPIO HAL.  SPI mode is fixed
+    // to SPI_MODE0 (ST ISM6HG256X SPI convention).
+    TR_ISM6HG256(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz = 2000000);
+
+    ~TR_ISM6HG256();
 
     TR_ISM6HG256Status begin();
     TR_ISM6HG256Status ReadWhoAmI(uint8_t *id);
@@ -52,9 +60,22 @@ public:
     TR_ISM6HG256Status Get_G_DRDY_Status(uint8_t *Status);
 
 private:
-    SPIClass *dev_spi;
-    int cs_pin;
-    uint32_t spi_speed;
+    // CS control (manual, IDF GPIO HAL).  spics_io_num is set to -1 in the
+    // device config, so IDF does not drive CS — this wrapper does.
+    inline void csSelect_()   { gpio_set_level(static_cast<gpio_num_t>(cs_pin_), 0); }
+    inline void csDeselect_() { gpio_set_level(static_cast<gpio_num_t>(cs_pin_), 1); }
+
+    // Lazily add the SPI device on first begin().  Returns false on
+    // add_device failure.  Idempotent.
+    bool ensureSpiDevice_();
+
+    // Configure cs_pin_ as a GPIO output, idle HIGH.
+    void configureCsPin_();
+
+    spi_host_device_t   host_;
+    uint8_t             cs_pin_;
+    uint32_t            clock_hz_;
+    spi_device_handle_t spi_dev_ = nullptr;
 
     uint8_t acc_is_enabled;
     uint8_t acc_hg_is_enabled;

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -65,7 +65,7 @@ SensorCollector::SensorCollector(
       bmp585(SPI2_HOST, BMP585_CS, spi_speed),
       mmc5983ma(this->spi, MMC5983MA_CS, SPISettings(2000000, MSBFIRST, SPI_MODE0)),  // MMC5983MA supports Mode 0 and Mode 3
       iis2mdc(IIS2MDC_I2C_ADDR),
-      ism6hg256(&this->spi, ISM6HG256_CS, spi_speed),
+      ism6hg256(SPI2_HOST, ISM6HG256_CS, spi_speed),
       gyro_cal_x(0), gyro_cal_y(0), gyro_cal_z(0) {}
 
 void SensorCollector::begin(uint8_t imu_execution_core) 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1611,6 +1611,11 @@ static void setup_fc()
     };
     esp_task_wdt_reconfigure(&wdt_cfg);
 
+    // Quiet the IDF gpio driver — each gpio_config() (CS pins, INT pins,
+    // pyro pins) prints a multi-field INFO line that drowns the rest of
+    // boot.  Drop to WARN so genuine GPIO problems still surface.
+    esp_log_level_set("gpio", ESP_LOG_WARN);
+
     // Pyro channels: safe pins FIRST, before any other peripheral init
     initPyroPins();
 


### PR DESCRIPTION
## Summary

Second slice of [#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) (Arduino vestige cleanup), mirrors the BMP585 conversion (#208). Converts `TR_ISM6HG256` from the `TR_Compat` `SPIClass` shim to native ESP-IDF `spi_master`.

- **Public API change:** ctor now `TR_ISM6HG256(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz=2000000)` instead of `(SPIClass*, int, uint32_t)`. Single caller (`SensorCollector`) updated in the same commit.
- **SPI transport:** `spi_bus_add_device` once on first `begin()` (idempotent), `spi_device_polling_transmit` for transfers, ST register byte carried in `t.cmd` with `command_bits=8` (bit7=R/W per ST convention). The ISM6HG256X's IF_INC auto-increment makes the existing bulk-read pattern (e.g. the 24-byte gyro+accel+hg-accel read) map cleanly to a single IDF transaction with `rx_buffer` set to the caller's stack buffer.
- **CS handling:** still manual (`spics_io_num=-1`, `gpio_set_level`) so the `SensorCollector` pre-init flow that toggles `ISM6HG256_CS` is unchanged.
- **Component deps:** `TR_ISM6HG256` REQUIRES drops `TR_Compat` in favour of `driver esp_rom`. `SensorCollector` still pulls `TR_Compat` for the remaining MMC5983MA wrapper.

Next: `TR_MMC5983MA` as the third sensor PR, then `TR_Compat` slimming once all three are converted.

## Test plan

- [x] `idf.py set-target esp32p4 build` from a fresh build dir: success, `flight_computer.bin` 556 KB, 82% partition free, only pre-existing `loop_fc()` unused-variable warnings.
- [ ] Bench flash on FC: confirm WHO_AM_I read returns `ISM6HG256X_ID`, no init failures, and gyro+accel data look sane (low-G accel z ≈ 9.81 m/s² stationary, gyro near zero, high-G accel matches low-G).
- [ ] CI green.
