### PR TITLE
fc: TR_MMC5983MA to native IDF SPI (drop Arduino SPIClass shim)

### DIFF
--- a/tinkerrocket-idf/components/TR_MMC5983MA/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/CMakeLists.txt
@@ -1,2 +1,4 @@
-idf_component_register(SRCS "TR_MMC5983MA.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat)
+idf_component_register(SRCS "TR_MMC5983MA.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver freertos)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA.cpp
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA.cpp
@@ -1,14 +1,71 @@
 #include <TR_MMC5983MA.h>
+#include <cstring>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
-TR_MMC5983MA::TR_MMC5983MA(SPIClass &spi, uint8_t cs_pin, SPISettings settings)
-    : spi(spi), cs_pin(cs_pin), spi_settings(settings)
+static const char* MMC_TAG = "TR_MMC5983MA";
+
+// ---------------- Ctor / Dtor ----------------
+
+TR_MMC5983MA::TR_MMC5983MA(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz)
+    : host_(host),
+      cs_pin_(cs_pin),
+      clock_hz_(clock_hz)
 {
 }
 
+TR_MMC5983MA::~TR_MMC5983MA()
+{
+    if (spi_dev_) {
+        spi_bus_remove_device(spi_dev_);
+        spi_dev_ = nullptr;
+    }
+}
+
+// ---------------- IDF setup helpers ----------------
+
+void TR_MMC5983MA::configureCsPin_()
+{
+    gpio_config_t io = {};
+    io.pin_bit_mask  = 1ULL << cs_pin_;
+    io.mode          = GPIO_MODE_OUTPUT;
+    io.pull_up_en    = GPIO_PULLUP_DISABLE;
+    io.pull_down_en  = GPIO_PULLDOWN_DISABLE;
+    io.intr_type     = GPIO_INTR_DISABLE;
+    gpio_config(&io);
+    csDeselect_();
+}
+
+bool TR_MMC5983MA::ensureSpiDevice_()
+{
+    if (spi_dev_) return true;
+
+    // Configure CS as a GPIO output (idle HIGH) before the device is added.
+    // Idempotent across the cold path (begin()) and any pre-begin I/O.
+    configureCsPin_();
+
+    spi_device_interface_config_t devcfg = {};
+    devcfg.clock_speed_hz = clock_hz_;
+    devcfg.mode           = 0;          // SPI_MODE0 (MMC5983MA supports mode 0 and mode 3; we use 0)
+    devcfg.spics_io_num   = -1;         // CS driven manually by this wrapper
+    devcfg.queue_size     = 1;
+    devcfg.command_bits   = 8;          // reg byte goes in t.cmd
+
+    esp_err_t err = spi_bus_add_device(host_, &devcfg, &spi_dev_);
+    if (err != ESP_OK) {
+        ESP_LOGE(MMC_TAG, "spi_bus_add_device failed: %s", esp_err_to_name(err));
+        spi_dev_ = nullptr;
+        return false;
+    }
+    return true;
+}
+
+// ---------------- Public API ----------------
+
 bool TR_MMC5983MA::begin()
 {
-    pinMode(cs_pin, OUTPUT);
-    digitalWrite(cs_pin, HIGH);
+    if (!ensureSpiDevice_()) return false;
     return isConnected();
 }
 
@@ -23,7 +80,7 @@ bool TR_MMC5983MA::softReset()
 {
     const bool ok = setShadowBit(INT_CTRL_1_REG, SW_RST);
     clearShadowBit(INT_CTRL_1_REG, SW_RST, false);
-    delay(15);
+    vTaskDelay(pdMS_TO_TICKS(15));
     return ok;
 }
 
@@ -31,7 +88,7 @@ bool TR_MMC5983MA::performSetOperation()
 {
     const bool ok = setShadowBit(INT_CTRL_0_REG, SET_OPERATION);
     clearShadowBit(INT_CTRL_0_REG, SET_OPERATION, false);
-    delay(1);
+    vTaskDelay(pdMS_TO_TICKS(1));
     return ok;
 }
 
@@ -39,7 +96,7 @@ bool TR_MMC5983MA::performResetOperation()
 {
     const bool ok = setShadowBit(INT_CTRL_0_REG, RESET_OPERATION);
     clearShadowBit(INT_CTRL_0_REG, RESET_OPERATION, false);
-    delay(1);
+    vTaskDelay(pdMS_TO_TICKS(1));
     return ok;
 }
 
@@ -190,36 +247,54 @@ bool TR_MMC5983MA::clearMeasDoneInterrupt(uint8_t measMask)
 bool TR_MMC5983MA::readSingleByte(uint8_t reg, uint8_t *value)
 {
     if (value == nullptr) return false;
-    spi.beginTransaction(spi_settings);
-    digitalWrite(cs_pin, LOW);
-    spi.transfer(READ_REG(reg));
-    *value = spi.transfer(0x00);
-    digitalWrite(cs_pin, HIGH);
-    spi.endTransaction();
+    if (!ensureSpiDevice_()) return false;
+
+    spi_transaction_t t = {};
+    t.cmd       = static_cast<uint16_t>(READ_REG(reg));  // bit7=1 for read
+    t.length    = 8;
+    t.flags     = SPI_TRANS_USE_RXDATA;
+
+    csSelect_();
+    esp_err_t err = spi_device_polling_transmit(spi_dev_, &t);
+    csDeselect_();
+
+    if (err != ESP_OK) return false;
+    *value = t.rx_data[0];
     return true;
 }
 
 bool TR_MMC5983MA::writeSingleByte(uint8_t reg, uint8_t value)
 {
-    spi.beginTransaction(spi_settings);
-    digitalWrite(cs_pin, LOW);
-    spi.transfer(reg);
-    spi.transfer(value);
-    digitalWrite(cs_pin, HIGH);
-    spi.endTransaction();
-    return true;
+    if (!ensureSpiDevice_()) return false;
+
+    spi_transaction_t t = {};
+    t.cmd        = static_cast<uint16_t>(reg & 0x7F);  // bit7=0 for write
+    t.length     = 8;
+    t.flags      = SPI_TRANS_USE_TXDATA;
+    t.tx_data[0] = value;
+
+    csSelect_();
+    esp_err_t err = spi_device_polling_transmit(spi_dev_, &t);
+    csDeselect_();
+
+    return (err == ESP_OK);
 }
 
 bool TR_MMC5983MA::readMultipleBytes(uint8_t reg, uint8_t *buffer, uint8_t len)
 {
     if (buffer == nullptr || len == 0U) return false;
-    spi.beginTransaction(spi_settings);
-    digitalWrite(cs_pin, LOW);
-    spi.transfer(READ_REG(reg));
-    spi.transfer(buffer, len);
-    digitalWrite(cs_pin, HIGH);
-    spi.endTransaction();
-    return true;
+    if (!ensureSpiDevice_()) return false;
+
+    spi_transaction_t t = {};
+    t.cmd       = static_cast<uint16_t>(READ_REG(reg));  // bit7=1 for read (auto-increment)
+    t.length    = len * 8;
+    t.rx_buffer = buffer;
+
+    csSelect_();
+    esp_err_t err = spi_device_polling_transmit(spi_dev_, &t);
+    csDeselect_();
+
+    return (err == ESP_OK);
 }
 
 bool TR_MMC5983MA::setRegisterBit(uint8_t reg, uint8_t bitMask)

--- a/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA.h
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/TR_MMC5983MA.h
@@ -1,12 +1,20 @@
 #ifndef TR_MMC5983MA_H
 #define TR_MMC5983MA_H
 
-#include <compat.h>
+#include <cstdint>
+#include <driver/spi_master.h>
+#include <driver/gpio.h>
 
 class TR_MMC5983MA
 {
 public:
-    TR_MMC5983MA(SPIClass &spi, uint8_t cs_pin, SPISettings settings = SPISettings(2000000, MSBFIRST, SPI_MODE0));
+    // ESP-IDF native constructor.  The SPI bus identified by `host` must be
+    // initialised (spi_bus_initialize) before begin() is called.  CS is
+    // driven manually by the wrapper via the GPIO HAL.  SPI mode is fixed
+    // to SPI_MODE0 (MMC5983MA supports modes 0 and 3; we use 0).
+    TR_MMC5983MA(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz = 2000000);
+
+    ~TR_MMC5983MA();
 
     bool begin();
     bool isConnected();
@@ -60,9 +68,21 @@ private:
     uint8_t internal_ctrl_2 = 0x00;
     uint8_t internal_ctrl_3 = 0x00;
 
-    SPIClass &spi;
-    uint8_t cs_pin;
-    SPISettings spi_settings;
+    // CS control (manual, IDF GPIO HAL).  spics_io_num is set to -1 in the
+    // device config, so IDF does not drive CS — this wrapper does.
+    inline void csSelect_()   { gpio_set_level(static_cast<gpio_num_t>(cs_pin_), 0); }
+    inline void csDeselect_() { gpio_set_level(static_cast<gpio_num_t>(cs_pin_), 1); }
+
+    // Lazily add the SPI device on first I/O.  Returns false on add_device
+    // failure.  Idempotent.  Also configures the CS pin on first call so
+    // the wrapper is self-contained.
+    bool ensureSpiDevice_();
+    void configureCsPin_();
+
+    spi_host_device_t   host_;
+    uint8_t             cs_pin_;
+    uint32_t            clock_hz_;
+    spi_device_handle_t spi_dev_ = nullptr;
 
     static constexpr uint8_t READ_REG(uint8_t reg) { return (uint8_t)(0x80U | reg); }
 

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -63,7 +63,7 @@ SensorCollector::SensorCollector(
       spi(spi),
       spi_speed(spi_speed),
       bmp585(SPI2_HOST, BMP585_CS, spi_speed),
-      mmc5983ma(this->spi, MMC5983MA_CS, SPISettings(2000000, MSBFIRST, SPI_MODE0)),  // MMC5983MA supports Mode 0 and Mode 3
+      mmc5983ma(SPI2_HOST, MMC5983MA_CS, 2000000),  // MMC5983MA supports Mode 0 and Mode 3; wrapper uses Mode 0
       iis2mdc(IIS2MDC_I2C_ADDR),
       ism6hg256(SPI2_HOST, ISM6HG256_CS, spi_speed),
       gyro_cal_x(0), gyro_cal_y(0), gyro_cal_z(0) {}


### PR DESCRIPTION
## Summary

Third sensor PR for [#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) (Arduino vestige cleanup), mirrors BMP585 ([#208](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/208)) and ISM6 ([#209](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/209)). Converts `TR_MMC5983MA` from the `TR_Compat` `SPIClass` shim to native ESP-IDF `spi_master`.

- **Public API change:** ctor now `TR_MMC5983MA(spi_host_device_t host, uint8_t cs_pin, uint32_t clock_hz=2000000)` instead of `(SPIClass&, uint8_t, SPISettings)`. Single caller (`SensorCollector`) updated in the same commit.
- **SPI transport:** `spi_bus_add_device` once on first I/O (idempotent — same lazy-init pattern ISM6 needed once we bench-tested it; preemptive here so any code path is safe). `spi_device_polling_transmit` for transfers with the MMC reg byte in the SPI command field (`command_bits=8`, bit7=R/W per MMC convention). Single-byte reads/writes use `SPI_TRANS_USE_RXDATA`/`SPI_TRANS_USE_TXDATA` (status/ctrl0..2/prod_id are 1-byte chatter — no point setting up DMA). 7-byte `readFieldsXYZ` burst stays on `rx_buffer`.
- **CS handling:** still manual (`spics_io_num=-1`, `gpio_set_level`).
- **Delays:** `delay()` / `delayMicroseconds()` in `softReset` / `performSetOperation` / `performResetOperation` replaced with `vTaskDelay(pdMS_TO_TICKS(N))`.
- **Component deps:** `TR_MMC5983MA` REQUIRES drops `TR_Compat` in favour of `driver freertos`. `SensorCollector` still pulls `TR_Compat` for its own `pinMode`/`digitalWrite`/`attachInterrupt` calls; that's the next slice (item #3 / #5 in the issue).

Next: `main.cpp` Arduino-isms migration (issue #21 item #3) and then `TR_Compat` slim (item #5).

## Test plan

- [x] `idf.py set-target esp32p4 build` from a fresh build dir: success, `flight_computer.bin` 555 KB, 82% partition free, only pre-existing `loop_fc()` unused-variable warnings.
- [ ] Bench flash on FC: confirm `PROD_ID_REG` reads `0x30` (no `isConnected()` failure → no `mmc5983ma.begin()` retry loop), softReset / set / reset operations succeed, continuous mode starts producing field readings.
- [ ] CI green.
