### PR TITLE
fc: migrate main.cpp + SensorCollector Arduino-isms to native IDF

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/CMakeLists.txt
@@ -1,2 +1,5 @@
-idf_component_register(SRCS "TR_Sensor_Collector.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_RocketComputerTypes TR_ISM6HG256 TR_BMP585 TR_MMC5983MA TR_IIS2MDC TR_GNSSReceiverUBlox_Serial)
+idf_component_register(SRCS "TR_Sensor_Collector.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES TR_RocketComputerTypes TR_ISM6HG256 TR_BMP585 TR_MMC5983MA TR_IIS2MDC TR_GNSSReceiverUBlox_Serial
+                                driver esp_timer esp_rom)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -3,7 +3,19 @@
 
 #include <TR_Sensor_Collector.h>
 #include <esp_log.h>
+#include <esp_timer.h>
+#include <esp_rom_sys.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 static const char* SC_TAG = "SENSORS";
+
+// IDF-native timing helpers — replace the Arduino-shim millis()/time_us()
+// and delay_ms() that came in via compat.h.  See main.cpp for the same
+// pattern; `time_*` names avoid colliding with local vars / parameters
+// named `now_ms`, `now_us` etc.
+static inline uint32_t time_ms() { return (uint32_t)(esp_timer_get_time() / 1000); }
+static inline uint32_t time_us() { return (uint32_t)esp_timer_get_time(); }
+static inline void     delay_ms(uint32_t ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }
 
 SensorCollector* SensorCollector::ism6hg256_instance = nullptr;
 SensorCollector* SensorCollector::bmp585_instance = nullptr;
@@ -122,11 +134,11 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     digitalWrite(BMP585_CS, HIGH);
     pinMode(MMC5983MA_CS, OUTPUT);
     digitalWrite(MMC5983MA_CS, HIGH);
-    delay(10);
+    delay_ms(10);
     
     // Update periods calculated from frequencies
     ism6hg256_update_period = (uint32_t)(1000000/ISM6HG256_UPDATE_RATE);
-    mmc_last_sample_time_us = micros();
+    mmc_last_sample_time_us = time_us();
     mmc_last_recover_time_us = 0;
     // Stall = 5 nominal periods; cooldown = 15 nominal periods. Scales with configured rate.
     mmc_stall_threshold_us  = 5U  * (1000000UL / (uint32_t)MMC5983MA_UPDATE_RATE);
@@ -136,7 +148,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (ism6hg256DataSemaphore == NULL)
     {
         ESP_LOGE(SC_TAG, "Failed to create ISM6HG256 data semaphore!");
-        while (1) delay(1000);
+        while (1) delay_ms(1000);
     }
     xSemaphoreGive(ism6hg256DataSemaphore);
 
@@ -144,7 +156,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (bmp585DataSemaphore == NULL)
     {
         ESP_LOGE(SC_TAG, "Failed to create BMP585 data semaphore!");
-        while (1) delay(1000);
+        while (1) delay_ms(1000);
     }
     xSemaphoreGive(bmp585DataSemaphore);
 
@@ -152,7 +164,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (mmc5983maDataSemaphore == NULL)
     {
         ESP_LOGE(SC_TAG, "Failed to create MMC5983MA data semaphore!");
-        while (1) delay(1000);
+        while (1) delay_ms(1000);
     }
     xSemaphoreGive(mmc5983maDataSemaphore);
 
@@ -160,7 +172,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (iis2mdcDataSemaphore == NULL)
     {
         ESP_LOGE(SC_TAG, "Failed to create IIS2MDC data semaphore!");
-        while (1) delay(1000);
+        while (1) delay_ms(1000);
     }
     xSemaphoreGive(iis2mdcDataSemaphore);
 
@@ -168,7 +180,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (gnssDataSemaphore == NULL)
     {
         ESP_LOGE(SC_TAG, "Failed to create GNSS data semaphore!");
-        while (1) delay(1000);
+        while (1) delay_ms(1000);
     }
     xSemaphoreGive(gnssDataSemaphore);
 
@@ -190,13 +202,13 @@ void SensorCollector::begin(uint8_t imu_execution_core)
             // Re-drive CS high between retries to avoid bus ambiguity.
             pinMode(BMP585_CS, OUTPUT);
             digitalWrite(BMP585_CS, HIGH);
-            delay(10);
+            delay_ms(10);
 
             if ((bmp_retry_count % 5U) == 0U)
             {
                 ESP_LOGW(SC_TAG, "BMP585 retry count: %lu", (unsigned long)bmp_retry_count);
             }
-            delay(500);
+            delay_ms(500);
         }
 
         ESP_LOGI(SC_TAG, "BMP585 OK. chip_id = 0x%02X", bmp585.readChipId());
@@ -216,7 +228,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         if (!bmp_ok)
         {
             ESP_LOGE(SC_TAG, "BMP585 configuration failed, stopping.");
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
 
         ESP_LOGI(SC_TAG, "BMP585 continuous mode active; throughput set by OSR/filter (ODR ignored in this mode).");
@@ -259,7 +271,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
             if (iis2mdc.configure() != TR_IIS2MDC_OK)
             {
                 ESP_LOGE(SC_TAG, "IIS2MDC configuration failed, stopping.");
-                while (1) { delay(1000); }
+                while (1) { delay_ms(1000); }
             }
 
             iis2mdc_active = true;
@@ -279,7 +291,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
 
             // Sanity print — read a few samples to confirm the part is alive.
             // Continuous mode at 100 Hz means a fresh sample is ready every 10 ms.
-            delay(20);  // allow the first conversion to complete
+            delay_ms(20);  // allow the first conversion to complete
             for (int s = 0; s < 5; s++)
             {
                 float x_uT = 0.0f, y_uT = 0.0f, z_uT = 0.0f;
@@ -293,7 +305,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
                 {
                     ESP_LOGW(SC_TAG, "IIS2MDC sample %d read failed", s);
                 }
-                delay(15);
+                delay_ms(15);
             }
         }
         else
@@ -311,21 +323,21 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         // Pin 13 was potentially driven by the I2C probe above; restore CS high.
         pinMode(MMC5983MA_CS, OUTPUT);
         digitalWrite(MMC5983MA_CS, HIGH);
-        delay(2);
+        delay_ms(2);
 
         while (!mmc5983ma.begin())
         {
             ESP_LOGW(SC_TAG, "MMC5983MA did not respond. Retrying...");
-            delay(500);
+            delay_ms(500);
             (void)mmc5983ma.softReset();
-            delay(500);
+            delay_ms(500);
         }
 
         (void)mmc5983ma.softReset();
         (void)mmc5983ma.performSetOperation();
-        delay(10);
+        delay_ms(10);
         (void)mmc5983ma.performResetOperation();
-        delay(10);
+        delay_ms(10);
         (void)mmc5983ma.enableAutomaticSetReset();  // Eliminates hysteresis drift
 
         bool mmc_ok = true;
