### PR TITLE
OTA Phase 4: Flight Computer firmware update via OC relay

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -93,6 +93,14 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// pushed its identity yet or is running pre-#8 firmware (no "fw" field).
     @Published var firmwareVersion: String = ""
 
+    /// Flight Computer firmware version, relayed by the OUT computer from the FC
+    /// over I2C (config "fc_identity" / "fc_fw"; #8 Phase 4). Same format as
+    /// `firmwareVersion`. Empty until the OC has relayed it (or "unknown" if the
+    /// OC can't reach the FC). For an *FC*-targeted OTA, rollback detection must
+    /// compare THIS — the connected device's `firmwareVersion` is the OC's and
+    /// never changes when only the FC is updated.
+    @Published var fcFirmwareVersion: String = ""
+
     /// Latest OTA status frame from the device (#8 phase 2). Driven by
     /// ota_status JSON notifications on the file-ops characteristic.
     /// nil between sessions; OTASession observes this to advance its
@@ -1320,6 +1328,16 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             }
             if let fw = dict["fw"] as? String { firmwareVersion = fw }
             print("[CFG] Identity: uid=\(unitID) name=\(unitName) nid=\(networkID) rid=\(rocketID) type=\(deviceType.rawValue) fw=\(firmwareVersion)")
+            return
+        }
+
+        // FC identity readback: "type":"fc_identity" — the Flight Computer's own
+        // firmware version, relayed by the OUT computer over I2C (#8 Phase 4).
+        // A separate small message so it stays well under the BLE notify MTU.
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           dict["type"] as? String == "fc_identity" {
+            if let fcFw = dict["fc_fw"] as? String { fcFirmwareVersion = fcFw }
+            print("[CFG] FC identity: fc_fw=\(fcFirmwareVersion)")
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -108,7 +108,12 @@ final class OTASession: ObservableObject {
         let sha = Data(SHA256.hash(data: fileData))
         imageSize = fileData.count
         imageSha256Hex = sha.map { String(format: "%02x", $0) }.joined()
-        preFlashFirmwareVersion = device?.firmwareVersion ?? ""
+        // An FC OTA changes the *FC's* version (relayed as fcFirmwareVersion);
+        // the OC's own firmwareVersion is untouched by an FC-only update — so the
+        // rollback check must compare the right device's version for the chosen
+        // target, else an FC OTA always looks like "version unchanged" (#8 P4).
+        preFlashFirmwareVersion = (targetIsFC ? device?.fcFirmwareVersion
+                                              : device?.firmwareVersion) ?? ""
 
         // ---- 2. Send OTA_BEGIN ----
         guard let beginDevice = device, beginDevice.isConnected else {
@@ -205,20 +210,27 @@ final class OTASession: ObservableObject {
             return
         }
 
-        // ---- 9. Wait for the new identity push (fw field) ----
-        // The firmware republishes config_identity on each connect; we wait
-        // for any non-empty fw value that arrives AFTER reconnect.
+        // ---- 9. Wait for the new version to publish ----
+        // OC/local OTA: the device reboots and republishes config_identity on
+        // reconnect (fast). FC OTA: the OC<->app link never drops; we wait for
+        // the OC to relay the FC's *new* version (fc_identity), which can't
+        // arrive until the FC finishes rebooting (~8 s, longer if GNSS bootstrap
+        // is slow) and pushes FC_IDENTITY — so give it a much wider window.
         let preFlash = preFlashFirmwareVersion
-        let gotNewFw = await waitFor(timeout: 10.0) { [weak self] in
-            guard let fw = self?.device?.firmwareVersion, !fw.isEmpty else { return false }
+        let fwTimeout: TimeInterval = targetIsFC ? 40.0 : 10.0
+        let gotNewFw = await waitFor(timeout: fwTimeout) { [weak self] in
+            let fw = (targetIsFC ? self?.device?.fcFirmwareVersion
+                                 : self?.device?.firmwareVersion) ?? ""
+            guard !fw.isEmpty else { return false }
             return fw != preFlash
         }
-        let postFw = device?.firmwareVersion ?? ""
+        let postFw = (targetIsFC ? device?.fcFirmwareVersion
+                                 : device?.firmwareVersion) ?? ""
         if !gotNewFw {
             if postFw == preFlash && !postFw.isEmpty {
                 state = .rollbackDetected(version: preFlash)
             } else {
-                state = .failed(reason: "Reconnected but device didn't publish a new firmware version within 10s")
+                state = .failed(reason: "Reconnected but device didn't publish a new firmware version within \(Int(fwTimeout))s")
             }
             return
         }

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -118,10 +118,14 @@ final class OTASession: ObservableObject {
         beginDevice.sendOtaBegin(targetIsFC: targetIsFC, totalSize: UInt32(fileData.count), sha256: sha)
 
         // ---- 3. Wait for status=ready ----
+        // The FC relay round-trip (BLE -> OC -> I2C poll -> FC erases ota_1 ->
+        // I2S -> OC -> BLE) is far slower than a local OTA's begin, so give it
+        // a much longer window before declaring failure (#8 Phase 4).
+        let beginTimeoutS: TimeInterval = targetIsFC ? 20.0 : 5.0
         do {
-            try await awaitOtaState(.ready, timeout: 5.0)
+            try await awaitOtaState(.ready, timeout: beginTimeoutS)
         } catch {
-            state = .failed(reason: "Device did not accept OTA_BEGIN within 5s")
+            state = .failed(reason: "Device did not accept OTA_BEGIN within \(Int(beginTimeoutS))s")
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -60,10 +60,10 @@ final class OTASession: ObservableObject {
     /// Kick off the OTA flow. Reads `fileURL` (typically from `.fileImporter`)
     /// into memory, computes its SHA-256, then walks the state machine.
     /// Re-callable: cancels any prior in-flight run.
-    func start(fileURL: URL) {
+    func start(fileURL: URL, targetIsFC: Bool = false) {
         task?.cancel()
         task = Task { [weak self] in
-            await self?.runFlow(fileURL: fileURL)
+            await self?.runFlow(fileURL: fileURL, targetIsFC: targetIsFC)
         }
     }
 
@@ -87,7 +87,7 @@ final class OTASession: ObservableObject {
 
     // MARK: - Flow
 
-    private func runFlow(fileURL: URL) async {
+    private func runFlow(fileURL: URL, targetIsFC: Bool) async {
         // ---- 1. Load file + compute SHA-256 ----
         state = .loading
         let didOpen = fileURL.startAccessingSecurityScopedResource()
@@ -115,7 +115,7 @@ final class OTASession: ObservableObject {
             state = .failed(reason: "Device disconnected before OTA_BEGIN")
             return
         }
-        beginDevice.sendOtaBegin(targetIsFC: false, totalSize: UInt32(fileData.count), sha256: sha)
+        beginDevice.sendOtaBegin(targetIsFC: targetIsFC, totalSize: UInt32(fileData.count), sha256: sha)
 
         // ---- 3. Wait for status=ready ----
         do {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -109,15 +109,7 @@ private struct FirmwareUpdateContent: View {
     private var statusBlock: some View {
         switch session.state {
         case .idle:
-            Button(action: startFlash) {
-                HStack {
-                    Image(systemName: "arrow.up.circle.fill")
-                    Text(targetIsFC ? "Flash Flight Computer" : "Flash \(device.displayName)")
-                }
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(pickedFileURL == nil || !device.isConnected)
+            flashButton
 
         case .loading:
             ProgressView("Reading file + computing SHA…")
@@ -156,7 +148,7 @@ private struct FirmwareUpdateContent: View {
                 }
                 LabeledRow(label: "Previous", value: session.preFlashFirmwareVersion, mono: true)
                 LabeledRow(label: "Now running", value: newVersion, mono: true)
-                flashAnotherButton
+                flashButton
             }
 
         case .rollbackDetected(let version):
@@ -167,7 +159,7 @@ private struct FirmwareUpdateContent: View {
                 }
                 Text("Device reconnected but is still running the previous firmware (\(version)). The new image likely failed to boot — bootloader auto-reverted to the prior partition.")
                     .font(.subheadline).foregroundColor(.secondary)
-                flashAnotherButton
+                flashButton
             }
 
         case .failed(let reason):
@@ -177,27 +169,32 @@ private struct FirmwareUpdateContent: View {
                     Text("Failed").font(.headline)
                 }
                 Text(reason).font(.subheadline).foregroundColor(.secondary)
-                flashAnotherButton
+                flashButton
             }
         }
     }
 
-    private var flashAnotherButton: some View {
-        Button(action: resetForNextFlash) {
+    // The Flash action, shown in .idle and (greyed) in the terminal states.
+    // After a result it's disabled — choosing a file (which re-arms the
+    // session, see handleFileImport) is the explicit way to start the next
+    // flash, so there's no separate "flash another firmware" reset button.
+    private var flashButton: some View {
+        Button(action: startFlash) {
             HStack {
-                Image(systemName: "arrow.clockwise")
-                Text("Flash another firmware")
+                Image(systemName: "arrow.up.circle.fill")
+                Text(targetIsFC ? "Flash Flight Computer" : "Flash \(device.displayName)")
             }
+            .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.bordered)
-        .padding(.top, 4)
+        .buttonStyle(.borderedProminent)
+        .disabled(pickedFileURL == nil || !device.isConnected || isTerminalState)
     }
 
-    private func resetForNextFlash() {
-        session.reset()
-        pickedFileURL = nil
-        pickedFileName = ""
-        pickedFileSize = 0
+    private var isTerminalState: Bool {
+        switch session.state {
+        case .verified, .rollbackDetected, .failed: return true
+        default: return false
+        }
     }
 
     private var cancelButton: some View {
@@ -231,6 +228,9 @@ private struct FirmwareUpdateContent: View {
             } else {
                 pickedFileSize = 0
             }
+            // Re-arm after a completed/failed run: clearing the terminal state
+            // back to .idle re-enables the Flash button for this new file.
+            if isTerminalState { session.reset() }
         case .failure(let error):
             print("File picker error: \(error)")
         }

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -46,6 +46,15 @@ private struct FirmwareUpdateContent: View {
                 LabeledRow(label: "Firmware",
                            value: device.firmwareVersion.isEmpty ? "(pre-#8 image)" : device.firmwareVersion,
                            mono: true)
+                // FC firmware is relayed by the OC (#8 Phase 4). Show it when
+                // targeting the FC so the user can watch it flip after an update
+                // (or stay put on a rollback) — the OC's own version above never
+                // changes on an FC-only OTA.
+                if targetIsFC && !device.isBaseStation {
+                    LabeledRow(label: "FC firmware",
+                               value: device.fcFirmwareVersion.isEmpty ? "(awaiting relay…)" : device.fcFirmwareVersion,
+                               mono: true)
+                }
                 LabeledRow(label: "Connection", value: device.isConnected ? "Connected" : "Disconnected")
             }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift
@@ -34,6 +34,7 @@ private struct FirmwareUpdateContent: View {
     @State private var pickedFileURL: URL?
     @State private var pickedFileSize: Int = 0
     @State private var pickedFileName: String = ""
+    @State private var targetIsFC = false   // #14: relay the OTA to the Flight Computer via the OC
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -70,6 +71,21 @@ private struct FirmwareUpdateContent: View {
                 .disabled(isInProgress)
             }
 
+            // ----- Target picker (#14) -----
+            // A rocket's BLE peer is the Out Computer, which can relay an OTA
+            // over the OC↔FC link to the Flight Computer. (The Base Station has
+            // no FC, so it only ever flashes itself.)
+            if !device.isBaseStation {
+                GroupBox("Target") {
+                    Picker("Target", selection: $targetIsFC) {
+                        Text("This device").tag(false)
+                        Text("Flight Computer").tag(true)
+                    }
+                    .pickerStyle(.segmented)
+                    .disabled(isInProgress)
+                }
+            }
+
             // ----- Action / status block -----
             statusBlock
 
@@ -96,7 +112,7 @@ private struct FirmwareUpdateContent: View {
             Button(action: startFlash) {
                 HStack {
                     Image(systemName: "arrow.up.circle.fill")
-                    Text("Flash \(device.displayName)")
+                    Text(targetIsFC ? "Flash Flight Computer" : "Flash \(device.displayName)")
                 }
                 .frame(maxWidth: .infinity)
             }
@@ -222,7 +238,7 @@ private struct FirmwareUpdateContent: View {
 
     private func startFlash() {
         guard let url = pickedFileURL else { return }
-        session.start(fileURL: url)
+        session.start(fileURL: url, targetIsFC: targetIsFC)
     }
 
     private func byteCountString(_ bytes: Int) -> String {

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -907,6 +907,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         MT(OTA_BEGIN_PENDING),        MT(OTA_BEGIN_MSG),
         MT(OTA_FINISH_CMD),           MT(OTA_ABORT_CMD),
         MT(OTA_STATUS_MSG),           MT(OTA_DATA_CHUNK),
+        // FC->OC firmware-version push, relayed to the app for OTA verify (#8 P4).
+        MT(FC_IDENTITY),
         MT(LORA_MSG),
     };
 #undef MT
@@ -927,7 +929,7 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 77u)
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 78u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -900,6 +900,13 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         MT(SENSOR_CAL_APPLY_PENDING), MT(SENSOR_CAL_APPLY_MSG),
         MT(SENSOR_CAL_READ),          MT(SENSOR_CAL_STATUS_MSG),
         MT(FLIGHT_SETTINGS_MSG),      MT(LOG_BUFFER_STATS_MSG),
+        // OTA relay control block (#8 Phase 4): OC->FC control over I2C
+        // (0xE3-0xE6), FC->OC status over I2S (OTA_STATUS_MSG=0xE7).  The
+        // sensor-cal block was deliberately moved to 0xE8+ to keep 0xE3-0xE7
+        // free for these (see RocketComputerTypes.h).
+        MT(OTA_BEGIN_PENDING),        MT(OTA_BEGIN_MSG),
+        MT(OTA_FINISH_CMD),           MT(OTA_ABORT_CMD),
+        MT(OTA_STATUS_MSG),
         MT(LORA_MSG),
     };
 #undef MT
@@ -920,7 +927,7 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 71u)
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 76u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -906,7 +906,7 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         // free for these (see RocketComputerTypes.h).
         MT(OTA_BEGIN_PENDING),        MT(OTA_BEGIN_MSG),
         MT(OTA_FINISH_CMD),           MT(OTA_ABORT_CMD),
-        MT(OTA_STATUS_MSG),
+        MT(OTA_STATUS_MSG),           MT(OTA_DATA_CHUNK),
         MT(LORA_MSG),
     };
 #undef MT
@@ -927,7 +927,7 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 76u)
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 77u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1449,11 +1449,13 @@ void TR_BLE_To_APP::handleOtaAbort()
 void TR_BLE_To_APP::setOtaRelayDelegate(void (*begin_cb)(void*, uint32_t, const uint8_t*),
                                         void (*finish_cb)(void*),
                                         void (*abort_cb)(void*),
+                                        void (*data_cb)(void*, uint32_t, const uint8_t*, size_t),
                                         void* ctx)
 {
     ota_relay_begin_cb_  = begin_cb;
     ota_relay_finish_cb_ = finish_cb;
     ota_relay_abort_cb_  = abort_cb;
+    ota_relay_data_cb_   = data_cb;
     ota_relay_ctx_       = ctx;
 }
 
@@ -1471,14 +1473,6 @@ void TR_BLE_To_APP::relayFcOtaStatus(const char* state, const char* err,
 
 void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)
 {
-    // During a target==1 (FC relay) session the image bytes don't belong to
-    // this device's OTA partition — they're relayed to the FC over I2S (Phase
-    // 4 Layer 3). Until that path exists, drop chunks here so they never reach
-    // the idle local receiver (which would error and clobber the relay status).
-    if (ota_relay_active_)
-    {
-        return;
-    }
     // Frame: [offset:4 LE][length:2 LE][flags:1][payload:N]
     if (length < 7)
     {
@@ -1495,6 +1489,17 @@ void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)
     {
         ESP_LOGW(BLE_TAG, "OTA chunk truncated: declared %u, frame %u",
                  (unsigned)chunk_len, (unsigned)length);
+        return;
+    }
+
+    // During a target==1 (FC relay) session the image doesn't belong to this
+    // device's OTA partition — hand each chunk to the relay delegate, which
+    // pumps it to the FC over the flipped I2S link (Phase 4 Layer 3). The local
+    // OTA receiver stays idle. (Before Layer 3 existed, chunks were dropped.)
+    if (ota_relay_active_)
+    {
+        if (ota_relay_data_cb_)
+            ota_relay_data_cb_(ota_relay_ctx_, offset, data + 7, chunk_len);
         return;
     }
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1368,9 +1368,27 @@ void TR_BLE_To_APP::handleOtaBegin(const uint8_t* data, size_t length)
     uint32_t total_size = (uint32_t)data[1] | ((uint32_t)data[2] << 8) |
                           ((uint32_t)data[3] << 16) | ((uint32_t)data[4] << 24);
 
+    if (target == 1)
+    {
+        // FC relay (#8 Phase 4). Hand off to the OC-registered delegate, which
+        // stages OTA_BEGIN to the FC over I2C. Devices without a delegate (BS)
+        // can't relay → bad_target.
+        if (ota_relay_begin_cb_)
+        {
+            ESP_LOGI(BLE_TAG, "OTA_BEGIN target=1 (FC relay): size=%u bytes", (unsigned)total_size);
+            ota_relay_active_   = true;
+            ota_session_active_ = true;  // gate the OC's periodic I2C poll, as for a local OTA
+            ota_relay_begin_cb_(ota_relay_ctx_, total_size, data + 5);
+        }
+        else
+        {
+            ESP_LOGW(BLE_TAG, "OTA_BEGIN target=1 but no relay delegate on this device");
+            sendOtaStatusJSON("verify_failed", "bad_target", 0, nullptr);
+        }
+        return;
+    }
     if (target != 0)
     {
-        // target==1 is FC relay (Phase 4); BS/OC only accept target==0 today.
         ESP_LOGW(BLE_TAG, "OTA_BEGIN target=%u not supported on this device", target);
         sendOtaStatusJSON("verify_failed", "bad_target", 0, nullptr);
         return;
@@ -1392,6 +1410,12 @@ void TR_BLE_To_APP::handleOtaBegin(const uint8_t* data, size_t length)
 
 void TR_BLE_To_APP::handleOtaFinish()
 {
+    if (ota_relay_active_)
+    {
+        ESP_LOGI(BLE_TAG, "OTA_FINISH (FC relay)");
+        if (ota_relay_finish_cb_) ota_relay_finish_cb_(ota_relay_ctx_);
+        return;  // session ends when the OC relays the FC's terminal status
+    }
     ESP_LOGI(BLE_TAG, "OTA_FINISH (bytes_written=%u)", (unsigned)ota_receiver_.bytesWritten());
     TR_OTA_Receiver::Error e = ota_receiver_.finish();
     if (e == TR_OTA_Receiver::Error::Ok)
@@ -1410,8 +1434,39 @@ void TR_BLE_To_APP::handleOtaFinish()
 void TR_BLE_To_APP::handleOtaAbort()
 {
     ESP_LOGW(BLE_TAG, "OTA_ABORT");
+    if (ota_relay_active_)
+    {
+        if (ota_relay_abort_cb_) ota_relay_abort_cb_(ota_relay_ctx_);
+        ota_relay_active_   = false;
+        ota_session_active_ = false;
+        sendOtaStatusJSON("aborted", nullptr, 0, nullptr);
+        return;
+    }
     ota_pending_restart_at_ms_ = 0;
     (void)ota_receiver_.abort();   // -> Idle -> callback clears ota_session_active_
+}
+
+void TR_BLE_To_APP::setOtaRelayDelegate(void (*begin_cb)(void*, uint32_t, const uint8_t*),
+                                        void (*finish_cb)(void*),
+                                        void (*abort_cb)(void*),
+                                        void* ctx)
+{
+    ota_relay_begin_cb_  = begin_cb;
+    ota_relay_finish_cb_ = finish_cb;
+    ota_relay_abort_cb_  = abort_cb;
+    ota_relay_ctx_       = ctx;
+}
+
+void TR_BLE_To_APP::relayFcOtaStatus(const char* state, const char* err,
+                                     uint32_t bytes_written, bool terminal)
+{
+    if (!ota_relay_active_) return;  // ignore stray FC status outside a relay session
+    sendOtaStatusJSON(state, err, bytes_written, nullptr);
+    if (terminal)
+    {
+        ota_relay_active_   = false;
+        ota_session_active_ = false;
+    }
 }
 
 void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1471,6 +1471,14 @@ void TR_BLE_To_APP::relayFcOtaStatus(const char* state, const char* err,
 
 void TR_BLE_To_APP::onFileTransferWrite(const uint8_t* data, size_t length)
 {
+    // During a target==1 (FC relay) session the image bytes don't belong to
+    // this device's OTA partition — they're relayed to the FC over I2S (Phase
+    // 4 Layer 3). Until that path exists, drop chunks here so they never reach
+    // the idle local receiver (which would error and clobber the relay status).
+    if (ota_relay_active_)
+    {
+        return;
+    }
     // Frame: [offset:4 LE][length:2 LE][flags:1][payload:N]
     if (length < 7)
     {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -263,6 +263,16 @@ private:
     // task, read on the main loop task.
     volatile bool ota_session_active_ = false;
 
+    // ---- OTA relay delegate (#8 Phase 4, OC only) --------------------------
+    // When set, an OTA_BEGIN with target==1 is relayed to the FC over I2C (the
+    // handlers below invoke these) instead of flashing this device. BS leaves
+    // them null → target==1 returns bad_target. Invoked on the NimBLE host task.
+    void (*ota_relay_begin_cb_)(void* ctx, uint32_t total_size, const uint8_t* sha256) = nullptr;
+    void (*ota_relay_finish_cb_)(void* ctx) = nullptr;
+    void (*ota_relay_abort_cb_)(void* ctx) = nullptr;
+    void* ota_relay_ctx_ = nullptr;
+    bool  ota_relay_active_ = false;  // a target==1 relay session is in progress
+
     void onFileTransferWrite(const uint8_t* data, size_t length);
     void handleOtaBegin(const uint8_t* data, size_t length);
     void handleOtaFinish();
@@ -273,6 +283,19 @@ private:
                                    TR_OTA_Receiver::Error err, size_t bytes_written);
 
 public:
+    // ---- OTA relay wiring (#8 Phase 4, OC only) ----------------------------
+    // The OC registers callbacks that relay OTA_BEGIN/FINISH/ABORT to the FC
+    // over I2C. relayFcOtaStatus() pushes the FC's status (already mapped to
+    // the ota_status JSON vocabulary) back up to the app and ends the relay
+    // session on a terminal state. BS never registers → target==1 = bad_target.
+    void setOtaRelayDelegate(void (*begin_cb)(void*, uint32_t, const uint8_t*),
+                             void (*finish_cb)(void*),
+                             void (*abort_cb)(void*),
+                             void* ctx);
+    bool isOtaRelayActive() const { return ota_relay_active_; }
+    void relayFcOtaStatus(const char* state, const char* err,
+                          uint32_t bytes_written, bool terminal);
+
     // ---- NimBLE callbacks (static, forwarded via user-data pointer) --------
     static int  gap_event_cb(struct ble_gap_event* event, void* arg);
     static int  gatt_svc_access_cb(uint16_t conn_handle, uint16_t attr_handle,

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -270,6 +270,9 @@ private:
     void (*ota_relay_begin_cb_)(void* ctx, uint32_t total_size, const uint8_t* sha256) = nullptr;
     void (*ota_relay_finish_cb_)(void* ctx) = nullptr;
     void (*ota_relay_abort_cb_)(void* ctx) = nullptr;
+    // Image chunk handler (Phase 4 Layer 3): the OC pumps each relayed chunk to
+    // the FC over the flipped I2S link. offset is the absolute byte offset.
+    void (*ota_relay_data_cb_)(void* ctx, uint32_t offset, const uint8_t* data, size_t len) = nullptr;
     void* ota_relay_ctx_ = nullptr;
     bool  ota_relay_active_ = false;  // a target==1 relay session is in progress
 
@@ -291,6 +294,7 @@ public:
     void setOtaRelayDelegate(void (*begin_cb)(void*, uint32_t, const uint8_t*),
                              void (*finish_cb)(void*),
                              void (*abort_cb)(void*),
+                             void (*data_cb)(void*, uint32_t, const uint8_t*, size_t),
                              void* ctx);
     bool isOtaRelayActive() const { return ota_relay_active_; }
     void relayFcOtaStatus(const char* state, const char* err,

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -188,6 +188,25 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         active_tx = GNSS_TX;
     }
 
+    // Warm-boot fast path for swapped-wiring boards: the module persists its
+    // configured baud (preferred_baud) across resets, so a swapped rev comes
+    // up already at preferred_baud on the swapped pins. Try that before the
+    // 9600 orientation probe + full sweep — otherwise the sweep crawls
+    // 9600→…→preferred (~30 s) even though the orientation was found quickly.
+    if (connected_baud == 0U && GNSS_RX != GNSS_TX)
+    {
+        ESP_LOGI(TAG, "Bootstrap try %lu baud on swapped RX/TX", (unsigned long)bootstrap_baud);
+        uartBegin(bootstrap_baud, GNSS_TX, GNSS_RX);
+        delay(80);
+        if (gnss.begin(_uartPort, 800))
+        {
+            connected_baud = preferred_baud;
+            active_rx = GNSS_TX;
+            active_tx = GNSS_RX;
+            ESP_LOGW(TAG, "Bootstrap: connected at %lu baud on swapped RX/TX", (unsigned long)preferred_baud);
+        }
+    }
+
     // Fast cold-boot orientation probe: u-blox modules power up at 9600 baud
     // (factory default). A ~650 ms listen at 9600 on each orientation finds
     // which way the RX/TX is wired and short-circuits the slow ~30 s

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -99,7 +99,8 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         ESP_LOGI(TAG, "Pulsed RESET_N on pin %d", reset_n_pin);
     };
 
-    auto hasSerialActivity = [&](uint8_t rx_pin, uint8_t tx_pin, uint32_t baud) -> bool
+    auto hasSerialActivity = [&](uint8_t rx_pin, uint8_t tx_pin, uint32_t baud,
+                                 uint32_t window_ms = 400U) -> bool
     {
         uartBegin(baud, rx_pin, tx_pin);
 
@@ -113,7 +114,7 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         }
 
         const uint32_t activity_window_start = millis();
-        while ((millis() - activity_window_start) < 400U)
+        while ((millis() - activity_window_start) < window_ms)
         {
             if (uartAvailable() > 0)
             {
@@ -199,11 +200,18 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         bool    detected = false;
         bool    swapped  = false;
 
-        if (hasSerialActivity(GNSS_RX, GNSS_TX, 9600U))
+        // u-blox modules power up at 9600 baud / 1 Hz output, so the listen
+        // window must exceed one full output period (~1 s) to catch a burst
+        // regardless of phase. A 400 ms window missed it intermittently and
+        // dropped boot into the ~30 s full baud scan (bench 2026-05-29). Probe
+        // the schematic orientation first, then the swapped wiring — both rev's
+        // now detect reliably in one or two ~1.2 s windows instead of ~35 s.
+        const uint32_t kOrientationProbeMs = 1200U;
+        if (hasSerialActivity(GNSS_RX, GNSS_TX, 9600U, kOrientationProbeMs))
         {
             detected = true;
         }
-        else if ((GNSS_RX != GNSS_TX) && hasSerialActivity(GNSS_TX, GNSS_RX, 9600U))
+        else if ((GNSS_RX != GNSS_TX) && hasSerialActivity(GNSS_TX, GNSS_RX, 9600U, kOrientationProbeMs))
         {
             detected = true;
             swapped  = true;

--- a/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.cpp
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.cpp
@@ -7,12 +7,24 @@ static const char* TAG = "I2S_STREAM";
 
 TR_I2S_Stream::~TR_I2S_Stream()
 {
+    end();
+}
+
+void TR_I2S_Stream::end()
+{
     if (chan_handle_)
     {
         i2s_channel_disable(chan_handle_);
         i2s_del_channel(chan_handle_);
         chan_handle_ = nullptr;
     }
+    // Reset role/callback state so a subsequent beginMasterTx()/beginSlaveRx()
+    // + registerRecvCallback() starts from a clean slate (the callback was
+    // bound to the now-deleted channel).
+    recv_cb_        = nullptr;
+    recv_cb_ctx_    = nullptr;
+    is_tx_          = false;
+    frame_sync_pin_ = -1;
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.h
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.h
@@ -147,6 +147,19 @@ public:
      */
     int readFrameSync() const;
 
+    /**
+     * Tear down the channel so the object can be re-initialised in a
+     * different role (e.g. flipping OC slave-RX <-> master-TX for the Phase 4
+     * OTA image pump). Disables + deletes the I2S channel, clears the recv
+     * callback, and resets to the uninitialised state. Safe to call when not
+     * initialised (no-op). After end() a fresh beginMasterTx()/beginSlaveRx()
+     * (and registerRecvCallback() for RX) may be called.
+     *
+     * Must run in task context (not ISR) — i2s_channel_disable/del_channel
+     * take the driver mutex.
+     */
+    void end();
+
     /** True if beginMasterTx() or beginSlaveRx() succeeded. */
     bool isInitialized() const { return chan_handle_ != nullptr; }
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1464,6 +1464,13 @@ static constexpr uint8_t OTA_STATUS_MSG      = 0xE7;  // FC→OC: OtaRelayStatus
 // that replays a DMA buffer can't corrupt the image. 0xE8-0xEA are sensor cal.
 static constexpr uint8_t OTA_DATA_CHUNK      = 0xEB;
 
+// FC→OC: firmware version string (null-terminated, <=31 chars), pushed by the
+// FC every ~2 s over I2C. The OC caches it and relays it to the app as a small
+// "fc_identity" config JSON. Lets the app detect a *FC* OTA rollback by comparing
+// the FC's real running version — the OC's own "fw" never changes on an FC-only
+// update, which is why the connected-device version check false-positived (#8).
+static constexpr uint8_t FC_IDENTITY         = 0xEC;
+
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
 // real bottleneck, and the FC writes each received frame to flash (~2-3 ms/frame)

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1455,7 +1455,21 @@ static constexpr uint8_t OTA_BEGIN_PENDING   = 0xE3;  // OC→FC: OTA_BEGIN_MSG 
 static constexpr uint8_t OTA_BEGIN_MSG       = 0xE4;  // [size:4 LE][sha256:32] = 36 bytes
 static constexpr uint8_t OTA_FINISH_CMD      = 0xE5;  // OC→FC: finalize + verify + reboot
 static constexpr uint8_t OTA_ABORT_CMD       = 0xE6;  // OC→FC: abort session
-static constexpr uint8_t OTA_STATUS_MSG      = 0xE7;  // FC→OC over I2S: OtaRelayStatusData
+static constexpr uint8_t OTA_STATUS_MSG      = 0xE7;  // FC→OC: OtaRelayStatusData. Rides I2S in
+                                                      // Layer 2; once the link flips for the image
+                                                      // pump it rides I2C instead (FC master write).
+// Image-pump frame (Layer 3): OC→FC over the *flipped* I2S link (OC master TX,
+// FC slave RX). Payload = [offset:4 LE][image bytes:N]; the FC writes each by
+// offset, ignoring stale-repeat offsets (< bytes_written) so an I2S underrun
+// that replays a DMA buffer can't corrupt the image. 0xE8-0xEA are sensor cal.
+static constexpr uint8_t OTA_DATA_CHUNK      = 0xEB;
+
+// I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit
+// stereo), so this targets ~2.5 MHz BCLK per the design doc §7.  Bench-tunable
+// (#15): back off if PCB-trace signal integrity is marginal, raise toward
+// 10 MHz if the traces handle it.  Both OC and FC read this one constant when
+// they re-init the flipped link, so the master/slave clock can't drift.
+static constexpr uint32_t OTA_I2S_SAMPLE_RATE_HZ = 78125;  // ~2.5 MHz BCLK
 
 // OtaRelayStatusData.state values (FC→OC). The OC maps these to the iOS
 // ota_status JSON strings it already sends for local (OC/BS) OTA.
@@ -1464,6 +1478,8 @@ static constexpr uint8_t OTA_RELAY_WRITING       = 2;  // receiving image (Layer
 static constexpr uint8_t OTA_RELAY_READY_TO_BOOT = 3;  // verified, rebooting (Layer 3)
 static constexpr uint8_t OTA_RELAY_VERIFY_FAILED = 4;  // begin/verify error (see err)
 static constexpr uint8_t OTA_RELAY_ABORTED       = 5;  // session aborted
+static constexpr uint8_t OTA_RELAY_DATA_READY    = 6;  // FC flipped to I2S slave-RX; OC may start
+                                                       // the image pump (Layer 3 flip handshake)
 
 struct __attribute__((packed)) OtaRelayStatusData {
     uint8_t  state;          // OTA_RELAY_* above

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1445,6 +1445,32 @@ static constexpr uint8_t FLIGHT_SETTINGS_MSG = 0xE1;
 // high-water mark per flight).  See LogBufferStatsData.
 static constexpr uint8_t LOG_BUFFER_STATS_MSG = 0xE2;
 
+// --- OTA firmware relay to the Flight Computer (#8 Phase 4) ---
+// Control plane rides the OC↔FC I2C link: the OC stages OTA_BEGIN_PENDING
+// (with the OTA_BEGIN_MSG payload) / OTA_FINISH_CMD / OTA_ABORT_CMD as
+// pending commands, the FC pulls them on its poll. The FC reports progress
+// back over I2S via OTA_STATUS_MSG (Layer 2). The image bytes themselves
+// travel over the reconfigured I2S link (Phase 4 Layer 3), not here.
+static constexpr uint8_t OTA_BEGIN_PENDING   = 0xE3;  // OC→FC: OTA_BEGIN_MSG payload follows
+static constexpr uint8_t OTA_BEGIN_MSG       = 0xE4;  // [size:4 LE][sha256:32] = 36 bytes
+static constexpr uint8_t OTA_FINISH_CMD      = 0xE5;  // OC→FC: finalize + verify + reboot
+static constexpr uint8_t OTA_ABORT_CMD       = 0xE6;  // OC→FC: abort session
+static constexpr uint8_t OTA_STATUS_MSG      = 0xE7;  // FC→OC over I2S: OtaRelayStatusData
+
+// OtaRelayStatusData.state values (FC→OC). The OC maps these to the iOS
+// ota_status JSON strings it already sends for local (OC/BS) OTA.
+static constexpr uint8_t OTA_RELAY_READY         = 1;  // begin OK, ota_1 erased, ready for image
+static constexpr uint8_t OTA_RELAY_WRITING       = 2;  // receiving image (Layer 3)
+static constexpr uint8_t OTA_RELAY_READY_TO_BOOT = 3;  // verified, rebooting (Layer 3)
+static constexpr uint8_t OTA_RELAY_VERIFY_FAILED = 4;  // begin/verify error (see err)
+static constexpr uint8_t OTA_RELAY_ABORTED       = 5;  // session aborted
+
+struct __attribute__((packed)) OtaRelayStatusData {
+    uint8_t  state;          // OTA_RELAY_* above
+    uint8_t  err;            // 0 = none; else TR_OTA_Receiver::Error code
+    uint32_t bytes_written;  // progress / final size
+};
+
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
 // Camera types

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1464,12 +1464,18 @@ static constexpr uint8_t OTA_STATUS_MSG      = 0xE7;  // FC→OC: OtaRelayStatus
 // that replays a DMA buffer can't corrupt the image. 0xE8-0xEA are sensor cal.
 static constexpr uint8_t OTA_DATA_CHUNK      = 0xEB;
 
-// I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit
-// stereo), so this targets ~2.5 MHz BCLK per the design doc §7.  Bench-tunable
-// (#15): back off if PCB-trace signal integrity is marginal, raise toward
-// 10 MHz if the traces handle it.  Both OC and FC read this one constant when
-// they re-init the flipped link, so the master/slave clock can't drift.
-static constexpr uint32_t OTA_I2S_SAMPLE_RATE_HZ = 78125;  // ~2.5 MHz BCLK
+// I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
+// Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
+// real bottleneck, and the FC writes each received frame to flash (~2-3 ms/frame)
+// with its I2S RX effectively blind during that write.  At a fast BCLK the OC's
+// per-chunk burst outruns the FC: the frames after the first arrive while it's
+// mid-flash-write and are dropped, and the forward-only pump can't resend them
+// (bench 2026-05-31: stuck at bytes_written=212, every later frame logged as a
+// "gap").  ~50 KB/s spaces frames ~4 ms apart — longer than one flash write — so
+// the FC catches every frame, while still far exceeding the BLE feed rate.  Both
+// OC and FC read this one constant so the master/slave clock can't drift.
+// Bench-tunable (#15); the doc's 2.5 MHz target assumed I2S was the bottleneck.
+static constexpr uint32_t OTA_I2S_SAMPLE_RATE_HZ = 12500;  // ~50 KB/s, ~400 kHz BCLK
 
 // OtaRelayStatusData.state values (FC→OC). The OC maps these to the iOS
 // ota_status JSON strings it already sends for local (OC/BS) OTA.

--- a/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
@@ -21,5 +21,33 @@ endif()
 # Exclude BLE and LoRa components not used by FlightComputer
 list(APPEND EXCLUDE_COMPONENTS TR_BLE_To_APP TR_LoRa_Comms TR_INA230)
 
+# Embed git short-sha + build timestamp into the firmware image header
+# (esp_app_desc.version), max 32 chars. Read at runtime via
+# esp_app_get_description()->version and reported as the "fw" field so the OTA
+# flow can verify the running FC image — the OC relays it up over BLE (#8 §7).
+# (Separate from the FW_GIT_SHA compile-def in main/CMakeLists.txt, which feeds
+# the per-flight settings snapshot.)
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TR_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT TR_GIT_SHA)
+    set(TR_GIT_SHA "unknown")
+endif()
+execute_process(
+    COMMAND git diff-index --quiet HEAD --
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE TR_GIT_DIRTY_CODE
+    OUTPUT_QUIET ERROR_QUIET
+)
+if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
+    set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
+endif()
+string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
+set(PROJECT_VER "${TR_GIT_SHA}+${TR_BUILD_DATE}")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(flight_computer)

--- a/tinkerrocket-idf/projects/flight_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/flight_computer/dependencies.lock
@@ -1,10 +1,18 @@
 dependencies:
+  espressif/dhara:
+    component_hash: 88968cff2e88853a29366ad556e9c27596d18e15028b6e9f3cd627665f914440
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.0.0
   idf:
     source:
       type: idf
     version: 5.3.2
 direct_dependencies:
+- espressif/dhara
 - idf
-manifest_hash: 405b18f8e5814ebcdc7c93737a0aa6a9f5b809db0db73cdb5b5e551e21805af6
+manifest_hash: 6f4972c0cd856d2015cba9831063a6a730deae8bd16edbea178fa4c6411182a3
 target: esp32p4
 version: 2.0.0

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -27,6 +27,9 @@ idf_component_register(
         TR_ControlMixer
         TR_GNSSReceiverUBlox_Serial
         TR_IMU_Int_V2
+        TR_OTA
+        app_update
+        esp_app_format
         driver
         esp_timer
         nvs_flash

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2554,7 +2554,24 @@ static void setup_fc()
 
 // Loop is responsible for reading sensor data
 static void loop_fc()
-{ 
+{
+    // ── OTA image pump: yield the core to the OTA RX parser ──
+    // During an FC OTA the board is grounded and its I2S is flipped to slave RX.
+    // This flight task runs at the top priority (configMAX_PRIORITIES-1) on the
+    // SAME core as fcOtaParserTask (prio 3), so without backing off it starves
+    // the parser — the 8 KB RX ring then overflows the moment flash writes + the
+    // EKF land, and the forward-only image stalls (bench 2026-06-01 stuck at 714,
+    // sawtooth gaps = drop-oldest eviction). Nothing on the FC needs to run during
+    // the transfer except the I2C control poll (to catch OTA_FINISH/ABORT); the
+    // GUI is fed by the OC, not us. So sleep most of each iteration: the parser
+    // (now the top READY task on this core) drains the ring, and we still fall
+    // through to service I2C. fcRevertToTx() clears the flag and full-rate flight
+    // resumes. The EKF is additionally skipped below for the brief awake windows.
+    if (fc_ota_data_mode)
+    {
+        vTaskDelay(pdMS_TO_TICKS(5));
+    }
+
     // ### Read and Send Sensor Data ###
     // Poll as fast as possible so high-rate sensor frames are not dropped by
     // loop-period gating.
@@ -2967,7 +2984,7 @@ static void loop_fc()
             // (tPrev_us_) automatically accounts for the longer interval.
             static uint8_t ekf_decim_ctr = 0;
             const bool run_ekf_this_tick =
-                (++ekf_decim_ctr >= config::EKF_DECIMATION);
+                (++ekf_decim_ctr >= config::EKF_DECIMATION) && !fc_ota_data_mode;
             if (run_ekf_this_tick) ekf_decim_ctr = 0;
 
             if (!ekf_initialized && rocket_state != MAG_CALIBRATION)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1110,6 +1110,14 @@ static volatile size_t   fc_ota_head = 0;
 static volatile size_t   fc_ota_tail = 0;
 static volatile uint32_t fc_ota_ring_ovf = 0;
 static TaskHandle_t fc_ota_parser_task = nullptr;
+// OTA RX diagnostics (#8 Phase 4, bench) — counted in fcOtaParseRing, summarized
+// at FINISH. Distinguish a frame-loss stall (gaps climb, write_fail=0) from a
+// flash-write stall (write_fail>0) from an I2S signal-integrity problem
+// (crc_fail climbs).
+static uint32_t fc_ota_crc_fail   = 0;   // frames that failed CRC (resync drops)
+static uint32_t fc_ota_gap        = 0;   // valid frames ahead of bytesWritten (skipped)
+static uint32_t fc_ota_write_fail = 0;   // writeChunk() errors
+static uint32_t fc_ota_written_frames = 0;  // frames accepted in order
 
 static inline IRAM_ATTR void fcOtaRingPush(uint8_t b)
 {
@@ -1161,6 +1169,7 @@ static void fcOtaParseRing()
         if (!TR_I2C_Interface::unpackMessage(frame, frame_len, type,
                                              payload, sizeof(payload), out_len, true))
         {
+            fc_ota_crc_fail++;
             fcOtaRingPop();          // bad CRC — resync one byte
             continue;
         }
@@ -1176,11 +1185,19 @@ static void fcOtaParseRing()
             {
                 const TR_OTA_Receiver::Error e = fc_ota_receiver.writeChunk(off, img, img_len);
                 if (e != TR_OTA_Receiver::Error::Ok)
+                {
+                    fc_ota_write_fail++;
                     ESP_LOGE(TAG, "[OTA] writeChunk @%u (%uB) failed: %d",
                              (unsigned)off, (unsigned)img_len, (int)e);
+                }
+                else
+                {
+                    fc_ota_written_frames++;
+                }
             }
             else if (off > have)
             {
+                fc_ota_gap++;
                 ESP_LOGW(TAG, "[OTA] gap: chunk @%u but have %u", (unsigned)off, (unsigned)have);
             }
             // off < have: stale-repeat from an I2S underrun — skip silently.
@@ -1207,6 +1224,11 @@ static void fcFlipToRx()
     delay_ms(50);                       // settle: last frame leaves the DMA
     fc_ota_head = 0;                    // clear any stale ring contents
     fc_ota_tail = 0;
+    fc_ota_ring_ovf = 0;                // reset RX diagnostics for this session
+    fc_ota_crc_fail = 0;
+    fc_ota_gap = 0;
+    fc_ota_write_fail = 0;
+    fc_ota_written_frames = 0;
     fc_ota_data_mode = true;            // i2sSenderTask idles from here on
     if (fc_i2s_mutex) xSemaphoreTake(fc_i2s_mutex, portMAX_DELAY);
     i2s_stream.end();
@@ -3914,6 +3936,14 @@ static void loop_fc()
                 ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u/%u)",
                          (unsigned)fc_ota_receiver.bytesWritten(),
                          (unsigned)fc_ota_total_size);
+                // RX diagnostics summary (bench): which failure mode stalled it?
+                //   write_fail>0  -> flash-write error (not a transport issue)
+                //   gap>0, crc_fail~0 -> frames lost/reordered (forward-only pump)
+                //   crc_fail high -> I2S signal integrity (back off BCLK)
+                ESP_LOGW(TAG, "[OTA RX] frames_ok=%u gap=%u crc_fail=%u write_fail=%u ring_ovf=%u",
+                         (unsigned)fc_ota_written_frames, (unsigned)fc_ota_gap,
+                         (unsigned)fc_ota_crc_fail, (unsigned)fc_ota_write_fail,
+                         (unsigned)fc_ota_ring_ovf);
                 const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
                 if (e == TR_OTA_Receiver::Error::Ok)
                 {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3984,12 +3984,12 @@ static void loop_fc()
             }
             else if (out_pending_command == OTA_FINISH_CMD)
             {
-                // Layer 3: the OC pumped the tail of the image just before
-                // sending FINISH; give the parser a moment to drain the last
-                // in-flight frames, then revert the I2S link to master-TX so the
-                // terminal status rides the normal-direction path back. (Without
-                // Layer 3 image transfer the SHA won't match and finish() fails
-                // — the expected Layer 2 result.) On success the FC reboots.
+                // Layer 3: the OC pumped the tail of the image just before sending
+                // FINISH; give the parser a moment to drain the last in-flight frames,
+                // then revert the I2S link to master-TX so the terminal status rides
+                // the normal-direction path back. Only finalize when an OTA session is
+                // actually active (fc_ota_data_mode); a FINISH with no session is a
+                // stale/duplicate (handled in the else). On success the FC reboots.
                 if (fc_ota_data_mode)
                 {
                     // Wait for the image tail to land. The OC drains its TX queue and
@@ -4012,33 +4012,45 @@ static void loop_fc()
                         else { quiet = 0; last_cb = cb; }
                     }
                     fcRevertToTx();
-                }
-                ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u/%u)",
-                         (unsigned)fc_ota_receiver.bytesWritten(),
-                         (unsigned)fc_ota_total_size);
-                // RX diagnostics summary (bench): which failure mode stalled it?
-                //   write_fail>0  -> flash-write error (not a transport issue)
-                //   gap>0, crc_fail~0 -> frames lost/reordered (forward-only pump)
-                //   crc_fail high -> I2S signal integrity (back off BCLK)
-                ESP_LOGW(TAG, "[OTA RX] frames_ok=%u gap=%u crc_fail=%u write_fail=%u ring_ovf=%u",
-                         (unsigned)fc_ota_written_frames, (unsigned)fc_ota_gap,
-                         (unsigned)fc_ota_crc_fail, (unsigned)fc_ota_write_fail,
-                         (unsigned)fc_ota_ring_ovf);
-                const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
-                if (e == TR_OTA_Receiver::Error::Ok)
-                {
-                    // Robust resend spans ~1.4 s, which also gives the app
-                    // time to catch ready_to_boot before the I2S link drops at
-                    // reboot (replaces the old fixed 500 ms pre-restart delay).
-                    sendOtaRelayStatusRobust(OTA_RELAY_READY_TO_BOOT, 0,
-                                             (uint32_t)fc_ota_receiver.bytesWritten());
-                    esp_restart();
+
+                    ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u/%u)",
+                             (unsigned)fc_ota_receiver.bytesWritten(),
+                             (unsigned)fc_ota_total_size);
+                    // RX diagnostics summary (bench): which failure mode stalled it?
+                    //   write_fail>0  -> flash-write error (not a transport issue)
+                    //   gap>0, crc_fail~0 -> frames lost/reordered (forward-only pump)
+                    //   crc_fail high -> I2S signal integrity (back off BCLK)
+                    ESP_LOGW(TAG, "[OTA RX] frames_ok=%u gap=%u crc_fail=%u write_fail=%u ring_ovf=%u",
+                             (unsigned)fc_ota_written_frames, (unsigned)fc_ota_gap,
+                             (unsigned)fc_ota_crc_fail, (unsigned)fc_ota_write_fail,
+                             (unsigned)fc_ota_ring_ovf);
+                    const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
+                    if (e == TR_OTA_Receiver::Error::Ok)
+                    {
+                        // Robust resend spans ~1.4 s, which also gives the app
+                        // time to catch ready_to_boot before the I2S link drops at
+                        // reboot (replaces the old fixed 500 ms pre-restart delay).
+                        sendOtaRelayStatusRobust(OTA_RELAY_READY_TO_BOOT, 0,
+                                                 (uint32_t)fc_ota_receiver.bytesWritten());
+                        esp_restart();
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "[OTA] finish failed: %d", (int)e);
+                        sendOtaRelayStatusRobust(OTA_RELAY_VERIFY_FAILED, (uint8_t)e,
+                                                 (uint32_t)fc_ota_receiver.bytesWritten());
+                    }
                 }
                 else
                 {
-                    ESP_LOGE(TAG, "[OTA] finish failed: %d", (int)e);
-                    sendOtaRelayStatusRobust(OTA_RELAY_VERIFY_FAILED, (uint8_t)e,
-                                             (uint32_t)fc_ota_receiver.bytesWritten());
+                    // Stale/duplicate FINISH with no active OTA session — e.g. the OC's
+                    // pre-loaded I2C status response, read by the freshly-rebooted FC
+                    // right after a *successful* OTA (bench: "finish failed: 2" at boot).
+                    // finish() here only returns SessionNotActive and logs a scary error,
+                    // so a completed OTA appears to end in failure. Ignore it instead —
+                    // the FC is idempotent to a duplicate FINISH regardless of why the
+                    // OC re-sent it.
+                    ESP_LOGI(TAG, "[OTA] FINISH ignored — no active OTA session (stale/duplicate)");
                 }
             }
             else if (out_pending_command == OTA_ABORT_CMD)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -21,6 +21,7 @@
 #include <esp_system.h>           // esp_restart after a verified relayed OTA
 #include <driver/spi_master.h>
 #include <esp_timer.h>
+#include <esp_ota_ops.h>          // Layer 4: esp_ota_mark_app_valid_cancel_rollback (#8/#13)
 #include <driver/gpio.h>
 #include <driver/uart.h>
 #include <esp_private/esp_gpio_reserve.h>
@@ -1878,6 +1879,32 @@ static inline void serviceHeartbeatBeep(uint32_t now_ms)
                time_us());
 }
 
+// ── OTA rollback gate (#8 Phase 4 / Layer 4, #13) ─────────────────────────
+// A freshly OTA-installed FC image boots in ESP_OTA_IMG_PENDING_VERIFY (rollback
+// is enabled in sdkconfig). Unless we call esp_ota_mark_app_valid_cancel_rollback()
+// the bootloader auto-reverts to the previous partition on the next reset — the
+// safety net against a bad image. setup_fc() detects pending-verify at boot;
+// fcMaybeMarkOtaValid() (called every flight-loop tick) confirms the image only
+// after it has run the real flight loop stably for ~10 s. A broken image that
+// boot-loops, hangs (WDT reset), or crashes never reaches the mark, so it rolls
+// back. Mirrors the OC's maybeMarkOtaValid().
+static bool fc_ota_pending_verify = false;
+
+static inline void fcMaybeMarkOtaValid()
+{
+    if (!fc_ota_pending_verify) return;
+    static int64_t first_us = 0;                 // first tick after setup_fc() completed
+    const int64_t now = esp_timer_get_time();
+    if (first_us == 0) { first_us = now; return; }
+    if ((now - first_us) < 10LL * 1000000LL) return;   // need ~10 s of healthy running
+    const esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+    if (err == ESP_OK)
+        ESP_LOGW(TAG, "[OTA] new image validated after 10 s stable run; rollback cancelled");
+    else
+        ESP_LOGE(TAG, "[OTA] mark_app_valid_cancel_rollback failed: %s", esp_err_to_name(err));
+    fc_ota_pending_verify = false;
+}
+
 static void setup_fc()
 {
     // Ensure NVS is initialised (ESP-IDF on ESP32-P4 may not auto-init)
@@ -1889,6 +1916,22 @@ static void setup_fc()
     }
 
     ESP_LOGI(TAG, "NVS init: %s", esp_err_to_name(nvs_err));
+
+    // OTA boot-state check (#8 Layer 4). A just-OTA'd image boots PENDING_VERIFY;
+    // arm the rollback gate so fcMaybeMarkOtaValid() confirms it only after a
+    // stable run. A normal USB-flashed image is UNDEFINED here, so this is a no-op.
+    {
+        const esp_partition_t* running = esp_ota_get_running_partition();
+        esp_ota_img_states_t st = ESP_OTA_IMG_UNDEFINED;
+        if (running && esp_ota_get_state_partition(running, &st) == ESP_OK &&
+            st == ESP_OTA_IMG_PENDING_VERIFY)
+        {
+            fc_ota_pending_verify = true;
+            ESP_LOGW(TAG, "[OTA] running PENDING_VERIFY image (partition '%s' @ 0x%08x); "
+                          "rollback armed until ~10 s stable run",
+                     running->label, (unsigned)running->address);
+        }
+    }
 
     // The flight task runs continuously and starves IDLE tasks on CPU 1.
     // Reconfigure WDT to not monitor IDLE cores (the flight task itself
@@ -2557,6 +2600,8 @@ static void setup_fc()
 // Loop is responsible for reading sensor data
 static void loop_fc()
 {
+    fcMaybeMarkOtaValid();   // Layer 4: confirm a freshly OTA'd image after a stable run
+
     // ── OTA image pump: yield the core to the OTA RX parser ──
     // During an FC OTA the board is grounded and its I2S is flipped to slave RX.
     // This flight task runs at the top priority (configMAX_PRIORITIES-1) on the

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1057,6 +1057,38 @@ static void sendOtaRelayStatus(uint8_t state, uint8_t err, uint32_t bytes_writte
     (void)enqueueI2STx(OTA_STATUS_MSG, (const uint8_t*)&st, sizeof(st));
 }
 
+// Resend an OTA status several times, spread over ~1.4 s.  A long flash op on
+// the FC (the ota_1 erase in begin(), or the verify/finalize in finish())
+// runs with the cache disabled, which suspends i2sSenderTask — it executes
+// from flash, not IRAM.  With nothing feeding the I2S DMA, the continuously-
+// running clock replays whatever was in the DMA buffers, so the OC sees a
+// burst of stale/duplicate frames for the whole op (the "dedup storm", per
+// the i2sSenderTask idle-fill comment).  A single OTA_STATUS_MSG sent the
+// instant the op finishes lands in that window: the OC's rx_ring is still
+// draining the storm backlog (drop-oldest overflow) and the first real frame
+// can be corrupted by the stale->fresh DMA transition (CRC drop).  Either way
+// the one-shot status is lost and the app strands at "OTA_BEGIN not accepted".
+// Spreading copies over ~1.4 s guarantees at least one lands after the OC has
+// drained the backlog and the stream is back to clean idle-fill.  This mirrors
+// the #165 flight-settings resend (one-shot frame re-emitted on the first few
+// INFLIGHT ticks so a dropped launch frame doesn't lose the record).  Status
+// frames are idempotent — the OC just re-relays the same ota_status and the
+// app keys off the first matching state — so duplicates are harmless.  Safe to
+// block: OTA is refused in flight, and the erase/finish that precedes this
+// already blocked the caller for seconds.  delay_ms() is vTaskDelay-based, so
+// IDLE still pets the task watchdog between sends.
+static void sendOtaRelayStatusRobust(uint8_t state, uint8_t err, uint32_t bytes_written)
+{
+    static constexpr int      kOtaStatusResends = 7;    // + the immediate send = 8 total
+    static constexpr uint32_t kOtaStatusGapMs   = 200;  // 7 * 200 ms ~= 1.4 s span
+    sendOtaRelayStatus(state, err, bytes_written);
+    for (int i = 0; i < kOtaStatusResends; ++i)
+    {
+        delay_ms(kOtaStatusGapMs);
+        sendOtaRelayStatus(state, err, bytes_written);
+    }
+}
+
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
 // the live PID gains from servo_control (these can be NVS- or BLE-overridden),
 // the runtime override globals, the config:: defaults for the compile-time-only
@@ -3665,12 +3697,12 @@ static void loop_fc()
                         if (e == TR_OTA_Receiver::Error::Ok)
                         {
                             ESP_LOGI(TAG, "[OTA] ready for image");
-                            sendOtaRelayStatus(OTA_RELAY_READY, 0, 0);
+                            sendOtaRelayStatusRobust(OTA_RELAY_READY, 0, 0);
                         }
                         else
                         {
                             ESP_LOGE(TAG, "[OTA] begin failed: %d", (int)e);
-                            sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, (uint8_t)e, 0);
+                            sendOtaRelayStatusRobust(OTA_RELAY_VERIFY_FAILED, (uint8_t)e, 0);
                         }
                     }
                     else
@@ -3690,23 +3722,25 @@ static void loop_fc()
                 const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
                 if (e == TR_OTA_Receiver::Error::Ok)
                 {
-                    sendOtaRelayStatus(OTA_RELAY_READY_TO_BOOT, 0,
-                                       (uint32_t)fc_ota_receiver.bytesWritten());
-                    delay_ms(500);
+                    // Robust resend spans ~1.4 s, which also gives the app
+                    // time to catch ready_to_boot before the I2S link drops at
+                    // reboot (replaces the old fixed 500 ms pre-restart delay).
+                    sendOtaRelayStatusRobust(OTA_RELAY_READY_TO_BOOT, 0,
+                                             (uint32_t)fc_ota_receiver.bytesWritten());
                     esp_restart();
                 }
                 else
                 {
                     ESP_LOGE(TAG, "[OTA] finish failed: %d", (int)e);
-                    sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, (uint8_t)e,
-                                       (uint32_t)fc_ota_receiver.bytesWritten());
+                    sendOtaRelayStatusRobust(OTA_RELAY_VERIFY_FAILED, (uint8_t)e,
+                                             (uint32_t)fc_ota_receiver.bytesWritten());
                 }
             }
             else if (out_pending_command == OTA_ABORT_CMD)
             {
                 ESP_LOGW(TAG, "[OTA] ABORT");
                 (void)fc_ota_receiver.abort();
-                sendOtaRelayStatus(OTA_RELAY_ABORTED, 0, 0);
+                sendOtaRelayStatusRobust(OTA_RELAY_ABORTED, 0, 0);
             }
             else if (out_pending_command == GAIN_SCHED_ENABLE)
             {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -22,6 +22,7 @@
 #include <driver/spi_master.h>
 #include <esp_timer.h>
 #include <esp_ota_ops.h>          // Layer 4: esp_ota_mark_app_valid_cancel_rollback (#8/#13)
+#include <esp_app_desc.h>         // esp_app_get_description() for FC_IDENTITY version push (#8)
 #include <driver/gpio.h>
 #include <driver/uart.h>
 #include <esp_private/esp_gpio_reserve.h>
@@ -3252,6 +3253,26 @@ static void loop_fc()
                 sizeof(out_status_query_data),
                 10);
             if (send_err == ESP_OK) { query_pending = true; }
+
+            // Push the FC firmware version to the OC every ~8 polls (~2 s) so it
+            // can relay it to the app (config "fc_identity"); the app uses it to
+            // tell a real FC-OTA update from a rollback. Static string, separate
+            // message type so it bypasses the OC's timestamp dedup. Skipped while
+            // an image is streaming in (the version can't change mid-OTA and the
+            // OC already has it — keep the OTA control bus quiet). #8 Phase 4.
+            if (!fc_ota_data_mode)
+            {
+                static uint32_t fc_id_throttle = 1000;  // fire on first poll, then ~2 s
+                if (++fc_id_throttle >= 8)
+                {
+                    fc_id_throttle = 0;
+                    const esp_app_desc_t* d = esp_app_get_description();
+                    const char* v = (d && d->version[0]) ? d->version : "unknown";
+                    (void)i2c_interface.sendMessage(
+                        FC_IDENTITY, reinterpret_cast<const uint8_t*>(v),
+                        strlen(v), 10);
+                }
+            }
 
             // NOTE: mutex is held through command processing below, so
             // readConfigFrame() I2C reads have an idle bus.  Released after

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -16,6 +16,9 @@
 #include <TR_GuidancePN.h>
 #include <TR_ControlMixer.h>
 #include <RocketComputerTypes.h>
+#include <TR_OTA_Receiver.h>      // FC-side OTA relay receiver (#8 Phase 4)
+#include <TR_OTA_Backend_esp.h>
+#include <esp_system.h>           // esp_restart after a verified relayed OTA
 #include <driver/spi_master.h>
 #include <esp_timer.h>
 #include <driver/gpio.h>
@@ -1035,6 +1038,23 @@ static inline bool enqueueI2STx(uint8_t type, const uint8_t *payload, size_t len
 
     i2s_tx_enqueue_drop++;
     return false;
+}
+
+// ---- OTA relay receiver (#8 Phase 4) -------------------------------------
+// The FC receives an OTA image relayed from the OC. Control (begin/finish/
+// abort) arrives over I2C as pending commands; the image bytes arrive over
+// I2S in Layer 3. Status is reported back to the OC over I2S (OTA_STATUS_MSG),
+// which the OC relays up to the app as ota_status.
+static TR_OTA_Backend_esp fc_ota_backend;
+static TR_OTA_Receiver    fc_ota_receiver(fc_ota_backend);
+
+static void sendOtaRelayStatus(uint8_t state, uint8_t err, uint32_t bytes_written)
+{
+    OtaRelayStatusData st;
+    st.state         = state;
+    st.err           = err;
+    st.bytes_written = bytes_written;
+    (void)enqueueI2STx(OTA_STATUS_MSG, (const uint8_t*)&st, sizeof(st));
 }
 
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
@@ -3611,6 +3631,77 @@ static void loop_fc()
             {
                 ESP_LOGI(TAG, "[SENSORCAL] READ -> publish status from NVS");
                 publishSensorCalFromNVS();
+            }
+            else if (out_pending_command == OTA_BEGIN_PENDING)
+            {
+                // #8 Phase 4: OTA relay from the OC. Refuse unless READY so an
+                // OTA can't start mid-flight (mirrors the cal handlers). Read
+                // the image header (size + sha256) and begin the session
+                // (erases ota_1). Image bytes arrive over I2S in Layer 3;
+                // Layer 2 exercises just this control handshake.
+                if (rocket_state != READY)
+                {
+                    ESP_LOGW(TAG, "[OTA] BEGIN refused: state=%u (require READY)",
+                             (unsigned)rocket_state);
+                    sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, 0, 0);
+                }
+                else
+                {
+                    delay_ms(1);
+                    uint8_t hdr[36];
+                    size_t  hlen = 0;
+                    if (readConfigFrame(OTA_BEGIN_MSG, 36, hdr, sizeof(hdr), hlen)
+                        && hlen >= 36)
+                    {
+                        uint32_t total_size = 0;
+                        memcpy(&total_size, hdr, 4);
+                        ESP_LOGW(TAG, "[OTA] BEGIN size=%u — erasing ota_1", (unsigned)total_size);
+                        const TR_OTA_Receiver::Error e = fc_ota_receiver.begin(total_size, hdr + 4);
+                        if (e == TR_OTA_Receiver::Error::Ok)
+                        {
+                            ESP_LOGI(TAG, "[OTA] ready for image");
+                            sendOtaRelayStatus(OTA_RELAY_READY, 0, 0);
+                        }
+                        else
+                        {
+                            ESP_LOGE(TAG, "[OTA] begin failed: %d", (int)e);
+                            sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, (uint8_t)e, 0);
+                        }
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "[OTA] BEGIN header read failed");
+                        sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, 0, 0);
+                    }
+                }
+            }
+            else if (out_pending_command == OTA_FINISH_CMD)
+            {
+                // Image transfer (I2S) is Layer 3 — without it the SHA won't
+                // match and finish() fails, which is the expected Layer 2
+                // result. On success (Layer 3) the FC reboots into ota_1.
+                ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u)",
+                         (unsigned)fc_ota_receiver.bytesWritten());
+                const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
+                if (e == TR_OTA_Receiver::Error::Ok)
+                {
+                    sendOtaRelayStatus(OTA_RELAY_READY_TO_BOOT, 0,
+                                       (uint32_t)fc_ota_receiver.bytesWritten());
+                    delay_ms(500);
+                    esp_restart();
+                }
+                else
+                {
+                    ESP_LOGE(TAG, "[OTA] finish failed: %d", (int)e);
+                    sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, (uint8_t)e,
+                                       (uint32_t)fc_ota_receiver.bytesWritten());
+                }
+            }
+            else if (out_pending_command == OTA_ABORT_CMD)
+            {
+                ESP_LOGW(TAG, "[OTA] ABORT");
+                (void)fc_ota_receiver.abort();
+                sendOtaRelayStatus(OTA_RELAY_ABORTED, 0, 0);
             }
             else if (out_pending_command == GAIN_SCHED_ENABLE)
             {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1118,6 +1118,7 @@ static uint32_t fc_ota_crc_fail   = 0;   // frames that failed CRC (resync drops
 static uint32_t fc_ota_gap        = 0;   // valid frames ahead of bytesWritten (skipped)
 static uint32_t fc_ota_write_fail = 0;   // writeChunk() errors
 static uint32_t fc_ota_written_frames = 0;  // frames accepted in order
+static volatile uint32_t fc_ota_rx_cb_count = 0;  // I2S RX cb ticks; teardown silence detect
 
 static inline IRAM_ATTR void fcOtaRingPush(uint8_t b)
 {
@@ -1137,6 +1138,7 @@ static inline void    fcOtaRingPop()         { fc_ota_tail = (fc_ota_tail + 1) %
 static IRAM_ATTR bool fcOtaRecvCallback(const uint8_t* buf, size_t len, void* /*ctx*/)
 {
     if (!fc_ota_data_mode) return false;
+    fc_ota_rx_cb_count = fc_ota_rx_cb_count + 1;   // (-Wvolatile: avoid ++) teardown silence
     for (size_t i = 0; i < len; i++) fcOtaRingPush(buf[i]);
     BaseType_t woken = pdFALSE;
     if (fc_ota_parser_task) vTaskNotifyGiveFromISR(fc_ota_parser_task, &woken);
@@ -3945,9 +3947,25 @@ static void loop_fc()
                 // — the expected Layer 2 result.) On success the FC reboots.
                 if (fc_ota_data_mode)
                 {
-                    for (int i = 0; i < 100 &&
+                    // Wait for the image tail to land. The OC drains its TX queue and
+                    // keeps the link clocked briefly after FINISH, so bytesWritten
+                    // should reach the total (it stalled 1 frame short before this).
+                    for (int i = 0; i < 200 &&
                             (uint32_t)fc_ota_receiver.bytesWritten() < fc_ota_total_size; i++)
-                        delay_ms(5);   // up to ~500 ms for the tail to land
+                        delay_ms(5);   // up to ~1 s for the tail to land
+                    // Do NOT seize the bus as master TX until the OC has stopped
+                    // driving BCLK (reverted to slave RX). Otherwise both ends drive
+                    // BCLK = contention and the terminal status is garbled — and the
+                    // final frame is lost. Silence == the I2S RX callback stops firing.
+                    uint32_t last_cb = fc_ota_rx_cb_count;
+                    int quiet = 0;
+                    for (int i = 0; i < 400 && quiet < 20; i++)   // ~100 ms quiet, <=2 s cap
+                    {
+                        delay_ms(5);
+                        const uint32_t cb = fc_ota_rx_cb_count;
+                        if (cb == last_cb) { quiet++; }
+                        else { quiet = 0; last_cb = cb; }
+                    }
                     fcRevertToTx();
                 }
                 ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u/%u)",

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1089,6 +1089,155 @@ static void sendOtaRelayStatusRobust(uint8_t state, uint8_t err, uint32_t bytes_
     }
 }
 
+// --- Phase 4 Layer 3: FC side of the I2S image pump --------------------------
+// On OTA_BEGIN (after erasing ota_1 and sending READY over the normal-direction
+// I2S) the FC flips its I2S master-TX link to slave-RX, receives the image as
+// OTA_DATA_CHUNK frames (each prefixed with its absolute offset), and on
+// FINISH/ABORT reverts to master-TX so its terminal status rides the normal I2S
+// path back to the OC. i2s_stream is touched by i2sSenderTask (normal TX) and
+// the flip (command-handler task), so fc_i2s_mutex serializes them; the sender
+// idles while fc_ota_data_mode is set.
+static SemaphoreHandle_t fc_i2s_mutex = nullptr;
+static volatile bool fc_ota_data_mode = false;   // flipped to slave RX for the image
+static uint32_t fc_ota_total_size = 0;            // expected image size (from BEGIN)
+
+// Image RX ring: filled by the I2S recv callback (ISR), drained by
+// fcOtaParserTask. Sized to absorb a chunk burst while a flash write (which
+// suspends the parser task with the cache off) completes.
+static constexpr size_t FC_OTA_RING = 8192;
+static uint8_t  fc_ota_ring[FC_OTA_RING];
+static volatile size_t   fc_ota_head = 0;
+static volatile size_t   fc_ota_tail = 0;
+static volatile uint32_t fc_ota_ring_ovf = 0;
+static TaskHandle_t fc_ota_parser_task = nullptr;
+
+static inline IRAM_ATTR void fcOtaRingPush(uint8_t b)
+{
+    fc_ota_ring[fc_ota_head] = b;
+    fc_ota_head = (fc_ota_head + 1) % FC_OTA_RING;
+    if (fc_ota_head == fc_ota_tail)
+    {
+        fc_ota_ring_ovf = fc_ota_ring_ovf + 1;           // (-Wvolatile: avoid ++)
+        fc_ota_tail = (fc_ota_tail + 1) % FC_OTA_RING;   // drop oldest
+    }
+}
+static inline size_t  fcOtaRingLen()         { return (fc_ota_head + FC_OTA_RING - fc_ota_tail) % FC_OTA_RING; }
+static inline uint8_t fcOtaRingPeek(size_t i){ return fc_ota_ring[(fc_ota_tail + i) % FC_OTA_RING]; }
+static inline void    fcOtaRingPop()         { fc_ota_tail = (fc_ota_tail + 1) % FC_OTA_RING; }
+
+// I2S recv callback (ISR): push image bytes into the ring + wake the parser.
+static IRAM_ATTR bool fcOtaRecvCallback(const uint8_t* buf, size_t len, void* /*ctx*/)
+{
+    if (!fc_ota_data_mode) return false;
+    for (size_t i = 0; i < len; i++) fcOtaRingPush(buf[i]);
+    BaseType_t woken = pdFALSE;
+    if (fc_ota_parser_task) vTaskNotifyGiveFromISR(fc_ota_parser_task, &woken);
+    return woken == pdTRUE;
+}
+
+// Extract OTA_DATA_CHUNK frames from the ring and write each by offset. Stale
+// repeats (offset < bytesWritten, from an I2S underrun replaying a DMA buffer)
+// are skipped; an offset ahead of bytesWritten is a gap (logged).
+static void fcOtaParseRing()
+{
+    uint8_t payload[MAX_PAYLOAD];
+    while (fcOtaRingLen() >= (4 + 1 + 1 + 2))
+    {
+        if (!(fcOtaRingPeek(0) == 0xAA && fcOtaRingPeek(1) == 0x55 &&
+              fcOtaRingPeek(2) == 0xAA && fcOtaRingPeek(3) == 0x55))
+        {
+            fcOtaRingPop();          // resync on SOF
+            continue;
+        }
+        const size_t payload_len = fcOtaRingPeek(5);
+        if (payload_len > MAX_PAYLOAD) { fcOtaRingPop(); continue; }
+        const size_t frame_len = 4 + 1 + 1 + payload_len + 2;
+        if (fcOtaRingLen() < frame_len) return;   // rest hasn't arrived yet
+
+        uint8_t frame[MAX_FRAME];
+        for (size_t i = 0; i < frame_len; i++) frame[i] = fcOtaRingPeek(i);
+
+        uint8_t type = 0; size_t out_len = 0;
+        if (!TR_I2C_Interface::unpackMessage(frame, frame_len, type,
+                                             payload, sizeof(payload), out_len, true))
+        {
+            fcOtaRingPop();          // bad CRC — resync one byte
+            continue;
+        }
+        for (size_t i = 0; i < frame_len; i++) fcOtaRingPop();
+
+        if (type == OTA_DATA_CHUNK && out_len >= 4)
+        {
+            uint32_t off = 0; memcpy(&off, payload, 4);
+            const uint8_t* img     = payload + 4;
+            const size_t   img_len = out_len - 4;
+            const uint32_t have    = (uint32_t)fc_ota_receiver.bytesWritten();
+            if (off == have)
+            {
+                const TR_OTA_Receiver::Error e = fc_ota_receiver.writeChunk(off, img, img_len);
+                if (e != TR_OTA_Receiver::Error::Ok)
+                    ESP_LOGE(TAG, "[OTA] writeChunk @%u (%uB) failed: %d",
+                             (unsigned)off, (unsigned)img_len, (int)e);
+            }
+            else if (off > have)
+            {
+                ESP_LOGW(TAG, "[OTA] gap: chunk @%u but have %u", (unsigned)off, (unsigned)have);
+            }
+            // off < have: stale-repeat from an I2S underrun — skip silently.
+        }
+    }
+}
+
+static void fcOtaParserTask(void*)
+{
+    for (;;)
+    {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        if (fc_ota_data_mode) fcOtaParseRing();
+    }
+}
+
+// Flip master-TX -> slave-RX to receive the image. Called from the OTA_BEGIN
+// handler after the READY resends have drained over the still-TX link.
+static void fcFlipToRx()
+{
+    // Let the queued OTA_RELAY_READY resends fully clock out before flipping.
+    for (int i = 0; i < 60 && uxQueueMessagesWaiting(i2s_tx_queue) > 0; i++)
+        delay_ms(10);
+    delay_ms(50);                       // settle: last frame leaves the DMA
+    fc_ota_head = 0;                    // clear any stale ring contents
+    fc_ota_tail = 0;
+    fc_ota_data_mode = true;            // i2sSenderTask idles from here on
+    if (fc_i2s_mutex) xSemaphoreTake(fc_i2s_mutex, portMAX_DELAY);
+    i2s_stream.end();
+    const esp_err_t e = i2s_stream.beginSlaveRx(config::I2S_BCLK_PIN,
+                                                config::I2S_WS_PIN,
+                                                config::I2S_DOUT_PIN,   // former DOUT now reads DIN
+                                                -1,                     // no frame-sync for OTA
+                                                OTA_I2S_SAMPLE_RATE_HZ,
+                                                4, 64);
+    if (e == ESP_OK)
+        i2s_stream.registerRecvCallback(fcOtaRecvCallback, nullptr);
+    if (fc_i2s_mutex) xSemaphoreGive(fc_i2s_mutex);
+    ESP_LOGW(TAG, "[OTA] I2S -> slave RX for image (%s)", esp_err_to_name(e));
+}
+
+// Revert slave-RX -> master-TX (normal telemetry + status). Called before
+// finalizing/aborting so the terminal status rides the normal I2S path.
+static void fcRevertToTx()
+{
+    if (fc_i2s_mutex) xSemaphoreTake(fc_i2s_mutex, portMAX_DELAY);
+    i2s_stream.end();
+    const esp_err_t e = i2s_stream.beginMasterTx(config::I2S_BCLK_PIN,
+                                                 config::I2S_WS_PIN,
+                                                 config::I2S_DOUT_PIN,
+                                                 config::I2S_FSYNC_PIN,
+                                                 config::I2S_SAMPLE_RATE);
+    fc_ota_data_mode = false;           // i2sSenderTask resumes
+    if (fc_i2s_mutex) xSemaphoreGive(fc_i2s_mutex);
+    ESP_LOGW(TAG, "[OTA] I2S -> master TX (%s)", esp_err_to_name(e));
+}
+
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
 // the live PID gains from servo_control (these can be NVS- or BLE-overridden),
 // the runtime override globals, the config:: defaults for the compile-time-only
@@ -1178,6 +1327,20 @@ static void i2sSenderTask(void *)
     I2STxMessage msg = {};
     for (;;)
     {
+        // Phase 4 Layer 3: while an OTA image is streaming the link is flipped
+        // to slave RX — stop driving TX entirely.  fc_i2s_mutex serializes the
+        // actual channel access vs the flip/revert (double-checked under lock).
+        if (fc_ota_data_mode)
+        {
+            delay_ms(5);
+            continue;
+        }
+        if (fc_i2s_mutex) xSemaphoreTake(fc_i2s_mutex, portMAX_DELAY);
+        if (fc_ota_data_mode)
+        {
+            if (fc_i2s_mutex) xSemaphoreGive(fc_i2s_mutex);
+            continue;
+        }
         // Try to dequeue with a short timeout (1ms).
         // If a frame is ready, send it immediately.
         // If not, write idle fill zeros to keep the DMA pipe clean.
@@ -1191,6 +1354,7 @@ static void i2sSenderTask(void *)
             // This prevents stale data replay when the slave reads.
             i2s_stream.writeIdleFill(64, 1);
         }
+        if (fc_i2s_mutex) xSemaphoreGive(fc_i2s_mutex);
     }
 }
 
@@ -1802,6 +1966,14 @@ static void setup_fc()
         ESP_LOGE(TAG, "Failed to create I2C bus mutex");
         while (1) { delay_ms(1000); }
     }
+    // Phase 4 Layer 3: mutex serializing i2s_stream across i2sSenderTask and the
+    // OTA flip/revert; created before the sender task starts so it's always set.
+    fc_i2s_mutex = xSemaphoreCreateMutex();
+    if (fc_i2s_mutex == nullptr)
+    {
+        ESP_LOGE(TAG, "Failed to create I2S mutex");
+        while (1) { delay_ms(1000); }
+    }
     // I2S sender runs on the SAME core as sensor collection (Core 0).
     // Priority 2: below pollIMUdata (4) so sensor SPI reads are never
     // delayed, but above pollGNSSdata (1).  This frees Core 1 entirely
@@ -1817,6 +1989,13 @@ static void setup_fc()
                             2,
                             &i2s_sender_task_handle,
                             i2s_sender_core);
+
+    // Phase 4 Layer 3: OTA image parser. Idle (blocked on notify) until the
+    // I2S link is flipped to slave RX and the recv callback starts waking it.
+    // Pinned to Core 1 (off the sensor core) at low priority — it only runs
+    // during an OTA, when flight is not in progress.
+    xTaskCreatePinnedToCore(fcOtaParserTask, "FC OTA RX", 4096, nullptr, 3,
+                            &fc_ota_parser_task, 1);
 
     // Load persistent rocket settings from NVS (factory default from config.h)
     ESP_LOGI(TAG, "NVS prefs loading...");
@@ -3697,7 +3876,12 @@ static void loop_fc()
                         if (e == TR_OTA_Receiver::Error::Ok)
                         {
                             ESP_LOGI(TAG, "[OTA] ready for image");
+                            fc_ota_total_size = total_size;
                             sendOtaRelayStatusRobust(OTA_RELAY_READY, 0, 0);
+                            // Layer 3: flip to slave RX and receive the image
+                            // over the (now reversed) I2S link. Blocks until the
+                            // READY resends have drained off the still-TX link.
+                            fcFlipToRx();
                         }
                         else
                         {
@@ -3714,11 +3898,22 @@ static void loop_fc()
             }
             else if (out_pending_command == OTA_FINISH_CMD)
             {
-                // Image transfer (I2S) is Layer 3 — without it the SHA won't
-                // match and finish() fails, which is the expected Layer 2
-                // result. On success (Layer 3) the FC reboots into ota_1.
-                ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u)",
-                         (unsigned)fc_ota_receiver.bytesWritten());
+                // Layer 3: the OC pumped the tail of the image just before
+                // sending FINISH; give the parser a moment to drain the last
+                // in-flight frames, then revert the I2S link to master-TX so the
+                // terminal status rides the normal-direction path back. (Without
+                // Layer 3 image transfer the SHA won't match and finish() fails
+                // — the expected Layer 2 result.) On success the FC reboots.
+                if (fc_ota_data_mode)
+                {
+                    for (int i = 0; i < 100 &&
+                            (uint32_t)fc_ota_receiver.bytesWritten() < fc_ota_total_size; i++)
+                        delay_ms(5);   // up to ~500 ms for the tail to land
+                    fcRevertToTx();
+                }
+                ESP_LOGW(TAG, "[OTA] FINISH (bytes_written=%u/%u)",
+                         (unsigned)fc_ota_receiver.bytesWritten(),
+                         (unsigned)fc_ota_total_size);
                 const TR_OTA_Receiver::Error e = fc_ota_receiver.finish();
                 if (e == TR_OTA_Receiver::Error::Ok)
                 {
@@ -3739,6 +3934,7 @@ static void loop_fc()
             else if (out_pending_command == OTA_ABORT_CMD)
             {
                 ESP_LOGW(TAG, "[OTA] ABORT");
+                if (fc_ota_data_mode) fcRevertToTx();  // back to TX so status rides I2S
                 (void)fc_ota_receiver.abort();
                 sendOtaRelayStatusRobust(OTA_RELAY_ABORTED, 0, 0);
             }

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3639,9 +3639,14 @@ static void loop_fc()
                 // the image header (size + sha256) and begin the session
                 // (erases ota_1). Image bytes arrive over I2S in Layer 3;
                 // Layer 2 exercises just this control handshake.
-                if (rocket_state != READY)
+                if (isCommandLockoutState(rocket_state))
                 {
-                    ESP_LOGW(TAG, "[OTA] BEGIN refused: state=%u (require READY)",
+                    // Block OTA only in the genuinely-unsafe states (INFLIGHT,
+                    // MAG_CALIBRATION) — same lockout as the test commands (#218).
+                    // READY/PRELAUNCH/LANDED are all fine: a GPS lock on the
+                    // bench puts us in PRELAUNCH, and the OTA reboot lands in a
+                    // safe state anyway.
+                    ESP_LOGW(TAG, "[OTA] BEGIN refused: state=%u (no OTA while INFLIGHT or in MAG_CALIBRATION)",
                              (unsigned)rocket_state);
                     sendOtaRelayStatus(OTA_RELAY_VERIFY_FAILED, 0, 0);
                 }

--- a/tinkerrocket-idf/projects/flight_computer/partitions.csv
+++ b/tinkerrocket-idf/projects/flight_computer/partitions.csv
@@ -1,5 +1,5 @@
 # Name,   Type, SubType, Offset,  Size,    Flags
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x300000,
-spiffs,   data, spiffs,  0x310000,0x4F0000,
+ota_0,    app,  ota_0,   0x10000, 0x300000,
+ota_1,    app,  ota_1,   0x310000,0x300000,

--- a/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
@@ -17,5 +17,10 @@ CONFIG_FREERTOS_HZ=1000
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
+# OTA rollback: a relayed image boots PENDING_VERIFY and auto-reverts to ota_0
+# unless the FC marks itself valid after resuming its I2S telemetry stream to
+# the OC post-reboot. See docs/plans/08-ota-firmware-update.md §4 / §7.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
+
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1554,6 +1554,29 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         }
         if (prev != nullptr)
         {
+            // FC-reboot detection (#16). The FC's time_us restarts near 0 on every
+            // reboot — including the one right after a successful OTA. All the
+            // prev_time_*/max_time_us state here is from the prior session, so every
+            // post-reboot frame looks non-monotonic (dropped below) AND stale (dropped
+            // by the 5 s filter) until ts climbs back past the old high-water mark —
+            // tens of seconds of lost telemetry, so the app shows stale FC data right
+            // after an update. A timestamp far behind the global high-water mark (well
+            // beyond any reorder/jitter, which is sub-second) can only mean a new
+            // session: reset the dedup baseline and adopt the new stream. Also covers a
+            // uint32 µs wrap (~71 min) gracefully.
+            static constexpr uint32_t REBOOT_BACKSTEP_US = 10'000'000;  // 10 s
+            if (time_us != 0 && max_time_us > REBOOT_BACKSTEP_US &&
+                time_us < (max_time_us - REBOOT_BACKSTEP_US))
+            {
+                ESP_LOGW("DEDUP", "FC reboot detected (ts=%lu << max=%lu); resetting baseline",
+                         (unsigned long)time_us, (unsigned long)max_time_us);
+                prev_time_ism6 = prev_time_bmp = prev_time_mmc = prev_time_iis2mdc =
+                    prev_time_gnss = prev_time_ns = prev_time_pwr = prev_time_guid = 0;
+                max_time_us = 0;
+                // *prev now reads 0, so this frame passes the checks below as the first
+                // of the new session and re-seeds the baseline.
+            }
+
             // Non-monotonic or exact-duplicate frame for this type — drop.
             // time_us == 0 is excluded so the very first frame of each type
             // (which finds *prev == 0) still passes.

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1225,7 +1225,9 @@ static volatile bool oc_ota_tx_mode = false;                // flipped to master
 static volatile bool oc_ota_await_flip = false;             // READY seen; waiting for the FC to go quiet
 static volatile bool oc_ota_relay_ready_pending = false;    // relay "ready" to app once flipped to TX
 static volatile bool oc_ota_revert_to_rx_requested = false; // set on FINISH/ABORT staged
-static uint32_t oc_ota_frames_pumped = 0;                   // diag
+static uint32_t oc_ota_frames_pumped = 0;                   // diag: frames enqueued by relay cb
+static uint32_t oc_ota_feed_sent     = 0;                   // diag: frames the feeder wrote to I2S
+static uint32_t oc_ota_feed_idle     = 0;                   // diag: idle-fill writes (queue empty)
 static uint32_t oc_ota_silence_ref_count = 0;               // dma_cb_count snapshot for silence detect
 static uint32_t oc_ota_silence_since_ms  = 0;               // when RX last went quiet
 static uint32_t oc_ota_total_size = 0;                      // image size (diag)
@@ -1362,10 +1364,25 @@ static void ocOtaTxFeederTask(void *)
         }
         if (oc_ota_tx_queue != nullptr &&
             xQueueReceive(oc_ota_tx_queue, &f, pdMS_TO_TICKS(1)) == pdTRUE)
+        {
             (void)i2s_stream.writeFrame(OTA_DATA_CHUNK, f.payload, f.len);
+            oc_ota_feed_sent++;
+        }
         else
+        {
             (void)i2s_stream.writeIdleFill(64, 1);   // keep BCLK fed; no stale replay
+            oc_ota_feed_idle++;
+        }
         xSemaphoreGive(oc_i2s_mutex);
+        // Diag (~every 512 writes): is the app actually feeding image frames, or are
+        // we only emitting idle-fill?  enq==0/sent==0 -> the app's BLE data never
+        // reached ocOtaRelayData (routing/app). sent>0 while the FC sees nothing ->
+        // loss on the I2S link / FC RX. This is the step neither log showed before.
+        if (((oc_ota_feed_sent + oc_ota_feed_idle) & 0x1FFu) == 0u)
+            ESP_LOGW("OC", "[OTA feed] enq=%u sent=%u idle=%u qdepth=%u",
+                     (unsigned)oc_ota_frames_pumped, (unsigned)oc_ota_feed_sent,
+                     (unsigned)oc_ota_feed_idle,
+                     (unsigned)(oc_ota_tx_queue ? uxQueueMessagesWaiting(oc_ota_tx_queue) : 0u));
     }
 }
 
@@ -1377,6 +1394,8 @@ static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* s
     last_relay_err_   = 0xFF;
     last_relay_bytes_ = 0xFFFFFFFFu;
     oc_ota_frames_pumped          = 0;
+    oc_ota_feed_sent              = 0;
+    oc_ota_feed_idle              = 0;
     oc_ota_await_flip             = false;
     oc_ota_relay_ready_pending    = false;
     oc_ota_revert_to_rx_requested = false;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1199,10 +1199,26 @@ static void queueOutStatusResponse(bool ready)
 // for BEGIN) for the FC to pull on its next I2C poll — identical delivery to
 // servo/sim config. The FC reports progress back over I2S (OTA_STATUS_MSG),
 // relayed to BLE by the frame processor. (Image bytes are Phase 4 Layer 3.)
+// OTA relay status dedupe (#8 Phase 4): the FC resends each OTA status ~8x over
+// ~1.4s to survive the I2S dedup storm during its flash erase
+// (sendOtaRelayStatusRobust on the FC). That FC->OC (I2S) hop is lossy so the
+// resend is needed there, but the OC->app (BLE/GATT) hop is reliable — relaying
+// every copy just spams the app with identical notifications. Track the last
+// relayed status and collapse identical (state,err,bytes) runs into a single
+// notify; WRITING progress (Layer 3) still flows because bytes_written advances
+// each tick. Reset at session start so a new session's first status always
+// relays even if it matches the prior session's terminal status.
+static uint8_t  last_relay_state_ = 0xFF;
+static uint8_t  last_relay_err_   = 0xFF;
+static uint32_t last_relay_bytes_ = 0xFFFFFFFFu;
+
 static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* sha256)
 {
     static_assert(sizeof(pending_config_data) >= 4 + 32,
                   "pending_config_data too small for the OTA_BEGIN_MSG payload");
+    last_relay_state_ = 0xFF;
+    last_relay_err_   = 0xFF;
+    last_relay_bytes_ = 0xFFFFFFFFu;
     memcpy(pending_config_data, &total_size, 4);
     memcpy(pending_config_data + 4, sha256, 32);
     pending_config_data_len = 36;
@@ -1501,9 +1517,22 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                 case OTA_RELAY_ABORTED:       state = "aborted"; terminal = true; break;
                 default: break;
             }
-            ESP_LOGI("OC", "OTA relay: FC status state=%u err=%u bytes=%u",
-                     (unsigned)st.state, (unsigned)st.err, (unsigned)st.bytes_written);
-            ble_app.relayFcOtaStatus(state, err, st.bytes_written, terminal);
+            // Dedupe identical consecutive FC resends (see last_relay_* above):
+            // keep the per-frame serial log (confirms the resends arrived over
+            // I2S) but only re-notify the app when the status actually changes.
+            const bool dup = (st.state == last_relay_state_ &&
+                              st.err   == last_relay_err_ &&
+                              st.bytes_written == last_relay_bytes_);
+            ESP_LOGI("OC", "OTA relay: FC status state=%u err=%u bytes=%u%s",
+                     (unsigned)st.state, (unsigned)st.err, (unsigned)st.bytes_written,
+                     dup ? " (dup, not relayed)" : "");
+            if (!dup)
+            {
+                last_relay_state_ = st.state;
+                last_relay_err_   = st.err;
+                last_relay_bytes_ = st.bytes_written;
+                ble_app.relayFcOtaStatus(state, err, st.bytes_written, terminal);
+            }
         }
     }
     else if (type == GNSS_MSG)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -637,6 +637,14 @@ static uint32_t ready_entry_ms    = 0;
 
 static OutStatusQueryData last_query_cfg = {};
 
