### PR TITLE
ios: emit IIS2MDC (0xD1) mag frames in CSV export

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -114,6 +114,16 @@ nonisolated class CSVGenerator {
                         magData.append((raw.time_us, si))
                     }
 
+                case .iis2mdc:
+                    // New Mini PCB rev: IIS2MDC replaces MMC5983MA.
+                    // Converter output type is MMC5983MADataSI so the
+                    // downstream Magnetic Field X/Y/Z (µT) columns
+                    // emit the same way regardless of which mag chip
+                    // is fitted.
+                    let raw = try IIS2MDCData(from: frame.payload)
+                    let si = converter.convertIIS2MDC(raw)
+                    magData.append((raw.time_us, si))
+
                 case .power:
                     // Power encoding is the same for both devices
                     let raw = try POWERData(from: frame.payload)

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -191,6 +191,36 @@ nonisolated class SensorConverter {
         )
     }
 
+    // MARK: - IIS2MDC Conversion (new Mini PCB rev)
+
+    /// Convert IIS2MDC raw counts to MMC5983MADataSI (µT) so CSV writer
+    /// stays unified between MMC and IIS2MDC boards.  IIS2MDC sensitivity
+    /// is 0.15 µT/LSB (datasheet 9.13).  Frame rotation reuses
+    /// mmc_rot_z_rad — only one mag rotation comes back in the status
+    /// query (mmc_rot_z_cdeg), applied to whichever mag chip is present.
+    func convertIIS2MDC(_ raw: IIS2MDCData) -> MMC5983MADataSI {
+        let UT_PER_LSB = 0.15
+
+        let mx = Double(raw.mag_x) * UT_PER_LSB
+        let my = Double(raw.mag_y) * UT_PER_LSB
+        let mz = Double(raw.mag_z) * UT_PER_LSB
+
+        let c = cos(mmc_rot_z_rad)
+        let s = sin(mmc_rot_z_rad)
+
+        // Sensor frame -> board frame, rotation about +Z.
+        let mag_x = (mx * c) - (my * s)
+        let mag_y = (mx * s) + (my * c)
+        let mag_z = mz
+
+        return MMC5983MADataSI(
+            time_us: raw.time_us,
+            mag_x: mag_x,
+            mag_y: mag_y,
+            mag_z: mag_z
+        )
+    }
+
     // MARK: - Legacy Sensor Conversions
     // Legacy uses different sensors (ICM45686, H3LIS331, MS5611, LIS3MDL).
     // All converters output the same SI types as Mini so CSVGenerator stays unified.

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -24,6 +24,7 @@ enum MessageType: UInt8 {
     case cameraStart = 0xAA
     case cameraStop = 0xAB
     case flightSettings = 0xE1  // FlightSettingsData (149B) — runtime settings snapshot at launch (#165)
+    case iis2mdc = 0xD1    // IIS2MDC magnetometer (new Mini PCB rev, 10B)
     case lora = 0xF1
 }
 