@@ -343,7 +355,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         if (!mmc_ok)
         {
             ESP_LOGE(SC_TAG, "MMC5983MA configuration failed, stopping.");
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
 
         ESP_LOGI(SC_TAG, "MMC5983MA found and initialized");
@@ -381,12 +393,12 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         if (ism6hg256.ReadWhoAmI(&whoami) != TR_ISM6HG256_OK)
         {
             ESP_LOGE(SC_TAG, "ISM6HG256 WHOAMI read failed, stopping.");
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
         if (whoami != ISM6HG256X_ID)
         {
             ESP_LOGE(SC_TAG, "ISM6HG256 WHOAMI mismatch, got 0x%02X expected 0x%02X", whoami, ISM6HG256X_ID);
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
 
         // Initialize and configure ISM6HG256 (low-g + high-g + gyro)
@@ -410,7 +422,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         if (status != TR_ISM6HG256_OK)
         {
             ESP_LOGE(SC_TAG, "ISM6HG256 initialization/configuration failed, stopping.");
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
 
         ESP_LOGI(SC_TAG, "ISM6HG256 found and initialized");
@@ -444,7 +456,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
                                  GNSS_SAFEBOOT_N))
         {
             ESP_LOGE(SC_TAG, "GNSS initialization failed, stopping.");
-            while (1) { delay(1000); }
+            while (1) { delay_ms(1000); }
         }
         ESP_LOGI(SC_TAG, "GNSS found and initialized");
     }
@@ -483,7 +495,7 @@ void SensorCollector::pollIMUdata(void* parameter)
     while (true)
     {
         // ### Read Sensor Data ###
-        const uint32_t iter_start_us = micros();
+        const uint32_t iter_start_us = time_us();
 
         // Block for sensor interrupt to avoid busy-spinning and WDT starvation.
         const uint32_t notify_count = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(100));
@@ -516,7 +528,7 @@ void SensorCollector::pollIMUdata(void* parameter)
         {
             self->ism6_isr_fired = false;
 
-            const uint32_t ism6_t0 = micros();
+            const uint32_t ism6_t0 = time_us();
             self->ism6_drdy_triplet_hits++;
 
             TR_ISM6HG256_AxesRaw_t lg_raw = {};
@@ -528,7 +540,7 @@ void SensorCollector::pollIMUdata(void* parameter)
 
             if (xSemaphoreTake(self->ism6hg256DataSemaphore, 0) == pdTRUE)
             {
-                self->start_time = micros();
+                self->start_time = time_us();
                 self->ism6hg256_data.time_us = self->start_time;
 
                 self->ism6hg256_data.acc_low_raw.x = lg_raw.x;
@@ -564,7 +576,7 @@ void SensorCollector::pollIMUdata(void* parameter)
                 xSemaphoreGive(self->ism6hg256DataSemaphore);
             }
 
-            const uint32_t ism6_elapsed = micros() - ism6_t0;
+            const uint32_t ism6_elapsed = time_us() - ism6_t0;
             if (ism6_elapsed > self->pt_ism6_read_max_us)
             {
                 self->pt_ism6_read_max_us = ism6_elapsed;
@@ -582,7 +594,7 @@ void SensorCollector::pollIMUdata(void* parameter)
 
             if (bmp_pending > 0)
             {
-                const uint32_t bmp_t0 = micros();
+                const uint32_t bmp_t0 = time_us();
 
                 while (bmp_pending > 0)
                 {
@@ -601,7 +613,7 @@ void SensorCollector::pollIMUdata(void* parameter)
                     bmp_pending--;
                 }
 
-                const uint32_t bmp_elapsed = micros() - bmp_t0;
+                const uint32_t bmp_elapsed = time_us() - bmp_t0;
                 if (bmp_elapsed > self->pt_bmp_max_us)
                 {
                     self->pt_bmp_max_us = bmp_elapsed;
@@ -625,7 +637,7 @@ void SensorCollector::pollIMUdata(void* parameter)
 
             if (mmc_pending > 0)
             {
-                const uint32_t mmc_t0 = micros();
+                const uint32_t mmc_t0 = time_us();
                 self->mmc5983ma_irq_path_hits += mmc_pending;
                 self->mmc5983ma_process_hits++;
 
@@ -639,14 +651,14 @@ void SensorCollector::pollIMUdata(void* parameter)
                     self->mmc5983ma_read_ok++;
                     if (xSemaphoreTake(self->mmc5983maDataSemaphore, 0) == pdTRUE)
                     {
-                        self->mmc5983ma_data.time_us = micros();
+                        self->mmc5983ma_data.time_us = time_us();
                         self->mmc5983ma_data.mag_x = mx;
                         self->mmc5983ma_data.mag_y = my;
                         self->mmc5983ma_data.mag_z = mz;
                         self->mmc5983ma_data_ready = true;
                         xSemaphoreGive(self->mmc5983maDataSemaphore);
                     }
-                    self->mmc_last_sample_time_us = micros();
+                    self->mmc_last_sample_time_us = time_us();
                 }
                 else
                 {
@@ -663,7 +675,7 @@ void SensorCollector::pollIMUdata(void* parameter)
                     self->mmc5983ma_clear_fail++;
                 }
 
-                const uint32_t mmc_elapsed = micros() - mmc_t0;
+                const uint32_t mmc_elapsed = time_us() - mmc_t0;
                 if (mmc_elapsed > self->pt_mmc_max_us)
                 {
                     self->pt_mmc_max_us = mmc_elapsed;
@@ -671,7 +683,7 @@ void SensorCollector::pollIMUdata(void* parameter)
             }
 
             // Stall recovery — infrequent, only when no data for several periods
-            const uint32_t now_us = micros();
+            const uint32_t now_us = time_us();
             const bool mmc_stalled = ((int32_t)(now_us - self->mmc_last_sample_time_us) > (int32_t)self->mmc_stall_threshold_us);
             const bool recover_due = ((int32_t)(now_us - self->mmc_last_recover_time_us) > (int32_t)self->mmc_recover_cooldown_us);
             if (mmc_stalled && recover_due)
@@ -712,7 +724,7 @@ void SensorCollector::pollIMUdata(void* parameter)
         // complete sample instead of tearing.
         if (self->iis2mdc_active)
         {
-            const uint32_t iis2_now_us = micros();
+            const uint32_t iis2_now_us = time_us();
             if ((int32_t)(iis2_now_us - self->iis2mdc_last_sample_us) >=
                 (int32_t)IIS2MDC_PERIOD_US)
             {
@@ -734,7 +746,7 @@ void SensorCollector::pollIMUdata(void* parameter)
         }
 
         // Track total iteration time (excluding the notification wait)
-        const uint32_t iter_elapsed = micros() - iter_start_us;
+        const uint32_t iter_elapsed = time_us() - iter_start_us;
         if (iter_elapsed > self->pt_iter_max_us)
         {
             self->pt_iter_max_us = iter_elapsed;
@@ -760,14 +772,14 @@ void SensorCollector::pollGNSSdata(void* parameter)
 
         if (!self->use_gnss) continue;
 
-        const uint32_t gnss_t0 = micros();
+        const uint32_t gnss_t0 = time_us();
 
         // Non-blocking: parse serial bytes, return true only if a
         // brand-new NAV-PVT message was fully received.
         GNSSData gnss_sample = {};
         const bool have_new = self->gnss_receiver.pollNewPVT(gnss_sample);
 
-        const uint32_t gnss_elapsed = micros() - gnss_t0;
+        const uint32_t gnss_elapsed = time_us() - gnss_t0;
         self->pt_gnss_calls++;
         if (gnss_elapsed > self->pt_gnss_max_us)
         {
@@ -979,7 +991,7 @@ void SensorCollector::calibrateGyro(float rotation_z_deg)
             accel_count++;
         }
 
-        delay(10);
+        delay_ms(10);
     }
 
     // --- Gyro offsets ---

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -5,14 +5,15 @@
 #include <esp_log.h>
 #include <esp_timer.h>
 #include <esp_rom_sys.h>
+#include <driver/gpio.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 static const char* SC_TAG = "SENSORS";
 
-// IDF-native timing helpers — replace the Arduino-shim millis()/time_us()
-// and delay_ms() that came in via compat.h.  See main.cpp for the same
-// pattern; `time_*` names avoid colliding with local vars / parameters
-// named `now_ms`, `now_us` etc.
+// IDF-native timing helpers — replace the Arduino-shim millis()/micros()
+// and delay() that came in via compat.h.  See main.cpp for the same
+// pattern; the `time_*` names avoid colliding with local vars and
+// function parameters called `now_ms` / `now_us` throughout this file.
 static inline uint32_t time_ms() { return (uint32_t)(esp_timer_get_time() / 1000); }
 static inline uint32_t time_us() { return (uint32_t)esp_timer_get_time(); }
 static inline void     delay_ms(uint32_t ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }
@@ -46,7 +47,6 @@ SensorCollector::SensorCollector(
                            bool use_iis2mdc,
                            bool use_gnss,
                            bool use_ism6hg256,
-                           SPIClass &spi,
                            uint32_t spi_speed)
     : ISM6HG256_CS(ISM6HG256_CS),
       ISM6HG256_INT(ISM6HG256_INT),
@@ -72,7 +72,6 @@ SensorCollector::SensorCollector(
       use_iis2mdc(use_iis2mdc),
       use_gnss(use_gnss),
       use_ism6hg256(use_ism6hg256),
-      spi(spi),
       spi_speed(spi_speed),
       bmp585(SPI2_HOST, BMP585_CS, spi_speed),
       mmc5983ma(SPI2_HOST, MMC5983MA_CS, 2000000),  // MMC5983MA supports Mode 0 and Mode 3; wrapper uses Mode 0
@@ -127,13 +126,19 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         ism6_drdy_histogram[i] = 0;
     }
     
+    // Install the per-process gpio ISR service so the per-sensor
+    // gpio_isr_handler_add() calls later in begin() can attach handlers.
+    // Returns ESP_ERR_INVALID_STATE if already installed (e.g. by
+    // TR_LoRa_Comms' EspHal); benign — ignore.
+    (void)gpio_install_isr_service(0);
+
     // Initialize and turn off SPI for all sensors
-    pinMode(ISM6HG256_CS, OUTPUT);
-    digitalWrite(ISM6HG256_CS, HIGH);
-    pinMode(BMP585_CS, OUTPUT);
-    digitalWrite(BMP585_CS, HIGH);
-    pinMode(MMC5983MA_CS, OUTPUT);
-    digitalWrite(MMC5983MA_CS, HIGH);
+    gpio_set_direction((gpio_num_t)(ISM6HG256_CS), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(ISM6HG256_CS), 1);
+    gpio_set_direction((gpio_num_t)(BMP585_CS), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(BMP585_CS), 1);
+    gpio_set_direction((gpio_num_t)(MMC5983MA_CS), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(MMC5983MA_CS), 1);
     delay_ms(10);
     
     // Update periods calculated from frequencies
@@ -200,8 +205,8 @@ void SensorCollector::begin(uint8_t imu_execution_core)
             ESP_LOGI(SC_TAG, "BMP585 soft-reset recovery %s", reset_ok ? "OK" : "pending");
 
             // Re-drive CS high between retries to avoid bus ambiguity.
-            pinMode(BMP585_CS, OUTPUT);
-            digitalWrite(BMP585_CS, HIGH);
+            gpio_set_direction((gpio_num_t)(BMP585_CS), GPIO_MODE_OUTPUT);
+            gpio_set_level((gpio_num_t)(BMP585_CS), 1);
             delay_ms(10);
 
             if ((bmp_retry_count % 5U) == 0U)
@@ -234,8 +239,10 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         ESP_LOGI(SC_TAG, "BMP585 continuous mode active; throughput set by OSR/filter (ODR ignored in this mode).");
 
         bmp585_instance = this;
-        pinMode(BMP585_INT, INPUT);
-        attachInterrupt(BMP585_INT, onBMP585IntTrampoline, RISING);
+        gpio_set_direction((gpio_num_t)(BMP585_INT), GPIO_MODE_INPUT);
+        gpio_set_intr_type((gpio_num_t)(BMP585_INT), GPIO_INTR_POSEDGE);
+        gpio_isr_handler_add((gpio_num_t)(BMP585_INT), &onBMP585IntTrampoline, nullptr);
+        gpio_intr_enable((gpio_num_t)(BMP585_INT));
     }
 
     // ### Magnetometer auto-detection ###
@@ -321,8 +328,8 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     if (use_mmc5983ma && !iis2mdc_active)
     {
         // Pin 13 was potentially driven by the I2C probe above; restore CS high.
-        pinMode(MMC5983MA_CS, OUTPUT);
-        digitalWrite(MMC5983MA_CS, HIGH);
+        gpio_set_direction((gpio_num_t)(MMC5983MA_CS), GPIO_MODE_OUTPUT);
+        gpio_set_level((gpio_num_t)(MMC5983MA_CS), 1);
         delay_ms(2);
 
         while (!mmc5983ma.begin())
@@ -381,8 +388,10 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         }
 
         mmc5983ma_instance = this;
-        pinMode(MMC5983MA_INT, INPUT);
-        attachInterrupt(MMC5983MA_INT, onMMC5983MAIntTrampoline, RISING);
+        gpio_set_direction((gpio_num_t)(MMC5983MA_INT), GPIO_MODE_INPUT);
+        gpio_set_intr_type((gpio_num_t)(MMC5983MA_INT), GPIO_INTR_POSEDGE);
+        gpio_isr_handler_add((gpio_num_t)(MMC5983MA_INT), &onMMC5983MAIntTrampoline, nullptr);
+        gpio_intr_enable((gpio_num_t)(MMC5983MA_INT));
     }
 
     ESP_LOGI(SC_TAG, "Initializing ISM6HG256...");
@@ -429,7 +438,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
 
         // Route DRDY to MCU via INT1 and wake polling task from ISR.
         ism6hg256_instance = this;
-        pinMode(ISM6HG256_INT, INPUT);
+        gpio_set_direction((gpio_num_t)(ISM6HG256_INT), GPIO_MODE_INPUT);
 
         // Flush any pending DRDY by reading the data registers.
         // Without this, DRDY may already be HIGH before attachInterrupt
@@ -440,10 +449,12 @@ void SensorCollector::begin(uint8_t imu_execution_core)
             ism6hg256.Get_X_AxesRaw(&dummy_axes);
             ism6hg256.Get_HG_X_AxesRaw(&dummy_axes);
             ism6hg256.Get_G_AxesRaw(&dummy_axes);
-            ESP_LOGI(SC_TAG, "ISM6 DRDY flushed (pin=%d)", digitalRead(ISM6HG256_INT));
+            ESP_LOGI(SC_TAG, "ISM6 DRDY flushed (pin=%d)", gpio_get_level((gpio_num_t)(ISM6HG256_INT)));
         }
 
-        attachInterrupt(ISM6HG256_INT, onISM6HG256Int1Trampoline, RISING);
+        gpio_set_intr_type((gpio_num_t)(ISM6HG256_INT), GPIO_INTR_POSEDGE);
+        gpio_isr_handler_add((gpio_num_t)(ISM6HG256_INT), &onISM6HG256Int1Trampoline, nullptr);
+        gpio_intr_enable((gpio_num_t)(ISM6HG256_INT));
     }
 
     ESP_LOGI(SC_TAG, "Initializing GNSS (RX=%d TX=%d)...", GNSS_RX, GNSS_TX);
@@ -519,7 +530,7 @@ void SensorCollector::pollIMUdata(void* parameter)
         // treat it as if the ISR fired.  This handles the case where the
         // initial rising edge was missed before attachInterrupt was called.
         if (self->use_ism6hg256 && !self->ism6_isr_fired &&
-            digitalRead(self->ISM6HG256_INT))
+            gpio_get_level((gpio_num_t)(self->ISM6HG256_INT)))
         {
             self->ism6_isr_fired = true;
         }
@@ -587,10 +598,10 @@ void SensorCollector::pollIMUdata(void* parameter)
         if (self->use_bmp585)
         {
             uint32_t bmp_pending = 0;
-            noInterrupts();
+            portDISABLE_INTERRUPTS();
             bmp_pending = self->bmp585_irq_pending_count;
             if (bmp_pending > 0) self->bmp585_irq_pending_count = 0;
-            interrupts();
+            portENABLE_INTERRUPTS();
 
             if (bmp_pending > 0)
             {
@@ -628,10 +639,10 @@ void SensorCollector::pollIMUdata(void* parameter)
         if (self->use_mmc5983ma && !self->iis2mdc_active)
         {
             uint32_t mmc_pending = 0;
-            noInterrupts();
+            portDISABLE_INTERRUPTS();
             mmc_pending = self->mmc5983ma_irq_pending_count;
             if (mmc_pending > 0) self->mmc5983ma_irq_pending_count = 0;
-            interrupts();
+            portENABLE_INTERRUPTS();
 
             self->mmc5983ma_loop_checks++;
 
@@ -1070,7 +1081,7 @@ void SensorCollector::calibrateGyro(float rotation_z_deg)
     }
 }
 
-void IRAM_ATTR SensorCollector::onISM6HG256Int1Trampoline()
+void IRAM_ATTR SensorCollector::onISM6HG256Int1Trampoline(void* /*arg*/)
 {
     if (ism6hg256_instance)
     {
@@ -1094,7 +1105,7 @@ void IRAM_ATTR SensorCollector::onISM6HG256Int1()
     }
 }
 
-void IRAM_ATTR SensorCollector::onBMP585IntTrampoline()
+void IRAM_ATTR SensorCollector::onBMP585IntTrampoline(void* /*arg*/)
 {
     if (bmp585_instance)
     {
@@ -1118,7 +1129,7 @@ void IRAM_ATTR SensorCollector::onBMP585Int()
     }
 }
 
-void IRAM_ATTR SensorCollector::onMMC5983MAIntTrampoline()
+void IRAM_ATTR SensorCollector::onMMC5983MAIntTrampoline(void* /*arg*/)
 {
     if (mmc5983ma_instance)
     {

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -1,8 +1,11 @@
 #ifndef SENSORCOLLECTOR_H
 #define SENSORCOLLECTOR_H
 
-#include <compat.h>
+#include <cstdint>
 #include <driver/i2c_master.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 #include <TR_ISM6HG256.h>
 #include <TR_BMP585.h>
 #include <TR_MMC5983MA.h>
@@ -89,7 +92,6 @@ public:
                     bool use_iis2mdc,
                     bool use_gnss,
                     bool use_ism6hg256,
-                    SPIClass &spi,
                     uint32_t spi_speed);
 
     void begin(uint8_t imu_execution_core);
@@ -136,7 +138,6 @@ private:
 
     uint32_t start_time;
 
-    SPIClass &spi;
     uint32_t spi_speed;
 
     uint8_t ISM6HG256_CS;
@@ -249,11 +250,14 @@ private:
     void startPollingTask(uint8_t imu_execution_core);
     static void pollIMUdata(void *parameter);
     static void pollGNSSdata(void *parameter);
-    static void onISM6HG256Int1Trampoline();
+    // IDF gpio_isr_handler signature is void(*)(void*).  The arg is
+    // unused — each trampoline dispatches via its sensor-specific
+    // static *_instance pointer set in begin().
+    static void onISM6HG256Int1Trampoline(void* arg);
     void onISM6HG256Int1();
-    static void onBMP585IntTrampoline();
+    static void onBMP585IntTrampoline(void* arg);
     void onBMP585Int();
-    static void onMMC5983MAIntTrampoline();
+    static void onMMC5983MAIntTrampoline(void* arg);
     void onMMC5983MAInt();
 };
 

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -11,6 +11,10 @@
 
 #include "TR_Sensor_Collector_Sim.h"
 #include <cmath>
+// SensorCollector.h no longer transitively pulls in compat.h, but this
+// file still uses the Arduino-shim millis()/micros() heavily.  Pulled
+// in explicitly here until item #5 of issue #21 slims the sim too.
+#include <compat.h>
 
 // ============================================================================
 // Construction / Delegation

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -12,7 +12,6 @@ idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
     REQUIRES
-        TR_Compat
         TR_NVS
         TR_RocketComputerTypes
         TR_Sensor_Collector

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1,4 +1,3 @@
-#include <compat.h>
 #include <TR_NVS.h>
 
 // Configuration Parameters
@@ -87,7 +86,6 @@ SensorCollector sensor_collector_hw(config::ISM6HG256_CS,
                                     config::USE_IIS2MDC,
                                     config::USE_GNSS,
                                     config::USE_ISM6HG256,
-                                    SPI,
                                     config::SPI_SPEED);
 
 // Sim wrapper: passthrough when sim inactive, replaces data when sim active
@@ -1109,7 +1107,7 @@ static void i2sSenderTask(void *)
 
 static inline void triggerBlueLedFlash(uint32_t now_ms)
 {
-    digitalWrite(config::BLUE_LED_PIN, HIGH);
+    gpio_set_level((gpio_num_t)(config::BLUE_LED_PIN), 1);
     blue_led_flash_active = true;
     blue_led_flash_end_ms = now_ms + (uint32_t)config::BLUE_LED_FLASH_MS;
 }
@@ -1122,7 +1120,7 @@ static inline void serviceBlueLedFlash(uint32_t now_ms)
     }
     if ((int32_t)(now_ms - blue_led_flash_end_ms) >= 0)
     {
-        digitalWrite(config::BLUE_LED_PIN, LOW);
+        gpio_set_level((gpio_num_t)(config::BLUE_LED_PIN), 0);
         blue_led_flash_active = false;
     }
 }