+// FC firmware version, relayed from the FC via FC_IDENTITY (#8 Phase 4). Cached
+// here so the OC can publish it to the app as a "fc_identity" config message,
+// letting the app verify an FC OTA / detect a rollback against the FC's *own*
+// version (the OC's "fw" never changes on an FC-only update). Re-published when
+// it changes mid-connection (an FC OTA never drops the OC<->app BLE link).
+static char          fc_fw_version[40]  = {0};
+static volatile bool fc_identity_dirty  = false;
+
 static inline bool nsFlagSet(uint8_t flags, uint8_t mask)
 {
     return (flags & mask) != 0U;
@@ -1497,6 +1505,7 @@ static bool isKnownMessageType(uint8_t type)
         case MAG_CAL_STATUS_MSG:     // FC→OC over I2S — issue #96
         case OTA_STATUS_MSG:         // FC→OC over I2S — OTA relay status (#8 Phase 4)
         case FLIGHT_SETTINGS_MSG:    // FC→OC over I2S at flight-start — issue #165
+        case FC_IDENTITY:            // FC→OC over I2C — FC firmware version (#8 Phase 4)
             return true;
         default:
             return false;
@@ -1509,6 +1518,25 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
     // Reject unknown message types (CRC false positives from I2S noise)
     if (!isKnownMessageType(type))
         return;
+
+    // FC firmware-version push (#8 Phase 4): a version *string*, not timestamped
+    // telemetry, so handle it before the time_us-based dedup below (which would
+    // misread the string's first 4 bytes as a timestamp and drop it). Cache it;
+    // if it changed, flag a re-publish to the app — an FC OTA never drops our
+    // OC<->app BLE link, so the connect-time "fc_identity" won't refresh itself.
+    if (type == FC_IDENTITY)
+    {
+        char incoming[sizeof(fc_fw_version)] = {0};
+        size_t n = (payload_len < sizeof(incoming) - 1) ? payload_len
+                                                        : sizeof(incoming) - 1;
+        if (n > 0) memcpy(incoming, payload, n);
+        if (strncmp(incoming, fc_fw_version, sizeof(fc_fw_version)) != 0)
+        {
+            memcpy(fc_fw_version, incoming, sizeof(fc_fw_version));
+            fc_identity_dirty = true;
+        }
+        return;
+    }
 
     // ── Duplicate, replay & stale frame detection for I2S DMA ──
     // Within a boot session, each FC-side time_us (= micros() on the FC) is
@@ -2357,6 +2385,22 @@ static void sendLoRaBeacon()
 // Config readback: send current config to app over BLE
 // ============================================================================
 
+// Publish the FC's relayed firmware version to the app as a compact "fc_identity"
+// config message (#8 Phase 4). Kept separate from "config_identity" so it stays
+// well under the BLE notify MTU (sendConfigJSON silently drops anything over
+// MTU-3). Sent on connect (from sendCurrentConfig) and re-sent whenever the FC
+// version changes mid-connection (after an FC OTA), so the app verifies the
+// update / spots a rollback against the FC's own version, not the OC's.
+static void sendFcIdentity()
+{
+    const char* fc_fw = fc_fw_version[0] ? fc_fw_version : "unknown";
+    char buf[80];
+    snprintf(buf, sizeof(buf),
+             "{\"type\":\"fc_identity\",\"fc_fw\":\"%s\"}", fc_fw);
+    ble_app.sendConfigJSON(String(buf));
+    ESP_LOGI("CFG", "Sent fc_identity (fc_fw=%s)", fc_fw);
+}
+
 static void sendCurrentConfig()
 {
     // Split config into two smaller JSON messages to stay within MTU limits.
@@ -2425,6 +2469,10 @@ static void sendCurrentConfig()
     String id_json(id_buf);
     ble_app.sendConfigJSON(id_json);
     ESP_LOGI("CFG", "Sent identity readback (%u bytes)", (unsigned)id_json.length());
+
+    // Also push the relayed FC firmware version as its own small message (#8).
+    delay(50);
+    sendFcIdentity();
 }
 
 // Cache servo config to NVS (mirrors what FlightComputer stores)
@@ -4644,6 +4692,16 @@ static void loop_oc()
             }
         }
         ble_was_connected = ble_now;
