### PR TITLE
fix(ekf): re-reference baro to GNSS altitude frame (#44)

### DIFF
--- a/Data_Analysis/replay_flight_ekf.py
+++ b/Data_Analysis/replay_flight_ekf.py
@@ -88,8 +88,11 @@ def detect_flight_phases(records, t0_us):
     return boost_start, boost_end, apogee_us
 
 
-def replay(binary_file, plot_dir=None):
+def replay(binary_file, plot_dir=None, align_baro=True):
+    mode = ("aligned baro+GNSS frame (the FIX)" if align_baro
+            else "pad-relative baro (firmware behaviour, the BUG)")
     print(f"Parsing: {binary_file}")
+    print(f"  Baro frame mode: {mode}")
     records, stats, config = parse_binary_file(str(binary_file))
     print(f"  Frames: {stats['good_crc']:,} good, {stats['bad_crc']} bad CRC")
     print(f"  IMU: {len(records['ISM6HG256']):,}  GNSS: {len(records['GNSS']):,}  "
@@ -199,8 +202,13 @@ def replay(binary_file, plot_dir=None):
                           f"(from {len(baro_samples_for_ref)} samples at t={t_rel:.2f}s)")
                 continue
 
-            # Defer baro offset until we have a valid GNSS fix
-            if not baro_alt_offset_set and latest_gnss is not None:
+            # Defer baro offset until we have a valid GNSS fix.
+            #   align_baro=True  -> add GNSS alt so baro shares the EKF's
+            #                       absolute-hMSL state frame (the FIX).
+            #   align_baro=False -> leave offset 0, feeding pad-relative
+            #                       altitude — reproduces the firmware bug at
+            #                       flight_computer/main/main.cpp:2812.
+            if align_baro and not baro_alt_offset_set and latest_gnss is not None:
                 baro_alt_offset = latest_gnss["alt_m"]
                 baro_alt_offset_set = True
                 print(f"  Baro alt offset: {baro_alt_offset:.1f}m "
@@ -391,6 +399,17 @@ def replay(binary_file, plot_dir=None):
     print(f"  Accel bias final: X={accel_bias[-1,0]:.3f} Y={accel_bias[-1,1]:.3f} "
           f"Z={accel_bias[-1,2]:.3f} m/s²")
 
+    # Pad / pre-boost sanity metric: a stationary rocket's AGL altitude should
+    # sit at ~0.  The baro frame bug drags the fused altitude negative by
+    # roughly the launch-site MSL elevation.
+    pad_alt = float('nan')
+    if boost_start is not None:
+        bs_rel = (boost_start - t0_us) / 1e6
+        pad_mask = t_ekf < bs_rel
+        if pad_mask.any():
+            pad_alt = float(np.mean(ekf_u[pad_mask]))
+    print(f"  Pad EKF altitude AGL (pre-boost mean): {pad_alt:.2f} m   [should be ~0]")
+
     # ---- Plot ----
     if plot_dir is None:
         plot_dir = Path(__file__).parent.parent / "plots"
@@ -519,7 +538,19 @@ def replay(binary_file, plot_dir=None):
 
     plots = [out1, out2, out3, out4]
     print(f"\nPlots saved to {plot_dir}/")
-    return plots
+    return {
+        "align_baro": align_baro,
+        "t_ekf": t_ekf,
+        "ekf_u": ekf_u,
+        "t_gnss": t_gnss,
+        "gnss_u": gnss_u,
+        "accel_bias": accel_bias,
+        "pad_alt": pad_alt,
+        "ekf_alt_range": (float(ekf_u.min()), float(ekf_u.max())),
+        "boost_start_rel": (boost_start - t0_us) / 1e6 if boost_start else None,
+        "apogee_rel": (apogee_us - t0_us) / 1e6 if apogee_us else None,
+        "plots": plots,
+    }
 
 
 if __name__ == "__main__":
@@ -529,9 +560,13 @@ if __name__ == "__main__":
                                     "TestFlights/2026_03_08/Raw Downloads/"
                                     "Goblin Flight 2 F52/flight_20260308_190239.bin"))
     parser.add_argument("--plot-dir", default=None)
