### PR TITLE
ESP-IDF 6.0.1 migration + FC↔OC I2C V2-slave fix (#88)

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: espressif/idf:v5.3.2
+    container: espressif/idf:v6.0.1
 
     strategy:
       fail-fast: false

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -204,12 +204,14 @@ gtest_discover_tests(test_tr_flightlog_core)
 # ---------- test_tr_ota (#8 phase 2) ----------
 # Host coverage for TR_OTA_Receiver: state machine, offset/size validation,
 # SHA-256 verification, callback fan-out. Real esp_ota_* is replaced with
-# FakeOTABackend (tests_cpp/fakes/) and mbedtls/sha256 is replaced with the
-# portable shim in host_shim/.
+# FakeOTABackend (tests_cpp/fakes/) and PSA Crypto (psa/crypto.h, used since the
+# 6.0 migration) is replaced with the portable SHA-256 shim in host_shim/
+# (psa_crypto_impl.c over sha256_impl.c).
 add_executable(test_tr_ota
     test_tr_ota.cpp
     ${LIB_DIR}/TR_OTA/TR_OTA_Receiver.cpp
     ${SHIM_DIR}/sha256_impl.c
+    ${SHIM_DIR}/psa_crypto_impl.c
 )
 target_include_directories(test_tr_ota PRIVATE
     ${SHIM_DIR}

--- a/tests_cpp/host_shim/psa/crypto.h
+++ b/tests_cpp/host_shim/psa/crypto.h
@@ -1,0 +1,42 @@
+// Host-side psa/crypto.h shim. Mirrors the subset of the PSA Crypto hashing
+// API used by TR_OTA_Receiver (ESP-IDF 6.0+ uses the real TF-PSA-Crypto;
+// mbedtls/sha256.h became private). Backed by the portable SHA-256 in
+// sha256_impl.c via the mbedtls shim, so host unit tests exercise the real
+// PSA code path against a correct digest. Host tests only.
+#ifndef HOST_SHIM_PSA_CRYPTO_H
+#define HOST_SHIM_PSA_CRYPTO_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "mbedtls/sha256.h"   // reuse the host SHA-256 implementation
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int32_t  psa_status_t;
+typedef uint32_t psa_algorithm_t;
+
+#define PSA_SUCCESS         ((psa_status_t)0)
+#define PSA_ALG_SHA_256     ((psa_algorithm_t)0x02000009)  // real PSA value (shim ignores it)
+
+typedef struct {
+    mbedtls_sha256_context ctx;
+    int active;
+} psa_hash_operation_t;
+
+#define PSA_HASH_OPERATION_INIT { {0}, 0 }
+
+psa_status_t psa_crypto_init(void);
+psa_status_t psa_hash_setup(psa_hash_operation_t* operation, psa_algorithm_t alg);
+psa_status_t psa_hash_update(psa_hash_operation_t* operation,
+                             const uint8_t* input, size_t input_length);
+psa_status_t psa_hash_finish(psa_hash_operation_t* operation,
+                             uint8_t* hash, size_t hash_size, size_t* hash_length);
+psa_status_t psa_hash_abort(psa_hash_operation_t* operation);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HOST_SHIM_PSA_CRYPTO_H

--- a/tests_cpp/host_shim/psa_crypto_impl.c
+++ b/tests_cpp/host_shim/psa_crypto_impl.c
@@ -1,0 +1,48 @@
+// Host PSA Crypto hashing shim backing psa/crypto.h, implemented over the
+// portable SHA-256 in sha256_impl.c (via the mbedtls/sha256.h shim). Lets
+// TR_OTA_Receiver's PSA code path compile and produce a correct SHA-256 in
+// host unit tests. ESP-IDF 6.0+ builds use the real TF-PSA-Crypto.
+#include "psa/crypto.h"
+
+psa_status_t psa_crypto_init(void)
+{
+    return PSA_SUCCESS;  // nothing to initialize for the host shim
+}
+
+psa_status_t psa_hash_setup(psa_hash_operation_t* op, psa_algorithm_t alg)
+{
+    (void)alg;  // shim only does SHA-256
+    if (!op) return (psa_status_t)-1;
+    mbedtls_sha256_init(&op->ctx);
+    mbedtls_sha256_starts(&op->ctx, 0);  // 0 = SHA-256 (not 224)
+    op->active = 1;
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_hash_update(psa_hash_operation_t* op,
+                             const uint8_t* input, size_t input_length)
+{
+    if (!op || !op->active) return (psa_status_t)-1;
+    mbedtls_sha256_update(&op->ctx, input, input_length);
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_hash_finish(psa_hash_operation_t* op,
+                             uint8_t* hash, size_t hash_size, size_t* hash_length)
+{
+    if (!op || !op->active) return (psa_status_t)-1;
+    if (hash_size < 32) return (psa_status_t)-1;
+    mbedtls_sha256_finish(&op->ctx, hash);
+    if (hash_length) *hash_length = 32;
+    op->active = 0;
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_hash_abort(psa_hash_operation_t* op)
+{
+    if (op && op->active) {
+        mbedtls_sha256_free(&op->ctx);
+        op->active = 0;
+    }
+    return PSA_SUCCESS;
+}

--- a/tinkerrocket-idf/components/RadioLib/CMakeLists.txt
+++ b/tinkerrocket-idf/components/RadioLib/CMakeLists.txt
@@ -17,8 +17,13 @@ if(ESP_PLATFORM)
   idf_component_register(
     SRCS ${RADIOLIB_SOURCES}
     INCLUDE_DIRS . src
-    REQUIRES driver
+    REQUIRES esp_driver_gpio driver
   )
+
+  # RadioLib (vendored) trips GCC-14's -Woverloaded-virtual: PhysicalLayer base
+  # methods are hidden by derived overloads. It's upstream third-party code, so
+  # downgrade that one warning from error rather than patch their sources (#88, 6.0).
+  target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=overloaded-virtual)
 
   return()
 endif()

--- a/tinkerrocket-idf/components/TR_BMP585/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_BMP585/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "TR_BMP585.cpp" "bmp5.c"
                        INCLUDE_DIRS "."
-                       REQUIRES driver esp_timer esp_rom)
+                       REQUIRES esp_driver_gpio esp_driver_spi driver esp_timer esp_rom)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_BQ27Z746/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_BQ27Z746/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_BQ27Z746.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_BQ27Z746.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_Compat/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_Compat/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
     INCLUDE_DIRS "include"
-    REQUIRES driver esp_timer
+    REQUIRES esp_driver_gpio esp_driver_spi driver esp_timer
 )

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_GNSSReceiverUBlox_Serial.cpp" "u-blox_GNSS.cpp" "sfe_bus.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_RocketComputerTypes driver)
+idf_component_register(SRCS "TR_GNSSReceiverUBlox_Serial.cpp" "u-blox_GNSS.cpp" "sfe_bus.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_uart TR_Compat TR_RocketComputerTypes driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_I2C_Interface/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_I2C_Interface.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_RocketComputerTypes CRC PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_I2C_Interface.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat TR_RocketComputerTypes CRC PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -3,14 +3,35 @@
 #include <cstring>
 #include <esp_log.h>
 
+// This component targets the ESP-IDF V2 I2C slave driver (on_receive /
+// on_request + i2c_slave_write). On IDF 5.4/5.5 that requires the option
+// below; on 6.0+ V2 is the only slave driver and the macro is absent, so
+// this guard is a no-op there.
+#if defined(CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2) && !CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
+#error "TR_I2C_Interface needs the V2 slave driver: set CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y"
+#endif
+
 static const char *TAG = "I2C_IF";
+
+// I2C slave TX service task (services the V2 on_request callback by writing
+// the staged response). Pinned to the slave ISR's core and run at high
+// priority so it clears the V2 address-match SCL stretch well within the
+// hardware stretch-protect window (I2C_LL_STRETCH_PROTECT_TIME ~= 2.55 ms at
+// 400 kHz) — otherwise the master sees a held bus and wedges on clear_bus.
+static constexpr uint32_t    SLAVE_TX_TASK_STACK       = 3072;
+static constexpr UBaseType_t SLAVE_TX_TASK_PRIO        = 20;
+static constexpr int         SLAVE_TX_WRITE_TIMEOUT_MS = 20;
 
 TR_I2C_Interface::TR_I2C_Interface(uint8_t device_address_7bit)
     : device_address(device_address_7bit),
       _master_bus(nullptr),
       _master_dev(nullptr),
       _slave_dev(nullptr),
-      _rx_queue(nullptr)
+      _rx_queue(nullptr),
+      _tx_req_queue(nullptr),
+      _tx_mux(nullptr),
+      _tx_task(nullptr),
+      _tx_len(0)
 {
 }
 
@@ -60,26 +81,32 @@ esp_err_t TR_I2C_Interface::beginSlave(int sda_pin,
                                        size_t tx_buffer_len,
                                        bool enable_internal_pullups)
 {
-    (void)clock_hz;       // slave clock is driven by master
-    (void)rx_buffer_len;  // new API uses per-transaction buffers
+    (void)clock_hz;  // slave clock is driven by master
 
-    // Queue for ISR → task notification of completed receives
-    _rx_queue = xQueueCreate(4, sizeof(uint8_t *));
-    if (_rx_queue == nullptr)
+    // ISR -> task signals: _rx_queue carries each received frame's byte count;
+    // _tx_req_queue carries one token per master-read request. _tx_mux guards
+    // the staged TX response shared between writeToSlave() and slaveTxTask().
+    _rx_queue     = xQueueCreate(4, sizeof(size_t));
+    _tx_req_queue = xQueueCreate(4, sizeof(uint8_t));
+    _tx_mux       = xSemaphoreCreateMutex();
+    if (_rx_queue == nullptr || _tx_req_queue == nullptr || _tx_mux == nullptr)
     {
-        ESP_LOGE(TAG, "Failed to create slave RX queue");
+        ESP_LOGE(TAG, "Failed to create slave queues/mutex");
         return ESP_ERR_NO_MEM;
     }
+    _tx_len = 0;
 
     i2c_slave_config_t slave_cfg = {};
     slave_cfg.i2c_port = I2C_NUM_0;
     slave_cfg.sda_io_num = static_cast<gpio_num_t>(sda_pin);
     slave_cfg.scl_io_num = static_cast<gpio_num_t>(scl_pin);
     slave_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
-    slave_cfg.send_buf_depth = tx_buffer_len;
+    slave_cfg.send_buf_depth = tx_buffer_len;     // TX ringbuffer depth
+    slave_cfg.receive_buf_depth = rx_buffer_len;  // driver-owned RX ring
     slave_cfg.slave_addr = device_address;
     slave_cfg.addr_bit_len = I2C_ADDR_BIT_LEN_7;
     slave_cfg.intr_priority = 0;
+    slave_cfg.flags.enable_internal_pullup = enable_internal_pullups;
 
     esp_err_t err = i2c_new_slave_device(&slave_cfg, &_slave_dev);
     if (err != ESP_OK)
@@ -88,33 +115,49 @@ esp_err_t TR_I2C_Interface::beginSlave(int sda_pin,
         return err;
     }
 
-    // Register receive-done callback
+    memset(_slave_rx_buf, 0, SLAVE_RX_BUF_SIZE);
+
+    // Start the TX service task before registering callbacks so the consumer
+    // is ready the instant on_request can fire. Pin it to the core this runs
+    // on — the slave ISR is allocated on the same core, so on_request -> task
+    // wakeups stay on-core and clear the SCL stretch with minimal latency.
+    BaseType_t task_ok = xTaskCreatePinnedToCore(slaveTxTask, "i2c_slv_tx",
+                                                 SLAVE_TX_TASK_STACK, this,
+                                                 SLAVE_TX_TASK_PRIO, &_tx_task,
+                                                 xPortGetCoreID());
+    if (task_ok != pdPASS)
+    {
+        ESP_LOGE(TAG, "Failed to create I2C slave TX task");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Register both halves of the V2 slave protocol: on_receive (master writes
+    // land in our RX ring) and on_request (master reads -> wake the TX task).
+    // The V2 driver auto-receives, so there is no i2c_slave_receive() arming
+    // call as in V1.
     i2c_slave_event_callbacks_t cbs = {};
-    cbs.on_recv_done = slaveRxDoneISR;
+    cbs.on_receive = slaveReceiveISR;
+    cbs.on_request = slaveRequestISR;
     err = i2c_slave_register_event_callbacks(_slave_dev, &cbs, this);
     if (err != ESP_OK)
     {
         ESP_LOGE(TAG, "i2c_slave_register_event_callbacks failed: %s", esp_err_to_name(err));
+        vTaskDelete(_tx_task);
+        _tx_task = nullptr;
         return err;
     }
 
-    // Zero the buffer and arm the first receive
-    memset(_slave_rx_buf, 0, SLAVE_RX_BUF_SIZE);
-    err = i2c_slave_receive(_slave_dev, _slave_rx_buf, SLAVE_RX_BUF_SIZE);
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "i2c_slave_receive (initial arm) failed: %s", esp_err_to_name(err));
-    }
-    return err;
+    return ESP_OK;
 }
 
 // ---------------------------------------------------------------------------
-//  Slave RX done ISR callback
-//  The new API fires this when the master completes a write transaction
-//  (STOP condition). edata->buffer points to our _slave_rx_buf.
-//  We post the buffer pointer to the queue so readFromSlave() can pick it up.
+//  Slave on_receive ISR (V2): master finished a write transaction.
+//  edata->buffer is driver-owned and reused on the next receive, so copy the
+//  payload into our class-scoped _slave_rx_buf and post the byte count to
+//  _rx_queue. Single-buffer: a second master write before readFromSlave()
+//  consumes the first overwrites it — acceptable at the FC->OC poll rate.
 // ---------------------------------------------------------------------------
-bool IRAM_ATTR TR_I2C_Interface::slaveRxDoneISR(
+bool IRAM_ATTR TR_I2C_Interface::slaveReceiveISR(
     i2c_slave_dev_handle_t channel,
     const i2c_slave_rx_done_event_data_t *edata,
     void *user_data)
@@ -123,11 +166,91 @@ bool IRAM_ATTR TR_I2C_Interface::slaveRxDoneISR(
     auto *self = static_cast<TR_I2C_Interface *>(user_data);
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-    // Post the buffer pointer (for identification, not ownership transfer)
-    uint8_t *buf = edata->buffer;
-    xQueueSendFromISR(self->_rx_queue, &buf, &xHigherPriorityTaskWoken);
+    size_t copy_len = edata->length;
+    if (copy_len > SLAVE_RX_BUF_SIZE)
+    {
+        copy_len = SLAVE_RX_BUF_SIZE;
+    }
+    memcpy(self->_slave_rx_buf, edata->buffer, copy_len);
+    xQueueSendFromISR(self->_rx_queue, &copy_len, &xHigherPriorityTaskWoken);
 
     return xHigherPriorityTaskWoken == pdTRUE;
+}
+
+// ---------------------------------------------------------------------------
+//  Slave on_request ISR (V2): master is addressing us for a read. We cannot
+//  call i2c_slave_write() here (it takes a mutex), so post a token and let the
+//  TX service task perform the write — that feeds the master and releases the
+//  address-match SCL stretch.
+// ---------------------------------------------------------------------------
+bool IRAM_ATTR TR_I2C_Interface::slaveRequestISR(
+    i2c_slave_dev_handle_t channel,
+    const i2c_slave_request_event_data_t *edata,
+    void *user_data)
+{
+    (void)channel;
+    (void)edata;
+    auto *self = static_cast<TR_I2C_Interface *>(user_data);
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+    const uint8_t token = 1;
+    xQueueSendFromISR(self->_tx_req_queue, &token, &xHigherPriorityTaskWoken);
+
+    return xHigherPriorityTaskWoken == pdTRUE;
+}
+
+// ---------------------------------------------------------------------------
+//  Slave TX service task: blocks on _tx_req_queue, then writes the staged
+//  response with i2c_slave_write() (which also clears the SCL stretch). If
+//  nothing has been staged yet, it writes a single zero byte so the master's
+//  read still completes and the bus is released promptly instead of hanging
+//  until the hardware stretch-protect timer.
+//
+//  Wire-alignment note: i2c_slave_write() pushes exactly _tx_len bytes; the FC
+//  reads a fixed size and resyncs on the SOF marker, so a small size mismatch
+//  is tolerated. Watch for cumulative drift on the bench — if the staged size
+//  and the master read size differ, leftover TX bytes can accumulate in the
+//  ringbuffer across polls.
+// ---------------------------------------------------------------------------
+void TR_I2C_Interface::slaveTxTask(void *arg)
+{
+    auto *self = static_cast<TR_I2C_Interface *>(arg);
+    uint8_t token = 0;
+
+    for (;;)
+    {
+        if (xQueueReceive(self->_tx_req_queue, &token, portMAX_DELAY) != pdTRUE)
+        {
+            continue;
+        }
+
+        // Snapshot the staged response under the mutex, then write outside it.
+        uint8_t local[SLAVE_TX_BUF_SIZE];
+        size_t len = 0;
+        if (xSemaphoreTake(self->_tx_mux, portMAX_DELAY) == pdTRUE)
+        {
+            len = self->_tx_len;
+            if (len > SLAVE_TX_BUF_SIZE)
+            {
+                len = SLAVE_TX_BUF_SIZE;
+            }
+            if (len > 0)
+            {
+                memcpy(local, self->_tx_buf, len);
+            }
+            xSemaphoreGive(self->_tx_mux);
+        }
+
+        if (len == 0)
+        {
+            local[0] = 0x00;
+            len = 1;
+        }
+
+        uint32_t written = 0;
+        i2c_slave_write(self->_slave_dev, local, static_cast<uint32_t>(len),
+                        &written, SLAVE_TX_WRITE_TIMEOUT_MS);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -195,8 +318,11 @@ int TR_I2C_Interface::readFromSlave(uint8_t* out_buf,
         return -1;
     }
 
-    uint8_t *buf_ptr = nullptr;
-    if (xQueueReceive(_rx_queue, &buf_ptr, pdMS_TO_TICKS(timeout_ms)) != pdTRUE)
+    // The on_receive ISR already copied the master-write payload into
+    // _slave_rx_buf and posted its byte count. The V2 driver auto-re-arms via
+    // its internal RX ring, so there is no explicit re-arming here.
+    size_t rx_len = 0;
+    if (xQueueReceive(_rx_queue, &rx_len, pdMS_TO_TICKS(timeout_ms)) != pdTRUE)
     {
         return 0; // no data available
     }
@@ -204,42 +330,29 @@ int TR_I2C_Interface::readFromSlave(uint8_t* out_buf,
     // Determine valid data length from frame protocol:
     // SOF(4) + type(1) + len(1) + payload(len) + CRC(2)
     size_t valid_len = 0;
-    if (buf_ptr[0] == SOF0 && buf_ptr[1] == SOF1 &&
-        buf_ptr[2] == SOF2 && buf_ptr[3] == SOF3)
+    if (rx_len >= 6 &&
+        _slave_rx_buf[0] == SOF0 && _slave_rx_buf[1] == SOF1 &&
+        _slave_rx_buf[2] == SOF2 && _slave_rx_buf[3] == SOF3)
     {
-        size_t payload_len = buf_ptr[5];
+        size_t payload_len = _slave_rx_buf[5];
         valid_len = 4 + 1 + 1 + payload_len + 2; // SOF + type + len + payload + CRC
-        if (valid_len > SLAVE_RX_BUF_SIZE)
+        if (valid_len > rx_len)
         {
-            valid_len = SLAVE_RX_BUF_SIZE; // safety clamp
+            valid_len = rx_len; // clamp to actually-received bytes
         }
     }
     else
     {
-        // Non-framed data or corrupted — return whatever we can
-        // Scan backwards for last non-zero byte
-        valid_len = SLAVE_RX_BUF_SIZE;
-        while (valid_len > 0 && buf_ptr[valid_len - 1] == 0)
-        {
-            valid_len--;
-        }
+        valid_len = rx_len;
     }
 
     if (valid_len == 0)
     {
-        // Re-arm and return no data
-        memset(_slave_rx_buf, 0, SLAVE_RX_BUF_SIZE);
-        i2c_slave_receive(_slave_dev, _slave_rx_buf, SLAVE_RX_BUF_SIZE);
         return 0;
     }
 
     size_t copy_len = (valid_len < out_buf_capacity) ? valid_len : out_buf_capacity;
-    memcpy(out_buf, buf_ptr, copy_len);
-
-    // Zero the buffer and re-arm for next receive
-    memset(_slave_rx_buf, 0, SLAVE_RX_BUF_SIZE);
-    i2c_slave_receive(_slave_dev, _slave_rx_buf, SLAVE_RX_BUF_SIZE);
-
+    memcpy(out_buf, _slave_rx_buf, copy_len);
     return static_cast<int>(copy_len);
 }
 
@@ -250,15 +363,28 @@ int TR_I2C_Interface::writeToSlave(const uint8_t* data,
                                    size_t len,
                                    uint32_t timeout_ms)
 {
-    if (data == nullptr || len == 0 || _slave_dev == nullptr)
+    if (data == nullptr || len == 0 || _slave_dev == nullptr || _tx_mux == nullptr)
     {
         return -1;
     }
-    esp_err_t err = i2c_slave_transmit(_slave_dev,
-                                       data,
-                                       static_cast<int>(len),
-                                       static_cast<int>(timeout_ms));
-    return (err == ESP_OK) ? static_cast<int>(len) : -1;
+    if (len > SLAVE_TX_BUF_SIZE)
+    {
+        len = SLAVE_TX_BUF_SIZE; // clamp to staging capacity
+    }
+
+    // Stage the latest response; slaveTxTask() serves it when on_request
+    // fires. Non-blocking when timeout_ms == 0: if the task momentarily holds
+    // the mutex, drop this update (the next poll stages a fresh one) — the
+    // same drop-on-contention behaviour the V1 path had on a full TX FIFO.
+    if (xSemaphoreTake(_tx_mux, pdMS_TO_TICKS(timeout_ms)) != pdTRUE)
+    {
+        return -1;
+    }
+    memcpy(_tx_buf, data, len);
+    _tx_len = len;
+    xSemaphoreGive(_tx_mux);
+
+    return static_cast<int>(len);
 }
 
 // ---------------------------------------------------------------------------

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -68,6 +68,14 @@ esp_err_t TR_I2C_Interface::beginMaster(int sda_pin,
     dev_cfg.dev_addr_length = I2C_ADDR_BIT_LEN_7;
     dev_cfg.device_address  = device_address;
     dev_cfg.scl_speed_hz    = clock_hz;
+    // The OC slave runs the ESP-IDF V2 driver, which stretches SCL on
+    // address-match until its on_request TX task calls i2c_slave_write
+    // (bounded by the ~2.56 ms hardware stretch-protect timer @ 400 kHz). The
+    // master's default SCL-wait (I2C_LL_SCL_WAIT_US_VAL_DEFAULT = 2000 us) is
+    // shorter than that window, so reads abort mid-stretch (#88 bench:
+    // "[I2C] read FAIL ... dur~2400us", query ok/fail=0/N). Wait past the
+    // protect timer so the master tolerates the V2 slave's stretch.
+    dev_cfg.scl_wait_us     = 5000;
 
     err = i2c_master_bus_add_device(_master_bus, &dev_cfg, &_master_dev);
     if (err != ESP_OK)

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -2,13 +2,19 @@
 #include <CRC.h>
 #include <cstring>
 #include <esp_log.h>
+#include <esp_idf_version.h>
 
 // This component targets the ESP-IDF V2 I2C slave driver (on_receive /
-// on_request + i2c_slave_write). On IDF 5.4/5.5 that requires the option
-// below; on 6.0+ V2 is the only slave driver and the macro is absent, so
-// this guard is a no-op there.
-#if defined(CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2) && !CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
-#error "TR_I2C_Interface needs the V2 slave driver: set CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y"
+// on_request + i2c_slave_write). Pre-6.0 it is opt-in, and a *missing* flag
+// (Kconfig "not set" => undefined macro, not defined-to-0) silently exposes
+// the V1 API — yielding a wall of confusing "no member 'on_receive'" /
+// "i2c_slave_write not declared" errors. Key the guard off the IDF version so
+// it fires on absent-OR-disabled, not just disabled. (On 6.0+ V2 is the only
+// slave driver and the flag no longer exists.)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+#  if !defined(CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2) || !CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
+#    error "TR_I2C_Interface requires the V2 I2C slave driver. Set CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y in sdkconfig.defaults, then regenerate sdkconfig (idf.py set-target <chip>)."
+#  endif
 #endif
 
 static const char *TAG = "I2C_IF";

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
@@ -6,6 +6,8 @@
 #include <driver/i2c_slave.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 #include <RocketComputerTypes.h>
 
 class TR_I2C_Interface
@@ -67,10 +69,25 @@ private:
     static constexpr uint8_t SOF2 = 0xAA;
     static constexpr uint8_t SOF3 = 0x55;
 
-    // Slave RX callback — signals that a receive transaction completed
-    static bool IRAM_ATTR slaveRxDoneISR(i2c_slave_dev_handle_t channel,
+    // --- Slave callbacks (ESP-IDF V2 slave driver; run in ISR context) ----
+    // on_receive: master finished writing to us. The driver-owned buffer is
+    // reused on the next receive, so we memcpy it into _slave_rx_buf and post
+    // the byte count to _rx_queue for readFromSlave() to pick up.
+    static bool IRAM_ATTR slaveReceiveISR(i2c_slave_dev_handle_t channel,
                                           const i2c_slave_rx_done_event_data_t *edata,
                                           void *user_data);
+    // on_request: master is addressing us for a read. The V2 driver stretches
+    // SCL on address-match and only releases it when i2c_slave_write() runs —
+    // but that call takes a mutex and is illegal in ISR context. So we just
+    // wake slaveTxTask(), which performs the write (feeding the master and
+    // clearing the stretch). This is the fix for the #88 V2 bus-wedge: the
+    // earlier attempt left on_request unregistered, so reads never got served
+    // and the bus hung until the hardware stretch-protect timer.
+    static bool IRAM_ATTR slaveRequestISR(i2c_slave_dev_handle_t channel,
+                                          const i2c_slave_request_event_data_t *edata,
+                                          void *user_data);
+    // TX service task: blocks on _tx_req_queue, writes the staged response.
+    static void slaveTxTask(void *arg);
 
     uint8_t device_address;
 
@@ -81,11 +98,22 @@ private:
     // Slave mode handles
     i2c_slave_dev_handle_t _slave_dev;
 
-    // Slave RX: ISR posts buffer pointer to queue, readFromSlave dequeues.
-    // The frame protocol (SOF + len) determines how many bytes are valid.
+    // Slave RX: on_receive ISR copies the received frame into _slave_rx_buf
+    // and posts its byte count to _rx_queue; readFromSlave() dequeues + parses
+    // the framed message (SOF + len) from it.
     QueueHandle_t _rx_queue;
     static constexpr size_t SLAVE_RX_BUF_SIZE = 256;
     uint8_t _slave_rx_buf[SLAVE_RX_BUF_SIZE];
+
+    // Slave TX: writeToSlave() stages the latest response into _tx_buf under
+    // _tx_mux. on_request posts a token to _tx_req_queue; slaveTxTask() wakes,
+    // snapshots the staged bytes, and calls i2c_slave_write().
+    QueueHandle_t _tx_req_queue;
+    SemaphoreHandle_t _tx_mux;
+    TaskHandle_t _tx_task;
+    static constexpr size_t SLAVE_TX_BUF_SIZE = 256;
+    uint8_t _tx_buf[SLAVE_TX_BUF_SIZE];
+    volatile size_t _tx_len;
 };
 
 #endif

--- a/tinkerrocket-idf/components/TR_I2S_Stream/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "TR_I2S_Stream.cpp"
     INCLUDE_DIRS "."
-    REQUIRES TR_Compat TR_I2C_Interface TR_RocketComputerTypes
+    REQUIRES esp_driver_gpio esp_driver_i2s TR_Compat TR_I2C_Interface TR_RocketComputerTypes
     PRIV_REQUIRES driver esp_driver_i2s esp_driver_gpio
 )

--- a/tinkerrocket-idf/components/TR_IIS2MDC/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_IIS2MDC/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_IIS2MDC.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_IIS2MDC.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_INA230/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_INA230/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_INA230.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_INA230.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_ISM6HG256/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_ISM6HG256/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "TR_ISM6HG256.cpp" "ism6hg256x_reg.c"
                        INCLUDE_DIRS "."
-                       REQUIRES driver esp_rom)
+                       REQUIRES esp_driver_gpio esp_driver_spi driver esp_rom)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_LoRa_Comms.cpp" INCLUDE_DIRS "." REQUIRES RadioLib TR_Compat driver esp_timer)
+idf_component_register(SRCS "TR_LoRa_Comms.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_gpio esp_driver_spi RadioLib TR_Compat driver esp_timer)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MAX17205G/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MAX17205G/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_MAX17205G.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_MAX17205G.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MMC5983MA/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MMC5983MA/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "TR_MMC5983MA.cpp"
                        INCLUDE_DIRS "."
-                       REQUIRES driver freertos)
+                       REQUIRES esp_driver_gpio esp_driver_spi driver freertos)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_OTA/TR_OTA_Receiver.cpp
+++ b/tinkerrocket-idf/components/TR_OTA/TR_OTA_Receiver.cpp
@@ -3,7 +3,9 @@
 #include <cstdlib>
 #include <cstring>
 
-#include <mbedtls/sha256.h>
+// ESP-IDF 6.0 (TF-PSA-Crypto) made mbedtls' low-level <mbedtls/sha256.h>
+// private. Use the public PSA Crypto hashing API for the OTA image digest.
+#include <psa/crypto.h>
 
 TR_OTA_Receiver::TR_OTA_Receiver(TR_OTA_Backend& backend)
     : backend_(backend)
@@ -46,10 +48,17 @@ void TR_OTA_Receiver::notify()
 void TR_OTA_Receiver::initShaCtx()
 {
     freeShaCtx();
-    auto* ctx = static_cast<mbedtls_sha256_context*>(std::malloc(sizeof(mbedtls_sha256_context)));
+    // psa_crypto_init() is idempotent; safe to call on each session start.
+    if (psa_crypto_init() != PSA_SUCCESS) return;
+    auto* ctx = static_cast<psa_hash_operation_t*>(std::malloc(sizeof(psa_hash_operation_t)));
     if (!ctx) return;
-    mbedtls_sha256_init(ctx);
-    mbedtls_sha256_starts(ctx, 0);  // 0 = SHA-256 (not 224)
+    static const psa_hash_operation_t kInit = PSA_HASH_OPERATION_INIT;
+    *ctx = kInit;
+    if (psa_hash_setup(ctx, PSA_ALG_SHA_256) != PSA_SUCCESS)
+    {
+        std::free(ctx);
+        return;
+    }
     sha_ctx_ = ctx;
 }
 
@@ -57,8 +66,8 @@ void TR_OTA_Receiver::freeShaCtx()
 {
     if (sha_ctx_)
     {
-        auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
-        mbedtls_sha256_free(ctx);
+        auto* ctx = static_cast<psa_hash_operation_t*>(sha_ctx_);
+        psa_hash_abort(ctx);  // safe on an already-finished/inactive op
         std::free(ctx);
         sha_ctx_ = nullptr;
     }
@@ -67,17 +76,21 @@ void TR_OTA_Receiver::freeShaCtx()
 void TR_OTA_Receiver::shaUpdate(const uint8_t* data, size_t len)
 {
     if (!sha_ctx_) return;
-    auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
-    mbedtls_sha256_update(ctx, data, len);
+    auto* ctx = static_cast<psa_hash_operation_t*>(sha_ctx_);
+    psa_hash_update(ctx, data, len);
 }
 
 bool TR_OTA_Receiver::shaFinalAndCompare(const uint8_t expected[32])
 {
     if (!sha_ctx_) return false;
-    auto* ctx = static_cast<mbedtls_sha256_context*>(sha_ctx_);
+    auto* ctx = static_cast<psa_hash_operation_t*>(sha_ctx_);
     uint8_t computed[32];
-    mbedtls_sha256_finish(ctx, computed);
-    return std::memcmp(computed, expected, 32) == 0;
+    size_t computed_len = 0;
+    if (psa_hash_finish(ctx, computed, sizeof(computed), &computed_len) != PSA_SUCCESS)
+    {
+        return false;
+    }
+    return (computed_len == 32) && (std::memcmp(computed, expected, 32) == 0);
 }
 
 TR_OTA_Receiver::Error TR_OTA_Receiver::begin(uint32_t total_size, const uint8_t sha256[32])

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "TR_Sensor_Collector.cpp"
                        INCLUDE_DIRS "."
-                       REQUIRES TR_RocketComputerTypes TR_ISM6HG256 TR_BMP585 TR_MMC5983MA TR_IIS2MDC TR_GNSSReceiverUBlox_Serial
+                       REQUIRES esp_driver_gpio esp_driver_i2c TR_RocketComputerTypes TR_ISM6HG256 TR_BMP585 TR_MMC5983MA TR_IIS2MDC TR_GNSSReceiverUBlox_Serial
                                 driver esp_timer esp_rom)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_ServoControl_ledc_mult.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_PID PRIV_REQUIRES driver)
