### PR TITLE
Add wire-code uniqueness guards (I2C message types + BLE command numbers)

### DIFF
--- a/.github/workflows/wire-codes.yml
+++ b/.github/workflows/wire-codes.yml
@@ -1,0 +1,37 @@
+name: Wire-Code Guards
+
+# Guards the hand-assigned BLE command-number spaces (app<->OC and app<->BS)
+# against silent duplicate assignment.  Both firmware dispatches are flat
+# `if (ble_cmd == N)` chains that take the first match, so a duplicate value
+# turns the later branch into dead code with no compiler/test error (#132/#148
+# shipped exactly that).  The OC<->FC I2C message-type space is guarded
+# separately by the host gtest in tests_cpp (RocketComputerTypes,
+# MessageTypeCodes_AllUnique), which runs under the "C++ Unit Tests" workflow.
+
+on:
+  push:
+    paths:
+      - 'tinkerrocket-idf/projects/out_computer/main/main.cpp'
+      - 'tinkerrocket-idf/projects/base_station/main/main.cpp'
+      - 'tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h'
+      - 'TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift'
+      - 'tools/check_ble_command_ids.py'
+      - '.github/workflows/wire-codes.yml'
+  pull_request:
+    paths:
+      - 'tinkerrocket-idf/projects/out_computer/main/main.cpp'
+      - 'tinkerrocket-idf/projects/base_station/main/main.cpp'
+      - 'tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h'
+      - 'TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift'
+      - 'tools/check_ble_command_ids.py'
+      - '.github/workflows/wire-codes.yml'
+
+jobs:
+  ble-command-ids:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pure stdlib (re, pathlib); ubuntu-latest ships python3, no deps needed.
+      - name: Check BLE command-number uniqueness (app<->OC / app<->BS)
+        run: python3 tools/check_ble_command_ids.py

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <cstring>
+#include <map>
 #include "RocketComputerTypes.h"
 
 // Verify packed struct sizes match the SIZE_OF_* constants.
@@ -833,4 +834,93 @@ TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
                             (1u << FlightSettingsData::F_FW_DIRTY) |
                             (1u << FlightSettingsData::F_SOUNDS));
     EXPECT_EQ(all, 0x3Fu);  // bits 0-5, no overlap