+    parser.add_argument("--emulate-firmware-baro", action="store_true",
+                        help="Feed pad-relative baro (no GNSS-frame offset) to "
+                             "reproduce the firmware bug at main.cpp:2812.")
     args = parser.parse_args()
 
-    plots = replay(Path(args.binary_file), args.plot_dir)
+    result = replay(Path(args.binary_file), args.plot_dir,
+                    align_baro=not args.emulate_firmware_baro)
 
     import subprocess
-    subprocess.run(["open"] + [str(p) for p in plots])
+    subprocess.run(["open"] + [str(p) for p in result["plots"]])

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2808,8 +2808,18 @@ static void loop_fc()
                     {
                         EkfBaroData ekf_baro = {};
                         ekf_baro.time_us = bmp_latest_si.time_us;
-                        // ISA pressure altitude relative to launch site
-                        ekf_baro.altitude_m = (double)pressure_altitude_m;
+                        // pressure_altitude_m is height above the launch pad
+                        // (~0 at the pad), but the EKF altitude state is
+                        // absolute MSL (init + fused from GNSS hMSL). Re-reference
+                        // baro into the GNSS frame by adding the launch-site
+                        // elevation, otherwise the baro innovation carries a
+                        // constant bias ≈ -(launch elevation) that the 15-state
+                        // filter leaks into altitude / accel_bias_z — the
+                        // stationary altitude drift in #44. (ref_alt_m is the
+                        // frozen running-average pad hMSL; ~0 until the first
+                        // GNSS fix, by which point the EKF isn't yet running
+                        // baro updates.)
+                        ekf_baro.altitude_m = (double)pressure_altitude_m + ref_alt_m;
                         ekf.baroMeasUpdate(ekf_baro);
                     }
                     else if (spike)


### PR DESCRIPTION
## Summary

The EKF altitude state is absolute MSL (initialised and fused from GNSS hMSL), but the barometer update was fed `pressure_altitude_m` — height above the launch pad (~0 at the pad). The baro innovation therefore carried a **constant bias of −(launch-site elevation)**, which the 15-state filter (no baro-offset state) leaked into the altitude and `accel_bias_z` states — the stationary EKF-altitude drift reported in #44 (−56.5 m on a bench).

One-line fix re-references baro into the GNSS frame at `flight_computer/main/main.cpp`:

```cpp
ekf_baro.altitude_m = (double)pressure_altitude_m + ref_alt_m;
```

`ref_alt_m` is the frozen running-average pad hMSL, established before baro updates begin.

## Evidence

- **A/B replay** of RolyPoly `flight_recovered_4` through the shared EKF binding (toggling only the baro frame): stationary pad altitude **−19.8 m (firmware) → +0.1 m (fixed)**, matching the +20.0 m pad elevation and the −23.4 m onboard nav sag.
- **ESP-IDF build** of `flight_computer` passes (esp32p4, 0 errors, no new warnings).

## Verification status

- ✅ Offline (shared-EKF replay) + compile-verified.
- ⏳ **Flight verification pending.** A near-sea-level bench run couldn't discriminate — the bug's offset scales with site elevation (~4.6 m there, within GNSS vertical noise). Will confirm at the next flight test. (#44 closed on root-cause + fix; flight verification is the follow-up.)

## Scope

- Firmware: **`flight_computer` only** (the baro→EKF feed). `TR_GpsInsEKF`, `base_station`, `out_computer`, and the iOS app are untouched — the fix is in the caller.
- Tooling: adds an `align_baro` toggle (`--emulate-firmware-baro`) + pad-altitude metric to `Data_Analysis/replay_flight_ekf.py` to reproduce the A/B.

Relates to #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
