### PR TITLE
compat: drop dead interrupt + type + SPI-mode shims

### DIFF
--- a/tinkerrocket-idf/components/TR_Compat/include/compat.h
+++ b/tinkerrocket-idf/components/TR_Compat/include/compat.h
@@ -92,46 +92,18 @@ static inline int digitalRead(uint8_t pin)
 }
 
 /* ── Interrupts ─────────────────────────────────────────── */
-
-#ifndef RISING
-#define RISING  GPIO_INTR_POSEDGE
-#endif
-#ifndef FALLING
-#define FALLING GPIO_INTR_NEGEDGE
-#endif
-#ifndef CHANGE
-#define CHANGE  GPIO_INTR_ANYEDGE
-#endif
-
-/* Arduino attachInterrupt takes void(*)(void), but ESP-IDF gpio_isr_handler
-   expects void(*)(void*).  We store the user's void(void) function pointer
-   in the arg field and use a thin wrapper to call it. */
-static void IRAM_ATTR _compat_isr_wrapper(void *arg)
-{
-    void (*fn)(void) = (void(*)(void))arg;
-    fn();
-}
-
-static inline void attachInterrupt(uint8_t pin, void (*isr)(void), int mode)
-{
-    gpio_set_intr_type((gpio_num_t)pin, (gpio_int_type_t)mode);
-    gpio_install_isr_service(0);
-    gpio_isr_handler_add((gpio_num_t)pin, _compat_isr_wrapper, (void*)isr);
-    gpio_intr_enable((gpio_num_t)pin);
-}
-
-static inline void detachInterrupt(uint8_t pin)
-{
-    gpio_isr_handler_remove((gpio_num_t)pin);
-    gpio_intr_disable((gpio_num_t)pin);
-}
-
-static inline void noInterrupts(void) { portDISABLE_INTERRUPTS(); }
-static inline void interrupts(void)   { portENABLE_INTERRUPTS(); }
+/* attachInterrupt / detachInterrupt / noInterrupts / interrupts and the
+   RISING / FALLING / CHANGE macros all had zero external users after the
+   #21 cleanup landed (gpio_isr_handler_add is the IDF idiom; see
+   TR_Sensor_Collector.cpp).  Removed.  If a future consumer needs the
+   Arduino spellings, prefer the native IDF calls — they're not much
+   longer. */
 
 /* ── Arduino type aliases ───────────────────────────────── */
+/* `boolean` had no users; only `byte` remains.  Kept because TR_LogToFlash,
+   CRC, TR_BLE_To_APP, and a handful of others still use it as a uint8_t
+   alias in their public APIs. */
 
-typedef bool     boolean;
 typedef uint8_t  byte;
 
 /* ── Misc Arduino macros ────────────────────────────────── */
@@ -168,18 +140,13 @@ typedef uint8_t  byte;
 
 #include <driver/spi_master.h>
 
-/* Arduino-style SPI mode / bit-order constants */
+/* Arduino-style SPI mode / bit-order constants.  Only SPI_MODE0 and
+   MSBFIRST are still referenced externally (TR_LogToFlash, RadioLib's
+   BuildOpt.h default settings).  SPI_MODE1/2/3 had zero external uses
+   after the #21 cleanup, removed.  LSBFIRST kept because the SPIClass
+   shim below references it internally to set SPI_DEVICE_BIT_LSBFIRST. */
 #ifndef SPI_MODE0
 #define SPI_MODE0 0
-#endif
-#ifndef SPI_MODE1
-#define SPI_MODE1 1
-#endif
-#ifndef SPI_MODE2
-#define SPI_MODE2 2
-#endif
-#ifndef SPI_MODE3
-#define SPI_MODE3 3
 #endif
 #ifndef MSBFIRST
 #define MSBFIRST 1


### PR DESCRIPTION
## Summary

Final slice of [#21](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/21) (item #5). After the earlier #21 PRs ([#208](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/208) / [#209](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/209) / [#210](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/210) / [#211](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/211) / [#212](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/212) / [#214](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/214)) converted the sensor wrappers, SensorCollector, and main.cpp to native IDF, several sections of `compat.h` no longer have a single external user. Removing them:

- **`attachInterrupt` / `detachInterrupt`** free functions + the `_compat_isr_wrapper` helper. `gpio_isr_handler_add` is the idiom now; see `TR_Sensor_Collector::begin` for the canonical pattern.
- **`noInterrupts()` / `interrupts()`** free functions — replaced by `portDISABLE_INTERRUPTS()` / `portENABLE_INTERRUPTS()` at the two SensorCollector sites that used them.
- **`RISING` / `FALLING` / `CHANGE`** macros — RadioLib's HAL backends carry their own definitions; the compat copies had no other users.
- **`boolean`** typedef — zero external uses; only `byte` is still needed.
- **`SPI_MODE1` / `SPI_MODE2` / `SPI_MODE3`** — only `SPI_MODE0` is used (TR_LogToFlash, RadioLib defaults). `LSBFIRST` is kept because compat's own `SPIClass` shim references it internally.

Diff: 1 file, +14 / −47.

What remains in compat.h after this:
- Timing (millis/micros/delay/delayMicroseconds/yield) — still used by OC, BS, Sim, LoRa, Data_Converter, etc.
- GPIO (pinMode/digitalWrite/digitalRead + OUTPUT/INPUT/HIGH/LOW) — still used in OC/BS/test projects
- `byte` typedef, `PI`, `constrain`, `map`, `radians`, `degrees` — still widely used
- `SPIClass` / `SPISettings` / `SPI_MODE0` / `MSBFIRST` / `LSBFIRST` — still used by TR_LogToFlash and RadioLib's vendored ArduinoHal

Further slimming (e.g. removing SPIClass after migrating TR_LogToFlash, or migrating Sim/Data_Converter/I2C/PID/etc. off compat) is bigger than what #21 specified and would naturally fall into its own follow-up issue.

## Test plan

- [x] FC `idf.py set-target esp32p4 build` clean
- [x] OC `idf.py set-target esp32s3 build` clean
- [x] BS `idf.py set-target esp32s3 build` clean
- [ ] CI green