@@ -1240,7 +1238,7 @@ static inline void piezoStop()
     }
     if (piezo_pwm_ready)
     {
-        digitalWrite(config::PIEZO_PIN, LOW);
+        gpio_set_level((gpio_num_t)(config::PIEZO_PIN), 0);
     }
 }
 
@@ -1259,7 +1257,7 @@ static inline void piezoStart(uint32_t freq_hz, uint32_t duration_ms, uint32_t n
     piezo_wave_end_us = (int64_t)now_us + ((int64_t)duration_ms * 1000LL);
     piezo_pin_high = false;
     piezo_wave_active = true;
-    digitalWrite(config::PIEZO_PIN, LOW);
+    gpio_set_level((gpio_num_t)(config::PIEZO_PIN), 0);
     triggerBlueLedFlash((uint32_t)(now_us / 1000ULL));
 
     (void)esp_timer_stop(piezo_toggle_timer);
@@ -1274,7 +1272,7 @@ static inline void startGoProPulse(uint32_t now_ms)
 {
     if ((config::CAM_SHUTTER_PIN < 0) || !config::USE_GOPRO)
         return;
-    digitalWrite(config::CAM_SHUTTER_PIN, LOW);
+    gpio_set_level((gpio_num_t)(config::CAM_SHUTTER_PIN), 0);
     gopro_pulse_active = true;
     gopro_pulse_end_ms = now_ms + (uint32_t)config::GOPRO_PULSE_MS;
 }
@@ -1285,7 +1283,7 @@ static inline void serviceGoProPulse(uint32_t now_ms)
         return;
     if ((int32_t)(now_ms - gopro_pulse_end_ms) >= 0)
     {
-        digitalWrite(config::CAM_SHUTTER_PIN, HIGH);
+        gpio_set_level((gpio_num_t)(config::CAM_SHUTTER_PIN), 1);
         gopro_pulse_active = false;
     }
 }