+    }
+
+    // Re-publish the FC version to the app when it changes mid-connection: an FC
+    // OTA reboots the FC (new version) but never drops the OC<->app BLE link, so
+    // the connect-time fc_identity won't refresh on its own. This is what lets
+    // the app's FC-OTA verify see the new version (or catch a rollback). #8.
+    if (fc_identity_dirty && ble_app.isConnected() && ble_app.isReadyForNotify())
+    {
+        fc_identity_dirty = false;
+        sendFcIdentity();
     }
 
     // Service the BLE library's poll-style work — currently just the OTA

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -15,6 +15,7 @@
 #include <esp_partition.h>        // esp_ota_get_running_partition for rollback gate (#8)
 #include "soc/rtc_cntl_reg.h"  // Brownout detector control
 #include "freertos/queue.h"
+#include "freertos/semphr.h"    // oc_i2s_mutex for the Phase 4 Layer 3 I2S flip
 #include "host/ble_gap.h"       // ble_gap_update_params
 
 // Nimble's os.h (pulled in by host/ble_gap.h) defines `max` and `min` as
@@ -1212,6 +1213,101 @@ static uint8_t  last_relay_state_ = 0xFF;
 static uint8_t  last_relay_err_   = 0xFF;
 static uint32_t last_relay_bytes_ = 0xFFFFFFFFu;
 
