### PR TITLE
IMU mounting orientation: board can be mounted any direction (auto-detect + manual)

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -52,7 +52,7 @@ MSG_NAMES = {
 }
 
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY: 16,
+    MSG_OUT_STATUS_QUERY: (16, 26),  # v2 / v3 (+b2r orientation)
     MSG_GNSS:             42,
     MSG_ISM6HG256:        22,
     MSG_BMP585:           12,
@@ -159,9 +159,11 @@ def parse_file(filepath):
 
         if msg_type in MSG_EXPECTED_LEN:
             expected = MSG_EXPECTED_LEN[msg_type]
-            if expected is not None and msg_len != expected:
-                pos -= 1
-                continue
+            if expected is not None:
+                valid = expected if isinstance(expected, tuple) else (expected,)
+                if msg_len not in valid:
+                    pos -= 1
+                    continue
 
         if pos + msg_len + 2 > file_size:
             break

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -86,9 +86,10 @@ MSG_NAMES = {
     MSG_LORA:             "LoRa",
 }
 
-# Expected payload sizes for validation
+# Expected payload sizes for validation.  A tuple lists every valid size
+# (wire structs grow by appending version-gated fields).
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY:  16,   # OutStatusQueryData
+    MSG_OUT_STATUS_QUERY:  (16, 26),  # OutStatusQueryData v2 / v3 (+b2r orientation)
     MSG_GNSS:              42,
     MSG_ISM6HG256:         22,
     MSG_BMP585:            12,
@@ -116,8 +117,9 @@ FMT_POWER = '<I Hhh'
 FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'     # legacy (no pyro_status)
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'  # +pyro_status byte (#34)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'  # +apogee_flags byte (#142/#143)
-# OutStatusQueryData: 16 bytes
+# OutStatusQueryData: 16 bytes (v2) / 26 bytes (v3, +b2r orientation)
 FMT_STATUS_QUERY = '<B H H hh B hhh'
+FMT_STATUS_QUERY_B2R = '<BB hhhh'  # b2r_code, b2r_mode, quat×10000 (payload[16:26])
 # LogBufferStatsData: 28 bytes (time_us + 6× uint32 ring counters)
 FMT_LOG_BUFFER_STATS = '<I IIIIII'
 
@@ -166,6 +168,34 @@ PSF_CH3_CONT  = (1 << 4)
 PSF_CH3_FIRED = (1 << 5)
 PSF_CH4_CONT  = (1 << 6)
 PSF_CH4_FIRED = (1 << 7)