@@ -1305,8 +1303,8 @@ static void initRunCam()
     // Camera is powered on only when the user presses "Start Recording".
     if (config::RUNCAM_PWR_PIN >= 0)
     {
-        pinMode(config::RUNCAM_PWR_PIN, OUTPUT);
-        digitalWrite(config::RUNCAM_PWR_PIN, LOW);  // OFF at boot
+        gpio_set_direction((gpio_num_t)(config::RUNCAM_PWR_PIN), GPIO_MODE_OUTPUT);
+        gpio_set_level((gpio_num_t)(config::RUNCAM_PWR_PIN), 0);  // OFF at boot
         ESP_LOGI(TAG, "RunCam pin %d configured (camera OFF)", (int)config::RUNCAM_PWR_PIN);
     }
 
@@ -1452,7 +1450,7 @@ static void cameraStart(uint32_t now_ms)
         // auto-starts recording on power-up; the deferred GET_DEVICE_INFO
         // probe just confirms the UART link once it has booted.
         if (config::RUNCAM_PWR_PIN >= 0)
-            digitalWrite(config::RUNCAM_PWR_PIN, HIGH);
+            gpio_set_level((gpio_num_t)(config::RUNCAM_PWR_PIN), 1);
         gopro_recording = true;
         camera_start_phase = CameraStartPhase::WaitingForBoot;
         camera_start_due_ms = now_ms + 5000U;  // RunCam boot time