+// --- Phase 4 Layer 3: OC side of the I2S image pump --------------------------
+// During an FC OTA the OC flips its I2S slave-RX link (normal FC->OC telemetry)
+// to master-TX, pumps the image to the FC as OTA_DATA_CHUNK frames, then reverts
+// to slave-RX so the FC's terminal status (READY_TO_BOOT / VERIFY_FAILED) comes
+// back over the normal-direction link. i2s_stream is touched by loop_oc (the
+// flip/revert) and the BLE host task (ocOtaRelayData pump), so oc_i2s_mutex
+// serializes them. Flip is triggered by OTA_RELAY_READY; revert by FINISH/ABORT.
+static SemaphoreHandle_t oc_i2s_mutex = nullptr;
+static volatile bool oc_ota_tx_mode = false;                // flipped to master TX
+static volatile bool oc_ota_await_flip = false;             // READY seen; waiting for the FC to go quiet
+static volatile bool oc_ota_revert_to_rx_requested = false; // set on FINISH/ABORT staged
+static uint32_t oc_ota_frames_pumped = 0;                   // diag
+static uint32_t oc_ota_silence_ref_count = 0;               // dma_cb_count snapshot for silence detect
+static uint32_t oc_ota_silence_since_ms  = 0;               // when RX last went quiet
+static uint32_t oc_ota_total_size = 0;                      // image size (diag)
+// We must not drive BCLK as master until the FC has released it (flipped to its
+// own slave RX). The FC keeps the link active (idle-fill) right up until it
+// flips, so "I2S RX has gone quiet for this long" is a robust signal that the
+// FC is now in slave RX — more reliable than a fixed delay coupled to the FC's
+// READY-resend duration. The exact window is a bench item (#15).
+static constexpr uint32_t OTA_FLIP_SILENCE_MS = 500;
+
+static bool i2sRecvCallback(const uint8_t* buf, size_t len, void* user_ctx);  // defined below
+
+// Flip slave-RX -> master-TX for the image pump. Runs in loop_oc once the FC's
+// I2S TX has gone quiet (it has flipped to slave RX), so there's no contention.
+static void ocFlipToTx()
+{
+    if (oc_ota_tx_mode || oc_i2s_mutex == nullptr) return;
+    xSemaphoreTake(oc_i2s_mutex, portMAX_DELAY);
+    i2s_stream.end();
+    const esp_err_t e = i2s_stream.beginMasterTx(config::I2S_BCLK_PIN,
+                                                 config::I2S_WS_PIN,
+                                                 config::I2S_DIN_PIN,   // former DIN now drives DOUT
+                                                 -1,                    // no frame-sync for OTA
+                                                 OTA_I2S_SAMPLE_RATE_HZ,
+                                                 4, 64);
+    oc_ota_tx_mode = (e == ESP_OK);
+    xSemaphoreGive(oc_i2s_mutex);
+    ESP_LOGW("OC", "OTA relay: I2S -> master TX for image pump (%s)", esp_err_to_name(e));
+}
+
+// Revert master-TX -> slave-RX (normal telemetry + OTA status path). loop_oc.
+static void ocRevertToRx()
+{
+    if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr) return;
+    // Settle before tearing down TX: let the last pumped image frames fully
+    // clock out of the DMA to the FC (a few ms at the OTA BCLK), and catch any
+    // chunk that arrived just after FINISH (oc_ota_tx_mode is still true here,
+    // so a late ocOtaRelayData still pumps). The FC's FINISH handler separately
+    // waits for its byte count to reach the total, covering parse lag.
+    vTaskDelay(pdMS_TO_TICKS(100));
+    xSemaphoreTake(oc_i2s_mutex, portMAX_DELAY);
+    i2s_stream.end();
+    const esp_err_t e = i2s_stream.beginSlaveRx(config::I2S_BCLK_PIN,
+                                                config::I2S_WS_PIN,
+                                                config::I2S_DIN_PIN,
+                                                config::I2S_FSYNC_PIN,
+                                                config::I2S_SAMPLE_RATE,
+                                                4, 64);
+    if (e == ESP_OK)
+        i2s_stream.registerRecvCallback(i2sRecvCallback, nullptr);
+    oc_ota_tx_mode = false;
+    xSemaphoreGive(oc_i2s_mutex);
+    ESP_LOGW("OC", "OTA relay: I2S -> slave RX (%s)", esp_err_to_name(e));
+}
+
+// Pump one relayed BLE chunk to the FC. Splits into <= (MAX_PAYLOAD-4)-byte
+// OTA_DATA_CHUNK frames, each prefixed with its absolute offset so the FC writes
+// in order and skips stale-repeat offsets from an I2S underrun. BLE host task;
+// oc_i2s_mutex serializes vs the loop_oc flip/revert.
+static void ocOtaRelayData(void* /*ctx*/, uint32_t offset, const uint8_t* data, size_t len)
+{
+    if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr)
+    {
+        ESP_LOGW("OC", "OTA relay: chunk @%u dropped — I2S not in TX mode", (unsigned)offset);
+        return;
+    }
+    static constexpr size_t kMaxImg = MAX_PAYLOAD - 4;   // 4-byte offset header
+    uint8_t fp[MAX_PAYLOAD];
+    xSemaphoreTake(oc_i2s_mutex, portMAX_DELAY);
+    size_t sent = 0;
+    while (sent < len && oc_ota_tx_mode)
+    {
+        const size_t n = (len - sent > kMaxImg) ? kMaxImg : (len - sent);
+        const uint32_t off = offset + (uint32_t)sent;
+        memcpy(fp, &off, 4);
+        memcpy(fp + 4, data + sent, n);
+        (void)i2s_stream.writeFrame(OTA_DATA_CHUNK, fp, 4 + n);
+        sent += n;
+        oc_ota_frames_pumped++;
+    }
+    xSemaphoreGive(oc_i2s_mutex);
+}
+
 static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* sha256)
 {
     static_assert(sizeof(pending_config_data) >= 4 + 32,
@@ -1219,6 +1315,10 @@ static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* s
     last_relay_state_ = 0xFF;
     last_relay_err_   = 0xFF;
     last_relay_bytes_ = 0xFFFFFFFFu;
+    oc_ota_frames_pumped          = 0;
+    oc_ota_await_flip             = false;
+    oc_ota_revert_to_rx_requested = false;
+    oc_ota_total_size             = total_size;
     memcpy(pending_config_data, &total_size, 4);
     memcpy(pending_config_data + 4, sha256, 32);
     pending_config_data_len = 36;
@@ -1229,11 +1329,15 @@ static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* s
 static void ocOtaRelayFinish(void* /*ctx*/)
 {
     setPendingCommand(OTA_FINISH_CMD);
+    // Revert to slave-RX (in loop_oc) so we can hear the FC's terminal status,
+    // which it sends over the normal-direction I2S after IT reverts to TX.
+    oc_ota_revert_to_rx_requested = true;
     ESP_LOGI("OC", "OTA relay: staged OTA_FINISH for FC");
 }
 static void ocOtaRelayAbort(void* /*ctx*/)
 {
     setPendingCommand(OTA_ABORT_CMD);
+    oc_ota_revert_to_rx_requested = true;
     ESP_LOGI("OC", "OTA relay: staged OTA_ABORT for FC");
 }
 
@@ -1510,7 +1614,15 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             bool terminal     = false;
             switch (st.state)
             {
-                case OTA_RELAY_READY:         state = "ready"; break;
+                case OTA_RELAY_READY:         state = "ready";
+                    // FC has erased ota_1 and (after its READY resends) will flip
+                    // to slave-RX. Arm the flip: loop_oc watches for the I2S link
+                    // to go quiet (FC released BCLK) before flipping us to
+                    // master-TX to pump the image (Phase 4 Layer 3).
+                    oc_ota_await_flip       = true;
+                    oc_ota_silence_ref_count = dma_cb_count;
+                    oc_ota_silence_since_ms  = (uint32_t)(esp_timer_get_time() / 1000);
+                    break;
                 case OTA_RELAY_WRITING:       state = "writing"; break;
                 case OTA_RELAY_READY_TO_BOOT: state = "ready_to_boot"; terminal = true; break;
                 case OTA_RELAY_VERIFY_FAILED: state = "verify_failed"; err = "fc_error"; terminal = true; break;
@@ -3849,6 +3961,12 @@ void initPeripherals()
     // init the slave so the bus is stable.
     ESP_LOGI("PWR", "I2C slave deferred (waiting for FC I2S activity)");
 
+    // Mutex serializing i2s_stream across the loop_oc flip/revert and the BLE
+    // task's image pump during an FC OTA (Phase 4 Layer 3). Created before the
+    // channel so it's ready if an OTA starts immediately after power-on.
+    if (oc_i2s_mutex == nullptr)
+        oc_i2s_mutex = xSemaphoreCreateMutex();
+
     // I2S telemetry stream from FlightComputer (DMA-based slave RX)
     // Small DMA buffers (4 × 256 bytes = 1 KB) minimize latency.
     // FRAME_SYNC interrupt gating prevents stale replay regardless of
@@ -4133,7 +4251,8 @@ static void setup_oc()
         ESP_LOGE("BLE", "BLE app interface failed to start");
     }
     // Relay target==1 (Flight Computer) OTA to the FC over I2C (#8 Phase 4).
-    ble_app.setOtaRelayDelegate(ocOtaRelayBegin, ocOtaRelayFinish, ocOtaRelayAbort, nullptr);
+    ble_app.setOtaRelayDelegate(ocOtaRelayBegin, ocOtaRelayFinish, ocOtaRelayAbort,
+                                ocOtaRelayData, nullptr);
 
     // Enter low-power mode: 80 MHz, DFS to 40 MHz when idle
     enterLowPowerMode();
@@ -4181,6 +4300,32 @@ static void loop_oc()
     // --- Active mode: FlightComputer + sensors powered on ---
     if (pwr_pin_on)
     {
+        // Phase 4 Layer 3: service the I2S direction flip for an FC OTA image
+        // pump. Done here (not in the BLE/parser task) so all i2s_stream
+        // lifecycle calls live in one place. After READY we wait for the FC's
+        // I2S TX to go quiet — proof it has flipped to slave RX and released
+        // BCLK — before we flip to master TX, so the two never drive BCLK at
+        // once. (The FC idle-fills until it flips, so quiet == flipped.)
+        if (oc_ota_await_flip && !oc_ota_tx_mode)
+        {
+            const uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+            if (dma_cb_count != oc_ota_silence_ref_count)
+            {
+                oc_ota_silence_ref_count = dma_cb_count;   // still receiving — reset timer
+                oc_ota_silence_since_ms  = now_ms;
+            }
+            else if ((now_ms - oc_ota_silence_since_ms) >= OTA_FLIP_SILENCE_MS)
+            {
+                oc_ota_await_flip = false;
+                ocFlipToTx();                              // FC is quiet → safe to drive
+            }
+        }
+        if (oc_ota_revert_to_rx_requested)
+        {
+            oc_ota_revert_to_rx_requested = false;
+            ocRevertToRx();
+        }
+
         // Deferred I2C slave init: wait for I2S DMA activity confirming
         // the FC is alive before enabling the slave on the bus.
         if (!i2c_slave_initialized && dma_cb_count > 50)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1238,6 +1238,7 @@ static uint32_t oc_ota_feed_sent     = 0;                   // diag: frames the 
 static uint32_t oc_ota_feed_idle     = 0;                   // diag: idle-fill writes (queue empty)
 static uint32_t oc_ota_silence_ref_count = 0;               // dma_cb_count snapshot for silence detect
 static uint32_t oc_ota_silence_since_ms  = 0;               // when RX last went quiet
+static uint32_t oc_ota_warmup_since_ms   = 0;               // post-flip RX-lock warmup start (0 = inactive)
 static uint32_t oc_ota_total_size = 0;                      // image size (diag)
 // OC->FC image pump. The BLE callback enqueues image frames here; a dedicated
 // feeder task (ocOtaTxFeederTask) is the SOLE I2S writer while flipped to master
@@ -1256,6 +1257,14 @@ static TaskHandle_t  oc_ota_feeder_task = nullptr;
 // FC is now in slave RX — more reliable than a fixed delay coupled to the FC's
 // READY-resend duration. The exact window is a bench item (#15).
 static constexpr uint32_t OTA_FLIP_SILENCE_MS = 500;
+
+// After flipping to master TX, idle-fill this long before telling the app it may
+// pump real image data, so the FC's slave RX locks onto the just-started master
+// BCLK first. Offset 0 pumped into a not-yet-locked RX is lost, and the
+// forward-only receiver never recovers (bench 2026-06-02: frames_ok=0, every
+// frame "gap", finish err=7). Generous vs the observed ~tens-of-ms lock; the OTA
+// itself is ~15 s so the cost is negligible. Bench-tunable (#15).
+static constexpr uint32_t OTA_RX_WARMUP_MS = 150;
 
 static bool i2sRecvCallback(const uint8_t* buf, size_t len, void* user_ctx);  // defined below
 
@@ -1416,6 +1425,7 @@ static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* s
     oc_ota_feed_idle              = 0;
     oc_ota_await_flip             = false;
     oc_ota_relay_ready_pending    = false;
+    oc_ota_warmup_since_ms        = 0;
     oc_ota_revert_to_rx_requested = false;
     oc_ota_total_size             = total_size;
     memcpy(pending_config_data, &total_size, 4);
@@ -4506,14 +4516,28 @@ static void loop_oc()
             {
                 oc_ota_await_flip = false;
                 ocFlipToTx();                              // FC is quiet → safe to drive
-                // Only now — once we're actually in TX and able to receive —
-                // tell the app it may start pumping. (Held since READY so the
-                // app can't drop offset 0 into a not-yet-flipped link.)
-                if (oc_ota_tx_mode && oc_ota_relay_ready_pending)
-                {
-                    oc_ota_relay_ready_pending = false;
-                    ble_app.relayFcOtaStatus("ready", nullptr, 0, false);
-                }
+                // Don't release "ready" yet: the FC's slave RX needs a few ms to
+                // lock onto the just-started master BCLK. Offset 0 pumped before
+                // then is lost and the forward-only receiver never recovers
+                // (bench: frames_ok=0, every frame "gap"). Start a warmup window —
+                // the feeder idle-fills (BCLK live) so RX can lock; the gate below
+                // releases the app once it has. #15.
+                if (oc_ota_tx_mode)
+                    oc_ota_warmup_since_ms = now_ms;
+            }
+        }
+        // Post-flip RX warmup gate: hold the app's "ready" until the FC slave RX
+        // has had time to lock onto BCLK (feeder idle-filling meanwhile), so the
+        // first real image frame (offset 0) lands. (Held since READY so the app
+        // can't drop offset 0 into a not-yet-locked link.) #8 Phase 4 / #15.
+        if (oc_ota_tx_mode && oc_ota_relay_ready_pending && oc_ota_warmup_since_ms != 0)
+        {
+            const uint32_t warm_now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+            if ((warm_now_ms - oc_ota_warmup_since_ms) >= OTA_RX_WARMUP_MS)
+            {
+                oc_ota_relay_ready_pending = false;
+                oc_ota_warmup_since_ms     = 0;
+                ble_app.relayFcOtaStatus("ready", nullptr, 0, false);
             }
         }
         if (oc_ota_revert_to_rx_requested)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1351,7 +1351,14 @@ static void ocOtaTxFeederTask(void *)
     OcOtaTxFrame f;
     for (;;)
     {
-        if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr)
+        // Back off the bus the instant a revert is requested. ocRevertToRx() runs
+        // in loop_oc at LOWER priority than this feeder and must take oc_i2s_mutex
+        // to tear down the TX channel; while we keep re-grabbing that mutex at the
+        // higher priority, the revert can never win the race. Bench 2026-06-01
+        // deadlocked exactly here after FINISH — loop_oc wedged in ocRevertToRx and
+        // we idle-filled forever. Stop touching the bus so the revert proceeds; the
+        // flag stays set until ocRevertToRx() completes (see loop_oc).
+        if (!oc_ota_tx_mode || oc_ota_revert_to_rx_requested || oc_i2s_mutex == nullptr)
         {
             vTaskDelay(pdMS_TO_TICKS(5));
             continue;
@@ -4437,8 +4444,14 @@ static void loop_oc()
         }
         if (oc_ota_revert_to_rx_requested)
         {
-            oc_ota_revert_to_rx_requested = false;
+            // Clear AFTER the revert completes, not before. The feeder watches this
+            // flag to back off oc_i2s_mutex so ocRevertToRx() can acquire it (see the
+            // feeder's comment). Clearing first would let the higher-priority feeder
+            // resume mid-revert and starve ocRevertToRx()'s mutex take — the FINISH
+            // deadlock. ocRevertToRx() sets oc_ota_tx_mode=false, so the feeder idles
+            // regardless once it returns.
             ocRevertToRx();
+            oc_ota_revert_to_rx_requested = false;
         }
 
         // Deferred I2C slave init: wait for I2S DMA activity confirming

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1229,6 +1229,17 @@ static uint32_t oc_ota_frames_pumped = 0;                   // diag
 static uint32_t oc_ota_silence_ref_count = 0;               // dma_cb_count snapshot for silence detect
 static uint32_t oc_ota_silence_since_ms  = 0;               // when RX last went quiet
 static uint32_t oc_ota_total_size = 0;                      // image size (diag)
+// OC->FC image pump. The BLE callback enqueues image frames here; a dedicated
+// feeder task (ocOtaTxFeederTask) is the SOLE I2S writer while flipped to master
+// TX, writing idle-fill in the gaps between BLE chunks. This is essential: I2S
+// master clocks continuously, so any gap in writes makes the DMA replay its last
+// buffer — the FC then sees a relentless stream of duplicate frames, its RX ring
+// overflows (bench 2026-06-01: ring_ovf=1.37M, transfer stalled at 714 B), and
+// that corruption shreds the real in-order frames too. This mirrors the FC's own
+// i2sSenderTask, whose comment already documents exactly this replay hazard.
+struct OcOtaTxFrame { uint8_t payload[MAX_PAYLOAD]; uint16_t len; };
+static QueueHandle_t oc_ota_tx_queue    = nullptr;
+static TaskHandle_t  oc_ota_feeder_task = nullptr;
 // We must not drive BCLK as master until the FC has released it (flipped to its
 // own slave RX). The FC keeps the link active (idle-fill) right up until it
 // flips, so "I2S RX has gone quiet for this long" is a robust signal that the
@@ -1287,26 +1298,63 @@ static void ocRevertToRx()
 // oc_i2s_mutex serializes vs the loop_oc flip/revert.
 static void ocOtaRelayData(void* /*ctx*/, uint32_t offset, const uint8_t* data, size_t len)
 {
-    if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr)
+    if (!oc_ota_tx_mode || oc_ota_tx_queue == nullptr)
     {
         ESP_LOGW("OC", "OTA relay: chunk @%u dropped — I2S not in TX mode", (unsigned)offset);
         return;
     }
     static constexpr size_t kMaxImg = MAX_PAYLOAD - 4;   // 4-byte offset header
-    uint8_t fp[MAX_PAYLOAD];
-    xSemaphoreTake(oc_i2s_mutex, portMAX_DELAY);
     size_t sent = 0;
-    while (sent < len && oc_ota_tx_mode)
+    while (sent < len)
     {
+        OcOtaTxFrame f;
         const size_t n = (len - sent > kMaxImg) ? kMaxImg : (len - sent);
         const uint32_t off = offset + (uint32_t)sent;
-        memcpy(fp, &off, 4);
-        memcpy(fp + 4, data + sent, n);
-        (void)i2s_stream.writeFrame(OTA_DATA_CHUNK, fp, 4 + n);
+        memcpy(f.payload, &off, 4);
+        memcpy(f.payload + 4, data + sent, n);
+        f.len = (uint16_t)(4 + n);
+        // Block (back-pressure BLE) if the feeder is briefly behind; it drains far
+        // faster than BLE delivers, so this should not actually wait. The long
+        // timeout is only a safety valve against a permanent BLE-host-task hang.
+        if (xQueueSend(oc_ota_tx_queue, &f, pdMS_TO_TICKS(1000)) != pdTRUE)
+        {
+            ESP_LOGW("OC", "OTA relay: TX queue full, dropped frame @%u", (unsigned)off);
+            return;
+        }
         sent += n;
         oc_ota_frames_pumped++;
     }
-    xSemaphoreGive(oc_i2s_mutex);
+}
+
+// Sole I2S writer while flipped to master TX. Drains the image-frame queue and
+// writes idle-fill zeros in the gaps so the I2S DMA never replays a stale buffer
+// (see OcOtaTxFrame comment). Idles harmlessly outside TX mode. Mirrors the FC's
+// i2sSenderTask. The per-iteration mutex serialises against ocFlipToTx /
+// ocRevertToRx (which recreate the channel) — the double-checked oc_ota_tx_mode
+// guarantees we never writeFrame into a torn-down channel.
+static void ocOtaTxFeederTask(void *)
+{
+    OcOtaTxFrame f;
+    for (;;)
+    {
+        if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr)
+        {
+            vTaskDelay(pdMS_TO_TICKS(5));
+            continue;
+        }
+        xSemaphoreTake(oc_i2s_mutex, portMAX_DELAY);
+        if (!oc_ota_tx_mode)            // flipped back to RX while we waited for the mutex
+        {
+            xSemaphoreGive(oc_i2s_mutex);
+            continue;
+        }
+        if (oc_ota_tx_queue != nullptr &&
+            xQueueReceive(oc_ota_tx_queue, &f, pdMS_TO_TICKS(1)) == pdTRUE)
+            (void)i2s_stream.writeFrame(OTA_DATA_CHUNK, f.payload, f.len);
+        else
+            (void)i2s_stream.writeIdleFill(64, 1);   // keep BCLK fed; no stale replay
+        xSemaphoreGive(oc_i2s_mutex);
+    }
 }
 
 static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* sha256)