+
+
+# ---------- Board→rocket orientation ----------
+# Names for the 24 discrete mounting codes (TR_Orientation): which board
+# axis points at the nose + quarter-turn clocking about the nose.
+def b2r_code_name(code):
+    if code is None:
+        return "+X (default)"
+    axes = ["+X", "-X", "+Y", "-Y", "+Z", "-Z"]
+    if not (0 <= code < 24):
+        return f"? ({code})"
+    name = axes[code // 4]
+    clock = (code % 4) * 90
+    return name if clock == 0 else f"{name} r{clock}"
+
+
+def quat_to_matrix(q):
+    """Scalar-first unit quaternion → row-major 3x3 rotation (list of rows)."""
+    w, x, y, z = q
+    n = math.sqrt(w * w + x * x + y * y + z * z)
+    if n < 1e-9:
+        return [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    w, x, y, z = w / n, x / n, y / n, z / n
+    return [
+        [1 - 2 * (y * y + z * z), 2 * (x * y - w * z), 2 * (x * z + w * y)],
+        [2 * (x * y + w * z), 1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+        [2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x * x + y * y)],
+    ]
 
 
 # ---------- CRC-16 (Rob Tillaart CRC library defaults) ----------
@@ -258,6 +288,11 @@ def parse_binary_file(filepath):
         "ism6_rot_z_deg": ISM6_ROT_Z_DEG,
         "mmc_rot_z_deg":  MMC_ROT_Z_DEG,
         "hg_bias": (0.0, 0.0, 0.0),
+        # Board→rocket mounting orientation (OutStatusQueryData v3+).
+        # None = identity (board +X toward the nose, pre-v3 logs).
+        "b2r_code": None,
+        "b2r_mode": None,
+        "b2r_quat": None,
     }
 
     stats = {
@@ -287,12 +322,14 @@ def parse_binary_file(filepath):
         msg_len = data[pos + 1]
         pos += 2
 
-        # Validate known types
+        # Validate known types (int = exact size, tuple = any listed size)
         if msg_type in MSG_EXPECTED_LEN:
             expected = MSG_EXPECTED_LEN[msg_type]
-            if expected is not None and msg_len != expected:
-                pos -= 1
-                continue
+            if expected is not None:
+                valid = expected if isinstance(expected, tuple) else (expected,)
+                if msg_len not in valid:
+                    pos -= 1
+                    continue
 
         if pos + msg_len + 2 > file_size:
             break
@@ -334,6 +371,12 @@ def parse_binary_file(filepath):
                             fields[7] / 100.0,
                             fields[8] / 100.0,
                         )
+                    if fmt_ver >= 3 and msg_len >= 26:
+                        b2r = struct.unpack(FMT_STATUS_QUERY_B2R, payload[16:26])
+                        config["b2r_code"] = b2r[0]
+                        config["b2r_mode"] = b2r[1]
+                        config["b2r_quat"] = (b2r[2] / 10000.0, b2r[3] / 10000.0,
+                                              b2r[4] / 10000.0, b2r[5] / 10000.0)
                     config_seen = True
 
             elif msg_type == MSG_GNSS:
@@ -497,6 +540,17 @@ def parse_binary_file(filepath):
     c_rot, s_rot = math.cos(rot_rad), math.sin(rot_rad)
     hg_bx, hg_by, hg_bz = config["hg_bias"]
 
+    # Board→rocket mounting rotation (matches SensorConverter: applied LAST,
+    # after the chip Z rotation and bias subtraction).  Identity when absent.
+    b2r = quat_to_matrix(config["b2r_quat"]) if config["b2r_quat"] else None
+
+    def apply_b2r(x, y, z):
+        if b2r is None:
+            return x, y, z
+        return (b2r[0][0] * x + b2r[0][1] * y + b2r[0][2] * z,
+                b2r[1][0] * x + b2r[1][1] * y + b2r[1][2] * z,
+                b2r[2][0] * x + b2r[2][1] * y + b2r[2][2] * z)
+
     for r in ism6_raw:
         # Low-g accel → m/s², rotate to board frame
         lg_x = r["lg_x"] * acc_low_scale
@@ -511,17 +565,27 @@ def parse_binary_file(filepath):
         gy_y = r["gy_y"] * gyro_scale
         gy_z = r["gy_z"] * gyro_scale
 
+        low = apply_b2r(lg_x * c_rot - lg_y * s_rot,
+                        lg_x * s_rot + lg_y * c_rot,
+                        lg_z)
+        high = apply_b2r((hg_x * c_rot - hg_y * s_rot) - hg_bx,
+                         (hg_x * s_rot + hg_y * c_rot) - hg_by,
+                         hg_z - hg_bz)
+        gyro = apply_b2r(gy_x * c_rot - gy_y * s_rot,
+                         gy_x * s_rot + gy_y * c_rot,
+                         gy_z)
+
         records["ISM6HG256"].append({
             "time_us":     r["time_us"],
-            "low_acc_x":   lg_x * c_rot - lg_y * s_rot,
-            "low_acc_y":   lg_x * s_rot + lg_y * c_rot,
-            "low_acc_z":   lg_z,
-            "high_acc_x":  (hg_x * c_rot - hg_y * s_rot) - hg_bx,
-            "high_acc_y":  (hg_x * s_rot + hg_y * c_rot) - hg_by,
-            "high_acc_z":  hg_z - hg_bz,
-            "gyro_x":      gy_x * c_rot - gy_y * s_rot,
-            "gyro_y":      gy_x * s_rot + gy_y * c_rot,
-            "gyro_z":      gy_z,
+            "low_acc_x":   low[0],
+            "low_acc_y":   low[1],
+            "low_acc_z":   low[2],
+            "high_acc_x":  high[0],
+            "high_acc_y":  high[1],
+            "high_acc_z":  high[2],
+            "gyro_x":      gyro[0],
+            "gyro_y":      gyro[1],
+            "gyro_z":      gyro[2],
         })
 
     # --- Post-process MMC raw data with rotation ---
@@ -531,9 +595,12 @@ def parse_binary_file(filepath):
         mx = decode_mmc_centered(rec.pop("raw_x"))
         my = decode_mmc_centered(rec.pop("raw_y"))
         mz = decode_mmc_centered(rec.pop("raw_z"))
-        rec["mag_x"] = mx * c_mmc - my * s_mmc
-        rec["mag_y"] = mx * s_mmc + my * c_mmc
-        rec["mag_z"] = mz
+        mag = apply_b2r(mx * c_mmc - my * s_mmc,
+                        mx * s_mmc + my * c_mmc,
+                        mz)
+        rec["mag_x"] = mag[0]
+        rec["mag_y"] = mag[1]
+        rec["mag_z"] = mag[2]
 
     # Sort each sensor type by timestamp so MRAM ring-buffer drain
     # (which can interleave older pre-launch frames with newer ones)
@@ -1436,6 +1503,9 @@ def main(filepath=BINARY_FILE, output_dir=OUTPUT_DIR, show_plots=SHOW_PLOTS,
     print(f"    MMC rot Z:     {config['mmc_rot_z_deg']:.1f}°")
     print(f"    HG bias:       ({config['hg_bias'][0]:.2f}, "
           f"{config['hg_bias'][1]:.2f}, {config['hg_bias'][2]:.2f}) m/s²")
+    mode_names = {0: "default", 1: "manual", 2: "auto-snap", 3: "auto-exact"}
+    mode = mode_names.get(config["b2r_mode"], "pre-v3 log")
+    print(f"    Board→rocket:  {b2r_code_name(config['b2r_code'])} ({mode})")
     print()
 
     # Determine global t0 (earliest timestamp)

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -160,6 +160,7 @@ final class ActiveRocketSyncer: ObservableObject {
         })
         device.sendGuidanceConfig(enabled: profile.guidanceEnabled)
         device.sendCameraConfig(cameraType: profile.cameraType)
+        device.sendImuOrientationConfig(profile.imuOrientSetting)
         device.sendSoundConfig(enabled: profile.soundsEnabled)
         device.sendPyroConfig(channels: [
             (profile.pyro1Enabled, profile.pyro1TriggerMode, profile.pyro1TriggerValue),

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -727,6 +727,16 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendRawCommand(33, payload: Data([cameraType]))
     }
 
+    /// IMU mounting orientation: 0xFF = auto (pad-gravity detect), 0..23 =
+    /// manual board→rocket code (authoritative incl. roll clocking).
+    func sendImuOrientationConfig(_ setting: UInt8) {
+        sendRawCommand(64, payload: Data([setting]))
+        if var cfg = rocketConfig {
+            cfg.imuOrientSetting = setting
+            rocketConfig = cfg
+        }
+    }
+
     /// 4-channel pyro config. Each tuple is (enabled, trigger_mode, trigger_value).
     /// Wire layout (24 bytes): 4 × {u8 enabled, u8 mode, f32 value}.
     func sendPyroConfig(channels: [(enabled: Bool, mode: UInt8, value: Float)]) {
@@ -1352,11 +1362,17 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // axis the FC has mapped to the rocket nose and how it decided
         // (default / manual / pad-gravity auto-detect). Re-sent whenever the
         // FC re-orients on the pad, so the display tracks the live mapping.
+        // "set" is the user's setting (0xFF auto / manual code), cached into
+        // rocketConfig like the other readback values.
         if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            dict["type"] as? String == "imu_orient" {
             if let name = dict["name"] as? String { imuOrientationName = name }
             if let mode = dict["mode"] as? Int {
                 imuOrientationMode = IMUOrientationMode(rawValue: mode) ?? .unknown
+            }
+            if let set = dict["set"] as? Int, var cfg = rocketConfig {
+                cfg.imuOrientSetting = UInt8(clamping: set)
+                rocketConfig = cfg
             }
             print("[CFG] IMU orientation: \(imuOrientationName) (\(imuOrientationMode.label))")
             return

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -107,6 +107,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// state machine.
     @Published var otaStatus: OTAStatusUpdate?
 
+    /// FC's active board→rocket mounting orientation ("imu_orient" config
+    /// message, relayed by the OC). Display name like "+X" or "-Z r90" plus
+    /// how it was determined. Lets the flyer confirm the auto-detected
+    /// mounting before arming. Empty until a v3-orientation FC reports it.
+    @Published var imuOrientationName: String = ""
+    @Published var imuOrientationMode: IMUOrientationMode = .unknown
+
     /// Display name: unitName if set, otherwise connectedDeviceName
     var displayName: String {
         unitName.isEmpty ? connectedDeviceName : unitName
@@ -1338,6 +1345,20 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
            dict["type"] as? String == "fc_identity" {
             if let fcFw = dict["fc_fw"] as? String { fcFirmwareVersion = fcFw }
             print("[CFG] FC identity: fc_fw=\(fcFirmwareVersion)")
+            return
+        }
+
+        // Board→rocket mounting orientation: "type":"imu_orient" — which board
+        // axis the FC has mapped to the rocket nose and how it decided
+        // (default / manual / pad-gravity auto-detect). Re-sent whenever the
+        // FC re-orients on the pad, so the display tracks the live mapping.
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           dict["type"] as? String == "imu_orient" {
+            if let name = dict["name"] as? String { imuOrientationName = name }
+            if let mode = dict["mode"] as? Int {
+                imuOrientationMode = IMUOrientationMode(rawValue: mode) ?? .unknown
+            }
+            print("[CFG] IMU orientation: \(imuOrientationName) (\(imuOrientationMode.label))")
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -100,6 +100,7 @@ struct RocketConfig {
     var rollDelayMs: UInt16 = 0
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2
+    var imuOrientSetting: UInt8? = nil   // 0xFF auto / 0..23 manual (nil = not reported)
     var loraFreqMHz: Float? = nil
     var loraSF: UInt8? = nil
     var loraBwKHz: Float? = nil

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -707,7 +707,8 @@ nonisolated struct FlightSettings: Codable, Sendable {
         imu = IMUSettings(
             gyro_fs_dps: Int(raw.ism6_gyro_fs_dps),
             low_g_fs_g: Int(raw.ism6_low_g_fs_g),
-            high_g_fs_g: Int(raw.ism6_high_g_fs_g)
+            high_g_fs_g: Int(raw.ism6_high_g_fs_g),
+            mounting: MountingSettings(from: raw)
         )
     }
 }
@@ -845,6 +846,30 @@ nonisolated struct IMUSettings: Codable, Sendable {
     let gyro_fs_dps: Int
     let low_g_fs_g: Int
     let high_g_fs_g: Int
+    /// Board→rocket mounting orientation (v2 settings frames). nil on
+    /// pre-orientation logs, which always meant the +X-nose mounting.
+    let mounting: MountingSettings?
+}
+
+nonisolated struct MountingSettings: Codable, Sendable {
+    /// Which board axis pointed at the nose + clocking, e.g. "+X", "-Z r90".
+    let orientation: String
+    /// How it was determined: "default" | "manual" | "auto_snap" | "auto_exact".
+    let mode: String
+    /// Auto-snap residual angle (deg); 0 for default/manual.
+    let residual_deg: Double
+
+    init?(from raw: FlightSettingsData) {
+        guard let code = raw.b2r_code, let mode = raw.b2r_mode else { return nil }
+        orientation = FlightSettingsData.b2rName(code: code)
+        switch mode {
+        case 1: self.mode = "manual"
+        case 2: self.mode = "auto_snap"
+        case 3: self.mode = "auto_exact"
+        default: self.mode = "default"
+        }
+        residual_deg = sigFig(raw.b2r_residual_deg ?? 0, 3)
+    }
 }
 
 // MARK: - CSV Errors

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -86,6 +86,11 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var rollDelayMs: UInt16 = 0
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2          // 0=None, 1=GoPro, 2=RunCam
+    /// IMU mounting orientation: 0xFF = auto (pad-gravity detect), 0..23 =
+    /// manual board→rocket code. Manual fixes the roll clocking the control
+    /// surfaces need — required for roll-controlled/guided flights with an
+    /// off-axis board; optional for non-controlled flights.
+    var imuOrientSetting: UInt8 = 0xFF
 
     // MARK: Servo
     var servoBias1: Int16 = 85
@@ -176,6 +181,7 @@ extension RocketProfile {
         rollDelayMs = try c.decodeIfPresent(UInt16.self, forKey: .rollDelayMs) ?? defaults.rollDelayMs
         guidanceEnabled = try c.decodeIfPresent(Bool.self, forKey: .guidanceEnabled) ?? defaults.guidanceEnabled
         cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
+        imuOrientSetting = try c.decodeIfPresent(UInt8.self, forKey: .imuOrientSetting) ?? defaults.imuOrientSetting
 
         servoBias1 = try c.decodeIfPresent(Int16.self, forKey: .servoBias1) ?? defaults.servoBias1
         servoBias2 = try c.decodeIfPresent(Int16.self, forKey: .servoBias2) ?? defaults.servoBias2

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -23,7 +23,7 @@ enum MessageType: UInt8 {
     case h3lis331 = 0xA9   // Legacy-only high-G accelerometer (10B)
     case cameraStart = 0xAA
     case cameraStop = 0xAB
-    case flightSettings = 0xE1  // FlightSettingsData (149B) — runtime settings snapshot at launch (#165)
+    case flightSettings = 0xE1  // FlightSettingsData (188B v1 / 200B v2) — runtime settings snapshot at launch (#165)
     case iis2mdc = 0xD1    // IIS2MDC magnetometer (new Mini PCB rev, 10B)
     case lora = 0xF1
 }
@@ -129,6 +129,25 @@ nonisolated struct FlightSettingsData {
     let num_waypoints: UInt8
     let waypoints: [RollWaypointRaw]
 
+    // v2 tail: board→rocket mounting orientation, appended at fixed offset
+    // 188 after the full v1 layout. nil on v1 frames (pre-orientation
+    // firmware, which always assumed the +X-nose mounting).
+    let b2r_code: UInt8?
+    let b2r_mode: UInt8?            // 0 default, 1 manual, 2 auto-snap, 3 auto-exact
+    let b2r_residual_deg: Float?    // auto-snap residual angle
+    let b2r_quat: [Float]?          // board→rocket quaternion, scalar-first
+
+    /// "−Z r90"-style mounting name (mirrors firmware orientCodeName):
+    /// which board axis points at the nose + quarter-turn clocking.
+    static func b2rName(code: UInt8) -> String {
+        let axes = ["+X", "-X", "+Y", "-Y", "+Z", "-Z"]
+        guard code < 24 else { return "?" }
+        let base = axes[Int(code) / 4]
+        let clock = (Int(code) % 4) * 90
+        return clock == 0 ? base : "\(base) r\(clock)"
+    }
+    var b2rDisplayName: String? { b2r_code.map { FlightSettingsData.b2rName(code: $0) } }
+
     var useAngleControl: Bool { flags & (1 << FlightSettingsData.fUseAngleControl) != 0 }
     var gainScheduleEnabled: Bool { flags & (1 << FlightSettingsData.fGainSchedule) != 0 }
     var guidanceEnabled: Bool { flags & (1 << FlightSettingsData.fGuidance) != 0 }
@@ -213,6 +232,21 @@ nonisolated struct FlightSettingsData {
             wps.append(RollWaypointRaw(time_s: t, angle_deg: a, mode: m))
         }
         waypoints = wps
+
+        // v2 board→rocket orientation tail at fixed offset 188 (after the
+        // full 76-byte roll profile, independent of num_waypoints).
+        if version >= 2 && data.count >= 200 {
+            var o = 188
+            b2r_code = data.readUInt8(at: &o)
+            b2r_mode = data.readUInt8(at: &o)
+            b2r_residual_deg = Float(data.readInt16LE(at: &o)) / 100.0
+            b2r_quat = (0..<4).map { _ in Float(data.readInt16LE(at: &o)) / 10000.0 }
+        } else {
+            b2r_code = nil
+            b2r_mode = nil
+            b2r_residual_deg = nil
+            b2r_quat = nil
+        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -77,6 +77,26 @@ nonisolated struct RollWaypointRaw {
     let mode: UInt8       // 0 = ROLL_SEG_ANGLE, 1 = ROLL_SEG_NULL_RATE
 }
 
+/// How the FC determined its board→rocket mounting orientation
+/// (mirrors TR_Orientation ORIENT_MODE_*; "imu_orient" config message).
+nonisolated enum IMUOrientationMode: Int, Sendable {
+    case unknown = -1
+    case defaultMounting = 0   // identity, nothing configured
+    case manual = 1            // user/config supplied
+    case autoSnap = 2          // pad-gravity detect, snapped to an axis
+    case autoExact = 3         // pad-gravity detect, exact off-axis rotation
+
+    var label: String {
+        switch self {
+        case .unknown:         return "—"
+        case .defaultMounting: return "default"
+        case .manual:          return "manual"
+        case .autoSnap:        return "auto"
+        case .autoExact:       return "auto, off-axis"
+        }
+    }
+}
+
 /// Decoded FlightSettingsData wire frame. Layout mirrors the packed C++
 /// struct in RocketComputerTypes.h byte-for-byte (verified by offset).
 nonisolated struct FlightSettingsData {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -397,7 +397,9 @@ struct ConnectedDashboardView: View {
 
             if showRocketViews {
                 IMUView(telemetry: device.telemetry,
-                        isBaseStation: device.isBaseStation)
+                        isBaseStation: device.isBaseStation,
+                        orientationName: device.isBaseStation ? "" : device.imuOrientationName,
+                        orientationMode: device.imuOrientationMode)
                     .opacity(staleOpacity)
             }
 
@@ -909,11 +911,24 @@ struct AltitudeView: View {
 struct IMUView: View {
     let telemetry: TelemetryData
     var isBaseStation: Bool = false
+    // Board→rocket mounting orientation (direct rocket connection only).
+    // Empty until the FC reports it; shown so the flyer can confirm the
+    // auto-detected mounting before arming.
+    var orientationName: String = ""
+    var orientationMode: IMUOrientationMode = .unknown
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("IMU")
-                .font(.headline)
+            HStack {
+                Text("IMU")
+                    .font(.headline)
+                Spacer()
+                if !orientationName.isEmpty {
+                    Text("nose: \(orientationName) (\(orientationMode.label))")
+                        .font(.caption)
+                        .foregroundColor(orientationMode == .autoExact ? .orange : .secondary)
+                }
+            }
 
             HStack(spacing: 0) {
                 Text("")

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -222,6 +222,8 @@ struct SettingsView: View {
             Section(header: Text("Summary")) {
                 summaryRow("Control mode", p.useAngleControl ? "Track Profile" : "Null Roll")
                 summaryRow("Camera", cameraLabel(p.cameraType))
+                summaryRow("IMU mounting", p.imuOrientSetting == 0xFF
+                    ? "Auto" : "Nose \(FlightSettingsData.b2rName(code: p.imuOrientSetting))")
                 summaryRow("Gain scheduling", p.gainScheduleEnabled ? "On" : "Off")
                 summaryRow("Mag cal", p.magCal == nil ? "Not saved" : "Saved")
                 summaryRow("Sensor cal", p.sensorCal == nil ? "Not saved" : "Saved")
@@ -513,6 +515,37 @@ struct SettingsView: View {
                     .font(.caption).foregroundColor(.orange)
             }
         }
+
+        Section("IMU Mounting") {
+            Picker("Orientation", selection: imuOrientBinding) {
+                Text("Auto-detect").tag(255)
+                ForEach(0..<24, id: \.self) { code in
+                    Text("Nose \(FlightSettingsData.b2rName(code: UInt8(code)))").tag(code)
+                }
+            }
+            if !device.imuOrientationName.isEmpty {
+                HStack {
+                    Text("Active on rocket")
+                    Spacer()
+                    Text("\(device.imuOrientationName) (\(device.imuOrientationMode.label))")
+                        .foregroundColor(.secondary)
+                }
+            }
+            Text(profile.imuOrientSetting == 0xFF
+                ? "Auto detects which board axis points at the nose from gravity on the pad. Fine for non-controlled flights."
+                : "Manual mounting also fixes the fin clocking (rNN = quarter-turns about the nose) — required for roll-controlled or guided flights when the board is mounted off-axis.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    private var imuOrientBinding: Binding<Int> {
+        Binding(
+            get: { Int(profile.imuOrientSetting) },
+            set: { newValue in
+                let v = UInt8(clamping: newValue)
+                updateProfile { $0.imuOrientSetting = v }
+                if device.isConnected { device.sendImuOrientationConfig(v) }
+            })
     }
 
     @ViewBuilder

--- a/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/MessageParserTests.swift
@@ -290,5 +290,36 @@ final class MessageParserTests: XCTestCase {
 
         // Undersized payload is rejected.
         XCTAssertThrowsError(try FlightSettingsData(from: Data(p.prefix(187))))
+
+        // v1 frame: no board→rocket orientation tail.
+        XCTAssertNil(raw.b2r_code)
+        XCTAssertNil(raw.b2rDisplayName)
+        XCTAssertNil(s.imu.mounting)
+
+        // ---- v2: board→rocket orientation tail @188 (firmware VERSION 2) ----
+        var p2 = p
+        p2[4] = 2                  // version
+        p2.append(17)              // b2r_code @188: +Z nose, r90 clocking
+        p2.append(2)               // b2r_mode @189: auto-snap
+        p2 += leI16(350)           // b2r_residual_cdeg @190: 3.5°
+        // board→rocket quat for +Z r90 — the x→y→z cyclic permutation,
+        // 120° about (1,1,1): (0.5, 0.5, 0.5, 0.5) ×10000
+        p2 += leI16(5000); p2 += leI16(5000); p2 += leI16(5000); p2 += leI16(5000)
+        XCTAssertEqual(p2.count, 200)
+
+        let raw2 = try FlightSettingsData(from: Data(p2))
+        XCTAssertEqual(raw2.version, 2)
+        XCTAssertEqual(raw2.b2r_code, 17)
+        XCTAssertEqual(raw2.b2r_mode, 2)
+        XCTAssertEqual(raw2.b2r_residual_deg ?? -1, 3.5, accuracy: 1e-4)
+        XCTAssertEqual(raw2.b2r_quat?.count, 4)
+        XCTAssertEqual(raw2.b2r_quat?[0] ?? -1, 0.5, accuracy: 1e-4)
+        XCTAssertEqual(raw2.b2r_quat?[3] ?? -1, 0.5, accuracy: 1e-4)
+        XCTAssertEqual(raw2.b2rDisplayName, "+Z r90")
+
+        let s2 = FlightSettings(from: raw2)
+        XCTAssertEqual(s2.imu.mounting?.orientation, "+Z r90")
+        XCTAssertEqual(s2.imu.mounting?.mode, "auto_snap")
+        XCTAssertEqual(s2.imu.mounting?.residual_deg ?? -1, 3.5, accuracy: 1e-6)
     }
 }

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -145,14 +145,29 @@ gtest_discover_tests(test_coordinates)
 # ---------- test_sensor_data_converter ----------
 add_executable(test_sensor_data_converter test_sensor_data_converter.cpp
     ${LIB_DIR}/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+    ${LIB_DIR}/TR_Orientation/TR_Orientation.cpp
 )
 target_include_directories(test_sensor_data_converter PRIVATE
     ${SHIM_DIR}
     ${LIB_DIR}/TR_Sensor_Data_Converter
     ${LIB_DIR}/TR_RocketComputerTypes
+    ${LIB_DIR}/TR_Orientation
 )
 target_link_libraries(test_sensor_data_converter GTest::gtest_main)
 gtest_discover_tests(test_sensor_data_converter)
+
+# ---------- test_orientation ----------
+# Board→rocket mounting orientation utilities (discrete 24-code set,
+# quaternion round-trips, gravity nose snap, pad attitude init).
+add_executable(test_orientation test_orientation.cpp
+    ${LIB_DIR}/TR_Orientation/TR_Orientation.cpp
+)
+target_include_directories(test_orientation PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_Orientation
+)
+target_link_libraries(test_orientation GTest::gtest_main)
+gtest_discover_tests(test_orientation)
 
 # ---------- test_lora_roundtrip ----------
 # This tests the OutComputer -> BaseStation -> iOS App data pipeline

--- a/tests_cpp/test_orientation.cpp
+++ b/tests_cpp/test_orientation.cpp
@@ -324,3 +324,209 @@ TEST(Orientation, PadQuat_DegenerateInput_NoNaN) {
     quatFromAccelHeading(0.0f, 0.0f, 0.0f, 0.0f, q);
     for (int i = 0; i < 4; i++) EXPECT_FALSE(std::isnan(q[i]));
 }
+
+// ---------- Exact shortest-arc rotation ----------
+
+TEST(Orientation, NoseVectorMatrix_AxisAligned_MatchesCanonical) {
+    // For each ±axis the exact shortest-arc rotation must reproduce the
+    // canonical clock=0 matrix (same -X 180°-about-+Z convention), so
+    // snapped and exact paths agree at the boundary.
+    const float axes[6][3] = {
+        { 1, 0, 0 }, { -1, 0, 0 },
+        { 0, 1, 0 }, { 0, -1, 0 },
+        { 0, 0, 1 }, { 0, 0, -1 },
+    };
+    for (int nose = 0; nose < 6; nose++)
+    {
+        float R_exact[9], R_canon[9];
+        ASSERT_TRUE(orientMatrixFromNoseVector(axes[nose], R_exact));
+        orientCodeToMatrix((uint8_t)(nose * 4), R_canon);
+        for (int i = 0; i < 9; i++)
+        {
+            EXPECT_NEAR(R_exact[i], R_canon[i], 1e-5f)
+                << "nose " << nose << " entry " << i;
+        }
+    }
+}
+
+TEST(Orientation, NoseVectorMatrix_OffAxis_ProperAndMapsToX) {
+    // 30° off +Z toward +Y — a genuinely off-orthogonal mount.
+    const float v[3] = { 0.0f, kG * 0.5f, kG * 0.866025f };
+    float R[9];
+    ASSERT_TRUE(orientMatrixFromNoseVector(v, R));
+
+    // Proper rotation
+    EXPECT_NEAR(det3(R), 1.0f, 1e-5f);
+    float Rt[9] = { R[0], R[3], R[6], R[1], R[4], R[7], R[2], R[5], R[8] };
+    float I[9];
+    matMul(R, Rt, I);
+    for (int i = 0; i < 9; i++)
+    {
+        EXPECT_NEAR(I[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-5f);
+    }
+
+    // Maps the measured vector exactly onto rocket +X
+    float out[3];
+    matVec(R, v, out);
+    EXPECT_NEAR(out[0], kG, 1e-3f);
+    EXPECT_NEAR(out[1], 0.0f, 1e-3f);
+    EXPECT_NEAR(out[2], 0.0f, 1e-3f);
+}
+
+TEST(Orientation, NoseVectorMatrix_ZeroVector_IdentityFalse) {
+    const float v[3] = { 0, 0, 0 };
+    float R[9];
+    EXPECT_FALSE(orientMatrixFromNoseVector(v, R));
+    for (int i = 0; i < 9; i++)
+    {
+        EXPECT_NEAR(R[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-6f);
+    }
+}
+
+// ---------- Pad-gravity estimator ----------
+
+namespace {
+// Feed n samples of a constant stationary reading at the given rate.
+// Returns true if any update() call reported a completed window.
+bool feedStill(OrientationEstimator& est, uint32_t& t_us, int n,
+               const float acc[3], uint32_t dt_us = 2000)
+{
+    bool fresh = false;
+    for (int i = 0; i < n; i++)
+    {
+        t_us += dt_us;
+        fresh |= est.update(t_us, acc[0], acc[1], acc[2], 0.1f, -0.2f, 0.05f);
+    }
+    return fresh;
+}
+}
+
+TEST(OrientationEstimator, StationaryWindow_ProducesUnitEstimate) {
+    OrientationEstimator est;
+    uint32_t t = 1000;
+    const float acc[3] = { 0.0f, 0.0f, kG };   // board +Z up (rocket-frame feed)
+
+    // 2 s window at 500 Hz = 1000 samples — must complete exactly once
+    EXPECT_TRUE(feedStill(est, t, 1100, acc));
+    float up[3];
+    ASSERT_TRUE(est.takeEstimate(up));
+    EXPECT_NEAR(up[0], 0.0f, 1e-4f);
+    EXPECT_NEAR(up[1], 0.0f, 1e-4f);
+    EXPECT_NEAR(up[2], 1.0f, 1e-4f);
+    // Fresh flag cleared
+    EXPECT_FALSE(est.takeEstimate(up));
+}
+
+TEST(OrientationEstimator, Motion_ResetsWindow) {
+    OrientationEstimator est;
+    uint32_t t = 1000;
+    const float acc[3] = { kG, 0.0f, 0.0f };
+
+    // Almost a full window…
+    EXPECT_FALSE(feedStill(est, t, 900, acc));
+    // …then a gyro spike (handling / wind rock)
+    t += 2000;
+    EXPECT_FALSE(est.update(t, acc[0], acc[1], acc[2], 50.0f, 0.0f, 0.0f));
+    // …then 900 more quiet samples: still not enough for a NEW window
+    EXPECT_FALSE(feedStill(est, t, 900, acc));
+    // …and completing the new window works
+    EXPECT_TRUE(feedStill(est, t, 200, acc));
+}
+
+TEST(OrientationEstimator, NonOneG_NeverAccumulates) {
+    OrientationEstimator est;
+    uint32_t t = 1000;
+    const float boost[3] = { 5.0f * kG, 0.0f, 0.0f };  // clearly not stationary
+    EXPECT_FALSE(feedStill(est, t, 2000, boost));
+    float up[3];
+    EXPECT_FALSE(est.takeEstimate(up));
+}
+
+TEST(OrientationEstimator, DuplicateTimestamps_Ignored) {
+    OrientationEstimator est;
+    const float acc[3] = { 0.0f, 0.0f, kG };
+    // Same timestamp fed repeatedly (caller polling faster than the IMU)
+    // must not advance the window.
+    for (int i = 0; i < 5000; i++)
+    {
+        EXPECT_FALSE(est.update(1000, acc[0], acc[1], acc[2], 0, 0, 0));
+    }
+}
+
+TEST(OrientationEstimator, ContinuousReestimation_TracksRerack) {
+    OrientationEstimator est;
+    uint32_t t = 1000;
+    const float horiz[3] = { 0.0f, -kG, 0.0f };   // prepped horizontal
+    const float vert[3]  = { 0.0f, 0.0f, kG };    // racked vertical
+
+    EXPECT_TRUE(feedStill(est, t, 1100, horiz));
+    float up[3];
+    ASSERT_TRUE(est.takeEstimate(up));
+    EXPECT_NEAR(up[1], -1.0f, 1e-4f);
+
+    // Movement to the rail, then stillness again → next window reflects it
+    t += 2000;
+    est.update(t, 3.0f, 3.0f, 3.0f, 90.0f, 0.0f, 0.0f);
+    EXPECT_TRUE(feedStill(est, t, 1100, vert));
+    ASSERT_TRUE(est.takeEstimate(up));
+    EXPECT_NEAR(up[2], 1.0f, 1e-4f);
+}
+
+// ---------- Thrust-axis cross-check ----------
+
+TEST(ThrustAxisCheck, AlignedThrust_SmallAngle) {
+    ThrustAxisCheck chk;
+    uint32_t t = 5000;
+    chk.start(t);
+    // 150 ms of 8 g thrust along +X at 1 kHz, slight lateral noise
+    bool done = false;
+    for (int i = 0; i < 200 && !done; i++)
+    {
+        t += 1000;
+        done = chk.update(t, 8.0f * kG, 1.5f, -1.0f);
+    }
+    ASSERT_TRUE(done);
+    ASSERT_TRUE(chk.valid());
+    EXPECT_LT(chk.angleFromNoseDeg(), 5.0f);
+}
+
+TEST(ThrustAxisCheck, MisalignedThrust_LargeAngle) {
+    ThrustAxisCheck chk;
+    uint32_t t = 5000;
+    chk.start(t);
+    // Thrust mostly along +Z — the latched orientation is wrong by ~90°
+    bool done = false;
+    for (int i = 0; i < 200 && !done; i++)
+    {
+        t += 1000;
+        done = chk.update(t, 2.0f, 0.0f, 8.0f * kG);
+    }
+    ASSERT_TRUE(done);
+    ASSERT_TRUE(chk.valid());
+    EXPECT_GT(chk.angleFromNoseDeg(), 80.0f);
+}
+
+TEST(ThrustAxisCheck, WeakSignal_NoVerdict) {
+    ThrustAxisCheck chk;
+    uint32_t t = 5000;
+    chk.start(t);
+    // Sub-threshold accel for the whole window (chuffing motor)
+    bool done = false;
+    for (int i = 0; i < 200 && !done; i++)
+    {
+        t += 1000;
+        done = chk.update(t, 5.0f, 0.0f, 0.0f);
+    }
+    ASSERT_TRUE(done);
+    EXPECT_FALSE(chk.valid());
+}
+
+TEST(ThrustAxisCheck, NotStarted_NeverFinalizes) {
+    ThrustAxisCheck chk;
+    // Reboot-recovery path: update() called without start()
+    for (int i = 0; i < 1000; i++)
+    {
+        EXPECT_FALSE(chk.update(1000 + i * 1000, 8.0f * kG, 0, 0));
+    }
+    EXPECT_FALSE(chk.done());
+}

--- a/tests_cpp/test_orientation.cpp
+++ b/tests_cpp/test_orientation.cpp
@@ -1,0 +1,326 @@
+// Tests for TR_Orientation — the board→rocket mounting orientation
+// utilities behind the arbitrary-mounting feature.  Covers the 24-code
+// discrete rotation set, quaternion round-trips, the gravity-vector
+// nose snap (pad auto-detect building block), and the pad attitude
+// quaternion previously inlined in flight_computer main.cpp.
+
+#include <gtest/gtest.h>
+#include "TR_Orientation.h"
+#include <cmath>
+#include <cstring>
+#include <set>
+#include <array>
+
+namespace {
+
+constexpr float kG = 9.80665f;
+
+void matMul(const float A[9], const float B[9], float out[9])
+{
+    for (int r = 0; r < 3; r++)
+        for (int c = 0; c < 3; c++)
+        {
+            float s = 0.0f;
+            for (int k = 0; k < 3; k++) s += A[r * 3 + k] * B[k * 3 + c];
+            out[r * 3 + c] = s;
+        }
+}
+
+void matVec(const float R[9], const float v[3], float out[3])
+{
+    for (int r = 0; r < 3; r++)
+        out[r] = R[r * 3 + 0] * v[0] + R[r * 3 + 1] * v[1] + R[r * 3 + 2] * v[2];
+}
+
+float det3(const float R[9])
+{
+    return R[0] * (R[4] * R[8] - R[5] * R[7])
+         - R[1] * (R[3] * R[8] - R[5] * R[6])
+         + R[2] * (R[3] * R[7] - R[4] * R[6]);
+}
+
+}  // namespace
+
+// ---------- Discrete code set ----------
+
+TEST(Orientation, Code0_IsIdentity) {
+    float R[9];
+    orientCodeToMatrix(ORIENT_CODE_IDENTITY, R);
+    for (int i = 0; i < 9; i++)
+    {
+        EXPECT_NEAR(R[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-6f) << "entry " << i;
+    }
+}
+
+TEST(Orientation, All24_ProperRotations_AndDistinct) {
+    std::set<std::array<int, 9>> seen;
+    for (uint8_t code = 0; code < ORIENT_CODE_COUNT; code++)
+    {
+        float R[9];
+        orientCodeToMatrix(code, R);
+
+        // Orthonormal: R * R^T == I
+        float Rt[9] = { R[0], R[3], R[6], R[1], R[4], R[7], R[2], R[5], R[8] };
+        float I[9];
+        matMul(R, Rt, I);
+        for (int i = 0; i < 9; i++)
+        {
+            EXPECT_NEAR(I[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-5f)
+                << "code " << (int)code << " entry " << i;
+        }
+
+        // Proper (det +1), and entries are exact 0/±1
+        EXPECT_NEAR(det3(R), 1.0f, 1e-5f) << "code " << (int)code;
+        std::array<int, 9> key{};
+        for (int i = 0; i < 9; i++)
+        {
+            EXPECT_NEAR(R[i], roundf(R[i]), 1e-6f) << "code " << (int)code;
+            key[i] = (int)lroundf(R[i]);
+        }
+        EXPECT_TRUE(seen.insert(key).second) << "duplicate matrix for code " << (int)code;
+    }
+}
+
+TEST(Orientation, NoseAxis_MapsToRocketX_AllClocks) {
+    // nose_sel order: +X, -X, +Y, -Y, +Z, -Z
+    const float axes[6][3] = {
+        { 1, 0, 0 }, { -1, 0, 0 },
+        { 0, 1, 0 }, { 0, -1, 0 },
+        { 0, 0, 1 }, { 0, 0, -1 },
+    };
+    for (int nose = 0; nose < 6; nose++)
+    {
+        for (int clock = 0; clock < 4; clock++)
+        {
+            float R[9], out[3];
+            orientCodeToMatrix((uint8_t)(nose * 4 + clock), R);
+            matVec(R, axes[nose], out);
+            EXPECT_NEAR(out[0], 1.0f, 1e-6f) << "nose " << nose << " clock " << clock;
+            EXPECT_NEAR(out[1], 0.0f, 1e-6f) << "nose " << nose << " clock " << clock;
+            EXPECT_NEAR(out[2], 0.0f, 1e-6f) << "nose " << nose << " clock " << clock;
+        }
+    }
+}
+
+TEST(Orientation, Clock_IsQuarterTurnAboutRocketX) {
+    // Rx(90°) about rocket +X, CCW (right-hand rule)
+    const float Rx90[9] = { 1, 0, 0,   0, 0, -1,   0, 1, 0 };
+    for (int nose = 0; nose < 6; nose++)
+    {
+        float prev[9];
+        orientCodeToMatrix((uint8_t)(nose * 4), prev);
+        for (int clock = 1; clock < 4; clock++)
+        {
+            float expected[9], actual[9];
+            matMul(Rx90, prev, expected);
+            orientCodeToMatrix((uint8_t)(nose * 4 + clock), actual);
+            for (int i = 0; i < 9; i++)
+            {
+                EXPECT_NEAR(actual[i], expected[i], 1e-5f)
+                    << "nose " << nose << " clock " << clock << " entry " << i;
+            }
+            memcpy(prev, actual, sizeof(prev));
+        }
+    }
+}
+
+TEST(Orientation, MatrixToCode_RoundTrip) {
+    for (uint8_t code = 0; code < ORIENT_CODE_COUNT; code++)
+    {
+        float R[9];
+        orientCodeToMatrix(code, R);
+        uint8_t back = 0xFF;
+        ASSERT_TRUE(orientMatrixToCode(R, back)) << "code " << (int)code;
+        EXPECT_EQ(back, code);
+    }
+    // A non-discrete rotation must NOT match (10° about Z)
+    const float c = cosf(10.0f * (float)M_PI / 180.0f);
+    const float s = sinf(10.0f * (float)M_PI / 180.0f);
+    const float R10[9] = { c, -s, 0,   s, c, 0,   0, 0, 1 };
+    uint8_t code = 0;
+    EXPECT_FALSE(orientMatrixToCode(R10, code));
+}
+
+TEST(Orientation, InvalidCode_FallsBackToIdentity) {
+    float R[9];
+    orientCodeToMatrix(24, R);
+    for (int i = 0; i < 9; i++)
+    {
+        EXPECT_NEAR(R[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-6f);
+    }
+    EXPECT_STREQ(orientCodeName(24), "?");
+}
+
+// ---------- Quaternion round-trips ----------
+
+TEST(Orientation, Quat_RoundTrips_AllCodes) {
+    for (uint8_t code = 0; code < ORIENT_CODE_COUNT; code++)
+    {
+        float R[9], q[4], R2[9];
+        orientCodeToMatrix(code, R);
+        orientCodeToQuat(code, q);
+
+        // Unit norm, canonical sign
+        const float n = sqrtf(q[0]*q[0] + q[1]*q[1] + q[2]*q[2] + q[3]*q[3]);
+        EXPECT_NEAR(n, 1.0f, 1e-5f) << "code " << (int)code;
+        EXPECT_GE(q[0], -1e-6f) << "code " << (int)code;
+
+        orientQuatToMatrix(q, R2);
+        for (int i = 0; i < 9; i++)
+        {
+            EXPECT_NEAR(R2[i], R[i], 1e-5f) << "code " << (int)code << " entry " << i;
+        }
+    }
+}
+
+TEST(Orientation, Quat_SurvivesWireQuantization) {
+    // Round-trip every code through the int16 ×10000 wire encoding the
+    // OC/flight-settings use; the recovered matrix must still match.
+    for (uint8_t code = 0; code < ORIENT_CODE_COUNT; code++)
+    {
+        float q[4], R[9], R2[9];
+        orientCodeToQuat(code, q);
+        float qw[4];
+        for (int i = 0; i < 4; i++)
+        {
+            const int16_t wire = (int16_t)lroundf(q[i] * ORIENT_QUAT_WIRE_SCALE);
+            qw[i] = (float)wire / ORIENT_QUAT_WIRE_SCALE;
+        }
+        orientCodeToMatrix(code, R);
+        orientQuatToMatrix(qw, R2);
+        for (int i = 0; i < 9; i++)
+        {
+            EXPECT_NEAR(R2[i], R[i], 1e-3f) << "code " << (int)code << " entry " << i;
+        }
+    }
+}
+
+// ---------- Gravity-vector nose snap ----------
+
+TEST(Orientation, NearestNose_CleanAxes) {
+    const float vecs[6][3] = {
+        { kG, 0, 0 }, { -kG, 0, 0 },
+        { 0, kG, 0 }, { 0, -kG, 0 },
+        { 0, 0, kG }, { 0, 0, -kG },
+    };
+    for (int nose = 0; nose < 6; nose++)
+    {
+        float residual = -1.0f;
+        const uint8_t code = orientNearestNoseCode(vecs[nose], &residual);
+        EXPECT_EQ(code, (uint8_t)(nose * 4)) << "nose " << nose;
+        EXPECT_NEAR(residual, 0.0f, 1e-3f) << "nose " << nose;
+    }
+}
+
+TEST(Orientation, NearestNose_TiltedVector_ResidualAngle) {
+    // 10° off +Z toward +X — still snaps to +Z with ~10° residual
+    const float tilt = 10.0f * (float)M_PI / 180.0f;
+    const float v[3] = { kG * sinf(tilt), 0.0f, kG * cosf(tilt) };
+    float residual = -1.0f;
+    const uint8_t code = orientNearestNoseCode(v, &residual);
+    EXPECT_EQ(code, (uint8_t)(4 * 4));  // +Z nose
+    EXPECT_NEAR(residual, 10.0f, 0.1f);
+}
+
+TEST(Orientation, NearestNose_SnappedCodeMapsVectorNearRocketX) {
+    // The snapped code's matrix must take the measured vector to within
+    // the residual of rocket +X — the property the pad auto-detect needs.
+    const float v[3] = { 2.0f, 1.0f, 9.5f };  // mostly +Z, messy
+    float residual = -1.0f;
+    const uint8_t code = orientNearestNoseCode(v, &residual);
+    float R[9], out[3];
+    orientCodeToMatrix(code, R);
+    matVec(R, v, out);
+    const float n = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    const float angle = acosf(out[0] / n) * 180.0f / (float)M_PI;
+    EXPECT_NEAR(angle, residual, 1e-3f);
+    EXPECT_LT(angle, 45.0f);
+}
+
+TEST(Orientation, NearestNose_ZeroVector_Identity) {
+    const float v[3] = { 0, 0, 0 };
+    float residual = -1.0f;
+    EXPECT_EQ(orientNearestNoseCode(v, &residual), ORIENT_CODE_IDENTITY);
+    EXPECT_EQ(residual, 0.0f);
+}
+
+TEST(Orientation, Quat_PinnedValue_Code17) {
+    // +Z r90 is the x→y→z cyclic permutation: 120° about (1,1,1), so the
+    // quaternion is exactly (0.5, 0.5, 0.5, 0.5).  Pinned because the iOS
+    // decode test (MessageParserTests.testFlightSettingsDecode) embeds the
+    // same value — keep the two in sync.
+    float q[4];
+    orientCodeToQuat(17, q);
+    EXPECT_NEAR(q[0], 0.5f, 1e-5f);
+    EXPECT_NEAR(q[1], 0.5f, 1e-5f);
+    EXPECT_NEAR(q[2], 0.5f, 1e-5f);
+    EXPECT_NEAR(q[3], 0.5f, 1e-5f);
+}
+
+TEST(Orientation, CodeNames) {
+    EXPECT_STREQ(orientCodeName(0), "+X");
+    EXPECT_STREQ(orientCodeName(4), "-X");
+    EXPECT_STREQ(orientCodeName(16), "+Z");
+    EXPECT_STREQ(orientCodeName(17), "+Z r90");
+    EXPECT_STREQ(orientCodeName(23), "-Z r270");
+}
+
+// ---------- Pad attitude quaternion (EKF init) ----------
+
+namespace {
+// Body-to-NED rotate via quaternion (scalar-first)
+void quatRotate(const float q[4], const float v[3], float out[3])
+{
+    float R[9];
+    orientQuatToMatrix(q, R);
+    matVec(R, v, out);
+}
+}
+
+TEST(Orientation, PadQuat_NoseUp_MatchesLegacyInit) {
+    // Stationary nose-up FRD: specific force +g along body X.  The legacy
+    // EKF init hardcoded (0.7071, 0, 0.7071, 0) — gravity init must agree.
+    float q[4];
+    quatFromAccelHeading(kG, 0.0f, 0.0f, 0.0f, q);
+    EXPECT_NEAR(q[0], 0.70711f, 1e-3f);
+    EXPECT_NEAR(q[1], 0.0f, 1e-3f);
+    EXPECT_NEAR(q[2], 0.70711f, 1e-3f);
+    EXPECT_NEAR(q[3], 0.0f, 1e-3f);
+}
+
+TEST(Orientation, PadQuat_GravityMapsToNedUp) {
+    // For any stationary attitude, the init quaternion must take the
+    // measured specific force to NED "up" (0, 0, -g).
+    const float cases[][3] = {
+        { kG, 0, 0 },           // nose up
+        { -kG, 0, 0 },          // nose down
+        { 0, 0, -kG },          // level (body Z down)
+        { kG * 0.7071f, 0, -kG * 0.7071f },   // 45° pitch
+        { kG * 0.5f, kG * 0.5f, -kG * 0.7071f },  // pitched + rolled
+    };
+    for (const auto& acc : cases)
+    {
+        float q[4], up[3];
+        quatFromAccelHeading(acc[0], acc[1], acc[2], 0.0f, q);
+        quatRotate(q, acc, up);
+        EXPECT_NEAR(up[0], 0.0f, 0.02f) << acc[0] << "," << acc[1] << "," << acc[2];
+        EXPECT_NEAR(up[1], 0.0f, 0.02f) << acc[0] << "," << acc[1] << "," << acc[2];
+        EXPECT_NEAR(up[2], -kG, 0.02f) << acc[0] << "," << acc[1] << "," << acc[2];
+    }
+}
+
+TEST(Orientation, PadQuat_HeadingOnlyYaw_WhenLevel) {
+    // Level body with 90° heading: yaw quaternion about NED Z.
+    float q[4];
+    quatFromAccelHeading(0.0f, 0.0f, -kG, (float)M_PI / 2.0f, q);
+    EXPECT_NEAR(q[0], 0.70711f, 1e-3f);
+    EXPECT_NEAR(q[1], 0.0f, 1e-3f);
+    EXPECT_NEAR(q[2], 0.0f, 1e-3f);
+    EXPECT_NEAR(q[3], 0.70711f, 1e-3f);
+}
+
+TEST(Orientation, PadQuat_DegenerateInput_NoNaN) {
+    float q[4];
+    quatFromAccelHeading(0.0f, 0.0f, 0.0f, 0.0f, q);
+    for (int i = 0; i < 4; i++) EXPECT_FALSE(std::isnan(q[i]));
+}

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -916,6 +916,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         MT(OTA_STATUS_MSG),           MT(OTA_DATA_CHUNK),
         // FC->OC firmware-version push, relayed to the app for OTA verify (#8 P4).
         MT(FC_IDENTITY),
+        // Board->rocket mounting orientation setting (app->OC->FC).
+        MT(ORIENT_CONFIG_PENDING),    MT(ORIENT_CONFIG_MSG),
         MT(LORA_MSG),
     };
 #undef MT
@@ -936,7 +938,7 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 78u)
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 80u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -790,7 +790,7 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
 // by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
 // here so a struct edit can't silently desync the cross-language decode.
 TEST(RocketComputerTypes, FlightSettingsData_Layout) {
-    EXPECT_EQ(sizeof(FlightSettingsData), 188u);  // +12 vs pre-4ch pyro
+    EXPECT_EQ(sizeof(FlightSettingsData), 200u);  // v2: +12 for b2r orientation
     EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
 
     EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
@@ -824,6 +824,13 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
 
     // Roll profile waypoints start (RollProfileData @ 112, after num+pad).
     EXPECT_EQ(offsetof(FlightSettingsData, roll_profile) + offsetof(RollProfileData, waypoints), 116u);
+
+    // v2 board→rocket orientation tail — appended after the full v1 layout
+    // (188 bytes) so v1 parsers still decode their prefix unchanged.
+    EXPECT_EQ(offsetof(FlightSettingsData, b2r_code),          188u);
+    EXPECT_EQ(offsetof(FlightSettingsData, b2r_mode),          189u);
+    EXPECT_EQ(offsetof(FlightSettingsData, b2r_residual_cdeg), 190u);
+    EXPECT_EQ(offsetof(FlightSettingsData, b2r_q),             192u);
 }
 
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {

--- a/tests_cpp/test_sensor_data_converter.cpp
+++ b/tests_cpp/test_sensor_data_converter.cpp
@@ -194,3 +194,110 @@ TEST_F(SensorConverterTest, NonSensor_QuatAndPosition) {
     EXPECT_EQ(si.rocket_state, INFLIGHT);
     EXPECT_NEAR(si.altitude_rate, 10.0f, 0.1f);
 }
+
+// ---------- Board→Rocket Mounting Orientation ----------
+// The converter applies an optional board→rocket rotation LAST (after the
+// per-chip Z rotation and bias subtraction) so PCB-fact calibrations stay
+// valid for any mounting.  Codes/matrices come from TR_Orientation.
+
+#include "TR_Orientation.h"
+
+class SensorConverterB2RTest : public SensorConverterTest {
+protected:
+    void configureNose(uint8_t code) {
+        float R[9];
+        orientCodeToMatrix(code, R);
+        conv.configureBoardToRocket(R);
+    }
+};
+
+TEST_F(SensorConverterB2RTest, ZNose_MovesBoardZToRocketX_AllChannels) {
+    configureNose(16);  // +Z toward the nose
+
+    ISM6HG256Data raw{};
+    raw.acc_low_raw.z  = 16384;  // +8g
+    raw.acc_high_raw.z = 1024;   // +8g at 256g FS
+    raw.gyro_raw.z     = 8192;   // +1000 dps at 4000 FS
+    ISM6HG256DataSI si{};
+    conv.convertISM6HG256Data(raw, si);
+
+    const double exp_lg = 8.0 * 9.80665;
+    EXPECT_NEAR(si.low_g_acc_x, exp_lg, 0.1);
+    EXPECT_NEAR(si.low_g_acc_y, 0.0, 1e-6);
+    EXPECT_NEAR(si.low_g_acc_z, 0.0, 1e-6);
+    EXPECT_NEAR(si.high_g_acc_x, exp_lg, 0.2);
+    EXPECT_NEAR(si.gyro_x, 1000.0, 0.5);
+    EXPECT_NEAR(si.gyro_z, 0.0, 1e-6);
+}
+
+TEST_F(SensorConverterB2RTest, IdentityCode_MatchesUnconfigured) {
+    ISM6HG256Data raw{};
+    raw.acc_low_raw.x = 16384;
+    raw.acc_low_raw.y = -8192;
+    raw.acc_low_raw.z = 4096;
+    ISM6HG256DataSI base{};
+    conv.convertISM6HG256Data(raw, base);
+
+    configureNose(ORIENT_CODE_IDENTITY);
+    ISM6HG256DataSI si{};
+    conv.convertISM6HG256Data(raw, si);
+
+    EXPECT_DOUBLE_EQ(si.low_g_acc_x, base.low_g_acc_x);
+    EXPECT_DOUBLE_EQ(si.low_g_acc_y, base.low_g_acc_y);
+    EXPECT_DOUBLE_EQ(si.low_g_acc_z, base.low_g_acc_z);
+}
+
+TEST_F(SensorConverterB2RTest, HighGBias_SubtractedInBoardFrame_BeforeB2R) {
+    // Bias is a board-frame (PCB) fact: with zero raw input the board-frame
+    // value is (-1,-2,-3); a +Z-nose mounting must then rotate that vector,
+    // giving rocket (-3,-2,+1).  If bias were wrongly subtracted after the
+    // rotation the result would stay (-1,-2,-3).
+    conv.setHighGBias(1.0f, 2.0f, 3.0f);
+    configureNose(16);  // +Z nose: rocket x=+z_b, y=+y_b, z=-x_b
+
+    ISM6HG256Data raw{};
+    ISM6HG256DataSI si{};
+    conv.convertISM6HG256Data(raw, si);
+
+    EXPECT_NEAR(si.high_g_acc_x, -3.0, 0.01);
+    EXPECT_NEAR(si.high_g_acc_y, -2.0, 0.01);
+    EXPECT_NEAR(si.high_g_acc_z,  1.0, 0.01);
+}
+
+TEST_F(SensorConverterB2RTest, ComposesWithChipRotZ_ChipFirst) {
+    // Chip rotZ 90° maps sensor +X → board +Y; a -Y-nose mounting (code 12)
+    // then maps board +Y → rocket -X.  Sensor +X must come out at rocket -X.
+    conv.configureISM6HG256RotationZ(90.0f);
+    configureNose(12);  // -Y toward the nose
+
+    ISM6HG256Data raw{};
+    raw.acc_low_raw.x = 16384;  // +8g on sensor X
+    ISM6HG256DataSI si{};
+    conv.convertISM6HG256Data(raw, si);
+
+    EXPECT_NEAR(si.low_g_acc_x, -8.0 * 9.80665, 0.1);
+    EXPECT_NEAR(si.low_g_acc_y, 0.0, 0.5);
+    EXPECT_NEAR(si.low_g_acc_z, 0.0, 1e-6);
+}
+
+TEST_F(SensorConverterB2RTest, Magnetometers_GetSameRotation) {
+    configureNose(16);  // +Z nose
+
+    MMC5983MAData mmc{};
+    mmc.mag_x = 131072;
+    mmc.mag_y = 131072;
+    mmc.mag_z = 131072 + 16384;  // +100 µT on board Z
+    MMC5983MADataSI mmc_si{};
+    conv.convertMMC5983MAData(mmc, mmc_si);
+    EXPECT_NEAR(mmc_si.mag_x_uT, 100.0, 0.1);   // board z → rocket x
+    EXPECT_NEAR(mmc_si.mag_z_uT, 0.0, 0.1);
+
+    IIS2MDCData iis{};
+    iis.mag_x = 0;
+    iis.mag_y = 0;
+    iis.mag_z = 400;  // 400 * 0.15 = 60 µT on board Z
+    IIS2MDCDataSI iis_si{};
+    conv.convertIIS2MDCData(iis, iis_si);
+    EXPECT_NEAR(iis_si.mag_x_uT, 60.0, 0.1);
+    EXPECT_NEAR(iis_si.mag_z_uT, 0.0, 0.1);
+}

--- a/tinkerrocket-idf/components/TR_Orientation/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_Orientation/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "TR_Orientation.cpp" INCLUDE_DIRS ".")

--- a/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.cpp
+++ b/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.cpp
@@ -179,6 +179,170 @@ const char *orientCodeName(uint8_t code)
     return (code < ORIENT_CODE_COUNT) ? names[code] : "?";
 }
 
+bool orientMatrixFromNoseVector(const float v_board[3], float R[9])
+{
+    const float n = sqrtf(v_board[0] * v_board[0] +
+                          v_board[1] * v_board[1] +
+                          v_board[2] * v_board[2]);
+    for (int i = 0; i < 9; i++) R[i] = (i % 4 == 0) ? 1.0f : 0.0f;
+    if (n < 1e-9f) return false;
+
+    const float ax = v_board[0] / n;
+    const float ay = v_board[1] / n;
+    const float az = v_board[2] / n;
+
+    // Shortest arc a→x̂:  R = I + [k]× + [k]×² / (1 + c),  k = a × x̂.
+    // c = a·x̂ = ax;  k = (a_y*0 - a_z*0, a_z*1 - a_x*0, a_x*0 - a_y*1)
+    //              = (0, az, -ay).
+    const float c = ax;
+    if (c < -1.0f + 1e-6f)
+    {
+        // a ≈ -x̂: arc is ambiguous; use the -X convention (180° about +Z).
+        R[0] = -1.0f; R[4] = -1.0f; R[8] = 1.0f;
+        R[1] = R[2] = R[3] = R[5] = R[6] = R[7] = 0.0f;
+        return true;
+    }
+
+    const float kx = 0.0f, ky = az, kz = -ay;
+    const float f = 1.0f / (1.0f + c);
+    // [k]× and [k]×² expanded (kx = 0 simplifies the products).
+    R[0] = 1.0f + f * (-(ky * ky + kz * kz));
+    R[1] = -kz + f * (kx * ky);
+    R[2] =  ky + f * (kx * kz);
+    R[3] =  kz + f * (kx * ky);
+    R[4] = 1.0f + f * (-(kx * kx + kz * kz));
+    R[5] = -kx + f * (ky * kz);
+    R[6] = -ky + f * (kx * kz);
+    R[7] =  kx + f * (ky * kz);
+    R[8] = 1.0f + f * (-(kx * kx + ky * ky));
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// OrientationEstimator
+
+static constexpr float kOrientG = 9.80665f;
+
+void OrientationEstimator::reset()
+{
+    sum_[0] = sum_[1] = sum_[2] = 0.0;
+    count_ = 0;
+    accumulating_ = false;
+    fresh_ = false;
+}
+
+bool OrientationEstimator::update(uint32_t t_us, float ax, float ay, float az,
+                                  float gx, float gy, float gz)
+{
+    if (t_us == last_t_us_) return false;  // caller re-fed the same sample
+    last_t_us_ = t_us;
+
+    const float a_mag = sqrtf(ax * ax + ay * ay + az * az);
+    const bool quiet = fabsf(gx) < gyro_quiet_dps &&
+                       fabsf(gy) < gyro_quiet_dps &&
+                       fabsf(gz) < gyro_quiet_dps &&
+                       fabsf(a_mag - kOrientG) < acc_tol_ms2;
+    if (!quiet)
+    {
+        // Motion: drop the partial window and wait for stillness again.
+        sum_[0] = sum_[1] = sum_[2] = 0.0;
+        count_ = 0;
+        accumulating_ = false;
+        return false;
+    }
+
+    if (!accumulating_)
+    {
+        accumulating_ = true;
+        window_start_us_ = t_us;
+        sum_[0] = sum_[1] = sum_[2] = 0.0;
+        count_ = 0;
+    }
+
+    sum_[0] += ax; sum_[1] += ay; sum_[2] += az;
+    count_++;
+
+    if ((uint32_t)(t_us - window_start_us_) < window_us || count_ < min_samples)
+    {
+        return false;
+    }
+
+    const double m = sqrt(sum_[0] * sum_[0] + sum_[1] * sum_[1] + sum_[2] * sum_[2]);
+    if (m > 1e-9)
+    {
+        est_[0] = (float)(sum_[0] / m);
+        est_[1] = (float)(sum_[1] / m);
+        est_[2] = (float)(sum_[2] / m);
+        fresh_ = true;
+    }
+    // Start the next window immediately — continuous re-estimation until
+    // the caller latches at launch.
+    accumulating_ = false;
+    return fresh_;
+}
+
+bool OrientationEstimator::takeEstimate(float up_rocket[3])
+{
+    if (!fresh_) return false;
+    up_rocket[0] = est_[0];
+    up_rocket[1] = est_[1];
+    up_rocket[2] = est_[2];
+    fresh_ = false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// ThrustAxisCheck
+
+void ThrustAxisCheck::start(uint32_t t_us)
+{
+    sum_[0] = sum_[1] = sum_[2] = 0.0;
+    count_ = 0;
+    start_us_ = t_us;
+    last_t_us_ = 0;
+    running_ = true;
+    done_ = false;
+    valid_ = false;
+    angle_deg_ = 0.0f;
+}
+
+bool ThrustAxisCheck::update(uint32_t t_us, float ax, float ay, float az)
+{
+    if (!running_ || done_) return false;
+    if (t_us == last_t_us_) return false;
+    last_t_us_ = t_us;
+
+    if ((uint32_t)(t_us - start_us_) <= window_us)
+    {
+        const float a_mag = sqrtf(ax * ax + ay * ay + az * az);
+        if (a_mag > min_acc_ms2)
+        {
+            sum_[0] += ax; sum_[1] += ay; sum_[2] += az;
+            count_++;
+        }
+        return false;
+    }
+
+    // Window elapsed — finalize.
+    done_ = true;
+    running_ = false;
+    // Require a sensible number of thrusting samples; a chuffed/slow
+    // ignition or saturated channel shouldn't produce a verdict.
+    if (count_ >= 10)
+    {
+        const double m = sqrt(sum_[0] * sum_[0] + sum_[1] * sum_[1] + sum_[2] * sum_[2]);
+        if (m > 1e-9)
+        {
+            double cx = sum_[0] / m;
+            if (cx > 1.0) cx = 1.0;
+            if (cx < -1.0) cx = -1.0;
+            angle_deg_ = (float)(acos(cx) * 180.0 / M_PI);
+            valid_ = true;
+        }
+    }
+    return true;
+}
+
 void quatFromAccelHeading(float acc_x_frd, float acc_y_frd, float acc_z_frd,
                           float heading_rad, float q[4])
 {

--- a/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.cpp
+++ b/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.cpp
@@ -1,0 +1,213 @@
+#include "TR_Orientation.h"
+
+#include <math.h>
+
+// clock=0 base rotations: shortest arc taking the selected board axis to
+// the rocket nose (+X).  Row-major, v_rocket = R0 * v_board.  All entries
+// are exact 0/±1 — see header for the -X (180°) axis convention.
+static const int8_t kNoseBase[6][9] = {
+    // +X: identity
+    { 1, 0, 0,   0, 1, 0,   0, 0, 1 },
+    // -X: 180° about board +Z
+    { -1, 0, 0,   0, -1, 0,   0, 0, 1 },
+    // +Y: shortest arc +Y→+X (90° about -Z)
+    { 0, 1, 0,   -1, 0, 0,   0, 0, 1 },
+    // -Y: shortest arc -Y→+X (90° about +Z)
+    { 0, -1, 0,   1, 0, 0,   0, 0, 1 },
+    // +Z: shortest arc +Z→+X (90° about +Y)
+    { 0, 0, 1,   0, 1, 0,   -1, 0, 0 },
+    // -Z: shortest arc -Z→+X (90° about -Y)
+    { 0, 0, -1,   0, 1, 0,   1, 0, 0 },
+};
+
+// Quarter-turn about rocket +X (CCW, right-hand rule), applied AFTER the
+// nose alignment: cos/sin pairs for clock = 0..3.
+static const int8_t kClockCos[4] = { 1, 0, -1, 0 };
+static const int8_t kClockSin[4] = { 0, 1, 0, -1 };
+
+void orientCodeToMatrix(uint8_t code, float R[9])
+{
+    if (code >= ORIENT_CODE_COUNT) code = ORIENT_CODE_IDENTITY;
+    const int8_t *B = kNoseBase[code / 4];
+    const int8_t c = kClockCos[code % 4];
+    const int8_t s = kClockSin[code % 4];
+
+    // R = Rx(clock) * B with Rx = [[1,0,0],[0,c,-s],[0,s,c]]:
+    // row0 = B row0, row1 = c*B row1 - s*B row2, row2 = s*B row1 + c*B row2.
+    for (int j = 0; j < 3; j++)
+    {
+        R[0 + j] = (float)B[0 + j];
+        R[3 + j] = (float)(c * B[3 + j] - s * B[6 + j]);
+        R[6 + j] = (float)(s * B[3 + j] + c * B[6 + j]);
+    }
+}
+
+bool orientMatrixToCode(const float R[9], uint8_t &code)
+{
+    for (uint8_t cand = 0; cand < ORIENT_CODE_COUNT; cand++)
+    {
+        float C[9];
+        orientCodeToMatrix(cand, C);
+        bool match = true;
+        for (int i = 0; i < 9; i++)
+        {
+            if (fabsf(R[i] - C[i]) > 1e-3f) { match = false; break; }
+        }
+        if (match) { code = cand; return true; }
+    }
+    return false;
+}
+
+void orientMatrixToQuat(const float R[9], float q[4])
+{
+    // Shepperd's method: pick the largest of the four squared components
+    // for numeric stability, then normalize with scalar part >= 0.
+    const float r00 = R[0], r01 = R[1], r02 = R[2];
+    const float r10 = R[3], r11 = R[4], r12 = R[5];
+    const float r20 = R[6], r21 = R[7], r22 = R[8];
+    const float tr = r00 + r11 + r22;
+
+    float w, x, y, z;
+    if (tr > 0.0f)
+    {
+        float s = sqrtf(tr + 1.0f) * 2.0f;
+        w = 0.25f * s;
+        x = (r21 - r12) / s;
+        y = (r02 - r20) / s;
+        z = (r10 - r01) / s;
+    }
+    else if (r00 > r11 && r00 > r22)
+    {
+        float s = sqrtf(1.0f + r00 - r11 - r22) * 2.0f;
+        w = (r21 - r12) / s;
+        x = 0.25f * s;
+        y = (r01 + r10) / s;
+        z = (r02 + r20) / s;
+    }
+    else if (r11 > r22)
+    {
+        float s = sqrtf(1.0f + r11 - r00 - r22) * 2.0f;
+        w = (r02 - r20) / s;
+        x = (r01 + r10) / s;
+        y = 0.25f * s;
+        z = (r12 + r21) / s;
+    }
+    else
+    {
+        float s = sqrtf(1.0f + r22 - r00 - r11) * 2.0f;
+        w = (r10 - r01) / s;
+        x = (r02 + r20) / s;
+        y = (r12 + r21) / s;
+        z = 0.25f * s;
+    }
+
+    float n = sqrtf(w * w + x * x + y * y + z * z);
+    if (n < 1e-9f) { q[0] = 1.0f; q[1] = q[2] = q[3] = 0.0f; return; }
+    if (w < 0.0f) n = -n;  // canonical sign: scalar part >= 0
+    q[0] = w / n; q[1] = x / n; q[2] = y / n; q[3] = z / n;
+}
+
+void orientCodeToQuat(uint8_t code, float q[4])
+{
+    float R[9];
+    orientCodeToMatrix(code, R);
+    orientMatrixToQuat(R, q);
+}
+
+void orientQuatToMatrix(const float q[4], float R[9])
+{
+    float w = q[0], x = q[1], y = q[2], z = q[3];
+    float n = sqrtf(w * w + x * x + y * y + z * z);
+    if (n < 1e-9f)
+    {
+        // Degenerate input: fall back to identity rather than NaN.
+        for (int i = 0; i < 9; i++) R[i] = (i % 4 == 0) ? 1.0f : 0.0f;
+        return;
+    }
+    w /= n; x /= n; y /= n; z /= n;
+
+    R[0] = 1.0f - 2.0f * (y * y + z * z);
+    R[1] = 2.0f * (x * y - w * z);
+    R[2] = 2.0f * (x * z + w * y);
+    R[3] = 2.0f * (x * y + w * z);
+    R[4] = 1.0f - 2.0f * (x * x + z * z);
+    R[5] = 2.0f * (y * z - w * x);
+    R[6] = 2.0f * (x * z - w * y);
+    R[7] = 2.0f * (y * z + w * x);
+    R[8] = 1.0f - 2.0f * (x * x + y * y);
+}
+
+uint8_t orientNearestNoseCode(const float v_board[3], float *residual_deg)
+{
+    const float ax = fabsf(v_board[0]);
+    const float ay = fabsf(v_board[1]);
+    const float az = fabsf(v_board[2]);
+    const float n  = sqrtf(ax * ax + ay * ay + az * az);
+    if (n < 1e-9f)
+    {
+        if (residual_deg) *residual_deg = 0.0f;
+        return ORIENT_CODE_IDENTITY;
+    }
+
+    int axis = 0;
+    float amax = ax;
+    if (ay > amax) { axis = 1; amax = ay; }
+    if (az > amax) { axis = 2; amax = az; }
+
+    const bool neg = v_board[axis] < 0.0f;
+    const uint8_t nose_sel = (uint8_t)(axis * 2 + (neg ? 1 : 0));
+
+    if (residual_deg)
+    {
+        float c = amax / n;
+        if (c > 1.0f) c = 1.0f;
+        *residual_deg = acosf(c) * (180.0f / (float)M_PI);
+    }
+    return (uint8_t)(nose_sel * 4);
+}
+
+const char *orientCodeName(uint8_t code)
+{
+    static const char *names[ORIENT_CODE_COUNT] = {
+        "+X",      "+X r90",  "+X r180", "+X r270",
+        "-X",      "-X r90",  "-X r180", "-X r270",
+        "+Y",      "+Y r90",  "+Y r180", "+Y r270",
+        "-Y",      "-Y r90",  "-Y r180", "-Y r270",
+        "+Z",      "+Z r90",  "+Z r180", "+Z r270",
+        "-Z",      "-Z r90",  "-Z r180", "-Z r270",
+    };
+    return (code < ORIENT_CODE_COUNT) ? names[code] : "?";
+}
+
+void quatFromAccelHeading(float acc_x_frd, float acc_y_frd, float acc_z_frd,
+                          float heading_rad, float q[4])
+{
+    static constexpr float DEG2RAD_f = (float)M_PI / 180.0f;
+
+    float g_mag = sqrtf(acc_x_frd * acc_x_frd +
+                        acc_y_frd * acc_y_frd +
+                        acc_z_frd * acc_z_frd);
+    if (g_mag < 0.1f) g_mag = 9.807f;
+
+    float sx = acc_x_frd / g_mag;
+    if (sx > 1.0f) sx = 1.0f;
+    if (sx < -1.0f) sx = -1.0f;
+    const float pitch_rad = asinf(sx);
+
+    // Roll is ill-conditioned near vertical (Y/Z components vanish);
+    // matches the original FC init's 80° gate.
+    float roll_rad = 0.0f;
+    if (fabsf(pitch_rad) < 80.0f * DEG2RAD_f)
+    {
+        roll_rad = atan2f(-acc_y_frd, -acc_z_frd);
+    }
+
+    // Body-to-NED quaternion from ZYX Euler (yaw, pitch, roll)
+    const float cy = cosf(heading_rad * 0.5f), sy = sinf(heading_rad * 0.5f);
+    const float cp = cosf(pitch_rad * 0.5f),   sp = sinf(pitch_rad * 0.5f);
+    const float cr = cosf(roll_rad * 0.5f),    sr = sinf(roll_rad * 0.5f);
+    q[0] = cr * cp * cy + sr * sp * sy;
+    q[1] = sr * cp * cy - cr * sp * sy;
+    q[2] = cr * sp * cy + sr * cp * sy;
+    q[3] = cr * cp * sy - sr * sp * cy;
+}

--- a/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.h
+++ b/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.h
@@ -1,0 +1,86 @@
+#ifndef TR_ORIENTATION_H
+#define TR_ORIENTATION_H
+
+// Board→rocket mounting orientation utilities.
+//
+// The SensorConverter maps sensor frame → board frame with a fixed
+// per-chip Z rotation (PCB layout fact).  This component describes the
+// second hop: how the *board* sits in the *rocket* (an airframe
+// integration fact).  Board frame and rocket frame are both FLU
+// (+X forward/nose, +Y left, +Z up); when the board is mounted with its
+// +X toward the nose the mapping is identity and nothing changes.
+//
+// Discrete orientations are encoded in one byte:
+//   code = nose_sel * 4 + clock        (24 proper rotations, 0 = identity)
+//   nose_sel: which BOARD axis points toward the rocket NOSE
+//     0=+X  1=-X  2=+Y  3=-Y  4=+Z  5=-Z
+//   clock: extra quarter-turns (0..3, CCW looking down the nose from
+//     outside, i.e. right-hand rule about rocket +X) applied after the
+//     nose alignment.  clock matters only for roll-referenced features
+//     (roll control / canard mixing); recovery logic is roll-agnostic.
+//
+// For each nose_sel, clock=0 is the shortest-arc rotation from the board
+// axis to the nose (for -X, where the arc is ambiguous, the convention is
+// a 180° turn about board +Z).  This matches what a gravity-vector
+// auto-detect naturally produces, so snapped auto codes and manual codes
+// agree.
+//
+// Matrices are row-major 3x3, v_rocket = R * v_board.
+
+#include <stdint.h>
+
+// Identity mounting: board +X toward the nose, no clocking.
+static constexpr uint8_t ORIENT_CODE_IDENTITY = 0;
+static constexpr uint8_t ORIENT_CODE_COUNT    = 24;
+
+// How the active board→rocket rotation was determined.  Carried beside
+// the code/quaternion on the wire and in the flight-settings snapshot.
+static constexpr uint8_t ORIENT_MODE_DEFAULT    = 0;  // identity, nothing configured
+static constexpr uint8_t ORIENT_MODE_MANUAL     = 1;  // user/config supplied code
+static constexpr uint8_t ORIENT_MODE_AUTO_SNAP  = 2;  // pad-gravity detect, snapped to axis
+static constexpr uint8_t ORIENT_MODE_AUTO_EXACT = 3;  // pad-gravity detect, exact vector (snap tolerance exceeded)
+
+// Scale used when quaternions ride the wire as int16 (matches the
+// NonSensorData quaternion convention).
+static constexpr float ORIENT_QUAT_WIRE_SCALE = 10000.0f;
+
+// code → rotation matrix (row-major, v_rocket = R * v_board).
+// Invalid codes (>= ORIENT_CODE_COUNT) yield identity.
+void orientCodeToMatrix(uint8_t code, float R[9]);
+
+// Exact inverse of orientCodeToMatrix: matches R against the 24 discrete
+// rotations (tolerance ~1e-3 per entry).  Returns false (code untouched)
+// if R is not one of them — e.g. an AUTO_EXACT rotation.
+bool orientMatrixToCode(const float R[9], uint8_t &code);
+
+// code → unit quaternion (scalar-first, board→rocket).
+void orientCodeToQuat(uint8_t code, float q[4]);
+
+// Unit quaternion (scalar-first) → rotation matrix (row-major).
+void orientQuatToMatrix(const float q[4], float R[9]);
+
+// Rotation matrix → unit quaternion (scalar-first, q0 >= 0).
+void orientMatrixToQuat(const float R[9], float q[4]);
+
+// Snap a board-frame "toward the nose" vector (e.g. averaged specific
+// force on a vertical pad) to the nearest ±axis.  Returns the orientation
+// code (clock = 0) and, optionally, the residual angle between the vector
+// and the snapped axis in degrees.  Zero-length input returns identity
+// with residual 0.
+uint8_t orientNearestNoseCode(const float v_board[3], float *residual_deg);
+
+// Short human-readable name for a code: "+X", "-Z r90", ...  Returns a
+// pointer to a static string ("?" for invalid codes).
+const char *orientCodeName(uint8_t code);
+
+// Pad attitude initialization: body-to-NED quaternion from a stationary
+// FRD specific-force measurement plus a known pad heading.  This is the
+// EKF init previously inlined in flight_computer main.cpp — pitch from
+// the X component, roll from Y/Z (skipped within 10° of vertical where it
+// is ill-conditioned), yaw from the supplied heading.  Works for any
+// attitude, which is what makes the EKF init mounting-agnostic once the
+// board→rocket rotation is applied upstream.
+void quatFromAccelHeading(float acc_x_frd, float acc_y_frd, float acc_z_frd,
+                          float heading_rad, float q[4]);
+
+#endif // TR_ORIENTATION_H

--- a/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.h
+++ b/tinkerrocket-idf/components/TR_Orientation/TR_Orientation.h
@@ -83,4 +83,94 @@ const char *orientCodeName(uint8_t code);
 void quatFromAccelHeading(float acc_x_frd, float acc_y_frd, float acc_z_frd,
                           float heading_rad, float q[4]);
 
+// Exact (non-snapped) board→rocket rotation from a measured nose vector:
+// the shortest-arc rotation taking v̂ to +X.  Used when the pad-gravity
+// estimate is further than the snap tolerance from every axis (board
+// mounted off-orthogonal).  For axis-aligned v this reproduces the
+// canonical clock=0 matrices, including the 180°-about-+Z convention for
+// -X.  Returns false (R = identity) for a zero-length input.
+bool orientMatrixFromNoseVector(const float v_board[3], float R[9]);
+
+// ---------------------------------------------------------------------------
+// Pad-gravity orientation estimator.
+//
+// Continuously averages the specific-force direction while the rocket sits
+// still before launch.  On a (near-)vertical pad that direction IS the nose
+// direction, so it reveals how the board is mounted.  The caller feeds
+// converted ROCKET-frame samples (post board→rocket rotation) and, on each
+// completed window, decides whether the active rotation needs updating —
+// if the mounting is already correct the estimate simply confirms +X.
+//
+// Stationarity gating: every gyro axis under gyro_quiet_dps AND |‖a‖−g|
+// under acc_tol_ms2; any violation restarts the window, so handling,
+// wind-rock, and transport never contribute samples.  Duplicate timestamps
+// (caller polls faster than the IMU updates) are ignored.
+class OrientationEstimator
+{
+public:
+    // Thresholds are members (not constructor params) so tests and future
+    // config plumbing can tune them; defaults match the landing detector's
+    // notion of "still" with margin for pad wind.
+    float    gyro_quiet_dps = 3.0f;      // per-axis |gyro| ceiling
+    float    acc_tol_ms2    = 2.0f;      // | ‖a‖ − g | ceiling (~0.2 g)
+    uint32_t window_us      = 2000000;   // averaging window
+    uint32_t min_samples    = 200;       // floor on samples per window
+
+    void reset();
+
+    // Feed one rocket-frame SI sample (accel m/s², gyro dps).  Returns true
+    // when this sample completed a window (a fresh estimate is available).
+    bool update(uint32_t t_us, float ax, float ay, float az,
+                float gx, float gy, float gz);
+
+    // Fetch the latest completed estimate (unit "up/nose" vector in rocket
+    // frame) and clear the fresh flag.  False if no unread estimate.
+    bool takeEstimate(float up_rocket[3]);
+
+private:
+    double   sum_[3]        = {0.0, 0.0, 0.0};
+    uint32_t count_         = 0;
+    uint32_t window_start_us_ = 0;
+    uint32_t last_t_us_     = 0;
+    bool     accumulating_  = false;
+    bool     fresh_         = false;
+    float    est_[3]        = {1.0f, 0.0f, 0.0f};
+};
+
+// ---------------------------------------------------------------------------
+// Thrust-axis cross-check.
+//
+// During the first instants of powered flight the specific force is
+// dominated by thrust, which acts along the rocket axis regardless of rail
+// tilt.  Averaging the rocket-frame accel direction right after launch
+// detection and comparing it to +X validates the latched orientation: a
+// large angle means the pad-gravity estimate (or a manual setting) was
+// wrong — e.g. the rocket sat non-vertical at the final stationary window.
+// The result is a flag, not a correction: re-orienting mid-boost would
+// yank the EKF and control frames at the worst possible moment.
+class ThrustAxisCheck
+{
+public:
+    float    min_acc_ms2 = 20.0f;   // only count clearly-thrusting samples
+    uint32_t window_us   = 150000;  // averaging window after start()
+
+    void start(uint32_t t_us);
+    // Feed rocket-frame accel.  Returns true once, when the window closes.
+    bool update(uint32_t t_us, float ax, float ay, float az);
+
+    bool  done() const  { return done_; }
+    bool  valid() const { return valid_; }      // enough samples to judge
+    float angleFromNoseDeg() const { return angle_deg_; }
+
+private:
+    double   sum_[3]   = {0.0, 0.0, 0.0};
+    uint32_t count_    = 0;
+    uint32_t start_us_ = 0;
+    uint32_t last_t_us_ = 0;
+    bool     running_  = false;
+    bool     done_     = false;
+    bool     valid_    = false;
+    float    angle_deg_ = 0.0f;
+};
+
 #endif // TR_ORIENTATION_H

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1085,6 +1085,11 @@ static constexpr uint8_t NSF2_MASTER_APOGEE    = (1u << 2);
 // 4-channel pyro layout.
 static constexpr uint8_t NSF2_REBOOT_RECOVERY  = (1u << 3);  // mid-flight reboot recovery occurred
 static constexpr uint8_t NSF2_GUIDANCE_ENABLED = (1u << 4);  // FC's live guidance_enabled config
+// Thrust-axis cross-check failed: the boost-phase accel direction
+// disagreed with the latched board→rocket orientation by >25°.  The
+// orientation is NOT corrected mid-flight — this flags the mismatch for
+// telemetry and post-flight analysis (suspect attitude-derived data).
+static constexpr uint8_t NSF2_ORIENT_THRUST_MISMATCH = (1u << 5);
 
 // Pyro status byte — 4 channels × (continuity, fired) = exactly 8 bits.
 static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);
@@ -1774,7 +1779,8 @@ static_assert(sizeof(GuidanceTelemData) == 15, "GuidanceTelemData must be 15 byt
 struct __attribute__((packed)) FlightSnapshotData
 {
     static constexpr uint32_t MAGIC   = 0xF1A75A7E;  // distinct from old NVS magic (0xF1A7C0DE)
-    static constexpr uint8_t  VERSION = 2;           // v2: 4-channel pyro layout, no per-channel ARM
+    static constexpr uint8_t  VERSION = 3;           // v2: 4-channel pyro layout, no per-channel ARM
+                                                     // v3: board→rocket orientation (b2r_*)
 
     // --- Header ---
     uint32_t magic;
@@ -1797,7 +1803,13 @@ struct __attribute__((packed)) FlightSnapshotData
     uint8_t  pyro2_fired;
     uint8_t  pyro3_fired;
     uint8_t  pyro4_fired;
-    uint8_t  pad2[3];
+    // Board→rocket orientation that was active at launch (v3, reclaimed
+    // from pad2).  Restored BEFORE the EKF state below — the quaternion,
+    // velocities and biases were all estimated in this rocket frame, so a
+    // post-reboot boot-default orientation would silently invalidate them.
+    uint8_t  b2r_code;            // discrete orientation code
+    uint8_t  b2r_mode;            // ORIENT_MODE_*
+    uint8_t  pad2[1];
 
     // --- Flight references ---
     float    ground_pressure_pa;
@@ -1821,11 +1833,15 @@ struct __attribute__((packed)) FlightSnapshotData
     uint32_t ekf_t_prev_us;
     float    ekf_euler[3];
 
+    // Board→rocket quaternion ×10000 (v3) — authoritative rotation,
+    // covers AUTO_EXACT mountings the discrete code can't express.
+    int16_t  b2r_q[4];
+
     // --- Integrity (CRC32 over all preceding bytes) ---
     uint32_t crc32;
 };
-static_assert(sizeof(FlightSnapshotData) == 216,
-              "FlightSnapshotData must be 216 bytes — fits one I2S frame and one I2C TX response");
+static_assert(sizeof(FlightSnapshotData) == 224,
+              "FlightSnapshotData must be 224 bytes — fits one I2S frame and one I2C TX response");
 
 static constexpr size_t SIZE_OF_GNSS_DATA = sizeof(GNSSData);
 static constexpr size_t SIZE_OF_BMP585_DATA     = sizeof(BMP585Data);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -555,13 +555,24 @@ typedef struct __attribute__((packed))
     uint16_t ism6_gyro_fs_dps;    // e.g. 4000
     int16_t  ism6_rot_z_cdeg;     // centi-deg
     int16_t  mmc_rot_z_cdeg;      // centi-deg
-    uint8_t  format_version;      // payload format version (2 = has HG bias)
+    uint8_t  format_version;      // payload format version
+                                  //   2 = has HG bias
+                                  //   3 = has board→rocket orientation
     int16_t  hg_bias_x_cmss;     // high-g bias X, centi-m/s² (0.01 m/s² units)
     int16_t  hg_bias_y_cmss;     // high-g bias Y, centi-m/s²
     int16_t  hg_bias_z_cmss;     // high-g bias Z, centi-m/s²
+
+    // Board→rocket mounting orientation (format_version >= 3).  The
+    // quaternion (scalar-first, ×10000 like NonSensorData) is what the
+    // OC actually applies to its SensorConverter — it covers both the
+    // 24 discrete codes and a future exact (non-snapped) auto rotation.
+    // code/mode (TR_Orientation ORIENT_*) describe it for display/log.
+    uint8_t  b2r_code;           // discrete orientation code (0 = +X nose)
+    uint8_t  b2r_mode;           // ORIENT_MODE_* (how it was determined)
+    int16_t  b2r_q[4];           // board→rocket quaternion ×10000
 } OutStatusQueryData;
-static_assert(sizeof(OutStatusQueryData) == 16,
-              "OutStatusQueryData must be 16 bytes");
+static_assert(sizeof(OutStatusQueryData) == 26,
+              "OutStatusQueryData must be 26 bytes");
 
 // ### Data Structures ###
 // Packed and unpacked data structures for each type ---
@@ -1635,7 +1646,8 @@ static_assert(sizeof(RollControlConfigData) == 4, "RollControlConfigData must be
 // bytes" convention still holds.
 struct __attribute__((packed)) FlightSettingsData
 {
-    static constexpr uint8_t VERSION = 1;
+    // v2: appended board→rocket mounting orientation (b2r_* fields).
+    static constexpr uint8_t VERSION = 2;
 
     // flags bit positions
     static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only
@@ -1692,8 +1704,18 @@ struct __attribute__((packed)) FlightSettingsData
 
     // Active roll profile (num_waypoints == 0 → rate-only)
     RollProfileData roll_profile;
+
+    // Board→rocket mounting orientation that actually flew (v2+).
+    // Mirrors OutStatusQueryData v3: quaternion is authoritative,
+    // code/mode (TR_Orientation ORIENT_*) describe it.  residual is the
+    // angle between the auto-detected nose vector and the snapped axis
+    // (0 for manual/default; meaningful once auto-detect lands).
+    uint8_t  b2r_code;            // discrete orientation code (0 = +X nose)
+    uint8_t  b2r_mode;            // ORIENT_MODE_*
+    int16_t  b2r_residual_cdeg;   // auto-snap residual, centi-deg
+    int16_t  b2r_q[4];            // board→rocket quaternion ×10000
 };
-static_assert(sizeof(FlightSettingsData) == 188, "FlightSettingsData layout check");
+static_assert(sizeof(FlightSettingsData) == 200, "FlightSettingsData layout check");
 
 // --- Log Buffer Stats Data (OC self-emitted, ~1 Hz while logging) -----------
 // Snapshot of the OC's ring-buffer health written into the flight log so the

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1487,6 +1487,15 @@ static constexpr uint8_t OTA_DATA_CHUNK      = 0xEB;
 // update, which is why the connected-device version check false-positived (#8).
 static constexpr uint8_t FC_IDENTITY         = 0xEC;
 
+// --- Board→rocket mounting orientation setting (app → OC → FC) ---
+// Two-phase like CAMERA_CONFIG: the OC stages ORIENT_CONFIG_PENDING with an
+// ImuOrientConfigData payload readable as ORIENT_CONFIG_MSG.  The OC also
+// re-stages a stored MANUAL setting whenever the FC's status query reports a
+// different mapping (e.g. after an FC reboot fell back to auto), so manual
+// roll clocking survives power cycles without the app connected.
+static constexpr uint8_t ORIENT_CONFIG_PENDING = 0xED;  // OC→FC: payload follows as ORIENT_CONFIG_MSG
+static constexpr uint8_t ORIENT_CONFIG_MSG     = 0xEE;  // 1-byte ImuOrientConfigData
+
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
 // real bottleneck, and the FC writes each received frame to flash (~2-3 ms/frame)
@@ -1529,6 +1538,19 @@ typedef struct __attribute__((packed))
     uint8_t camera_type;  // CAM_TYPE_NONE, CAM_TYPE_GOPRO, CAM_TYPE_RUNCAM
 } CameraConfigData;
 static_assert(sizeof(CameraConfigData) == 1, "CameraConfigData must be 1 byte");
+
+// Board→rocket mounting orientation setting (ORIENT_CONFIG_MSG payload).
+// IMU_ORIENT_AUTO lets the pad-gravity detect drive the mapping (fine for
+// non-controlled flights); a manual TR_Orientation code (0..23) is
+// authoritative and also fixes the roll clocking, which gravity cannot
+// observe — required when roll control / guidance must know which way the
+// control surfaces point.
+static constexpr uint8_t IMU_ORIENT_AUTO = 0xFF;
+typedef struct __attribute__((packed))
+{
+    uint8_t setting;  // IMU_ORIENT_AUTO or orientation code 0..23
+} ImuOrientConfigData;
+static_assert(sizeof(ImuOrientConfigData) == 1, "ImuOrientConfigData must be 1 byte");
 
 // Pyro trigger modes
 enum PyroTriggerMode : uint8_t {

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -106,6 +106,24 @@ void SensorCollectorSim::configureSimRotation(float ism6_rot_z_deg)
              (double)ism6_rot_z_deg, (double)ism6_inv_c_, (double)ism6_inv_s_);
 }
 
+void SensorCollectorSim::configureSimBoardToRocket(const float R[9])
+{
+    // Store the transpose (rocket→board); flag identity to skip the
+    // multiply in the hot encode path.
+    bool identity = true;
+    for (int r = 0; r < 3; r++)
+    {
+        for (int c = 0; c < 3; c++)
+        {
+            const float v = R[c * 3 + r];  // transpose
+            b2r_inv_[r * 3 + c] = v;
+            const float ref = (r == c) ? 1.0f : 0.0f;
+            if (fabsf(v - ref) > 1e-6f) identity = false;
+        }
+    }
+    b2r_identity_ = identity;
+}
+
 void SensorCollectorSim::startSim(float ground_pressure_pa)
 {
     if (!configured_)
@@ -424,13 +442,18 @@ void SensorCollectorSim::encodeISM6(uint32_t time_us, ISM6HG256Data& out)
     const float sp = sinf(pitch_rad_);
     const float cp = cosf(pitch_rad_);
     const float sf_vert = accel_mps2_ + GRAVITY;  // specific force if perfectly vertical
-    const float body_ax = sf_vert * sp;  // axial (along rocket)
-    const float body_az = sf_vert * cp;  // perpendicular
+    float body_ax = sf_vert * sp;  // axial (along rocket)
+    float body_ay = 0.0f;
+    float body_az = sf_vert * cp;  // perpendicular
 
-    // Inverse rotation: body-frame → sensor-frame (ISM6 board rotation about Z)
+    // Rocket frame → board frame (inverse of the mounting orientation;
+    // identity for the standard +X-nose mounting).
+    rocketToBoard(body_ax, body_ay, body_az);
+
+    // Inverse rotation: board-frame → sensor-frame (ISM6 board rotation about Z)
     // Only rotates X/Y; Z passes through
-    const float sensor_ax =  body_ax * ism6_inv_c_;
-    const float sensor_ay = -body_ax * ism6_inv_s_;
+    const float sensor_ax =  body_ax * ism6_inv_c_ + body_ay * ism6_inv_s_;
+    const float sensor_ay = -body_ax * ism6_inv_s_ + body_ay * ism6_inv_c_;
     const float sensor_az =  body_az;
 
     // Low-G accelerometer (±16g range)
@@ -449,15 +472,22 @@ void SensorCollectorSim::encodeISM6(uint32_t time_us, ISM6HG256Data& out)
     out.acc_high_raw.z = (int16_t)constrain(
         lroundf(sensor_az / ACC_HIGH_MS2_PER_LSB), -32768, 32767);
 
-    // Gyro: pitch rate on body Y axis (right-hand rule: Y = pitch axis)
-    // Rotated by ISM6 board angle same as accel X/Y
-    const float gyro_body_y_dps = pitch_rate_rps_ * (180.0f / 3.14159265f);
-    const float sensor_gx =  gyro_body_y_dps * ism6_inv_s_;  // cross-coupling
-    const float sensor_gy =  gyro_body_y_dps * ism6_inv_c_;
+    // Gyro: pitch rate on body Y axis (right-hand rule: Y = pitch axis),
+    // through the same inverse chain as accel (rocket → board → sensor).
+    float gyro_body_x_dps = 0.0f;
+    float gyro_body_y_dps = pitch_rate_rps_ * (180.0f / 3.14159265f);
+    float gyro_body_z_dps = 0.0f;
+    rocketToBoard(gyro_body_x_dps, gyro_body_y_dps, gyro_body_z_dps);
+
+    const float sensor_gx =  gyro_body_x_dps * ism6_inv_c_ + gyro_body_y_dps * ism6_inv_s_;
+    const float sensor_gy = -gyro_body_x_dps * ism6_inv_s_ + gyro_body_y_dps * ism6_inv_c_;
+    const float sensor_gz =  gyro_body_z_dps;
     out.gyro_raw.x = (int16_t)constrain(
         lroundf(sensor_gx / GYRO_DPS_PER_LSB), -32768, 32767);
     out.gyro_raw.y = (int16_t)constrain(
         lroundf(sensor_gy / GYRO_DPS_PER_LSB), -32768, 32767);
+    out.gyro_raw.z = (int16_t)constrain(
+        lroundf(sensor_gz / GYRO_DPS_PER_LSB), -32768, 32767);
 }
 
 void SensorCollectorSim::encodeBMP585(uint32_t time_us, BMP585Data& out)
@@ -488,9 +518,13 @@ void SensorCollectorSim::encodeMMC5983MA(uint32_t time_us, MMC5983MAData& out)
 
     const float sp = sinf(pitch_rad_);
     const float cp = cosf(pitch_rad_);
-    const float body_x =  B_NORTH * sp + B_DOWN * cp;
-    const float body_y =  B_EAST;
-    const float body_z = -B_NORTH * cp + B_DOWN * sp;
+    float body_x =  B_NORTH * sp + B_DOWN * cp;
+    float body_y =  B_EAST;
+    float body_z = -B_NORTH * cp + B_DOWN * sp;
+
+    // Rocket frame → board frame (inverse mounting orientation), matching
+    // the forward board→rocket rotation the converter now applies to mag.
+    rocketToBoard(body_x, body_y, body_z);
 
     out.mag_x = (uint32_t)(lroundf(body_x * COUNTS_PER_UT) + 131072);
     out.mag_y = (uint32_t)(lroundf(body_y * COUNTS_PER_UT) + 131072);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
@@ -57,6 +57,11 @@ public:
     // ---- Sim control ----
     void configureSim(const SimConfigData& cfg);
     void configureSimRotation(float ism6_rot_z_deg);
+    // Board→rocket mounting rotation (row-major, v_rocket = R * v_board).
+    // The sim's physics are rocket-frame; encoders apply the INVERSE so the
+    // forward conversion (chip rotZ, then board→rocket) reproduces the
+    // simulated values regardless of the configured mounting.
+    void configureSimBoardToRocket(const float R[9]);
     void startSim(float ground_pressure_pa);
     void stopSim();
     bool isSimActive() const;
@@ -101,6 +106,22 @@ private:
     // Inverse rotation (body frame → sensor frame) for ISM6 encoding
     float ism6_inv_c_ = 1.0f;   // cos(config_angle)
     float ism6_inv_s_ = 0.0f;   // sin(config_angle)
+
+    // Inverse board→rocket rotation (rocket frame → board frame), i.e. the
+    // transpose of the configured mounting matrix.  Identity by default.
+    float b2r_inv_[9] = {1.0f, 0.0f, 0.0f,
+                         0.0f, 1.0f, 0.0f,
+                         0.0f, 0.0f, 1.0f};
+    bool  b2r_identity_ = true;
+
+    inline void rocketToBoard(float &x, float &y, float &z) const
+    {
+        if (b2r_identity_) return;
+        const float bx = b2r_inv_[0] * x + b2r_inv_[1] * y + b2r_inv_[2] * z;
+        const float by = b2r_inv_[3] * x + b2r_inv_[4] * y + b2r_inv_[5] * z;
+        const float bz = b2r_inv_[6] * x + b2r_inv_[7] * y + b2r_inv_[8] * z;
+        x = bx; y = by; z = bz;
+    }
 
     // GNSS fallback timer (for indoor testing without GPS fix)
     uint32_t last_gnss_real_us_ = 0;

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -59,6 +59,18 @@ void SensorConverter::configureIIS2MDCRotationZ(float rotation_z_deg)
     iis2mdc_rot_z_rad = rotation_z_deg * (PI / 180.0f);
 }
 
+void SensorConverter::configureBoardToRocket(const float R[9])
+{
+    bool identity = true;
+    for (int i = 0; i < 9; i++)
+    {
+        b2r_[i] = R[i];
+        const float ref = (i % 4 == 0) ? 1.0f : 0.0f;
+        if (fabsf(R[i] - ref) > 1e-6f) identity = false;
+    }
+    b2r_identity_ = identity;
+}
+
 void SensorConverter::setHighGBias(float bx, float by, float bz)
 {
     if (bx == hg_bias_x_ && by == hg_bias_y_ && bz == hg_bias_z_)
@@ -195,6 +207,8 @@ void SensorConverter::convertISM6HG256Data(const ISM6HG256Data& in, ISM6HG256Dat
     out.low_g_acc_z = (double)in.acc_low_raw.z * (double)acc_low_ms2_per_lsb;
 
     // High-g accel (m/s^2), rotate about +Z to board frame, subtract bias.
+    // Bias is calibrated in board frame, so it must come off BEFORE the
+    // board→rocket rotation below.
     const double hg_x = (double)in.acc_high_raw.x * (double)acc_high_ms2_per_lsb;
     const double hg_y = (double)in.acc_high_raw.y * (double)acc_high_ms2_per_lsb;
     out.high_g_acc_x = (hg_x * c) - (hg_y * s) - (double)hg_bias_x_;
@@ -208,6 +222,11 @@ void SensorConverter::convertISM6HG256Data(const ISM6HG256Data& in, ISM6HG256Dat
     out.gyro_y = (g_x * s) + (g_y * c);
     out.gyro_z = (double)in.gyro_raw.z * (double)gyro_dps_per_lsb;
 
+    // Board frame → rocket frame (mounting orientation; identity when the
+    // board's +X points at the nose).
+    applyB2R(out.low_g_acc_x,  out.low_g_acc_y,  out.low_g_acc_z);
+    applyB2R(out.high_g_acc_x, out.high_g_acc_y, out.high_g_acc_z);
+    applyB2R(out.gyro_x,       out.gyro_y,       out.gyro_z);
 }
 
 // ---------------- MMC5983MA ----------------
@@ -243,6 +262,9 @@ void SensorConverter::convertMMC5983MAData(const MMC5983MAData& in, MMC5983MADat
   out.mag_x_uT = (mx * c) - (my * s);
   out.mag_y_uT = (mx * s) + (my * c);
   out.mag_z_uT = mz;
+
+  // Board frame → rocket frame (mounting orientation).
+  applyB2R(out.mag_x_uT, out.mag_y_uT, out.mag_z_uT);
 }
 
 // --- IIS2MDC (new-PCB magnetometer) ---
@@ -267,6 +289,9 @@ void SensorConverter::convertIIS2MDCData(const IIS2MDCData& in, IIS2MDCDataSI& o
     out.mag_x_uT = (mx * c) - (my * s);
     out.mag_y_uT = (mx * s) + (my * c);
     out.mag_z_uT = mz;
+
+    // Board frame → rocket frame (mounting orientation).
+    applyB2R(out.mag_x_uT, out.mag_y_uT, out.mag_z_uT);
 }
 
 // --- NonSensor ---

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.h
@@ -45,6 +45,13 @@ public:
     void configureMMC5983MARotationZ(float rotation_z_deg);
     void configureIIS2MDCRotationZ(float rotation_z_deg);
 
+    // Board→rocket mounting rotation (row-major 3x3, v_rocket = R * v_board).
+    // Applied LAST in every vector conversion (after the per-chip Z rotation
+    // and after bias subtraction, both of which are board-frame facts fixed
+    // by the PCB), so changing the mounting never invalidates stored
+    // calibrations.  Defaults to identity (board +X toward the nose).
+    void configureBoardToRocket(const float R[9]);
+
     // Set high-g accelerometer bias (m/s², in body frame).
     // Subtracted from ISM6HG256 high-g output during conversion.
     void setHighGBias(float bx, float by, float bz);
@@ -97,6 +104,24 @@ private:
 
     // High-g accelerometer bias (m/s², body frame)
     float hg_bias_x_ = 0.0f, hg_bias_y_ = 0.0f, hg_bias_z_ = 0.0f;
+
+    // Board→rocket mounting rotation (row-major; identity by default).
+    // b2r_identity_ short-circuits the matrix multiply on the hot path
+    // for the standard +X-nose mounting.
+    float b2r_[9] = {1.0f, 0.0f, 0.0f,
+                     0.0f, 1.0f, 0.0f,
+                     0.0f, 0.0f, 1.0f};
+    bool  b2r_identity_ = true;
+
+    // Apply board→rocket rotation in place (no-op when identity).
+    inline void applyB2R(double &x, double &y, double &z) const
+    {
+        if (b2r_identity_) return;
+        const double rx = b2r_[0] * x + b2r_[1] * y + b2r_[2] * z;
+        const double ry = b2r_[3] * x + b2r_[4] * y + b2r_[5] * z;
+        const double rz = b2r_[6] * x + b2r_[7] * y + b2r_[8] * z;
+        x = rx; y = ry; z = rz;
+    }
 
     // MMC5983MA hard-iron offset (centered-counts, issue #96).  Applied in
     // convertMMC5983MAData; zero by default so behaviour is unchanged

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -19,6 +19,7 @@ idf_component_register(
         TR_I2C_Interface
         TR_I2S_Stream
         TR_Sensor_Data_Converter
+        TR_Orientation
         TR_GpsInsEKF
         TR_KinematicChecks
         TR_MagCalibrator

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -85,8 +85,15 @@ struct config
     // to the IMU's Z axis.
     static constexpr float IIS2MDC_ROT_Z_DEG = 0.0f;
 
-    // TODO Auto dection of orientation and rotation of aribtrary board position
-    // to body frame
+    // Board -> rocket mounting orientation (TR_Orientation code, 0-23).
+    // 0 = board +X toward the nose (the historical assumption).  Set to a
+    // different code when the board is mounted off-axis: nose_sel*4 + clock,
+    // nose_sel 0..5 = +X,-X,+Y,-Y,+Z,-Z, clock = quarter-turns about the
+    // nose.  Applied after the per-chip rotations above, so those stay
+    // PCB facts and this stays an airframe fact.  Pad-gravity auto-detect
+    // and the app-side setting arrive in later phases; until then this
+    // constant is the manual override.
+    static constexpr uint8_t BOARD_TO_ROCKET_ORIENT = 0;
 
     // ### Camera Controls ###
     // Camera type: 0 = none, 1 = GoPro (GPIO pulse), 2 = RunCam (UART command)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4372,6 +4372,50 @@ static void loop_fc()
                              runtime_camera_type == CAM_TYPE_RUNCAM ? "RunCam" : "None");
                 }
             }
+            else if (out_pending_command == ORIENT_CONFIG_PENDING)
+            {
+                delay_ms(1);
+                uint8_t cfg_payload[sizeof(ImuOrientConfigData)];
+                size_t  cfg_len = 0;
+                if (readConfigFrame(ORIENT_CONFIG_MSG, sizeof(ImuOrientConfigData),
+                                    cfg_payload, sizeof(cfg_payload), cfg_len)
+                    && cfg_len >= sizeof(ImuOrientConfigData))
+                {
+                    const uint8_t setting = cfg_payload[0];
+                    if (rocket_state == INFLIGHT)
+                    {
+                        // Never re-frame mid-flight: EKF/control state is
+                        // only meaningful in the latched frame.
+                        ESP_LOGW(TAG, "[CFG] IMU orientation change ignored INFLIGHT");
+                    }
+                    else if (setting == IMU_ORIENT_AUTO)
+                    {
+                        // Back to auto.  Only act when leaving MANUAL —
+                        // reset to identity and let the pad-gravity detect
+                        // re-derive within a couple of seconds.
+                        if (b2r_active_mode == ORIENT_MODE_MANUAL)
+                        {
+                            applyBoardToRocketOrientation(ORIENT_CODE_IDENTITY,
+                                                          ORIENT_MODE_DEFAULT);
+                            orient_estimator.reset();
+                            if (ekf_initialized) ekf_initialized = false;
+                            ESP_LOGI(TAG, "[CFG] IMU orientation: AUTO (pad-gravity detect)");
+                        }
+                    }
+                    else if (setting < ORIENT_CODE_COUNT)
+                    {
+                        // Manual code is authoritative — it also fixes the
+                        // roll clocking the control surfaces need, which
+                        // auto-detect cannot observe.
+                        const bool changed = (b2r_active_code != setting) ||
+                                             (b2r_active_mode != ORIENT_MODE_MANUAL);
+                        applyBoardToRocketOrientation(setting, ORIENT_MODE_MANUAL);
+                        if (changed && ekf_initialized) ekf_initialized = false;
+                        ESP_LOGI(TAG, "[CFG] IMU orientation: MANUAL %s",
+                                 orientCodeName(setting));
+                    }
+                }
+            }
             else if (out_pending_command == PYRO_CONFIG_PENDING)
             {
                 delay_ms(1);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -9,6 +9,7 @@
 #include <TR_I2C_Interface.h>
 #include <TR_I2S_Stream.h>
 #include <TR_Sensor_Data_Converter.h>
+#include <TR_Orientation.h>
 #include <TR_GpsInsEKF.h>
 #include <TR_KinematicChecks.h>
 #include <TR_MagCalibrator.h>
@@ -249,6 +250,15 @@ static uint8_t out_pending_command = 0U;
 static uint8_t last_processed_cmd = 0U;  // dedup: ignore OutComputer repeats
 static bool end_flight_sent = false;
 static OutStatusQueryData out_status_query_data = {};
+
+// Active board→rocket mounting orientation.  Phase 1: static from
+// config::BOARD_TO_ROCKET_ORIENT at boot; pad-gravity auto-detect (phase 2)
+// and the app setting (phase 3) will call applyBoardToRocketOrientation()
+// again at runtime.  Cached here so the OC status query and the flight
+// settings snapshot both report what the converter is actually applying.
+static uint8_t b2r_active_code = ORIENT_CODE_IDENTITY;
+static uint8_t b2r_active_mode = ORIENT_MODE_DEFAULT;
+static float   b2r_active_quat[4] = {1.0f, 0.0f, 0.0f, 0.0f};
 static float ground_pressure_pa = 101325.0f;
 static float pressure_alt_m = 0.0f;
 static float pressure_alt_rate_mps = 0.0f;
@@ -1264,6 +1274,36 @@ static void fcRevertToTx()
     ESP_LOGW(TAG, "[OTA] I2S -> master TX (%s)", esp_err_to_name(e));
 }
 
+// Apply a discrete board→rocket mounting orientation everywhere it matters:
+// the converter (rotates all vector sensors into rocket frame), the sim
+// collector (inverse, so synthesized sensor counts survive the forward
+// path), the cached b2r_active_* globals (flight settings snapshot), and
+// the OC status query payload (keeps the OC's converter consistent — the
+// query repeats every poll, so a runtime change propagates within one
+// cycle).  Phase 1 calls this once at boot from config; auto-detect
+// (phase 2) and the app setting (phase 3) re-call it at runtime.
+static void applyBoardToRocketOrientation(uint8_t code, uint8_t mode)
+{
+    float R[9];
+    orientCodeToMatrix(code, R);
+    sensor_converter.configureBoardToRocket(R);
+    sensor_collector.configureSimBoardToRocket(R);
+
+    b2r_active_code = code;
+    b2r_active_mode = mode;
+    orientCodeToQuat(code, b2r_active_quat);
+
+    out_status_query_data.b2r_code = code;
+    out_status_query_data.b2r_mode = mode;
+    for (int i = 0; i < 4; ++i) {
+        out_status_query_data.b2r_q[i] =
+            (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
+    }
+
+    ESP_LOGI(TAG, "Board→rocket orientation: %s (code %u, mode %u)",
+             orientCodeName(code), (unsigned)code, (unsigned)mode);
+}
+
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
 // the live PID gains from servo_control (these can be NVS- or BLE-overridden),
 // the runtime override globals, the config:: defaults for the compile-time-only
@@ -1326,6 +1366,14 @@ static void buildFlightSettings(FlightSettingsData& s)
     strncpy(s.fw_git_sha, FW_GIT_SHA, sizeof(s.fw_git_sha) - 1);
 
     s.roll_profile = roll_profile;
+
+    // Board→rocket mounting orientation that actually flew (v2).
+    s.b2r_code = b2r_active_code;
+    s.b2r_mode = b2r_active_mode;
+    s.b2r_residual_cdeg = 0;  // meaningful once pad-gravity auto-detect lands
+    for (int i = 0; i < 4; ++i) {
+        s.b2r_q[i] = (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
+    }
 }
 
 static void sendFlightSettings()
@@ -2282,6 +2330,12 @@ static void setup_fc()
     sensor_converter.configureIIS2MDCRotationZ(config::IIS2MDC_ROT_Z_DEG);
     sensor_collector.configureSimRotation(config::ISM6HG256_ROT_Z_DEG);
 
+    // Board→rocket mounting orientation (converter + sim + OC query payload).
+    applyBoardToRocketOrientation(
+        config::BOARD_TO_ROCKET_ORIENT,
+        (config::BOARD_TO_ROCKET_ORIENT == ORIENT_CODE_IDENTITY)
+            ? ORIENT_MODE_DEFAULT : ORIENT_MODE_MANUAL);
+
     // Apply mag hard-iron offset to the IIS2MDC chip now that begin() has
     // finished its softReset (which zeroes OFFSET_X/Y/Z).  Issue #96.
     if (pending_mag_apply && sensor_collector.isIIS2MDCActive())
@@ -2308,7 +2362,9 @@ static void setup_fc()
     out_status_query_data.ism6_gyro_fs_dps = config::ISM6_GYRO_FS_DPS;
     out_status_query_data.ism6_rot_z_cdeg = (int16_t)lroundf(config::ISM6HG256_ROT_Z_DEG * 100.0f);
     out_status_query_data.mmc_rot_z_cdeg = (int16_t)lroundf(config::MMC5983MA_ROT_Z_DEG * 100.0f);
-    out_status_query_data.format_version = 2;
+    // v3: adds board→rocket orientation (b2r_* fields, filled by
+    // applyBoardToRocketOrientation above and on any runtime change).
+    out_status_query_data.format_version = 3;
 
     // NOTE: Do NOT drain the slave TX buffer here.  With the new
     // i2c_slave driver, reading when the slave has no TX data queued
@@ -3052,36 +3108,24 @@ static void loop_fc()
                 if (have_ref_pos && gnss_gate3_init) {
                     ekf.init(ekf_imu, ekf_gnss, ekf_mag);
 
-                    // Pad heading initialization: compute initial quaternion from
-                    // accel (pitch) + known heading, bypassing noisy magnetometer.
+                    // Pad attitude initialization: quaternion from measured
+                    // gravity (any attitude — see quatFromAccelHeading) plus
+                    // the known pad heading, bypassing the noisy magnetometer.
+                    // The IMU data is already in ROCKET frame here (the
+                    // converter applies the board→rocket mounting rotation),
+                    // so this is mounting-agnostic by construction.
                     {
                         static constexpr double DEG2RAD_d = M_PI / 180.0;
-                        const float g = 9.807f;
-                        // acc in FRD: nose-up → acc_x ≈ +g, acc_z ≈ 0
-                        float g_mag = sqrtf(ekf_imu.acc_x*ekf_imu.acc_x +
-                                            ekf_imu.acc_y*ekf_imu.acc_y +
-                                            ekf_imu.acc_z*ekf_imu.acc_z);
-                        if (g_mag < 0.1f) g_mag = g;
-                        float pitch_rad = asinf((float)ekf_imu.acc_x / g_mag);
-                        float roll_rad = 0.0f;
-                        if (fabsf(pitch_rad) < 80.0f * (float)DEG2RAD_d) {
-                            roll_rad = atan2f(-(float)ekf_imu.acc_y, -(float)ekf_imu.acc_z);
-                        }
-                        float heading_rad = (float)(config::PAD_HEADING_DEG * DEG2RAD_d);
-
-                        // Build body-to-NED quaternion from ZYX Euler (yaw, pitch, roll)
-                        float cy = cosf(heading_rad * 0.5f), sy = sinf(heading_rad * 0.5f);
-                        float cp = cosf(pitch_rad * 0.5f),   sp = sinf(pitch_rad * 0.5f);
-                        float cr = cosf(roll_rad * 0.5f),     sr = sinf(roll_rad * 0.5f);
-                        float q0 = cr*cp*cy + sr*sp*sy;
-                        float q1 = sr*cp*cy - cr*sp*sy;
-                        float q2 = cr*sp*cy + sr*cp*sy;
-                        float q3 = cr*cp*sy - sr*sp*cy;
-
-                        ekf.setQuaternion(q0, q1, q2, q3);
-                        ESP_LOGI(TAG, "[EKF] Init: pitch=%.1f roll=%.1f heading=%.1f deg",
-                                      (double)(pitch_rad * 180.0f / M_PI),
-                                      (double)(roll_rad * 180.0f / M_PI),
+                        const float heading_rad =
+                            (float)(config::PAD_HEADING_DEG * DEG2RAD_d);
+                        float q[4];
+                        quatFromAccelHeading((float)ekf_imu.acc_x,
+                                             (float)ekf_imu.acc_y,
+                                             (float)ekf_imu.acc_z,
+                                             heading_rad, q);
+                        ekf.setQuaternion(q[0], q[1], q[2], q[3]);
+                        ESP_LOGI(TAG, "[EKF] Init: acc=(%.2f,%.2f,%.2f) heading=%.1f deg",
+                                      ekf_imu.acc_x, ekf_imu.acc_y, ekf_imu.acc_z,
                                       (double)config::PAD_HEADING_DEG);
                     }
                     ekf_initialized = true;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -259,6 +259,16 @@ static OutStatusQueryData out_status_query_data = {};
 static uint8_t b2r_active_code = ORIENT_CODE_IDENTITY;
 static uint8_t b2r_active_mode = ORIENT_MODE_DEFAULT;
 static float   b2r_active_quat[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+static float   b2r_active_R[9] = {1.0f, 0.0f, 0.0f,
+                                  0.0f, 1.0f, 0.0f,
+                                  0.0f, 0.0f, 1.0f};
+static int16_t b2r_active_residual_cdeg = 0;
+
+// Pad-gravity auto-detect (runs READY/PRELAUNCH, latched at launch) and
+// the boost-phase thrust-axis cross-check on the latched orientation.
+static OrientationEstimator orient_estimator;
+static ThrustAxisCheck      orient_thrust_check;
+static bool                 orient_thrust_mismatch = false;
 static float ground_pressure_pa = 101325.0f;
 static float pressure_alt_m = 0.0f;
 static float pressure_alt_rate_mps = 0.0f;
@@ -447,6 +457,14 @@ static void buildFlightSnapshot(FlightSnapshotData& snap, uint32_t now_ms, uint8
     snap.guidance_enabled = guidance_enabled ? 1 : 0;
     snap.burnout_detected = burnout_detected ? 1 : 0;
     snap.servo_enabled    = servo_enabled    ? 1 : 0;
+
+    // Board→rocket orientation latched at launch (v3) — the EKF state
+    // below is only meaningful in this rocket frame.
+    snap.b2r_code = b2r_active_code;
+    snap.b2r_mode = b2r_active_mode;
+    for (int i = 0; i < 4; ++i) {
+        snap.b2r_q[i] = (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
+    }
 
     if (ekf_initialized) {
         EkfStateSnapshot s;
@@ -1282,16 +1300,17 @@ static void fcRevertToTx()
 // query repeats every poll, so a runtime change propagates within one
 // cycle).  Phase 1 calls this once at boot from config; auto-detect
 // (phase 2) and the app setting (phase 3) re-call it at runtime.
-static void applyBoardToRocketOrientation(uint8_t code, uint8_t mode)
+static void applyBoardToRocketRotation(const float R[9], uint8_t code,
+                                       uint8_t mode, int16_t residual_cdeg)
 {
-    float R[9];
-    orientCodeToMatrix(code, R);
     sensor_converter.configureBoardToRocket(R);
     sensor_collector.configureSimBoardToRocket(R);
 
+    memcpy(b2r_active_R, R, sizeof(b2r_active_R));
     b2r_active_code = code;
     b2r_active_mode = mode;
-    orientCodeToQuat(code, b2r_active_quat);
+    b2r_active_residual_cdeg = residual_cdeg;
+    orientMatrixToQuat(R, b2r_active_quat);
 
     out_status_query_data.b2r_code = code;
     out_status_query_data.b2r_mode = mode;
@@ -1300,8 +1319,99 @@ static void applyBoardToRocketOrientation(uint8_t code, uint8_t mode)
             (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
     }
 
-    ESP_LOGI(TAG, "Board→rocket orientation: %s (code %u, mode %u)",
-             orientCodeName(code), (unsigned)code, (unsigned)mode);
+    ESP_LOGI(TAG, "Board→rocket orientation: %s (code %u, mode %u, residual %.2f°)",
+             orientCodeName(code), (unsigned)code, (unsigned)mode,
+             (double)residual_cdeg / 100.0);
+}
+
+static void applyBoardToRocketOrientation(uint8_t code, uint8_t mode)
+{
+    float R[9];
+    orientCodeToMatrix(code, R);
+    applyBoardToRocketRotation(R, code, mode, 0);
+}
+
+// Snap tolerance: a measured nose vector within this angle of a board axis
+// is treated as that axis (covers rail tilt + sensor noise for orthogonal
+// mounts).  Beyond it the board is genuinely mounted off-axis and the
+// exact shortest-arc rotation is used instead.
+static constexpr float ORIENT_SNAP_TOL_DEG   = 15.0f;
+// Leave the active orientation alone while the measured nose stays within
+// this angle of rocket +X — normal rail tilt never causes churn.
+static constexpr float ORIENT_ACCEPT_TOL_DEG = 5.0f;
+
+// One completed pad-gravity window: decide whether the active board→rocket
+// rotation still matches how the rocket is actually sitting on the rail.
+static void handleOrientationEstimate(const float up_rocket[3])
+{
+    float cx = up_rocket[0];
+    if (cx > 1.0f) cx = 1.0f;
+    if (cx < -1.0f) cx = -1.0f;
+    const float off_deg = acosf(cx) * (180.0f / (float)M_PI);
+
+    // A manual orientation is authoritative (it also encodes the roll
+    // clocking for the control surfaces, which gravity cannot observe).
+    // Auto-detect only warns when gravity disagrees badly.
+    if (b2r_active_mode == ORIENT_MODE_MANUAL)
+    {
+        static uint32_t last_warn_ms = 0;
+        const uint32_t now_ms = time_ms();
+        if (off_deg > ORIENT_SNAP_TOL_DEG && (now_ms - last_warn_ms) > 10000U)
+        {
+            last_warn_ms = now_ms;
+            ESP_LOGW(TAG, "[ORIENT] pad gravity %.1f° off nose with MANUAL "
+                          "orientation %s — check the setting",
+                     (double)off_deg, orientCodeName(b2r_active_code));
+        }
+        return;
+    }
+
+    if (off_deg <= ORIENT_ACCEPT_TOL_DEG) return;  // mapping already right
+
+    // Un-rotate the measurement into BOARD frame (transpose = inverse) and
+    // re-derive the mapping from scratch.
+    float n_board[3];
+    n_board[0] = b2r_active_R[0] * up_rocket[0] + b2r_active_R[3] * up_rocket[1] + b2r_active_R[6] * up_rocket[2];
+    n_board[1] = b2r_active_R[1] * up_rocket[0] + b2r_active_R[4] * up_rocket[1] + b2r_active_R[7] * up_rocket[2];
+    n_board[2] = b2r_active_R[2] * up_rocket[0] + b2r_active_R[5] * up_rocket[1] + b2r_active_R[8] * up_rocket[2];
+
+    float residual_deg = 0.0f;
+    const uint8_t code = orientNearestNoseCode(n_board, &residual_deg);
+    const int16_t residual_cdeg = (int16_t)lroundf(residual_deg * 100.0f);
+
+    float R[9];
+    uint8_t mode;
+    if (residual_deg <= ORIENT_SNAP_TOL_DEG)
+    {
+        if (code == b2r_active_code && b2r_active_mode != ORIENT_MODE_AUTO_EXACT)
+        {
+            return;  // same discrete mounting — off_deg was just rail tilt
+        }
+        orientCodeToMatrix(code, R);
+        mode = ORIENT_MODE_AUTO_SNAP;
+    }
+    else
+    {
+        // Off-orthogonal mounting (or an extreme rail angle — the two are
+        // indistinguishable from gravity alone; the thrust-axis check at
+        // launch is the cross-check).  Use the exact rotation.
+        if (!orientMatrixFromNoseVector(n_board, R)) return;
+        mode = ORIENT_MODE_AUTO_EXACT;
+        ESP_LOGW(TAG, "[ORIENT] nose %.1f° from nearest board axis — using "
+                      "exact rotation (off-orthogonal mount or steep rail?)",
+                 (double)residual_deg);
+    }
+
+    applyBoardToRocketRotation(R, code, mode, residual_cdeg);
+
+    // EKF attitude/velocity/biases were estimated in the OLD rocket frame.
+    // Re-init from scratch (pad-only path: GNSS gates re-pass within ~1 s
+    // and the gravity init re-aligns attitude in the new frame).
+    if (ekf_initialized)
+    {
+        ekf_initialized = false;
+        ESP_LOGI(TAG, "[ORIENT] EKF re-init scheduled after orientation change");
+    }
 }
 
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
@@ -1370,7 +1480,7 @@ static void buildFlightSettings(FlightSettingsData& s)
     // Board→rocket mounting orientation that actually flew (v2).
     s.b2r_code = b2r_active_code;
     s.b2r_mode = b2r_active_mode;
-    s.b2r_residual_cdeg = 0;  // meaningful once pad-gravity auto-detect lands
+    s.b2r_residual_cdeg = b2r_active_residual_cdeg;
     for (int i = 0; i < 4; ++i) {
         s.b2r_q[i] = (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
     }
@@ -2603,6 +2713,23 @@ static void setup_fc()
             ref_pos_frozen = true;
             ground_pressure_found = true;
 
+            // Restore the board→rocket orientation BEFORE the EKF state —
+            // the snapshot's quaternion/velocities/biases were estimated in
+            // this rocket frame, and every conversion from here on must
+            // match it (the boot default from config may differ when the
+            // pad auto-detect re-oriented before launch).
+            {
+                float q[4];
+                for (int i = 0; i < 4; ++i) {
+                    q[i] = (float)snap.b2r_q[i] / ORIENT_QUAT_WIRE_SCALE;
+                }
+                float R[9];
+                orientQuatToMatrix(q, R);
+                applyBoardToRocketRotation(R, snap.b2r_code, snap.b2r_mode, 0);
+                ESP_LOGW(TAG, "[RECOVERY] Board→rocket orientation restored: %s (mode %u)",
+                         orientCodeName(snap.b2r_code), (unsigned)snap.b2r_mode);
+            }
+
             // Restore control state
             ekf_initialized  = snap.ekf_initialized;
             guidance_enabled = snap.guidance_enabled;
@@ -2952,6 +3079,50 @@ static void loop_fc()
             const float acc_y = low_g_near_sat ? hy : ay;
             const float acc_z = low_g_near_sat ? hz : az;
             accel_norm = sqrtf(acc_x * acc_x + acc_y * acc_y + acc_z * acc_z);
+
+            // ── Board→rocket orientation: pad auto-detect + thrust check ──
+            // On the pad, the averaged specific-force direction reveals the
+            // mounting (continuously re-estimated, so late re-racking after
+            // horizontal prep self-corrects; latched by leaving READY/
+            // PRELAUNCH at launch).  During boost, the thrust direction
+            // cross-checks whatever was latched.
+            if (rocket_state == READY || rocket_state == PRELAUNCH)
+            {
+                if (orient_estimator.update(ism6_latest_si.time_us,
+                                            acc_x, acc_y, acc_z,
+                                            (float)ism6_latest_si.gyro_x,
+                                            (float)ism6_latest_si.gyro_y,
+                                            (float)ism6_latest_si.gyro_z))
+                {
+                    float up_rocket[3];
+                    if (orient_estimator.takeEstimate(up_rocket))
+                    {
+                        handleOrientationEstimate(up_rocket);
+                    }
+                }
+            }
+            else if (rocket_state == INFLIGHT && !orient_thrust_check.done())
+            {
+                if (orient_thrust_check.update(ism6_latest_si.time_us,
+                                               acc_x, acc_y, acc_z))
+                {
+                    if (orient_thrust_check.valid() &&
+                        orient_thrust_check.angleFromNoseDeg() > 25.0f)
+                    {
+                        orient_thrust_mismatch = true;
+                        ESP_LOGE(TAG, "[ORIENT] thrust axis %.1f° off nose — "
+                                      "latched orientation %s (mode %u) suspect",
+                                 (double)orient_thrust_check.angleFromNoseDeg(),
+                                 orientCodeName(b2r_active_code),
+                                 (unsigned)b2r_active_mode);
+                    }
+                    else if (orient_thrust_check.valid())
+                    {
+                        ESP_LOGI(TAG, "[ORIENT] thrust-axis check OK (%.1f° off nose)",
+                                 (double)orient_thrust_check.angleFromNoseDeg());
+                    }
+                }
+            }
 
             // ── Build EKF input: IMU in FRD body frame ──
             // SensorConverter outputs FLU (X=Fwd, Y=Left, Z=Up).
@@ -4672,6 +4843,11 @@ static void loop_fc()
                 {
                     rocket_state = INFLIGHT;
                     launch_time_millis = now_ms;
+                    // Orientation is now latched (estimator only runs in
+                    // READY/PRELAUNCH).  Start the boost-phase thrust-axis
+                    // cross-check on what was latched.
+                    orient_thrust_mismatch = false;
+                    orient_thrust_check.start(time_us());
                     // Safety: warn and disable guidance if EKF never initialized
                     if (!ekf_initialized) {
                         ESP_LOGW(TAG, "[EKF] WARNING: Launching without EKF initialization!");
@@ -5147,6 +5323,7 @@ static void loop_fc()
         if (kinematics.apogee_flag)       non_sensor_data.apogee_flags |= NSF2_MASTER_APOGEE;
         if (reboot_recovery_telem)        non_sensor_data.apogee_flags |= NSF2_REBOOT_RECOVERY;
         if (guidance_enabled)             non_sensor_data.apogee_flags |= NSF2_GUIDANCE_ENABLED;
+        if (orient_thrust_mismatch)       non_sensor_data.apogee_flags |= NSF2_ORIENT_THRUST_MISMATCH;
         // Snapshot pyro state under spinlock for telemetry. With per-fire
         // arming the global "armed" bit just mirrors the live PYRO_ARM pin.
         bool arm_now;

--- a/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
@@ -13,6 +13,7 @@ idf_component_register(
         TR_FlightLog
         TR_LoRa_Comms
         TR_Sensor_Data_Converter
+        TR_Orientation
         TR_Coordinates
         TR_BLE_To_APP
         TR_INA230

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -572,6 +572,25 @@ static bool    cfg_use_angle_ctrl = false;
 static uint16_t cfg_roll_delay_ms  = 0;
 static bool    cfg_guidance_en  = false;
 static uint8_t cfg_camera_type  = CAM_TYPE_RUNCAM;  // default: RunCam
+
+// IMU mounting orientation setting (#phase3): IMU_ORIENT_AUTO lets the
+// FC's pad-gravity detect drive the mapping; 0..23 pins a manual code.
+// NVS-persisted so a manual roll clocking survives power cycles.
+static uint8_t cfg_imu_orient = IMU_ORIENT_AUTO;
+
+// Stage the orientation setting as a two-phase config command to the FC
+// (same shape as camera/servo config).  Called from the BLE handler and
+// from the status-query self-heal when an FC reboot dropped a MANUAL
+// setting back to auto.
+static void stageImuOrientConfig()
+{
+    ImuOrientConfigData cfg;
+    cfg.setting = cfg_imu_orient;
+    memcpy(pending_config_data, &cfg, sizeof(cfg));
+    pending_config_data_len = sizeof(cfg);
+    pending_config_msg_type = ORIENT_CONFIG_MSG;
+    setPendingCommand(ORIENT_CONFIG_PENDING);
+}
 // Pyro config cache (4 channels on new PCB)
 static bool    cfg_pyro_enabled[4]      = { false, false, false, false };
 static uint8_t cfg_pyro_trigger_mode[4] = { 0, 0, 0, 0 };
@@ -1096,6 +1115,7 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == SERVO_REPLAY_PENDING ||
            cmd == ROLL_CTRL_CONFIG_PENDING ||
            cmd == PYRO_CONFIG_PENDING ||
+           cmd == ORIENT_CONFIG_PENDING ||
            cmd == PYRO_CONT_TEST ||
            cmd == PYRO_FIRE_TEST ||
            cmd == MAG_CAL_APPLY_PENDING ||     // #132: app-pushed mag cal payload
@@ -1532,6 +1552,8 @@ static bool isKnownMessageType(uint8_t type)
         case GUIDANCE_TELEM_MSG:
         case CAMERA_CONFIG_PENDING:
         case CAMERA_CONFIG_MSG:
+        case ORIENT_CONFIG_PENDING:
+        case ORIENT_CONFIG_MSG:
         case LORA_MSG:
         case SNAPSHOT_MSG:           // FC→OC over I2S during INFLIGHT
         case GET_FLIGHT_SNAPSHOT:    // FC→OC over I2C at boot recovery
@@ -1729,6 +1751,27 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                     last_query_cfg.b2r_mode != imu_orient_pub_mode)
                 {
                     imu_orient_dirty = true;
+                }
+
+                // Self-heal a stored MANUAL setting: if the FC reports a
+                // different mapping (e.g. it rebooted and fell back to
+                // auto), re-stage the config.  Idempotent — once applied
+                // the query reflects MANUAL+code and this goes quiet.
+                // Never during flight (the FC refuses mid-flight anyway).
+                if (cfg_imu_orient != IMU_ORIENT_AUTO &&
+                    latest_rocket_state != INFLIGHT &&
+                    (last_query_cfg.b2r_mode != ORIENT_MODE_MANUAL ||
+                     last_query_cfg.b2r_code != cfg_imu_orient))
+                {
+                    static uint32_t last_restage_ms = 0;
+                    const uint32_t now = millis();
+                    if ((now - last_restage_ms) > 5000U && pending_out_command == 0U)
+                    {
+                        last_restage_ms = now;
+                        stageImuOrientConfig();
+                        ESP_LOGI("CFG", "Re-staged MANUAL IMU orientation %u to FC",
+                                 (unsigned)cfg_imu_orient);
+                    }
                 }
             }
         }
@@ -2465,12 +2508,15 @@ static void sendFcIdentity()
 static void sendImuOrientation()
 {
     if (last_query_cfg.format_version < 3) return;  // pre-orientation FC
-    char buf[96];
+    // "set" is the user's SETTING (0xFF auto / manual code), distinct from
+    // code/mode/name which describe what the FC is actively applying.
+    char buf[112];
     snprintf(buf, sizeof(buf),
-             "{\"type\":\"imu_orient\",\"code\":%u,\"mode\":%u,\"name\":\"%s\"}",
+             "{\"type\":\"imu_orient\",\"code\":%u,\"mode\":%u,\"name\":\"%s\",\"set\":%u}",
              (unsigned)last_query_cfg.b2r_code,
              (unsigned)last_query_cfg.b2r_mode,
-             orientCodeName(last_query_cfg.b2r_code));
+             orientCodeName(last_query_cfg.b2r_code),
+             (unsigned)cfg_imu_orient);
     ble_app.sendConfigJSON(String(buf));
     imu_orient_pub_code = last_query_cfg.b2r_code;
     imu_orient_pub_mode = last_query_cfg.b2r_mode;
@@ -4158,6 +4204,16 @@ void initPeripherals()
                  cfg_camera_type == CAM_TYPE_GOPRO ? "GoPro" :
                  cfg_camera_type == CAM_TYPE_RUNCAM ? "RunCam" : "None");
 
+        // Load cached IMU mounting orientation setting from NVS.  A MANUAL
+        // value gets pushed to the FC by the status-query self-heal once
+        // the FC starts polling — no explicit boot staging needed.
+        prefs.begin("orient", false);
+        cfg_imu_orient = prefs.getUChar("set", cfg_imu_orient);
+        prefs.end();
+        ESP_LOGI("CFG", "NVS IMU orientation: %s",
+                 cfg_imu_orient == IMU_ORIENT_AUTO
+                     ? "AUTO" : orientCodeName(cfg_imu_orient));
+
         // Load cached pyro config from NVS (4 channels)
         prefs.begin("pyro", true);
         size_t pyro_sz = prefs.getBytesLength("cfg");
@@ -5416,6 +5472,26 @@ static void loop_oc()
                          cfg_camera_type,
                          cfg_camera_type == CAM_TYPE_GOPRO ? "GoPro" :
                          cfg_camera_type == CAM_TYPE_RUNCAM ? "RunCam" : "None");
+            }
+        }
+        else if (ble_cmd == 64)
+        {
+            // IMU mounting orientation: [setting:1] — IMU_ORIENT_AUTO or
+            // a TR_Orientation code (0..23, manual incl. roll clocking).
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= 1 &&
+                (payload[0] == IMU_ORIENT_AUTO || payload[0] < ORIENT_CODE_COUNT))
+            {
+                cfg_imu_orient = payload[0];
+                stageImuOrientConfig();
+                Preferences prefs;
+                prefs.begin("orient", false);
+                prefs.putUChar("set", cfg_imu_orient);
+                prefs.end();
+                ESP_LOGI("BLE", "IMU orientation setting: %s",
+                         cfg_imu_orient == IMU_ORIENT_AUTO
+                             ? "AUTO" : orientCodeName(cfg_imu_orient));
             }
         }
         else if (ble_cmd == 34)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -52,6 +52,7 @@ static inline std::string itos(int v)
 #include <TR_LogToFlash.h>
 #include <TR_LoRa_Comms.h>
 #include <TR_Sensor_Data_Converter.h>
+#include <TR_Orientation.h>
 #include <TR_Coordinates.h>
 #include <TR_BLE_To_APP.h>
 #include <RocketComputerTypes.h>
@@ -1701,6 +1702,20 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                     (float)last_query_cfg.hg_bias_x_cmss / 100.0f,
                     (float)last_query_cfg.hg_bias_y_cmss / 100.0f,
                     (float)last_query_cfg.hg_bias_z_cmss / 100.0f);
+            }
+            // Apply board→rocket mounting orientation (format v3+) so the
+            // OC's conversions match the FC's.  The quaternion is the
+            // authoritative rotation; code/mode are descriptive.
+            if (last_query_cfg.format_version >= 3)
+            {
+                float q[4];
+                for (int i = 0; i < 4; i++)
+                {
+                    q[i] = (float)last_query_cfg.b2r_q[i] / ORIENT_QUAT_WIRE_SCALE;
+                }
+                float R[9];
+                orientQuatToMatrix(q, R);
+                sensor_converter.configureBoardToRocket(R);
             }
         }
         queueOutStatusResponse(true);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -646,6 +646,13 @@ static OutStatusQueryData last_query_cfg = {};
 static char          fc_fw_version[40]  = {0};
 static volatile bool fc_identity_dirty  = false;
 
+// FC's active board→rocket mounting orientation, mirrored from the v3
+// status query.  Re-published to the app when it changes mid-connection
+// (the pad auto-detect can re-orient any time before launch).
+static volatile bool imu_orient_dirty    = false;
+static uint8_t       imu_orient_pub_code = 0xFF;   // last published (0xFF = never)
+static uint8_t       imu_orient_pub_mode = 0xFF;
+
 static inline bool nsFlagSet(uint8_t flags, uint8_t mask)
 {
     return (flags & mask) != 0U;
@@ -1716,6 +1723,13 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                 float R[9];
                 orientQuatToMatrix(q, R);
                 sensor_converter.configureBoardToRocket(R);
+
+                // Surface changes to the app (pre-arm orientation display).
+                if (last_query_cfg.b2r_code != imu_orient_pub_code ||
+                    last_query_cfg.b2r_mode != imu_orient_pub_mode)
+                {
+                    imu_orient_dirty = true;
+                }
             }
         }
         queueOutStatusResponse(true);
@@ -2441,6 +2455,30 @@ static void sendFcIdentity()
     ESP_LOGI("CFG", "Sent fc_identity (fc_fw=%s)", fc_fw);
 }
 
+// Publish the FC's active board→rocket mounting orientation as its own
+// compact config message.  Lets the app show "nose = -Z (auto)" before
+// arming so a wrong auto-detect is caught while the rocket is still on
+// the ground.  Sent on connect and whenever the FC reports a change
+// (auto-detect re-orients on the pad; the status query repeats every
+// poll, so changes surface within a cycle).  Kept tiny — sendConfigJSON
+// drops anything over the BLE notify MTU.
+static void sendImuOrientation()
+{
+    if (last_query_cfg.format_version < 3) return;  // pre-orientation FC
+    char buf[96];
+    snprintf(buf, sizeof(buf),
+             "{\"type\":\"imu_orient\",\"code\":%u,\"mode\":%u,\"name\":\"%s\"}",
+             (unsigned)last_query_cfg.b2r_code,
+             (unsigned)last_query_cfg.b2r_mode,
+             orientCodeName(last_query_cfg.b2r_code));
+    ble_app.sendConfigJSON(String(buf));
+    imu_orient_pub_code = last_query_cfg.b2r_code;
+    imu_orient_pub_mode = last_query_cfg.b2r_mode;
+    ESP_LOGI("CFG", "Sent imu_orient (%s, mode %u)",
+             orientCodeName(last_query_cfg.b2r_code),
+             (unsigned)last_query_cfg.b2r_mode);
+}
+
 static void sendCurrentConfig()
 {
     // Split config into two smaller JSON messages to stay within MTU limits.
@@ -2513,6 +2551,10 @@ static void sendCurrentConfig()
     // Also push the relayed FC firmware version as its own small message (#8).
     delay(50);
     sendFcIdentity();
+
+    // And the FC's board→rocket mounting orientation (pre-arm display).
+    delay(50);
+    sendImuOrientation();
 }
 
 // Cache servo config to NVS (mirrors what FlightComputer stores)
@@ -4756,6 +4798,15 @@ static void loop_oc()
     {
         fc_identity_dirty = false;
         sendFcIdentity();
+    }
+
+    // Same pattern for the board→rocket orientation: the pad auto-detect
+    // can re-orient mid-connection, and the app's pre-arm display should
+    // follow without a reconnect.
+    if (imu_orient_dirty && ble_app.isConnected() && ble_app.isReadyForNotify())
+    {
+        imu_orient_dirty = false;
+        sendImuOrientation();
     }
 
     // Service the BLE library's poll-style work — currently just the OTA


### PR DESCRIPTION
Removes the assumption that the IMU board is mounted with its +X axis toward the nose. The board can now be mounted in any orientation; a board→rocket rotation is applied as the last step of sensor conversion, so the EKF, kinematics, roll control, and telemetry all keep seeing rocket-frame data unchanged.

## Phases

**1 — Rotation seam + logging.** New `TR_Orientation` component (24 discrete codes ↔ matrix ↔ quaternion, gravity-vector nose snap, `quatFromAccelHeading` pad-init). `SensorConverter` applies `R_board→rocket` after the per-chip Z rotation and bias subtraction, so PCB-fact calibrations stay valid. The orientation that flew is recorded in `OutStatusQueryData` v3 and `FlightSettingsData` v2, decoded by the iOS app into the per-flight summary JSON (`imu.mounting`), and applied in the Data_Analysis parsers + EKF replay.

**2 — Pad-gravity auto-detect.** While stationary pre-launch, the averaged specific-force direction reveals the mounting; snapped to the nearest board axis within 15°, exact shortest-arc beyond that. Continuous until launch (horizontal prep self-corrects). At launch the orientation latches and a thrust-axis cross-check flags (never corrects) a >25° disagreement. Latched orientation rides the reboot-recovery snapshot (v3).

**3 — Optional manual setting.** Per-rocket "IMU Mounting" picker (Auto or a manual code), app→OC→FC, NVS-persisted, re-staged by the OC if the FC drops it. Manual is authoritative and pins the roll clocking the control surfaces need — required for roll-controlled/guided flights with an off-axis board; optional for non-controlled flights.

## Verification

- 342 host gtests (54 new: orientation math, estimator windows, thrust check, converter b2r), FC+OC build on IDF 6.0.1, iOS unit tests pass.
- **Bench-validated on real captures** (static + sim flight): near-axis AUTO_SNAP (1.3° accurate), off-axis AUTO_EXACT (0.14° accurate), MANUAL suppresses auto, launch latch + thrust check (0 false positives, 100% axial). Shipped C++ estimator reproduces field results deterministically; 24/24 .bin replay regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)