+}
+
+// ============================================================================
+// Wire-code uniqueness guard: OC<->FC I2C message types (#132 / #148)
+// ============================================================================
+// The "### Message Types from In ESP32 ###" block in RocketComputerTypes.h is
+// a hand-assigned 8-bit code space (~0xA0-0xF1).  Both the OC and the FC
+// dispatch on these with flat if/else-if chains that take the FIRST matching
+// branch, so two constants sharing a value silently turn the later handler
+// into dead code -- no compiler error, no link error, no test failure.
+//
+// That is exactly how #132 (rocket-profile sensor-cal sync) and #148 (mag-cal
+// user-verify) collided: SENSOR_CAL_APPLY_PENDING/MSG/READ were assigned
+// 0xDD/0xDE/0xDF, aliasing MAG_CAL_VERIFY_DONE/RESET/FORCE_APPLY, and a
+// connect-time SENSOR_CAL_READ was silently handled as MAG_CAL_FORCE_APPLY
+// ("force_apply refused: not in MAG_CALIBRATION session" -- bench 2026-05-29).
+//
+// This test makes that class of bug a hard failure: every message-type
+// constant is listed once below and the values must be pairwise distinct.
+// The list IS the registry -- when you add a message type to that header
+// block, add it here too (and bump the count tripwire at the end).
+//
+// NOTE on scope: the REG_* read addresses (0x00-0x08) and the LoRa-namespace
+// constants (LORA_BEACON_SYNC=0xBE, LORA_CMD_*, ...) are SEPARATE code spaces
+// and are intentionally NOT included -- e.g. LORA_BEACON_SYNC=0xBE deliberately
+// coincides with SERVO_TEST_MSG=0xBE and that overlap is harmless.  Only the
+// OC<->FC message-type block must be internally unique.
+TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
+    struct MsgType { uint8_t value; const char* name; };
+#define MT(c) MsgType{ (c), #c }
+    const MsgType codes[] = {
+        MT(OUT_STATUS_QUERY),         MT(GNSS_MSG),
+        MT(ISM6HG256_MSG),            MT(BMP585_MSG),
+        MT(MMC5983MA_MSG),            MT(NON_SENSOR_MSG),
+        MT(POWER_MSG),                MT(START_LOGGING),
+        MT(END_FLIGHT),               MT(OUT_STATUS_RESPONSE),
+        MT(CAMERA_START),             MT(CAMERA_STOP),
+        MT(SOUNDS_ENABLE),            MT(SOUNDS_DISABLE),
+        MT(SERVO_CONFIG_PENDING),     MT(PID_CONFIG_PENDING),
+        MT(SERVO_CONFIG_MSG),         MT(PID_CONFIG_MSG),
+        MT(SERVO_CTRL_ENABLE),        MT(SERVO_CTRL_DISABLE),
+        MT(SIM_CONFIG_PENDING),       MT(SIM_CONFIG_MSG),
+        MT(SIM_START_CMD),            MT(SIM_STOP_CMD),
+        MT(GROUND_TEST_START),        MT(GROUND_TEST_STOP),
+        MT(GYRO_CAL_CMD),             MT(GAIN_SCHED_ENABLE),
+        MT(GAIN_SCHED_DISABLE),       MT(SERVO_TEST_PENDING),
+        MT(SERVO_TEST_MSG),           MT(SERVO_TEST_STOP),
+        MT(ROLL_PROFILE_PENDING),     MT(ROLL_PROFILE_MSG),
+        MT(ROLL_PROFILE_CLEAR),       MT(SERVO_REPLAY_PENDING),
+        MT(SERVO_REPLAY_MSG),         MT(SERVO_REPLAY_STOP),
+        MT(ROLL_CTRL_CONFIG_PENDING), MT(ROLL_CTRL_CONFIG_MSG),
+        MT(GUIDANCE_ENABLE),          MT(GUIDANCE_DISABLE),
+        MT(GUIDANCE_TELEM_MSG),       MT(CAMERA_CONFIG_PENDING),
+        MT(CAMERA_CONFIG_MSG),        MT(PYRO_CONFIG_PENDING),
+        MT(PYRO_CONFIG_MSG),          MT(PYRO_CONT_TEST),
+        MT(PYRO_FIRE_TEST),           MT(IIS2MDC_MSG),
+        MT(SNAPSHOT_MSG),             MT(GET_FLIGHT_SNAPSHOT),
+        MT(MAG_CAL_START),            MT(MAG_CAL_ABORT),
+        MT(MAG_CAL_ACCEPT),           MT(MAG_CAL_RETRY),
+        MT(MAG_CAL_STATUS_MSG),       MT(MAG_CAL_COMPUTE_FIT),
+        MT(MAG_CAL_VERIFY_DONE),      MT(MAG_CAL_VERIFY_RESET),
+        MT(MAG_CAL_FORCE_APPLY),      MT(MAG_CAL_APPLY_PENDING),
+        MT(MAG_CAL_APPLY_MSG),        MT(MAG_CAL_READ),
+        MT(SENSOR_CAL_APPLY_PENDING), MT(SENSOR_CAL_APPLY_MSG),
+        MT(SENSOR_CAL_READ),          MT(SENSOR_CAL_STATUS_MSG),
+        MT(FLIGHT_SETTINGS_MSG),      MT(LOG_BUFFER_STATS_MSG),
+        MT(LORA_MSG),
+    };
+#undef MT
+
+    std::map<uint8_t, const char*> seen;
+    for (const auto& c : codes) {
+        auto result = seen.emplace(c.value, c.name);
+        const bool inserted = result.second;
+        const char* first   = result.first->second;
+        EXPECT_TRUE(inserted)
+            << "Duplicate OC<->FC message-type code 0x" << std::hex
+            << std::uppercase << (int)c.value << std::dec << ": " << c.name
+            << " collides with " << first << ". Flat if/else-if dispatch on "
+               "both ends takes the first match, so one of these handlers is "
+               "silently dead. Reassign one to a free value.";
+    }
+
+    // Tripwire: keep the registry above exhaustive.  If you add or remove a
+    // message type in RocketComputerTypes.h, update this list AND this count
+    // -- the uniqueness check is only as strong as the list it walks.
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 71u)
+        << "Message-type count changed: update the registry in this test to "
+           "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tools/check_ble_command_ids.py
+++ b/tools/check_ble_command_ids.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Wire-code uniqueness guard: app<->device BLE command numbers (#132 / #148).
+
+Both the Out Computer and the Base Station dispatch an incoming BLE command
+byte with a flat `if (ble_cmd == N) ... else if (ble_cmd == M) ...` chain.
+The chain takes the FIRST matching branch, so two branches sharing a value
+silently turn the later one into dead code -- no compiler error, no link
+error, no test failure.  #132/#148 hit exactly this: ble_cmd 56/57/58 were
+each assigned to two features, and the second handler never ran.
+
+This script makes that class of bug a hard CI failure.  Within each device's
+dispatch, every `ble_cmd == <value>` must be unique.  Right-hand sides that
+are named constants (e.g. `LORA_CMD_SET_HOP_DISABLED`) are resolved to their
+numeric value from RocketComputerTypes.h, so a bare literal can't silently
+collide with a named one.
+
+Why a script and not a C++ unit test (the I2C message types ARE a gtest):
+the dispatch lives in `projects/*/main/main.cpp`, which pulls in app_main,
+FreeRTOS and the full IDF -- not host-linkable -- and the cases are if/else
+branches, not constants.  Grepping the chain is the maintainable option.
+
+Why per-device and not one global space: the app talks to EITHER an OC or a
+BS, so the two command spaces are independent.  cmd 50 is "mag-cal start" to
+the OC but "relay to rocket" to the BS; that overlap is correct.  The Swift
+app therefore mixes both spaces and is reported for information only -- the
+firmware dispatch is the authority where a duplicate actually causes a bug.
+
+Usage (runs from anywhere):
+    python3 tools/check_ble_command_ids.py
+Exit 0 = OK, exit 1 = duplicate (or unresolved RHS) found.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+HEADER = REPO / "tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h"
+DISPATCHES = [
+    ("Out Computer", REPO / "tinkerrocket-idf/projects/out_computer/main/main.cpp"),
+    ("Base Station", REPO / "tinkerrocket-idf/projects/base_station/main/main.cpp"),
+]
+SWIFT = REPO / "TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift"
+
+# `static constexpr uint8_t NAME = 0xNN;`  /  `= 17;`
+CONST_RE = re.compile(
+    r"static\s+constexpr\s+uint8_t\s+(\w+)\s*=\s*(0[xX][0-9A-Fa-f]+|\d+)\s*;"
+)
+# RHS of `ble_cmd ==` is either a numeric literal or an identifier.
+BLE_CMD_RE = re.compile(r"ble_cmd\s*==\s*(0[xX][0-9A-Fa-f]+|\d+|[A-Za-z_]\w*)")
+# Swift senders: sendCommand(N) / sendRawCommand(N, ...)
+SWIFT_RE = re.compile(r"send(?:Raw)?Command\(\s*(\d+)")
+
+NUMERIC_RE = re.compile(r"\A(?:0[xX][0-9A-Fa-f]+|\d+)\Z")
+
+
+def load_constants(path):
+    """Map every `static constexpr uint8_t` name -> int value in the header."""
+    consts = {}
+    if not path.exists():
+        return consts
+    for line in path.read_text().splitlines():
+        m = CONST_RE.search(line)
+        if m:
+            consts[m.group(1)] = int(m.group(2), 0)
+    return consts
+
+
+def resolve(token, consts):
+    """Return the int value of a `ble_cmd ==` RHS token, or None if unknown."""
+    if NUMERIC_RE.match(token):
+        return int(token, 0)
+    return consts.get(token)
+
+
+def check_dispatch(name, path, consts):
+    """Return (failed: bool, lines: list[str]) for one device's dispatch."""
+    out = []
+    if not path.exists():
+        return True, [f"{name}: MISSING source file {path}"]
+
+    rel = path.relative_to(REPO)
+    # value -> list of (lineno, token); also track unresolved tokens.
+    by_value = {}
+    unresolved = []
+    total = 0
+    named = {}
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        for m in BLE_CMD_RE.finditer(line):
+            token = m.group(1)
+            total += 1
+            val = resolve(token, consts)
+            if val is None:
+                unresolved.append((lineno, token))
+                continue
+            if not NUMERIC_RE.match(token):
+                named[token] = val
+            by_value.setdefault(val, []).append((lineno, token))
+
+    failed = False
+    out.append(f"{name}  ({rel})")
+    out.append(f"  {total} ble_cmd branches, {len(by_value)} distinct values")
+    for tok, val in sorted(named.items(), key=lambda kv: kv[1]):
+        out.append(f"  resolved named constant: {tok} = {val}")
+
+    dups = {v: hits for v, hits in by_value.items() if len(hits) > 1}
+    if dups:
+        failed = True
+        for val, hits in sorted(dups.items()):
+            where = ", ".join(f"line {ln} (`{tok}`)" for ln, tok in hits)
+            out.append(
+                f"  DUPLICATE: ble_cmd == {val} appears {len(hits)}x -> {where}"
+            )
+            out.append(
+                "            first match wins; the later branch(es) are dead code."
+            )
+    if unresolved:
+        failed = True
+        for ln, tok in unresolved:
+            out.append(
+                f"  UNRESOLVED: ble_cmd == {tok} (line {ln}) is not a literal and "
+                f"is not defined in {HEADER.name}; cannot verify uniqueness."
+            )
+    if not failed:
+        out.append("  -> OK (all values unique)")
+    return failed, out
+
+
+def swift_cross_reference(oc_values):
+    """Informational only: list the app's command numbers vs the OC dispatch."""
+    out = ["App cross-reference (informational, not enforced):"]
+    if not SWIFT.exists():
+        out.append(f"  (skipped: {SWIFT} not found)")
+        return out
+    rel = SWIFT.relative_to(REPO)
+    nums = sorted({int(m.group(1)) for m in SWIFT_RE.finditer(SWIFT.read_text())})
+    out.append(f"  {rel}: {len(nums)} distinct send(Raw)Command numbers")
+    not_oc = [n for n in nums if n not in oc_values]
+    if not_oc:
+        out.append(
+            "  not in the OC ble_cmd dispatch (expected: base-station / relay / "
+            "OTA / out-of-band handlers) -> " + ", ".join(map(str, not_oc))
+        )
+    return out
+
+
+def main():
+    consts = load_constants(HEADER)
+    if not consts:
+        print(f"ERROR: could not read constants from {HEADER}", file=sys.stderr)
+        return 1
+
+    print("=== BLE command-number uniqueness guard ===\n")
+    any_failed = False
+    oc_values = set()
+    for name, path in DISPATCHES:
+        failed, lines = check_dispatch(name, path, consts)
+        any_failed = any_failed or failed
+        print("\n".join(lines))
+        print()
+        if name == "Out Computer" and path.exists():
+            for m in BLE_CMD_RE.finditer(path.read_text()):
+                v = resolve(m.group(1), consts)
+                if v is not None:
+                    oc_values.add(v)
+
+    print("\n".join(swift_cross_reference(oc_values)))
+    print()
+
+    if any_failed:
+        print("RESULT: FAIL -- fix the duplicate/unresolved command number(s) above.")
+        return 1
+    print("RESULT: PASS -- every device's ble_cmd dispatch is internally unique.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two automated guards so the #132/#148-class collision (a silently double-assigned wire code shadowing a flat-dispatch branch) can't recur:

1. **I2C OC↔FC message types** — new gtest `RocketComputerTypes.MessageTypeCodes_AllUnique` in `tests_cpp/test_rocket_computer_types.cpp`: an explicit 71-entry registry of the `### Message Types from In ESP32 ###` block, asserted pairwise-distinct (names both colliding symbols on failure). `REG_*` and the LoRa-namespace constants are intentionally excluded (separate code spaces — e.g. `LORA_BEACON_SYNC=0xBE` harmlessly coincides with `SERVO_TEST_MSG=0xBE`). Runs under the existing **C++ Unit Tests** workflow.

2. **BLE command numbers (app↔OC / app↔BS)** — new `tools/check_ble_command_ids.py` + `wire-codes.yml` CI workflow. Asserts each device's `ble_cmd ==` values are unique, resolving named RHS constants (e.g. `LORA_CMD_SET_HOP_DISABLED=17`) so a literal can't silently alias a named one. Enforced **per-device** because OC and BS are independent command spaces (cmd 50 = mag-cal-start on OC, relay-to-rocket on BS). Swift `sendCommand`/`sendRawCommand` numbers are reported informationally (they mix both spaces).

## Why a script for BLE (not a switch refactor or a comment registry)

The dispatch lives in `projects/*/main/main.cpp` (needs `app_main` + the full IDF, not host-linkable) and the cases are if/else branches, not constants — so a host unit test doesn't fit. A `switch` would catch duplicate case labels at compile time but is a large, risky refactor of flight firmware. A comment registry has no enforcement (effectively what failed before). The grep-based CI check is the maintainable, enforceable option.

## Verification

- Both guards verified failing-then-passing: the gtest catches a reintroduced `SENSOR_CAL_READ=0xDF` collision (the exact #132/#148 case, naming `MAG_CAL_FORCE_APPLY`); the script catches a reintroduced `ble_cmd == 56` dup.
- Full `tests_cpp` suite: **307/307 pass**.
- **No wire codes changed** — purely additive guards.

## Known blind spot

Both only see the current tree; they cannot catch a collision against an *unmerged* branch's reserved codes (e.g. `ota/phase4-fc`'s `0xE3–0xE7` / `ble_cmd` 70-72). When that branch lands, add its new message types to the gtest registry — the count tripwire (71) will flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