@@ -3981,6 +4029,10 @@ void initPeripherals()
     // channel so it's ready if an OTA starts immediately after power-on.
     if (oc_i2s_mutex == nullptr)
         oc_i2s_mutex = xSemaphoreCreateMutex();
+    // Image-pump frame queue + feeder task (Phase 4 Layer 3). 16 frames (~4 KB)
+    // is several BLE chunks deep; the feeder drains far faster than BLE fills.
+    if (oc_ota_tx_queue == nullptr)
+        oc_ota_tx_queue = xQueueCreate(16, sizeof(OcOtaTxFrame));
 
     // I2S telemetry stream from FlightComputer (DMA-based slave RX)
     // Small DMA buffers (4 × 256 bytes = 1 KB) minimize latency.
@@ -4020,6 +4072,15 @@ void initPeripherals()
         // rx_ring to fill until drop_oldest evicted bytes (#104).
         xTaskCreatePinnedToCore(i2sParserTask, "I2S Parse", 4096,
                                 nullptr, 6, &i2s_rx_task_handle, 1);
+
+        // OTA image-pump feeder (Phase 4 Layer 3). Sole I2S writer during an FC
+        // OTA, keeping the master TX DMA continuously fed (frame-or-idle-fill)
+        // so it never replays stale buffers. Idles when not in TX mode. Core 1 /
+        // prio 6 like the parser; during OTA the RX parser is blocked (link is
+        // flipped to TX), so the feeder gets the core to itself.
+        if (oc_ota_feeder_task == nullptr)
+            xTaskCreatePinnedToCore(ocOtaTxFeederTask, "OTA Feed", 4096,
+                                    nullptr, 6, &oc_ota_feeder_task, 1);
     }
 
     // NOTE: do NOT pre-queue a status response here.  With the new

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1082,7 +1082,8 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == PYRO_CONT_TEST ||
            cmd == PYRO_FIRE_TEST ||
            cmd == MAG_CAL_APPLY_PENDING ||     // #132: app-pushed mag cal payload