@@ -1517,7 +1515,7 @@ static inline void serviceCameraStop(uint32_t now_ms)
     else  // RunCamToggleSent
     {
         if (config::RUNCAM_PWR_PIN >= 0)
-            digitalWrite(config::RUNCAM_PWR_PIN, LOW);
+            gpio_set_level((gpio_num_t)(config::RUNCAM_PWR_PIN), 0);
         ESP_LOGI(TAG, "Camera STOP (RunCam) — powered off");
         gopro_recording = false;
         camera_stop_phase = CameraStopPhase::Idle;
@@ -1634,20 +1632,36 @@ static void setup_fc()
     initPyroPins();
 
     ESP_LOGI(TAG, "Starting ....");
-    pinMode(config::RED_LED_PIN, OUTPUT);
-    digitalWrite(config::RED_LED_PIN, HIGH);
-    pinMode(config::BLUE_LED_PIN, OUTPUT);
-    digitalWrite(config::BLUE_LED_PIN, LOW);
+    gpio_set_direction((gpio_num_t)(config::RED_LED_PIN), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(config::RED_LED_PIN), 1);
+    gpio_set_direction((gpio_num_t)(config::BLUE_LED_PIN), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(config::BLUE_LED_PIN), 0);
 
     // Disable all SPI chip-selects before bus init to avoid MISO contention.
-    pinMode(config::MMC5983MA_CS, OUTPUT); digitalWrite(config::MMC5983MA_CS, HIGH);
-    pinMode(config::BMP585_CS, OUTPUT);    digitalWrite(config::BMP585_CS, HIGH);
-    pinMode(config::ISM6HG256_CS, OUTPUT); digitalWrite(config::ISM6HG256_CS, HIGH);
+    gpio_set_direction((gpio_num_t)(config::MMC5983MA_CS), GPIO_MODE_OUTPUT); gpio_set_level((gpio_num_t)(config::MMC5983MA_CS), 1);
+    gpio_set_direction((gpio_num_t)(config::BMP585_CS), GPIO_MODE_OUTPUT);    gpio_set_level((gpio_num_t)(config::BMP585_CS), 1);
+    gpio_set_direction((gpio_num_t)(config::ISM6HG256_CS), GPIO_MODE_OUTPUT); gpio_set_level((gpio_num_t)(config::ISM6HG256_CS), 1);
     delay_ms(10);
 
-    // SPI bus — compat shim wraps spi_bus_initialize(SPI2_HOST, ...)
+    // SPI bus init — native IDF.  Matches what compat's SPIClass.begin()
+    // was doing under the hood (SPI2_HOST, DMA auto, 4 KB transfer cap)
+    // but lifted out of the shim so this file no longer depends on
+    // compat.h's SPIClass.
     ESP_LOGI(TAG, "SPI init...");
-    SPI.begin(config::SPI_SCK, config::SPI_SDO, config::SPI_SDI);
+    {
+        spi_bus_config_t buscfg = {};
+        buscfg.mosi_io_num     = config::SPI_SDO;
+        buscfg.miso_io_num     = config::SPI_SDI;
+        buscfg.sclk_io_num     = config::SPI_SCK;
+        buscfg.quadwp_io_num   = -1;
+        buscfg.quadhd_io_num   = -1;
+        buscfg.max_transfer_sz = 4096;
+        esp_err_t err = spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "spi_bus_initialize failed: %s", esp_err_to_name(err));
+        }
+    }
     delay_ms(10);
 
     // Re-init pyro pins AFTER spi_bus_initialize() — on ESP32-P4, SPI2
@@ -1908,8 +1922,8 @@ static void setup_fc()
     prefs.end();
 
     // Always initialise piezo hardware so it's ready if enabled at runtime