+idf_component_register(SRCS "TR_ServoControl_ledc_mult.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_ledc TR_Compat TR_PID PRIV_REQUIRES driver)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/spi_nand_flash/CMakeLists.txt
+++ b/tinkerrocket-idf/components/spi_nand_flash/CMakeLists.txt
@@ -45,5 +45,5 @@ endif()
 idf_component_register(SRCS ${srcs}
         INCLUDE_DIRS ${inc}
         PRIV_INCLUDE_DIRS ${priv_inc}
-        REQUIRES ${reqs}
+        REQUIRES esp_driver_spi ${reqs}
         PRIV_REQUIRES ${priv_reqs})

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -2,7 +2,7 @@ idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
     REQUIRES
-        TR_Compat
+        esp_driver_i2c esp_driver_spi TR_Compat
         TR_NVS
         TR_RocketComputerTypes
         TR_Sensor_Data_Converter

--- a/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
@@ -38,8 +38,3 @@ CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 
 # FAT filesystem — enable long filenames (required for timestamped CSV logs)
 CONFIG_FATFS_LFN_HEAP=y
-
-# I2C slave driver V2: BS doesn't use slave functionality, but IDF builds the
-# shared TR_I2C_Interface component for every project, so the flag must match
-# OC/FC for the same .cpp to compile. See issue #88.
-CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y

--- a/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
@@ -38,3 +38,8 @@ CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 
 # FAT filesystem — enable long filenames (required for timestamped CSV logs)
 CONFIG_FATFS_LFN_HEAP=y
+
+# I2C slave driver V2: BS doesn't use slave functionality, but IDF builds the
+# shared TR_I2C_Interface component for every project, so the flag must match
+# OC/FC for the same .cpp to compile. See issue #88.
+CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y

--- a/tinkerrocket-idf/projects/flight_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/flight_computer/dependencies.lock
@@ -9,10 +9,10 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.3
+    version: 6.0.1
 direct_dependencies:
 - espressif/dhara
 - idf
 manifest_hash: 6f4972c0cd856d2015cba9831063a6a730deae8bd16edbea178fa4c6411182a3
 target: esp32p4
-version: 2.0.0
+version: 3.0.0

--- a/tinkerrocket-idf/projects/flight_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/flight_computer/dependencies.lock
@@ -9,7 +9,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.3.2
+    version: 5.5.3
 direct_dependencies:
 - espressif/dhara
 - idf

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -12,7 +12,7 @@ idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
     REQUIRES
-        TR_NVS
+        esp_driver_gpio esp_driver_spi esp_driver_uart TR_NVS
         TR_RocketComputerTypes
         TR_Sensor_Collector
         TR_Sensor_Collector_Sim

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4260,10 +4260,14 @@ static void loop_fc()
                         pin_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
                         gpio_config(&pin_cfg);
 
+                        // Force IO MUX back to plain GPIO. gpio_iomux_out()
+                        // was removed in ESP-IDF 6.0; gpio_func_sel(.., PIN_FUNC_GPIO)
+                        // is the supported replacement and matches the canonical
+                        // safePyroOutputInit() path above.
                         esp_rom_gpio_connect_out_signal(arm_pin, SIG_GPIO_OUT_IDX, false, false);
-                        gpio_iomux_out(arm_pin, 1, false);
+                        gpio_func_sel(arm_pin, PIN_FUNC_GPIO);
                         esp_rom_gpio_connect_out_signal(fire_pin, SIG_GPIO_OUT_IDX, false, false);
-                        gpio_iomux_out(fire_pin, 1, false);
+                        gpio_func_sel(fire_pin, PIN_FUNC_GPIO);
 
                         // ARM → settle → FIRE pulse → disarm (synchronous; ground only)
                         portENTER_CRITICAL(&pyro_spinlock);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2451,8 +2451,14 @@ static void setup_fc()
                 delay_ms(20);  // let OC service the request and queue the response
 
                 constexpr size_t kRespFrameLen = 4 + 1 + 1 + sizeof(FlightSnapshotData) + 2;
-                uint8_t buf[kRespFrameLen + 16] = {};  // + slack for SOF byte loss
-                esp_err_t rerr = i2c_interface.masterRead(buf, sizeof(buf), 100);
+                // Read EXACTLY the staged frame size. The OC stages
+                // kRespFrameLen bytes; under the V2 slave driver, clocking out
+                // more than was staged underflows the TX path (the +16 "SOF
+                // byte loss" slack was a V1-only defense and V2 keeps the SOF
+                // at offset 0). Over-reading here is the inverse of the #88
+                // status-path residue bug. Buffer keeps slack for the scan.
+                uint8_t buf[kRespFrameLen + 16] = {};
+                esp_err_t rerr = i2c_interface.masterRead(buf, kRespFrameLen, 100);
                 if (rerr == ESP_OK) {
                     // SOF scan — same defensive pattern as the [CFG READ] path.
                     for (size_t off = 0; off + kRespFrameLen <= sizeof(buf); off++) {

--- a/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
@@ -25,12 +25,8 @@ CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 
-# --- IDF 5.5 bench-branch additions (#88) --------------------------------
-# I2C slave driver V2 — FC is I2C master-only, but TR_I2C_Interface includes
-# <driver/i2c_slave.h> unconditionally, so the flag must match OC's.
-CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y
-
-# ESP32-P4 silicon: our boards are v1.x. IDF 5.5 raises the default min chip
+# --- ESP32-P4 / IDF version tuning (#88) ---------------------------------
+# ESP32-P4 silicon: our boards are v1.x. IDF 5.5+ raises the default min chip
 # rev to v3.x, which refuses to boot on v1.x. Accept the legacy series.
 CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
 CONFIG_ESP32P4_REV_MIN_100=y

--- a/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/flight_computer/sdkconfig.defaults
@@ -24,3 +24,21 @@ CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y
 
 # Serial
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# --- IDF 5.5 bench-branch additions (#88) --------------------------------
+# I2C slave driver V2 — FC is I2C master-only, but TR_I2C_Interface includes
+# <driver/i2c_slave.h> unconditionally, so the flag must match OC's.
+CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y
+
+# ESP32-P4 silicon: our boards are v1.x. IDF 5.5 raises the default min chip
+# rev to v3.x, which refuses to boot on v1.x. Accept the legacy series.
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
+CONFIG_ESP32P4_REV_MIN_100=y
+
+# Brownout: IDF 5.5 defaults the P4 detector to 2.6V (LVL_SEL_7), which trips
+# during servo-PWM init on this board. Pin to the most-lenient level (2.42V).
+CONFIG_ESP_BROWNOUT_DET_LVL_SEL_5=y
+
+# Main task stack: the 5.5 default (3584 B) overflows FC's synchronous sensor
+# init when the Arduino loop stack isn't present. Restore the prior 16 KB.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384

--- a/tinkerrocket-idf/projects/out_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/out_computer/dependencies.lock
@@ -9,7 +9,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.3.2
+    version: 5.5.3
 direct_dependencies:
 - espressif/dhara
 - idf

--- a/tinkerrocket-idf/projects/out_computer/dependencies.lock
+++ b/tinkerrocket-idf/projects/out_computer/dependencies.lock
@@ -9,10 +9,10 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.3
+    version: 6.0.1
 direct_dependencies:
 - espressif/dhara
 - idf
 manifest_hash: 6f4972c0cd856d2015cba9831063a6a730deae8bd16edbea178fa4c6411182a3
 target: esp32s3
-version: 2.0.0
+version: 3.0.0

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1111,10 +1111,14 @@ static constexpr size_t FC_COMBINED_READ_SIZE = 96;
 //       Under V2, stage exactly what the FC reads (pad = 0). Staged == read
 //       also avoids the V2 driver's "master clocked out more than staged"
 //       underflow.
-#if CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
-static constexpr size_t I2C_TX_PAD = 0;
+// V2 is in use when the 5.4/5.5 opt-in flag is set, OR unconditionally on
+// 6.0+ (V1 removed). The flag macro is absent on 6.0, so test the version too.
+#include <esp_idf_version.h>
+#if (defined(CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2) && CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2) \
+    || (ESP_IDF_VERSION_MAJOR >= 6)
+static constexpr size_t I2C_TX_PAD = 0;   // V2 slave driver
 #else
-static constexpr size_t I2C_TX_PAD = 1;
+static constexpr size_t I2C_TX_PAD = 1;   // legacy V1
 #endif
 static constexpr size_t I2C_TX_SIZE = FC_COMBINED_READ_SIZE + I2C_TX_PAD;
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1100,11 +1100,22 @@ static bool isConfigCommand(uint8_t cmd)
 // than are in the TX ringbuffer.  Always write exactly this many bytes
 // so the slave hardware never underflows.
 static constexpr size_t FC_COMBINED_READ_SIZE = 96;
-// ESP-IDF I2C slave hardware eats 1 extra byte from the TX ring buffer
-// on each master read (prefetches into shift register, discarded at STOP).
-// Transmit 1 extra padding byte so the eaten byte is padding, not the
-// start of the next response.  FC still reads FC_COMBINED_READ_SIZE.
+// TX-byte accounting differs by slave-driver version (#88):
+//   V1: the hardware "eats" 1 extra byte per master read (prefetched into the
+//       shift register, discarded at STOP), so we padded by 1 to keep the
+//       ringbuffer drained and responses aligned.
+//   V2 (IDF >= 5.4): does NOT consume that extra byte. Anything staged beyond
+//       what the FC clocks out lingers in the TX ringbuffer and accumulates
+//       across polls, so the SOF drifts forward a byte each read and only the
+//       first (aligned) read parses (bench: query ok/fail stuck at 1/N).
+//       Under V2, stage exactly what the FC reads (pad = 0). Staged == read
+//       also avoids the V2 driver's "master clocked out more than staged"
+//       underflow.
+#if CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
+static constexpr size_t I2C_TX_PAD = 0;
+#else
 static constexpr size_t I2C_TX_PAD = 1;
+#endif
 static constexpr size_t I2C_TX_SIZE = FC_COMBINED_READ_SIZE + I2C_TX_PAD;
 
 static void queueOutStatusResponse(bool ready)

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -37,6 +37,11 @@ CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_INT_WDT=y
 CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
 
+# I2C slave driver V2 (added in IDF 5.4). TR_I2C_Interface targets the V2
+# slave API (on_receive/on_request + i2c_slave_write). Required on 5.5;
+# the macro is implicit on 6.0+. See issue #88.
+CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y
+
 # Core dump to flash — retrieve after crash with:
 #   espcoredump.py info_corefile -t raw -c 0x610000 build/out_computer.elf
 CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -37,16 +37,11 @@ CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_INT_WDT=y
 CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
 
-# I2C slave driver V2 (added in IDF 5.4). TR_I2C_Interface targets the V2
-# slave API (on_receive/on_request + i2c_slave_write). Required on 5.5;
-# the macro is implicit on 6.0+. See issue #88.
-CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2=y
-
 # Core dump to flash — retrieve after crash with:
 #   espcoredump.py info_corefile -t raw -c 0x610000 build/out_computer.elf
 CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
-CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
-CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y
+# (6.0 forces ELF format + SHA256 checksum; the legacy explicit ELF/CRC32
+#  selectors are gone — CRC32 is unsupported on 6.0.)
 
 # Partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y

--- a/tinkerrocket-idf/tools/build.sh
+++ b/tinkerrocket-idf/tools/build.sh
@@ -17,14 +17,18 @@ export PATH="/opt/homebrew/bin:$PATH"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Source ESP-IDF environment if not already loaded.
-# Pinned to the v5.5.x parallel install for the #88 I2C-V2 bench branch.
-IDF_EXPORT="$HOME/esp/esp-idf-v5.5/export.sh"
-if ! command -v idf.py &>/dev/null; then
-    if [ -f "$IDF_EXPORT" ]; then
-        . "$IDF_EXPORT" >/dev/null 2>&1
+# Source ESP-IDF environment. Pinned to the v5.5.x parallel install for the
+# #88 I2C-V2 bench branch. FORCE it even when a different IDF is already
+# sourced: if a stray 5.3.2 reconfigures the build dir, it silently drops
+# CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2 (sdkconfig.defaults is only applied
+# on a fresh set-target), which breaks the V2 slave build. So we re-source
+# whenever the active IDF isn't exactly this one.
+IDF_HOME="$HOME/esp/esp-idf-v5.5"
+if [ "$IDF_PATH" != "$IDF_HOME" ] || ! command -v idf.py &>/dev/null; then
+    if [ -f "$IDF_HOME/export.sh" ]; then
+        . "$IDF_HOME/export.sh" >/dev/null 2>&1
     else
-        echo "ERROR: ESP-IDF v5.5 not found. Run: . $IDF_EXPORT"
+        echo "ERROR: ESP-IDF v5.5 not found at $IDF_HOME"
         exit 1
     fi
 fi

--- a/tinkerrocket-idf/tools/build.sh
+++ b/tinkerrocket-idf/tools/build.sh
@@ -17,18 +17,17 @@ export PATH="/opt/homebrew/bin:$PATH"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Source ESP-IDF environment. Pinned to the v5.5.x parallel install for the
-# #88 I2C-V2 bench branch. FORCE it even when a different IDF is already
-# sourced: if a stray 5.3.2 reconfigures the build dir, it silently drops
-# CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2 (sdkconfig.defaults is only applied
-# on a fresh set-target), which breaks the V2 slave build. So we re-source
-# whenever the active IDF isn't exactly this one.
-IDF_HOME="$HOME/esp/esp-idf-v5.5"
+# Source ESP-IDF environment. Pinned to the v6.0.x parallel install for the
+# #88 6.0 migration branch. FORCE it even when a different IDF is already
+# sourced: if a stray older IDF reconfigures the build dir it can silently
+# drop/alter sdkconfig options (defaults are only applied on a fresh
+# set-target). So we re-source whenever the active IDF isn't exactly this one.
+IDF_HOME="$HOME/esp/esp-idf-v6.0"
 if [ "$IDF_PATH" != "$IDF_HOME" ] || ! command -v idf.py &>/dev/null; then
     if [ -f "$IDF_HOME/export.sh" ]; then
         . "$IDF_HOME/export.sh" >/dev/null 2>&1
     else
-        echo "ERROR: ESP-IDF v5.5 not found at $IDF_HOME"
+        echo "ERROR: ESP-IDF v6.0 not found at $IDF_HOME"
         exit 1
     fi
 fi

--- a/tinkerrocket-idf/tools/build.sh
+++ b/tinkerrocket-idf/tools/build.sh
@@ -17,12 +17,14 @@ export PATH="/opt/homebrew/bin:$PATH"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Source ESP-IDF environment if not already loaded
+# Source ESP-IDF environment if not already loaded.
+# Pinned to the v5.5.x parallel install for the #88 I2C-V2 bench branch.
+IDF_EXPORT="$HOME/esp/esp-idf-v5.5/export.sh"
 if ! command -v idf.py &>/dev/null; then
-    if [ -f "$HOME/esp/esp-idf/export.sh" ]; then
-        . "$HOME/esp/esp-idf/export.sh" >/dev/null 2>&1
+    if [ -f "$IDF_EXPORT" ]; then
+        . "$IDF_EXPORT" >/dev/null 2>&1
     else
-        echo "ERROR: ESP-IDF not found. Run: . ~/esp/esp-idf/export.sh"
+        echo "ERROR: ESP-IDF v5.5 not found. Run: . $IDF_EXPORT"
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary

Fixes the FC↔OC I2C link wedge that parked #88, and migrates both firmware projects from ESP-IDF 5.3.2 to **6.0.1**. Bench-validated on hardware (both boards): the link runs clean and both boards boot/run on 6.0.1.

## The I2C fix (root cause)

The wedge was a **missing `on_request` handler** in the V2 I2C-slave migration — not SCL stretching or hardware (the earlier parked attempt misdiagnosed it). On a master read, the V2 slave stretches SCL on address-match and only releases it when `i2c_slave_write()` runs; with no `on_request` handler the read was never served and the master wedged in the `clear_bus` cascade.

- **`TR_I2C_Interface`**: register `on_receive` + `on_request`; `on_request` (ISR) wakes a high-priority TX-service task that calls `i2c_slave_write()` (can't call it from the ISR — it takes a mutex).
- **Master `scl_wait_us=5000`** so it tolerates the V2 stretch (~2.56 ms protect window) instead of timing out at the 2 ms default.
- **OC `I2C_TX_PAD=0`** under V2: V1 hardware consumed 1 prefetch byte per read so we padded by 1; V2 doesn't, so the pad accumulated in the TX ringbuffer and only the first read parsed. Stage exactly what the master reads.
- **Snapshot/recovery** read reads the exact frame size (avoids the inverse V2 underflow).

## The 6.0 migration

- **`driver` → `esp_driver_*` REQUIRES sweep**: 6.0 moved `esp_driver_gpio`/`spi`/etc. to the `driver` umbrella's `PRIV_REQUIRES`, so they no longer propagate; added the specific components to 16 in-tree components + the FC/BS project mains.
- **RadioLib** (vendored): downgrade GCC-14 `-Werror=overloaded-virtual`.
- **TR_OTA**: `mbedtls/sha256.h` is private in 6.0 → PSA Crypto (`psa_hash_*`). *(Security-relevant: OTA image integrity check — worth a review.)*
- **Pyro**: `gpio_iomux_out()` removed → `gpio_func_sel(pin, PIN_FUNC_GPIO)`.
- **FC sdkconfig**: accept v1.x P4 silicon, brownout level, 16 KB main-task stack.
- `tools/build.sh` pinned to `~/esp/esp-idf-v6.0` (force-sources it).
- **No Picolibc breakage** surfaced at compile or runtime.

## Testing

- ✅ OC (esp32s3) + FC (esp32p4) build clean on 6.0.1.
- ✅ **Bench (both boards on 6.0.1)**: boot OK; FC↔OC link `query ok` climbing with **0 failures**, no wedge/crash, command + `fc_identity` round-trips; sensors/GNSS/BLE/telemetry healthy. Same validation also passed on the interim 5.5 build.
- ⚠️ **Not bench-tested**: the snapshot/flight-recovery path (read-size fix applied by analogy; needs an in-flight snapshot in OC MRAM + an FC reboot to exercise).

## Notes

- Built on the validated I2C fix (also available standalone on `idf/v5.5-i2c-onrequest` as a 5.5 fallback).
- Pre-existing `BT_NIMBLE_SLEEP_ENABLE` sdkconfig warning left as-is (orthogonal to this work).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