-           cmd == SENSOR_CAL_APPLY_PENDING;    // #132: app-pushed sensor cal payload
+           cmd == SENSOR_CAL_APPLY_PENDING ||  // #132: app-pushed sensor cal payload
+           cmd == OTA_BEGIN_PENDING;           // #8 Phase 4: FC OTA image header
 }
 
 // The FC reads exactly FC_COMBINED_READ_SIZE bytes per I2C poll.
@@ -1192,6 +1193,34 @@ static void queueOutStatusResponse(bool ready)
     }
 }
 
+// ---- OTA relay to the Flight Computer (#8 Phase 4) ------------------------
+// TR_BLE_To_APP invokes these when an OTA_BEGIN/FINISH/ABORT with target==1
+// arrives over BLE. We stage the matching command (+ the 36-byte image header
+// for BEGIN) for the FC to pull on its next I2C poll — identical delivery to
+// servo/sim config. The FC reports progress back over I2S (OTA_STATUS_MSG),
+// relayed to BLE by the frame processor. (Image bytes are Phase 4 Layer 3.)
+static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* sha256)
+{
+    static_assert(sizeof(pending_config_data) >= 4 + 32,
+                  "pending_config_data too small for the OTA_BEGIN_MSG payload");
+    memcpy(pending_config_data, &total_size, 4);
+    memcpy(pending_config_data + 4, sha256, 32);
+    pending_config_data_len = 36;
+    pending_config_msg_type = OTA_BEGIN_MSG;
+    setPendingCommand(OTA_BEGIN_PENDING);
+    ESP_LOGI("OC", "OTA relay: staged OTA_BEGIN for FC (size=%u)", (unsigned)total_size);
+}
+static void ocOtaRelayFinish(void* /*ctx*/)
+{
+    setPendingCommand(OTA_FINISH_CMD);
+    ESP_LOGI("OC", "OTA relay: staged OTA_FINISH for FC");
+}
+static void ocOtaRelayAbort(void* /*ctx*/)
+{
+    setPendingCommand(OTA_ABORT_CMD);
+    ESP_LOGI("OC", "OTA relay: staged OTA_ABORT for FC");
+}
+
 static const char* rocketStateToString(RocketState s)
 {
     switch (s)
@@ -1255,6 +1284,7 @@ static bool isKnownMessageType(uint8_t type)
         case SNAPSHOT_MSG:           // FC→OC over I2S during INFLIGHT
         case GET_FLIGHT_SNAPSHOT:    // FC→OC over I2C at boot recovery
         case MAG_CAL_STATUS_MSG:     // FC→OC over I2S — issue #96
+        case OTA_STATUS_MSG:         // FC→OC over I2S — OTA relay status (#8 Phase 4)
         case FLIGHT_SETTINGS_MSG:    // FC→OC over I2S at flight-start — issue #165
             return true;
         default:
@@ -1447,6 +1477,33 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         if (payload_len >= sizeof(SensorCalStatusData))
         {
             ble_app.sendSensorCalStatus(payload, sizeof(SensorCalStatusData));
+        }
+    }
+    else if (type == OTA_STATUS_MSG)
+    {
+        // #8 Phase 4: FC→OC OTA relay status. Map the FC's state byte to the
+        // ota_status JSON vocabulary the app already understands for local OTA,
+        // and forward it up over BLE. relayFcOtaStatus() ends the relay session
+        // on a terminal state (ready_to_boot / verify_failed / aborted).
+        if (payload_len >= sizeof(OtaRelayStatusData))
+        {
+            OtaRelayStatusData st;
+            memcpy(&st, payload, sizeof(st));
+            const char* state = "writing";
+            const char* err   = nullptr;
+            bool terminal     = false;
+            switch (st.state)
+            {
+                case OTA_RELAY_READY:         state = "ready"; break;
+                case OTA_RELAY_WRITING:       state = "writing"; break;
+                case OTA_RELAY_READY_TO_BOOT: state = "ready_to_boot"; terminal = true; break;
+                case OTA_RELAY_VERIFY_FAILED: state = "verify_failed"; err = "fc_error"; terminal = true; break;
+                case OTA_RELAY_ABORTED:       state = "aborted"; terminal = true; break;
+                default: break;
+            }
+            ESP_LOGI("OC", "OTA relay: FC status state=%u err=%u bytes=%u",
+                     (unsigned)st.state, (unsigned)st.err, (unsigned)st.bytes_written);
+            ble_app.relayFcOtaStatus(state, err, st.bytes_written, terminal);
         }
     }
     else if (type == GNSS_MSG)