-    pinMode(config::PIEZO_PIN, OUTPUT);
-    digitalWrite(config::PIEZO_PIN, LOW);
+    gpio_set_direction((gpio_num_t)(config::PIEZO_PIN), GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)(config::PIEZO_PIN), 0);
     piezo_pwm_ready = initPiezoTimer();
     if (!piezo_pwm_ready)
     {
@@ -2015,13 +2029,13 @@ static void setup_fc()
     {
         if (config::CAM_PWR_PIN >= 0)
         {
-            pinMode(config::CAM_PWR_PIN, OUTPUT);
-            digitalWrite(config::CAM_PWR_PIN, HIGH);
+            gpio_set_direction((gpio_num_t)(config::CAM_PWR_PIN), GPIO_MODE_OUTPUT);
+            gpio_set_level((gpio_num_t)(config::CAM_PWR_PIN), 1);
         }
         if (config::CAM_SHUTTER_PIN >= 0)
         {
-            pinMode(config::CAM_SHUTTER_PIN, OUTPUT);
-            digitalWrite(config::CAM_SHUTTER_PIN, HIGH);
+            gpio_set_direction((gpio_num_t)(config::CAM_SHUTTER_PIN), GPIO_MODE_OUTPUT);
+            gpio_set_level((gpio_num_t)(config::CAM_SHUTTER_PIN), 1);
         }
     }
     else if (config::USE_RUNCAM)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -32,8 +32,22 @@
 #include <esp_log.h>
 #include <esp_task_wdt.h>
 #include <esp_system.h>
+#include <esp_rom_sys.h>           // esp_rom_delay_us
 #include <CRC32.h>
 static const char* TAG = "FC";
+
+// IDF-native timing helpers — replace the Arduino-shim time_ms()/time_us()
+// that used to come in via compat.h.  Returned as uint32_t to keep
+// arithmetic width unchanged at the (many) call sites that compare
+// against a stashed timestamp.  Named with the `time_*()` prefix so
+// they don't collide with existing parameters and locals called `now_ms`
+// / `now_us` throughout this file.
+static inline uint32_t time_ms() { return (uint32_t)(esp_timer_get_time() / 1000); }
+static inline uint32_t time_us() { return (uint32_t)esp_timer_get_time(); }
+// `delay_ms(N)` (Arduino) → `delay_ms(N)` here, wraps vTaskDelay.  Keeps
+// existing single-line call-site form; pdMS_TO_TICKS handles the
+// configTICK_RATE_HZ conversion.
+static inline void     delay_ms(uint32_t ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }
 
 // Firmware revision recorded in the flight settings snapshot (#165).
 // Injected by CMake (git rev-parse / git diff); fall back when building
@@ -424,7 +438,7 @@ static void clearFlightSnapshot()
     // restores when state==INFLIGHT, so a LANDED snapshot effectively
     // clears the recovery slot via the same I2S path as normal saves.
     FlightSnapshotData snap = {};
-    buildFlightSnapshot(snap, millis(), /* override_state = */ (uint8_t)LANDED);
+    buildFlightSnapshot(snap, time_ms(), /* override_state = */ (uint8_t)LANDED);
     (void)enqueueI2STx(SNAPSHOT_MSG,
                        reinterpret_cast<const uint8_t*>(&snap),
                        sizeof(snap));
@@ -520,7 +534,7 @@ static bool readConfigFrame(uint8_t expected_type,
             {
                 ESP_LOGE(TAG, "[CFG READ] attempt %d: i2c err=0x%X (%s)",
                               attempt, (unsigned)err, esp_err_to_name(err));
-                delay(5 * (attempt + 1));
+                delay_ms(5 * (attempt + 1));
                 continue;
             }
         }
@@ -587,7 +601,7 @@ static bool readConfigFrame(uint8_t expected_type,
 
         ESP_LOGW(TAG, "[CFG READ] attempt %d: config frame (type=0x%02X) not found in %u bytes",
                       attempt, (unsigned)expected_type, (unsigned)actual_read);
-        delay(5 * (attempt + 1));
+        delay_ms(5 * (attempt + 1));
     }
 
     payload_len_out = 0;
@@ -996,7 +1010,7 @@ static inline bool enqueueI2STx(uint8_t type, const uint8_t *payload, size_t len
 static void buildFlightSettings(FlightSettingsData& s)
 {
     memset(&s, 0, sizeof(s));
-    s.time_us = micros();
+    s.time_us = time_us();
     s.version = FlightSettingsData::VERSION;
 
     uint8_t flags = 0;
@@ -1515,7 +1529,7 @@ static inline void serviceCameraStop(uint32_t now_ms)
 // confirm the UART link and log the camera's feature set.  The probe's
 // brief blocking read (~2 ms typical, ~450 ms worst case on a dead RX)
 // is bounded and runs only on a manual start — unlike the old inline
-// delay(5000), it can't stall the flight task into a watchdog reset.
+// delay_ms(5000), it can't stall the flight task into a watchdog reset.
 static inline void serviceCameraStart(uint32_t now_ms)
 {
     if (camera_start_phase == CameraStartPhase::Idle) return;
@@ -1586,7 +1600,7 @@ static inline void serviceHeartbeatBeep(uint32_t now_ms)
     }
     piezoStart(config::HEARTBEAT_BEEP_FREQ_HZ,
                config::HEARTBEAT_BEEP_DURATION_MS,
-               micros());
+               time_us());
 }
 
 static void setup_fc()
@@ -1629,12 +1643,12 @@ static void setup_fc()
     pinMode(config::MMC5983MA_CS, OUTPUT); digitalWrite(config::MMC5983MA_CS, HIGH);
     pinMode(config::BMP585_CS, OUTPUT);    digitalWrite(config::BMP585_CS, HIGH);
     pinMode(config::ISM6HG256_CS, OUTPUT); digitalWrite(config::ISM6HG256_CS, HIGH);
-    delay(10);
+    delay_ms(10);
 
     // SPI bus — compat shim wraps spi_bus_initialize(SPI2_HOST, ...)
     ESP_LOGI(TAG, "SPI init...");
     SPI.begin(config::SPI_SCK, config::SPI_SDO, config::SPI_SDI);
-    delay(10);
+    delay_ms(10);
 
     // Re-init pyro pins AFTER spi_bus_initialize() — on ESP32-P4, SPI2
     // default pins (14-16) overlap with pyro pins, and the bus init may
@@ -1651,7 +1665,7 @@ static void setup_fc()
                                   false) != ESP_OK)
     {
         ESP_LOGE(TAG, "Failed to initialize ESP I2C interface");
-        while (1) { delay(1000); }
+        while (1) { delay_ms(1000); }
     }
     ESP_LOGI(TAG, "I2C master addr=0x%02X SDA=%d SCL=%d clk=%lu",
                   (unsigned)config::ESP_I2C_ADR,
@@ -1667,19 +1681,19 @@ static void setup_fc()
                                   config::I2S_SAMPLE_RATE) != ESP_OK)
     {
         ESP_LOGE(TAG, "Failed to initialize I2S TX stream");
-        while (1) { delay(1000); }
+        while (1) { delay_ms(1000); }
     }
     i2s_tx_queue = xQueueCreate(config::I2S_TX_QUEUE_LEN, sizeof(I2STxMessage));
     if (i2s_tx_queue == nullptr)
     {
         ESP_LOGE(TAG, "Failed to create I2S TX queue");
-        while (1) { delay(1000); }
+        while (1) { delay_ms(1000); }
     }
     i2c_bus_mutex = xSemaphoreCreateMutex();
     if (i2c_bus_mutex == nullptr)
     {
         ESP_LOGE(TAG, "Failed to create I2C bus mutex");
-        while (1) { delay(1000); }
+        while (1) { delay_ms(1000); }
     }
     // I2S sender runs on the SAME core as sensor collection (Core 0).
     // Priority 2: below pollIMUdata (4) so sensor SPI reads are never
@@ -1953,7 +1967,7 @@ static void setup_fc()
     (void)i2c_interface.sendMessage(OUT_STATUS_QUERY,
                                     reinterpret_cast<const uint8_t*>(&out_status_query_data),
                                     sizeof(out_status_query_data));
