### PR TITLE
fix(oc): eliminate ~1 s idle-loop stall that dropped connect-time BLE commands (#221)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4066,6 +4066,15 @@ static void setup_oc()
 // LFS_TIMING / STALL_THRESHOLD_US instrumentation in TR_LogToFlash.cpp.
 static constexpr int64_t LOOP_STALL_THRESHOLD_US = 100'000;  // 100 ms
 
+// Idle (FC-off / low-power) loop period.  loop_oc drains the single-slot BLE
+// command buffer (pending_command_) once per iteration via ble_app.getCommand(),
+// so the loop must cycle faster than connect-time commands arrive (~60-90 ms
+// apart) or a burst overwrites itself — the root cause of #221 (was delay(1000)).
+// 20 ms keeps the loop responsive with negligible power cost (light sleep is
+// disabled while BLE is on, so the CPU idles at 40 MHz either way).  This is the
+// only knob: raise it if bench idle-current measurement ever shows it matters.
+static constexpr uint32_t IDLE_LOOP_DELAY_MS = 20;
+
 #define LOOP_STALL_INSTR(name, expr) do {                                       \
     const int64_t _stall_t0_ = esp_timer_get_time();                            \
     expr;                                                                       \
@@ -4211,11 +4220,16 @@ static void loop_oc()
             }
         }
 
-        // Yield to FreeRTOS — everything in low-power mode is 1 Hz or slower
-        // (INA230 read, BLE telemetry, BLE command check).  BLE commands arrive
-        // via NimBLE callbacks on their own task, no polling needed.
-        // Longer delay = more time at 40 MHz (DFS min) = lower average current.
-        delay(1000);
+        // Yield to FreeRTOS.  This was delay(1000) for power, but the BLE
+        // command buffer (pending_command_) is single-slot and is only drained
+        // below via ble_app.getCommand() — a 1 s loop period let a connect-time
+        // command burst overwrite itself (only the last survived) and lagged
+        // in-loop connection setup up to 1 s, surfacing as flaky connects /
+        // dropped config+cal sync (#221).  Light sleep is disabled while BLE is
+        // on, so the CPU idles at 40 MHz (DFS min) regardless and the long delay
+        // saved little real power.  Stay responsive so the slot is drained as
+        // fast as commands arrive (~60-90 ms apart on connect).
+        delay(IDLE_LOOP_DELAY_MS);
 
     }
 


### PR DESCRIPTION
## What & why

`loop_oc`'s low-power (FC-off) idle path blocked on `delay(1000)` every iteration. The BLE command buffer (`pending_command_`) is single-slot and is only drained in `loop_oc` via `ble_app.getCommand()`, so a 1 s loop period let connect-time command bursts overwrite themselves (only the last survived — `Overwriting unconsumed cmd …`) and lagged in-loop connection setup (rising-edge `sendCurrentConfig` / `requestSlowBLEParams`) up to 1 s → dropped config/cal sync and flaky connects requiring a re-scan.

Replace the fixed `delay(1000)` with `IDLE_LOOP_DELAY_MS` (20 ms) so the loop drains the slot faster than commands arrive (~60–90 ms apart on connect). Light sleep is disabled while BLE is on, so the CPU idles at 40 MHz (DFS min) regardless — the long delay saved little real power.

Full root-cause analysis in #221.

## Bench-verified (OC flashed @ `27ce97a`, repeated connects)
- **Idle stall gone:** ~7 s of idle between advertising and connect with **zero** `LOOP_STALL` (was solid ~1011 ms catch-all every second).
- **No dropped commands:** the full connect-time burst (servo / PID / servo-ctrl / gain-sched / roll / roll-profile / guidance / camera / sounds / pyro / sensor-cal-read) is processed in order — no `Overwriting unconsumed cmd`.
- Cal sync intact end-to-end (`cmd 63 → Sensor cal READ → I2C 0xEA`); loop healthy when powered (`iter=42 us`).
- Connects reliably across repeated attempts (no re-scan needed).

The remaining `LOOP_STALL` lines on connect/power-on are one-time costs (the connect rising-edge `delay(500)`, the config-readback notify burst, the ~3.3 s power-on flight-log recovery, and the LoRa reconfigure) — none recur.

## Known minor follow-up (not blocking)
The faster loop exposed a pre-existing connect-time race: the rising-edge config auto-push now fires before MTU negotiation completes (`Config JSON … > MTU limit 20, SKIPPING`). It's functionally recovered — the app's `cmd 20` re-requests config after MTU comes up — so it's log noise + a wasted push, not data loss. Clean fix: trigger the push on the MTU-negotiated event instead of `delay(500)`. Tracked separately; intentionally **not** included here so this PR stays the bench-verified one-liner.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