@@ -4046,6 +4103,8 @@ static void setup_oc()
     {
         ESP_LOGE("BLE", "BLE app interface failed to start");
     }
+    // Relay target==1 (Flight Computer) OTA to the FC over I2C (#8 Phase 4).
+    ble_app.setOtaRelayDelegate(ocOtaRelayBegin, ocOtaRelayFinish, ocOtaRelayAbort, nullptr);
 
     // Enter low-power mode: 80 MHz, DFS to 40 MHz when idle
     enterLowPowerMode();

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1223,6 +1223,7 @@ static uint32_t last_relay_bytes_ = 0xFFFFFFFFu;
 static SemaphoreHandle_t oc_i2s_mutex = nullptr;
 static volatile bool oc_ota_tx_mode = false;                // flipped to master TX
 static volatile bool oc_ota_await_flip = false;             // READY seen; waiting for the FC to go quiet
+static volatile bool oc_ota_relay_ready_pending = false;    // relay "ready" to app once flipped to TX
 static volatile bool oc_ota_revert_to_rx_requested = false; // set on FINISH/ABORT staged
 static uint32_t oc_ota_frames_pumped = 0;                   // diag
 static uint32_t oc_ota_silence_ref_count = 0;               // dma_cb_count snapshot for silence detect
@@ -1317,6 +1318,7 @@ static void ocOtaRelayBegin(void* /*ctx*/, uint32_t total_size, const uint8_t* s
     last_relay_bytes_ = 0xFFFFFFFFu;
     oc_ota_frames_pumped          = 0;
     oc_ota_await_flip             = false;
+    oc_ota_relay_ready_pending    = false;
     oc_ota_revert_to_rx_requested = false;
     oc_ota_total_size             = total_size;
     memcpy(pending_config_data, &total_size, 4);
@@ -1618,10 +1620,19 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                     // FC has erased ota_1 and (after its READY resends) will flip
                     // to slave-RX. Arm the flip: loop_oc watches for the I2S link
                     // to go quiet (FC released BCLK) before flipping us to
-                    // master-TX to pump the image (Phase 4 Layer 3).
-                    oc_ota_await_flip       = true;
-                    oc_ota_silence_ref_count = dma_cb_count;
-                    oc_ota_silence_since_ms  = (uint32_t)(esp_timer_get_time() / 1000);
+                    // master-TX to pump the image (Phase 4 Layer 3). CRITICAL:
+                    // do NOT relay "ready" to the app yet. If the app starts
+                    // pumping chunks before we're in TX mode, the early chunks
+                    // (including offset 0) are dropped and the FC stalls forever
+                    // at bytesWritten=0 (every later chunk is a "gap"). loop_oc
+                    // relays "ready" only after the flip to TX completes.
+                    if (!oc_ota_tx_mode)
+                    {
+                        oc_ota_await_flip          = true;
+                        oc_ota_relay_ready_pending = true;
+                        oc_ota_silence_ref_count   = dma_cb_count;
+                        oc_ota_silence_since_ms    = (uint32_t)(esp_timer_get_time() / 1000);
+                    }
                     break;
                 case OTA_RELAY_WRITING:       state = "writing"; break;
                 case OTA_RELAY_READY_TO_BOOT: state = "ready_to_boot"; terminal = true; break;
@@ -1635,10 +1646,14 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             const bool dup = (st.state == last_relay_state_ &&
                               st.err   == last_relay_err_ &&
                               st.bytes_written == last_relay_bytes_);
+            // READY is held until the OC has flipped to master TX (relayed from
+            // loop_oc post-flip), so the app can't start pumping into a link
+            // that isn't receiving yet.
+            const bool defer_ready = (st.state == OTA_RELAY_READY);
             ESP_LOGI("OC", "OTA relay: FC status state=%u err=%u bytes=%u%s",
                      (unsigned)st.state, (unsigned)st.err, (unsigned)st.bytes_written,
-                     dup ? " (dup, not relayed)" : "");
-            if (!dup)
+                     dup ? " (dup, not relayed)" : (defer_ready ? " (ready held for TX flip)" : ""));
+            if (!dup && !defer_ready)
             {
                 last_relay_state_ = st.state;
                 last_relay_err_   = st.err;
@@ -4318,6 +4333,14 @@ static void loop_oc()
             {
                 oc_ota_await_flip = false;
                 ocFlipToTx();                              // FC is quiet → safe to drive
+                // Only now — once we're actually in TX and able to receive —
+                // tell the app it may start pumping. (Held since READY so the
+                // app can't drop offset 0 into a not-yet-flipped link.)
+                if (oc_ota_tx_mode && oc_ota_relay_ready_pending)
+                {
+                    oc_ota_relay_ready_pending = false;
+                    ble_app.relayFcOtaStatus("ready", nullptr, 0, false);
+                }
             }
         }
         if (oc_ota_revert_to_rx_requested)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1313,16 +1313,28 @@ static void ocOtaRelayData(void* /*ctx*/, uint32_t offset, const uint8_t* data, 
         memcpy(f.payload, &off, 4);
         memcpy(f.payload + 4, data + sent, n);
         f.len = (uint16_t)(4 + n);
-        // Block (back-pressure BLE) if the feeder is briefly behind; it drains far
-        // faster than BLE delivers, so this should not actually wait. The long
-        // timeout is only a safety valve against a permanent BLE-host-task hang.
-        if (xQueueSend(oc_ota_tx_queue, &f, pdMS_TO_TICKS(1000)) != pdTRUE)
+        // The very first frame (offset 0) is reliably lost to the I2S master-TX
+        // startup transient on the FC's slave RX: bench 2026-06-01 showed the
+        // whole 578 KB image streaming in order EXCEPT offset 0, so writeChunk
+        // never started and every later frame was rejected as "ahead of have=0".
+        // Resend offset 0 a few times back-to-back; the FC writes whichever copy
+        // lands first and skips the rest (offset < bytesWritten -> benign gap).
+        // Mirrors the #165 critical-one-shot-frame resend. The image streams
+        // cleanly after the first frame, so only offset 0 needs this.
+        const int copies = (off == 0) ? 5 : 1;
+        for (int c = 0; c < copies; ++c)
         {
-            ESP_LOGW("OC", "OTA relay: TX queue full, dropped frame @%u", (unsigned)off);
-            return;
+            // Block (back-pressure BLE) if the feeder is briefly behind; it drains
+            // far faster than BLE delivers, so this should not actually wait. The
+            // long timeout is only a safety valve against a BLE-host-task hang.
+            if (xQueueSend(oc_ota_tx_queue, &f, pdMS_TO_TICKS(1000)) != pdTRUE)
+            {
+                ESP_LOGW("OC", "OTA relay: TX queue full, dropped frame @%u", (unsigned)off);
+                return;
+            }
+            oc_ota_frames_pumped++;
         }
         sent += n;
-        oc_ota_frames_pumped++;
     }
 }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1351,14 +1351,17 @@ static void ocOtaTxFeederTask(void *)
     OcOtaTxFrame f;
     for (;;)
     {
-        // Back off the bus the instant a revert is requested. ocRevertToRx() runs
-        // in loop_oc at LOWER priority than this feeder and must take oc_i2s_mutex
-        // to tear down the TX channel; while we keep re-grabbing that mutex at the
-        // higher priority, the revert can never win the race. Bench 2026-06-01
-        // deadlocked exactly here after FINISH — loop_oc wedged in ocRevertToRx and
-        // we idle-filled forever. Stop touching the bus so the revert proceeds; the
-        // flag stays set until ocRevertToRx() completes (see loop_oc).
-        if (!oc_ota_tx_mode || oc_ota_revert_to_rx_requested || oc_i2s_mutex == nullptr)
+        // Back off the bus once a revert is requested so ocRevertToRx() (in loop_oc,
+        // LOWER priority) can take oc_i2s_mutex to tear down TX — while we keep
+        // re-grabbing it at higher priority the revert never wins (bench: deadlock,
+        // idle-filled forever). BUT only back off after the queue is DRAINED: the app
+        // sends FINISH right after the last data chunk, so the image tail can still be
+        // queued here; backing off immediately stranded it (bench: FC 1 frame short ->
+        // SizeMismatch). Drain the tail first, then yield; we just stop idle-filling.
+        const bool revert_drained =
+            oc_ota_revert_to_rx_requested &&
+            (oc_ota_tx_queue == nullptr || uxQueueMessagesWaiting(oc_ota_tx_queue) == 0);
+        if (!oc_ota_tx_mode || oc_i2s_mutex == nullptr || revert_drained)
         {
             vTaskDelay(pdMS_TO_TICKS(5));
             continue;


### PR DESCRIPTION
Part of #8 — Phase 4: over-the-air firmware update for the **Flight Computer**, relayed from the iOS app through the OUT computer over the existing OC↔FC link (the FC has no radio of its own).

## What works (bench-validated)
- Full app→OC→FC image transfer, gap-free, into the FC's inactive OTA slot.
- Survives a power cycle: the FC marks the new image valid after a ~10 s stable self-test; a bad image auto-reverts.
- The app shows the FC's *own* firmware version and reports **Verified** (or a genuine rollback) by comparing the FC's running version — not the OC's.

## How it's built
- **FC scaffolding**: dual OTA partitions, rollback-enable, embedded version string.
- **I2C control relay** (OC↔FC): BEGIN / FINISH / ABORT + status, dispatched on the FC under the safe-state lockout.
- **I2S image pump** (OC→FC): the telemetry I2S link is flipped to master-TX and the image is streamed in. Reliability fixes from bench iterations — OC idle-fill (no FC RX overflow), offset-0 resend + a deterministic RX-lock **warmup** before real data (fixes the flaky first-chunk loss), teardown drain + silence-gated swap, BCLK ~400 kHz.
- **Persistence & resume**: `esp_ota_mark_app_valid_cancel_rollback` after a stable run; the FC ignores a stale post-reboot FINISH; the OC resets its telemetry-dedup baseline when the FC's `time_us` regresses on reboot.
- **Version relay**: new `FC_IDENTITY` (0xEC) I2C message carries the FC's version to the OC, relayed to the app as a compact `fc_identity` config message; the app verifies the FC OTA against it. Registered in the message-type uniqueness gtest.
- **iOS**: Flight-Computer target picker, FC-firmware display, verify/rollback handling with a wider post-reboot window.

## Test
- Host gtest green (incl. `RocketComputerTypes.MessageTypeCodes_AllUnique`).
- FC + OC + iOS all build clean.
- Bench: clean transfer (`frames_ok=3496 gap=0`, `bytes=584960/584960`), persistence across power-cycle, and FC-version relay → **Verified** on a real version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
