### PR TITLE
Fix Reverse Drift Cast blank sheet when disconnected; seed launch/landing from GPS (#42)

### DIFF
--- a/TinkerRocketApp/Info.plist
+++ b/TinkerRocketApp/Info.plist
@@ -15,5 +15,7 @@
 	<string>Microphone access is needed for video recording during pyro channel testing.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Photo library access is needed to save pyro test videos.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location access sets the launch and landing points from your current position in the drift cast tool, and shows the direction and distance to your rocket.</string>
 </dict>
 </plist>

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -227,24 +227,25 @@ struct DashboardView: View {
             }
         }
         .sheet(item: $activeSheet) { sheet in
-            if let device = fleet.activeDevice {
-                Group {
-                    switch sheet {
-                    case .simulator:
-                        SimulationView(device: device)
-                    case .settings:
-                        SettingsView(device: device)
-                    case .servoTest:
-                        ServoTestView(device: device)
-                    case .driftCast:
-                        DriftCastView(device: device)
-                    }
+            Group {
+                switch sheet {
+                // Reverse Drift Cast is a standalone wind/trajectory tool — it
+                // runs with no live device (#42).  "Send to Unit" inside the
+                // view is the only part gated on an active connection.
+                case .driftCast:
+                    DriftCastView(device: fleet.activeDevice)
+                case .simulator:
+                    if let device = fleet.activeDevice { SimulationView(device: device) }
+                case .settings:
+                    if let device = fleet.activeDevice { SettingsView(device: device) }
+                case .servoTest:
+                    if let device = fleet.activeDevice { ServoTestView(device: device) }
                 }
-                // SwiftUI sheets get a fresh environment by default — re-inject
-                // fleet so SettingsView's FirmwareUpdateView can resolve the
-                // OTASession off it (#15 second pass).
-                .environmentObject(fleet)
             }
+            // SwiftUI sheets get a fresh environment by default — re-inject
+            // fleet so SettingsView's FirmwareUpdateView can resolve the
+            // OTASession off it (#15 second pass).
+            .environmentObject(fleet)
         }
         .sheet(isPresented: $showProvisioning) {
             if let device = fleet.activeDevice {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -525,7 +525,10 @@ struct Trajectory3DView: UIViewRepresentable {
 // MARK: - Main Drift Cast View
 
 struct DriftCastView: View {
-    @ObservedObject var device: BLEDevice
+    /// Optional: Reverse Drift Cast runs as a standalone wind/trajectory tool
+    /// with no live device (#42).  Only "Send to Unit" needs a connection, and
+    /// that control (DriftCastSendButton) is shown only when a device exists.
+    var device: BLEDevice?
     @Environment(\.dismiss) var dismiss
 
     // Display units (#160).  DriftCast is feet/knots-native (winds-aloft
@@ -568,8 +571,6 @@ struct DriftCastView: View {
     @State private var result: GuidanceResult?
     @State private var isComputing = false
     @State private var errorMessage: String?
-    @State private var showSendConfirm = false
-    @State private var showSentAlert = false
 
     // GPS for "Use GPS" button
     @State private var locationManager = CLLocationManager()
@@ -620,10 +621,6 @@ struct DriftCastView: View {
         return true
     }
 
-    private var canSend: Bool {
-        device.isConnected && result != nil && result!.feasible
-    }
-
     // MARK: - Body
 
     var body: some View {
@@ -648,24 +645,6 @@ struct DriftCastView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") { dismiss() }
-                }
-            }
-            .alert("Guidance Sent", isPresented: $showSentAlert) {
-                Button("OK") { }
-            } message: {
-                if let r = result {
-                    Text(String(format: "Guidance point sent to unit:\n%.6f, %.6f\nAltitude: ", r.guidanceLat, r.guidanceLon)
-                         + UnitFormatter.altitude(ftToM(r.apogeeFt), system: unitSystem) + " AGL")
-                }
-            }
-            .alert("Send to Unit?", isPresented: $showSendConfirm) {
-                Button("Send", role: .none) { sendToUnit() }
-                Button("Cancel", role: .cancel) { }
-            } message: {
-                if let r = result {
-                    Text(String(format: "Send guidance point (%.6f, %.6f) at ", r.guidanceLat, r.guidanceLon)
-                         + UnitFormatter.altitude(ftToM(r.apogeeFt), system: unitSystem)
-                         + String(format: " AGL to %@?", device.connectedDeviceName))
                 }
             }
         }
@@ -789,19 +768,11 @@ struct DriftCastView: View {
                 resultsSection(r)
                 windProfileSection(r.windProfile)
 
-                // Send to unit
-                Button(action: { showSendConfirm = true }) {
-                    Label("Send to Unit", systemImage: "antenna.radiowaves.left.and.right")
-                        .fontWeight(.bold)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(canSend ? Color.blue : Color.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
+                // Send to unit — only when a device is connected (#42).  The
+                // tool itself runs standalone; uploading guidance needs a link.
+                if let device = device {
+                    DriftCastSendButton(device: device, result: r, unitSystem: unitSystem)
                 }
-                .disabled(!canSend)
-                .padding(.horizontal)
-                .padding(.bottom, 20)
             }
         }
         .padding(.top, 12)
@@ -1043,10 +1014,58 @@ struct DriftCastView: View {
         )
     }
 
+}
+
+// MARK: - Send-to-Unit Button
+
+/// Send-to-unit control for the drift cast result.  Split out so it can hold an
+/// `@ObservedObject` device — re-disabling itself the moment the BLE link drops
+/// — while the parent DriftCastView runs device-free (#42).  Only rendered when
+/// a device is present, so the standalone tool never shows a dead "Send" button.
+private struct DriftCastSendButton: View {
+    @ObservedObject var device: BLEDevice
+    let result: GuidanceResult
+    let unitSystem: UnitSystem
+
+    @State private var showSendConfirm = false
+    @State private var showSentAlert = false
+
+    private var canSend: Bool {
+        device.isConnected && result.feasible
+    }
+
+    var body: some View {
+        Button(action: { showSendConfirm = true }) {
+            Label("Send to Unit", systemImage: "antenna.radiowaves.left.and.right")
+                .fontWeight(.bold)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(canSend ? Color.blue : Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(10)
+        }
+        .disabled(!canSend)
+        .padding(.horizontal)
+        .padding(.bottom, 20)
+        .alert("Send to Unit?", isPresented: $showSendConfirm) {
+            Button("Send", role: .none) { sendToUnit() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text(String(format: "Send guidance point (%.6f, %.6f) at ", result.guidanceLat, result.guidanceLon)
+                 + UnitFormatter.altitude(ftToM(result.apogeeFt), system: unitSystem)
+                 + String(format: " AGL to %@?", device.connectedDeviceName))
+        }
+        .alert("Guidance Sent", isPresented: $showSentAlert) {
+            Button("OK") { }
+        } message: {
+            Text(String(format: "Guidance point sent to unit:\n%.6f, %.6f\nAltitude: ", result.guidanceLat, result.guidanceLon)
+                 + UnitFormatter.altitude(ftToM(result.apogeeFt), system: unitSystem) + " AGL")
+        }
+    }
+
     private func sendToUnit() {
-        guard let r = result else { return }
-        let altM = Float(ftToM(r.apogeeFt))
-        device.sendGuidancePoint(lat: r.guidanceLat, lon: r.guidanceLon, altitudeM: altM)
+        let altM = Float(ftToM(result.apogeeFt))
+        device.sendGuidancePoint(lat: result.guidanceLat, lon: result.guidanceLon, altitudeM: altM)
         showSentAlert = true
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import MapKit
 import CoreLocation
 import SceneKit
+import Combine
 
 // MARK: - Map Representable
 
@@ -544,11 +545,13 @@ struct DriftCastView: View {
     )
     @State private var tapMode: TapMode = .launch
 
-    // Input fields (persisted)
-    @AppStorage("dc_launchLat") private var launchLat: String = "37.7608"
-    @AppStorage("dc_launchLon") private var launchLon: String = "-75.7446"
-    @AppStorage("dc_landingLat") private var landingLat: String = "37.7608"
-    @AppStorage("dc_landingLon") private var landingLon: String = "-75.7446"
+    // Input fields (persisted).  Launch/landing default to empty so a fresh
+    // install seeds them from the phone's GPS on first open instead of an
+    // arbitrary fixed site; once set they persist across opens as before.
+    @AppStorage("dc_launchLat") private var launchLat: String = ""
+    @AppStorage("dc_launchLon") private var launchLon: String = ""
+    @AppStorage("dc_landingLat") private var landingLat: String = ""
+    @AppStorage("dc_landingLon") private var landingLon: String = ""
     @AppStorage("dc_apogeeFt") private var apogeeFt: String = "10000"
     @AppStorage("dc_drogueRate") private var drogueRate: String = "60"
     @AppStorage("dc_mainRate") private var mainRate: String = "18"
@@ -572,9 +575,11 @@ struct DriftCastView: View {
     @State private var isComputing = false
     @State private var errorMessage: String?
 
-    // GPS for "Use GPS" button
-    @State private var locationManager = CLLocationManager()
-    @State private var lastUserLocation: CLLocationCoordinate2D?
+    // Phone GPS — seeds the launch/landing points on first open and backs the
+    // "Use GPS" button.  Reuses the app's delegate-backed manager so we get a
+    // real fix asynchronously, rather than whatever a bare CLLocationManager
+    // happened to have cached.
+    @StateObject private var locationManager = LocationManager()
 
     enum TapMode: String, CaseIterable {
         case launch = "Set Launch"
@@ -646,6 +651,14 @@ struct DriftCastView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .onAppear { locationManager.startUpdates() }
+            .onDisappear { locationManager.stopUpdates() }
+            // Seed the launch/landing points from the first GPS fix, but only
+            // while they're still blank — never clobber a value the user typed
+            // or one restored from a previous session.
+            .onReceive(locationManager.$userLocation) { coord in
+                if let coord = coord { seedPointsIfBlank(from: coord) }
             }
         }
     }
@@ -920,20 +933,34 @@ struct DriftCastView: View {
         }
     }
 
-    private func useGPS() {
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
-
-        // Use the cached location directly instead of requestLocation(),
-        // which requires a CLLocationManagerDelegate that isn't set up here.
-        if let loc = locationManager.location {
-            launchLat = String(format: "%.6f", loc.coordinate.latitude)
-            launchLon = String(format: "%.6f", loc.coordinate.longitude)
+    /// Fill the launch/landing fields from a GPS fix the first time we get one,
+    /// leaving any field the user has already populated (or one restored from a
+    /// previous session) untouched.
+    private func seedPointsIfBlank(from coord: CLLocationCoordinate2D) {
+        if launchLat.isEmpty || launchLon.isEmpty {
+            launchLat = String(format: "%.6f", coord.latitude)
+            launchLon = String(format: "%.6f", coord.longitude)
             mapRegion = MKCoordinateRegion(
-                center: loc.coordinate,
+                center: coord,
                 span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
             )
         }
+        if landingLat.isEmpty || landingLon.isEmpty {
+            landingLat = String(format: "%.6f", coord.latitude)
+            landingLon = String(format: "%.6f", coord.longitude)
+        }
+    }
+
+    /// "Use GPS" button: snap the launch point to the phone's current location.
+    /// (Landing is the target, so it's intentionally left untouched here.)
+    private func useGPS() {
+        guard let coord = locationManager.userLocation else { return }
+        launchLat = String(format: "%.6f", coord.latitude)
+        launchLon = String(format: "%.6f", coord.longitude)
+        mapRegion = MKCoordinateRegion(
+            center: coord,
+            span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+        )
     }
 
     private func compute() {


### PR DESCRIPTION
## Summary

Two related changes to the Reverse Drift Cast tool.

### 1. Run without a connected device (fixes #42)
The dashboard's sheet dispatcher wrapped its whole `switch` in `if let device = fleet.activeDevice`, so tapping **Reverse Drift Cast** from the disconnected dashboard presented a blank sheet. Drift Cast is a standalone wind/trajectory tool (it exists precisely for when no rocket is live), so its case is hoisted out of the device guard and rendered unconditionally; the other three sheets keep a per-case device guard.

`DriftCastView.device` is now optional. Its only device-dependent piece — **Send to Unit** — moved into a small `DriftCastSendButton` subview that holds the `@ObservedObject` device, so it still disables the moment the BLE link drops (`sendGuidancePoint` has no internal connection guard). That button renders only when a device is present, so the standalone tool never shows a dead Send control.

### 2. Seed launch/landing from the phone's GPS instead of a hardcoded site
The tool hardcoded its launch/landing points (and map center) to Wallops Island (`37.7608/-75.7446`). Launch/landing now default to blank and seed from the phone's current GPS position on the first fix — **only while still blank**, so typed or previously-saved coordinates are never clobbered. Rocket/chute parameters (apogee, descent rates, max steering) persist as before.

The view's bare `CLLocationManager` (which read a possibly-nil cached `.location` with no delegate) is replaced by the app's delegate-backed `LocationManager` `@StateObject`, started on appear / stopped on disappear.

### 3. Add missing location permission (latent bug)
`NSLocationWhenInUseUsageDescription` was absent from `Info.plist` entirely, so iOS never prompted for location and never delivered a fix. This revives not just the seeding above but also the **base-station rocket-direction** arrow/distance on the dashboard, which had the same dependency.

## Testing
- Builds clean for the iOS Simulator (`xcodebuild`, no errors).
- Ran on-device: blank sheet is gone, and launch/landing seed to current position.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
