### PR TITLE
ota(oc): Phase 3 — OTA self-update for Out Computer (#8)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -157,6 +157,9 @@ struct SettingsView: View {
                 } else {
                     rocketSettingsSections
                 }
+                // Firmware update is device-level (not profile-level), so it
+                // sits outside the branch above and shows for BS + OC alike.
+                firmwareSection
             }
             .navigationTitle(navTitle)
             .overlay { if isInitializing { initializingOverlay } }
@@ -226,9 +229,15 @@ struct SettingsView: View {
         }
 
         loRaSections
+    }
 
-        // Firmware update entry (#8 phase 2 — BS-gated; phase 3 removes the gate
-        // when the OC implementation lands).
+    // Firmware update entry. Shown for any connected device (#8): Phase 2
+    // shipped it BS-only; Phase 3 added the Out Computer firmware side, so the
+    // entry is no longer gated on isBaseStation. (The connected device is
+    // always a BS or OC — the FC has no BLE radio. Phase 4 will add an
+    // FC-relay target picker when connected to an OC.)
+    @ViewBuilder
+    private var firmwareSection: some View {
         Section(header: Text("Firmware")) {
             HStack {
                 Text("Version")

--- a/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
@@ -3,5 +3,32 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
 # out_computer doesn't use guidance — exclude both the real submodule and
 # the stub so neither ends up in the component list.
 set(EXCLUDE_COMPONENTS "TR_GuidancePN TR_GuidancePN_Stub")
+
+# Embed git short-sha + build timestamp into the firmware image header
+# (esp_app_desc.version), max 32 chars. Read at runtime via
+# esp_app_get_description()->version and surfaced in BLE config_identity's
+# "fw" field. See docs/plans/08-ota-firmware-update.md §3.
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TR_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT TR_GIT_SHA)
+    set(TR_GIT_SHA "unknown")
+endif()
+execute_process(
+    COMMAND git diff-index --quiet HEAD --
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE TR_GIT_DIRTY_CODE
+    OUTPUT_QUIET ERROR_QUIET
+)
+if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
+    set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
+endif()
+string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
+set(PROJECT_VER "${TR_GIT_SHA}+${TR_BUILD_DATE}")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(out_computer)

--- a/tinkerrocket-idf/projects/out_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/out_computer/dependencies.lock
@@ -1,10 +1,18 @@
 dependencies:
+  espressif/dhara:
+    component_hash: 88968cff2e88853a29366ad556e9c27596d18e15028b6e9f3cd627665f914440
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.0.0
   idf:
     source:
       type: idf
     version: 5.3.2
 direct_dependencies:
+- espressif/dhara
 - idf
-manifest_hash: 405b18f8e5814ebcdc7c93737a0aa6a9f5b809db0db73cdb5b5e551e21805af6
+manifest_hash: 6f4972c0cd856d2015cba9831063a6a730deae8bd16edbea178fa4c6411182a3
 target: esp32s3
 version: 2.0.0

--- a/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
@@ -16,6 +16,9 @@ idf_component_register(
         TR_Coordinates
         TR_BLE_To_APP
         TR_INA230
+        TR_OTA
+        app_update
+        esp_app_format
         nvs_flash
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format -Wno-narrowing)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -10,6 +10,9 @@
 #include <nvs_flash.h>
 #include <esp_log.h>
 #include <esp_mac.h>              // esp_efuse_mac_get_default for unit_id
+#include <esp_app_desc.h>         // esp_app_get_description for firmware version readback (#8)
+#include <esp_ota_ops.h>          // esp_ota_mark_app_valid_cancel_rollback (#8)
+#include <esp_partition.h>        // esp_ota_get_running_partition for rollback gate (#8)
 #include "soc/rtc_cntl_reg.h"  // Brownout detector control
 #include "freertos/queue.h"
 #include "host/ble_gap.h"       // ble_gap_update_params
@@ -57,6 +60,29 @@ static inline std::string itos(int v)
 #include <NvsBitmapStore.h>
 #include <WireFormat.h>
 // FlightSimulator.h removed — sim now runs on FlightComputer via TR_Sensor_Collector_Sim
+
+// OTA rollback gate (#8). True only between boot and the first successful
+// telemetry-while-connected event when we booted PENDING_VERIFY (i.e., a
+// fresh OTA image). On first hit we call esp_ota_mark_app_valid_cancel_rollback
+// once and clear the flag. If we never get there (panic, hang, BLE init
+// failure) the bootloader auto-reverts to ota_0 on next boot.
+static bool g_ota_pending_verify = false;
+
+static inline void maybeMarkOtaValid()
+{
+    if (!g_ota_pending_verify) return;
+    esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+    if (err == ESP_OK)
+    {
+        ESP_LOGW("OC", "OTA: new image validated, rollback cancelled");
+    }
+    else
+    {
+        ESP_LOGE("OC", "OTA: mark_app_valid_cancel_rollback failed: %s",
+                 esp_err_to_name(err));
+    }
+    g_ota_pending_verify = false;
+}
 
 static TR_I2C_Interface i2c_interface(config::I2C_ADDRESS);
 static bool i2c_slave_initialized = false;
@@ -2056,17 +2082,21 @@ static void sendCurrentConfig()
     delay(50);
 
     // Message 3: device identity ("config_identity" type)
-    char id_buf[128];
+    const esp_app_desc_t* app_desc = esp_app_get_description();
+    const char* fw_ver = (app_desc && app_desc->version[0]) ? app_desc->version : "unknown";
+    char id_buf[192];
     snprintf(id_buf, sizeof(id_buf),
              "{\"type\":\"config_identity\""
              ",\"uid\":\"%s\""
              ",\"un\":\"%s\""
              ",\"nid\":%u"
              ",\"rid\":%u"
-             ",\"dt\":\"%s\"}",
+             ",\"dt\":\"%s\""
+             ",\"fw\":\"%s\"}",
              unit_id_hex, unit_name,
              (unsigned)network_id, (unsigned)rocket_id,
-             config::DEVICE_TYPE);
+             config::DEVICE_TYPE,
+             fw_ver);
     String id_json(id_buf);
     ble_app.sendConfigJSON(id_json);
     ESP_LOGI("CFG", "Sent identity readback (%u bytes)", (unsigned)id_json.length());
@@ -2929,7 +2959,15 @@ static void printStats()
     // --- Low-power mode: send minimal BLE telemetry only ---
     if (!pwr_pin_on)
     {
-        readINA230Power();
+        // Skip the INA230 I2C poll while an OTA is in flight (#17): the
+        // esp_ota_begin() partition erase blocks SPI flash for ~1-2 s and the
+        // gauge transaction collides with it, logging spurious I2C timeouts.
+        // The telemetry push below still runs so the app sees liveness +
+        // OTA status during the flash.
+        if (!ble_app.isOtaActive())
+        {
+            readINA230Power();
+        }
 
         TR_BLE_To_APP::TelemetryData ble_telem = {};
         if (latest_power_valid)
@@ -2973,6 +3011,11 @@ static void printStats()
         ble_telem.bs_current = NAN;
         ble_telem.pwr_pin_on = false;
         ble_app.sendTelemetry(ble_telem);
+        // OC boots into low-power mode, so this is the path that runs right
+        // after a post-OTA reboot + app reconnect — the critical place to
+        // validate the new image. Gate on a live connection so we only cancel
+        // rollback once we've proven BLE works end-to-end with a client (#8).
+        if (ble_app.isConnected()) maybeMarkOtaValid();
         return;
     }
 
@@ -3376,6 +3419,7 @@ static void printStats()
     {
         ble_app.sendTelemetry(ble_telem);
         telem_send_count++;
+        maybeMarkOtaValid();   // validate a fresh OTA image once telemetry flows to a connected client (#8)
     }
     else
     {
@@ -3822,6 +3866,30 @@ static void setup_oc()
     pwr_pin_on = false;
 
     ESP_LOGI("OC", "Starting OutComputer (low-power mode)...");
+
+    // OTA boot-state check (#8). If this image was just OTA-installed it
+    // boots PENDING_VERIFY; we hold off the "valid" mark until we've seen
+    // BLE work end-to-end (first telemetry sent while connected). If the
+    // app crashes or hangs before that, the bootloader auto-rolls back to
+    // ota_0 on the next boot.
+    {
+        const esp_partition_t* running = esp_ota_get_running_partition();
+        esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+        if (running && esp_ota_get_state_partition(running, &state) == ESP_OK)
+        {
+            if (state == ESP_OTA_IMG_PENDING_VERIFY)
+            {
+                ESP_LOGW("OC", "OTA: running on PENDING_VERIFY image (partition '%s' @ 0x%08x); "
+                              "rollback armed until first telemetry round-trip",
+                         running->label, (unsigned)running->address);
+                g_ota_pending_verify = true;
+            }
+            else
+            {
+                ESP_LOGI("OC", "OTA: running partition '%s' state=%d", running->label, (int)state);
+            }
+        }
+    }
 
     // --- Load NVS settings early so config readback to app is correct ---
     {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4237,6 +4237,13 @@ static void loop_oc()
         ble_was_connected = ble_now;
     }
 
+    // Service the BLE library's poll-style work — currently just the OTA
+    // deferred-restart watchdog. handleOtaFinish() sets the boot partition and
+    // schedules esp_restart() ~500 ms out, but the reboot only fires from here.
+    // Without this, an OTA completes and sets ota_1 yet the device never reboots
+    // into the new image (#8 Phase-3 OC bench finding; loop_bs always called it).
+    ble_app.loop();
+
     // Check for BLE commands
     uint8_t ble_cmd = ble_app.getCommand();
     if (ble_cmd != 0)

--- a/tinkerrocket-idf/projects/out_computer/partitions.csv
+++ b/tinkerrocket-idf/projects/out_computer/partitions.csv
@@ -1,6 +1,6 @@
 # Name,   Type, SubType, Offset,  Size,    Flags
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x300000,
-coredump, data, coredump,0x310000,0x10000,
-spiffs,   data, spiffs,  0x320000,0x4E0000,
+ota_0,    app,  ota_0,   0x10000, 0x300000,
+ota_1,    app,  ota_1,   0x310000,0x300000,
+coredump, data, coredump,0x610000,0x10000,

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -38,7 +38,7 @@ CONFIG_ESP_INT_WDT=y
 CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
 
 # Core dump to flash — retrieve after crash with:
-#   espcoredump.py info_corefile -t raw -c 0x310000 build/out_computer.elf
+#   espcoredump.py info_corefile -t raw -c 0x610000 build/out_computer.elf
 CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
 CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
 CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y
@@ -46,6 +46,11 @@ CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y
 # Partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+
+# OTA rollback: new images boot as PENDING_VERIFY and auto-roll back to ota_0
+# unless app calls esp_ota_mark_app_valid_cancel_rollback() after first
+# successful telemetry round-trip. See docs/plans/08-ota-firmware-update.md §4.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y


### PR DESCRIPTION
## What this is

**Phase 3 of #8** — OTA firmware update for the **Out Computer**, porting the proven Phase 2 (Base Station, #219) pattern. The protocol, `OTAReceiver`, and BLE command handling all live in the shared `TR_OTA` / `TR_BLE_To_APP` components, so this is the OC project-level wiring plus the OC-specific bits.

Part of #8 (Phase 3 of 4) — **#8 stays open**; Phase 4 (Flight Computer relay over OC) is the remaining work.

## Changes

- **Partitions** (`out_computer/partitions.csv`): `app0`→`ota_0` + new `ota_1` (dual 3 MB); coredump relocated `0x310000`→`0x610000`; SPIFFS dropped (OC never mounts it). NVS stays at `0x9000` so unit name / network+rocket ID / cal survive the table change.
- **Rollback**: `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`; PENDING_VERIFY boot-state check + `maybeMarkOtaValid()` after the first telemetry-while-connected. **OC-specific:** OC boots into low-power mode, so the validation gate had to live on the low-power telemetry path (not just the active path) — otherwise a fresh image would never self-validate and the next power-cycle would silently revert.
- **Version**: `PROJECT_VER` (git-sha + build timestamp) surfaced as `"fw"` in `config_identity` (iOS `BLEDevice` already parses it generically).
- **I2C poll guard**: `readINA230Power()` skipped while `isOtaActive()` so it doesn't collide with the `esp_ota_begin()` flash erase (the #17 pattern, ported from the BS gauge poll).
- **iOS**: the Firmware-update entry was BS-gated (nested in `baseStationSections`); extracted to a `firmwareSection` rendered for any connected device (BS + OC; the FC has no BLE radio).
- **Reboot fix** (`f689f25`): `loop_oc` never called `ble_app.loop()`, so the poll-based deferred-restart watchdog never fired — an OTA set the boot partition but the device never rebooted. `loop_bs` always called it; `loop_oc` didn't. Now wired in. (Found on the bench, not in the build.)
- **Lockfile** (`8d3910c`): reconciled `out_computer/dependencies.lock` (was missing `espressif/dhara`, the NAND FTL); pre-existing drift, unrelated to OTA.

## Bench verification (OC hardware + iPhone, IDF v5.3.2)

| Path | Result |
|---|---|
| Happy path: OTA → reboot → validate | ✅ app "Updated successfully"; version readback correct |
| Rollback-validation gate (low-power) | ✅ `OTA: new image validated, rollback cancelled` after reconnect |
| **Auto-rollback** (deliberate bad image) | ✅ bad image panics in `setup_oc` → bootloader reverts to the good slot (`state=2` VALID, no "rollback armed") → app "Rollback detected" |
| OC firmware build | ✅ `out_computer.bin` `0xc1ae0` (≈775 KB), 75% of the 3 MB slot free; dual-OTA partition table parses |
| iOS build | ✅ BUILD SUCCEEDED (generic iOS Simulator) |

## Not in this PR / follow-ups

- Phase 4 (FC relay over OC) — next, separate PR.
- `loop_oc` shows a chronic ~1 s per-iteration stall in low-power mode (consistent with the known #90 Core-1 stall; likely the I2S read timing out with the FC powered off). It only delays the post-OTA reboot by ~1 s. Separately, the on-connect config readback can race MTU negotiation and get skipped (the app re-requests and recovers). Both pre-existing, not OTA — tracked under #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