@@ -380,6 +381,28 @@ nonisolated struct MMC5983MAData {
         mag_x = data.readUInt32LE(at: &offset)
         mag_y = data.readUInt32LE(at: &offset)
         mag_z = data.readUInt32LE(at: &offset)
+    }
+}
+
+// IIS2MDC Magnetometer Data (10 bytes) — new Mini PCB rev, replaces MMC5983MA.
+// Raw int16 per axis at 0.15 µT/LSB (datasheet 9.13).
+nonisolated struct IIS2MDCData {
+    let time_us: UInt32
+    let mag_x: Int16  // Raw counts (signed)
+    let mag_y: Int16
+    let mag_z: Int16
+
+    init(from data: Data) throws {
+        guard data.count >= 10 else {
+            throw ParseError.invalidSize(expected: 10, got: data.count)
+        }
+
+        var offset = 0
+
+        time_us = data.readUInt32LE(at: &offset)
+        mag_x = data.readInt16LE(at: &offset)
+        mag_y = data.readInt16LE(at: &offset)
+        mag_z = data.readInt16LE(at: &offset)
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
@@ -41,6 +41,13 @@ private func makeMag(timeUs: UInt32 = 0, x: UInt32, y: UInt32, z: UInt32) throws
     return try MMC5983MAData(from: d)
 }
 
+private func makeIIS2MDC(timeUs: UInt32 = 0, x: Int16, y: Int16, z: Int16) throws -> IIS2MDCData {
+    var d = Data()
+    d.appendLE(timeUs)
+    d.appendLE(x); d.appendLE(y); d.appendLE(z)
+    return try IIS2MDCData(from: d)
+}
+
 private func makeGNSS(
     timeUs: UInt32 = 0,
     latE7: Int32, lonE7: Int32, altMm: Int32,
@@ -146,6 +153,28 @@ final class SensorConverterTests: XCTestCase {
         XCTAssertEqual(si.mag_x, 0.0, accuracy: 0.01)
         XCTAssertEqual(si.mag_y, 0.0, accuracy: 0.01)
         XCTAssertEqual(si.mag_z, 0.0, accuracy: 0.01)
+    }
+
+    func testIIS2MDC_ZeroRaw() throws {
+        // Raw 0 -> 0 µT; signed-int axes so no centering needed.
+        let raw = try makeIIS2MDC(timeUs: 3000, x: 0, y: 0, z: 0)
+        let si = converter.convertIIS2MDC(raw)
+
+        XCTAssertEqual(si.time_us, 3000)
+        XCTAssertEqual(si.mag_x, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(si.mag_y, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(si.mag_z, 0.0, accuracy: 1e-9)
+    }
+
+    func testIIS2MDC_SensitivityIs0_15uTPerLSB() throws {
+        // Datasheet 9.13: 0.15 µT/LSB.  With zero rotation (default),
+        // raw 100 should map directly to 15 µT on each axis.
+        let raw = try makeIIS2MDC(x: 100, y: 200, z: -100)
+        let si = converter.convertIIS2MDC(raw)
+
+        XCTAssertEqual(si.mag_x,  15.0, accuracy: 1e-6)
+        XCTAssertEqual(si.mag_y,  30.0, accuracy: 1e-6)
+        XCTAssertEqual(si.mag_z, -15.0, accuracy: 1e-6)
     }
 
     // MARK: - NonSensor flag extraction (#196)


### PR DESCRIPTION
## Summary

Pre-existing iOS bug surfaced while bench-testing the FC IDF-SPI cleanup (PRs [#208](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/208) / [#209](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/209) / [#210](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/210)): on the new Mini PCB rev that uses IIS2MDC (I2C) in place of MMC5983MA (SPI), the iOS `MessageType` enum had no case for `0xD1` (IIS2MDC_MSG). `CSVGenerator`'s `MessageType(rawValue: 0xD1)` guard fell through to `continue` for every IIS2MDC frame, silently dropping ~1,700 mag samples per ~17 s of log.

- **`SensorTypes.swift`** — add `iis2mdc = 0xD1` to `MessageType`; add `IIS2MDCData` parser (10 bytes: `u32 time_us + 3× int16 raw`, mirrors firmware-side struct in `RocketComputerTypes.h`).
- **`SensorConverter.swift`** — `convertIIS2MDC(_:) -> MMC5983MADataSI` at 0.15 µT/LSB (datasheet 9.13), reusing the existing `mmc_rot_z_rad` rotation since only one mag rotation comes back in the status query and applies to whichever mag chip is fitted. Output type matches `MMC5983MADataSI` so the downstream CSV emission path is unchanged.
- **`CSVGenerator.swift`** — `.iis2mdc` switch arm parses + converts + appends to the same `magData` stream MMC frames feed.
- **`SensorConverterTests.swift`** — two new unit tests (zero-raw, sensitivity 100→15 µT).

## Test plan

- [x] `xcodebuild test` on iPhone 17 simulator: full suite passes including the two new IIS2MDC tests.
- [x] Re-exported the existing bench `.bin` with the rebuilt app: **7,561 mag rows now populate the Magnetic Field X/Y/Z columns**. |B| at the mean = **1.72 mT**, exactly matching the documented hard-iron residual on the new PCB. Per-axis noise stddev 0.4–0.6 µT — within sensor spec.
- [ ] CI green.
