### PR TITLE
OTA firmware update via iOS app — Phase 1 (design) + Phase 2 (Base Station) (#8)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -185,6 +185,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     func onDisconnect() {
         isConnected = false
         stopRSSITimer()
+        drainOtaWriteQueue(error: OTAError.notConnected)
         telemetryCharacteristic = nil
         commandCharacteristic = nil
         fileOpsCharacteristic = nil
@@ -338,11 +339,17 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         return max(20, maxWrite - 7)
     }
 
-    private var otaWriteContinuation: CheckedContinuation<Void, Error>?
+    // FIFO of per-write continuations. iOS's CoreBluetooth queues
+    // writeValue(.withResponse) internally and fires didWriteValueFor in the
+    // same order, so we can have multiple chunks in flight at once — the
+    // OTASession sliding-window pumps the pipeline. Each entry resumes when
+    // its corresponding write callback fires.
+    private var otaWriteQueue: [CheckedContinuation<Void, Error>] = []
 
     /// Send a single OTA image chunk. Frame: [offset:4 LE][length:2 LE][flags:1][data:N].
-    /// Awaits the BLE stack's per-write ack via didWriteValueFor — only one
-    /// write may be in flight at a time, so the OTASession pumps serially.
+    /// Awaits the BLE stack's per-write ack via didWriteValueFor. Safe to
+    /// call concurrently — multiple in-flight writes pipeline via the
+    /// otaWriteQueue FIFO.
     func sendOtaChunk(offset: UInt32, data: Data, isLast: Bool) async throws {
         guard let characteristic = fileTransferCharacteristic,
               let peripheral = peripheral else {
@@ -357,12 +364,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         frame.append(data)
 
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            if otaWriteContinuation != nil {
-                cont.resume(throwing: OTAError.writeInFlight)
-                return
-            }
-            otaWriteContinuation = cont
+            otaWriteQueue.append(cont)
             peripheral.writeValue(frame, for: characteristic, type: .withResponse)
+        }
+    }
+
+    /// Fail all in-flight OTA chunk continuations. Called from onDisconnect
+    /// so pending sendOtaChunk awaits don't hang forever when the device
+    /// drops mid-transfer.
+    private func drainOtaWriteQueue(error: Error) {
+        let pending = otaWriteQueue
+        otaWriteQueue.removeAll()
+        for cont in pending {
+            cont.resume(throwing: error)
         }
     }
 
