### PR TITLE
fix(oc): defer connect-time config push until BLE is notify-ready (#224)

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -109,6 +109,7 @@ static int gatt_access_cb(uint16_t conn_handle, uint16_t attr_handle,
 TR_BLE_To_APP::TR_BLE_To_APP(const char* device_name)
     : device_connected_(false),
       negotiated_mtu_(0),
+      telem_notify_subscribed_(false),
       conn_handle_(0),
       pending_command_(0),
       pending_file_list_page_(0),
@@ -222,6 +223,11 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
     case BLE_GAP_EVENT_SUBSCRIBE:
         ESP_LOGI(BLE_TAG, "Subscribe event: attr_handle=%u, cur_notify=%d",
                  event->subscribe.attr_handle, event->subscribe.cur_notify);
+        // Track notify-enable on the telemetry/config characteristic so the
+        // connect-time config push can wait until the app can actually receive
+        // it (#224).
+        if (event->subscribe.attr_handle == self->telemetry_val_handle_)
+            self->telem_notify_subscribed_ = event->subscribe.cur_notify;
         break;
 
     default:
@@ -241,6 +247,7 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     device_connected_ = true;
     conn_handle_ = conn_handle;
     negotiated_mtu_ = 0;  // Reset until MTU exchange completes
+    telem_notify_subscribed_ = false;
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
 
@@ -268,6 +275,7 @@ void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
 {
     device_connected_ = false;
     negotiated_mtu_ = 0;
+    telem_notify_subscribed_ = false;
     conn_handle_ = 0;
     ESP_LOGW(BLE_TAG, "Device DISCONNECTED, reason=%d", reason);
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -191,6 +191,15 @@ public:
     // Returns 0 if not yet negotiated
     uint16_t getNegotiatedMTU() const { return negotiated_mtu_; }
 
+    // True once the central is ready to receive a notify-based push: it has
+    // negotiated a larger MTU AND enabled notifications (CCCD) on the
+    // telemetry/config characteristic.  loop_oc gates the connect-time config
+    // auto-push on this so the notifies aren't dropped (#224 — the faster idle
+    // loop from #221 made the old fixed delay(500) race the MTU + subscribe).
+    bool isReadyForNotify() const {
+        return device_connected_ && negotiated_mtu_ > 0 && telem_notify_subscribed_;
+    }
+
     // Get max data bytes per BLE chunk (MTU - ATT overhead - our header)
     // Falls back to 170 if MTU not yet negotiated
     size_t getMaxChunkDataSize() const;
@@ -206,6 +215,7 @@ private:
 
     volatile bool device_connected_;
     volatile uint16_t negotiated_mtu_;
+    volatile bool telem_notify_subscribed_;  // central enabled notifications on telemetry/config char
     volatile uint16_t conn_handle_;          // NimBLE connection handle
     volatile uint8_t pending_command_;
     volatile uint8_t pending_file_list_page_;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4233,17 +4233,25 @@ static void loop_oc()
 
     }
 
-    // Auto-send config on BLE connect (rising edge)
+    // Auto-send config once the BLE connection is fully ready — MTU negotiated
+    // AND the app has enabled notifications on the telemetry/config char.
+    // Edge-armed on connect, then deferred (no blocking delay) until ready.
+    // Pushing earlier dropped the config notifies (#224): the faster idle loop
+    // (#221) made the old fixed delay(500) race the MTU exchange + CCCD
+    // subscribe, so the pushes were skipped (recovered only by the app's later
+    // config re-request).  ble_app.isReadyForNotify() is the deterministic gate.
     {
         static bool ble_was_connected = false;
+        static bool config_push_pending = false;
         bool ble_now = ble_app.isConnected();
-        if (ble_now && !ble_was_connected) {
-            delay(500); // Let app subscribe to notifications
+        if (ble_now && !ble_was_connected) config_push_pending = true;    // arm on connect
+        if (!ble_now)                      config_push_pending = false;   // disarm on disconnect
+        if (config_push_pending && ble_app.isReadyForNotify()) {
+            config_push_pending = false;
             sendCurrentConfig();
-            // In low-power mode, override the fast params set by onConnect
-            // with slow params to save power.  The library's onConnect always
-            // requests fast params (needed for file transfer when powered on),
-            // so we correct it here after a short delay.
+            // In low-power mode, override the fast params set by onConnect with
+            // slow params to save power (onConnect always requests fast params,
+            // needed for file transfer when powered on).
             if (!pwr_pin_on) {
                 requestSlowBLEParams(0);
             }


### PR DESCRIPTION
## What & why

The connect rising-edge config auto-push used a fixed `delay(500)` ("let app subscribe") before sending. #221's idle-loop speedup made that delay race the MTU exchange + CCCD subscribe, so the config/pyro/identity notifies were sent against the default 23-byte MTU (or before the app subscribed) and skipped — `Config JSON … > MTU limit 20, SKIPPING` — recovered only by the app's later `cmd 20` config re-request.

## Fix

Track notify-enable on the telemetry/config characteristic in `TR_BLE_To_APP` and expose `isReadyForNotify()` = *connected && MTU negotiated && subscribed*. `loop_oc` now arms the push on connect and fires it **once** (non-blocking, no delay) when `isReadyForNotify()` is true — deterministic, no skipped pushes, and it drops the blocking `delay(500)` connect-time stall as a bonus.

The component change is additive (new member/getter + subscribe tracking); base-station behavior is unchanged.

## Verification

- **CI:** firmware-build (out/flight/base) — compile-checks the shared-component change across all consumers.
- **Bench (in progress):** on a fresh connect, no `Config JSON … SKIPPING`; the config auto-push lands once MTU + subscribe complete, independent of the app's `cmd 20`. (#221 idle stays stall-free; cal read still round-trips.)

Follow-on to #221 / #223. Closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