-    delay(10); // let OutComputer process query and queue 96-byte response
+    delay_ms(10); // let OutComputer process query and queue 96-byte response
     {
         uint8_t init_buf[COMBINED_READ_SIZE] = {};
         esp_err_t read_err = i2c_interface.masterRead(
@@ -2080,7 +2094,7 @@ static void setup_fc()
             // response.  OC reads from MRAM (~150 us) and queues the
             // ~224-byte response into its I2C TX ringbuffer (256 B).
             if (i2c_interface.sendMessage(GET_FLIGHT_SNAPSHOT, nullptr, 0) == ESP_OK) {
-                delay(20);  // let OC service the request and queue the response
+                delay_ms(20);  // let OC service the request and queue the response
 
                 constexpr size_t kRespFrameLen = 4 + 1 + 1 + sizeof(FlightSnapshotData) + 2;
                 uint8_t buf[kRespFrameLen + 16] = {};  // + slack for SOF byte loss
@@ -2129,12 +2143,12 @@ static void setup_fc()
             ESP_LOGW(TAG, "[RECOVERY] Flight elapsed: %lu ms", (unsigned long)snap.flight_elapsed_ms);
             ESP_LOGW(TAG, "========================================");
 
-            const uint32_t now_ms = millis();
+            const uint32_t now_ms = time_ms();
 
             // Restore flight state
             rocket_state = INFLIGHT;
 
-            // Rebase timestamps to new millis() epoch
+            // Rebase timestamps to new time_ms() epoch
             launch_time_millis = now_ms - snap.flight_elapsed_ms;
             if (snap.pyro_apogee_detected) {
                 pyro_apogee_detected = true;
@@ -2226,7 +2240,7 @@ static void setup_fc()
 
     ESP_LOGI(TAG, "Setup complete");
     ESP_LOGI(TAG, "Setup complete…");
-    triggerBlueLedFlash(millis());
+    triggerBlueLedFlash(time_ms());
 
 }
 
@@ -2361,14 +2375,14 @@ static void loop_fc()
     }
 
     // --- Flight logic update ---
-    const uint32_t logic_now_us = micros();
+    const uint32_t logic_now_us = time_us();
     if ((logic_now_us - last_flight_loop_update_time) >= flight_loop_period)
     {
         lt_loop_count++;
         last_flight_loop_update_time = logic_now_us;
 
         // ### Pressure altitude calculation (for kinematic checks) ###
-        const uint32_t now_ms = millis();
+        const uint32_t now_ms = time_ms();
         float pressure_altitude_m = 0.0f;
         if (have_bmp_si)
         {
@@ -2614,7 +2628,7 @@ static void loop_fc()
             }
             else if (run_ekf_this_tick)
             {
-                const uint32_t ekf_t0 = micros();
+                const uint32_t ekf_t0 = time_us();
 
                 // AHRS accel correction: enabled on pad and after apogee (descent).
                 // Disabled during thrust and coast where accel is far from 1g.
@@ -2673,7 +2687,7 @@ static void loop_fc()
                     prev_baro_valid = true;
                 }
 
-                const uint32_t ekf_us = micros() - ekf_t0;
+                const uint32_t ekf_us = time_us() - ekf_t0;
                 lt_ekf_total_us += ekf_us;
                 lt_ekf_count++;
                 if (ekf_us > lt_ekf_max_us) lt_ekf_max_us = ekf_us;
@@ -2735,7 +2749,7 @@ static void loop_fc()
 
             if (query_pending)
             {
-                const uint32_t gor_start = micros();
+                const uint32_t gor_start = time_us();
                 uint8_t combined_buf[COMBINED_READ_SIZE] = {};
                 esp_err_t read_err = i2c_interface.masterRead(
                     combined_buf, COMBINED_READ_SIZE, 10);
@@ -2764,7 +2778,7 @@ static void loop_fc()
                     }
                 }
 
-                const uint32_t gor_us = micros() - gor_start;
+                const uint32_t gor_us = time_us() - gor_start;
                 if (gor_us > i2c_gor_max_us) { i2c_gor_max_us = gor_us; }
                 if (query_ok) { i2c_query_ok++; } else { i2c_query_fail++; }
 
@@ -2818,7 +2832,7 @@ static void loop_fc()
                 // Confirmation beep so the user knows it worked
                 if (piezo_pwm_ready)
                 {
-                    piezoStart(2600, 100, micros());
+                    piezoStart(2600, 100, time_us());
                 }
             }
             else if (out_pending_command == SOUNDS_DISABLE)
@@ -2832,7 +2846,7 @@ static void loop_fc()
             }
             else if (out_pending_command == SERVO_CONFIG_PENDING)
             {
-                delay(1);  // let slave TX FIFO settle
+                delay_ms(1);  // let slave TX FIFO settle
                 uint8_t cfg_payload[14];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(SERVO_CONFIG_MSG, sizeof(ServoConfigData),
@@ -2878,7 +2892,7 @@ static void loop_fc()
             }
             else if (out_pending_command == PID_CONFIG_PENDING)
             {
-                delay(1);
+                delay_ms(1);
                 uint8_t cfg_payload[20];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(PID_CONFIG_MSG, sizeof(PIDConfigData),
@@ -2932,7 +2946,7 @@ static void loop_fc()
             }
             else if (out_pending_command == SIM_CONFIG_PENDING)
             {
-                delay(5);  // let slave TX FIFO settle
+                delay_ms(5);  // let slave TX FIFO settle
                 uint8_t cfg_payload[16];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(SIM_CONFIG_MSG, sizeof(SimConfigData),
@@ -2955,7 +2969,7 @@ static void loop_fc()
                 // the start may have overwritten the config command before we read it.
                 // Try reading any pending config frame before starting the sim.
                 {
-                    delay(5);
+                    delay_ms(5);
                     uint8_t cfg_payload[16];
                     size_t  cfg_len = 0;
                     if (readConfigFrame(SIM_CONFIG_MSG, sizeof(SimConfigData),
@@ -3164,7 +3178,7 @@ static void loop_fc()
                 }
                 else
                 {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[sizeof(MagCalApplyData)];
                     size_t  cfg_len = 0;
                     if (readConfigFrame(MAG_CAL_APPLY_MSG, sizeof(MagCalApplyData),
@@ -3226,7 +3240,7 @@ static void loop_fc()
                 }
                 else
                 {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[sizeof(SensorCalApplyData)];
                     size_t  cfg_len = 0;
                     if (readConfigFrame(SENSOR_CAL_APPLY_MSG, sizeof(SensorCalApplyData),
@@ -3309,7 +3323,7 @@ static void loop_fc()
             }
             else if (out_pending_command == CAMERA_CONFIG_PENDING)
             {
-                delay(1);
+                delay_ms(1);
                 uint8_t cfg_payload[1];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(CAMERA_CONFIG_MSG, sizeof(CameraConfigData),
@@ -3331,7 +3345,7 @@ static void loop_fc()
             }
             else if (out_pending_command == PYRO_CONFIG_PENDING)
             {
-                delay(1);
+                delay_ms(1);
                 uint8_t cfg_payload[sizeof(PyroConfigData)];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(PYRO_CONFIG_MSG, sizeof(PyroConfigData),
@@ -3358,7 +3372,7 @@ static void loop_fc()
                 if (rocket_state == INFLIGHT) {
                     ESP_LOGW(TAG, "[PYRO CONT TEST] Rejected — INFLIGHT");
                 } else {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[4];
                     size_t  cfg_len = 0;
                     uint8_t ch = 0;
@@ -3402,7 +3416,7 @@ static void loop_fc()
                 if (rocket_state == INFLIGHT) {
                     ESP_LOGW(TAG, "[PYRO FIRE TEST] Rejected — INFLIGHT");
                 } else {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[4];
                     size_t  cfg_len = 0;
                     uint8_t ch = 0;
@@ -3439,12 +3453,12 @@ static void loop_fc()
                         portENTER_CRITICAL(&pyro_spinlock);
                         pyroSetArmLocked(true);
                         portEXIT_CRITICAL(&pyro_spinlock);
-                        delay(config::PYRO_ARM_SETTLE_MS);
+                        delay_ms(config::PYRO_ARM_SETTLE_MS);
                         portENTER_CRITICAL(&pyro_spinlock);
                         gpio_set_level(fire_pin, 1);
                         portEXIT_CRITICAL(&pyro_spinlock);
 
-                        delay(config::PYRO_FIRE_DURATION_MS);
+                        delay_ms(config::PYRO_FIRE_DURATION_MS);
 
                         portENTER_CRITICAL(&pyro_spinlock);
                         gpio_set_level(fire_pin, 0);
@@ -3464,7 +3478,7 @@ static void loop_fc()
                 if (rocket_state == INFLIGHT) {
                     ESP_LOGW(TAG, "[SERVO TEST] Rejected — INFLIGHT");
                 } else {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[8];
                     size_t  cfg_len = 0;
                     if (readConfigFrame(SERVO_TEST_MSG, sizeof(ServoTestAnglesData),
@@ -3498,7 +3512,7 @@ static void loop_fc()
             }
             else if (out_pending_command == ROLL_PROFILE_PENDING)
             {
-                delay(1);
+                delay_ms(1);
                 uint8_t cfg_payload[sizeof(RollProfileData)];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(ROLL_PROFILE_MSG, sizeof(RollProfileData),
@@ -3540,7 +3554,7 @@ static void loop_fc()
             }
             else if (out_pending_command == ROLL_CTRL_CONFIG_PENDING)
             {
-                delay(1);
+                delay_ms(1);
                 uint8_t cfg_payload[4];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(ROLL_CTRL_CONFIG_MSG, sizeof(RollControlConfigData),
@@ -3570,7 +3584,7 @@ static void loop_fc()
                 if (rocket_state == INFLIGHT) {
                     ESP_LOGW(TAG, "[SERVO REPLAY] Rejected — INFLIGHT");
                 } else {
-                    delay(1);
+                    delay_ms(1);
                     uint8_t cfg_payload[sizeof(ServoReplayData)];
                     size_t  cfg_len = 0;
                     if (readConfigFrame(SERVO_REPLAY_MSG, sizeof(ServoReplayData),
@@ -3751,7 +3765,7 @@ static void loop_fc()
                     rocket_state = READY;
                     if (!ready_chirp_played)
                     {
-                        startBootReadyChirp(now_ms, micros());
+                        startBootReadyChirp(now_ms, time_us());
                         ready_chirp_played = true;
                     }
                     ESP_LOGI(TAG, "[STATE] INITIALIZATION -> READY");
@@ -4301,8 +4315,8 @@ static void loop_fc()
         }
     }
     
-    const uint32_t now_ms_for_sound = millis();
-    serviceBootReadyChirp(now_ms_for_sound, micros());
+    const uint32_t now_ms_for_sound = time_ms();
+    serviceBootReadyChirp(now_ms_for_sound, time_us());
     serviceHeartbeatBeep(now_ms_for_sound);
     serviceBlueLedFlash(now_ms_for_sound);
     serviceGoProPulse(now_ms_for_sound);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1649,9 +1649,13 @@ static void setup_fc()
     // compat.h's SPIClass.
     ESP_LOGI(TAG, "SPI init...");
     {
+        // Pin naming follows the sensor's perspective in config.h:
+        // SDO = "Sensor Data Out" → MISO on the controller; SDI = "Sensor
+        // Data In" → MOSI on the controller.  The compat SPIClass.begin
+        // used the same mapping (its signature was sck, miso, mosi, ss).
         spi_bus_config_t buscfg = {};
-        buscfg.mosi_io_num     = config::SPI_SDO;
-        buscfg.miso_io_num     = config::SPI_SDI;
+        buscfg.miso_io_num     = config::SPI_SDO;
+        buscfg.mosi_io_num     = config::SPI_SDI;
         buscfg.sclk_io_num     = config::SPI_SCK;
         buscfg.quadwp_io_num   = -1;
         buscfg.quadhd_io_num   = -1;


### PR DESCRIPTION
## Summary

[#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) item #3 — `flight_computer/main/main.cpp` Arduino-isms cleanup. Three thematic commits:

1. **`033cbc8` — timing primitives**
   `millis()` / `micros()` / `delay()` replaced with local `time_ms()` / `time_us()` / `delay_ms()` helpers that wrap `esp_timer_get_time()` and `vTaskDelay(pdMS_TO_TICKS(...))`. Helpers named with the `time_*` prefix so they don't collide with the existing local-variable convention `now_ms` / `now_us`. 6 + 26 + 27 sites in main.cpp; 0 + 26 + 24 in `TR_Sensor_Collector.cpp`.

2. **`4dd9d7a` — GPIO + ISR + SPI bus init + compat decoupling**
   - `pinMode` → `gpio_set_direction`
   - `digitalWrite` → `gpio_set_level`
   - `digitalRead` → `gpio_get_level`
   - `noInterrupts()` / `interrupts()` → `portDISABLE_INTERRUPTS()` / `portENABLE_INTERRUPTS()`
   - `attachInterrupt(p, fn, RISING)` → `gpio_set_intr_type` + `gpio_isr_handler_add` + `gpio_intr_enable`, with a one-time `gpio_install_isr_service(0)` at the top of `SensorCollector::begin()`. The three static ISR trampolines updated to the IDF `void(void*)` signature.
   - `SPI.begin(SCK,SDO,SDI)` → `spi_bus_initialize(SPI2_HOST, ...)`.
   - `#include <compat.h>` dropped from `main.cpp` and `TR_Sensor_Collector.h`; `TR_Compat` removed from both REQUIRES lists. `TR_Sensor_Collector_Sim` still uses `millis()`/`micros()` internally so it now pulls `compat.h` explicitly (was getting it transitively) — that's slated for issue #21 item #5.
   - `SensorCollector` ctor's `SPIClass &spi` parameter + member dropped entirely (was already unused after PRs [#208](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/208) / [#209](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/209) / [#210](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/210)).

3. **`fbdb3a9` — fix MOSI/MISO swap in the new `spi_bus_initialize`**
   Bench caught a regression in commit 2: I assigned `config::SPI_SDO` to `mosi_io_num` instead of `miso_io_num`. `config.h` uses sensor-side pin naming (`SDO` = Sensor Data Out → controller's MISO). BMP585 reported chip ID `0x00` on every retry until the swap landed. Comment added at the call site so the convention is explicit.

## Test plan

- [x] `idf.py fullclean && set-target esp32p4 build` clean (only pre-existing `loop_fc()` unused-variable warnings)
- [x] Bench: chip IDs read correctly (BMP585 `0x51`, ISM6 `0x73`), all three sensor inits succeed without retries
- [x] Bench: simulated 201 m / 57 m/s flight, **113,564 frames @ 0 CRC errors**. ISR-driven sensor rates match pre-cleanup (ISM6 921 Hz, BMP 490 Hz, IIS2MDC 98 Hz, GNSS 18 Hz) — gpio_isr_handler_add path is functionally identical to attachInterrupt
- [x] Bench mag |B| = 1.63 mT (matches documented IIS2MDC hard-iron residual on new PCB)
- [ ] CI green

After this lands, only issue #21 item #5 (slim `TR_Compat` and migrate `Sim` / `Data_Converter`) remains.