@@ -1142,10 +1156,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                    didWriteValueFor characteristic: CBCharacteristic,
                    error: Error?) {
         // OTA chunk pump waits on per-write acks; the command characteristic
-        // also uses writeValue(.withResponse) but fires-and-forgets.
+        // also uses writeValue(.withResponse) but fires-and-forgets. iOS
+        // dispatches writes in order, so popping the FIFO head matches each
+        // ack to the oldest in-flight chunk.
         if characteristic.uuid == fileTransferCharUUID,
-           let cont = otaWriteContinuation {
-            otaWriteContinuation = nil
+           !otaWriteQueue.isEmpty {
+            let cont = otaWriteQueue.removeFirst()
             if let error = error {
                 cont.resume(throwing: OTAError.writeFailed(error.localizedDescription))
             } else {

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -356,6 +356,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// lets iOS batch multiple writes per connection event (~10-20× faster).
     /// No per-chunk ATT ack — relies on link-layer CRC + retransmit for
     /// reliability and on OTA_FINISH's SHA-256 check to catch any drops.
+    ///
+    /// Throws .writeFailed if canSendWriteWithoutResponse stays false for
+    /// 5 s straight — that means the characteristic isn't advertising the
+    /// WRITE_NO_RSP property (firmware-side bug) and we'd otherwise hang.
     func sendOtaChunk(offset: UInt32, data: Data, isLast: Bool) async throws {
         guard let characteristic = fileTransferCharacteristic,
               let peripheral = peripheral else {
@@ -363,16 +367,24 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
 
         // Backpressure: if iOS's outgoing buffer is full, wait for it to drain
-        // before queuing another write.
+        // before queuing another write. Bound the wait so a missing
+        // WRITE_NO_RSP property on the firmware side doesn't hang the pump
+        // forever (we hit exactly that on bench 2026-05-28).
         if !peripheral.canSendWriteWithoutResponse {
-            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                // Re-check inside the continuation body — state may have
-                // changed between the if-check above and now.
-                if peripheral.canSendWriteWithoutResponse {
-                    cont.resume()
-                    return
+            let ready = await withTimeout(seconds: 5.0) {
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    if peripheral.canSendWriteWithoutResponse {
+                        cont.resume()
+                        return
+                    }
+                    self.otaReadyContinuation = cont
                 }
-                otaReadyContinuation = cont
+            }
+            if !ready {
+                // Drain the pending continuation if it was set so the
+                // delegate doesn't try to resume a dead waiter later.
+                otaReadyContinuation = nil
+                throw OTAError.writeFailed("Timed out waiting for canSendWriteWithoutResponse — firmware may not advertise WRITE_NO_RSP on file-transfer characteristic")
             }
         }
 
@@ -385,6 +397,25 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         frame.append(data)
 
         peripheral.writeValue(frame, for: characteristic, type: .withoutResponse)
+    }
+
+    /// Run `body`; return true if it completed within `seconds`, false on
+    /// timeout. Used to bound waits on CoreBluetooth state changes.
+    private func withTimeout(seconds: TimeInterval,
+                             body: @escaping @Sendable () async -> Void) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await body()
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
     }
 
     /// Wake any pending sendOtaChunk awaiter with an error when the device

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -185,7 +185,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     func onDisconnect() {
         isConnected = false
         stopRSSITimer()
-        drainOtaWriteQueue(error: OTAError.notConnected)
+        drainOtaReadyContinuation()
         telemetryCharacteristic = nil
         commandCharacteristic = nil
         fileOpsCharacteristic = nil
@@ -333,28 +333,49 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// Maximum image-payload bytes per file-transfer write. Negotiated MTU
     /// minus 7-byte chunk header. Falls back to 170 (iOS default 185 MTU)
     /// before MTU negotiation completes.
+    ///
+    /// Uses .withoutResponse limit (which CoreBluetooth advertises separately)
+    /// — typically equal to the with-response limit for the same MTU.
     var otaMaxChunkSize: Int {
         guard let peripheral = peripheral else { return 170 }
-        let maxWrite = peripheral.maximumWriteValueLength(for: .withResponse)
+        let maxWrite = peripheral.maximumWriteValueLength(for: .withoutResponse)
         return max(20, maxWrite - 7)
     }
 
-    // FIFO of per-write continuations. iOS's CoreBluetooth queues
-    // writeValue(.withResponse) internally and fires didWriteValueFor in the
-    // same order, so we can have multiple chunks in flight at once — the
-    // OTASession sliding-window pumps the pipeline. Each entry resumes when
-    // its corresponding write callback fires.
-    private var otaWriteQueue: [CheckedContinuation<Void, Error>] = []
+    /// Resumed by peripheralIsReady(toSendWriteWithoutResponse:) when the BLE
+    /// stack's outgoing write buffer drains and we can queue more chunks.
+    /// At most one waiter at a time — the OTASession chunk pump is serial.
+    private var otaReadyContinuation: CheckedContinuation<Void, Never>?
 
-    /// Send a single OTA image chunk. Frame: [offset:4 LE][length:2 LE][flags:1][data:N].
-    /// Awaits the BLE stack's per-write ack via didWriteValueFor. Safe to
-    /// call concurrently — multiple in-flight writes pipeline via the
-    /// otaWriteQueue FIFO.
+    /// Send a single OTA image chunk over the file-transfer characteristic.
+    /// Frame: [offset:4 LE][length:2 LE][flags:1][data:N].
+    ///
+    /// Uses writeWithoutResponse for throughput — write-with-response forced
+    /// the BLE link into a serial req/resp cycle per chunk, giving ~2.5 KB/s.
+    /// writeWithoutResponse + canSendWriteWithoutResponse backpressure
+    /// lets iOS batch multiple writes per connection event (~10-20× faster).
+    /// No per-chunk ATT ack — relies on link-layer CRC + retransmit for
+    /// reliability and on OTA_FINISH's SHA-256 check to catch any drops.
     func sendOtaChunk(offset: UInt32, data: Data, isLast: Bool) async throws {
         guard let characteristic = fileTransferCharacteristic,
               let peripheral = peripheral else {
             throw OTAError.notConnected
         }
+
+        // Backpressure: if iOS's outgoing buffer is full, wait for it to drain
+        // before queuing another write.
+        if !peripheral.canSendWriteWithoutResponse {
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                // Re-check inside the continuation body — state may have
+                // changed between the if-check above and now.
+                if peripheral.canSendWriteWithoutResponse {
+                    cont.resume()
+                    return
+                }
+                otaReadyContinuation = cont
+            }
+        }
+
         var frame = Data(capacity: 7 + data.count)
         var offLE = offset.littleEndian
         withUnsafeBytes(of: &offLE) { frame.append(contentsOf: $0) }
@@ -363,20 +384,16 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         frame.append(isLast ? 0x01 : 0x00)
         frame.append(data)
 
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            otaWriteQueue.append(cont)
-            peripheral.writeValue(frame, for: characteristic, type: .withResponse)
-        }
+        peripheral.writeValue(frame, for: characteristic, type: .withoutResponse)
     }
 
-    /// Fail all in-flight OTA chunk continuations. Called from onDisconnect
-    /// so pending sendOtaChunk awaits don't hang forever when the device
-    /// drops mid-transfer.
-    private func drainOtaWriteQueue(error: Error) {
-        let pending = otaWriteQueue
-        otaWriteQueue.removeAll()
-        for cont in pending {
-            cont.resume(throwing: error)
+    /// Wake any pending sendOtaChunk awaiter with an error when the device
+    /// drops mid-transfer (called from onDisconnect).
+    private func drainOtaReadyContinuation() {
+        if let cont = otaReadyContinuation {
+            otaReadyContinuation = nil
+            cont.resume()   // Non-throwing — sendOtaChunk will fail on the
+                            // next peripheral guard since peripheral is nil.
         }
     }
 
@@ -1152,21 +1169,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
-    func peripheral(_ peripheral: CBPeripheral,
-                   didWriteValueFor characteristic: CBCharacteristic,
-                   error: Error?) {
-        // OTA chunk pump waits on per-write acks; the command characteristic
-        // also uses writeValue(.withResponse) but fires-and-forgets. iOS
-        // dispatches writes in order, so popping the FIFO head matches each
-        // ack to the oldest in-flight chunk.
-        if characteristic.uuid == fileTransferCharUUID,
-           !otaWriteQueue.isEmpty {
-            let cont = otaWriteQueue.removeFirst()
-            if let error = error {
-                cont.resume(throwing: OTAError.writeFailed(error.localizedDescription))
-            } else {
-                cont.resume()
-            }
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // Wake the OTA chunk pump if it parked on a full outgoing buffer.
+        // sendOtaChunk uses writeWithoutResponse for throughput; this
+        // delegate is iOS's signal that the buffer has drained.
+        if let cont = otaReadyContinuation {
+            otaReadyContinuation = nil
+            cont.resume()
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -99,6 +99,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// state machine.
     @Published var otaStatus: OTAStatusUpdate?
 
+    /// Per-device OTA driver. Lazy so it's only instantiated when the user
+    /// opens the firmware-update screen, but persists for the device's
+    /// lifetime — survives FirmwareUpdateView being torn down and re-shown
+    /// across the post-OTA disconnect/reconnect so the "Updated successfully"
+    /// state isn't lost when the view rebuilds.
+    @MainActor lazy var otaSession: OTASession = OTASession(device: self)
+
     /// Display name: unitName if set, otherwise connectedDeviceName
     var displayName: String {
         unitName.isEmpty ? connectedDeviceName : unitName

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -87,6 +87,18 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var rocketID: UInt8 = 0
     @Published var deviceType: BLEDeviceType = .unknown
 
+    /// Firmware version stamp from config_identity "fw" field (#8).
+    /// Format: `<git_short_sha>+<build_yyyymmdd-hhmm>`, optionally with
+    /// `-dirty` between the sha and `+`. Empty if the device hasn't
+    /// pushed its identity yet or is running pre-#8 firmware (no "fw" field).
+    @Published var firmwareVersion: String = ""
+
+    /// Latest OTA status frame from the device (#8 phase 2). Driven by
+    /// ota_status JSON notifications on the file-ops characteristic.
+    /// nil between sessions; OTASession observes this to advance its
+    /// state machine.
+    @Published var otaStatus: OTAStatusUpdate?
+
     /// Display name: unitName if set, otherwise connectedDeviceName
     var displayName: String {
         unitName.isEmpty ? connectedDeviceName : unitName
@@ -272,6 +284,79 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         data.append(payload)
         peripheral.writeValue(data, for: characteristic, type: .withResponse)
         print("Sent command \(command) with \(payload.count) bytes payload")
+    }
+
+    // MARK: - OTA helpers (#8 phase 2)
+
+    enum OTAError: Error, LocalizedError {
+        case notConnected
+        case writeInFlight
+        case writeFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConnected:        return "Device is not connected"
+            case .writeInFlight:       return "A chunk write is already in flight"
+            case .writeFailed(let m):  return "Chunk write failed: \(m)"
+            }
+        }
+    }
+
+    /// Send OTA_BEGIN (cmd 70). Payload: [target:1][size:4 LE][sha256:32].
+    /// targetIsFC=false → flashes this BS/OC device's own app. targetIsFC=true
+    /// is reserved for phase 4 (OC-relayed Flight Computer OTA).
+    func sendOtaBegin(targetIsFC: Bool, totalSize: UInt32, sha256: Data) {
+        precondition(sha256.count == 32, "SHA-256 must be exactly 32 bytes")
+        var payload = Data(capacity: 37)
+        payload.append(targetIsFC ? 0x01 : 0x00)
+        var sizeLE = totalSize.littleEndian
+        withUnsafeBytes(of: &sizeLE) { payload.append(contentsOf: $0) }
+        payload.append(sha256)
+        sendRawCommand(70, payload: payload)
+    }
+
+    /// Send OTA_FINISH (cmd 71). Device verifies SHA, sets boot partition,
+    /// then reboots ~500 ms later.
+    func sendOtaFinish() { sendRawCommand(71) }
+
+    /// Send OTA_ABORT (cmd 72). Always safe; clears any in-flight session.
+    func sendOtaAbort() { sendRawCommand(72) }
+
+    /// Maximum image-payload bytes per file-transfer write. Negotiated MTU
+    /// minus 7-byte chunk header. Falls back to 170 (iOS default 185 MTU)
+    /// before MTU negotiation completes.
+    var otaMaxChunkSize: Int {
+        guard let peripheral = peripheral else { return 170 }
+        let maxWrite = peripheral.maximumWriteValueLength(for: .withResponse)
+        return max(20, maxWrite - 7)
+    }
+
+    private var otaWriteContinuation: CheckedContinuation<Void, Error>?
+
+    /// Send a single OTA image chunk. Frame: [offset:4 LE][length:2 LE][flags:1][data:N].
+    /// Awaits the BLE stack's per-write ack via didWriteValueFor — only one
+    /// write may be in flight at a time, so the OTASession pumps serially.
+    func sendOtaChunk(offset: UInt32, data: Data, isLast: Bool) async throws {
+        guard let characteristic = fileTransferCharacteristic,
+              let peripheral = peripheral else {
+            throw OTAError.notConnected
+        }
+        var frame = Data(capacity: 7 + data.count)
+        var offLE = offset.littleEndian
+        withUnsafeBytes(of: &offLE) { frame.append(contentsOf: $0) }
+        var lenLE = UInt16(data.count).littleEndian
+        withUnsafeBytes(of: &lenLE) { frame.append(contentsOf: $0) }
+        frame.append(isLast ? 0x01 : 0x00)
+        frame.append(data)
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            if otaWriteContinuation != nil {
+                cont.resume(throwing: OTAError.writeInFlight)
+                return
+            }
+            otaWriteContinuation = cont
+            peripheral.writeValue(frame, for: characteristic, type: .withResponse)
+        }
     }
 
     /// Kick off a base-station frequency scan.  Clears any previous results
@@ -1047,6 +1132,22 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     }
 
     func peripheral(_ peripheral: CBPeripheral,
+                   didWriteValueFor characteristic: CBCharacteristic,
+                   error: Error?) {
+        // OTA chunk pump waits on per-write acks; the command characteristic
+        // also uses writeValue(.withResponse) but fires-and-forgets.
+        if characteristic.uuid == fileTransferCharUUID,
+           let cont = otaWriteContinuation {
+            otaWriteContinuation = nil
+            if let error = error {
+                cont.resume(throwing: OTAError.writeFailed(error.localizedDescription))
+            } else {
+                cont.resume()
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral,
                    didUpdateValueFor characteristic: CBCharacteristic,
                    error: Error?) {
         if characteristic.uuid == telemetryCharUUID {
@@ -1061,7 +1162,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 case 0xAA: parseScanResult(data)
                 case 0xCA: parseMagCalStatus(data)     // issue #96
                 case 0xCB: parseSensorCalStatus(data)  // issue #132
-                default:   parseFileList(data)
+                case 0x7B:                              // '{' → JSON object
+                    if let s = OTAStatusUpdate.parse(data) {
+                        otaStatus = s
+                    } else {
+                        parseFileList(data)
+                    }
+                default:   parseFileList(data)         // '[' or anything else (file list arrays)
                 }
             }
         } else if characteristic.uuid == fileTransferCharUUID {
@@ -1148,7 +1255,8 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             if let dt = dict["dt"] as? String {
                 deviceType = BLEDeviceType(rawValue: dt) ?? deviceType
             }
-            print("[CFG] Identity: uid=\(unitID) name=\(unitName) nid=\(networkID) rid=\(rocketID) type=\(deviceType.rawValue)")
+            if let fw = dict["fw"] as? String { firmwareVersion = fw }
+            print("[CFG] Identity: uid=\(unitID) name=\(unitName) nid=\(networkID) rid=\(rocketID) type=\(deviceType.rawValue) fw=\(firmwareVersion)")
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -99,13 +99,6 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// state machine.
     @Published var otaStatus: OTAStatusUpdate?
 
-    /// Per-device OTA driver. Lazy so it's only instantiated when the user
-    /// opens the firmware-update screen, but persists for the device's
-    /// lifetime — survives FirmwareUpdateView being torn down and re-shown
-    /// across the post-OTA disconnect/reconnect so the "Updated successfully"
-    /// state isn't lost when the view rebuilds.
-    @MainActor lazy var otaSession: OTASession = OTASession(device: self)
-
     /// Display name: unitName if set, otherwise connectedDeviceName
     var displayName: String {
         unitName.isEmpty ? connectedDeviceName : unitName

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -32,6 +32,25 @@ class BLEFleet: NSObject, ObservableObject {
     /// the base station.  In-memory only; cleared on app kill.  #140.
     @Published var lastValidRocketFixes: [UInt8: LastValidRocketFix] = [:]
 
+    /// Per-device OTA driver (#8 phase 2, #15 second pass).  Same rationale
+    /// as lastValidRocketFixes: BLEDevice is recreated on each reconnect,
+    /// so OTASession must live above it — otherwise the "Updated successfully"
+    /// state on FirmwareUpdateView gets wiped by the post-OTA reboot's
+    /// disconnect cycle. Keyed by peripheral.identifier (stable across
+    /// reconnect for the same physical device).
+    @Published var otaSessions: [UUID: OTASession] = [:]
+
+    /// Get-or-create the OTA driver for `device`. The same OTASession
+    /// instance is returned across reconnects for the same peripheral.
+    @MainActor
+    func otaSession(for device: BLEDevice) -> OTASession {
+        let id = device.peripheral?.identifier ?? UUID()  // transient if no peripheral yet
+        if let existing = otaSessions[id] { return existing }
+        let session = OTASession(fleet: self, peripheralID: id)
+        otaSessions[id] = session
+        return session
+    }
+
     /// Convenience: the active device, or nil.
     var activeDevice: BLEDevice? {
         guard let id = activeDeviceID else { return devices.first }

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -146,31 +146,62 @@ final class OTASession: ObservableObject {
             return
         }
 
-        // ---- 5. Chunk pump ----
+        // ---- 5. Chunk pump (pipelined writes-with-response) ----
+        // Serial writes hit ~1.7 KB/s on bench (#16) because each chunk
+        // waits a full iOS BLE pacing interval. iOS lets us queue multiple
+        // writeValue(.withResponse) calls in flight and fires didWriteValueFor
+        // in the same order, so we maintain a sliding window of `pipelineDepth`
+        // outstanding chunks. BLE link still serializes at the wire level,
+        // but we eliminate the per-chunk dispatch round-trip.
         let chunkSize = max(64, device.otaMaxChunkSize)
+        let pipelineDepth = 8
         var offset = 0
+        var completedBytes = 0
+        var inFlight: [(offset: Int, size: Int, task: Task<Void, Error>)] = []
         state = .uploading(bytesSent: 0, totalBytes: fileData.count)
-        while offset < fileData.count {
-            if Task.isCancelled { return }
+
+        while offset < fileData.count || !inFlight.isEmpty {
+            if Task.isCancelled {
+                for entry in inFlight { entry.task.cancel() }
+                return
+            }
 
             // VerifyFailed during the pump? Surface and bail.
             if let st = lastStatusUpdate, st.state == .verifyFailed {
+                for entry in inFlight { entry.task.cancel() }
                 state = .failed(reason: "Device rejected chunk: \(st.err ?? "unknown")")
-                return
-            }
-
-            let end = min(offset + chunkSize, fileData.count)
-            let chunk = fileData.subdata(in: offset..<end)
-            let isLast = (end == fileData.count)
-            do {
-                try await device.sendOtaChunk(offset: UInt32(offset), data: chunk, isLast: isLast)
-            } catch {
-                state = .failed(reason: "Chunk write failed at offset \(offset): \(error.localizedDescription)")
                 device.sendOtaAbort()
                 return
             }
-            offset = end
-            state = .uploading(bytesSent: offset, totalBytes: fileData.count)
+
+            // Fill the pipeline up to depth, as long as we have more to send.
+            while inFlight.count < pipelineDepth && offset < fileData.count {
+                let end = min(offset + chunkSize, fileData.count)
+                let chunk = fileData.subdata(in: offset..<end)
+                let isLast = (end == fileData.count)
+                let chunkOffset = offset
+                let chunkLen = chunk.count
+                let task = Task { @MainActor in
+                    try await self.device.sendOtaChunk(offset: UInt32(chunkOffset), data: chunk, isLast: isLast)
+                }
+                inFlight.append((offset: chunkOffset, size: chunkLen, task: task))
+                offset = end
+            }
+
+            // Drain the oldest in-flight chunk so we can refill.
+            if !inFlight.isEmpty {
+                let entry = inFlight.removeFirst()
+                do {
+                    try await entry.task.value
+                    completedBytes += entry.size
+                    state = .uploading(bytesSent: completedBytes, totalBytes: fileData.count)
+                } catch {
+                    for remaining in inFlight { remaining.task.cancel() }
+                    state = .failed(reason: "Chunk write failed at offset \(entry.offset): \(error.localizedDescription)")
+                    device.sendOtaAbort()
+                    return
+                }
+            }
         }
 
         // ---- 6. OTA_FINISH ----

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import CoreBluetooth
 import CryptoKit
 
 /// Drives an OTA upload on a single BLEDevice end-to-end:
@@ -28,25 +29,28 @@ final class OTASession: ObservableObject {
 
     @Published private(set) var state: State = .idle
 
-    // Owning BLEDevice — unowned because BLEDevice owns this object via
-    // `lazy var otaSession`, so the cycle is structural and the session
-    // can't outlive its device.
-    private unowned let device: BLEDevice
+    // Owning fleet (weak — BLEFleet owns this OTASession via
+    // `otaSessions[peripheralID]`, so the cycle would leak both objects).
+    // The current BLEDevice for our peripheral is looked up via the fleet
+    // each time we need it; the device gets destroyed+recreated on every
+    // BLE disconnect/reconnect (#140), but the session lives on.
+    private weak var fleet: BLEFleet?
+    let peripheralID: UUID
+
+    /// The current BLEDevice for our peripheral, or nil between reconnects.
+    var device: BLEDevice? {
+        fleet?.devices.first { $0.peripheral?.identifier == peripheralID }
+    }
+
     private(set) var preFlashFirmwareVersion: String = ""
     private(set) var imageSize: Int = 0
     private(set) var imageSha256Hex: String = ""
 
     private var task: Task<Void, Never>?
-    private var statusCancellable: AnyCancellable?
-    private var fwCancellable: AnyCancellable?
-    private var connCancellable: AnyCancellable?
 
-    // Reboot/reconnect plumbing — set by Combine sinks, consumed by Task.sleep loops.
-    private var lastStatusUpdate: OTAStatusUpdate?
-    private var sawDisconnect: Bool = false
-
-    init(device: BLEDevice) {
-        self.device = device
+    init(fleet: BLEFleet, peripheralID: UUID) {
+        self.fleet = fleet
+        self.peripheralID = peripheralID
     }
 
     deinit {
@@ -58,12 +62,6 @@ final class OTASession: ObservableObject {
     /// Re-callable: cancels any prior in-flight run.
     func start(fileURL: URL) {
         task?.cancel()
-        statusCancellable?.cancel()
-        fwCancellable?.cancel()
-        connCancellable?.cancel()
-        lastStatusUpdate = nil
-        sawDisconnect = false
-
         task = Task { [weak self] in
             await self?.runFlow(fileURL: fileURL)
         }
@@ -72,7 +70,7 @@ final class OTASession: ObservableObject {
     /// User-initiated cancel. Sends OTA_ABORT and tears the task down.
     func cancel() {
         task?.cancel()
-        device.sendOtaAbort()
+        device?.sendOtaAbort()
         state = .failed(reason: "Cancelled")
     }
 
@@ -81,17 +79,9 @@ final class OTASession: ObservableObject {
     /// .rollbackDetected / .failed.
     func reset() {
         task?.cancel()
-        statusCancellable?.cancel()
-        fwCancellable?.cancel()
-        connCancellable?.cancel()
-        statusCancellable = nil
-        fwCancellable = nil
-        connCancellable = nil
         preFlashFirmwareVersion = ""
         imageSize = 0
         imageSha256Hex = ""
-        lastStatusUpdate = nil
-        sawDisconnect = false
         state = .idle
     }
 
@@ -118,27 +108,16 @@ final class OTASession: ObservableObject {
         let sha = Data(SHA256.hash(data: fileData))
         imageSize = fileData.count
         imageSha256Hex = sha.map { String(format: "%02x", $0) }.joined()
-        preFlashFirmwareVersion = device.firmwareVersion
+        preFlashFirmwareVersion = device?.firmwareVersion ?? ""
 
-        // ---- 2. Subscribe to device.$otaStatus + connection edges ----
-        statusCancellable = device.$otaStatus
-            .compactMap { $0 }
-            .sink { [weak self] s in self?.lastStatusUpdate = s }
-
-        connCancellable = device.$isConnected
-            .removeDuplicates()
-            .sink { [weak self] connected in
-                if !connected { self?.sawDisconnect = true }
-            }
-
-        // ---- 3. Send OTA_BEGIN ----
-        guard device.isConnected else {
+        // ---- 2. Send OTA_BEGIN ----
+        guard let beginDevice = device, beginDevice.isConnected else {
             state = .failed(reason: "Device disconnected before OTA_BEGIN")
             return
         }
-        device.sendOtaBegin(targetIsFC: false, totalSize: UInt32(fileData.count), sha256: sha)
+        beginDevice.sendOtaBegin(targetIsFC: false, totalSize: UInt32(fileData.count), sha256: sha)
 
-        // ---- 4. Wait for status=ready ----
+        // ---- 3. Wait for status=ready ----
         do {
             try await awaitOtaState(.ready, timeout: 5.0)
         } catch {
@@ -146,7 +125,7 @@ final class OTASession: ObservableObject {
             return
         }
 
-        // ---- 5. Chunk pump (writeWithoutResponse, serial) ----
+        // ---- 4. Chunk pump (writeWithoutResponse, serial) ----
         // Pipelining at the GATT API level didn't help (#16 first attempt) —
         // CoreBluetooth still serializes write-with-response at the link
         // layer, ~2.5 KB/s. Switching the underlying writeValue type to
@@ -155,16 +134,21 @@ final class OTASession: ObservableObject {
         // when iOS's outgoing buffer fills, so this serial loop won't outrun
         // the link. No per-chunk ATT ack — the firmware's OTA_FINISH SHA
         // check is what catches a dropped chunk.
-        let chunkSize = max(64, device.otaMaxChunkSize)
+        let chunkSize = max(64, beginDevice.otaMaxChunkSize)
         var offset = 0
         state = .uploading(bytesSent: 0, totalBytes: fileData.count)
         while offset < fileData.count {
             if Task.isCancelled { return }
 
             // VerifyFailed during the pump? Surface and bail.
-            if let st = lastStatusUpdate, st.state == .verifyFailed {
+            if let st = device?.otaStatus, st.state == .verifyFailed {
                 state = .failed(reason: "Device rejected chunk: \(st.err ?? "unknown")")
-                device.sendOtaAbort()
+                device?.sendOtaAbort()
+                return
+            }
+
+            guard let pumpDevice = device, pumpDevice.isConnected else {
+                state = .failed(reason: "Device disconnected mid-upload at offset \(offset)")
                 return
             }
 
@@ -172,25 +156,25 @@ final class OTASession: ObservableObject {
             let chunk = fileData.subdata(in: offset..<end)
             let isLast = (end == fileData.count)
             do {
-                try await device.sendOtaChunk(offset: UInt32(offset), data: chunk, isLast: isLast)
+                try await pumpDevice.sendOtaChunk(offset: UInt32(offset), data: chunk, isLast: isLast)
             } catch {
                 state = .failed(reason: "Chunk write failed at offset \(offset): \(error.localizedDescription)")
-                device.sendOtaAbort()
+                device?.sendOtaAbort()
                 return
             }
             offset = end
             state = .uploading(bytesSent: offset, totalBytes: fileData.count)
         }
 
-        // ---- 6. OTA_FINISH ----
+        // ---- 5. OTA_FINISH ----
         state = .verifying
-        device.sendOtaFinish()
+        device?.sendOtaFinish()
 
-        // ---- 7. Wait for status=ready_to_boot (or verify_failed) ----
+        // ---- 6. Wait for status=ready_to_boot (or verify_failed) ----
         do {
             try await awaitOtaState(.readyToBoot, timeout: 15.0)
         } catch {
-            if let st = lastStatusUpdate, st.state == .verifyFailed {
+            if let st = device?.otaStatus, st.state == .verifyFailed {
                 state = .failed(reason: "Verify failed: \(st.err ?? "unknown")")
             } else {
                 state = .failed(reason: "Device did not finalize OTA within 15s")
@@ -198,30 +182,36 @@ final class OTASession: ObservableObject {
             return
         }
 
-        // ---- 8. Wait for disconnect (device reboots ~500ms after ready_to_boot) ----
+        // ---- 7. Wait for disconnect (device reboots ~500ms after ready_to_boot) ----
+        // BLEFleet destroys the BLEDevice on disconnect, so `device == nil`
+        // also counts as "disconnected".
         state = .rebooting
-        sawDisconnect = false
-        if !(await waitFor(timeout: 5.0, { [weak self] in self?.sawDisconnect == true || self?.device.isConnected == false })) {
-            // No disconnect seen — odd, but proceed to reconnect-await anyway.
+        _ = await waitFor(timeout: 5.0) { [weak self] in
+            self?.device == nil || self?.device?.isConnected == false
         }
 
-        // ---- 9. Wait for reconnect ----
-        if !(await waitFor(timeout: 60.0, { [weak self] in self?.device.isConnected == true })) {
+        // ---- 8. Wait for reconnect ----
+        // After BLEFleet creates a fresh BLEDevice for our peripheralID,
+        // self.device starts returning the new instance.
+        let reconnected = await waitFor(timeout: 60.0) { [weak self] in
+            self?.device?.isConnected == true
+        }
+        if !reconnected {
             state = .failed(reason: "Device did not reconnect within 60s — try power-cycling")
             return
         }
 
-        // ---- 10. Wait for the new identity push (fw field) ----
+        // ---- 9. Wait for the new identity push (fw field) ----
         // The firmware republishes config_identity on each connect; we wait
         // for any non-empty fw value that arrives AFTER reconnect.
         let preFlash = preFlashFirmwareVersion
-        if !(await waitFor(timeout: 10.0, { [weak self] in
-            guard let self else { return false }
-            return !self.device.firmwareVersion.isEmpty &&
-                   self.device.firmwareVersion != preFlash
-        })) {
-            // Either no fw push came in (old firmware?) or it matches pre-flash.
-            if device.firmwareVersion == preFlash {
+        let gotNewFw = await waitFor(timeout: 10.0) { [weak self] in
+            guard let fw = self?.device?.firmwareVersion, !fw.isEmpty else { return false }
+            return fw != preFlash
+        }
+        let postFw = device?.firmwareVersion ?? ""
+        if !gotNewFw {
+            if postFw == preFlash && !postFw.isEmpty {
                 state = .rollbackDetected(version: preFlash)
             } else {
                 state = .failed(reason: "Reconnected but device didn't publish a new firmware version within 10s")
@@ -229,19 +219,21 @@ final class OTASession: ObservableObject {
             return
         }
 
-        state = .verified(newVersion: device.firmwareVersion)
+        state = .verified(newVersion: postFw)
     }
 
     // MARK: - Wait helpers
 
-    /// Spin-wait for `lastStatusUpdate.state == expected` (or VerifyFailed,
+    /// Spin-wait for `device.otaStatus.state == expected` (or VerifyFailed,
     /// which fails fast). Polls every 50 ms up to `timeout` seconds.
+    /// Reads `device?.otaStatus` directly each iteration so a BLEDevice
+    /// reconnect (new instance) is picked up automatically.
     private func awaitOtaState(_ expected: OTAStatusUpdate.State, timeout: TimeInterval) async throws {
         struct TimedOut: Error {}
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if Task.isCancelled { throw CancellationError() }
-            if let st = lastStatusUpdate {
+            if let st = device?.otaStatus {
                 if st.state == expected { return }
                 if st.state == .verifyFailed { throw TimedOut() }
             }

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -146,62 +146,40 @@ final class OTASession: ObservableObject {
             return
         }
 
-        // ---- 5. Chunk pump (pipelined writes-with-response) ----
-        // Serial writes hit ~1.7 KB/s on bench (#16) because each chunk
-        // waits a full iOS BLE pacing interval. iOS lets us queue multiple
-        // writeValue(.withResponse) calls in flight and fires didWriteValueFor
-        // in the same order, so we maintain a sliding window of `pipelineDepth`
-        // outstanding chunks. BLE link still serializes at the wire level,
-        // but we eliminate the per-chunk dispatch round-trip.
+        // ---- 5. Chunk pump (writeWithoutResponse, serial) ----
+        // Pipelining at the GATT API level didn't help (#16 first attempt) —
+        // CoreBluetooth still serializes write-with-response at the link
+        // layer, ~2.5 KB/s. Switching the underlying writeValue type to
+        // .withoutResponse lets iOS batch multiple chunks per BLE
+        // connection event. sendOtaChunk parks on canSendWriteWithoutResponse
+        // when iOS's outgoing buffer fills, so this serial loop won't outrun
+        // the link. No per-chunk ATT ack — the firmware's OTA_FINISH SHA
+        // check is what catches a dropped chunk.
         let chunkSize = max(64, device.otaMaxChunkSize)
-        let pipelineDepth = 8
         var offset = 0
-        var completedBytes = 0
-        var inFlight: [(offset: Int, size: Int, task: Task<Void, Error>)] = []
         state = .uploading(bytesSent: 0, totalBytes: fileData.count)
-
-        while offset < fileData.count || !inFlight.isEmpty {
-            if Task.isCancelled {
-                for entry in inFlight { entry.task.cancel() }
-                return
-            }
+        while offset < fileData.count {
+            if Task.isCancelled { return }
 
             // VerifyFailed during the pump? Surface and bail.
             if let st = lastStatusUpdate, st.state == .verifyFailed {
-                for entry in inFlight { entry.task.cancel() }
                 state = .failed(reason: "Device rejected chunk: \(st.err ?? "unknown")")
                 device.sendOtaAbort()
                 return
             }
 
-            // Fill the pipeline up to depth, as long as we have more to send.
-            while inFlight.count < pipelineDepth && offset < fileData.count {
-                let end = min(offset + chunkSize, fileData.count)
-                let chunk = fileData.subdata(in: offset..<end)
-                let isLast = (end == fileData.count)
-                let chunkOffset = offset
-                let chunkLen = chunk.count
-                let task = Task { @MainActor in
-                    try await self.device.sendOtaChunk(offset: UInt32(chunkOffset), data: chunk, isLast: isLast)
-                }
-                inFlight.append((offset: chunkOffset, size: chunkLen, task: task))
-                offset = end
+            let end = min(offset + chunkSize, fileData.count)
+            let chunk = fileData.subdata(in: offset..<end)
+            let isLast = (end == fileData.count)
+            do {
+                try await device.sendOtaChunk(offset: UInt32(offset), data: chunk, isLast: isLast)
+            } catch {
+                state = .failed(reason: "Chunk write failed at offset \(offset): \(error.localizedDescription)")
+                device.sendOtaAbort()
+                return
             }
-
-            // Drain the oldest in-flight chunk so we can refill.
-            if !inFlight.isEmpty {
-                let entry = inFlight.removeFirst()
-                do {
-                    try await entry.task.value
-                    completedBytes += entry.size
-                    state = .uploading(bytesSent: completedBytes, totalBytes: fileData.count)
-                } catch {
-                    for remaining in inFlight { remaining.task.cancel() }
-                    state = .failed(reason: "Chunk write failed at offset \(entry.offset): \(error.localizedDescription)")
-                    device.sendOtaAbort()
-                    return
-                }
-            }
+            offset = end
+            state = .uploading(bytesSent: offset, totalBytes: fileData.count)
         }
 
         // ---- 6. OTA_FINISH ----

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -6,9 +6,10 @@ import CryptoKit
 /// load file → SHA-256 → OTA_BEGIN → chunk pump → OTA_FINISH →
 /// wait for reboot → wait for reconnect → compare new fw vs pre-flash fw.
 ///
-/// One-shot: instantiate, call start(fileURL:), observe `state`. Throw it
-/// away when done. Tasks created internally are cancelled on cancel() or
-/// deinit.
+/// Lifetime: owned by BLEDevice as a lazy property — survives view churn
+/// across the post-OTA disconnect/reconnect so FirmwareUpdateView can pick
+/// up the final state when the user navigates back. Call reset() to clear
+/// for the next run.
 ///
 /// Per design doc §5 (docs/plans/08-ota-firmware-update.md).
 @MainActor
@@ -27,7 +28,10 @@ final class OTASession: ObservableObject {
 
     @Published private(set) var state: State = .idle
 
-    let device: BLEDevice
+    // Owning BLEDevice — unowned because BLEDevice owns this object via
+    // `lazy var otaSession`, so the cycle is structural and the session
+    // can't outlive its device.
+    private unowned let device: BLEDevice
     private(set) var preFlashFirmwareVersion: String = ""
     private(set) var imageSize: Int = 0
     private(set) var imageSha256Hex: String = ""
@@ -57,6 +61,8 @@ final class OTASession: ObservableObject {
         statusCancellable?.cancel()
         fwCancellable?.cancel()
         connCancellable?.cancel()
+        lastStatusUpdate = nil
+        sawDisconnect = false
 
         task = Task { [weak self] in
             await self?.runFlow(fileURL: fileURL)
@@ -68,6 +74,25 @@ final class OTASession: ObservableObject {
         task?.cancel()
         device.sendOtaAbort()
         state = .failed(reason: "Cancelled")
+    }
+
+    /// Reset back to .idle so the same instance can drive another OTA run.
+    /// Called by the UI's "Flash another firmware" button after .verified /
+    /// .rollbackDetected / .failed.
+    func reset() {
+        task?.cancel()
+        statusCancellable?.cancel()
+        fwCancellable?.cancel()
+        connCancellable?.cancel()
+        statusCancellable = nil
+        fwCancellable = nil
+        connCancellable = nil
+        preFlashFirmwareVersion = ""
+        imageSize = 0
+        imageSha256Hex = ""
+        lastStatusUpdate = nil
+        sawDisconnect = false
+        state = .idle
     }
 
     // MARK: - Flow

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Combine
+import CryptoKit
+
+/// Drives an OTA upload on a single BLEDevice end-to-end:
+/// load file → SHA-256 → OTA_BEGIN → chunk pump → OTA_FINISH →
+/// wait for reboot → wait for reconnect → compare new fw vs pre-flash fw.
+///
+/// One-shot: instantiate, call start(fileURL:), observe `state`. Throw it
+/// away when done. Tasks created internally are cancelled on cancel() or
+/// deinit.
+///
+/// Per design doc §5 (docs/plans/08-ota-firmware-update.md).
+@MainActor
+final class OTASession: ObservableObject {
+
+    enum State: Equatable {
+        case idle
+        case loading                                              // reading file + computing SHA
+        case uploading(bytesSent: Int, totalBytes: Int)
+        case verifying                                            // OTA_FINISH sent, awaiting ready_to_boot
+        case rebooting                                            // disconnected, waiting up to 60 s for reconnect
+        case verified(newVersion: String)                         // new fw confirmed on reconnect
+        case rollbackDetected(version: String)                    // post-reboot fw same as pre-flash fw
+        case failed(reason: String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    let device: BLEDevice
+    private(set) var preFlashFirmwareVersion: String = ""
+    private(set) var imageSize: Int = 0
+    private(set) var imageSha256Hex: String = ""
+
+    private var task: Task<Void, Never>?
+    private var statusCancellable: AnyCancellable?
+    private var fwCancellable: AnyCancellable?
+    private var connCancellable: AnyCancellable?
+
+    // Reboot/reconnect plumbing — set by Combine sinks, consumed by Task.sleep loops.
+    private var lastStatusUpdate: OTAStatusUpdate?
+    private var sawDisconnect: Bool = false
+
+    init(device: BLEDevice) {
+        self.device = device
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    /// Kick off the OTA flow. Reads `fileURL` (typically from `.fileImporter`)
+    /// into memory, computes its SHA-256, then walks the state machine.
+    /// Re-callable: cancels any prior in-flight run.
+    func start(fileURL: URL) {
+        task?.cancel()
+        statusCancellable?.cancel()
+        fwCancellable?.cancel()
+        connCancellable?.cancel()
+
+        task = Task { [weak self] in
+            await self?.runFlow(fileURL: fileURL)
+        }
+    }
+
+    /// User-initiated cancel. Sends OTA_ABORT and tears the task down.
+    func cancel() {
+        task?.cancel()
+        device.sendOtaAbort()
+        state = .failed(reason: "Cancelled")
+    }
+
+    // MARK: - Flow
+
+    private func runFlow(fileURL: URL) async {
+        // ---- 1. Load file + compute SHA-256 ----
+        state = .loading
+        let didOpen = fileURL.startAccessingSecurityScopedResource()
+        defer { if didOpen { fileURL.stopAccessingSecurityScopedResource() } }
+
+        let fileData: Data
+        do {
+            fileData = try Data(contentsOf: fileURL)
+        } catch {
+            state = .failed(reason: "Could not read file: \(error.localizedDescription)")
+            return
+        }
+        if fileData.count < 64 {   // ESP32 app images have a non-trivial header
+            state = .failed(reason: "File looks too small to be firmware (\(fileData.count) bytes)")
+            return
+        }
+
+        let sha = Data(SHA256.hash(data: fileData))
+        imageSize = fileData.count
+        imageSha256Hex = sha.map { String(format: "%02x", $0) }.joined()
+        preFlashFirmwareVersion = device.firmwareVersion
+
+        // ---- 2. Subscribe to device.$otaStatus + connection edges ----
+        statusCancellable = device.$otaStatus
+            .compactMap { $0 }
+            .sink { [weak self] s in self?.lastStatusUpdate = s }
+
+        connCancellable = device.$isConnected
+            .removeDuplicates()
+            .sink { [weak self] connected in
+                if !connected { self?.sawDisconnect = true }
+            }
+
+        // ---- 3. Send OTA_BEGIN ----
+        guard device.isConnected else {
+            state = .failed(reason: "Device disconnected before OTA_BEGIN")
+            return
+        }
+        device.sendOtaBegin(targetIsFC: false, totalSize: UInt32(fileData.count), sha256: sha)
+
+        // ---- 4. Wait for status=ready ----
+        do {
+            try await awaitOtaState(.ready, timeout: 5.0)
+        } catch {
+            state = .failed(reason: "Device did not accept OTA_BEGIN within 5s")
+            return
+        }
+
+        // ---- 5. Chunk pump ----
+        let chunkSize = max(64, device.otaMaxChunkSize)
+        var offset = 0
+        state = .uploading(bytesSent: 0, totalBytes: fileData.count)
+        while offset < fileData.count {
+            if Task.isCancelled { return }
+
+            // VerifyFailed during the pump? Surface and bail.
+            if let st = lastStatusUpdate, st.state == .verifyFailed {
+                state = .failed(reason: "Device rejected chunk: \(st.err ?? "unknown")")
+                return
+            }
+
+            let end = min(offset + chunkSize, fileData.count)
+            let chunk = fileData.subdata(in: offset..<end)
+            let isLast = (end == fileData.count)
+            do {
+                try await device.sendOtaChunk(offset: UInt32(offset), data: chunk, isLast: isLast)
+            } catch {
+                state = .failed(reason: "Chunk write failed at offset \(offset): \(error.localizedDescription)")
+                device.sendOtaAbort()
+                return
+            }
+            offset = end
+            state = .uploading(bytesSent: offset, totalBytes: fileData.count)
+        }
+
+        // ---- 6. OTA_FINISH ----
+        state = .verifying
+        device.sendOtaFinish()
+
+        // ---- 7. Wait for status=ready_to_boot (or verify_failed) ----
+        do {
+            try await awaitOtaState(.readyToBoot, timeout: 15.0)
+        } catch {
+            if let st = lastStatusUpdate, st.state == .verifyFailed {
+                state = .failed(reason: "Verify failed: \(st.err ?? "unknown")")
+            } else {
+                state = .failed(reason: "Device did not finalize OTA within 15s")
+            }
+            return
+        }
+
+        // ---- 8. Wait for disconnect (device reboots ~500ms after ready_to_boot) ----
+        state = .rebooting
+        sawDisconnect = false
+        if !(await waitFor(timeout: 5.0, { [weak self] in self?.sawDisconnect == true || self?.device.isConnected == false })) {
+            // No disconnect seen — odd, but proceed to reconnect-await anyway.
+        }
+
+        // ---- 9. Wait for reconnect ----
+        if !(await waitFor(timeout: 60.0, { [weak self] in self?.device.isConnected == true })) {
+            state = .failed(reason: "Device did not reconnect within 60s — try power-cycling")
+            return
+        }
+
+        // ---- 10. Wait for the new identity push (fw field) ----
+        // The firmware republishes config_identity on each connect; we wait
+        // for any non-empty fw value that arrives AFTER reconnect.
+        let preFlash = preFlashFirmwareVersion
+        if !(await waitFor(timeout: 10.0, { [weak self] in
+            guard let self else { return false }
+            return !self.device.firmwareVersion.isEmpty &&
+                   self.device.firmwareVersion != preFlash
+        })) {
+            // Either no fw push came in (old firmware?) or it matches pre-flash.
+            if device.firmwareVersion == preFlash {
+                state = .rollbackDetected(version: preFlash)
+            } else {
+                state = .failed(reason: "Reconnected but device didn't publish a new firmware version within 10s")
+            }
+            return
+        }
+
+        state = .verified(newVersion: device.firmwareVersion)
+    }
+
+    // MARK: - Wait helpers
+
+    /// Spin-wait for `lastStatusUpdate.state == expected` (or VerifyFailed,
+    /// which fails fast). Polls every 50 ms up to `timeout` seconds.
+    private func awaitOtaState(_ expected: OTAStatusUpdate.State, timeout: TimeInterval) async throws {
+        struct TimedOut: Error {}
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if Task.isCancelled { throw CancellationError() }
+            if let st = lastStatusUpdate {
+                if st.state == expected { return }
+                if st.state == .verifyFailed { throw TimedOut() }
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        throw TimedOut()
+    }
+
+    /// Generic predicate-based wait. Returns true if predicate fired before
+    /// timeout. 50 ms poll interval.
+    private func waitFor(timeout: TimeInterval, _ predicate: @MainActor @escaping () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if Task.isCancelled { return false }
+            if predicate() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return false
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTAStatus.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTAStatus.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// OTA receiver-side status, parsed from `ota_status` JSON notifications on
+/// the file-ops characteristic (#8 phase 2). The firmware sends one of these
+/// on every state transition (begin / verify_failed / ready_to_boot / aborted)
+/// plus rate-limited ~2 Hz "writing" updates during the chunk pump.
+struct OTAStatusUpdate: Equatable {
+    enum State: String {
+        case ready              // OTA_BEGIN accepted, awaiting chunks
+        case writing            // chunks landing; `bytes` is cumulative
+        case readyToBoot        = "ready_to_boot"   // finish OK; device about to esp_restart
+        case verifyFailed       = "verify_failed"   // terminal — see `err`
+        case aborted            // OTA_ABORT acknowledged
+        case idle
+        case unknown
+    }
+
+    let state: State
+    /// Cumulative bytes written so far (0 outside `writing` / `ready` states).
+    let bytes: Int
+    /// Stable error token from the firmware (`sha_mismatch`, `bad_offset`,
+    /// `size_overflow`, `write_failed`, etc.). nil on non-failure states.
+    let err: String?
+    /// Version stamp of the image currently running on the device. Present on
+    /// `ready_to_boot` (= the image about to take over after reboot — used by
+    /// the iOS app as a debug anchor while waiting for the post-reboot identity).
+    let fw: String?
+
+    static func parse(_ data: Data) -> OTAStatusUpdate? {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            json["type"] as? String == "ota_status"
+        else { return nil }
+
+        let rawState = json["state"] as? String ?? ""
+        let state = State(rawValue: rawState) ?? .unknown
+        let bytes = json["bytes"] as? Int ?? 0
+        let err = json["err"] as? String
+        let fw = json["fw"] as? String
+        return OTAStatusUpdate(state: state, bytes: bytes, err: err, fw: fw)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -228,16 +228,22 @@ struct DashboardView: View {
         }
         .sheet(item: $activeSheet) { sheet in
             if let device = fleet.activeDevice {
-                switch sheet {
-                case .simulator:
-                    SimulationView(device: device)
-                case .settings:
-                    SettingsView(device: device)
-                case .servoTest:
-                    ServoTestView(device: device)
-                case .driftCast:
-                    DriftCastView(device: device)
+                Group {
+                    switch sheet {
+                    case .simulator:
+                        SimulationView(device: device)
+                    case .settings:
+                        SettingsView(device: device)
+                    case .servoTest:
+                        ServoTestView(device: device)
+                    case .driftCast:
+                        DriftCastView(device: device)
+                    }
                 }
+                // SwiftUI sheets get a fresh environment by default — re-inject
+                // fleet so SettingsView's FirmwareUpdateView can resolve the
+                // OTASession off it (#15 second pass).
+                .environmentObject(fleet)
             }
         }
         .sheet(isPresented: $showProvisioning) {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -14,15 +14,19 @@ import UniformTypeIdentifiers
 
 struct FirmwareUpdateView: View {
     @ObservedObject var device: BLEDevice
-    @StateObject private var session: OTASession
+    @ObservedObject var session: OTASession
     @State private var showingFilePicker = false
     @State private var pickedFileURL: URL?
     @State private var pickedFileSize: Int = 0
     @State private var pickedFileName: String = ""
 
     init(device: BLEDevice) {
-        self.device = device
-        _session = StateObject(wrappedValue: OTASession(device: device))
+        // Pull the per-device OTA session off BLEDevice rather than spinning
+        // up a fresh one — it survives the device disconnect/reconnect that
+        // tears down this view, so the "verified" state is still visible when
+        // the user navigates back after the OTA reboot. See #15.
+        _device = ObservedObject(initialValue: device)
+        _session = ObservedObject(initialValue: device.otaSession)
     }
 
     var body: some View {
@@ -130,6 +134,7 @@ struct FirmwareUpdateView: View {
                 }
                 LabeledRow(label: "Previous", value: session.preFlashFirmwareVersion, mono: true)
                 LabeledRow(label: "Now running", value: newVersion, mono: true)
+                flashAnotherButton
             }
 
         case .rollbackDetected(let version):
@@ -140,6 +145,7 @@ struct FirmwareUpdateView: View {
                 }
                 Text("Device reconnected but is still running the previous firmware (\(version)). The new image likely failed to boot — bootloader auto-reverted to the prior partition.")
                     .font(.subheadline).foregroundColor(.secondary)
+                flashAnotherButton
             }
 
         case .failed(let reason):
@@ -149,8 +155,27 @@ struct FirmwareUpdateView: View {
                     Text("Failed").font(.headline)
                 }
                 Text(reason).font(.subheadline).foregroundColor(.secondary)
+                flashAnotherButton
             }
         }
+    }
+
+    private var flashAnotherButton: some View {
+        Button(action: resetForNextFlash) {
+            HStack {
+                Image(systemName: "arrow.clockwise")
+                Text("Flash another firmware")
+            }
+        }
+        .buttonStyle(.bordered)
+        .padding(.top, 4)
+    }
+
+    private func resetForNextFlash() {
+        session.reset()
+        pickedFileURL = nil
+        pickedFileName = ""
+        pickedFileSize = 0
     }
 
     private var cancelButton: some View {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -1,0 +1,217 @@
+//
+//  FirmwareUpdateView.swift
+//  TinkerRocketApp
+//
+//  OTA firmware update flow — pick a .bin from Files, push it over BLE,
+//  wait for device reboot, confirm the new firmware version.
+//
+//  Phase 2 (#8): scoped to Base Station only via the call-site gate in
+//  SettingsView. Phase 3 will drop the gate to include the Out Computer.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FirmwareUpdateView: View {
+    @ObservedObject var device: BLEDevice
+    @StateObject private var session: OTASession
+    @State private var showingFilePicker = false
+    @State private var pickedFileURL: URL?
+    @State private var pickedFileSize: Int = 0
+    @State private var pickedFileName: String = ""
+
+    init(device: BLEDevice) {
+        self.device = device
+        _session = StateObject(wrappedValue: OTASession(device: device))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+
+            // ----- Current device state -----
+            GroupBox("Device") {
+                LabeledRow(label: "Name", value: device.displayName)
+                LabeledRow(label: "Hardware ID", value: device.unitID.isEmpty ? "—" : device.unitID)
+                LabeledRow(label: "Firmware",
+                           value: device.firmwareVersion.isEmpty ? "(pre-#8 image)" : device.firmwareVersion,
+                           mono: true)
+                LabeledRow(label: "Connection", value: device.isConnected ? "Connected" : "Disconnected")
+            }
+
+            // ----- Picked-file summary -----
+            GroupBox("Firmware image") {
+                if let url = pickedFileURL {
+                    LabeledRow(label: "File", value: pickedFileName)
+                    LabeledRow(label: "Size", value: byteCountString(pickedFileSize))
+                    LabeledRow(label: "Path", value: url.lastPathComponent, mono: true)
+                } else {
+                    Text("No file selected")
+                        .foregroundColor(.secondary)
+                        .font(.subheadline)
+                }
+                Button(action: { showingFilePicker = true }) {
+                    HStack {
+                        Image(systemName: "doc.badge.plus")
+                        Text(pickedFileURL == nil ? "Choose .bin…" : "Choose a different file…")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .padding(.top, 4)
+                .disabled(isInProgress)
+            }
+
+            // ----- Action / status block -----
+            statusBlock
+
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .navigationTitle("Firmware update")
+        .navigationBarTitleDisplayMode(.inline)
+        .fileImporter(
+            isPresented: $showingFilePicker,
+            allowedContentTypes: [.data, UTType(filenameExtension: "bin") ?? .data],
+            allowsMultipleSelection: false
+        ) { result in
+            handleFileImport(result)
+        }
+    }
+
+    // MARK: - Action / status
+
+    @ViewBuilder
+    private var statusBlock: some View {
+        switch session.state {
+        case .idle:
+            Button(action: startFlash) {
+                HStack {
+                    Image(systemName: "arrow.up.circle.fill")
+                    Text("Flash \(device.displayName)")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(pickedFileURL == nil || !device.isConnected)
+
+        case .loading:
+            ProgressView("Reading file + computing SHA…")
+                .frame(maxWidth: .infinity)
+
+        case .uploading(let sent, let total):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Uploading…").font(.subheadline)
+                    Spacer()
+                    Text("\(byteCountString(sent)) / \(byteCountString(total))")
+                        .font(.caption.monospacedDigit())
+                        .foregroundColor(.secondary)
+                }
+                ProgressView(value: Double(sent), total: Double(total))
+                    .progressViewStyle(LinearProgressViewStyle())
+                cancelButton
+            }
+
+        case .verifying:
+            VStack(alignment: .leading, spacing: 8) {
+                ProgressView("Verifying SHA on device…")
+                cancelButton
+            }
+
+        case .rebooting:
+            VStack(alignment: .leading, spacing: 8) {
+                ProgressView("Device rebooting — waiting for reconnect (60 s)…")
+            }
+
+        case .verified(let newVersion):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "checkmark.seal.fill").foregroundColor(.green)
+                    Text("Updated successfully").font(.headline)
+                }
+                LabeledRow(label: "Previous", value: session.preFlashFirmwareVersion, mono: true)
+                LabeledRow(label: "Now running", value: newVersion, mono: true)
+            }
+
+        case .rollbackDetected(let version):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "arrow.uturn.backward.circle.fill").foregroundColor(.orange)
+                    Text("Rollback detected").font(.headline)
+                }
+                Text("Device reconnected but is still running the previous firmware (\(version)). The new image likely failed to boot — bootloader auto-reverted to the prior partition.")
+                    .font(.subheadline).foregroundColor(.secondary)
+            }
+
+        case .failed(let reason):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "xmark.octagon.fill").foregroundColor(.red)
+                    Text("Failed").font(.headline)
+                }
+                Text(reason).font(.subheadline).foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var cancelButton: some View {
+        Button(role: .destructive, action: { session.cancel() }) {
+            Text("Cancel")
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private var isInProgress: Bool {
+        switch session.state {
+        case .idle, .verified, .rollbackDetected, .failed: return false
+        default: return true
+        }
+    }
+
+    // MARK: - File picker
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            pickedFileURL = url
+            pickedFileName = url.lastPathComponent
+            // Size: peek with security-scoped access
+            let didOpen = url.startAccessingSecurityScopedResource()
+            defer { if didOpen { url.stopAccessingSecurityScopedResource() } }
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+               let size = attrs[.size] as? Int {
+                pickedFileSize = size
+            } else {
+                pickedFileSize = 0
+            }
+        case .failure(let error):
+            print("File picker error: \(error)")
+        }
+    }
+
+    private func startFlash() {
+        guard let url = pickedFileURL else { return }
+        session.start(fileURL: url)
+    }
+
+    private func byteCountString(_ bytes: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .binary)
+    }
+}
+
+private struct LabeledRow: View {
+    let label: String
+    let value: String
+    var mono: Bool = false
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(mono ? .body.monospaced() : .body)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 struct FirmwareUpdateView: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var fleet: BLEFleet
+
+    /// OTASession lives on BLEFleet (not BLEDevice) because BLEFleet
+    /// destroys+recreates BLEDevice on every BLE disconnect/reconnect —
+    /// including the post-OTA reboot cycle. Same pattern as #140's
+    /// lastValidRocketFixes. The fleet returns the same session instance
+    /// for this peripheral across reconnects, so the .verified result
+    /// survives the view being torn down + re-shown. See #15 second pass.
+    var body: some View {
+        FirmwareUpdateContent(device: device, session: fleet.otaSession(for: device))
+    }
+}
+
+private struct FirmwareUpdateContent: View {
+    @ObservedObject var device: BLEDevice
     @ObservedObject var session: OTASession
     @State private var showingFilePicker = false
     @State private var pickedFileURL: URL?
     @State private var pickedFileSize: Int = 0
     @State private var pickedFileName: String = ""
-
-    init(device: BLEDevice) {
-        // Pull the per-device OTA session off BLEDevice rather than spinning
-        // up a fresh one — it survives the device disconnect/reconnect that
-        // tears down this view, so the "verified" state is still visible when
-        // the user navigates back after the OTA reboot. See #15.
-        _device = ObservedObject(initialValue: device)
-        _session = ObservedObject(initialValue: device.otaSession)
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -225,6 +225,26 @@ struct SettingsView: View {
         }
 
         loRaSections
+
+        // Firmware update entry (#8 phase 2 — BS-gated; phase 3 removes the gate
+        // when the OC implementation lands).
+        Section(header: Text("Firmware")) {
+            HStack {
+                Text("Version")
+                Spacer()
+                Text(device.firmwareVersion.isEmpty ? "(pre-#8)" : device.firmwareVersion)
+                    .font(.body.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            NavigationLink {
+                FirmwareUpdateView(device: device)
+            } label: {
+                Label("Update firmware…", systemImage: "arrow.up.circle")
+            }
+            .disabled(!device.isConnected)
+        }
     }
 
     @ViewBuilder

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -18,6 +18,7 @@ import Combine
 
 struct SettingsView: View {
     @ObservedObject var device: BLEDevice
+    @EnvironmentObject var fleet: BLEFleet   // injected by DashboardView for FirmwareUpdateView → OTASession lookup
     @EnvironmentObject var store: RocketProfileStore
     @Environment(\.dismiss) var dismiss
 

--- a/docs/plans/08-ota-firmware-update.md
+++ b/docs/plans/08-ota-firmware-update.md
@@ -1,0 +1,350 @@
+# OTA firmware update via iOS app
+
+**Issue:** [#8](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/8)
+**Status:** Phase 1 — design. No firmware or iOS code lands in Phase 1.
+**Last updated:** 2026-05-28
+
+Enable over-the-air firmware updates for all three computers (Flight Computer, Out Computer, Base Station) directly from the iOS app over BLE. Today, every firmware change requires opening the rocket, plugging in USB-C, and running `idf.py flash` — fine on the bench, painful at the field.
+
+This document is the contract that Phases 2–4 implement against.
+
+## Phasing
+
+| Phase | Scope | Why this order |
+|---|---|---|
+| 1 | Design doc covering all three targets | Lock the protocol, partition layout, identity contract, and FC relay strategy before any code lands. |
+| 2 | Base Station implementation | BS is the lowest-risk target — handheld, easy USB recovery, not airborne. Shake the protocol down here first. |
+| 3 | Out Computer implementation | Same protocol, ported. Mostly mechanical once Phase 2 is solid. |
+| 4 | Flight Computer (relayed via OC) | Hardest. FC has no BLE; firmware must traverse OC → I2C/UART → FC. Depends on Phase 1 schematic finding (§7). |
+
+## Resolved design decisions
+
+| # | Decision |
+|---|---|
+| 1 | Partition layout: keep 3 MB app slots, add a second 3 MB `ota_1` slot. Drop SPIFFS entirely on OC and FC (never mounted in source today). BS keeps a 2 MB SPIFFS for SD-fallback logging. |
+| 2 | BLE transport: reuse the existing File Transfer characteristic (made writable from the central) for image chunks; reuse the existing Command characteristic with three new command codes (10/11/12) for control; reuse the existing File Operations characteristic for status replies. No new GATT characteristics. |
+| 3 | Integrity: full-image SHA-256 sent in `OTA_BEGIN`, verified by firmware before `esp_ota_set_boot_partition`. |
+| 4 | Rollback: enable `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`. Newly-booted firmware calls `esp_ota_mark_app_valid_cancel_rollback()` only after its first successful telemetry round-trip; anything earlier (panic, hang, BLE-stack init failure) auto-rolls back to `ota_0`. |
+| 5 | Identity: add `"fw"` field to the existing `config_identity` JSON. Format: `<git_short_sha>+<build_yyyymmdd-hhmm>`. iOS uses it for pre-flash display and post-reboot verification. |
+| 6 | iOS source for `.bin` files: native `.fileImporter` (Files / iCloud / AirDrop). No bundled-in-app firmware, no HTTPS distribution in v1. |
+| 7 | FC relay path (UART-bootloader vs. custom I2C OTA receiver): **TBD** — gated on a schematic check in Phase 1. See §7. |
+| 8 | Out of scope: secure boot v2 (separate hardening issue); HTTPS firmware distribution; OTA over LoRa; parallel multi-device flash. |
+
+---
+
+## 1. Partition layout
+
+All three boards are 8 MB. New `partitions.csv`:
+
+### Base Station
+
+```
+# Name,   Type, SubType, Offset,  Size
+nvs,      data, nvs,     0x9000,  0x5000
+otadata,  data, ota,     0xe000,  0x2000
+ota_0,    app,  ota_0,   0x10000, 0x300000
+ota_1,    app,  ota_1,   0x310000,0x300000
+spiffs,   data, spiffs,  0x610000,0x1F0000
+```
+
+Total ends at `0x800000` (8 MB). BS keeps 2 MB SPIFFS because [base_station/main/main.cpp:2676](../../tinkerrocket-idf/projects/base_station/main/main.cpp:2676) mounts it as an SD-card fallback log store; 2 MB is enough for an emergency log when no SD is present.
+
+### Out Computer
+
+```
+# Name,   Type, SubType, Offset,  Size
+nvs,      data, nvs,     0x9000,  0x5000
+otadata,  data, ota,     0xe000,  0x2000
+ota_0,    app,  ota_0,   0x10000, 0x300000
+ota_1,    app,  ota_1,   0x310000,0x300000
+coredump, data, coredump,0x610000,0x10000
+```
+
+Total ends at `0x620000` (6.125 MB used of 8 MB). SPIFFS removed — `grep` confirms OC never mounts a SPIFFS partition. Coredump partition retained. ~1.9 MB trailing space available for future partitions (e.g., dedicated OTA staging area for Phase 4 if NAND staging proves awkward).
+
+### Flight Computer
+
+```
+# Name,   Type, SubType, Offset,  Size
+nvs,      data, nvs,     0x9000,  0x5000
+otadata,  data, ota,     0xe000,  0x2000
+ota_0,    app,  ota_0,   0x10000, 0x300000
+ota_1,    app,  ota_1,   0x310000,0x300000
+```
+
+Total ends at `0x610000` (6.06 MB used of 8 MB). SPIFFS removed. ~2 MB trailing space available.
+
+### Headroom
+
+Current binaries (May 2026): BS = 763 KB, FC = 558 KB. The 3 MB app slot leaves ~4× headroom — sufficient for the medium-term feature roadmap. Revisit only if a single binary crosses ~2 MB.
+
+### NVS offset unchanged
+
+NVS stays at `0x9000` on every board, so existing NVS contents (unit name, network ID, rocket ID, mag-cal data, etc.) survive the partition-table change. No migration step needed.
+
+---
+
+## 2. BLE OTA protocol
+
+Reuses existing characteristics defined in [TR_BLE_To_APP.h:213](../../tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h):
+
+- **Service** `4fafc201-1fb5-459e-8fcc-c5c9c331914b` (unchanged)
+- **Command** `cba1d466-344c-4be3-ab3f-189f80dd7518` (write — extended with new command codes)
+- **File Operations** `8d53dc1d-1db7-4cd3-868b-8a527460aa84` (notify — extended with `ota_status` JSON replies)
+- **File Transfer** `1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d` (currently read+notify; extended to also be writable)
+
+### 2.1 Control commands (Command characteristic)
+
+| Code | Name | Payload | Firmware action |
+|------|------|---------|-----------------|
+| 10 | `OTA_BEGIN` | `[target:1][total_size:4 LE][sha256:32]` (37 bytes) | `esp_ota_begin()` on `ota_1`; reset SHA-256 state; notify `ota_status: ready` |
+| 11 | `OTA_FINISH` | none | Finalize SHA; compare to expected; if match: `esp_ota_set_boot_partition()` + schedule 500ms-deferred `esp_restart()`; if mismatch: `esp_ota_abort()`, notify `verify_failed` |
+| 12 | `OTA_ABORT` | none | `esp_ota_abort()`; clear state; notify `aborted` |
+
+`target` field in `OTA_BEGIN`:
+- `0` = app on this device (BS or OC self-update; Phase 2 and Phase 3)
+- `1` = Flight Computer relay (OC only; Phase 4)
+
+A new `OTA_BEGIN` while a session is already active aborts the prior session first.
+
+### 2.2 Image stream (File Transfer characteristic)
+
+Today this characteristic is read+notify (device → phone). For OTA we add the **write** property (`BLE_GATT_CHR_F_WRITE`) so the phone can stream chunks in.
+
+Per-chunk write payload — **identical framing to the existing download direction**:
+
+```
+[offset:4 LE][length:2 LE][flags:1][data:length]
+```
+
+`flags` bit 0 = EOF marker (set on the final chunk).
+
+The phone writes with response (`writeValue(_:for:type: .withResponse)`) — the BLE stack's per-write callback gives delivery acknowledgment. On callback failure the phone retries the same chunk. No application-layer per-chunk ACK protocol is needed.
+
+Chunk size matches the existing download path: `MTU - 10` bytes of payload (so ~502 B at 512 MTU, ~175 B at 185 MTU).
+
+### 2.3 Status replies (File Operations characteristic)
+
+Firmware notifies JSON status as state changes. All replies use the `"type":"ota_status"` discriminator (existing convention — peer-existing types include `config_identity`, `config_rocket`, etc.).
+
+```json
+{"type":"ota_status","state":"ready","slot":1}
+{"type":"ota_status","state":"writing","bytes":131072}
+{"type":"ota_status","state":"verify_failed","err":"sha_mismatch"}
+{"type":"ota_status","state":"verify_failed","err":"write_failed"}
+{"type":"ota_status","state":"aborted"}
+{"type":"ota_status","state":"ready_to_boot","fw":"abc1234+20260601-1430"}
+```
+
+`writing` is rate-limited to ≤ 2 Hz to avoid drowning the notify queue mid-flash.
+
+Each JSON message must stay under `MTU - 3` bytes — already enforced for the existing config JSONs by the guard at [TR_BLE_To_APP.cpp:800](../../tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp:800). All `ota_status` messages above fit easily within 185-byte MTU.
+
+### 2.4 Session lifecycle (happy path)
+
+```
+phone                                            device
+  │  OTA_BEGIN(target, size, sha256)               │
+  │ ────────────────────────────────────────────►  │  esp_ota_begin(ota_1)
+  │  ◄──────────────  {state:"ready"}              │
+  │                                                │
+  │  chunk[0..N]   (FileTransfer write)            │
+  │ ────────────►                                  │  esp_ota_write
+  │  ◄────────────  {state:"writing", bytes:…}     │  (throttled to 2 Hz)
+  │                          …                     │
+  │  chunk[N], EOF flag set                        │
+  │ ────────────►                                  │
+  │                                                │
+  │  OTA_FINISH                                    │
+  │ ────────────────────────────────────────────►  │  SHA verify, set_boot_partition
+  │  ◄────────────  {state:"ready_to_boot", fw:…}  │
+  │                                                │  esp_restart() after 500 ms
+  │  (BLE disconnect)                              │
+  │  reconnect → read identity → compare fw        │
+```
+
+### 2.5 Error paths
+
+| Trigger | Firmware response | Phone reaction |
+|---|---|---|
+| SHA mismatch in `OTA_FINISH` | `verify_failed`, `esp_ota_abort`, no boot change | Surface error, allow retry from picker |
+| Out-of-order or out-of-range chunk offset | `verify_failed: bad_offset`, `esp_ota_abort` | Treat as fatal; abort + restart from scratch |
+| Phone-side disconnect mid-stream | (device times out after 30s of no chunks, calls `esp_ota_abort`) | On reconnect, send `OTA_ABORT` defensively then start fresh |
+| Power loss mid-flash | (no change — `ota_1` is half-written but unused; bootloader still boots `ota_0`) | Restart OTA from scratch |
+| `OTA_BEGIN` while a session is active | `esp_ota_abort` prior session, start new | (initiated by phone; phone considers prior session lost) |
+
+### 2.6 Throughput estimate
+
+At 502 B chunks and ~15 ms between write-with-response acks (BLE 4.2 typical):
+- 800 KB BS binary → ~24 s
+- 1.5 MB worst-case → ~45 s
+- 3 MB hypothetical → ~90 s
+
+Acceptable for a manual-trigger workflow. If Phase 4's relayed FC OTA over I2C proves too slow, revisit with L2CAP CoC.
+
+---
+
+## 3. Identity / version contract
+
+Add `"fw"` field to the existing `config_identity` JSON, built at [out_computer/main/main.cpp:2058](../../tinkerrocket-idf/projects/out_computer/main/main.cpp:2058) and the analogous BS / FC spots.
+
+Format: `<git_short_sha>+<build_yyyymmdd-hhmm>`, e.g. `"fw":"dce9599+20260527-2103"`.
+
+Source — compile-time macro injected by each project's `CMakeLists.txt`:
+
+```cmake
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    OUTPUT_VARIABLE TR_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M")
+add_compile_definitions(TR_FW_VERSION="${TR_GIT_SHA}+${TR_BUILD_DATE}")
+```
+
+JSON change:
+
+```c
+snprintf(id_buf, sizeof(id_buf),
+         "{\"type\":\"config_identity\""
+         ",\"uid\":\"%s\""
+         ",\"un\":\"%s\""
+         ",\"nid\":%u"
+         ",\"rid\":%u"
+         ",\"dt\":\"%s\""
+         ",\"fw\":\"%s\"}",
+         unit_id_hex, unit_name,
+         (unsigned)network_id, (unsigned)rocket_id,
+         config::DEVICE_TYPE, TR_FW_VERSION);
+```
+
+Size impact: ~30 bytes per identity payload. Stays well under any MTU (per [feedback_ble_json_size.md](../../../.claude/projects/-Users-christianpedersen-Documents-Hobbies-ModelRockets-Code/memory/feedback_ble_json_size.md)).
+
+The 13-character `<sha>+<date>` form is also short enough to display verbatim in iOS UI.
+
+---
+
+## 4. Rollback safety
+
+Enable `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` in all three sdkconfig defaults.
+
+Sequence:
+
+1. Phone sends `OTA_BEGIN` → chunks → `OTA_FINISH`.
+2. Firmware verifies SHA, calls `esp_ota_set_boot_partition(ota_1)`, schedules `esp_restart()` 500 ms later (lets the final `ready_to_boot` status notification flush).
+3. On reboot, bootloader sees `ota_1` is marked `PENDING_VERIFY` in `otadata`; boots it.
+4. New firmware comes up. BLE stack starts. First client connects, requests identity, identity sent successfully.
+5. **Only then** does firmware call `esp_ota_mark_app_valid_cancel_rollback()`. Image becomes permanent.
+6. If any step in (4) fails — panic in startup, BLE stack init failure, hang — device reboots. Bootloader sees `PENDING_VERIFY` still set, automatically rolls back to `ota_0`.
+
+The "first client round-trip" gate is deliberately strong: it proves not just that the firmware boots, but that BLE + identity-builder are intact. The user reconnecting and seeing the *old* firmware version signals rollback occurred.
+
+### Migration for boards on single-slot factory image
+
+Today's deployed boards run a single `app0/ota_0` image without an `ota_1` partition. After the new partition table is flashed (via USB once), the first OTA-installed image bootstraps the dual-slot contract. NVS offset stays at `0x9000`, so unit name / network ID / mag-cal data survive. No data migration code needed.
+
+---
+
+## 5. iOS UI
+
+New `FirmwareUpdateView` reachable from each device's settings screen.
+
+- **File picker**: `.fileImporter(allowedContentTypes: [.data])`. On selection, validate by extension (`.bin`) and parse first 256 bytes for an ESP32 app header magic byte (0xE9). Read entire file into memory (worst case ~3 MB — fine on iOS).
+- **Pre-flash display**: file name, file size, computed SHA-256 of file, current device `firmwareVersion`. "Flash <device name>" button (disabled if not connected).
+- **Flash state machine** (`OTASession` class):
+
+  ```
+  idle → uploading → verifying → rebooting → reconnecting → verified
+                          │           │            │             │
+                          └───────────┴────────────┴─► failed (with error)
+                                                  └─► rollback_detected
+  ```
+
+- **Progress UI**: mirrors the existing `FileManagerView` linear progress bar at [FileManagerView.swift:63](../../TinkerRocketApp/Views/FileManagerView.swift:63). Show % + bytes-of-bytes + estimated remaining time.
+- **Reconnect timeout**: 60 s. Beyond that, surface "Device did not reconnect — try power-cycling and re-pairing." (Recovery is via USB.)
+- **Version verification**: on reconnect, read `config_identity`. If `fw` matches the expected (computed from the firmware file's git-sha header, or asked at pick-time — TBD in Phase 2), show "Updated to <version>". If it matches the pre-flash version, show "Rollback detected — flash did not take, device is on old firmware."
+- **Cancel button**: maps to `OTA_ABORT` cmd 12. Returns to file-picker state.
+
+### Targeting
+
+Initial Phase 2 implementation gates `FirmwareUpdateView` on `device.isBaseStation`. Phase 3 removes the gate. Phase 4 adds a "target" picker (this device / Flight Computer) when the connected device is an OC.
+
+---
+
+## 6. Rollback safety vs. secure boot
+
+This design does *not* enable secure boot v2 / signed images. Anyone with physical USB access can flash arbitrary firmware. That's an intentional v1 tradeoff:
+
+- Secure boot v2 requires burning eFuses — irreversible. We're not ready to commit to a signing key custody policy yet.
+- The threat model for a hobbyist rocket is "I might brick it", not "an adversary will field-flash malicious firmware".
+- Adding secure boot later is a separate hardening pass with its own ergonomics work (signing tool in CI, key rotation policy, USB-flash disabled).
+
+Tracked as a follow-up; not blocking this issue.
+
+---
+
+## 7. Flight Computer relay strategy (Phase 4 — TBD)
+
+The FC has no BLE radio. Reaching it requires the iOS app → OC over BLE → OC → FC. Two viable paths; Phase 1 must pick one based on a schematic check.
+
+### Option A — UART bootloader path
+
+OC pulls FC's reset + IO0 lines low+high in the right sequence, then streams the firmware binary into FC's ROM bootloader using the standard `esptool` SLIP protocol (an OC-side mini-`esptool` C implementation).
+
+- **Pros**: Fast (~30 s for 600 KB at 460800 baud). Well-trodden upstream protocol. No FC-side firmware changes — the ROM bootloader is always available.
+- **Cons**: Requires UART + reset + IO0 lines wired between OC and FC. Existing link is I2C-only.
+- **Blocker**: schematic + PCB inspection. Must confirm OC has free UART pins and that reset/IO0 are accessible on FC.
+
+### Option B — Custom FC-side OTA receiver
+
+FC firmware runs a perpetual I2C-driven OTA receiver in a low-priority task. OC forwards chunks from the iOS app over I2C using the existing `WireFormat.h` framing (extended with new `OTA_*` message types).
+
+- **Pros**: Zero hardware changes. Works with current PCB.
+- **Cons**: Slow — at I2C 400 kHz with framing overhead, throughput is ~30 KB/s, so 600 KB ≈ 20 minutes. FC must explicitly cooperate (no recovery if FC firmware itself is broken).
+- **Fallback if it ever bricks**: USB reflash, same as today.
+
+### Phase 1 follow-up task
+
+Inspect the OC↔FC PCB. If UART + reset + IO0 are wired, commit to Option A. If not, commit to Option B. Update this section with the chosen path before Phase 4 begins.
+
+(Phase 1 does not write code for either path. Just settles the choice.)
+
+---
+
+## 8. Verification per phase
+
+### Phase 1 (this doc)
+
+- Read-through with maintainer. Adjust per feedback.
+- One-off schematic check on the OC↔FC link (§7); record finding here.
+
+### Phase 2 (BS implementation)
+
+1. `idf.py fullclean && idf.py build` on `base_station/` — confirm binary still fits in 3 MB slot. (Per [feedback_idf_fullclean_when_suspect.md](../../../.claude/projects/-Users-christianpedersen-Documents-Hobbies-ModelRockets-Code/memory/feedback_idf_fullclean_when_suspect.md): always `fullclean` when partition table changes.)
+2. `idf.py partition-table` — confirm new layout parses.
+3. `idf.py flash monitor` — clean boot; BLE up; identity JSON includes `"fw"` field; SPIFFS fallback still works when SD is absent.
+4. Push a known-good firmware via a small Python `bleak` script (faster iteration than iOS for protocol debugging): observe `esp_restart`, reconnect, confirm identity `fw` matches.
+5. Negative tests:
+   - Corrupt one chunk → `verify_failed: sha_mismatch` → no flash damage.
+   - Disconnect mid-upload → next session starts cleanly.
+   - Power loss mid-flash → `otadata` keeps booting `ota_0`.
+6. Rollback test: install a deliberately broken image (panic in `app_main` after 5 s). One panic → automatic rollback to `ota_0`. BLE comes back on old firmware.
+7. iOS end-to-end on a physical iPhone: build firmware → AirDrop bin to phone → pick in app → watch flash → reconnect → confirm new `fw` shown.
+
+### Phase 3 (OC implementation)
+
+Same matrix as Phase 2, on OC. Additionally: smoke-test the I2C command-forward link to FC (existing app→FC commands like servo config, sim start should be unaffected).
+
+### Phase 4 (FC relay)
+
+Defined when we get there. Depends on §7 outcome.
+
+---
+
+## 9. Out of scope (explicit)
+
+- Secure boot v2 / signed images (separate hardening issue)
+- HTTPS firmware distribution from a release server
+- OTA over LoRa
+- Parallel multi-device flash (one device at a time)
+- A/B-test framework for trying experimental firmware (just use git branches)

--- a/docs/plans/08-ota-firmware-update.md
+++ b/docs/plans/08-ota-firmware-update.md
@@ -15,7 +15,7 @@ This document is the contract that Phases 2–4 implement against.
 | 1 | Design doc covering all three targets | Lock the protocol, partition layout, identity contract, and FC relay strategy before any code lands. |
 | 2 | Base Station implementation | BS is the lowest-risk target — handheld, easy USB recovery, not airborne. Shake the protocol down here first. |
 | 3 | Out Computer implementation | Same protocol, ported. Mostly mechanical once Phase 2 is solid. |
-| 4 | Flight Computer (relayed via OC) | Hardest. FC has no BLE; firmware must traverse OC → I2C/UART → FC. Depends on Phase 1 schematic finding (§7). |
+| 4 | Flight Computer (relayed via OC) | Hardest. FC has no BLE; firmware must traverse OC → existing OC↔FC wires → FC. See §7 for the chosen split-bus design. |
 
 ## Resolved design decisions
 
@@ -27,7 +27,7 @@ This document is the contract that Phases 2–4 implement against.
 | 4 | Rollback: enable `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`. Newly-booted firmware calls `esp_ota_mark_app_valid_cancel_rollback()` only after its first successful telemetry round-trip; anything earlier (panic, hang, BLE-stack init failure) auto-rolls back to `ota_0`. |
 | 5 | Identity: add `"fw"` field to the existing `config_identity` JSON. Format: `<git_short_sha>+<build_yyyymmdd-hhmm>`. iOS uses it for pre-flash display and post-reboot verification. |
 | 6 | iOS source for `.bin` files: native `.fileImporter` (Files / iCloud / AirDrop). No bundled-in-app firmware, no HTTPS distribution in v1. |
-| 7 | FC relay path (UART-bootloader vs. custom I2C OTA receiver): **TBD** — gated on a schematic check in Phase 1. See §7. |
+| 7 | FC relay path: cooperative FC-side OTA using the existing 5 wires — I2C (control plane) + I2S reconfigured OC→FC at high BCLK (data plane). FC pauses sensor operations during the transfer window. See §7. |
 | 8 | Out of scope: secure boot v2 (separate hardening issue); HTTPS firmware distribution; OTA over LoRa; parallel multi-device flash. |
 
 ---
@@ -180,7 +180,7 @@ At 502 B chunks and ~15 ms between write-with-response acks (BLE 4.2 typical):
 - 1.5 MB worst-case → ~45 s
 - 3 MB hypothetical → ~90 s
 
-Acceptable for a manual-trigger workflow. If Phase 4's relayed FC OTA over I2C proves too slow, revisit with L2CAP CoC.
+Acceptable for a manual-trigger workflow. Phase 4's FC relay uses a faster path (high-speed I2S between OC and FC — see §7), so the OC↔FC leg is not the bottleneck even with the BLE leg in front of it.
 
 ---
 
@@ -283,31 +283,58 @@ Tracked as a follow-up; not blocking this issue.
 
 ---
 
-## 7. Flight Computer relay strategy (Phase 4 — TBD)
+## 7. Flight Computer relay strategy (Phase 4)
 
-The FC has no BLE radio. Reaching it requires the iOS app → OC over BLE → OC → FC. Two viable paths; Phase 1 must pick one based on a schematic check.
+The FC has no BLE radio. Reaching it requires iOS → BLE → OC → wires → FC. The OC↔FC interface is 5 GPIOs split across two buses, both already in active use:
 
-### Option A — UART bootloader path
+| Wires | Bus | Today's role | Rate |
+|---|---|---|---|
+| FC 23 / 27 / 28 | **I2S** (DOUT / BCLK / WS) | FC → OC high-frequency telemetry stream | 22 050 sample/s × 4 B ≈ 88 KB/s |
+| FC 41 / 42 | **I2C** (SDA / SCL) | OC ↔ FC command/config | 400 kHz |
 
-OC pulls FC's reset + IO0 lines low+high in the right sequence, then streams the firmware binary into FC's ROM bootloader using the standard `esptool` SLIP protocol (an OC-side mini-`esptool` C implementation).
+There is **no hardware reset or IO0 line** between OC and FC, so the ESP32 ROM bootloader path (`esptool` SLIP over UART) is not on the table without a hardware change. Whatever we ship must be cooperative — the FC firmware itself receives the new image and writes it to `ota_1`.
 
-- **Pros**: Fast (~30 s for 600 KB at 460800 baud). Well-trodden upstream protocol. No FC-side firmware changes — the ROM bootloader is always available.
-- **Cons**: Requires UART + reset + IO0 lines wired between OC and FC. Existing link is I2C-only.
-- **Blocker**: schematic + PCB inspection. Must confirm OC has free UART pins and that reset/IO0 are accessible on FC.
+### Chosen design — split-bus cooperative OTA
 
-### Option B — Custom FC-side OTA receiver
+Use both buses, each for what it's best at, mirroring the BLE-side split:
 
-FC firmware runs a perpetual I2C-driven OTA receiver in a low-priority task. OC forwards chunks from the iOS app over I2C using the existing `WireFormat.h` framing (extended with new `OTA_*` message types).
+| Plane | Bus | Direction | Carries |
+|---|---|---|---|
+| **Control** | I2C (41/42) | bidirectional | `OTA_BEGIN(target=1, size, sha256)`, `OTA_FINISH`, `OTA_ABORT`, and `ota_status` reply frames. Reuses the existing `WireFormat.h` SOF/type/len/payload/CRC framing — new message types added. |
+| **Data** | I2S (23/27/28), reconfigured | OC → FC | Image chunks. OC becomes I2S master TX, FC becomes I2S slave RX (direction reversed from normal). BCLK cranked up well past the audio-rate default. |
 
-- **Pros**: Zero hardware changes. Works with current PCB.
-- **Cons**: Slow — at I2C 400 kHz with framing overhead, throughput is ~30 KB/s, so 600 KB ≈ 20 minutes. FC must explicitly cooperate (no recovery if FC firmware itself is broken).
-- **Fallback if it ever bricks**: USB reflash, same as today.
+**Why this rather than I2C-only**: I2C at 400 kHz tops out around 30 KB/s after framing overhead, so a 600 KB FC image would take ~20 minutes. I2S can run BCLK in the multi-MHz range; even a modest 2.5 MHz BCLK on 16-bit stereo slots gives 10 Mbps raw ≈ 1.25 MB/s effective. A 600 KB image transfers in under a second of wall time; flash erase + write dominates total OTA time (~5-10 s including the I2C handshake and SHA verify).
 
-### Phase 1 follow-up task
+**Why this rather than reconfiguring I2S pins to SPI**: We'd gain nothing material — I2S with DMA already drives the same physical pins at comparable rates, and we already have a working component (`TR_I2S_Stream`) that handles channel setup, DMA, and framing. SPI would mean writing a new slave-side ring buffer driver for no throughput win.
 
-Inspect the OC↔FC PCB. If UART + reset + IO0 are wired, commit to Option A. If not, commit to Option B. Update this section with the chosen path before Phase 4 begins.
+### Operating sequence
 
-(Phase 1 does not write code for either path. Just settles the choice.)
+1. iOS → BLE → OC: `OTA_BEGIN(target=1, size, sha256)` arrives.
+2. OC sends `OTA_BEGIN` to FC over I2C. FC pauses sensor reads and its I2S TX stream.
+3. Both sides tear down the I2S channel and re-init it with **OC = master TX, FC = slave RX**, at the higher OTA BCLK. The TR_I2S_Stream component grows a `beginMasterTx`/`beginSlaveRx` variant pair for this — most of the channel/DMA setup is already there.
+4. OC streams the image as raw bytes over the I2S data line; FC's `i2s_recv_cb_t` callback hands buffers to an `OTAReceiver` instance (same component as Phases 2/3) which calls `esp_ota_write` and updates the running SHA-256.
+5. OC sends `OTA_FINISH` over I2C. FC finalizes SHA, compares, calls `esp_ota_set_boot_partition(ota_1)`, replies `ready_to_boot` over I2C, then reboots.
+6. After FC reboot, the I2S channel is torn down + reverted to normal direction (FC = master TX) by both sides. Sensor stream resumes.
+7. The same `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE` contract from §4 applies on the FC: the new image marks itself valid only after publishing its first I2S frame back to OC.
+
+### Rollback signal
+
+FC has no direct phone-home path. The OC observes a watchdog window after the FC reboot — if FC doesn't resume I2S TX within (say) 10 s, OC notifies the phone over BLE as `{state:"verify_failed","err":"fc_no_resume"}`. The bootloader will already have auto-rolled back to `ota_0`; the FC will then come up on its previous firmware and the I2S stream resumes shortly after. OC reports the actual `fw` it observes from the FC's next `config_identity` response (relayed up over BLE).
+
+### Pin assignment confirmed (no schematic check needed)
+
+The original §7 listed "schematic check" as a Phase 1 follow-up. That's resolved: pin map is confirmed from [flight_computer/main/config.h:287-296](../../tinkerrocket-idf/projects/flight_computer/main/config.h:287). No additional hardware reset lines exist; the cooperative design above is the path.
+
+### Phase 4 dependencies / things to settle when we get there
+
+- **Maximum I2S BCLK** achievable between OC (ESP32-S3) and FC (ESP32-P4) over the existing PCB traces — bench-measure during Phase 4 bringup, back off if signal integrity is marginal. Doc target: 2.5 MHz, allow up to 10 MHz if traces handle it.
+- **FC OTA mode entry** — how does FC firmware know to drop into OTA mode? Options:
+  - Reactive: OTA_BEGIN over I2C interrupts sensor loop on a dedicated low-priority task.
+  - Pre-armed: phone sends an "arm OTA" command earlier, FC enters a quieter mode, then OTA_BEGIN proceeds.
+  - Default to reactive unless bench testing shows I2S-driver-teardown-while-running is unsafe.
+- **Failure to enter OTA mode** — what if FC is unresponsive over I2C at OTA_BEGIN time? OC times out, phone surfaces "FC didn't acknowledge — recover via USB."
+
+These are Phase 4 specifics, not Phase 1 design decisions.
 
 ---
 
@@ -316,7 +343,6 @@ Inspect the OC↔FC PCB. If UART + reset + IO0 are wired, commit to Option A. If
 ### Phase 1 (this doc)
 
 - Read-through with maintainer. Adjust per feedback.
-- One-off schematic check on the OC↔FC link (§7); record finding here.
 
 ### Phase 2 (BS implementation)
 

--- a/docs/plans/08-ota-firmware-update.md
+++ b/docs/plans/08-ota-firmware-update.md
@@ -22,7 +22,7 @@ This document is the contract that Phases 2–4 implement against.
 | # | Decision |
 |---|---|
 | 1 | Partition layout: keep 3 MB app slots, add a second 3 MB `ota_1` slot. Drop SPIFFS entirely on OC and FC (never mounted in source today). BS keeps a 2 MB SPIFFS for SD-fallback logging. |
-| 2 | BLE transport: reuse the existing File Transfer characteristic (made writable from the central) for image chunks; reuse the existing Command characteristic with three new command codes (10/11/12) for control; reuse the existing File Operations characteristic for status replies. No new GATT characteristics. |
+| 2 | BLE transport: reuse the existing File Transfer characteristic (made writable from the central) for image chunks; reuse the existing Command characteristic with three new command codes (70/71/72) for control; reuse the existing File Operations characteristic for status replies. No new GATT characteristics. |
 | 3 | Integrity: full-image SHA-256 sent in `OTA_BEGIN`, verified by firmware before `esp_ota_set_boot_partition`. |
 | 4 | Rollback: enable `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`. Newly-booted firmware calls `esp_ota_mark_app_valid_cancel_rollback()` only after its first successful telemetry round-trip; anything earlier (panic, hang, BLE-stack init failure) auto-rolls back to `ota_0`. |
 | 5 | Identity: add `"fw"` field to the existing `config_identity` JSON. Format: `<git_short_sha>+<build_yyyymmdd-hhmm>`. iOS uses it for pre-flash display and post-reboot verification. |
@@ -97,9 +97,11 @@ Reuses existing characteristics defined in [TR_BLE_To_APP.h:213](../../tinkerroc
 
 | Code | Name | Payload | Firmware action |
 |------|------|---------|-----------------|
-| 10 | `OTA_BEGIN` | `[target:1][total_size:4 LE][sha256:32]` (37 bytes) | `esp_ota_begin()` on `ota_1`; reset SHA-256 state; notify `ota_status: ready` |
-| 11 | `OTA_FINISH` | none | Finalize SHA; compare to expected; if match: `esp_ota_set_boot_partition()` + schedule 500ms-deferred `esp_restart()`; if mismatch: `esp_ota_abort()`, notify `verify_failed` |
-| 12 | `OTA_ABORT` | none | `esp_ota_abort()`; clear state; notify `aborted` |
+| 70 | `OTA_BEGIN` | `[target:1][total_size:4 LE][sha256:32]` (37 bytes) | `esp_ota_begin()` on `ota_1`; reset SHA-256 state; notify `ota_status: ready` |
+| 71 | `OTA_FINISH` | none | Finalize SHA; compare to expected; if match: `esp_ota_set_boot_partition()` + schedule 500ms-deferred `esp_restart()`; if mismatch: `esp_ota_abort()`, notify `verify_failed` |
+| 72 | `OTA_ABORT` | none | `esp_ota_abort()`; clear state; notify `aborted` |
+
+(Codes 70/71/72 picked to clear the existing 1-60 range used for LoRa/servo/PID/etc. command dispatch in main.cpp. The originally-proposed 10/11/12 collided with `sendLoRaConfig` and friends; corrected before any code shipped.)
 
 `target` field in `OTA_BEGIN`:
 - `0` = app on this device (BS or OC self-update; Phase 2 and Phase 3)
@@ -263,7 +265,7 @@ New `FirmwareUpdateView` reachable from each device's settings screen.
 - **Progress UI**: mirrors the existing `FileManagerView` linear progress bar at [FileManagerView.swift:63](../../TinkerRocketApp/Views/FileManagerView.swift:63). Show % + bytes-of-bytes + estimated remaining time.
 - **Reconnect timeout**: 60 s. Beyond that, surface "Device did not reconnect — try power-cycling and re-pairing." (Recovery is via USB.)
 - **Version verification**: on reconnect, read `config_identity`. If `fw` matches the expected (computed from the firmware file's git-sha header, or asked at pick-time — TBD in Phase 2), show "Updated to <version>". If it matches the pre-flash version, show "Rollback detected — flash did not take, device is on old firmware."
-- **Cancel button**: maps to `OTA_ABORT` cmd 12. Returns to file-picker state.
+- **Cancel button**: maps to `OTA_ABORT` cmd 72. Returns to file-picker state.
 
 ### Targeting
 

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(tinkerrocket_tests CXX)
+project(tinkerrocket_tests C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -200,6 +200,25 @@ target_include_directories(test_tr_flightlog_core PRIVATE
 )
 target_link_libraries(test_tr_flightlog_core GTest::gtest_main)
 gtest_discover_tests(test_tr_flightlog_core)
+
+# ---------- test_tr_ota (#8 phase 2) ----------
+# Host coverage for TR_OTA_Receiver: state machine, offset/size validation,
+# SHA-256 verification, callback fan-out. Real esp_ota_* is replaced with
+# FakeOTABackend (tests_cpp/fakes/) and mbedtls/sha256 is replaced with the
+# portable shim in host_shim/.
+add_executable(test_tr_ota
+    test_tr_ota.cpp
+    ${LIB_DIR}/TR_OTA/TR_OTA_Receiver.cpp
+    ${SHIM_DIR}/sha256_impl.c
+)
+target_include_directories(test_tr_ota PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_OTA/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/fakes
+)
+target_link_libraries(test_tr_ota GTest::gtest_main)
+gtest_discover_tests(test_tr_ota)
 
 # ---------- test_bs_log_policy ----------
 # Host-side test for the base-station LoRa CSV logging policy helpers

--- a/tests_cpp/fakes/fake_ota_backend.h
+++ b/tests_cpp/fakes/fake_ota_backend.h
@@ -1,0 +1,79 @@
+// Fake TR_OTA_Backend for host tests. Tracks bytes written + lets tests
+// inject failures into individual backend methods.
+#ifndef FAKE_OTA_BACKEND_H
+#define FAKE_OTA_BACKEND_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "TR_OTA_Backend.h"
+
+class FakeOTABackend : public TR_OTA_Backend
+{
+public:
+    // ---- failure injection (set non-zero to make the corresponding call fail) ----
+    int begin_rc           = 0;
+    int write_rc           = 0;
+    int end_rc             = 0;
+    int set_boot_rc        = 0;
+    bool fail_write_after_n = false;   // if true, write returns -100 after `write_fail_threshold` bytes
+    size_t write_fail_threshold = 0;
+
+    // ---- observable state ----
+    bool   active = false;
+    size_t total_size = 0;
+    size_t bytes_written = 0;
+    bool   boot_set = false;
+    bool   aborted_once = false;
+    bool   ended_once = false;
+    int    begin_calls = 0;
+    int    abort_calls = 0;
+    std::vector<uint8_t> bytes;   // exactly the data passed through write()
+
+    int begin(size_t image_size) override
+    {
+        ++begin_calls;
+        if (begin_rc != 0) return begin_rc;
+        active = true;
+        total_size = image_size;
+        bytes_written = 0;
+        bytes.clear();
+        bytes.reserve(image_size);
+        return 0;
+    }
+
+    int write(const uint8_t* data, size_t len) override
+    {
+        if (write_rc != 0) return write_rc;
+        if (fail_write_after_n && bytes_written + len > write_fail_threshold) return -100;
+        if (!active) return -1;
+        bytes.insert(bytes.end(), data, data + len);
+        bytes_written += len;
+        return 0;
+    }
+
+    int end() override
+    {
+        ended_once = true;
+        if (end_rc != 0) { active = false; return end_rc; }
+        active = false;
+        return 0;
+    }
+
+    int setBootPartition() override
+    {
+        if (set_boot_rc != 0) return set_boot_rc;
+        boot_set = true;
+        return 0;
+    }
+
+    void abort() override
+    {
+        ++abort_calls;
+        aborted_once = true;
+        active = false;
+    }
+};
+
+#endif  // FAKE_OTA_BACKEND_H

--- a/tests_cpp/host_shim/mbedtls/sha256.h
+++ b/tests_cpp/host_shim/mbedtls/sha256.h
@@ -1,0 +1,33 @@
+// Host-side mbedtls/sha256.h shim. Mirrors the subset of the real mbedtls
+// API used by TR_OTA_Receiver so the production source compiles unchanged
+// on the host. Implementation is a small portable SHA-256 (sha256_impl.c).
+#ifndef HOST_SHIM_MBEDTLS_SHA256_H
+#define HOST_SHIM_MBEDTLS_SHA256_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t state[8];
+    uint64_t bit_count;
+    uint8_t  buf[64];
+    size_t   buf_len;
+} mbedtls_sha256_context;
+
+void mbedtls_sha256_init(mbedtls_sha256_context* ctx);
+void mbedtls_sha256_free(mbedtls_sha256_context* ctx);
+int  mbedtls_sha256_starts(mbedtls_sha256_context* ctx, int is224);
+int  mbedtls_sha256_update(mbedtls_sha256_context* ctx,
+                           const unsigned char* input, size_t ilen);
+int  mbedtls_sha256_finish(mbedtls_sha256_context* ctx,
+                           unsigned char output[32]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HOST_SHIM_MBEDTLS_SHA256_H

--- a/tests_cpp/host_shim/sha256_impl.c
+++ b/tests_cpp/host_shim/sha256_impl.c
@@ -1,0 +1,133 @@
+// Portable SHA-256 implementation backing the mbedtls/sha256.h host shim.
+// Derived from FIPS 180-4 reference; public-domain style. Used only by host
+// unit tests; ESP-IDF builds use the real mbedtls (with HW acceleration on
+// ESP32-S3 / ESP32-P4).
+#include "mbedtls/sha256.h"
+
+#include <string.h>
+
+static const uint32_t K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+static const uint32_t H0[8] = {
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+};
+
+static uint32_t rotr(uint32_t x, unsigned n) { return (x >> n) | (x << (32 - n)); }
+
+static void compress(uint32_t state[8], const uint8_t block[64])
+{
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i) {
+        w[i] = ((uint32_t)block[i*4] << 24) | ((uint32_t)block[i*4+1] << 16) |
+               ((uint32_t)block[i*4+2] << 8)  | ((uint32_t)block[i*4+3]);
+    }
+    for (int i = 16; i < 64; ++i) {
+        uint32_t s0 = rotr(w[i-15], 7) ^ rotr(w[i-15], 18) ^ (w[i-15] >> 3);
+        uint32_t s1 = rotr(w[i-2], 17) ^ rotr(w[i-2], 19) ^ (w[i-2] >> 10);
+        w[i] = w[i-16] + s0 + w[i-7] + s1;
+    }
+
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+    for (int i = 0; i < 64; ++i) {
+        uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        uint32_t ch = (e & f) ^ (~e & g);
+        uint32_t t1 = h + S1 + ch + K[i] + w[i];
+        uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        uint32_t mj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t t2 = S0 + mj;
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+
+    state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+    state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+}
+
+void mbedtls_sha256_init(mbedtls_sha256_context* ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+void mbedtls_sha256_free(mbedtls_sha256_context* ctx)
+{
+    if (ctx) memset(ctx, 0, sizeof(*ctx));
+}
+
+int mbedtls_sha256_starts(mbedtls_sha256_context* ctx, int is224)
+{
+    (void)is224;  // shim only supports SHA-256
+    memcpy(ctx->state, H0, sizeof(H0));
+    ctx->bit_count = 0;
+    ctx->buf_len = 0;
+    return 0;
+}
+
+int mbedtls_sha256_update(mbedtls_sha256_context* ctx,
+                           const unsigned char* input, size_t ilen)
+{
+    ctx->bit_count += (uint64_t)ilen * 8;
+
+    // Drain any pending buffered partial block
+    if (ctx->buf_len > 0) {
+        size_t take = 64 - ctx->buf_len;
+        if (take > ilen) take = ilen;
+        memcpy(ctx->buf + ctx->buf_len, input, take);
+        ctx->buf_len += take;
+        input += take;
+        ilen  -= take;
+        if (ctx->buf_len == 64) {
+            compress(ctx->state, ctx->buf);
+            ctx->buf_len = 0;
+        }
+    }
+
+    while (ilen >= 64) {
+        compress(ctx->state, input);
+        input += 64;
+        ilen  -= 64;
+    }
+
+    if (ilen > 0) {
+        memcpy(ctx->buf, input, ilen);
+        ctx->buf_len = ilen;
+    }
+    return 0;
+}
+
+int mbedtls_sha256_finish(mbedtls_sha256_context* ctx, unsigned char output[32])
+{
+    // Append 0x80, then zeros, then 8-byte big-endian length.
+    ctx->buf[ctx->buf_len++] = 0x80;
+    if (ctx->buf_len > 56) {
+        memset(ctx->buf + ctx->buf_len, 0, 64 - ctx->buf_len);
+        compress(ctx->state, ctx->buf);
+        ctx->buf_len = 0;
+    }
+    memset(ctx->buf + ctx->buf_len, 0, 56 - ctx->buf_len);
+    uint64_t bc = ctx->bit_count;
+    for (int i = 0; i < 8; ++i) {
+        ctx->buf[63 - i] = (uint8_t)(bc & 0xff);
+        bc >>= 8;
+    }
+    compress(ctx->state, ctx->buf);
+
+    for (int i = 0; i < 8; ++i) {
+        output[i*4]   = (uint8_t)(ctx->state[i] >> 24);
+        output[i*4+1] = (uint8_t)(ctx->state[i] >> 16);
+        output[i*4+2] = (uint8_t)(ctx->state[i] >> 8);
+        output[i*4+3] = (uint8_t)(ctx->state[i]);
+    }
+    return 0;
+}

--- a/tests_cpp/test_tr_ota.cpp
+++ b/tests_cpp/test_tr_ota.cpp
@@ -1,0 +1,338 @@
+// Host tests for TR_OTA_Receiver. Uses FakeOTABackend to track flash-side
+// state without touching real esp_ota_*, and a portable mbedtls/sha256.h
+// shim (host_shim/sha256_impl.c) so the receiver's SHA computation runs
+// unchanged on the host.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+#include "TR_OTA_Receiver.h"
+#include "fake_ota_backend.h"
+#include "mbedtls/sha256.h"
+
+namespace {
+
+using R = TR_OTA_Receiver;
+using S = R::State;
+using E = R::Error;
+
+std::array<uint8_t, 32> sha256_of(const std::vector<uint8_t>& data)
+{
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, data.data(), data.size());
+    std::array<uint8_t, 32> out{};
+    mbedtls_sha256_finish(&ctx, out.data());
+    mbedtls_sha256_free(&ctx);
+    return out;
+}
+
+std::vector<uint8_t> make_image(size_t n, uint8_t seed = 0x42)
+{
+    std::vector<uint8_t> v(n);
+    for (size_t i = 0; i < n; ++i) v[i] = (uint8_t)(seed + i * 31);
+    return v;
+}
+
+// ----------- happy path -----------
+
+TEST(TrOta, EndToEndHappyPath)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(1024);
+    auto hash = sha256_of(img);
+
+    EXPECT_EQ(E::Ok, rx.begin((uint32_t)img.size(), hash.data()));
+    EXPECT_EQ(S::Writing, rx.state());
+
+    // Push in 3 chunks
+    EXPECT_EQ(E::Ok, rx.writeChunk(0,   img.data(),       400));
+    EXPECT_EQ(E::Ok, rx.writeChunk(400, img.data() + 400, 400));
+    EXPECT_EQ(E::Ok, rx.writeChunk(800, img.data() + 800, 224));
+    EXPECT_EQ(1024u, rx.bytesWritten());
+
+    EXPECT_EQ(E::Ok, rx.finish());
+    EXPECT_EQ(S::ReadyToBoot, rx.state());
+    EXPECT_TRUE(be.boot_set);
+    EXPECT_TRUE(be.ended_once);
+    EXPECT_EQ(0, be.abort_calls);
+    EXPECT_EQ(img, be.bytes);
+}
+
+TEST(TrOta, SingleChunkImage)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(64);
+    auto hash = sha256_of(img);
+
+    EXPECT_EQ(E::Ok, rx.begin((uint32_t)img.size(), hash.data()));
+    EXPECT_EQ(E::Ok, rx.writeChunk(0, img.data(), img.size()));
+    EXPECT_EQ(E::Ok, rx.finish());
+    EXPECT_EQ(S::ReadyToBoot, rx.state());
+}
+
+// ----------- protocol errors -----------
+
+TEST(TrOta, BadOffsetAborts)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(512);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), 200);
+
+    // Next chunk should start at offset 200; sending 300 is a protocol error
+    EXPECT_EQ(E::BadOffset, rx.writeChunk(300, img.data() + 200, 200));
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_EQ(1, be.abort_calls);
+}
+
+TEST(TrOta, SizeOverflowAborts)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(100);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), 50);
+
+    // Try to write more bytes than total_size allows
+    EXPECT_EQ(E::SizeOverflow, rx.writeChunk(50, img.data() + 50, 100));
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_EQ(1, be.abort_calls);
+}
+
+TEST(TrOta, FinishWithShortImageIsSizeMismatch)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(200);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), 100);   // only half
+
+    EXPECT_EQ(E::SizeMismatch, rx.finish());
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_EQ(1, be.abort_calls);
+}
+
+TEST(TrOta, ShaMismatchAbortsBeforeSetBoot)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(300);
+    auto hash = sha256_of(img);
+
+    // Flip one byte of the expected hash so verification fails
+    hash[0] ^= 0xFF;
+
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), img.size());
+    EXPECT_EQ(E::ShaMismatch, rx.finish());
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_FALSE(be.boot_set);
+    EXPECT_EQ(1, be.abort_calls);
+}
+
+TEST(TrOta, WriteChunkWithoutBeginReturnsSessionNotActive)
+{
+    FakeOTABackend be;
+    R rx(be);
+    EXPECT_EQ(E::SessionNotActive, rx.writeChunk(0, nullptr, 0));
+    EXPECT_EQ(S::Idle, rx.state());
+}
+
+TEST(TrOta, FinishWithoutBeginReturnsSessionNotActive)
+{
+    FakeOTABackend be;
+    R rx(be);
+    EXPECT_EQ(E::SessionNotActive, rx.finish());
+    EXPECT_EQ(S::Idle, rx.state());
+}
+
+TEST(TrOta, ZeroSizeImageRejectedAtBegin)
+{
+    FakeOTABackend be;
+    R rx(be);
+    std::array<uint8_t, 32> z{};
+    EXPECT_EQ(E::BeginFailed, rx.begin(0, z.data()));
+}
+
+// ----------- backend-injected failures -----------
+
+TEST(TrOta, BackendBeginFailure)
+{
+    FakeOTABackend be;
+    be.begin_rc = -5;
+    R rx(be);
+    auto img = make_image(64);
+    auto hash = sha256_of(img);
+    EXPECT_EQ(E::BeginFailed, rx.begin((uint32_t)img.size(), hash.data()));
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+}
+
+TEST(TrOta, BackendWriteFailure)
+{
+    FakeOTABackend be;
+    be.fail_write_after_n = true;
+    be.write_fail_threshold = 100;
+    R rx(be);
+    auto img = make_image(300);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    EXPECT_EQ(E::Ok, rx.writeChunk(0, img.data(), 50));
+    EXPECT_EQ(E::WriteFailed, rx.writeChunk(50, img.data() + 50, 100));
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_EQ(1, be.abort_calls);
+}
+
+TEST(TrOta, BackendEndFailure)
+{
+    FakeOTABackend be;
+    be.end_rc = -7;
+    R rx(be);
+    auto img = make_image(128);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), img.size());
+    EXPECT_EQ(E::EndFailed, rx.finish());
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+    EXPECT_FALSE(be.boot_set);
+}
+
+TEST(TrOta, BackendSetBootFailure)
+{
+    FakeOTABackend be;
+    be.set_boot_rc = -8;
+    R rx(be);
+    auto img = make_image(128);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), img.size());
+    EXPECT_EQ(E::SetBootFailed, rx.finish());
+    EXPECT_EQ(S::VerifyFailed, rx.state());
+}
+
+// ----------- session lifecycle -----------
+
+TEST(TrOta, BeginWhileWritingIsAlreadyActive)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(64);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), 32);
+
+    EXPECT_EQ(E::AlreadyActive, rx.begin((uint32_t)img.size(), hash.data()));
+    EXPECT_EQ(S::Writing, rx.state());   // still in original session
+}
+
+TEST(TrOta, BeginAfterVerifyFailedRestartsCleanly)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img1 = make_image(64);
+    auto h1 = sha256_of(img1);
+    h1[0] ^= 0xFF;                       // force mismatch
+    rx.begin((uint32_t)img1.size(), h1.data());
+    rx.writeChunk(0, img1.data(), img1.size());
+    rx.finish();                          // -> VerifyFailed
+    ASSERT_EQ(S::VerifyFailed, rx.state());
+
+    // Now restart cleanly with the right hash
+    auto img2 = make_image(128, 0x99);
+    auto h2 = sha256_of(img2);
+    EXPECT_EQ(E::Ok, rx.begin((uint32_t)img2.size(), h2.data()));
+    EXPECT_EQ(S::Writing, rx.state());
+    EXPECT_EQ(E::Ok, rx.writeChunk(0, img2.data(), img2.size()));
+    EXPECT_EQ(E::Ok, rx.finish());
+    EXPECT_EQ(S::ReadyToBoot, rx.state());
+}
+
+TEST(TrOta, AbortReturnsToIdle)
+{
+    FakeOTABackend be;
+    R rx(be);
+    auto img = make_image(64);
+    auto hash = sha256_of(img);
+    rx.begin((uint32_t)img.size(), hash.data());
+    rx.writeChunk(0, img.data(), 32);
+    EXPECT_EQ(E::Ok, rx.abort());
+    EXPECT_EQ(S::Idle, rx.state());
+    EXPECT_EQ(1, be.abort_calls);
+    EXPECT_EQ(0u, rx.bytesWritten());
+}
+
+TEST(TrOta, AbortIdleSessionIsNoopButSafe)
+{
+    FakeOTABackend be;
+    R rx(be);
+    EXPECT_EQ(E::Ok, rx.abort());
+    EXPECT_EQ(S::Idle, rx.state());
+    EXPECT_EQ(0, be.abort_calls);   // nothing to abort
+}
+
+// ----------- status callback -----------
+
+struct CbCapture {
+    int calls = 0;
+    S last_state = S::Idle;
+    E last_err = E::Ok;
+    size_t last_bytes = 0;
+};
+
+void cb(void* user, S s, E e, size_t b)
+{
+    auto* c = static_cast<CbCapture*>(user);
+    ++c->calls;
+    c->last_state = s;
+    c->last_err = e;
+    c->last_bytes = b;
+}
+
+TEST(TrOta, StatusCallbackFiresOnStateTransitions)
+{
+    FakeOTABackend be;
+    R rx(be);
+    CbCapture c;
+    rx.setStatusCallback(&cb, &c);
+
+    auto img = make_image(64);
+    auto hash = sha256_of(img);
+
+    rx.begin((uint32_t)img.size(), hash.data());
+    EXPECT_EQ(1, c.calls);
+    EXPECT_EQ(S::Writing, c.last_state);
+
+    rx.writeChunk(0, img.data(), img.size());
+    // writeChunk is intentionally silent (rate-limited at the caller)
+    EXPECT_EQ(1, c.calls);
+
+    rx.finish();
+    EXPECT_EQ(2, c.calls);
+    EXPECT_EQ(S::ReadyToBoot, c.last_state);
+    EXPECT_EQ(64u, c.last_bytes);
+}
+
+// ----------- known-vector SHA-256 sanity (validates the host shim itself) ----
+
+TEST(TrOta, ShaShimMatchesKnownVector)
+{
+    // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    const uint8_t expected[32] = {
+        0xba,0x78,0x16,0xbf, 0x8f,0x01,0xcf,0xea, 0x41,0x41,0x40,0xde, 0x5d,0xae,0x22,0x23,
+        0xb0,0x03,0x61,0xa3, 0x96,0x17,0x7a,0x9c, 0xb4,0x10,0xff,0x61, 0xf2,0x00,0x15,0xad,
+    };
+    auto got = sha256_of({'a','b','c'});
+    EXPECT_EQ(0, std::memcmp(got.data(), expected, 32));
+}
+
+}  // namespace

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_BLE_To_APP.cpp" INCLUDE_DIRS "." REQUIRES bt TR_Compat)
+idf_component_register(SRCS "TR_BLE_To_APP.cpp" INCLUDE_DIRS "." REQUIRES bt TR_Compat TR_OTA)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -4,7 +4,9 @@
 #include <cstdio>
 #include <cmath>
 
+#include <esp_app_desc.h>           // esp_app_get_description for fw version in ota_status (#8)
 #include <esp_log.h>
+#include <esp_system.h>             // esp_restart for the post-OTA reboot (#8)
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <nimble/nimble_port.h>
@@ -118,11 +120,14 @@ TR_BLE_To_APP::TR_BLE_To_APP(const char* device_name)
       telemetry_val_handle_(0),
       command_val_handle_(0),
       file_ops_val_handle_(0),
-      file_transfer_val_handle_(0)
+      file_transfer_val_handle_(0),
+      ota_receiver_(ota_backend_)
 {
     // Copy initial name into the mutable buffer
     strncpy(device_name_, device_name, MAX_DEVICE_NAME_LEN);
     device_name_[MAX_DEVICE_NAME_LEN] = '\0';
+
+    ota_receiver_.setStatusCallback(&TR_BLE_To_APP::otaStatusCallback, this);
 }
 
 void TR_BLE_To_APP::setName(const char* name)
@@ -300,7 +305,6 @@ int TR_BLE_To_APP::gatt_svc_access_cb(uint16_t conn_handle,
     {
     case BLE_GATT_ACCESS_OP_WRITE_CHR:
     {
-        // Only the command characteristic accepts writes
         if (attr_handle == self->command_val_handle_)
         {
             // Flatten the mbuf chain into a contiguous buffer
@@ -314,6 +318,21 @@ int TR_BLE_To_APP::gatt_svc_access_cb(uint16_t conn_handle,
             if (rc != 0) return BLE_ATT_ERR_UNLIKELY;
 
             self->onCommandWrite(buf, out_len);
+        }
+        else if (attr_handle == self->file_transfer_val_handle_)
+        {
+            // OTA image chunks (#8). Frame: [offset:4 LE][length:2 LE][flags:1][data:N].
+            // Big enough for a 512 MTU minus ATT overhead.
+            uint16_t om_len = OS_MBUF_PKTLEN(ctxt->om);
+            if (om_len == 0) return 0;
+
+            uint8_t buf[520];
+            uint16_t copy_len = (om_len < sizeof(buf)) ? om_len : sizeof(buf);
+            uint16_t out_len = 0;
+            int rc = ble_hs_mbuf_to_flat(ctxt->om, buf, copy_len, &out_len);
+            if (rc != 0) return BLE_ATT_ERR_UNLIKELY;
+
+            self->onFileTransferWrite(buf, out_len);
         }
         return 0;
     }
@@ -408,6 +427,24 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
         pending_payload_len_ = payload_len;
         ESP_LOGI(BLE_TAG, "Time sync received");
     }
+    else if (cmd == 10)
+    {
+        // OTA_BEGIN (#8). Payload: [target:1][total_size:4 LE][sha256:32] = 37 bytes
+        handleOtaBegin(data + 1, length - 1);
+        return;  // handled in-place, no main-loop dispatch
+    }
+    else if (cmd == 11)
+    {
+        // OTA_FINISH (#8). No payload.
+        handleOtaFinish();
+        return;
+    }
+    else if (cmd == 12)
+    {
+        // OTA_ABORT (#8). No payload.
+        handleOtaAbort();
+        return;
+    }
     else if (length > 1)
     {
         // Generic payload handler for any other command carrying data
@@ -471,11 +508,13 @@ void TR_BLE_To_APP::registerGattServices()
     s_gatt_chrs[2].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY;
     s_gatt_chrs[2].val_handle = &file_ops_val_handle_;
 
-    // 3: File Transfer (READ + NOTIFY)
+    // 3: File Transfer (READ + NOTIFY + WRITE).
+    // WRITE is for the central pushing OTA image chunks (#8); notifies still
+    // carry device→app file downloads from the existing flow.
     memset(&s_gatt_chrs[3], 0, sizeof(s_gatt_chrs[3]));
     s_gatt_chrs[3].uuid       = &s_file_transfer_uuid.u;
     s_gatt_chrs[3].access_cb  = gatt_access_cb;
-    s_gatt_chrs[3].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY;
+    s_gatt_chrs[3].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY | BLE_GATT_CHR_F_WRITE;
     s_gatt_chrs[3].val_handle = &file_transfer_val_handle_;
 
     // 4: Terminator
@@ -631,7 +670,21 @@ bool TR_BLE_To_APP::begin()
 void TR_BLE_To_APP::loop()
 {
     // BLE stack handles events via callbacks on the NimBLE host task.
-    // Nothing to do here.
+    // Only OTA's deferred-restart watchdog needs poll-style handling here.
+    if (ota_pending_restart_at_ms_ != 0)
+    {
+        uint32_t now = (uint32_t)millis();
+        // Guard against millis() wraparound (49.7 days) by tolerating
+        // backward jumps: if 'now' is much less than the scheduled time we
+        // assume wrap and restart immediately rather than wait 49 days.
+        bool elapsed = (now >= ota_pending_restart_at_ms_) ||
+                       ((ota_pending_restart_at_ms_ - now) > 0x7FFFFFFFu);
+        if (elapsed)
+        {
+            ESP_LOGW(BLE_TAG, "OTA: rebooting now to load new partition");
+            esp_restart();
+        }
+    }
 }
 
 size_t TR_BLE_To_APP::getMaxChunkDataSize() const
@@ -1184,4 +1237,182 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     buf[pos] = '\0';
 
     return String(buf);
+}
+
+// ============================================================================
+// OTA receive (#8 phase 2) — owns the BLE-side state machine for OTAReceiver.
+// ============================================================================
+
+// Translate a TR_OTA_Receiver::Error to a short stable token the iOS app
+// can switch on without reproducing the enum. nullptr for Ok.
+static const char* ota_err_token(TR_OTA_Receiver::Error e)
+{
+    using E = TR_OTA_Receiver::Error;
+    switch (e)
+    {
+        case E::Ok:                  return nullptr;
+        case E::AlreadyActive:       return "already_active";
+        case E::SessionNotActive:    return "session_not_active";
+        case E::BeginFailed:         return "begin_failed";
+        case E::BadOffset:           return "bad_offset";
+        case E::SizeOverflow:        return "size_overflow";
+        case E::WriteFailed:         return "write_failed";
+        case E::SizeMismatch:        return "size_mismatch";
+        case E::ShaMismatch:         return "sha_mismatch";
+        case E::EndFailed:           return "end_failed";
+        case E::SetBootFailed:       return "set_boot_failed";
+    }
+    return "unknown";
+}
+
+void TR_BLE_To_APP::sendOtaStatusJSON(const char* state, const char* err,
+                                       size_t bytes, const char* fw)
+{
+    if (!device_connected_) return;
+
+    char buf[160];
+    int n = 0;
+    if (err && fw)
+    {
+        n = snprintf(buf, sizeof(buf),
+                     "{\"type\":\"ota_status\",\"state\":\"%s\",\"bytes\":%u,\"err\":\"%s\",\"fw\":\"%s\"}",
+                     state, (unsigned)bytes, err, fw);
+    }
+    else if (err)
+    {
+        n = snprintf(buf, sizeof(buf),
+                     "{\"type\":\"ota_status\",\"state\":\"%s\",\"bytes\":%u,\"err\":\"%s\"}",
+                     state, (unsigned)bytes, err);
+    }
+    else if (fw)
+    {
+        n = snprintf(buf, sizeof(buf),
+                     "{\"type\":\"ota_status\",\"state\":\"%s\",\"bytes\":%u,\"fw\":\"%s\"}",
+                     state, (unsigned)bytes, fw);
+    }
+    else
+    {
+        n = snprintf(buf, sizeof(buf),
+                     "{\"type\":\"ota_status\",\"state\":\"%s\",\"bytes\":%u}",
+                     state, (unsigned)bytes);
+    }
+    if (n < 0 || (size_t)n >= sizeof(buf)) return;
+
+    size_t max_notify = (negotiated_mtu_ > 3) ? (negotiated_mtu_ - 3) : 20;
+    if ((size_t)n > max_notify) return;  // silent skip per the project-wide MTU guard
+
+    notify_data(conn_handle_, file_ops_val_handle_, (const uint8_t*)buf, n);
+}
+
+void TR_BLE_To_APP::otaStatusCallback(void* user, TR_OTA_Receiver::State state,
+                                       TR_OTA_Receiver::Error err, size_t bytes_written)
+{
+    auto* self = static_cast<TR_BLE_To_APP*>(user);
+    using S = TR_OTA_Receiver::State;
+    const char* state_str = nullptr;
+    const char* fw_str = nullptr;
+    switch (state)
+    {
+        case S::Idle:         state_str = "idle";          break;
+        case S::Writing:      state_str = "ready";         break;
+        case S::ReadyToBoot:  state_str = "ready_to_boot"; {
+            // The "fw" in this status reflects the firmware ABOUT to boot
+            // (i.e., the freshly-flashed image). We can't read it from the
+            // staged partition cheaply, so we report the version embedded
+            // in the running image as a debug anchor; the iOS app compares
+            // its expected version against the post-reboot identity.
+            const esp_app_desc_t* d = esp_app_get_description();
+            fw_str = (d && d->version[0]) ? d->version : nullptr;
+        } break;
+        case S::VerifyFailed: state_str = "verify_failed"; break;
+    }
+    self->sendOtaStatusJSON(state_str, ota_err_token(err), bytes_written, fw_str);
+}
+
+void TR_BLE_To_APP::handleOtaBegin(const uint8_t* data, size_t length)
+{
+    // Payload: [target:1][total_size:4 LE][sha256:32] = 37 bytes
+    if (length < 37)
+    {
+        ESP_LOGW(BLE_TAG, "OTA_BEGIN payload too short (%u bytes)", (unsigned)length);
+        sendOtaStatusJSON("verify_failed", "bad_payload", 0, nullptr);
+        return;
+    }
+
+    uint8_t target = data[0];
+    uint32_t total_size = (uint32_t)data[1] | ((uint32_t)data[2] << 8) |
+                          ((uint32_t)data[3] << 16) | ((uint32_t)data[4] << 24);
+
+    if (target != 0)
+    {
+        // target==1 is FC relay (Phase 4); BS/OC only accept target==0 today.
+        ESP_LOGW(BLE_TAG, "OTA_BEGIN target=%u not supported on this device", target);
+        sendOtaStatusJSON("verify_failed", "bad_target", 0, nullptr);
+        return;
+    }
+
+    ESP_LOGI(BLE_TAG, "OTA_BEGIN: size=%u bytes", (unsigned)total_size);
+    ota_last_writing_notify_ms_ = 0;
+    ota_pending_restart_at_ms_ = 0;
+    (void)ota_receiver_.begin(total_size, data + 5);  // status pushed via callback
+}
+
+void TR_BLE_To_APP::handleOtaFinish()
+{
+    ESP_LOGI(BLE_TAG, "OTA_FINISH (bytes_written=%u)", (unsigned)ota_receiver_.bytesWritten());
+    TR_OTA_Receiver::Error e = ota_receiver_.finish();
+    if (e == TR_OTA_Receiver::Error::Ok)
+    {
+        // Defer the actual reboot by 500ms so the ready_to_boot status
+        // notification can drain through the BLE stack before the radio
+        // dies. loop() polls ota_pending_restart_at_ms_.
+        ota_pending_restart_at_ms_ = (uint32_t)millis() + 500;
+        ESP_LOGW(BLE_TAG, "OTA: ready to boot, restart scheduled in 500ms");
+    }
+}
+
+void TR_BLE_To_APP::handleOtaAbort()
+{
+    ESP_LOGW(BLE_TAG, "OTA_ABORT");
+    ota_pending_restart_at_ms_ = 0;
+    (void)ota_receiver_.abort();
+}
+
+void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)
+{
+    // Frame: [offset:4 LE][length:2 LE][flags:1][payload:N]
+    if (length < 7)
+    {
+        ESP_LOGW(BLE_TAG, "OTA chunk too short (%u bytes)", (unsigned)length);
+        return;
+    }
+    uint32_t offset = (uint32_t)data[0] | ((uint32_t)data[1] << 8) |
+                       ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+    uint16_t chunk_len = (uint16_t)data[4] | ((uint16_t)data[5] << 8);
+    // data[6] = flags; bit 0 = EOF. We don't act on EOF here — OTA_FINISH
+    // is the explicit close. Keeping the flag for symmetry with the
+    // download-direction wire format.
+    if ((size_t)7 + chunk_len > length)
+    {
+        ESP_LOGW(BLE_TAG, "OTA chunk truncated: declared %u, frame %u",
+                 (unsigned)chunk_len, (unsigned)length);
+        return;
+    }
+
+    TR_OTA_Receiver::Error e = ota_receiver_.writeChunk(offset, data + 7, chunk_len);
+    if (e != TR_OTA_Receiver::Error::Ok)
+    {
+        // writeChunk pushes its own status via the receiver callback on
+        // failure (state -> VerifyFailed). Nothing more to do here.
+        return;
+    }
+
+    // Rate-limit "writing" notifications to ~2 Hz so we don't drown the BLE
+    // notify queue mid-flash. The iOS app uses this only for the progress bar.
+    uint32_t now = (uint32_t)millis();
+    if ((now - ota_last_writing_notify_ms_) >= 500)
+    {
+        ota_last_writing_notify_ms_ = now;
+        sendOtaStatusJSON("writing", nullptr, ota_receiver_.bytesWritten(), nullptr);
+    }
 }

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -427,19 +427,21 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
         pending_payload_len_ = payload_len;
         ESP_LOGI(BLE_TAG, "Time sync received");
     }
-    else if (cmd == 10)
+    else if (cmd == 70)
     {
-        // OTA_BEGIN (#8). Payload: [target:1][total_size:4 LE][sha256:32] = 37 bytes
+        // OTA_BEGIN (#8). Payload: [target:1][total_size:4 LE][sha256:32] = 37 bytes.
+        // Cmd codes 70/71/72 picked to clear the existing 1-60 range used by
+        // LoRa/servo/PID/etc. dispatch in main.cpp; see docs/plans/08-…
         handleOtaBegin(data + 1, length - 1);
         return;  // handled in-place, no main-loop dispatch
     }
-    else if (cmd == 11)
+    else if (cmd == 71)
     {
         // OTA_FINISH (#8). No payload.
         handleOtaFinish();
         return;
     }
-    else if (cmd == 12)
+    else if (cmd == 72)
     {
         // OTA_ABORT (#8). No payload.
         handleOtaAbort();

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -510,13 +510,17 @@ void TR_BLE_To_APP::registerGattServices()
     s_gatt_chrs[2].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY;
     s_gatt_chrs[2].val_handle = &file_ops_val_handle_;
 
-    // 3: File Transfer (READ + NOTIFY + WRITE).
-    // WRITE is for the central pushing OTA image chunks (#8); notifies still
-    // carry device→app file downloads from the existing flow.
+    // 3: File Transfer (READ + NOTIFY + WRITE + WRITE_NO_RSP).
+    // Both write properties are needed: WRITE_NO_RSP is what iOS picks for
+    // high-throughput OTA chunks (writeValue(.withoutResponse) — see #16),
+    // and WRITE stays advertised so older iOS builds / debug tools that
+    // expect write-with-response still work. Notifies still carry
+    // device→app file downloads from the existing flow.
     memset(&s_gatt_chrs[3], 0, sizeof(s_gatt_chrs[3]));
     s_gatt_chrs[3].uuid       = &s_file_transfer_uuid.u;
     s_gatt_chrs[3].access_cb  = gatt_access_cb;
-    s_gatt_chrs[3].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY | BLE_GATT_CHR_F_WRITE;
+    s_gatt_chrs[3].flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY
+                              | BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_WRITE_NO_RSP;
     s_gatt_chrs[3].val_handle = &file_transfer_val_handle_;
 
     // 4: Terminator

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1315,6 +1315,17 @@ void TR_BLE_To_APP::otaStatusCallback(void* user, TR_OTA_Receiver::State state,
 {
     auto* self = static_cast<TR_BLE_To_APP*>(user);
     using S = TR_OTA_Receiver::State;
+
+    // Authoritative clear of the OTA-active flag (#17): any terminal,
+    // non-rebooting state means the I2C battery poll can resume. Covers
+    // begin-fail, mid-stream chunk-fail, finish-verify-fail, and abort —
+    // all of which the receiver routes through here. ReadyToBoot keeps the
+    // flag set because the device reboots within ~500 ms.
+    if (state == S::Idle || state == S::VerifyFailed)
+    {
+        self->ota_session_active_ = false;
+    }
+
     const char* state_str = nullptr;
     const char* fw_str = nullptr;
     switch (state)
@@ -1360,6 +1371,14 @@ void TR_BLE_To_APP::handleOtaBegin(const uint8_t* data, size_t length)
     ESP_LOGI(BLE_TAG, "OTA_BEGIN: size=%u bytes", (unsigned)total_size);
     ota_last_writing_notify_ms_ = 0;
     ota_pending_restart_at_ms_ = 0;
+
+    // Raise the OTA-active flag BEFORE begin(): esp_ota_begin() erases the
+    // target partition (~1-2 s of blocking SPI flash work) and the main
+    // loop's BQ27Z746 I2C poll collides with it, logging spurious
+    // i2c_master_transmit_receive failures (#17). main.cpp gates updateBattery()
+    // on isOtaActive(), so the flag has to be up before the erase starts.
+    // The status callback clears it again if begin() fails.
+    ota_session_active_ = true;
     (void)ota_receiver_.begin(total_size, data + 5);  // status pushed via callback
 }
 
@@ -1372,16 +1391,19 @@ void TR_BLE_To_APP::handleOtaFinish()
         // Defer the actual reboot by 500ms so the ready_to_boot status
         // notification can drain through the BLE stack before the radio
         // dies. loop() polls ota_pending_restart_at_ms_.
+        // Leave ota_session_active_ true — the device reboots momentarily.
         ota_pending_restart_at_ms_ = (uint32_t)millis() + 500;
         ESP_LOGW(BLE_TAG, "OTA: ready to boot, restart scheduled in 500ms");
     }
+    // On failure the receiver transitions to VerifyFailed, whose status
+    // callback clears ota_session_active_ (#17).
 }
 
 void TR_BLE_To_APP::handleOtaAbort()
 {
     ESP_LOGW(BLE_TAG, "OTA_ABORT");
     ota_pending_restart_at_ms_ = 0;
-    (void)ota_receiver_.abort();
+    (void)ota_receiver_.abort();   // -> Idle -> callback clears ota_session_active_
 }
 
 void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -16,6 +16,9 @@ using String = std::string;     // API-compatible subset used by callers
 #include <cstdint>
 #include <cstddef>
 
+#include "TR_OTA_Receiver.h"
+#include "TR_OTA_Backend_esp.h"
+
 class TR_BLE_To_APP
 {
 public:
@@ -224,6 +227,30 @@ private:
 
     // Helper to build JSON string
     String buildTelemetryJSON(const TelemetryData& data);
+
+    // ---- OTA receive state (#8) --------------------------------------------
+    // Owned here because the OTA flow lives entirely on BLE characteristics
+    // (cmd 10/11/12 on the command channel, chunks on file-transfer, status
+    // JSON on file-ops). main.cpp only needs to drive validation post-boot.
+    TR_OTA_Backend_esp ota_backend_;
+    TR_OTA_Receiver    ota_receiver_;
+    // When non-zero, loop() calls esp_restart() once millis() reaches it.
+    // Set by the OTA_FINISH handler after the ready_to_boot notification
+    // flushes so the iOS app sees the new partition selection.
+    uint32_t ota_pending_restart_at_ms_ = 0;
+    // Throttle the per-chunk "writing" status notifications. Updated on
+    // every successful chunk; we notify at most ~2 Hz so the BLE notify
+    // queue isn't saturated mid-flash.
+    uint32_t ota_last_writing_notify_ms_ = 0;
+
+    void onFileTransferWrite(const uint8_t* data, size_t length);
+    void handleOtaBegin(const uint8_t* data, size_t length);
+    void handleOtaFinish();
+    void handleOtaAbort();
+    void sendOtaStatusJSON(const char* state, const char* err,
+                           size_t bytes, const char* fw);
+    static void otaStatusCallback(void* user, TR_OTA_Receiver::State state,
+                                   TR_OTA_Receiver::Error err, size_t bytes_written);
 
 public:
     // ---- NimBLE callbacks (static, forwarded via user-data pointer) --------

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -195,6 +195,11 @@ public:
     // Falls back to 170 if MTU not yet negotiated
     size_t getMaxChunkDataSize() const;
 
+    // True from OTA_BEGIN until the session ends (finish→reboot, abort, or
+    // failure). main.cpp gates I2C battery-gauge polling on this so the
+    // esp_ota_begin() flash erase doesn't collide with the I2C bus (#17).
+    bool isOtaActive() const { return ota_session_active_; }
+
 private:
     static constexpr size_t MAX_DEVICE_NAME_LEN = 29;   // BLE adv name limit
     char device_name_[MAX_DEVICE_NAME_LEN + 1];          // mutable, null-terminated
@@ -242,6 +247,11 @@ private:
     // every successful chunk; we notify at most ~2 Hz so the BLE notify
     // queue isn't saturated mid-flash.
     uint32_t ota_last_writing_notify_ms_ = 0;
+    // True for the duration of an OTA session (#17). Read cross-task by
+    // main.cpp via isOtaActive() to pause I2C battery polling during the
+    // esp_ota_begin() flash erase. volatile: written on the NimBLE host
+    // task, read on the main loop task.
+    volatile bool ota_session_active_ = false;
 
     void onFileTransferWrite(const uint8_t* data, size_t length);
     void handleOtaBegin(const uint8_t* data, size_t length);

--- a/tinkerrocket-idf/components/TR_OTA/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_OTA/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "TR_OTA_Receiver.cpp" "TR_OTA_Backend_esp.cpp"
+    INCLUDE_DIRS "include"
+    REQUIRES app_update esp_partition mbedtls
+)

--- a/tinkerrocket-idf/components/TR_OTA/TR_OTA_Backend_esp.cpp
+++ b/tinkerrocket-idf/components/TR_OTA/TR_OTA_Backend_esp.cpp
@@ -1,0 +1,86 @@
+#include "TR_OTA_Backend_esp.h"
+
+#include <esp_log.h>
+
+static const char* TAG = "TR_OTA_BE";
+
+TR_OTA_Backend_esp::~TR_OTA_Backend_esp()
+{
+    abort();
+}
+
+int TR_OTA_Backend_esp::begin(size_t image_size)
+{
+    if (session_active_) return -1;
+
+    partition_ = esp_ota_get_next_update_partition(nullptr);
+    if (!partition_)
+    {
+        ESP_LOGE(TAG, "esp_ota_get_next_update_partition returned null");
+        return -2;
+    }
+
+    esp_err_t err = esp_ota_begin(partition_, image_size, &handle_);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_begin(size=%u): %s", (unsigned)image_size, esp_err_to_name(err));
+        partition_ = nullptr;
+        return err;
+    }
+
+    session_active_ = true;
+    ESP_LOGI(TAG, "OTA begin: partition '%s' @ 0x%08x, size=%u",
+             partition_->label, (unsigned)partition_->address, (unsigned)image_size);
+    return 0;
+}
+
+int TR_OTA_Backend_esp::write(const uint8_t* data, size_t len)
+{
+    if (!session_active_) return -1;
+    esp_err_t err = esp_ota_write(handle_, data, len);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_write(len=%u): %s", (unsigned)len, esp_err_to_name(err));
+        return err;
+    }
+    return 0;
+}
+
+int TR_OTA_Backend_esp::end()
+{
+    if (!session_active_) return -1;
+    esp_err_t err = esp_ota_end(handle_);
+    session_active_ = false;
+    handle_ = 0;
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_end: %s", esp_err_to_name(err));
+        return err;
+    }
+    return 0;
+}
+
+int TR_OTA_Backend_esp::setBootPartition()
+{
+    if (!partition_) return -1;
+    esp_err_t err = esp_ota_set_boot_partition(partition_);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_ota_set_boot_partition('%s'): %s",
+                 partition_->label, esp_err_to_name(err));
+        return err;
+    }
+    ESP_LOGI(TAG, "OTA boot partition set: '%s'", partition_->label);
+    return 0;
+}
+
+void TR_OTA_Backend_esp::abort()
+{
+    if (session_active_)
+    {
+        esp_ota_abort(handle_);
+        session_active_ = false;
+        handle_ = 0;
+    }
+    partition_ = nullptr;
+}

--- a/tinkerrocket-idf/components/TR_OTA/TR_OTA_Receiver.cpp
+++ b/tinkerrocket-idf/components/TR_OTA/TR_OTA_Receiver.cpp
@@ -1,0 +1,230 @@
+#include "TR_OTA_Receiver.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#include <mbedtls/sha256.h>
+
+TR_OTA_Receiver::TR_OTA_Receiver(TR_OTA_Backend& backend)
+    : backend_(backend)
+{
+}
+
+TR_OTA_Receiver::~TR_OTA_Receiver()
+{
+    if (state_ != State::Idle && state_ != State::ReadyToBoot)
+    {
+        backend_.abort();
+    }
+    freeShaCtx();
+}
+
+void TR_OTA_Receiver::setStatusCallback(StatusCb cb, void* user_ctx)
+{
+    status_cb_ = cb;
+    status_cb_user_ = user_ctx;
+}
+
+void TR_OTA_Receiver::resetSession()
+{
+    state_ = State::Idle;
+    total_size_ = 0;
+    bytes_written_ = 0;
+    last_error_ = Error::Ok;
+    std::memset(expected_sha_, 0, sizeof(expected_sha_));
+    freeShaCtx();
+}
+
+void TR_OTA_Receiver::notify()
+{
+    if (status_cb_)
+    {
+        status_cb_(status_cb_user_, state_, last_error_, bytes_written_);
+    }
+}
+
+void TR_OTA_Receiver::initShaCtx()
+{
+    freeShaCtx();
+    auto* ctx = static_cast<mbedtls_sha256_context*>(std::malloc(sizeof(mbedtls_sha256_context)));
+    if (!ctx) return;
+    mbedtls_sha256_init(ctx);
+    mbedtls_sha256_starts(ctx, 0);  // 0 = SHA-256 (not 224)
+    sha_ctx_ = ctx;
+}
+
+void TR_OTA_Receiver::freeShaCtx()
+{
+    if (sha_ctx_)
+    {
+        auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
+        mbedtls_sha256_free(ctx);
+        std::free(ctx);
+        sha_ctx_ = nullptr;
+    }
+}
+
+void TR_OTA_Receiver::shaUpdate(const uint8_t* data, size_t len)
+{
+    if (!sha_ctx_) return;
+    auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
+    mbedtls_sha256_update(ctx, data, len);
+}
+
+bool TR_OTA_Receiver::shaFinalAndCompare(const uint8_t expected[32])
+{
+    if (!sha_ctx_) return false;
+    auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
+    uint8_t computed[32];
+    mbedtls_sha256_finish(ctx, computed);
+    return std::memcmp(computed, expected, 32) == 0;
+}
+
+TR_OTA_Receiver::Error TR_OTA_Receiver::begin(uint32_t total_size, const uint8_t sha256[32])
+{
+    if (state_ == State::Writing)
+    {
+        last_error_ = Error::AlreadyActive;
+        notify();
+        return Error::AlreadyActive;
+    }
+
+    // Clean restart from VerifyFailed / ReadyToBoot
+    if (state_ != State::Idle)
+    {
+        backend_.abort();
+        resetSession();
+    }
+
+    if (total_size == 0)
+    {
+        last_error_ = Error::BeginFailed;
+        notify();
+        return Error::BeginFailed;
+    }
+
+    int rc = backend_.begin(total_size);
+    if (rc != 0)
+    {
+        last_error_ = Error::BeginFailed;
+        state_ = State::VerifyFailed;
+        notify();
+        return Error::BeginFailed;
+    }
+
+    total_size_ = total_size;
+    bytes_written_ = 0;
+    std::memcpy(expected_sha_, sha256, sizeof(expected_sha_));
+    initShaCtx();
+
+    state_ = State::Writing;
+    last_error_ = Error::Ok;
+    notify();
+    return Error::Ok;
+}
+
+TR_OTA_Receiver::Error TR_OTA_Receiver::writeChunk(uint32_t offset, const uint8_t* data, size_t len)
+{
+    if (state_ != State::Writing)
+    {
+        last_error_ = Error::SessionNotActive;
+        return Error::SessionNotActive;
+    }
+
+    if (offset != bytes_written_)
+    {
+        last_error_ = Error::BadOffset;
+        state_ = State::VerifyFailed;
+        backend_.abort();
+        notify();
+        return Error::BadOffset;
+    }
+
+    if (bytes_written_ + len > total_size_)
+    {
+        last_error_ = Error::SizeOverflow;
+        state_ = State::VerifyFailed;
+        backend_.abort();
+        notify();
+        return Error::SizeOverflow;
+    }
+
+    int rc = backend_.write(data, len);
+    if (rc != 0)
+    {
+        last_error_ = Error::WriteFailed;
+        state_ = State::VerifyFailed;
+        backend_.abort();
+        notify();
+        return Error::WriteFailed;
+    }
+
+    shaUpdate(data, len);
+    bytes_written_ += len;
+    // Don't notify on every chunk — the BLE layer rate-limits its own
+    // status pushes. Caller can poll bytesWritten().
+    return Error::Ok;
+}
+
+TR_OTA_Receiver::Error TR_OTA_Receiver::finish()
+{
+    if (state_ != State::Writing)
+    {
+        last_error_ = Error::SessionNotActive;
+        notify();
+        return Error::SessionNotActive;
+    }
+
+    if (bytes_written_ != total_size_)
+    {
+        last_error_ = Error::SizeMismatch;
+        state_ = State::VerifyFailed;
+        backend_.abort();
+        notify();
+        return Error::SizeMismatch;
+    }
+
+    if (!shaFinalAndCompare(expected_sha_))
+    {
+        last_error_ = Error::ShaMismatch;
+        state_ = State::VerifyFailed;
+        backend_.abort();
+        notify();
+        return Error::ShaMismatch;
+    }
+
+    int rc = backend_.end();
+    if (rc != 0)
+    {
+        last_error_ = Error::EndFailed;
+        state_ = State::VerifyFailed;
+        notify();
+        return Error::EndFailed;
+    }
+
+    rc = backend_.setBootPartition();
+    if (rc != 0)
+    {
+        last_error_ = Error::SetBootFailed;
+        state_ = State::VerifyFailed;
+        notify();
+        return Error::SetBootFailed;
+    }
+
+    state_ = State::ReadyToBoot;
+    last_error_ = Error::Ok;
+    freeShaCtx();
+    notify();
+    return Error::Ok;
+}
+
+TR_OTA_Receiver::Error TR_OTA_Receiver::abort()
+{
+    if (state_ == State::Writing || state_ == State::VerifyFailed)
+    {
+        backend_.abort();
+    }
+    resetSession();
+    notify();
+    return Error::Ok;
+}

--- a/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Backend.h
+++ b/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Backend.h
@@ -1,0 +1,27 @@
+#ifndef TR_OTA_BACKEND_H
+#define TR_OTA_BACKEND_H
+
+#include <cstdint>
+#include <cstddef>
+
+// Pure-virtual flash-side of an OTA session. The real ESP-IDF
+// implementation wraps esp_ota_begin / esp_ota_write / esp_ota_end /
+// esp_ota_set_boot_partition. Tests inject a fake that just tracks bytes.
+//
+// Owning, single-session: at most one begin() in flight at a time. abort()
+// is always safe to call. Return values are 0 on success, non-zero on
+// failure (errors are surfaced as TR_OTA_Receiver::Error::WriteFailed etc
+// rather than propagated verbatim).
+class TR_OTA_Backend
+{
+public:
+    virtual ~TR_OTA_Backend() = default;
+
+    virtual int begin(size_t image_size) = 0;
+    virtual int write(const uint8_t* data, size_t len) = 0;
+    virtual int end() = 0;
+    virtual int setBootPartition() = 0;
+    virtual void abort() = 0;
+};
+
+#endif // TR_OTA_BACKEND_H

--- a/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Backend_esp.h
+++ b/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Backend_esp.h
@@ -1,0 +1,30 @@
+#ifndef TR_OTA_BACKEND_ESP_H
+#define TR_OTA_BACKEND_ESP_H
+
+#include "TR_OTA_Backend.h"
+
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
+
+// Real ESP-IDF backend. Wraps esp_ota_begin / esp_ota_write / esp_ota_end /
+// esp_ota_set_boot_partition. Picks the next OTA partition via
+// esp_ota_get_next_update_partition().
+class TR_OTA_Backend_esp : public TR_OTA_Backend
+{
+public:
+    TR_OTA_Backend_esp() = default;
+    ~TR_OTA_Backend_esp() override;
+
+    int  begin(size_t image_size) override;
+    int  write(const uint8_t* data, size_t len) override;
+    int  end() override;
+    int  setBootPartition() override;
+    void abort() override;
+
+private:
+    const esp_partition_t* partition_ = nullptr;
+    esp_ota_handle_t       handle_ = 0;
+    bool                   session_active_ = false;
+};
+
+#endif // TR_OTA_BACKEND_ESP_H

--- a/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Receiver.h
+++ b/tinkerrocket-idf/components/TR_OTA/include/TR_OTA_Receiver.h
@@ -1,0 +1,97 @@
+#ifndef TR_OTA_RECEIVER_H
+#define TR_OTA_RECEIVER_H
+
+#include <cstdint>
+#include <cstddef>
+
+#include "TR_OTA_Backend.h"
+
+// State-machine + SHA-256 accumulator on top of a TR_OTA_Backend.
+//
+// Chunk ordering: writeChunk() requires the offset to equal bytesWritten().
+// The BLE transport already preserves order via write-with-response, so
+// out-of-order is treated as a protocol error rather than buffered.
+//
+// Thread model: not thread-safe. Caller serializes on a single task.
+class TR_OTA_Receiver
+{
+public:
+    enum class State : uint8_t {
+        Idle,           // No session
+        Writing,        // begin() succeeded, chunks accepted
+        ReadyToBoot,    // finish() OK; caller may esp_restart()
+        VerifyFailed,   // terminal — abort() to return to Idle
+    };
+
+    enum class Error : uint8_t {
+        Ok = 0,
+        AlreadyActive,          // begin() called twice
+        SessionNotActive,       // writeChunk/finish without begin
+        BeginFailed,            // backend->begin() returned non-zero
+        BadOffset,              // chunk offset != bytes_written_
+        SizeOverflow,           // chunk would push past total_size_
+        WriteFailed,            // backend->write() returned non-zero
+        SizeMismatch,           // finish() called before total bytes received
+        ShaMismatch,            // computed SHA != expected
+        EndFailed,              // backend->end() returned non-zero
+        SetBootFailed,          // backend->setBootPartition() returned non-zero
+    };
+
+    // Optional status callback. Fired synchronously inside begin/writeChunk/
+    // finish/abort whenever state_ or last_error_ changes. detail may be a
+    // brief string (machine-stable token, not human prose) or nullptr.
+    using StatusCb = void(*)(void* user_ctx, State state, Error err, size_t bytes_written);
+
+    explicit TR_OTA_Receiver(TR_OTA_Backend& backend);
+    ~TR_OTA_Receiver();
+
+    TR_OTA_Receiver(const TR_OTA_Receiver&) = delete;
+    TR_OTA_Receiver& operator=(const TR_OTA_Receiver&) = delete;
+
+    void setStatusCallback(StatusCb cb, void* user_ctx);
+
+    // Open a session. total_size: full image bytes; sha256: expected SHA-256
+    // of the full image, exactly 32 bytes.
+    Error begin(uint32_t total_size, const uint8_t sha256[32]);
+
+    // Append the next chunk. offset must equal bytesWritten().
+    Error writeChunk(uint32_t offset, const uint8_t* data, size_t len);
+
+    // Verify SHA, end backend write, set boot partition. State becomes
+    // ReadyToBoot on success (caller schedules reboot). On failure the
+    // session is aborted internally — state becomes VerifyFailed.
+    Error finish();
+
+    // Cancel an in-flight session. Always safe; resets to Idle.
+    Error abort();
+
+    State  state()         const { return state_; }
+    Error  lastError()     const { return last_error_; }
+    size_t bytesWritten()  const { return bytes_written_; }
+    size_t expectedSize()  const { return total_size_; }
+
+private:
+    TR_OTA_Backend& backend_;
+
+    State state_ = State::Idle;
+    Error last_error_ = Error::Ok;
+    size_t total_size_ = 0;
+    size_t bytes_written_ = 0;
+    uint8_t expected_sha_[32] = {};
+
+    // mbedtls SHA-256 context is opaque so we keep it via a void* + heap
+    // allocation to avoid pulling mbedtls into this header.
+    void* sha_ctx_ = nullptr;
+
+    StatusCb status_cb_ = nullptr;
+    void* status_cb_user_ = nullptr;
+
+    void resetSession();
+    void notify();
+    void initShaCtx();
+    void freeShaCtx();
+    void shaUpdate(const uint8_t* data, size_t len);
+    bool shaFinalAndCompare(const uint8_t expected[32]);
+};
+
+#endif // TR_OTA_RECEIVER_H

--- a/tinkerrocket-idf/projects/base_station/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/CMakeLists.txt
@@ -3,5 +3,32 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
 # base_station doesn't use guidance — exclude both the real submodule and
 # the stub so neither ends up in the component list.
 set(EXCLUDE_COMPONENTS "TR_GuidancePN TR_GuidancePN_Stub")
+
+# Embed git short-sha + build timestamp into the firmware image header
+# (esp_app_desc.version), max 32 chars. Read at runtime via
+# esp_app_get_description()->version and surfaced in BLE config_identity's
+# "fw" field. See docs/plans/08-ota-firmware-update.md §3.
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TR_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT TR_GIT_SHA)
+    set(TR_GIT_SHA "unknown")
+endif()
+execute_process(
+    COMMAND git diff-index --quiet HEAD --
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE TR_GIT_DIRTY_CODE
+    OUTPUT_QUIET ERROR_QUIET
+)
+if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
+    set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
+endif()
+string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
+set(PROJECT_VER "${TR_GIT_SHA}+${TR_BUILD_DATE}")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(base_station)

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -11,7 +11,9 @@ idf_component_register(
         TR_LoRa_Comms
         TR_MAX17205G
         TR_BQ27Z746
+        app_update
         driver
+        esp_app_format
         esp_timer
         fatfs
         sdmmc

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -11,6 +11,7 @@ idf_component_register(
         TR_LoRa_Comms
         TR_MAX17205G
         TR_BQ27Z746
+        TR_OTA
         app_update
         driver
         esp_app_format

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -2,6 +2,7 @@
 #include <TR_NVS.h>
 #include <algorithm>
 
+#include <esp_app_desc.h>         // esp_app_get_description for firmware version readback (#8)
 #include <esp_log.h>
 #include <esp_mac.h>              // esp_efuse_mac_get_default for unit_id
 #include <esp_vfs_fat.h>
@@ -1304,16 +1305,20 @@ static void sendCurrentConfig()
     delay(50);
 
     // Message 2: device identity ("config_identity" type)
-    char id_buf[128];
+    const esp_app_desc_t* app_desc = esp_app_get_description();
+    const char* fw_ver = (app_desc && app_desc->version[0]) ? app_desc->version : "unknown";
+    char id_buf[192];
     snprintf(id_buf, sizeof(id_buf),
              "{\"type\":\"config_identity\""
              ",\"uid\":\"%s\""
              ",\"un\":\"%s\""
              ",\"nid\":%u"
-             ",\"dt\":\"%s\"}",
+             ",\"dt\":\"%s\""
+             ",\"fw\":\"%s\"}",
              unit_id_hex, unit_name,
              (unsigned)network_id,
-             config::DEVICE_TYPE);
+             config::DEVICE_TYPE,
+             fw_ver);
     String id_json(id_buf);
     ble_app.sendConfigJSON(id_json);
     ESP_LOGI(TAG, "[CFG] Sent identity readback (%u bytes)", (unsigned)id_json.length());

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -5,6 +5,8 @@
 #include <esp_app_desc.h>         // esp_app_get_description for firmware version readback (#8)
 #include <esp_log.h>
 #include <esp_mac.h>              // esp_efuse_mac_get_default for unit_id
+#include <esp_ota_ops.h>          // esp_ota_mark_app_valid_cancel_rollback (#8)
+#include <esp_partition.h>        // esp_ota_get_running_partition for rollback gate (#8)
 #include <esp_vfs_fat.h>
 #include <esp_spiffs.h>
 #include <sdmmc_cmd.h>
@@ -36,6 +38,29 @@
 #include <RocketComputerTypes.h>
 
 static const char* TAG = "BS";
+
+// OTA rollback gate (#8). True only between boot and the first successful
+// telemetry-while-connected event when we booted PENDING_VERIFY (i.e., a
+// fresh OTA image). On first hit we call esp_ota_mark_app_valid_cancel_rollback
+// once and clear the flag. If we never get there (panic, hang, BLE init
+// failure) the bootloader auto-reverts to ota_0 on next boot.
+static bool g_ota_pending_verify = false;
+
+static inline void maybeMarkOtaValid()
+{
+    if (!g_ota_pending_verify) return;
+    esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+    if (err == ESP_OK)
+    {
+        ESP_LOGW(TAG, "OTA: new image validated, rollback cancelled");
+    }
+    else
+    {
+        ESP_LOGE(TAG, "OTA: mark_app_valid_cancel_rollback failed: %s",
+                 esp_err_to_name(err));
+    }
+    g_ota_pending_verify = false;
+}
 
 // Forward declarations
 static const char* rocketStateToString(uint8_t state);
@@ -2621,6 +2646,30 @@ static void setup_bs()
     ESP_LOGI(TAG, "  TinkerRocket Base Station");
     ESP_LOGI(TAG, "======================================");
 
+    // OTA boot-state check (#8). If this image was just OTA-installed it
+    // boots PENDING_VERIFY; we hold off the "valid" mark until we've seen
+    // BLE work end-to-end (first telemetry sent while connected). If the
+    // app crashes or hangs before that, the bootloader auto-rolls back to
+    // ota_0 on the next boot.
+    {
+        const esp_partition_t* running = esp_ota_get_running_partition();
+        esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+        if (running && esp_ota_get_state_partition(running, &state) == ESP_OK)
+        {
+            if (state == ESP_OTA_IMG_PENDING_VERIFY)
+            {
+                ESP_LOGW(TAG, "OTA: running on PENDING_VERIFY image (partition '%s' @ 0x%08x); "
+                              "rollback armed until first telemetry round-trip",
+                         running->label, (unsigned)running->address);
+                g_ota_pending_verify = true;
+            }
+            else
+            {
+                ESP_LOGI(TAG, "OTA: running partition '%s' state=%d", running->label, (int)state);
+            }
+        }
+    }
+
     // BLE time-sync arrives as broken-down UTC; pin TZ so mktime() in the
     // log-rename helper (#168) interprets it as UTC seconds, not local.
     setenv("TZ", "UTC0", 1);
@@ -3416,6 +3465,7 @@ static void loop_bs()
                     ble_telem.source_unit_name = tracked_rockets[slot].unit_name;
                 }
                 ble_app.sendTelemetry(ble_telem);
+                maybeMarkOtaValid();
             }
         }
         else
@@ -3515,6 +3565,7 @@ static void loop_bs()
                 ble_telem.data_status = TR_BLE_To_APP::TelemetryData::DataStatus::SYNCING;
             }
             ble_app.sendTelemetry(ble_telem);
+            maybeMarkOtaValid();
         }
     }
 

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3525,7 +3525,15 @@ static void loop_bs()
     if (millis() - last_battery_ms >= config::PWR_UPDATE_PERIOD_MS)
     {
         last_battery_ms = millis();
-        updateBattery();
+        // Skip the I2C gauge poll while an OTA is in flight (#17): the
+        // esp_ota_begin() partition erase blocks the SPI flash for ~1-2 s
+        // and the gauge transaction collides with it, logging spurious
+        // i2c_master_transmit_receive failures. The telemetry push below
+        // still runs so the app sees liveness + OTA status during the flash.
+        if (!ble_app.isOtaActive())
+        {
+            updateBattery();
+        }
 
         // Always push base station stats to BLE, even without LoRa packets,
         // so BS battery / logging state / RSSI stay live.  Tag each push

--- a/tinkerrocket-idf/projects/base_station/partitions.csv
+++ b/tinkerrocket-idf/projects/base_station/partitions.csv
@@ -1,5 +1,6 @@
 # Name,   Type, SubType, Offset,  Size,    Flags
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x300000,
-spiffs,   data, spiffs,  0x310000,0x4F0000,
+ota_0,    app,  ota_0,   0x10000, 0x300000,
+ota_1,    app,  ota_1,   0x310000,0x300000,
+spiffs,   data, spiffs,  0x610000,0x1F0000,

--- a/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
@@ -28,6 +28,11 @@ CONFIG_FREERTOS_HZ=1000
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
+# OTA rollback: new images boot as PENDING_VERIFY and auto-roll back to ota_0
+# unless app calls esp_ota_mark_app_valid_cancel_rollback() after first
+# successful telemetry round-trip. See docs/plans/08-ota-firmware-update.md §4.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 


### PR DESCRIPTION
## What this is

OTA firmware update over BLE from the iOS app — **Phase 1 (design, all 3 computers) + Phase 2 (Base Station implementation)** of #8.

Bench-verified end-to-end on real BS hardware + a physical iPhone: pick a `.bin` in the app → push over BLE → device flashes, reboots, validates → app confirms the new version. Includes a verified auto-rollback safety net.

This does **not** close #8 — Phase 3 (Out Computer) and Phase 4 (Flight Computer relay) remain. Design for all four phases is captured in `docs/plans/08-ota-firmware-update.md`.

## Design (Phase 1)

Full contract in [`docs/plans/08-ota-firmware-update.md`](docs/plans/08-ota-firmware-update.md). Key decisions:

- **Partitions**: dual 3 MB `ota_0`/`ota_1` slots on the existing 8 MB flash. SPIFFS dropped on OC/FC (unused); BS keeps 2 MB for its SD-fallback log.
- **Transport**: reuse the existing BLE characteristics — new command codes `70/71/72` (BEGIN/FINISH/ABORT) on the command char, image chunks written to the file-transfer char, `ota_status` JSON replies on the file-ops char. No new GATT characteristics.
- **Integrity**: full-image SHA-256 sent in BEGIN, verified on-device before `esp_ota_set_boot_partition`.
- **Rollback**: `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`; a freshly-OTA'd image boots `PENDING_VERIFY` and only marks itself valid after the first successful telemetry round-trip. Anything earlier (panic/hang/BLE-init failure) auto-reverts.
- **FC relay (Phase 4)**: settled on a split-bus design over the existing 5-wire OC↔FC link (I2C control plane + I2S reconfigured OC→FC for the image) — no chip-reset line exists, so the ROM-bootloader path is out. Code is Phase 4.

## Implementation (Phase 2 — Base Station)

**Firmware**
- New `TR_OTA` component: `OTAReceiver` state machine + SHA-256 over an abstract `TR_OTA_Backend` (real `esp_ota_*` impl + a fake for host tests). **19 host unit tests.**
- `TR_BLE_To_APP`: cmd 70/71/72 handlers; file-transfer char made writable (`WRITE` + `WRITE_NO_RSP`); `ota_status` notifications; deferred-reboot watchdog.
- Partition table, `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`, post-boot validation gate, and a `"fw"` field (git-sha + build timestamp via `PROJECT_VER`) added to `config_identity`.

**iOS**
- `FirmwareUpdateView` (file picker → progress → result), `OTASession` state machine, `fw`-version parse + display.
- Session lives on `BLEFleet` (not `BLEDevice`) so its state survives the post-OTA disconnect/reconnect — same persistence pattern as the `#140` GPS-fix cache.

## Bench verification (2026-05-28, BS hardware + iPhone)

| Check | Result |
|---|---|
| Happy-path OTA → reboot → validate | ✅ |
| Throughput | ✅ ~5 min → **~35–80 s** for 776 KB (writeWithoutResponse) |
| UI "Updated successfully" survives reboot | ✅ |
| **Auto-rollback** (deliberate broken image) | ✅ bad image panics → bootloader reverts to good slot → app shows "Rollback detected" |
| No spurious I2C errors during flash erase | ✅ (#17) |
| Host unit tests | ✅ 211/211 |
| `out_computer` still builds (shared component) | ✅ |

## Commit history note

The throughput + UI-lifetime fixes took a few iterations; the dead-ends are left in history with explanatory messages rather than squashed, since the "why not X" is useful context:
- `b48a940` pipelined writes-with-response — **didn't help** (CoreBluetooth serializes with-response at the link layer); superseded by `3def061` writeWithoutResponse + `0dd1796` (firmware must advertise `WRITE_NO_RSP`).
- `1c65c26` first UI-lifetime attempt (lazy var on `BLEDevice`) — **insufficient** (BLEDevice is recreated on reconnect); fixed properly in `c1a5b66` (move to `BLEFleet`).

## Not in this PR

- Phase 3 (Out Computer) / Phase 4 (Flight Computer) — separate PRs.
- Secure boot / signed images — separate hardening pass (documented as out-of-scope).
- A few negative paths beyond rollback (SHA-mismatch, mid-upload disconnect, power-loss) — the receiver state machine for these is covered by the host tests; full integrated coverage can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
