### PR TITLE
ci: add flight_computer to firmware-build matrix

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'tinkerrocket-idf/**'
+      - '.github/workflows/firmware-build.yml'
   pull_request:
     paths:
       - 'tinkerrocket-idf/**'
+      - '.github/workflows/firmware-build.yml'
 
 jobs:
   build:

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -19,9 +19,7 @@ jobs:
         project:
           - out_computer
           - base_station
-          # flight_computer excluded: uses Arduino-as-component with
-          # managed_components fetched at build time (gitignored).
-          # Add once we set up component caching in CI.
+          - flight_computer
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

[#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) item #6 — final payoff PR. Adds `flight_computer` to the `firmware-build` GitHub Actions matrix so a broken FC build can't sneak into main anymore. The exclusion comment ("Arduino-as-component with managed_components fetched at build time") was the historical justification, both halves of which are no longer true:

- `flight_computer/dependencies.lock` lists only `idf` since the framework swap. After PRs [#208](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/208) / [#209](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/209) / [#210](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/210) / [#211](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/211), no FC component pulls Arduino either.
- "Managed components fetched at build time" is exactly what `out_computer` and `base_station` already do via the same `idf.py build` step; nothing special is needed for FC.

`TR_GuidancePN` (private submodule) is already handled by the existing checkout step — if `TR_GUIDANCEPN_TOKEN` secret is present the submodule is checked out recursively; otherwise the project's CMakeLists falls back to `TR_GuidancePN_Stub` and the build still completes.

Diff: 1 file, +1 / −3.

## Test plan

- [ ] CI green — `build (flight_computer)` should join the existing `build (out_computer)` / `build (base_station)` jobs.
- [ ] **Bench**: flash the post-merge tip to the FC and verify nothing's regressed since [#210](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/210) landed (the MMC merge that didn't get bench-tested). BMP585 + ISM6 + IIS2MDC should all init cleanly, telemetry should flow, the GUI should show sane sensor values.
