### PR TITLE
oc/bs: drop dead #ifdef ARDUINO branch in TR_BLE_To_APP.h

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -9,13 +9,9 @@
  * base-station main.cpp files compile without modification.
  */
 
-#ifdef ARDUINO
-#include <Arduino.h>            // Pulls in String, millis(), etc.
-#else
 #include <string>
-#include "compat.h"             // millis(), delay(), etc. for pure-IDF builds
+#include "compat.h"             // millis(), delay(), etc.
 using String = std::string;     // API-compatible subset used by callers
-#endif
 
 #include <cstdint>
 #include <cstddef>


### PR DESCRIPTION
## Summary

[#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) item #2 (trivial). `TR_BLE_To_APP.h` had a leftover `#ifdef ARDUINO` / `#else` pair from when both Arduino-framework and pure-IDF builds coexisted. The macro `ARDUINO` is no longer defined anywhere in the codebase — out_computer and base_station have been NimBLE-host pure-IDF since the framework swap, and flight_computer excludes the component entirely. Drop the dead branch, keep the `std::string` + `compat.h` path verbatim so the existing `using String = std::string;` typedef and `millis()` usage in `TR_BLE_To_APP.cpp` (4 call sites) keep working.

Diff is 1 file, +1 / −5.

## Test plan

- [x] `idf.py set-target esp32s3 build` of `out_computer` (sole flight-side consumer): clean.
- [x] `idf.py set-target esp32s3 build` of `base_station` (the other consumer): clean.
- [ ] CI green.
