### PR TITLE
Offline map tiles for no-signal launch sites (Drift Cast + Rocket Map)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift
@@ -1,0 +1,36 @@
+//
+//  BasemapOverlayController.swift
+//  TinkerRocketApp
+//
+//  Offline maps (see docs/plans/offline-maps.md).
+//
+//  Shared helper that keeps an MKMapView's basemap-replacing tile overlay in
+//  sync with the selected TileSource — swapping only when the source actually
+//  changes, so panning and per-tick data updates don't tear down and reload
+//  tiles. Used by both the Rocket Map and Drift Cast map coordinators so the two
+//  views stay aligned.
+//
+
+import MapKit
+
+final class BasemapOverlayController {
+    private var currentSource: TileSource?
+    private(set) var overlay: MKTileOverlay?
+
+    func apply(_ source: TileSource, to mapView: MKMapView) {
+        guard currentSource != source else { return }
+        currentSource = source
+
+        if let existing = overlay {
+            mapView.removeOverlay(existing)
+            overlay = nil
+        }
+        // Apple basemap cases render natively (no overlay); USGS cases draw a
+        // cached, basemap-replacing overlay above the labels.
+        if source.isCacheable {
+            let tile = CachingTileOverlay(source: source)
+            mapView.addOverlay(tile, level: .aboveLabels)
+            overlay = tile
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/CachingTileOverlay.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/CachingTileOverlay.swift
@@ -1,0 +1,51 @@
+//
+//  CachingTileOverlay.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 1 (see docs/plans/offline-maps.md).
+//
+//  A basemap-replacing tile overlay with a read-through disk cache. Per tile:
+//  serve from disk if present; otherwise fetch from the provider, persist, and
+//  return; if offline and not cached, fail so MapKit leaves that tile blank
+//  rather than hanging. Only built for cache-permissive sources (USGS) — the
+//  Apple basemap cases never use an overlay.
+//
+
+import MapKit
+
+final class CachingTileOverlay: MKTileOverlay {
+    private let sourceKey: String
+    private let cache = OfflineTileCache.shared
+
+    init(source: TileSource) {
+        sourceKey = source.rawValue
+        super.init(urlTemplate: source.urlTemplate)
+        canReplaceMapContent = true
+        minimumZ = 0
+        maximumZ = 19
+    }
+
+    override func loadTile(at path: MKTileOverlayPath,
+                           result: @escaping (Data?, Error?) -> Void) {
+        let key = sourceKey
+        let cache = self.cache
+
+        if let data = cache.tileData(source: key, z: path.z, x: path.x, y: path.y) {
+            result(data, nil)
+            return
+        }
+
+        var request = URLRequest(url: url(forTilePath: path))
+        request.setValue("TinkerRocketApp/1.0 (offline map cache)",
+                         forHTTPHeaderField: "User-Agent")
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data,
+                  let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                result(nil, error)
+                return
+            }
+            cache.store(data, source: key, z: path.z, x: path.x, y: path.y)
+            result(data, nil)
+        }.resume()
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/CachingTileOverlay.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/CachingTileOverlay.swift
@@ -17,6 +17,29 @@ final class CachingTileOverlay: MKTileOverlay {
     private let sourceKey: String
     private let cache = OfflineTileCache.shared
 
+    /// Neutral "not downloaded / no imagery" tile — a faint hatch — returned on
+    /// any miss so offline gaps (or zoom past the provider's max) read as
+    /// intentional rather than a broken/blank map (canReplaceMapContent leaves
+    /// nothing underneath).
+    private static let placeholderTile: Data = {
+        let size = CGSize(width: 256, height: 256)
+        let img = UIGraphicsImageRenderer(size: size).image { ctx in
+            UIColor(white: 0.93, alpha: 1).setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            let c = ctx.cgContext
+            c.setStrokeColor(UIColor(white: 0.82, alpha: 1).cgColor)
+            c.setLineWidth(1)
+            var x: CGFloat = -256
+            while x < 256 {
+                c.move(to: CGPoint(x: x, y: 0))
+                c.addLine(to: CGPoint(x: x + 256, y: 256))
+                x += 16
+            }
+            c.strokePath()
+        }
+        return img.pngData() ?? Data()
+    }()
+
     init(source: TileSource) {
         sourceKey = source.rawValue
         super.init(urlTemplate: source.urlTemplate)
@@ -41,7 +64,8 @@ final class CachingTileOverlay: MKTileOverlay {
         URLSession.shared.dataTask(with: request) { data, response, error in
             guard let data = data,
                   let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                result(nil, error)
+                // Offline miss, 404 past max zoom, etc. → neutral placeholder.
+                result(Self.placeholderTile, nil)
                 return
             }
             cache.store(data, source: key, z: path.z, x: path.x, y: path.y)

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/NetworkMonitor.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/NetworkMonitor.swift
@@ -1,0 +1,52 @@
+//
+//  NetworkMonitor.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Phase 4 (see docs/plans/offline-maps.md).
+//
+//  Lightweight reachability so the map views can show an "OFFLINE" pill when
+//  there's no connection (and the basemap is therefore coming from cache).
+//
+
+import Foundation
+import Network
+import Combine
+import SwiftUI
+
+final class NetworkMonitor: ObservableObject {
+    static let shared = NetworkMonitor()
+
+    @Published private(set) var isOnline = true
+
+    private let monitor = NWPathMonitor()
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let online = path.status == .satisfied
+            DispatchQueue.main.async { self?.isOnline = online }
+        }
+        monitor.start(queue: DispatchQueue(label: "TinkerRocket.NetworkMonitor"))
+    }
+}
+
+/// Small "OFFLINE" pill — renders nothing while online. Drop into any map's
+/// overlay stack; it observes the shared monitor.
+struct OfflinePill: View {
+    @ObservedObject private var network = NetworkMonitor.shared
+
+    var body: some View {
+        if !network.isOnline {
+            HStack(spacing: 6) {
+                Image(systemName: "wifi.slash")
+                Text("OFFLINE").fontWeight(.bold)
+            }
+            .font(.caption2)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(.ultraThinMaterial)
+            .foregroundColor(.orange)
+            .cornerRadius(20)
+            .shadow(radius: 2)
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineRegion.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineRegion.swift
@@ -1,0 +1,84 @@
+//
+//  OfflineRegion.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 2 (see docs/plans/offline-maps.md).
+//
+//  A saved offline region and a persisted store of them. Lets the user see what
+//  they've downloaded, how much space it uses, and delete it to reclaim space.
+//  Manifest is JSON under Application Support.
+//
+
+import Foundation
+import CoreLocation
+import Combine
+
+struct OfflineRegion: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    var name: String
+    var lat: Double
+    var lon: Double
+    var radiusMeters: Double
+    var minZoom: Int
+    var maxZoom: Int
+    var source: String          // TileSource.rawValue
+    var tileCount: Int
+    var bytes: Int64
+    var savedAt: Date
+
+    var center: CLLocationCoordinate2D { .init(latitude: lat, longitude: lon) }
+
+    var spec: RegionSpec {
+        RegionSpec(center: center, radiusMeters: radiusMeters,
+                   minZoom: minZoom, maxZoom: maxZoom)
+    }
+
+    var tileSource: TileSource? { TileSource(rawValue: source) }
+}
+
+final class OfflineRegionStore: ObservableObject {
+    static let shared = OfflineRegionStore()
+
+    @Published private(set) var regions: [OfflineRegion] = []
+
+    private let url: URL
+    private let fm = FileManager.default
+
+    init() {
+        let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        try? fm.createDirectory(at: base, withIntermediateDirectories: true)
+        url = base.appendingPathComponent("offline_regions.json")
+        load()
+    }
+
+    var totalBytes: Int64 { regions.reduce(0) { $0 + $1.bytes } }
+
+    func add(_ region: OfflineRegion) {
+        regions.removeAll { $0.id == region.id }
+        regions.insert(region, at: 0)
+        save()
+    }
+
+    /// Remove a region from the manifest and delete its tiles from disk.
+    /// (Overlapping regions are rare here; a shared tile that gets removed will
+    /// simply re-download next time it's viewed online.)
+    func delete(_ region: OfflineRegion) {
+        OfflineTileCache.shared.removeTiles(source: region.source,
+                                            tiles: TileMath.tiles(for: region.spec))
+        regions.removeAll { $0.id == region.id }
+        save()
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([OfflineRegion].self, from: data) else { return }
+        regions = decoded
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(regions) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
@@ -60,6 +60,25 @@ final class OfflineTileCache {
         }
     }
 
+    // MARK: - Keyed blobs (non-tile images, e.g. the 3D ground texture)
+
+    func blob(forKey key: String) -> Data? {
+        try? Data(contentsOf: blobURL(key))
+    }
+
+    func storeBlob(_ data: Data, forKey key: String) {
+        let url = blobURL(key)
+        try? fm.createDirectory(at: url.deletingLastPathComponent(),
+                                withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private func blobURL(_ key: String) -> URL {
+        let safe = key.replacingOccurrences(of: "/", with: "_")
+        return root.appendingPathComponent("blobs", isDirectory: true)
+            .appendingPathComponent("\(safe).dat", isDirectory: false)
+    }
+
     // MARK: - Paths
 
     private func fileURL(source: String, z: Int, x: Int, y: Int) -> URL {

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
@@ -1,0 +1,70 @@
+//
+//  OfflineTileCache.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 1 (see docs/plans/offline-maps.md).
+//
+//  On-disk read-through cache for map tiles. Tiles live under Application
+//  Support — NOT Caches, which iOS purges under storage pressure, which would
+//  silently delete the field data the user pre-downloaded. Keyed per source so
+//  switching basemaps never mixes imagery.
+//
+//  Trial 1 fills this passively (tiles you view online get stored, then render
+//  offline). The explicit region downloader lands in Trial 2.
+//
+
+import Foundation
+
+final class OfflineTileCache {
+    static let shared = OfflineTileCache()
+
+    private let root: URL
+    private let fm = FileManager.default
+
+    private init() {
+        let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        root = base.appendingPathComponent("OfflineTiles", isDirectory: true)
+        try? fm.createDirectory(at: root, withIntermediateDirectories: true)
+        excludeFromBackup(root)
+    }
+
+    /// Cached bytes for a tile, or nil if not stored.
+    func tileData(source: String, z: Int, x: Int, y: Int) -> Data? {
+        try? Data(contentsOf: fileURL(source: source, z: z, x: x, y: y))
+    }
+
+    /// Persist tile bytes atomically, creating intermediate directories.
+    func store(_ data: Data, source: String, z: Int, x: Int, y: Int) {
+        let url = fileURL(source: source, z: z, x: x, y: y)
+        try? fm.createDirectory(at: url.deletingLastPathComponent(),
+                                withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Bytes on disk for a source (for the future region manager / debug).
+    func byteCount(source: String) -> Int64 {
+        let dir = root.appendingPathComponent(source, isDirectory: true)
+        guard let e = fm.enumerator(at: dir, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in e {
+            total += Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        }
+        return total
+    }
+
+    // MARK: - Paths
+
+    private func fileURL(source: String, z: Int, x: Int, y: Int) -> URL {
+        root.appendingPathComponent(source, isDirectory: true)
+            .appendingPathComponent("\(z)", isDirectory: true)
+            .appendingPathComponent("\(x)", isDirectory: true)
+            .appendingPathComponent("\(y).tile", isDirectory: false)
+    }
+
+    private func excludeFromBackup(_ url: URL) {
+        var u = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? u.setResourceValues(values)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/OfflineTileCache.swift
@@ -52,6 +52,14 @@ final class OfflineTileCache {
         return total
     }
 
+    /// Delete the given tiles for a source from disk (used when a saved region
+    /// is removed). Best-effort.
+    func removeTiles(source: String, tiles: [TileXYZ]) {
+        for t in tiles {
+            try? fm.removeItem(at: fileURL(source: source, z: t.z, x: t.x, y: t.y))
+        }
+    }
+
     // MARK: - Paths
 
     private func fileURL(source: String, z: Int, x: Int, y: Int) -> URL {

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileDownloader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileDownloader.swift
@@ -1,0 +1,109 @@
+//
+//  TileDownloader.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 2 (see docs/plans/offline-maps.md).
+//
+//  Downloads every tile in a RegionSpec to the OfflineTileCache with bounded
+//  concurrency, publishing progress for the UI. Resumable (already-cached tiles
+//  are counted instantly, not re-fetched) and cancelable. GCD-based to keep the
+//  concurrency bound simple and predictable.
+//
+
+import Foundation
+import Combine
+
+/// Rough bytes per imagery tile — only used for the pre-download estimate.
+let kEstimatedTileBytes: Int64 = 25_000
+
+final class TileDownloader: ObservableObject {
+    enum Phase: Equatable { case idle, downloading, finished, cancelled }
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var done = 0
+    @Published private(set) var total = 0
+    @Published private(set) var bytes: Int64 = 0
+
+    private var cancelFlag = false
+    private let session = URLSession(configuration: .default)
+    private let maxConcurrent = 5
+
+    var isRunning: Bool { phase == .downloading }
+
+    func start(region: RegionSpec, source: TileSource) {
+        guard let template = source.urlTemplate, !isRunning else { return }
+        let tiles = TileMath.tiles(for: region)
+        let key = source.rawValue
+
+        cancelFlag = false
+        phase = .downloading
+        total = tiles.count
+        done = 0
+        bytes = 0
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self = self else { return }
+            let sem = DispatchSemaphore(value: self.maxConcurrent)
+            let group = DispatchGroup()
+
+            for tile in tiles {
+                if self.cancelFlag { break }
+                sem.wait()
+                group.enter()
+                self.fetchOne(tile, key: key, template: template) { byteCount in
+                    self.report(byteCount)
+                    sem.signal()
+                    group.leave()
+                }
+            }
+            group.wait()
+
+            DispatchQueue.main.async {
+                self.phase = self.cancelFlag ? .cancelled : .finished
+            }
+        }
+    }
+
+    func cancel() { cancelFlag = true }
+
+    func reset() {
+        guard !isRunning else { return }
+        phase = .idle; done = 0; total = 0; bytes = 0
+    }
+
+    // MARK: - Internals
+
+    private func report(_ byteCount: Int) {
+        DispatchQueue.main.async {
+            self.done += 1
+            self.bytes += Int64(byteCount)
+        }
+    }
+
+    /// Fetch (or read from cache) one tile, then call completion with its byte
+    /// size. Completion is always called exactly once.
+    private func fetchOne(_ t: TileXYZ, key: String, template: String,
+                          completion: @escaping (Int) -> Void) {
+        if let data = OfflineTileCache.shared.tileData(source: key, z: t.z, x: t.x, y: t.y) {
+            completion(data.count)
+            return
+        }
+        let urlStr = template
+            .replacingOccurrences(of: "{z}", with: "\(t.z)")
+            .replacingOccurrences(of: "{x}", with: "\(t.x)")
+            .replacingOccurrences(of: "{y}", with: "\(t.y)")
+        guard let url = URL(string: urlStr) else { completion(0); return }
+
+        var req = URLRequest(url: url)
+        req.setValue("TinkerRocketApp/1.0 (offline map cache)", forHTTPHeaderField: "User-Agent")
+        session.dataTask(with: req) { data, response, _ in
+            if let data = data,
+               let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                OfflineTileCache.shared.store(data, source: key, z: t.z, x: t.x, y: t.y)
+                completion(data.count)
+            } else {
+                completion(0)  // missing/4xx tile — count it so progress completes
+            }
+        }.resume()
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileMath.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileMath.swift
@@ -1,0 +1,92 @@
+//
+//  TileMath.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 2 (see docs/plans/offline-maps.md).
+//
+//  Slippy-map tile math: convert a region (center + radius + zoom range) into
+//  the set of (z,x,y) tiles to download, and count them for the pre-download
+//  size estimate.
+//
+
+import Foundation
+import CoreLocation
+
+/// A single web-mercator tile coordinate.
+struct TileXYZ: Hashable {
+    let z: Int
+    let x: Int
+    let y: Int
+}
+
+/// What to download: a circle (center + radius) over a span of zoom levels.
+struct RegionSpec {
+    var center: CLLocationCoordinate2D
+    var radiusMeters: Double
+    var minZoom: Int = 10
+    var maxZoom: Int
+
+    /// Lat/lon bounding box of the circle (small-angle approximation — fine for
+    /// the few-km radii used here).
+    var bbox: (latMin: Double, latMax: Double, lonMin: Double, lonMax: Double) {
+        let dLat = radiusMeters / 111_320.0
+        let cosLat = max(0.01, cos(center.latitude * .pi / 180))
+        let dLon = radiusMeters / (111_320.0 * cosLat)
+        return (center.latitude - dLat, center.latitude + dLat,
+                center.longitude - dLon, center.longitude + dLon)
+    }
+}
+
+enum TileMath {
+    static func tileX(lon: Double, z: Int) -> Int {
+        let n = Double(1 << z)
+        return Int(floor((lon + 180.0) / 360.0 * n))
+    }
+
+    static func tileY(lat: Double, z: Int) -> Int {
+        let n = Double(1 << z)
+        let r = lat * .pi / 180.0
+        return Int(floor((1.0 - asinh(tan(r)) / .pi) / 2.0 * n))
+    }
+
+    private static func clamp(_ v: Int, _ lo: Int, _ hi: Int) -> Int {
+        min(max(v, lo), hi)
+    }
+
+    /// Inclusive tile rectangle for a bbox at one zoom level.
+    private static func rect(_ b: (latMin: Double, latMax: Double, lonMin: Double, lonMax: Double),
+                             z: Int) -> (xMin: Int, xMax: Int, yMin: Int, yMax: Int) {
+        let n = 1 << z
+        // North (latMax) maps to the smaller y; south (latMin) to the larger y.
+        return (clamp(tileX(lon: b.lonMin, z: z), 0, n - 1),
+                clamp(tileX(lon: b.lonMax, z: z), 0, n - 1),
+                clamp(tileY(lat: b.latMax, z: z), 0, n - 1),
+                clamp(tileY(lat: b.latMin, z: z), 0, n - 1))
+    }
+
+    /// Total tile count for the region (for the size estimate; no allocation).
+    static func tileCount(for region: RegionSpec) -> Int {
+        let b = region.bbox
+        var count = 0
+        for z in min(region.minZoom, region.maxZoom)...region.maxZoom {
+            let r = rect(b, z: z)
+            count += (r.xMax - r.xMin + 1) * (r.yMax - r.yMin + 1)
+        }
+        return count
+    }
+
+    /// The full list of tiles to download for the region.
+    static func tiles(for region: RegionSpec) -> [TileXYZ] {
+        let b = region.bbox
+        var out: [TileXYZ] = []
+        for z in min(region.minZoom, region.maxZoom)...region.maxZoom {
+            let r = rect(b, z: z)
+            for x in r.xMin...r.xMax {
+                for y in r.yMin...r.yMax {
+                    out.append(TileXYZ(z: z, x: x, y: y))
+                }
+            }
+        }
+        return out
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileSource.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileSource.swift
@@ -1,0 +1,96 @@
+//
+//  TileSource.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 0 (see docs/plans/offline-maps.md).
+//
+//  Defines the selectable map imagery sources. Apple cases use the built-in
+//  MapKit basemap, which CANNOT be cached for offline use. The tile cases point
+//  at cache-permissive providers (USGS public domain, Esri) and are drawn via an
+//  MKTileOverlay that replaces the basemap — these are the candidates for the
+//  eventual offline download. Trial 0 has no caching yet; this just lets us A/B
+//  the imagery on-device, online, before building the cache/download machinery.
+//
+
+import MapKit
+
+enum TileSource: String, CaseIterable, Identifiable {
+    case appleStandard
+    case appleHybrid
+    case usgsImagery
+    case usgsImageryTopo
+    case usgsTopo
+    case esriImagery
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .appleStandard:   return "Apple Standard"
+        case .appleHybrid:     return "Apple Hybrid"
+        case .usgsImagery:     return "USGS Imagery"
+        case .usgsImageryTopo: return "USGS Imagery + Topo"
+        case .usgsTopo:        return "USGS Topo"
+        case .esriImagery:     return "Esri World Imagery"
+        }
+    }
+
+    /// SF Symbol for the source menu.
+    var symbol: String {
+        switch self {
+        case .appleStandard:   return "map"
+        case .appleHybrid:     return "globe.americas.fill"
+        case .usgsImagery, .esriImagery: return "globe.desk.fill"
+        case .usgsImageryTopo: return "mountain.2.fill"
+        case .usgsTopo:        return "map.fill"
+        }
+    }
+
+    /// Apple basemap cases render natively; tile cases draw via MKTileOverlay.
+    var isAppleBasemap: Bool { self == .appleStandard || self == .appleHybrid }
+
+    /// MKMapType for the Apple cases. For tile cases the value is irrelevant
+    /// (the overlay replaces the basemap) but `.standard` keeps Apple from
+    /// fetching imagery underneath.
+    var appleMapType: MKMapType {
+        self == .appleHybrid ? .hybrid : .standard
+    }
+
+    /// `{x}`/`{y}`/`{z}` URL template for tile cases, nil for the Apple basemap.
+    /// ArcGIS REST tile endpoints are ordered `z/y/x`.
+    var urlTemplate: String? {
+        switch self {
+        case .appleStandard, .appleHybrid:
+            return nil
+        case .usgsImagery:
+            return "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
+        case .usgsImageryTopo:
+            return "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}"
+        case .usgsTopo:
+            return "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}"
+        case .esriImagery:
+            return "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+        }
+    }
+
+    /// Short attribution shown while the source is active (provider terms).
+    var attribution: String? {
+        switch self {
+        case .appleStandard, .appleHybrid: return nil
+        case .usgsImagery, .usgsImageryTopo, .usgsTopo: return "USGS · The National Map"
+        case .esriImagery: return "Esri, Maxar, Earthstar Geographics"
+        }
+    }
+
+    /// Builds the basemap-replacing tile overlay for tile cases (nil for Apple).
+    /// Trial 0: no on-disk caching yet — MKTileOverlay fetches straight from the
+    /// provider. The read-through cache lands in Trial 1.
+    func makeOverlay() -> MKTileOverlay? {
+        guard let template = urlTemplate else { return nil }
+        let overlay = MKTileOverlay(urlTemplate: template)
+        overlay.canReplaceMapContent = true
+        overlay.minimumZ = 0
+        overlay.maximumZ = 19
+        return overlay
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileSource.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Maps/Offline/TileSource.swift
@@ -2,14 +2,16 @@
 //  TileSource.swift
 //  TinkerRocketApp
 //
-//  Offline maps — Trial 0 (see docs/plans/offline-maps.md).
+//  Offline maps — see docs/plans/offline-maps.md.
 //
-//  Defines the selectable map imagery sources. Apple cases use the built-in
-//  MapKit basemap, which CANNOT be cached for offline use. The tile cases point
-//  at cache-permissive providers (USGS public domain, Esri) and are drawn via an
-//  MKTileOverlay that replaces the basemap — these are the candidates for the
-//  eventual offline download. Trial 0 has no caching yet; this just lets us A/B
-//  the imagery on-device, online, before building the cache/download machinery.
+//  Selectable map imagery sources, shared by the Rocket Map and (later) Drift
+//  Cast. Apple cases use the built-in MapKit basemap, which CANNOT be cached for
+//  offline use (no public API; against MapKit terms) — they stay as the global
+//  online option. The USGS cases are public-domain tiles drawn via a
+//  basemap-replacing MKTileOverlay and are the only sources we cache/download
+//  for offline use. (Esri World Imagery looked great online but its free terms
+//  restrict offline caching, which is the point of this feature — see the
+//  international-imagery follow-up issue.)
 //
 
 import MapKit
@@ -20,7 +22,6 @@ enum TileSource: String, CaseIterable, Identifiable {
     case usgsImagery
     case usgsImageryTopo
     case usgsTopo
-    case esriImagery
 
     var id: String { rawValue }
 
@@ -31,7 +32,6 @@ enum TileSource: String, CaseIterable, Identifiable {
         case .usgsImagery:     return "USGS Imagery"
         case .usgsImageryTopo: return "USGS Imagery + Topo"
         case .usgsTopo:        return "USGS Topo"
-        case .esriImagery:     return "Esri World Imagery"
         }
     }
 
@@ -40,23 +40,27 @@ enum TileSource: String, CaseIterable, Identifiable {
         switch self {
         case .appleStandard:   return "map"
         case .appleHybrid:     return "globe.americas.fill"
-        case .usgsImagery, .esriImagery: return "globe.desk.fill"
+        case .usgsImagery:     return "globe.desk.fill"
         case .usgsImageryTopo: return "mountain.2.fill"
         case .usgsTopo:        return "map.fill"
         }
     }
 
-    /// Apple basemap cases render natively; tile cases draw via MKTileOverlay.
+    /// Apple basemap cases render natively; USGS cases draw via MKTileOverlay.
     var isAppleBasemap: Bool { self == .appleStandard || self == .appleHybrid }
 
-    /// MKMapType for the Apple cases. For tile cases the value is irrelevant
+    /// Whether this source can be cached / downloaded for offline use.
+    /// USGS (public domain) yes; Apple no.
+    var isCacheable: Bool { !isAppleBasemap }
+
+    /// MKMapType for the Apple cases. For USGS cases the value is irrelevant
     /// (the overlay replaces the basemap) but `.standard` keeps Apple from
-    /// fetching imagery underneath.
+    /// fetching its own imagery underneath.
     var appleMapType: MKMapType {
         self == .appleHybrid ? .hybrid : .standard
     }
 
-    /// `{x}`/`{y}`/`{z}` URL template for tile cases, nil for the Apple basemap.
+    /// `{x}`/`{y}`/`{z}` URL template for USGS cases, nil for the Apple basemap.
     /// ArcGIS REST tile endpoints are ordered `z/y/x`.
     var urlTemplate: String? {
         switch self {
@@ -68,29 +72,11 @@ enum TileSource: String, CaseIterable, Identifiable {
             return "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}"
         case .usgsTopo:
             return "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}"
-        case .esriImagery:
-            return "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
         }
     }
 
     /// Short attribution shown while the source is active (provider terms).
     var attribution: String? {
-        switch self {
-        case .appleStandard, .appleHybrid: return nil
-        case .usgsImagery, .usgsImageryTopo, .usgsTopo: return "USGS · The National Map"
-        case .esriImagery: return "Esri, Maxar, Earthstar Geographics"
-        }
-    }
-
-    /// Builds the basemap-replacing tile overlay for tile cases (nil for Apple).
-    /// Trial 0: no on-disk caching yet — MKTileOverlay fetches straight from the
-    /// provider. The read-through cache lands in Trial 1.
-    func makeOverlay() -> MKTileOverlay? {
-        guard let template = urlTemplate else { return nil }
-        let overlay = MKTileOverlay(urlTemplate: template)
-        overlay.canReplaceMapContent = true
-        overlay.minimumZ = 0
-        overlay.maximumZ = 19
-        return overlay
+        isAppleBasemap ? nil : "USGS · The National Map"
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -238,10 +238,12 @@ struct Trajectory3DView: UIViewRepresentable {
         return SCNVector3(x, Float(altM), z)
     }
 
-    // MARK: - ArcGIS Satellite Imagery
+    // MARK: - USGS Satellite Imagery (cached)
 
-    /// Fetch satellite image from ArcGIS MapServer export API (no API key needed)
-    /// and apply as the ground plane texture.
+    /// Fetch the ground-plane texture from the USGS MapServer export API (no key,
+    /// public domain — consistent with the 2D source) and apply it. Routed
+    /// through OfflineTileCache so a scene viewed once renders offline later; if
+    /// there's no imagery and no connection, the grid stays.
     private static func fetchArcGISImagery(
         refLat: Double, refLon: Double, extent: Float,
         groundNode: SCNNode, sceneRoot: SCNNode
@@ -256,17 +258,12 @@ struct Trajectory3DView: UIViewRepresentable {
         let east = refLon + halfM / mPerDegLon
 
         let bbox = "\(west),\(south),\(east),\(north)"
-        let urlStr = "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/export"
+        let urlStr = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/export"
             + "?bbox=\(bbox)&bboxSR=4326&imageSR=4326"
             + "&size=1024,1024&format=png&f=image"
+        let cacheKey = "3d_\(bbox)"
 
-        guard let url = URL(string: urlStr) else { return }
-
-        URLSession.shared.dataTask(with: url) { data, response, error in
-            guard let data = data,
-                  let httpResp = response as? HTTPURLResponse,
-                  httpResp.statusCode == 200,
-                  let image = UIImage(data: data) else { return }
+        let apply: (UIImage) -> Void = { image in
             DispatchQueue.main.async {
                 groundNode.geometry?.firstMaterial?.diffuse.contents = image
                 groundNode.geometry?.firstMaterial?.diffuse.wrapS = .clamp
@@ -276,6 +273,23 @@ struct Trajectory3DView: UIViewRepresentable {
                 sceneRoot.childNode(withName: "groundGrid", recursively: false)?
                     .removeFromParentNode()
             }
+        }
+
+        // Cached copy first → renders offline for a scene viewed before.
+        if let data = OfflineTileCache.shared.blob(forKey: cacheKey),
+           let image = UIImage(data: data) {
+            apply(image)
+            return
+        }
+
+        guard let url = URL(string: urlStr) else { return }
+        URLSession.shared.dataTask(with: url) { data, response, _ in
+            guard let data = data,
+                  let httpResp = response as? HTTPURLResponse,
+                  httpResp.statusCode == 200,
+                  let image = UIImage(data: data) else { return }
+            OfflineTileCache.shared.storeBlob(data, forKey: cacheKey)
+            apply(image)
         }.resume()
     }
 
@@ -731,28 +745,32 @@ struct DriftCastView: View {
             .padding(.horizontal)
             .padding(.vertical, 8)
 
-            // Map view: 2D or 3D
-            if show3D {
-                Trajectory3DView(result: result, unitSystem: unitSystem)
-                    .frame(height: 350)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            // Map view: 2D or 3D (offline pill overlaid on top).
+            ZStack(alignment: .top) {
+                if show3D {
+                    Trajectory3DView(result: result, unitSystem: unitSystem)
+                        .frame(height: 350)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .padding(.horizontal)
+                } else {
+                    DriftCastMapView(
+                        tileSource: $tileSource,
+                        launchCoord: launchCoord,
+                        landingCoord: landingCoord,
+                        guidanceCoord: guidanceCoord,
+                        descentTrack: descentTrackCoords,
+                        boostLine: boostLineCoords,
+                        region: $mapRegion,
+                        onTap: { coord in
+                            handleMapTap(coord)
+                        }
+                    )
+                    .frame(height: 250)
+                    .cornerRadius(12)
                     .padding(.horizontal)
-            } else {
-                DriftCastMapView(
-                    tileSource: $tileSource,
-                    launchCoord: launchCoord,
-                    landingCoord: landingCoord,
-                    guidanceCoord: guidanceCoord,
-                    descentTrack: descentTrackCoords,
-                    boostLine: boostLineCoords,
-                    region: $mapRegion,
-                    onTap: { coord in
-                        handleMapTap(coord)
-                    }
-                )
-                .frame(height: 250)
-                .cornerRadius(12)
-                .padding(.horizontal)
+                }
+                OfflinePill()
+                    .padding(.top, 8)
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -547,15 +547,18 @@ struct DriftCastView: View {
     // Map state
     @State private var tileSource: TileSource = .appleHybrid
     @State private var showOfflineMaps = false
+    /// Per-open guard: auto-seed launch/landing + map from the first GPS fix
+    /// once each time the view opens, unless the user has already acted.
+    @State private var didAutoSeed = false
     @State private var mapRegion = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.7608, longitude: -75.7446),
         span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
     )
     @State private var tapMode: TapMode = .launch
 
-    // Input fields (persisted).  Launch/landing default to empty so a fresh
-    // install seeds them from the phone's GPS on first open instead of an
-    // arbitrary fixed site; once set they persist across opens as before.
+    // Input fields (persisted).  Launch/landing re-seed from the phone's GPS on
+    // each open (applyCurrentLocation); the persisted values are the fallback
+    // when no GPS fix is available, and hold any edits made within a session.
     @AppStorage("dc_launchLat") private var launchLat: String = ""
     @AppStorage("dc_launchLon") private var launchLon: String = ""
     @AppStorage("dc_landingLat") private var landingLat: String = ""
@@ -666,7 +669,9 @@ struct DriftCastView: View {
             // while they're still blank — never clobber a value the user typed
             // or one restored from a previous session.
             .onReceive(locationManager.$userLocation) { coord in
-                if let coord = coord { seedPointsIfBlank(from: coord) }
+                guard let coord = coord, !didAutoSeed else { return }
+                didAutoSeed = true
+                applyCurrentLocation(coord)
             }
             .sheet(isPresented: $showOfflineMaps) {
                 OfflineMapsView(suggestedCenter: mapRegion.center)
@@ -954,6 +959,7 @@ struct DriftCastView: View {
     // MARK: - Actions
 
     private func handleMapTap(_ coord: CLLocationCoordinate2D) {
+        didAutoSeed = true   // user is placing points — don't auto-seed over them
         if tapMode == .launch {
             launchLat = String(format: "%.6f", coord.latitude)
             launchLon = String(format: "%.6f", coord.longitude)
@@ -965,28 +971,26 @@ struct DriftCastView: View {
         }
     }
 
-    /// Fill the launch/landing fields from a GPS fix the first time we get one,
-    /// leaving any field the user has already populated (or one restored from a
-    /// previous session) untouched.
-    private func seedPointsIfBlank(from coord: CLLocationCoordinate2D) {
-        if launchLat.isEmpty || launchLon.isEmpty {
-            launchLat = String(format: "%.6f", coord.latitude)
-            launchLon = String(format: "%.6f", coord.longitude)
-            mapRegion = MKCoordinateRegion(
-                center: coord,
-                span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
-            )
-        }
-        if landingLat.isEmpty || landingLon.isEmpty {
-            landingLat = String(format: "%.6f", coord.latitude)
-            landingLon = String(format: "%.6f", coord.longitude)
-        }
+    /// Center the map on the phone's current location and seed launch+landing to
+    /// it. Called once per open from the first GPS fix (see the onReceive guard),
+    /// so "current location" is the default each time the tool opens — unless the
+    /// user has already tapped/used GPS this session.
+    private func applyCurrentLocation(_ coord: CLLocationCoordinate2D) {
+        let lat = String(format: "%.6f", coord.latitude)
+        let lon = String(format: "%.6f", coord.longitude)
+        launchLat = lat;  launchLon = lon
+        landingLat = lat; landingLon = lon
+        mapRegion = MKCoordinateRegion(
+            center: coord,
+            span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+        )
     }
 
     /// "Use GPS" button: snap the launch point to the phone's current location.
     /// (Landing is the target, so it's intentionally left untouched here.)
     private func useGPS() {
         guard let coord = locationManager.userLocation else { return }
+        didAutoSeed = true   // explicit user action — suppress the auto-seed
         launchLat = String(format: "%.6f", coord.latitude)
         launchLon = String(format: "%.6f", coord.longitude)
         mapRegion = MKCoordinateRegion(

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -17,7 +17,7 @@ import Combine
 
 /// MapKit wrapper with tap gesture, annotations, and polyline overlays.
 struct DriftCastMapView: UIViewRepresentable {
-    @Binding var mapType: MKMapType
+    @Binding var tileSource: TileSource
     var launchCoord: CLLocationCoordinate2D?
     var landingCoord: CLLocationCoordinate2D?
     var guidanceCoord: CLLocationCoordinate2D?
@@ -29,8 +29,9 @@ struct DriftCastMapView: UIViewRepresentable {
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
         mapView.delegate = context.coordinator
-        mapView.mapType = mapType
+        mapView.mapType = tileSource.appleMapType
         mapView.setRegion(region, animated: false)
+        context.coordinator.basemap.apply(tileSource, to: mapView)
 
         // Add tap gesture
         let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
@@ -40,9 +41,10 @@ struct DriftCastMapView: UIViewRepresentable {
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        if mapView.mapType != mapType {
-            mapView.mapType = mapType
+        if mapView.mapType != tileSource.appleMapType {
+            mapView.mapType = tileSource.appleMapType
         }
+        context.coordinator.basemap.apply(tileSource, to: mapView)
 
         // Update annotations
         mapView.removeAnnotations(mapView.annotations)
@@ -69,8 +71,8 @@ struct DriftCastMapView: UIViewRepresentable {
             mapView.addAnnotation(ann)
         }
 
-        // Update overlays
-        mapView.removeOverlays(mapView.overlays)
+        // Update DATA overlays only; leave the basemap tile overlay in place.
+        mapView.removeOverlays(mapView.overlays.filter { !($0 is MKTileOverlay) })
 
         if descentTrack.count > 1 {
             let polyline = MKPolyline(coordinates: descentTrack, count: descentTrack.count)
@@ -98,6 +100,8 @@ struct DriftCastMapView: UIViewRepresentable {
     class Coordinator: NSObject, MKMapViewDelegate {
         var parent: DriftCastMapView
         var userIsInteracting = false
+        /// Shared basemap overlay controller (aligns Drift Cast with Rocket Map).
+        let basemap = BasemapOverlayController()
 
         init(_ parent: DriftCastMapView) {
             self.parent = parent
@@ -156,6 +160,9 @@ struct DriftCastMapView: UIViewRepresentable {
         }
 
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let tile = overlay as? MKTileOverlay {
+                return MKTileOverlayRenderer(tileOverlay: tile)
+            }
             if let polyline = overlay as? MKPolyline {
                 let renderer = MKPolylineRenderer(polyline: polyline)
                 if polyline.title == "descent" {
@@ -538,7 +545,8 @@ struct DriftCastView: View {
     @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     // Map state
-    @State private var mapType: MKMapType = .hybrid
+    @State private var tileSource: TileSource = .appleHybrid
+    @State private var showOfflineMaps = false
     @State private var mapRegion = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.7608, longitude: -75.7446),
         span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
@@ -660,6 +668,9 @@ struct DriftCastView: View {
             .onReceive(locationManager.$userLocation) { coord in
                 if let coord = coord { seedPointsIfBlank(from: coord) }
             }
+            .sheet(isPresented: $showOfflineMaps) {
+                OfflineMapsView(suggestedCenter: mapRegion.center)
+            }
         }
     }
 
@@ -678,6 +689,27 @@ struct DriftCastView: View {
                     .pickerStyle(.segmented)
                 } else {
                     Spacer()
+                }
+
+                // Basemap source + offline downloads (shared with Rocket Map).
+                Menu {
+                    Picker("Map source", selection: $tileSource) {
+                        ForEach(TileSource.allCases) { src in
+                            Label(src.displayName, systemImage: src.symbol).tag(src)
+                        }
+                    }
+                    Divider()
+                    Button { showOfflineMaps = true } label: {
+                        Label("Manage offline maps…", systemImage: "arrow.down.circle")
+                    }
+                } label: {
+                    Image(systemName: "square.stack.3d.up")
+                        .font(.caption.bold())
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Color.blue.opacity(0.2))
+                        .foregroundColor(.blue)
+                        .cornerRadius(8)
                 }
 
                 Button(action: { show3D.toggle() }) {
@@ -702,7 +734,7 @@ struct DriftCastView: View {
                     .padding(.horizontal)
             } else {
                 DriftCastMapView(
-                    mapType: $mapType,
+                    tileSource: $tileSource,
                     launchCoord: launchCoord,
                     landingCoord: landingCoord,
                     guidanceCoord: guidanceCoord,

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -219,8 +219,12 @@ struct MapView: View {
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
 
-            // Trial 0: active source + attribution, so the on-device A/B is
-            // unambiguous about which provider is rendering.
+            // Offline indicator (top-center) when there's no connection.
+            OfflinePill()
+                .padding(.top, 12)
+                .frame(maxWidth: .infinity, alignment: .top)
+
+            // Active source + attribution, so it's clear which provider renders.
             VStack(alignment: .leading, spacing: 1) {
                 Text(tileSource.displayName)
                     .font(.caption.bold())

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -94,9 +94,10 @@ struct RocketMapView: UIViewRepresentable {
             mapView.removeOverlay(existing)
             context.coordinator.tileOverlay = nil
         }
-        if let overlay = tileSource.makeOverlay() {
+        if tileSource.isCacheable {
             // Above labels so Apple's basemap labels don't bleed through the
             // replacement imagery; data overlays added later still draw on top.
+            let overlay = CachingTileOverlay(source: tileSource)
             mapView.addOverlay(overlay, level: .aboveLabels)
             context.coordinator.tileOverlay = overlay
         }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -15,7 +15,10 @@ import MapKit
 private final class PredictedLandingAnnotation: MKPointAnnotation {}
 
 struct RocketMapView: UIViewRepresentable {
-    @Binding var mapType: MKMapType
+    /// Trial 0 (offline maps): selectable basemap. Apple cases use the native
+    /// basemap; tile cases draw a basemap-replacing MKTileOverlay so we can A/B
+    /// cache-permissive imagery on-device. See docs/plans/offline-maps.md.
+    @Binding var tileSource: TileSource
     var rocketCoordinate: CLLocationCoordinate2D?
     var rocketSubtitle: String?
     /// Predicted landing location (issue #156).  Nil until the predictor
@@ -30,20 +33,24 @@ struct RocketMapView: UIViewRepresentable {
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
         mapView.delegate = context.coordinator
-        mapView.mapType = mapType
+        mapView.mapType = tileSource.appleMapType
         mapView.setRegion(region, animated: false)
+        applyTileSource(to: mapView, context: context)
         return mapView
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        // Update map type when toggle changes
-        if mapView.mapType != mapType {
-            mapView.mapType = mapType
+        // Basemap: Apple mapType + optional tile overlay (Trial 0 source A/B).
+        if mapView.mapType != tileSource.appleMapType {
+            mapView.mapType = tileSource.appleMapType
         }
+        applyTileSource(to: mapView, context: context)
 
-        // Reset annotations + overlays each pass.  Cheap — a handful of objects.
+        // Reset annotations + DATA overlays each pass (cheap).  The basemap tile
+        // overlay is managed separately above so it isn't torn down/reloaded on
+        // every telemetry tick.
         mapView.removeAnnotations(mapView.annotations)
-        mapView.removeOverlays(mapView.overlays)
+        mapView.removeOverlays(mapView.overlays.filter { !($0 is MKTileOverlay) })
 
         if let coordinate = rocketCoordinate {
             let annotation = MKPointAnnotation()
@@ -76,6 +83,25 @@ struct RocketMapView: UIViewRepresentable {
         }
     }
 
+    /// Add/swap/remove the basemap tile overlay to match `tileSource`, only when
+    /// it actually changes — so panning and per-tick telemetry updates don't tear
+    /// the overlay down and reload every tile.
+    private func applyTileSource(to mapView: MKMapView, context: Context) {
+        guard context.coordinator.currentSource != tileSource else { return }
+        context.coordinator.currentSource = tileSource
+
+        if let existing = context.coordinator.tileOverlay {
+            mapView.removeOverlay(existing)
+            context.coordinator.tileOverlay = nil
+        }
+        if let overlay = tileSource.makeOverlay() {
+            // Above labels so Apple's basemap labels don't bleed through the
+            // replacement imagery; data overlays added later still draw on top.
+            mapView.addOverlay(overlay, level: .aboveLabels)
+            context.coordinator.tileOverlay = overlay
+        }
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -83,6 +109,9 @@ struct RocketMapView: UIViewRepresentable {
     class Coordinator: NSObject, MKMapViewDelegate {
         var parent: RocketMapView
         var userIsInteracting = false
+        /// Basemap overlay state, so updateUIView only swaps on real change.
+        var currentSource: TileSource?
+        var tileOverlay: MKTileOverlay?
 
         init(_ parent: RocketMapView) {
             self.parent = parent
@@ -140,6 +169,9 @@ struct RocketMapView: UIViewRepresentable {
 
         func mapView(_ mapView: MKMapView,
                      rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let tile = overlay as? MKTileOverlay {
+                return MKTileOverlayRenderer(tileOverlay: tile)
+            }
             if let line = overlay as? MKPolyline,
                line.title == "predicted-descent" {
                 let r = MKPolylineRenderer(polyline: line)
@@ -161,7 +193,7 @@ struct MapView: View {
 
     @StateObject private var landingPredictor = LandingPredictor()
 
-    @State private var mapType: MKMapType = .hybrid
+    @State private var tileSource: TileSource = .appleHybrid
     @State private var region = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.334_900, longitude: -122.009_020),
         span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
@@ -183,7 +215,7 @@ struct MapView: View {
             // would freeze at whatever it was on the most recent re-render.
             TimelineView(.periodic(from: .now, by: 1.0)) { context in
                 RocketMapView(
-                    mapType: $mapType,
+                    tileSource: $tileSource,
                     rocketCoordinate: rocketCoordinate,
                     rocketSubtitle: markerSubtitle(now: context.date),
                     predictedLandingCoordinate: landingPredictor.prediction?.landing,
@@ -206,14 +238,38 @@ struct MapView: View {
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
 
+            // Trial 0: active source + attribution, so the on-device A/B is
+            // unambiguous about which provider is rendering.
+            VStack(alignment: .leading, spacing: 1) {
+                Text(tileSource.displayName)
+                    .font(.caption.bold())
+                if let attr = tileSource.attribution {
+                    Text(attr)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(.ultraThinMaterial)
+            .cornerRadius(8)
+            .shadow(radius: 2)
+            .padding(.leading, 12)
+            .padding(.bottom, 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+
             // Floating control buttons
             VStack(spacing: 12) {
-                // Map type toggle
-                Button(action: {
-                    mapType = (mapType == .standard) ? .hybrid : .standard
-                }) {
-                    Image(systemName: mapType == .standard
-                          ? "globe.americas.fill" : "map.fill")
+                // Map source picker (Trial 0 offline-maps A/B): Apple basemap
+                // vs. cache-permissive USGS / Esri tile overlays.
+                Menu {
+                    Picker("Map source", selection: $tileSource) {
+                        ForEach(TileSource.allCases) { src in
+                            Label(src.displayName, systemImage: src.symbol).tag(src)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "square.stack.3d.up")
                         .font(.system(size: 20))
                         .foregroundColor(.primary)
                         .frame(width: 44, height: 44)

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -35,7 +35,7 @@ struct RocketMapView: UIViewRepresentable {
         mapView.delegate = context.coordinator
         mapView.mapType = tileSource.appleMapType
         mapView.setRegion(region, animated: false)
-        applyTileSource(to: mapView, context: context)
+        context.coordinator.basemap.apply(tileSource, to: mapView)
         return mapView
     }
 
@@ -44,7 +44,7 @@ struct RocketMapView: UIViewRepresentable {
         if mapView.mapType != tileSource.appleMapType {
             mapView.mapType = tileSource.appleMapType
         }
-        applyTileSource(to: mapView, context: context)
+        context.coordinator.basemap.apply(tileSource, to: mapView)
 
         // Reset annotations + DATA overlays each pass (cheap).  The basemap tile
         // overlay is managed separately above so it isn't torn down/reloaded on
@@ -83,26 +83,6 @@ struct RocketMapView: UIViewRepresentable {
         }
     }
 
-    /// Add/swap/remove the basemap tile overlay to match `tileSource`, only when
-    /// it actually changes — so panning and per-tick telemetry updates don't tear
-    /// the overlay down and reload every tile.
-    private func applyTileSource(to mapView: MKMapView, context: Context) {
-        guard context.coordinator.currentSource != tileSource else { return }
-        context.coordinator.currentSource = tileSource
-
-        if let existing = context.coordinator.tileOverlay {
-            mapView.removeOverlay(existing)
-            context.coordinator.tileOverlay = nil
-        }
-        if tileSource.isCacheable {
-            // Above labels so Apple's basemap labels don't bleed through the
-            // replacement imagery; data overlays added later still draw on top.
-            let overlay = CachingTileOverlay(source: tileSource)
-            mapView.addOverlay(overlay, level: .aboveLabels)
-            context.coordinator.tileOverlay = overlay
-        }
-    }
-
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -110,9 +90,8 @@ struct RocketMapView: UIViewRepresentable {
     class Coordinator: NSObject, MKMapViewDelegate {
         var parent: RocketMapView
         var userIsInteracting = false
-        /// Basemap overlay state, so updateUIView only swaps on real change.
-        var currentSource: TileSource?
-        var tileOverlay: MKTileOverlay?
+        /// Shared basemap overlay controller (swaps tiles only on source change).
+        let basemap = BasemapOverlayController()
 
         init(_ parent: RocketMapView) {
             self.parent = parent
@@ -200,6 +179,7 @@ struct MapView: View {
         span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
     )
     @State private var hasInitializedRegion = false
+    @State private var showOfflineMaps = false
 
     /// Always reads from the latched last-valid fix (#140), not raw
     /// telemetry — so a rocket-side GPS dropout or LoRa loss can't blank
@@ -261,13 +241,18 @@ struct MapView: View {
 
             // Floating control buttons
             VStack(spacing: 12) {
-                // Map source picker (Trial 0 offline-maps A/B): Apple basemap
-                // vs. cache-permissive USGS / Esri tile overlays.
+                // Map source picker + offline downloads (shared with Drift Cast).
                 Menu {
                     Picker("Map source", selection: $tileSource) {
                         ForEach(TileSource.allCases) { src in
                             Label(src.displayName, systemImage: src.symbol).tag(src)
                         }
+                    }
+                    Divider()
+                    Button {
+                        showOfflineMaps = true
+                    } label: {
+                        Label("Manage offline maps…", systemImage: "arrow.down.circle")
                     }
                 } label: {
                     Image(systemName: "square.stack.3d.up")
@@ -310,6 +295,9 @@ struct MapView: View {
         }
         .onDisappear {
             landingPredictor.detach()
+        }
+        .sheet(isPresented: $showOfflineMaps) {
+            OfflineMapsView(suggestedCenter: region.center)
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/OfflineMapsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/OfflineMapsView.swift
@@ -1,0 +1,79 @@
+//
+//  OfflineMapsView.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 2 (see docs/plans/offline-maps.md).
+//
+//  Manage downloaded regions: see what's saved, how much space it uses, delete
+//  to reclaim space, and add a new region. Shared entry point from both the
+//  Rocket Map and Drift Cast.
+//
+
+import SwiftUI
+import CoreLocation
+
+struct OfflineMapsView: View {
+    /// Default center for a new region (the calling map's current center).
+    let suggestedCenter: CLLocationCoordinate2D
+
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var store = OfflineRegionStore.shared
+    @State private var showSave = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                if store.regions.isEmpty {
+                    Section {
+                        Text("No offline areas saved yet. Tap ﹢ to download imagery for a launch site while you have signal.")
+                            .font(.callout)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Section {
+                        ForEach(store.regions) { region in
+                            regionRow(region)
+                        }
+                        .onDelete { idx in
+                            idx.map { store.regions[$0] }.forEach(store.delete)
+                        }
+                    } footer: {
+                        Text("Total offline storage · \(formatMB(store.totalBytes)) across \(store.regions.count) region\(store.regions.count == 1 ? "" : "s")")
+                    }
+                }
+            }
+            .navigationTitle("Offline Maps")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showSave = true } label: { Image(systemName: "plus") }
+                }
+            }
+            .sheet(isPresented: $showSave) {
+                SaveAreaView(initialCenter: suggestedCenter)
+            }
+        }
+    }
+
+    private func regionRow(_ r: OfflineRegion) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(r.name).fontWeight(.medium)
+            Text("\(String(format: "%.1f", r.radiusMeters / 1000)) km · z\(r.minZoom)–\(r.maxZoom) · \(formatMB(r.bytes)) · \(r.tileSource?.displayName ?? r.source)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text("Saved \(r.savedAt.formatted(date: .abbreviated, time: .omitted))")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func formatMB(_ bytes: Int64) -> String {
+        let mb = Double(bytes) / 1_048_576
+        if mb < 0.1 { return "0 MB" }
+        return String(format: "%.0f MB", mb)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/SaveAreaView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SaveAreaView.swift
@@ -1,0 +1,199 @@
+//
+//  SaveAreaView.swift
+//  TinkerRocketApp
+//
+//  Offline maps — Trial 2 (see docs/plans/offline-maps.md).
+//
+//  Pick an area (center + radius) and a detail level, see a live tile/size
+//  estimate, and download the tiles for offline use. Only cache-permissive
+//  sources (USGS) can be saved.
+//
+
+import SwiftUI
+import MapKit
+
+// MARK: - Region picker map (center crosshair + radius circle)
+
+struct RegionPickerMap: UIViewRepresentable {
+    @Binding var region: MKCoordinateRegion
+    var radiusMeters: Double
+    var source: TileSource
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView()
+        map.delegate = context.coordinator
+        map.mapType = source.appleMapType
+        map.setRegion(region, animated: false)
+        context.coordinator.basemap.apply(source, to: map)
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        if map.mapType != source.appleMapType { map.mapType = source.appleMapType }
+        context.coordinator.basemap.apply(source, to: map)
+
+        // Redraw the radius circle (centered on the current map center).
+        map.removeOverlays(map.overlays.filter { $0 is MKCircle })
+        map.addOverlay(MKCircle(center: region.center, radius: radiusMeters), level: .aboveLabels)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var parent: RegionPickerMap
+        let basemap = BasemapOverlayController()
+        init(_ parent: RegionPickerMap) { self.parent = parent }
+
+        func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+            parent.region = mapView.region
+        }
+
+        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let tile = overlay as? MKTileOverlay {
+                return MKTileOverlayRenderer(tileOverlay: tile)
+            }
+            if let circle = overlay as? MKCircle {
+                let r = MKCircleRenderer(circle: circle)
+                r.strokeColor = .systemBlue
+                r.lineWidth = 2
+                r.fillColor = UIColor.systemBlue.withAlphaComponent(0.15)
+                return r
+            }
+            return MKOverlayRenderer(overlay: overlay)
+        }
+    }
+}
+
+// MARK: - Save area sheet
+
+struct SaveAreaView: View {
+    let initialCenter: CLLocationCoordinate2D
+
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var store = OfflineRegionStore.shared
+    @StateObject private var downloader = TileDownloader()
+
+    @State private var source: TileSource = .usgsImageryTopo
+    @State private var region: MKCoordinateRegion
+    @State private var radiusKm: Double = 5
+    @State private var maxZoom: Double = 16
+    @State private var name: String = ""
+
+    private let cacheableSources = TileSource.allCases.filter { $0.isCacheable }
+
+    init(initialCenter: CLLocationCoordinate2D) {
+        self.initialCenter = initialCenter
+        _region = State(initialValue: MKCoordinateRegion(
+            center: initialCenter,
+            span: MKCoordinateSpan(latitudeDelta: 0.15, longitudeDelta: 0.15)))
+    }
+
+    private var spec: RegionSpec {
+        RegionSpec(center: region.center, radiusMeters: radiusKm * 1000,
+                   minZoom: 10, maxZoom: Int(maxZoom))
+    }
+    private var tileCount: Int { TileMath.tileCount(for: spec) }
+    private var estMB: Double { Double(Int64(tileCount) * kEstimatedTileBytes) / 1_048_576 }
+    private var tooBig: Bool { estMB > 200 }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                ZStack {
+                    RegionPickerMap(region: $region, radiusMeters: radiusKm * 1000, source: source)
+                    // Center crosshair = the region center used for the download.
+                    Image(systemName: "plus.viewfinder")
+                        .font(.system(size: 26, weight: .regular))
+                        .foregroundColor(.blue)
+                        .shadow(radius: 2)
+                }
+                .frame(height: 240)
+
+                Form {
+                    Section("Source") {
+                        Picker("Imagery", selection: $source) {
+                            ForEach(cacheableSources) { Text($0.displayName).tag($0) }
+                        }
+                    }
+                    Section("Area") {
+                        sliderRow(title: "Radius", value: String(format: "%.1f km", radiusKm),
+                                  binding: $radiusKm, range: 1...20, step: 0.5)
+                        sliderRow(title: "Detail (max zoom)", value: "z\(Int(maxZoom))",
+                                  binding: $maxZoom, range: 13...18, step: 1)
+                        HStack {
+                            Text("Estimate").foregroundColor(.secondary)
+                            Spacer()
+                            Text("~\(tileCount) tiles · ~\(String(format: "%.0f", estMB)) MB")
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundColor(tooBig ? .orange : .primary)
+                        }
+                        if tooBig {
+                            Text("Large download — consider a smaller radius or lower max zoom.")
+                                .font(.caption).foregroundColor(.orange)
+                        }
+                    }
+                    Section("Name") {
+                        TextField(defaultName, text: $name)
+                    }
+                    Section {
+                        if downloader.isRunning {
+                            VStack(alignment: .leading, spacing: 8) {
+                                ProgressView(value: downloader.total > 0
+                                             ? Double(downloader.done) / Double(downloader.total) : 0)
+                                Text("\(downloader.done) / \(downloader.total) tiles · "
+                                     + String(format: "%.0f MB", Double(downloader.bytes) / 1_048_576))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                                Button(role: .cancel) { downloader.cancel() } label: {
+                                    Text("Cancel").frame(maxWidth: .infinity)
+                                }
+                            }
+                        } else {
+                            Button {
+                                downloader.start(region: spec, source: source)
+                            } label: {
+                                Label("Download \(tileCount) tiles", systemImage: "arrow.down.circle.fill")
+                                    .fontWeight(.semibold)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Save area offline")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.disabled(downloader.isRunning)
+                }
+            }
+            .onChange(of: downloader.phase) { phase in
+                guard phase == .finished else { return }
+                store.add(OfflineRegion(
+                    name: name.isEmpty ? defaultName : name,
+                    lat: region.center.latitude, lon: region.center.longitude,
+                    radiusMeters: radiusKm * 1000, minZoom: 10, maxZoom: Int(maxZoom),
+                    source: source.rawValue, tileCount: downloader.total,
+                    bytes: downloader.bytes, savedAt: Date()))
+                dismiss()
+            }
+        }
+    }
+
+    private var defaultName: String {
+        String(format: "Area %.3f, %.3f", region.center.latitude, region.center.longitude)
+    }
+
+    private func sliderRow(title: String, value: String,
+                           binding: Binding<Double>, range: ClosedRange<Double>,
+                           step: Double) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title).foregroundColor(.secondary)
+                Spacer()
+                Text(value).font(.system(.body, design: .monospaced))
+            }
+            Slider(value: binding, in: range, step: step)
+        }
+    }
+}

--- a/docs/plans/offline-maps-mockups.html
+++ b/docs/plans/offline-maps-mockups.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Offline Maps — interaction mockups</title>
+<style>
+  :root{
+    --bg:#0f1115; --panel:#171a21; --ink:#e9edf2; --muted:#9aa3b2;
+    --blue:#0a84ff; --green:#30d158; --red:#ff453a; --orange:#ff9f0a; --purple:#5e5ce6;
+    --mat:rgba(28,30,36,.72);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:linear-gradient(180deg,#0b0d11,#12151b);color:var(--ink);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    padding:32px 24px 64px}
+  h1{font-size:24px;margin:0 0 4px} .sub{color:var(--muted);max-width:820px;margin:0 0 28px}
+  .note{background:#1b2230;border:1px solid #26334a;border-radius:10px;padding:12px 14px;
+    color:#c7d2e2;max-width:820px;margin:0 0 32px;font-size:13.5px}
+  .grid{display:flex;flex-wrap:wrap;gap:40px 36px;align-items:flex-start}
+  figure{margin:0;width:300px}
+  figcaption{color:var(--muted);font-size:13px;margin-top:12px}
+  figcaption b{color:var(--ink);font-weight:600}
+
+  /* phone */
+  .phone{position:relative;width:300px;height:620px;background:#000;border-radius:46px;
+    padding:11px;box-shadow:0 18px 50px rgba(0,0,0,.55),0 0 0 2px #2a2d34}
+  .screen{position:relative;width:100%;height:100%;border-radius:36px;overflow:hidden;background:#0b0e13}
+  .notch{position:absolute;top:0;left:50%;transform:translateX(-50%);width:120px;height:26px;
+    background:#000;border-radius:0 0 16px 16px;z-index:40}
+  .statusbar{position:absolute;top:0;left:0;right:0;height:44px;z-index:30;display:flex;
+    align-items:center;justify-content:space-between;padding:0 22px;font-size:12px;font-weight:600;
+    color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.4)}
+  .statusbar .r{letter-spacing:1px}
+
+  /* map canvas — faux aerial/topo, this is chrome not real tiles */
+  .map{position:absolute;inset:0}
+  .map.aerial{background:
+    radial-gradient(120px 90px at 30% 28%, #5c7a3e, transparent 70%),
+    radial-gradient(150px 120px at 72% 60%, #6f8b46, transparent 72%),
+    radial-gradient(90px 70px at 55% 80%, #4e6a39, transparent 70%),
+    repeating-linear-gradient(28deg,#54703c 0 14px,#5b7a40 14px 30px),
+    linear-gradient(160deg,#48623a,#3c5233)}
+  .map.topo{background:
+    repeating-radial-gradient(circle at 60% 45%, #cdb88e 0 9px, #c2ab7e 9px 18px),
+    linear-gradient(160deg,#e7dcc0,#d8c9a3)}
+  .map.apple{background:
+    radial-gradient(130px 100px at 32% 30%, #4f7a37, transparent 70%),
+    radial-gradient(150px 120px at 70% 62%, #5f8e3d, transparent 72%),
+    linear-gradient(160deg,#3f6a2f,#2f5527)}
+  .map:after{content:"";position:absolute;inset:0;opacity:.5;
+    background:
+      linear-gradient(90deg,transparent 0 46%, rgba(220,225,235,.55) 46% 47%, transparent 47%),
+      linear-gradient(18deg,transparent 0 62%, rgba(210,215,228,.45) 62% 63%, transparent 63%);
+    mix-blend-mode:screen}
+  .river{position:absolute;left:-10%;top:35%;width:130%;height:24px;
+    background:linear-gradient(#3a78b5,#2f6aa6);border-radius:40px;
+    transform:rotate(-12deg);filter:blur(.3px);opacity:.85}
+
+  /* pins */
+  .pin{position:absolute;transform:translate(-50%,-100%);z-index:10;text-align:center;
+    filter:drop-shadow(0 3px 4px rgba(0,0,0,.5))}
+  .pin .dot{width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+    color:#fff;font-size:13px;font-weight:700;border:2px solid #fff}
+  .pin .tip{width:2px;height:9px;background:#fff;margin:0 auto;opacity:.0}
+  .pin.red .dot{background:var(--red)} .pin.green .dot{background:var(--green)}
+  .pin.blue .dot{background:var(--blue)} .pin.purple .dot{background:var(--purple)}
+  .lbl{position:absolute;transform:translate(-50%,4px);z-index:10;font-size:10.5px;color:#fff;
+    background:rgba(0,0,0,.45);padding:1px 6px;border-radius:6px;white-space:nowrap}
+  .track{position:absolute;z-index:9;height:0;border-top:2.5px dashed var(--green);opacity:.9;
+    transform-origin:left center}
+
+  /* floating controls */
+  .fctrl{position:absolute;right:12px;z-index:20;display:flex;flex-direction:column;gap:10px}
+  .fbtn{width:44px;height:44px;border-radius:12px;background:var(--mat);backdrop-filter:blur(8px);
+    display:flex;align-items:center;justify-content:center;font-size:19px;color:#fff;
+    border:1px solid rgba(255,255,255,.12)}
+  .fbtn.blue{color:#5ac8ff}
+  .badge{position:absolute;left:12px;z-index:20;background:var(--mat);backdrop-filter:blur(8px);
+    border:1px solid rgba(255,255,255,.12);border-radius:9px;padding:6px 10px;font-size:12px;
+    display:flex;align-items:center;gap:7px;color:#fff}
+  .dotled{width:8px;height:8px;border-radius:50%}
+  .pill{position:absolute;z-index:20;background:rgba(255,159,10,.92);color:#1a1205;font-weight:700;
+    font-size:11px;border-radius:20px;padding:4px 10px}
+
+  /* bottom sheet */
+  .sheet{position:absolute;left:0;right:0;bottom:0;z-index:25;background:#1b1e25;
+    border-radius:22px 22px 0 0;padding:10px 18px 24px;box-shadow:0 -10px 30px rgba(0,0,0,.4)}
+  .grab{width:38px;height:5px;border-radius:3px;background:#3a3f4a;margin:2px auto 12px}
+  .sheet h3{margin:2px 0 14px;font-size:18px}
+  .row{display:flex;align-items:center;justify-content:space-between;padding:11px 0;
+    border-bottom:1px solid #262b34}
+  .row:last-of-type{border-bottom:0}
+  .row .k{color:var(--muted)} .row .v{font-variant-numeric:tabular-nums}
+  .seg{display:flex;background:#0e1116;border-radius:9px;padding:3px;gap:3px;margin:4px 0 6px}
+  .seg div{flex:1;text-align:center;font-size:12.5px;padding:7px 0;border-radius:7px;color:var(--muted)}
+  .seg div.on{background:#2c3340;color:#fff}
+  .slider{height:6px;border-radius:4px;background:#0e1116;position:relative;margin:14px 2px 6px}
+  .slider .fill{position:absolute;left:0;top:0;bottom:0;border-radius:4px;background:var(--blue)}
+  .slider .knob{position:absolute;top:50%;width:20px;height:20px;border-radius:50%;background:#fff;
+    transform:translate(-50%,-50%);box-shadow:0 2px 5px rgba(0,0,0,.5)}
+  .est{display:flex;gap:8px;align-items:baseline;margin:14px 0 4px;
+    font-variant-numeric:tabular-nums;color:#cdd6e4}
+  .est b{font-size:20px;color:#fff}
+  .btn{display:block;text-align:center;background:var(--blue);color:#fff;font-weight:600;
+    border-radius:13px;padding:14px;margin-top:14px}
+  .btn.ghost{background:#2a3140;color:#cdd6e4}
+  .warn{font-size:12px;color:var(--orange);margin-top:8px}
+
+  /* progress */
+  .pbar{height:8px;border-radius:5px;background:#0e1116;overflow:hidden;margin:18px 0 8px}
+  .pbar .fill{height:100%;background:var(--blue)}
+
+  /* region list rows */
+  .rgn{display:flex;align-items:center;gap:12px;padding:13px 0;border-bottom:1px solid #262b34}
+  .rgn .thumb{width:46px;height:46px;border-radius:10px;flex:0 0 auto}
+  .rgn .meta{flex:1;min-width:0}
+  .rgn .meta .t{font-weight:600} .rgn .meta .s{color:var(--muted);font-size:12.5px}
+  .rgn .del{color:var(--red);font-size:20px}
+  .tot{color:var(--muted);font-size:12.5px;margin:14px 2px 0}
+
+  /* missing-tile hatch */
+  .hatch{position:absolute;z-index:8;background:
+    repeating-linear-gradient(45deg,#21262f 0 10px,#1a1f27 10px 20px);}
+  .hatchlbl{position:absolute;z-index:9;color:#8d97a6;font-size:11px;background:rgba(0,0,0,.35);
+    padding:3px 8px;border-radius:6px}
+
+  /* A/B split */
+  .split{position:absolute;inset:0;display:flex}
+  .split>div{flex:1;position:relative}
+  .split .divider{position:absolute;left:50%;top:0;bottom:0;width:2px;background:rgba(255,255,255,.6);z-index:15}
+  .tag{position:absolute;top:50px;z-index:16;font-size:11px;font-weight:700;color:#fff;
+    background:rgba(0,0,0,.5);padding:3px 8px;border-radius:6px}
+  .titlebar{position:absolute;top:0;left:0;right:0;height:96px;z-index:22;
+    background:linear-gradient(#1b1e25,#1b1e25f0,transparent);padding:52px 18px 0}
+  .titlebar .h{font-size:17px;font-weight:600} .titlebar .x{position:absolute;right:18px;top:52px;color:var(--blue)}
+</style>
+</head>
+<body>
+  <h1>Offline Maps — interaction mockups</h1>
+  <p class="sub">Proposed screens for pre-downloading map imagery so Reverse Drift Cast and the Rocket Map work with no cell signal. These show the <b>interaction design and UI chrome</b>; the real look of USGS / Esri tiles vs. Apple's basemap is what <b>Trial 0</b> settles on-device. Faux map art below is illustrative only.</p>
+  <div class="note">Companion to <b>docs/plans/offline-maps.md</b>. Frames: ① source picker · ② save area · ③ download progress · ④ offline regions · ⑤ offline / missing tiles · ⑥ Trial 0 A/B.</div>
+
+  <div class="grid">
+
+    <!-- 1: source picker -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✦ ▮▮▮</span></div>
+        <div class="map aerial"><div class="river"></div></div>
+        <div class="track" style="left:38%;top:34%;width:120px;transform:rotate(34deg)"></div>
+        <div class="pin red" style="left:38%;top:34%"><div class="dot">▲</div></div>
+        <div class="pin green" style="left:64%;top:62%"><div class="dot">⚑</div></div>
+        <div class="badge" style="top:54px"><span class="dotled" style="background:var(--green)"></span>USGS Imagery</div>
+        <div class="fctrl" style="top:108px">
+          <div class="fbtn">⧉</div>
+          <div class="fbtn blue">◉</div>
+        </div>
+        <!-- source menu -->
+        <div class="sheet" style="padding-bottom:18px">
+          <div class="grab"></div>
+          <h3>Map source</h3>
+          <div class="row"><span class="k">Apple Standard</span><span class="v">○</span></div>
+          <div class="row"><span class="k">Apple Hybrid</span><span class="v">○</span></div>
+          <div class="row"><span class="k" style="color:#fff">USGS Imagery</span><span class="v" style="color:var(--blue)">●</span></div>
+          <div class="row"><span class="k">USGS Topo</span><span class="v">○</span></div>
+          <div class="btn ghost" style="margin-top:14px">⤓ Save this area offline…</div>
+        </div>
+      </div></div>
+      <figcaption>① <b>Source picker</b> replaces the map-type toggle. Cacheable sources (USGS) can be saved; Apple stays the default online layer. Same control doubles as the Trial 0 A/B switch. Active-source badge top-left.</figcaption>
+    </figure>
+
+    <!-- 2: save area -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✦ ▮▮▮</span></div>
+        <div class="map aerial"><div class="river"></div></div>
+        <!-- radius circle -->
+        <div style="position:absolute;left:50%;top:30%;width:190px;height:190px;transform:translate(-50%,-50%);
+          border-radius:50%;border:2px solid var(--blue);background:rgba(10,132,255,.16);z-index:6"></div>
+        <div class="pin blue" style="left:50%;top:30%"><div class="dot">◎</div></div>
+        <div class="titlebar"><span class="h">Save area offline</span><span class="x">Cancel</span></div>
+        <div class="sheet">
+          <div class="grab"></div>
+          <div class="seg"><div>Current location</div><div class="on">Map center</div></div>
+          <div class="row"><span class="k">Radius</span><span class="v">5.0 km</span></div>
+          <div class="slider"><div class="fill" style="width:42%"></div><div class="knob" style="left:42%"></div></div>
+          <div class="row"><span class="k">Detail (max zoom)</span><span class="v">z17 · ~2.4 m/px</span></div>
+          <div class="slider"><div class="fill" style="width:64%"></div><div class="knob" style="left:64%"></div></div>
+          <div class="est"><span>Estimate</span><b>~1,800 tiles</b><span>· ~45 MB · z10–17</span></div>
+          <a class="btn">⤓ Download</a>
+        </div>
+      </div></div>
+      <figcaption>② <b>Save area</b>: center + radius circle, max-zoom slider, and a <b>live tile/size estimate before committing</b>. Center on current GPS or the map. Bounds the download — each extra zoom ~4×'s the count.</figcaption>
+    </figure>
+
+    <!-- 3: download progress -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✦ ▮▮▮</span></div>
+        <div class="map aerial" style="filter:brightness(.6)"><div class="river"></div></div>
+        <div style="position:absolute;left:50%;top:30%;width:190px;height:190px;transform:translate(-50%,-50%);
+          border-radius:50%;border:2px solid var(--blue);background:rgba(10,132,255,.12);z-index:6"></div>
+        <div class="sheet">
+          <div class="grab"></div>
+          <h3>Downloading “Pad 0A field”</h3>
+          <div class="pbar"><div class="fill" style="width:57%"></div></div>
+          <div class="est" style="margin-top:4px"><b>1,840</b><span>/ 1,800… 3,200 tiles · 27 MB</span></div>
+          <div class="row"><span class="k">Source</span><span class="v">USGS Imagery</span></div>
+          <div class="row"><span class="k">Status</span><span class="v" style="color:var(--green)">Downloading…</span></div>
+          <a class="btn ghost">Cancel</a>
+        </div>
+      </div></div>
+      <figcaption>③ <b>Download progress</b>: determinate bar with tile/byte counts, cancelable, resumable (already-cached tiles are skipped). Keeps going if the app is backgrounded.</figcaption>
+    </figure>
+
+    <!-- 4: offline regions -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✦ ▮▮▮</span></div>
+        <div style="position:absolute;inset:0;background:#14171d"></div>
+        <div class="titlebar" style="background:#14171d"><span class="h">Offline regions</span><span class="x">＋</span></div>
+        <div style="position:absolute;top:104px;left:0;right:0;bottom:0;padding:4px 18px;overflow:auto">
+          <div class="rgn"><div class="thumb map aerial"></div>
+            <div class="meta"><div class="t">Pad 0A field</div><div class="s">5 km · z10–17 · 45 MB · USGS Imagery</div><div class="s">Saved Jun 3</div></div>
+            <div class="del">🗑</div></div>
+          <div class="rgn"><div class="thumb map topo"></div>
+            <div class="meta"><div class="t">Black Rock</div><div class="s">12 km · z10–16 · 88 MB · USGS Topo</div><div class="s">Saved May 28</div></div>
+            <div class="del">🗑</div></div>
+          <div class="rgn"><div class="thumb map aerial" style="filter:hue-rotate(40deg)"></div>
+            <div class="meta"><div class="t">Potter farm</div><div class="s">3 km · z10–18 · 61 MB · USGS Imagery</div><div class="s">Saved May 12</div></div>
+            <div class="del">🗑</div></div>
+          <div class="tot">Total offline storage · 194 MB across 3 regions</div>
+        </div>
+      </div></div>
+      <figcaption>④ <b>Offline regions manager</b>: review saved areas (size, zoom range, source, date), delete to reclaim space, see total storage. Reachable from DriftCast and the dashboard — one download serves both.</figcaption>
+    </figure>
+
+    <!-- 5: offline + missing tiles -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✈︎ ▱▱▱</span></div>
+        <div class="map aerial"><div class="river"></div></div>
+        <!-- missing region to the right -->
+        <div class="hatch" style="right:0;top:0;width:34%;bottom:0"></div>
+        <div class="hatchlbl" style="right:14px;top:50%">Outside saved area</div>
+        <div class="pin red" style="left:40%;top:46%"><div class="dot">▲</div></div>
+        <div class="lbl" style="left:40%;top:46%">3 sats · 12s ago</div>
+        <div class="pill" style="left:12px;top:54px">● OFFLINE</div>
+        <div class="fctrl" style="top:108px"><div class="fbtn">⧉</div><div class="fbtn blue">◉</div></div>
+      </div></div>
+      <figcaption>⑤ <b>Offline state</b>: saved area renders sharp from disk; an "OFFLINE" pill confirms no network; tiles outside the saved region/zoom show a neutral hatch + hint — never a crash or endless spinner. Rocket pin & telemetry keep working (GPS needs no cell).</figcaption>
+    </figure>
+
+    <!-- 6: A/B -->
+    <figure>
+      <div class="phone"><div class="screen">
+        <div class="notch"></div>
+        <div class="statusbar"><span>9:41</span><span class="r">✦ ▮▮▮</span></div>
+        <div class="split">
+          <div><div class="map apple"></div><div class="tag" style="left:12px">APPLE HYBRID</div></div>
+          <div><div class="map aerial"></div><div class="tag" style="right:12px">USGS IMAGERY</div></div>
+          <div class="divider"></div>
+        </div>
+        <div class="pin red" style="left:50%;top:46%"><div class="dot">▲</div></div>
+        <div class="badge" style="bottom:18px;left:50%;transform:translateX(-50%)">Trial 0 · is it worth it?</div>
+      </div></div>
+      <figcaption>⑥ <b>Trial 0 A/B</b> (debug): same field, Apple Hybrid vs. USGS Imagery side-by-side on-device. This is the cheap go/no-go before any cache/download code — does the cacheable imagery look good enough to be worth the offline win?</figcaption>
+    </figure>
+
+  </div>
+</body>
+</html>

--- a/docs/plans/offline-maps.md
+++ b/docs/plans/offline-maps.md
@@ -1,7 +1,7 @@
 # Offline map tiles for no-signal launch sites
 
 **Issue:** _to be filed_ (tracking issue TBD)
-**Status:** Phase 0 — design + trials. No production code lands until Trial 0 clears the look‑and‑feel gate.
+**Status:** Trial 1 (read-through cache) landed. Trial 0 cleared — standardizing on **Apple** (global, online-only) + **USGS** (cacheable). Esri dropped; international imagery deferred to [#231](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/231).
 **Last updated:** 2026-06-03
 **Mockups:** [`offline-maps-mockups.html`](offline-maps-mockups.html) (open in a browser)
 
@@ -104,7 +104,7 @@ A single shared subsystem, injected into both map views and the 3D texture fetch
 | Esri World Imagery | ✅* | none | Global | Already used by `Trajectory3DView`. *Verify current ToS for persistent offline caching + attribution before relying on it. |
 | OSM / MapTiler / Mapbox | ✅ | key (most) | Global / vector | For non-US or topo styling later; OSM policy discourages bulk download. |
 
-Recommendation: **USGS imagery as the saved source, USGS topo as a second saved option** (topo is often *more* useful than satellite for spotting recovery terrain — fields, tree lines, roads). Keep Apple Hybrid as the default online layer. The `TileSource` abstraction means Trial 0 swaps these with a one-line change.
+**Decided (Trial 0):** standardize on **Apple Standard/Hybrid** (global, online-only) + **USGS Imagery / Imagery+Topo / Topo** (public-domain, cacheable). Esri World Imagery looked best online and zoomed deeper, but its free terms restrict the persistent offline caching this feature is built around — and Apple already covers global *online* — so it was dropped. Only USGS is offered for offline download, gated on `TileSource.isCacheable`. International (non-US) cacheable imagery is deferred to [#231](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/231).
 
 ---
 
@@ -169,7 +169,7 @@ Entry points: a "layers/offline" button on `RocketMapView`'s existing floating c
 
 ## 7. Open questions
 
-1. Primary saved source: **USGS Imagery**, USGS Topo, or both selectable? (I lean both.)
+1. ~~Primary saved source~~ — **Resolved (Trial 0):** Apple + USGS (Imagery / Imagery+Topo / Topo); USGS-only caching; Esri dropped; international deferred to [#231](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/231).
 2. Acceptable default size cap / warning threshold per region?
 3. Region selection: center **+ radius** (recommended) vs. free-draw rectangle?
 4. Should "Save this area" auto-suggest a region centered on the DriftCast launch point / last rocket fix?

--- a/docs/plans/offline-maps.md
+++ b/docs/plans/offline-maps.md
@@ -1,0 +1,176 @@
+# Offline map tiles for no-signal launch sites
+
+**Issue:** _to be filed_ (tracking issue TBD)
+**Status:** Phase 0 — design + trials. No production code lands until Trial 0 clears the look‑and‑feel gate.
+**Last updated:** 2026-06-03
+**Mockups:** [`offline-maps-mockups.html`](offline-maps-mockups.html) (open in a browser)
+
+Launch sites frequently have no cell reception. Both map surfaces in the iOS app draw on Apple's MapKit basemap, and **Apple's tiles cannot be pre-downloaded or cached for offline use** — there is no public API and persisting them is against the MapKit terms. So at the field with no signal, the imagery behind the pins is blank in:
+
+- **Reverse Drift Cast** — `DriftCastMapView`, plus the ArcGIS ground texture in `Trajectory3DView` ([DriftCastView.swift](../../TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift))
+- **Rocket Map** — `RocketMapView`, used for live tracking and recovery ([MapView.swift](../../TinkerRocketApp/TinkerRocketApp/Views/MapView.swift))
+
+GPS and telemetry already work with no cell signal (`device.lastValidRocketFix`, distance/bearing, the landing predictor). **The only thing offline-broken today is the basemap imagery.** This plan adds the ability to pre-download imagery for a chosen area while connected, store it on-device, and serve it later with no signal — shared by both map views and the 3D texture.
+
+This document is the contract that the implementation phases build against.
+
+## Guiding principle: trial-driven and reversible
+
+The hard risk here is not technical, it's **subjective**: cache-permissive imagery (USGS / Esri) may look worse than Apple's polished hybrid basemap. So the first trial is a cheap on-device A/B at a real field, behind a debug toggle, before any download/cache machinery is built. Every phase ends in something testable with an explicit go/no-go, and the custom layer stays swappable so we can fall back to the Apple basemap (online) at any point.
+
+## Phasing & trials
+
+| Phase | Deliverable | Decision gate |
+|---|---|---|
+| **Trial 0** | A `CachingTileOverlay` stub (no caching yet) added to `RocketMapView` behind a hidden source toggle. Compare USGS Imagery / USGS Topo / Esri vs. Apple Hybrid on-device, online, **at an actual launch field**. | **Is the imagery good enough to be worth it?** If no → try another source, or stop and shelve the feature. Nothing else proceeds until this clears. |
+| **Trial 1** | Read-through on-disk cache behind the overlay. View an area online, enable Airplane Mode, confirm those tiles still render. | Does offline render actually work, and is the cache hit-path fast enough to not jank panning? |
+| **Trial 2** | `TileDownloader` + a minimal "save center + radius to max-zoom N" action with a live size estimate and progress. Download a field, Airplane Mode, verify. | Are tile counts / sizes / download times acceptable for a real field area? Is the estimate trustworthy? |
+| **Phase 3** | Share the overlay + cache into `DriftCastMapView`; route the `Trajectory3DView` texture through the same cache. | Both views + 3D work offline from one download. |
+| **Phase 4** | `OfflineRegionStore` + region manager UI (list / size / delete / re-download), offline indicator, missing-tile treatment, source toggle as a shipped control. | Feature-complete, manageable storage, no silent failures. |
+
+Trials 0–2 are deliberately throwaway-friendly: each is a few hundred lines behind a flag, and any of them can kill or redirect the feature.
+
+## Resolved design decisions
+
+| # | Decision |
+|---|---|
+| 1 | **Move the savable layer off Apple's basemap.** Add an `MKTileOverlay` subclass with `canReplaceMapContent = true` to both map views. Apple basemap stays as the default *online* layer; the custom source is what gets cached. |
+| 2 | **One shared offline subsystem**, not per-view. A single download serves `DriftCastMapView`, `RocketMapView`, and the `Trajectory3DView` texture. New module under `TinkerRocketApp/.../Maps/Offline/`. |
+| 3 | **Primary tile source: USGS *The National Map*** (`USGSImageryOnly`, `USGSTopo`). Public domain, free, no API key, caching/offline explicitly permitted, US coverage (our default site is Wallops Island, VA). Source is pluggable so Trial 0 can compare alternatives. |
+| 4 | **Cache lives in Application Support, not Caches.** The OS purges `Caches/` under storage pressure, which would silently delete exactly the data the user pre-downloaded for the field. Mark the directory excluded-from-backup. |
+| 5 | **Pre-download by center + radius + max-zoom**, not free-draw rectangles — bounds tile counts and is the natural "the field is here, this big" gesture. Always show a tile-count + MB estimate *before* committing. |
+| 6 | **Annotations/overlays are untouched.** Pins (launch/landing/guidance/rocket) and polylines (descent/boost/predicted) render on top of the tile overlay exactly as today, so existing map features carry over with no change. `mapType` becomes irrelevant for the offline layer and is replaced by a source picker. |
+| 7 | **Out of scope (v1):** vector maps, worldwide coverage, routing/search, automatic background pre-fetch, sharing regions between devices, non-US imagery. |
+
+---
+
+## 1. Architecture
+
+A single shared subsystem, injected into both map views and the 3D texture fetch.
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │            OfflineMapsManager (facade)        │
+                    │  - current TileSource (Apple | USGS img | …)  │
+                    │  - download(region) / regions / delete        │
+                    └───────────────┬───────────────┬──────────────┘
+                                    │               │
+              ┌─────────────────────▼──┐     ┌──────▼───────────────┐
+              │   TileDownloader       │     │  OfflineRegionStore   │
+              │  region → [z,x,y] →    │     │  manifest of saved    │
+              │  bounded concurrent    │     │  regions (JSON on disk)│
+              │  fetch + progress      │     └───────────────────────┘
+              └───────────┬────────────┘
+                          │ writes
+                ┌─────────▼──────────┐         reads
+                │  OfflineTileCache  │◄───────────────────┐
+                │  Application Support│                    │
+                │  /tiles/<src>/z/x/y │                    │
+                └─────────┬──────────┘                     │
+                          │                                │
+        ┌─────────────────▼─────────────────┐   ┌──────────┴─────────────┐
+        │  CachingTileOverlay : MKTileOverlay│   │ Trajectory3DView texture│
+        │  loadTile: disk → (online) network │   │ fetch (routed through   │
+        │  canReplaceMapContent = true        │   │ the same cache)         │
+        └──────┬───────────────────┬──────────┘   └────────────────────────┘
+               │                   │
+       ┌───────▼──────┐    ┌───────▼───────┐
+       │ RocketMapView│    │DriftCastMapView│   ← add overlay; pins/lines unchanged
+       └──────────────┘    └────────────────┘
+```
+
+### Components
+
+- **`TileSource`** — enum/struct describing a provider: display name, URL template (`{z}/{x}/{y}`), tile format, attribution, `cacheable: Bool`, min/max zoom. `apple` is a special non-tile case (uses MapKit basemap, `cacheable = false`).
+- **`OfflineTileCache`** — maps `(source, z, x, y)` → file path under `Application Support/OfflineTiles/<source>/<z>/<x>/<y>.<ext>`. `tileData(...) -> Data?`, `store(...)`, `bytesOnDisk(for:)`, `removeTiles(in:)`.
+- **`CachingTileOverlay: MKTileOverlay`** — override `loadTile(at:result:)`: return cached bytes if present; else if online, fetch via the URL template, persist, return; else return a neutral "not downloaded" tile. `canReplaceMapContent = true`.
+- **`TileDownloader`** — given a `RegionSpec` (center, radiusMeters, maxZoom), enumerate the `(z,x,y)` set (§3), dedupe, fetch with bounded concurrency (~4–6), persist through `OfflineTileCache`, publish `@Published progress`. Cancelable; resumable (skips tiles already cached).
+- **`OfflineRegionStore`** — persisted manifest (`[Region]`: id, name, center, radius, zoomRange, source, tileCount, bytes, dateSaved). Backs the region-manager UI.
+- **`OfflineMapsManager`** — `ObservableObject` facade injected via `@EnvironmentObject`, holding the active `TileSource` and orchestrating the above. Both map views observe it.
+
+### How each view plugs in
+
+- **`RocketMapView` / `DriftCastMapView`**: in `makeUIView`, if the active source is cacheable, add a `CachingTileOverlay` (level `.aboveLabels` is moot since it replaces content); in `updateUIView`, swap the overlay when the source changes. Everything else (annotations, polylines, region logic) is unchanged.
+- **`Trajectory3DView`**: its `fetchArcGISImagery(...)` becomes a call into `OfflineTileCache` (assemble from cached tiles, or cache the single export image keyed by bbox) so the 3D ground texture is available offline too.
+
+---
+
+## 2. Tile source decision
+
+| Source | Cacheable | Key | Coverage | Notes |
+|---|---|---|---|---|
+| Apple MapKit | ❌ | — | Global | Default *online* layer; cannot be saved. |
+| **USGS Imagery / Topo** ⭐ | ✅ | none | US | Public domain, caching permitted. `https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}`. |
+| Esri World Imagery | ✅* | none | Global | Already used by `Trajectory3DView`. *Verify current ToS for persistent offline caching + attribution before relying on it. |
+| OSM / MapTiler / Mapbox | ✅ | key (most) | Global / vector | For non-US or topo styling later; OSM policy discourages bulk download. |
+
+Recommendation: **USGS imagery as the saved source, USGS topo as a second saved option** (topo is often *more* useful than satellite for spotting recovery terrain — fields, tree lines, roads). Keep Apple Hybrid as the default online layer. The `TileSource` abstraction means Trial 0 swaps these with a one-line change.
+
+---
+
+## 3. Tile math & size estimation
+
+Standard slippy-map tiling. For zoom `z`, `n = 2^z`:
+
+```
+x = floor((lon + 180) / 360 * n)
+y = floor((1 - asinh(tan(lat_rad)) / π) / 2 * n)
+```
+
+For a region (center + radius), compute the lat/lon bbox, then for each `z` in `[minZoom…maxZoom]` take the tile rectangle `[xmin…xmax] × [ymin…ymax]`; union across zooms, dedupe.
+
+**Size estimate** (shown before download): `Σ_z (tilesAtZoom_z) × avgTileBytes`, with `avgTileBytes ≈ 25 KB` for imagery (refined empirically in Trial 2). Rough feel for a launch field:
+
+| Area (radius) | maxZoom | ~tiles | ~size |
+|---|---|---|---|
+| 5 km | 16 | ~500 | ~12 MB |
+| 5 km | 17 | ~1,800 | ~45 MB |
+| 10 km | 17 | ~6,500 | ~160 MB |
+| 10 km | 18 | ~26,000 | ~640 MB |
+
+The estimate table *is* the argument for center+radius+capped-zoom and an explicit pre-download confirmation: each extra zoom ~4×'s the count. Default the slider to z16–17 and warn above a threshold (e.g. > 200 MB).
+
+---
+
+## 4. UI / UX
+
+See [`offline-maps-mockups.html`](offline-maps-mockups.html) for rendered screens. Summary:
+
+- **Source picker** (replaces the map-type toggle): Apple Standard · Apple Hybrid · USGS Imagery · USGS Topo. A small badge shows the active source and an "Offline" pill when no network. This control is also the Trial 0 A/B tool.
+- **Save Area sheet**: a map centered on a draggable pin (or "use current location"), a translucent radius circle, a **Radius** stepper and a **Detail (max zoom)** slider, a live `~N tiles · ~M MB · z10–z17` readout, and a **Download** button (disabled until estimate < cap or user confirms a large download).
+- **Download progress**: determinate bar, `1,840 / 3,200 tiles · 27 MB`, **Cancel**. Survives backgrounding; resumable.
+- **Offline Regions manager**: list of saved regions (name, date, size, zoom range, source), per-row delete, total storage line, "Add region". Reachable from both DriftCast and the dashboard.
+- **Missing-tile treatment**: offline + outside a saved area/zoom → a neutral hatched tile with a one-line "Outside saved area" hint, never a crash or infinite spinner.
+
+Entry points: a "layers/offline" button on `RocketMapView`'s existing floating control stack, and the DriftCast map toolbar.
+
+---
+
+## 5. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Imagery looks worse than Apple** (the big one) | Trial 0 on-device A/B *before* any build-out; ship USGS topo too; keep Apple as default online layer. |
+| Tile-count / size explosion | center+radius+capped zoom; estimate before download; warn over threshold; per-region + total caps. |
+| `Caches/` purged → offline data vanishes at the field | store in Application Support, excluded-from-backup. |
+| Provider ToS / rate limits | USGS (public domain) as primary; bounded concurrency; attribution; verify Esri terms before using it for *saved* tiles. |
+| Storage bloat over time | region manager with sizes + delete; show total; optional age-based prompt. |
+| Jank from disk reads while panning | async `loadTile`, in-memory LRU on top of disk; measured in Trial 1. |
+
+---
+
+## 6. Sequencing summary
+
+1. **Trial 0** — source A/B behind a flag in `RocketMapView`. *Gate: worth it?*
+2. **Trial 1** — read-through cache; airplane-mode render.
+3. **Trial 2** — downloader + estimate + progress; download a field, verify offline.
+4. **Phase 3** — share into DriftCast + 3D texture.
+5. **Phase 4** — region store, manager UI, offline indicator, polish.
+
+## 7. Open questions
+
+1. Primary saved source: **USGS Imagery**, USGS Topo, or both selectable? (I lean both.)
+2. Acceptable default size cap / warning threshold per region?
+3. Region selection: center **+ radius** (recommended) vs. free-draw rectangle?
+4. Should "Save this area" auto-suggest a region centered on the DriftCast launch point / last rocket fix?
+5. File a GitHub tracking issue now (to number this plan per the `docs/plans` convention)?

--- a/docs/plans/offline-maps.md
+++ b/docs/plans/offline-maps.md
@@ -1,7 +1,7 @@
 # Offline map tiles for no-signal launch sites
 
 **Issue:** _to be filed_ (tracking issue TBD)
-**Status:** Trial 1 (read-through cache) landed. Trial 0 cleared — standardizing on **Apple** (global, online-only) + **USGS** (cacheable). Esri dropped; international imagery deferred to [#231](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/231).
+**Status:** Implemented — Trials 0–2 + Drift Cast alignment + Phase 4 polish (offline pill, neutral missing-tile fill, cached 3D ground texture). Local on `feat/offline-map-tiles`, not yet pushed. Source set: **Apple** (global, online-only) + **USGS** (cacheable); Esri dropped; international imagery deferred to [#231](https://github.com/Tinkerbug-Robotics/TinkerRocket/issues/231). Remaining/future: pre-download offline 3D from a saved region (today the 3D texture is passive-cached only, like Trial 1 was for 2D).
 **Last updated:** 2026-06-03
 **Mockups:** [`offline-maps-mockups.html`](offline-maps-mockups.html) (open in a browser)
 


### PR DESCRIPTION
## Summary

Offline map imagery for no-signal launch sites. Both map surfaces — **Reverse Drift Cast** and the **Rocket Map** — render on Apple's MapKit basemap, whose tiles can't be cached for offline use. This adds a shared offline stack so you can pre-download imagery for a flying area while you still have signal, and use it later with no cell connection. GPS/telemetry already work offline; this fills in the missing basemap.

Built trial-driven (see `docs/plans/offline-maps.md` + `offline-maps-mockups.html`); the load-bearing decision — imagery quality vs. Apple's basemap — was settled with an on-device A/B before any cache code landed.

## What's included

- **Selectable basemap source** (shared by both map views): Apple Standard/Hybrid (global, online-only) + **USGS** Imagery / Imagery+Topo / Topo (public-domain, cacheable). Only USGS is downloadable (`TileSource.isCacheable`). Esri was trialed and dropped — looked great online but its free terms restrict the persistent offline caching this feature is built around, and Apple already covers global online viewing.
- **Read-through tile cache** (`OfflineTileCache` under Application Support, excluded-from-backup) behind a basemap-replacing `MKTileOverlay`.
- **Region downloader**: pick center + radius + max-zoom over a live preview map with a radius circle, see a tile/MB estimate before committing, download with progress/cancel/resume.
- **Saved-region manager**: list regions (size, zoom, source, date), delete to reclaim space, total storage.
- **Drift Cast aligned** onto the same source picker + cache; its 3D ground texture also moved to USGS + cache (removing the last Esri dependency).
- **Polish**: an "OFFLINE" indicator pill, and a neutral hatch for un-downloaded tiles instead of a blank gap.
- **Drift Cast fix** (surfaced while testing): the map now opens on the phone's current GPS each time, rather than falling back to a hardcoded site once the launch/landing fields were populated.

## Testing

- Builds clean for the iOS Simulator (`xcodebuild`, no errors) at each step.
- Field/on-device verified through the trials: USGS A/B, offline render after a download (force-quit + Airplane Mode), and the current-location default.

## Notes

- US-only coverage (USGS). International cacheable imagery is a tracked follow-up: #231.
- 3D offline is passive-cached (works for a scene viewed once); pre-downloading 3D from a saved region (tile-stitching) is left as a future enhancement, noted in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
