### PR TITLE
Roll control: analysis plots, no-ramp shortest-path profile, app-configurable rate cap

### DIFF
--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -192,18 +192,29 @@ def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
 
 
 def _zoom_cmd_axis(ax, cmd_win, cmd_limit=None):
-    """Zoom a roll-command axis to the command's actual range (it typically uses
-    a tiny fraction of the ±cmd-limit authority), and note the peak / limit."""
+    """Zoom a roll-command axis to the command's actual range (the observed
+    min/max padded by 5°), and note the range / ±cmd-limit authority."""
     if cmd_win is None or len(cmd_win) == 0:
         return
-    peak = float(np.nanmax(np.abs(cmd_win)))
-    m = max(peak * 1.3, 1.0)
-    ax.set_ylim(-m, m)
-    note = f"peak |cmd| {peak:.1f}°"
+    lo, hi = float(np.nanmin(cmd_win)), float(np.nanmax(cmd_win))
+    ax.set_ylim(lo - 5.0, hi + 5.0)
+    note = f"cmd ∈ [{lo:.1f}, {hi:.1f}]°"
     if cmd_limit is not None:
         note += f"  ·  limit ±{cmd_limit:g}°"
-    ax.text(0.99, 0.05, note, transform=ax.transAxes, ha="right", va="bottom",
+    ax.text(0.99, 0.04, note, transform=ax.transAxes, ha="right", va="bottom",
             fontsize=8, color="0.4")
+
+
+def _overlay_speed(ax, t, speed):
+    """Overlay airspeed on a right-hand twin axis (roll authority scales with it).
+    Keeps the primary (command) line drawn on top."""
+    axb = ax.twinx()
+    axb.plot(t, speed, color="0.45", lw=1.1, alpha=0.7, zorder=1)
+    axb.set_ylabel("Speed (m/s)", color="0.45")
+    axb.tick_params(axis="y", labelcolor="0.45")
+    ax.set_zorder(axb.get_zorder() + 1)
+    ax.patch.set_visible(False)
+    return axb
 
 
 def _fine_time_axis(ax):
@@ -398,7 +409,17 @@ def analyze(flight: Flight) -> AnalysisResult:
         win_end = min(win_end, float(trim_t))
     win_end = float(min(win_end, t_imu[-1]))
 
-    track_tw = track_tgt = track_act = track_err = track_is_ang = None
+    # Steepest commanded ramp rate across the angle segments (deg/s).
+    rate_cap_cfg = _as_float(rc_cfg.get("rate_cap_dps"))
+    kp_angle_cfg = _as_float(rc_cfg.get("kp_angle"))
+    rate_setpt = _as_float(rc_cfg.get("roll_rate_set_point")) or 0.0
+    profile_ramp = 0.0
+    for i in range(len(wps) - 1):
+        (t0w, a0w, n0), (t1w, a1w, _) = wps[i], wps[i + 1]
+        if not n0 and t1w > t0w:
+            profile_ramp = max(profile_ramp, abs(a1w - a0w) / (t1w - t0w))
+
+    track_tw = track_tgt = track_act = track_err = track_is_ang = track_ratecmd = None
     angle_rms = angle_peak = float("nan")
     if has_angle_profile:
         roll_act = _quat_roll_deg(*(get_array(ns, k) for k in ("q0", "q1", "q2", "q3")))
@@ -421,6 +442,12 @@ def analyze(flight: Flight) -> AnalysisResult:
         if ea.size:
             angle_rms = float(np.sqrt(np.mean(ea ** 2)))
             angle_peak = float(np.max(np.abs(ea)))
+        # Reconstruct the firmware's outer-loop rate command: angle segments
+        # → clip(kp_angle·wrapped_err, ±rate_cap); null-rate segments → setpoint.
+        # Same sign frame as gyro_x (the inner loop drives gyro_x → rate_cmd).
+        if kp_angle_cfg is not None and rate_cap_cfg is not None:
+            rc_angle = np.clip(kp_angle_cfg * err, -rate_cap_cfg, rate_cap_cfg)
+            track_ratecmd = np.where(track_is_ang, rc_angle, rate_setpt)
 
     # ── Current gains (from sidecar if available) ──
     kp_flight, ki_flight, kd_flight = _gain_from_sidecar(flight.sidecar)
@@ -491,6 +518,12 @@ def analyze(flight: Flight) -> AnalysisResult:
     if has_angle_profile:
         metrics["profile_plan"] = "; ".join(
             f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
+        if profile_ramp > 0:
+            feasible = (rate_cap_cfg is None) or (profile_ramp <= rate_cap_cfg + 1e-6)
+            note = "" if feasible else f"  (EXCEEDS rate cap {rate_cap_cfg:g}°/s — target unreachable)"
+            metrics["profile_ramp_dps"] = f"{profile_ramp:.0f}{note}"
+        # NOTE: with an over-fast ramp the wrapped error reflects an unreachable
+        # setpoint, not control performance — read alongside profile_ramp_dps.
         metrics["angle_track_rms_deg"]  = round(angle_rms, 1)  if np.isfinite(angle_rms)  else "—"
         metrics["angle_track_peak_deg"] = round(angle_peak, 1) if np.isfinite(angle_peak) else "—"
     result.metrics = metrics
@@ -572,11 +605,13 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].set_title("Roll control — launch → ejection")
         _clip_rate_axis(axes[0], t_imu[win], g[win], win_end, rate_cap)
         _mark_events(axes[0], annotate=True)
-        axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
+        axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=1.0, zorder=3)
         axes[1].axhline(0, color="k", lw=0.5)
         axes[1].set_xlabel("Time since launch (s)")
-        axes[1].set_ylabel("Roll cmd (deg)")
+        axes[1].set_ylabel("Roll cmd (deg)", color="tab:orange")
+        axes[1].tick_params(axis="y", labelcolor="tab:orange")
         _zoom_cmd_axis(axes[1], cmd[win_c], _as_float(rc_cfg.get("cmd_limit_max_deg")))
+        _overlay_speed(axes[1], t_ns[win_c], speed[win_c])
         _mark_events(axes[1])
         for ax in axes:
             _fine_time_axis(ax)
@@ -612,14 +647,23 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[1].grid(True, alpha=0.3)
         _mark_events(axes[1])
         if np.isfinite(angle_rms):
-            axes[1].text(0.99, 0.05, f"RMS {angle_rms:.1f}°   peak {angle_peak:.1f}°",
-                         transform=axes[1].transAxes, ha="right", va="bottom", fontsize=9,
+            txt = f"RMS {angle_rms:.1f}°   peak {angle_peak:.1f}°"
+            if rate_cap is not None and profile_ramp > rate_cap + 1e-6:
+                txt += (f"\nramp {profile_ramp:.0f}°/s > cap {rate_cap:g}°/s"
+                        f"\n→ setpoint unreachable, error not a control metric")
+            axes[1].text(0.99, 0.05, txt,
+                         transform=axes[1].transAxes, ha="right", va="bottom", fontsize=8,
                          bbox=dict(boxstyle="round", fc="white", ec="0.7", alpha=0.85))
 
-        # Panel 2 — roll rate (gyro X), with the outer-loop rate cap for reference
+        # Panel 2 — roll rate: achieved (gyro) vs the firmware's commanded rate
+        # (outer loop, clipped to ±rate cap), so the cap + the ±180° wrap flip
+        # are visible against what the rocket actually did.
         _shade_segments(axes[2], track_tw, track_is_ang, label=None)
         axes[2].axhline(0, color="k", lw=0.5)
-        axes[2].plot(t_imu[win], g[win], color="tab:green", lw=0.9, label="roll rate (gyro)")
+        axes[2].plot(t_imu[win], g[win], color="tab:green", lw=0.9, label="roll rate (gyro, achieved)")
+        if track_ratecmd is not None:
+            axes[2].plot(track_tw, track_ratecmd, color="tab:blue", lw=1.5,
+                         label="commanded rate (outer loop)")
         axes[2].set_ylabel("Roll rate\n(deg/s)")
         axes[2].grid(True, alpha=0.3)
         _clip_rate_axis(axes[2], t_imu[win], g[win], win_end, rate_cap)
@@ -630,14 +674,16 @@ def analyze(flight: Flight) -> AnalysisResult:
         _mark_events(axes[2])
         axes[2].legend(loc="upper right", fontsize=8)
 
-        # Panel 3 — roll command (PID output → servo), zoomed to the command's
-        # actual range: it uses only a sliver of the ±cmd-limit authority.
+        # Panel 3 — roll command (PID output → servo), zoomed to its actual
+        # range, with airspeed overlaid (roll authority scales with speed).
         _shade_segments(axes[3], track_tw, track_is_ang, label=None)
         axes[3].axhline(0, color="k", lw=0.5)
-        axes[3].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
-        axes[3].set_ylabel("Roll cmd\n(deg)")
+        axes[3].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=1.0, zorder=3)
+        axes[3].set_ylabel("Roll cmd (deg)", color="tab:orange")
+        axes[3].tick_params(axis="y", labelcolor="tab:orange")
         axes[3].set_xlabel("Time since launch (s)")
         _zoom_cmd_axis(axes[3], cmd[win_c], _as_float(rc_cfg.get("cmd_limit_max_deg")))
+        _overlay_speed(axes[3], t_ns[win_c], speed[win_c])
         _mark_events(axes[3])
 
         for ax in axes:

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
 import numpy as np
 
 try:
@@ -188,6 +189,25 @@ def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
     if peak > lim * 1.05:
         ax.text(0.01, 0.04, f"axis clipped — peak |rate| {peak:.0f}°/s",
                 transform=ax.transAxes, ha="left", va="bottom", fontsize=8, color="0.4")
+
+
+def _fine_time_axis(ax):
+    """1 s major / 0.5 s minor ticks with a two-level grid, so transition times
+    are easy to read off the launch→eject figures."""
+    ax.xaxis.set_major_locator(MultipleLocator(1.0))
+    ax.xaxis.set_minor_locator(MultipleLocator(0.5))
+    ax.grid(True, which="major", alpha=0.35)
+    ax.grid(True, which="minor", alpha=0.15)
+
+
+def _phase_label(wps, i):
+    """Short label for the control phase that STARTS at waypoint i."""
+    wt, wa, wnull = wps[i]
+    if wnull:
+        return "null-rate"
+    if i < len(wps) - 1:
+        return f"angle ramp →{wps[i + 1][1]:g}°"
+    return f"hold {wa:g}°"
 
 
 def _baro_eject_time(flight, t0, launch_t, burnout_t, apogee_t):
@@ -491,19 +511,34 @@ def analyze(flight: Flight) -> AnalysisResult:
     fig.tight_layout()
     result.figures.append(fig)
 
-    # Event markers shared by the launch→eject figures (within the plotted window).
-    def _mark_events(ax, with_labels=False):
-        ax.axvline(t_control_on, color="red", linestyle="--", lw=1.0,
-                   label=(f"control on ({t_control_on:.2f}s)" if with_labels else None))
+    # Program events / phase transitions within the plotted window. With
+    # annotate=True, each line gets a timestamped, vertical label (use on the
+    # top panel only).
+    def _event_list():
+        evs = [(t_control_on, "control on", "red", "--")]
         if burnout_t is not None and -0.2 <= burnout_t <= win_end + 0.2:
-            ax.axvline(burnout_t, color="tab:purple", linestyle="--", lw=1.0,
-                       label=(f"burnout ({burnout_t:.2f}s)" if with_labels else None))
+            evs.append((burnout_t, "burnout", "tab:purple", "--"))
         if eject_t <= win_end + 0.2:
-            ax.axvline(eject_t, color="black", linestyle="--", lw=1.0,
-                       label=(f"apogee/eject ({eject_t:.2f}s)" if with_labels else None))
-        for (wt, _, _) in wps:
+            evs.append((eject_t, "apogee/eject", "black", "--"))
+        for i, (wt, _, wnull) in enumerate(wps):
             if -0.2 <= wt <= win_end + 0.2:
-                ax.axvline(wt, color="gray", linestyle=":", lw=0.8)
+                # null-rate segments are already shown by the gray shading; only
+                # label the meaningful mode-change transitions (angle / hold).
+                evs.append((wt, None if wnull else _phase_label(wps, i), "gray", ":"))
+        return evs
+
+    def _mark_events(ax, annotate=False):
+        for et, lbl, c, ls in _event_list():
+            ax.axvline(et, color=c, linestyle=ls, lw=(0.8 if ls == ":" else 1.0))
+        if annotate:
+            for et, lbl, c, ls in _event_list():
+                if lbl is None:
+                    continue
+                ax.annotate(f"{et:.2f}s  {lbl}", xy=(et, 0.0),
+                            xycoords=("data", "axes fraction"),
+                            xytext=(2, 3), textcoords="offset points",
+                            rotation=90, va="bottom", ha="left",
+                            fontsize=7, color=c)
 
     # Launch → ejection window (shared by the figures below), trimmed if configured.
     t_lo, t_hi = -0.2, win_end + 0.2
@@ -520,16 +555,15 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].axhline(0, color="k", lw=0.5)
         axes[0].set_ylabel("Roll rate (deg/s)")
         axes[0].set_title("Roll control — launch → ejection")
-        axes[0].grid(True, alpha=0.3)
         _clip_rate_axis(axes[0], t_imu[win], g[win], win_end, rate_cap)
-        _mark_events(axes[0], with_labels=True)
-        axes[0].legend(loc="upper right", fontsize=8)
+        _mark_events(axes[0], annotate=True)
         axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
         axes[1].axhline(0, color="k", lw=0.5)
         axes[1].set_xlabel("Time since launch (s)")
         axes[1].set_ylabel("Roll cmd (deg)")
-        axes[1].grid(True, alpha=0.3)
         _mark_events(axes[1])
+        for ax in axes:
+            _fine_time_axis(ax)
         fig.tight_layout()
         result.figures.append(fig)
 
@@ -551,8 +585,8 @@ def analyze(flight: Flight) -> AnalysisResult:
                 axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
                                  color="tab:orange", ha="left", va="bottom",
                                  xytext=(2, 2), textcoords="offset points")
-        _mark_events(axes[0], with_labels=True)
-        axes[0].legend(loc="upper left", fontsize=8, ncol=2)
+        _mark_events(axes[0], annotate=True)
+        axes[0].legend(loc="upper left", fontsize=8)
 
         # Panel 1 — tracking error
         _shade_segments(axes[1], track_tw, track_is_ang, label=None)
@@ -595,6 +629,8 @@ def analyze(flight: Flight) -> AnalysisResult:
         _mark_events(axes[3])
         axes[3].legend(loc="upper right", fontsize=8)
 
+        for ax in axes:
+            _fine_time_axis(ax)
         fig.tight_layout()
         result.figures.append(fig)
 

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -191,6 +191,21 @@ def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
                 transform=ax.transAxes, ha="left", va="bottom", fontsize=8, color="0.4")
 
 
+def _zoom_cmd_axis(ax, cmd_win, cmd_limit=None):
+    """Zoom a roll-command axis to the command's actual range (it typically uses
+    a tiny fraction of the ±cmd-limit authority), and note the peak / limit."""
+    if cmd_win is None or len(cmd_win) == 0:
+        return
+    peak = float(np.nanmax(np.abs(cmd_win)))
+    m = max(peak * 1.3, 1.0)
+    ax.set_ylim(-m, m)
+    note = f"peak |cmd| {peak:.1f}°"
+    if cmd_limit is not None:
+        note += f"  ·  limit ±{cmd_limit:g}°"
+    ax.text(0.99, 0.05, note, transform=ax.transAxes, ha="right", va="bottom",
+            fontsize=8, color="0.4")
+
+
 def _fine_time_axis(ax):
     """1 s major / 0.5 s minor ticks with a two-level grid, so transition times
     are easy to read off the launch→eject figures."""
@@ -561,6 +576,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[1].axhline(0, color="k", lw=0.5)
         axes[1].set_xlabel("Time since launch (s)")
         axes[1].set_ylabel("Roll cmd (deg)")
+        _zoom_cmd_axis(axes[1], cmd[win_c], _as_float(rc_cfg.get("cmd_limit_max_deg")))
         _mark_events(axes[1])
         for ax in axes:
             _fine_time_axis(ax)
@@ -614,20 +630,15 @@ def analyze(flight: Flight) -> AnalysisResult:
         _mark_events(axes[2])
         axes[2].legend(loc="upper right", fontsize=8)
 
-        # Panel 3 — roll command (PID output → servo), with saturation limits
+        # Panel 3 — roll command (PID output → servo), zoomed to the command's
+        # actual range: it uses only a sliver of the ±cmd-limit authority.
         _shade_segments(axes[3], track_tw, track_is_ang, label=None)
         axes[3].axhline(0, color="k", lw=0.5)
-        axes[3].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9, label="roll cmd")
+        axes[3].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
         axes[3].set_ylabel("Roll cmd\n(deg)")
         axes[3].set_xlabel("Time since launch (s)")
-        axes[3].grid(True, alpha=0.3)
-        cmin, cmax = _as_float(rc_cfg.get("cmd_limit_min_deg")), _as_float(rc_cfg.get("cmd_limit_max_deg"))
-        if cmax is not None:
-            axes[3].axhline(cmax, color="tab:purple", ls=":", lw=1.0, label="cmd limit")
-        if cmin is not None:
-            axes[3].axhline(cmin, color="tab:purple", ls=":", lw=1.0)
+        _zoom_cmd_axis(axes[3], cmd[win_c], _as_float(rc_cfg.get("cmd_limit_max_deg")))
         _mark_events(axes[3])
-        axes[3].legend(loc="upper right", fontsize=8)
 
         for ax in axes:
             _fine_time_axis(ax)

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -53,9 +53,19 @@ def _moving_average(arr: np.ndarray, window: int) -> np.ndarray:
     return np.convolve(padded, np.ones(w) / w, mode="valid")
 
 
+def _roll_cfg(sidecar: dict) -> dict:
+    """The `settings.roll_control` block from the #165 flight-settings snapshot, or {}."""
+    rc = (sidecar.get("settings") or {}).get("roll_control")
+    return rc if isinstance(rc, dict) else {}
+
+
 def _gain_from_sidecar(sidecar: dict) -> tuple[float | None, float | None, float | None]:
     """Best-effort extract of (Kp, Ki, Kd) from the per-flight .json sidecar."""
-    # The post-#178 RocketProfile dump nests these — accept a few common shapes.
+    # Current firmware (#165 settings snapshot) nests the flown gains under
+    # settings.roll_control.{kp,ki,kd}. Prefer that; fall back to older shapes.
+    rc = _roll_cfg(sidecar)
+    if all(k in rc for k in ("kp", "ki", "kd")):
+        return float(rc["kp"]), float(rc["ki"]), float(rc["kd"])
     for keyset in (("roll_kp", "roll_ki", "roll_kd"),
                    ("Kp", "Ki", "Kd")):
         if all(k in sidecar for k in keyset):
@@ -66,6 +76,85 @@ def _gain_from_sidecar(sidecar: dict) -> tuple[float | None, float | None, float
             if all(k in profile for k in keyset):
                 return tuple(float(profile[k]) for k in keyset)  # type: ignore[return-value]
     return None, None, None
+
+
+def _parse_profile(rc: dict) -> list[tuple[float, float, bool]]:
+    """Roll-control waypoints as [(time_s_after_launch, angle_deg, is_null_rate)], sorted by time."""
+    out: list[tuple[float, float, bool]] = []
+    for seg in rc.get("profile") or []:
+        try:
+            out.append((float(seg["time_s"]), float(seg["angle_deg"]),
+                        str(seg.get("mode", "")).lower() == "null_rate"))
+        except (KeyError, TypeError, ValueError):
+            continue
+    out.sort(key=lambda s: s[0])
+    return out
+
+
+def _profile_target(wps: list[tuple[float, float, bool]], t: float) -> tuple[float, bool]:
+    """Replicate firmware `roll_profile_query` (main.cpp): returns (target_angle_deg, is_angle_mode)
+    at flight time `t` (seconds since launch). Segment mode = mode of the waypoint that STARTS it;
+    the angle is linearly interpolated between consecutive waypoints. Holds the first / last
+    waypoint outside the profile span."""
+    if not wps:
+        return 0.0, False
+    if t <= wps[0][0]:
+        return wps[0][1], not wps[0][2]
+    if t >= wps[-1][0]:
+        return wps[-1][1], not wps[-1][2]
+    for i in range(len(wps) - 1):
+        if t < wps[i + 1][0]:
+            t0, a0, null0 = wps[i]
+            t1, a1, _ = wps[i + 1]
+            if t1 <= t0:
+                return a0, not null0
+            frac = (t - t0) / (t1 - t0)
+            return a0 + frac * (a1 - a0), not null0
+    return wps[-1][1], not wps[-1][2]
+
+
+def _quat_roll_deg(q0, q1, q2, q3):
+    """Roll angle (deg) extracted exactly as the flight controller does in main.cpp:
+    ``-atan2(z_east, z_north)`` from the body-Z axis projected into the nav frame.
+    NOTE: the logged ``NonSensor.roll`` Euler field uses a *different* convention and is
+    not what the roll controller regulates — always reconstruct from the quaternion."""
+    z_north = 2.0 * (q1 * q3 + q0 * q2)
+    z_east = 2.0 * (q2 * q3 - q0 * q1)
+    return -np.degrees(np.arctan2(z_east, z_north))
+
+
+def _wrap180(x):
+    """Wrap angle(s) in degrees to (-180, 180]."""
+    return (np.asarray(x, dtype=float) + 180.0) % 360.0 - 180.0
+
+
+def _break_seam(y):
+    """NaN-break a wrapped series where it jumps the ±180 seam, so a line plot
+    doesn't draw a vertical connector across the discontinuity."""
+    y = np.asarray(y, dtype=float).copy()
+    d = np.abs(np.diff(y))
+    y[1:][d > 180.0] = np.nan
+    return y
+
+
+def _shade_segments(ax, tw, is_ang, label="rate-null (no angle target)"):
+    """Shade the contiguous time spans where the profile is in null-rate mode."""
+    if tw is None or len(tw) == 0:
+        return
+    shown = False
+    start = None
+    for i in range(len(tw)):
+        null = not bool(is_ang[i])
+        if null and start is None:
+            start = float(tw[i])
+        elif not null and start is not None:
+            ax.axvspan(start, float(tw[i]), color="0.85", alpha=0.6, lw=0,
+                       label=(label if not shown else None))
+            shown = True
+            start = None
+    if start is not None:
+        ax.axvspan(start, float(tw[-1]), color="0.85", alpha=0.6, lw=0,
+                   label=(label if not shown else None))
 
 
 def analyze(flight: Flight) -> AnalysisResult:
@@ -174,8 +263,53 @@ def analyze(flight: Flight) -> AnalysisResult:
     mask_ss_v = (t_ns >= ss_t0) & (t_ns <= ss_t1)
     v_mean = float(np.mean(speed[mask_ss_v])) if mask_ss_v.any() else float("nan")
 
+    # ── Roll-angle tracking vs profile plan (launch → ejection) ──
+    # Reconstruct the commanded waypoint plan and the actual roll the controller
+    # regulated, both exactly as the firmware computes them.
+    rc_cfg = _roll_cfg(flight.sidecar)
+    wps = _parse_profile(rc_cfg)
+    has_angle_profile = any(not null for (_, _, null) in wps)
+
+    # Ejection ≈ apogee (end of roll authority), launch-relative.
+    eject_t = None
+    for r in ns:
+        if r.get("apogee_flag"):
+            eject_t = (r["time_us"] - t0) / 1e6 - launch_t
+            break
+    if eject_t is None or not np.isfinite(eject_t) or eject_t <= 0:
+        apo = flight.sidecar.get("apogee_time_s")
+        eject_t = (float(apo) if apo not in (None, "")
+                   else float(min(t_control_on + 6.0, t_imu[-1])))
+    eject_t = float(min(eject_t, t_imu[-1]))
+
+    burnout_t = flight.sidecar.get("burnout_time_s")
+    burnout_t = float(burnout_t) if burnout_t not in (None, "") else None
+
+    track_tw = track_tgt = track_act = track_err = track_is_ang = None
+    angle_rms = angle_peak = float("nan")
+    if has_angle_profile:
+        roll_act = _quat_roll_deg(*(get_array(ns, k) for k in ("q0", "q1", "q2", "q3")))
+        wmask = (t_ns >= 0.0) & (t_ns <= eject_t + 0.05) & np.isfinite(roll_act)
+        track_tw = t_ns[wmask]
+        act_w = roll_act[wmask]
+        tq = [_profile_target(wps, float(tt)) for tt in track_tw]
+        target_ang = np.array([x[0] for x in tq], dtype=float)
+        track_is_ang = np.array([x[1] for x in tq], dtype=bool)
+        # Wrapped shortest-path error, exactly like servo_control.controlAngle().
+        err = _wrap180(target_ang - act_w)
+        # Plot both target and actual wrapped to (-180,180] so the vertical gap
+        # equals the true error the controller acts on; break the ±180 seam.
+        track_tgt = _break_seam(np.where(track_is_ang, _wrap180(target_ang), np.nan))
+        track_act = _break_seam(np.where(track_is_ang, _wrap180(act_w), np.nan))
+        track_err = np.where(track_is_ang, err, np.nan)
+        ea = err[track_is_ang]
+        if ea.size:
+            angle_rms = float(np.sqrt(np.mean(ea ** 2)))
+            angle_peak = float(np.max(np.abs(ea)))
+
     # ── Current gains (from sidecar if available) ──
     kp_flight, ki_flight, kd_flight = _gain_from_sidecar(flight.sidecar)
+    kp_angle_flight = rc_cfg.get("kp_angle")
 
     # ── Stability with current gains ──
     pm_current: float | None = None
@@ -216,6 +350,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         "current_Kp":             round(kp_flight, 4) if kp_flight is not None else "—",
         "current_Ki":             round(ki_flight, 5) if ki_flight is not None else "—",
         "current_Kd":             round(kd_flight, 5) if kd_flight is not None else "—",
+        "current_Kp_angle":       kp_angle_flight if kp_angle_flight is not None else "—",
         "current_crossover_hz":   round(f_c_current, 2) if f_c_current is not None else "—",
         "current_phase_margin_°": round(pm_current, 1)  if pm_current  is not None else "—",
         "recommended_Kp":         round(kp_new, 4),
@@ -224,6 +359,21 @@ def analyze(flight: Flight) -> AnalysisResult:
         "target_crossover_hz":    round(_F_TARGET_HZ, 2),
         "target_phase_margin_°":  round(_PM_TARGET_DEG, 1),
     }
+    # Flown roll-control setup parameters (from the #165 settings snapshot).
+    if rc_cfg:
+        metrics["roll_mode"]      = rc_cfg.get("mode", "—")
+        metrics["roll_delay_ms"]  = rc_cfg.get("delay_ms", "—")
+        metrics["rate_cap_dps"]   = rc_cfg.get("rate_cap_dps", "—")
+        metrics["cmd_limit_deg"]  = (f"[{rc_cfg.get('cmd_limit_min_deg', '?')}, "
+                                     f"{rc_cfg.get('cmd_limit_max_deg', '?')}]")
+        metrics["d_lpf_hz"]       = rc_cfg.get("d_lpf_hz", "—")
+        metrics["guidance_enabled"] = rc_cfg.get("guidance_enabled", "—")
+    if has_angle_profile:
+        metrics["profile_plan"] = "; ".join(
+            f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
+        metrics["eject_time_s"]         = round(eject_t, 2)
+        metrics["angle_track_rms_deg"]  = round(angle_rms, 1)  if np.isfinite(angle_rms)  else "—"
+        metrics["angle_track_peak_deg"] = round(angle_peak, 1) if np.isfinite(angle_peak) else "—"
     result.metrics = metrics
 
     # ── Figures ──
@@ -257,27 +407,88 @@ def analyze(flight: Flight) -> AnalysisResult:
     fig.tight_layout()
     result.figures.append(fig)
 
-    # 2) Transient detail (-0.5 s … +2 s around control on)
-    fig, axes = plt.subplots(2, 1, figsize=(11, 6), sharex=True)
-    win = (t_imu >= t_control_on - 0.5) & (t_imu <= t_control_on + 2.0)
-    win_c = (t_ns  >= t_control_on - 0.5) & (t_ns  <= t_control_on + 2.0)
-    axes[0].plot(t_imu[win], g[win], color="tab:green", lw=1.0)
+    # Event markers shared by the launch→eject figures.
+    def _mark_events(ax, with_labels=False):
+        ax.axvline(t_control_on, color="red", linestyle="--", lw=1.0,
+                   label=(f"control on ({t_control_on:.2f}s)" if with_labels else None))
+        if burnout_t is not None and -0.2 <= burnout_t <= eject_t + 0.2:
+            ax.axvline(burnout_t, color="tab:purple", linestyle="--", lw=1.0,
+                       label=(f"burnout ({burnout_t:.2f}s)" if with_labels else None))
+        ax.axvline(eject_t, color="black", linestyle="--", lw=1.0,
+                   label=(f"apogee/eject ({eject_t:.2f}s)" if with_labels else None))
+        for (wt, _, _) in wps:
+            if -0.2 <= wt <= eject_t + 0.2:
+                ax.axvline(wt, color="gray", linestyle=":", lw=0.8)
+
+    # 2) Control timeline — launch → ejection (roll rate + servo command)
+    fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+    t_lo, t_hi = -0.2, eject_t + 0.2
+    win = (t_imu >= t_lo) & (t_imu <= t_hi)
+    win_c = (t_ns >= t_lo) & (t_ns <= t_hi)
+    axes[0].plot(t_imu[win], g[win], color="tab:green", lw=0.9)
     axes[0].axhline(0, color="k", lw=0.5)
-    axes[0].axvline(t_control_on, color="red", linestyle="--", lw=1.2, label="control on")
     axes[0].set_ylabel("Roll rate (deg/s)")
-    axes[0].set_title("Transient response — first 2 s of active control")
+    axes[0].set_title("Roll control — launch → ejection")
     axes[0].grid(True, alpha=0.3)
+    # Clip the rate axis to in-flight magnitudes so the apogee tumble spike
+    # doesn't crush the controlled-flight detail.
+    gw = g[win]
+    core = gw[t_imu[win] <= eject_t - 0.4]
+    core = core if core.size else gw
+    if core.size:
+        lim = max(float(np.percentile(np.abs(core), 99)) * 1.3, 30.0)
+        peak = float(np.max(np.abs(gw))) if gw.size else 0.0
+        axes[0].set_ylim(-lim, lim)
+        if peak > lim:
+            axes[0].text(0.01, 0.04, f"axis clipped — apogee tumble peaks {peak:.0f}°/s",
+                         transform=axes[0].transAxes, ha="left", va="bottom", fontsize=8,
+                         color="0.4")
+    _mark_events(axes[0], with_labels=True)
     axes[0].legend(loc="upper right", fontsize=8)
-    axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=1.0)
+    axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
     axes[1].axhline(0, color="k", lw=0.5)
-    axes[1].axvline(t_control_on, color="red", linestyle="--", lw=1.2)
     axes[1].set_xlabel("Time since launch (s)")
     axes[1].set_ylabel("Roll cmd (deg)")
     axes[1].grid(True, alpha=0.3)
+    _mark_events(axes[1])
     fig.tight_layout()
     result.figures.append(fig)
 
-    # 3) FFT of steady-state roll rate
+    # 3) Roll-angle tracking vs profile plan (launch → ejection)
+    if has_angle_profile and track_tw is not None and track_tw.size > 5:
+        fig, axes = plt.subplots(2, 1, figsize=(12, 7), sharex=True)
+        _shade_segments(axes[0], track_tw, track_is_ang)
+        axes[0].plot(track_tw, track_tgt, color="tab:orange", lw=2.2, label="profile target")
+        axes[0].plot(track_tw, track_act, color="tab:green", lw=1.4, label="actual roll (quaternion)")
+        axes[0].set_ylabel("Roll angle (deg, wrapped ±180)")
+        axes[0].set_ylim(-189, 189)
+        axes[0].set_yticks([-180, -90, 0, 90, 180])
+        axes[0].set_title("Roll angle tracking vs profile plan (launch → ejection)")
+        axes[0].grid(True, alpha=0.3)
+        # Annotate each angle waypoint with its absolute commanded target.
+        for (wt, wa, wn) in wps:
+            if not wn and 0 <= wt <= eject_t:
+                axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
+                                 color="tab:orange", ha="left", va="bottom",
+                                 xytext=(2, 2), textcoords="offset points")
+        _mark_events(axes[0])
+        axes[0].legend(loc="lower left", fontsize=8)
+
+        _shade_segments(axes[1], track_tw, track_is_ang)
+        axes[1].axhline(0, color="k", lw=0.5)
+        axes[1].plot(track_tw, track_err, color="tab:red", lw=1.1)
+        axes[1].set_ylabel("Tracking error (deg)")
+        axes[1].set_xlabel("Time since launch (s)")
+        axes[1].grid(True, alpha=0.3)
+        _mark_events(axes[1])
+        if np.isfinite(angle_rms):
+            axes[1].text(0.99, 0.05, f"RMS {angle_rms:.1f}°   peak {angle_peak:.1f}°",
+                         transform=axes[1].transAxes, ha="right", va="bottom", fontsize=9,
+                         bbox=dict(boxstyle="round", fc="white", ec="0.7", alpha=0.85))
+        fig.tight_layout()
+        result.figures.append(fig)
+
+    # 4) FFT of steady-state roll rate
     if fft_freqs is not None and fft_mag is not None:
         fig, ax = plt.subplots(figsize=(10, 4))
         ax.semilogy(fft_freqs, fft_mag, color="tab:blue", lw=0.8)

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -40,13 +40,11 @@ _K_PLANT_FALLBACK = 200.0                   # deg/s² per deg deflection
 _F_TARGET_HZ = 2.0                          # target closed-loop crossover
 _PM_TARGET_DEG = 50.0                       # target phase margin
 
-# Per-flight launch→ejection window trims (seconds since launch), keyed by .bin
-# stem. Some flights tumble well before apogee; capping the window keeps the
-# roll-tracking plots (and error stats) clean. The actual apogee is still
-# reported in the metrics.
-_WINDOW_TRIM_S: dict[str, float] = {
-    "flight_20260614_150808": 9.0,  # Rolly Polly III — tumble onset ~9s, apogee 10.27s
-}
+# Manual per-flight launch→ejection window overrides (seconds since launch),
+# keyed by .bin stem. The window end is normally found automatically from the
+# barometric ejection event (see _baro_eject_time); this map is only an escape
+# hatch for flights where that detection misfires. Empty by default.
+_WINDOW_TRIM_S: dict[str, float] = {}
 
 
 def _moving_average(arr: np.ndarray, window: int) -> np.ndarray:
@@ -192,6 +190,37 @@ def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
                 transform=ax.transAxes, ha="left", va="bottom", fontsize=8, color="0.4")
 
 
+def _baro_eject_time(flight, t0, launch_t, burnout_t, apogee_t):
+    """Detect the ejection event from the barometric pressure spike (the charge
+    gas pulse over-pressuring the baro port): the first post-burnout sample where
+    |dP/dt| massively exceeds the coast baseline. The spike is ~1e6 Pa/s vs ~1e3
+    in clean coast, so it separates cleanly. Returns launch-relative seconds, or
+    None if no clear event (then we fall back to apogee)."""
+    bmp = flight.records.get("BMP585") or []
+    if len(bmp) < 50:
+        return None
+    tb = (get_array(bmp, "time_us") - t0) / 1e6 - launch_t
+    p = get_array(bmp, "pressure_pa")
+    order = np.argsort(tb, kind="stable")
+    tb, p = tb[order], p[order]
+    keep = np.concatenate(([True], np.diff(tb) > 1e-6)) & np.isfinite(p)
+    tb, p = tb[keep], p[keep]
+    if tb.size < 50:
+        return None
+    dpdt = np.abs(np.gradient(p, tb))
+    bo = burnout_t if burnout_t is not None else 1.0
+    coast = tb > bo + 0.5
+    if coast.sum() < 20:
+        return None
+    # Threshold well above coast noise (absolute floor) yet far below the spike;
+    # the median term lifts it for unusually noisy baro.
+    thr = max(100000.0, 50.0 * float(np.median(dpdt[coast])))
+    # Ejection is at/near apogee for these motors — ignore later descent/landing spikes.
+    search = coast & (tb <= apogee_t + 2.0) & (dpdt > thr)
+    idx = np.where(search)[0]
+    return float(tb[idx[0]]) if idx.size else None
+
+
 def analyze(flight: Flight) -> AnalysisResult:
     result = AnalysisResult(name="roll_pid", title="Roll PID Tracking & Tuning")
     recs = flight.records
@@ -317,13 +346,22 @@ def analyze(flight: Flight) -> AnalysisResult:
                    else float(min(t_control_on + 6.0, t_imu[-1])))
     eject_t = float(min(eject_t, t_imu[-1]))
 
-    # Optional per-flight trim of the plot/analysis window (drop the messy
-    # pre-apogee tumble at the end). eject_t stays the real apogee for metrics.
-    trim_t = _WINDOW_TRIM_S.get(flight.bin_path.stem)
-    win_end = float(min(eject_t, trim_t)) if trim_t is not None else eject_t
-
     burnout_t = flight.sidecar.get("burnout_time_s")
     burnout_t = float(burnout_t) if burnout_t not in (None, "") else None
+
+    # End the plot/analysis window 0.25 s before the barometric ejection event
+    # (charge pressure spike), so the post-ejection tumble is excluded generally
+    # rather than per-flight. Fall back to apogee if no clear baro event. eject_t
+    # stays the real apogee for the metrics/marker.
+    eject_baro = _baro_eject_time(flight, t0, launch_t, burnout_t, eject_t)
+    if eject_baro is not None:
+        win_end = max(eject_baro - 0.25, (burnout_t or 0.0) + 0.5)
+    else:
+        win_end = eject_t
+    trim_t = _WINDOW_TRIM_S.get(flight.bin_path.stem)  # manual override (rare); wins if set
+    if trim_t is not None:
+        win_end = min(win_end, float(trim_t))
+    win_end = float(min(win_end, t_imu[-1]))
 
     track_tw = track_tgt = track_act = track_err = track_is_ang = None
     angle_rms = angle_peak = float("nan")
@@ -339,8 +377,10 @@ def analyze(flight: Flight) -> AnalysisResult:
         err = _wrap180(target_ang - act_w)
         # Plot both target and actual wrapped to (-180,180] so the vertical gap
         # equals the true error the controller acts on; break the ±180 seam.
+        # Actual roll is shown across the whole window (incl. the null-rate
+        # period); the target/error exist only where an angle is commanded.
         track_tgt = _break_seam(np.where(track_is_ang, _wrap180(target_ang), np.nan))
-        track_act = _break_seam(np.where(track_is_ang, _wrap180(act_w), np.nan))
+        track_act = _break_seam(_wrap180(act_w))
         track_err = np.where(track_is_ang, err, np.nan)
         ea = err[track_is_ang]
         if ea.size:
@@ -408,12 +448,14 @@ def analyze(flight: Flight) -> AnalysisResult:
                                      f"{rc_cfg.get('cmd_limit_max_deg', '?')}]")
         metrics["d_lpf_hz"]       = rc_cfg.get("d_lpf_hz", "—")
         metrics["guidance_enabled"] = rc_cfg.get("guidance_enabled", "—")
+    # Window timing (applies to every active-roll flight's launch→eject figure).
+    metrics["eject_time_s"] = round(eject_t, 2)
+    if eject_baro is not None:
+        metrics["baro_eject_s"] = round(eject_baro, 2)
+    metrics["plot_window_s"] = f"[0, {win_end:.2f}]"
     if has_angle_profile:
         metrics["profile_plan"] = "; ".join(
             f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
-        metrics["eject_time_s"]         = round(eject_t, 2)
-        if win_end < eject_t - 1e-6:
-            metrics["plot_window_trimmed_s"] = f"[0, {win_end:g}] (apogee {eject_t:.2f}s)"
         metrics["angle_track_rms_deg"]  = round(angle_rms, 1)  if np.isfinite(angle_rms)  else "—"
         metrics["angle_track_peak_deg"] = round(angle_peak, 1) if np.isfinite(angle_peak) else "—"
     result.metrics = metrics

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -157,6 +157,33 @@ def _shade_segments(ax, tw, is_ang, label="rate-null (no angle target)"):
                    label=(label if not shown else None))
 
 
+def _as_float(v):
+    """Parse a sidecar value to float, or None if missing / non-numeric."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
+    """Clip a roll-rate axis to in-flight magnitudes so the apogee tumble spike
+    doesn't crush the controlled-flight detail; annotate if anything is clipped.
+    Scale is anchored on the rate cap (the natural scale of controlled roll rate),
+    with a robust percentile floor; the final second before ejection is excluded
+    so a pre-apogee tumble ramp can't inflate the scale."""
+    if gw is None or len(gw) == 0:
+        return
+    core = gw[tw <= eject_t - 1.0]
+    core = core if core.size else gw
+    lim = max(float(np.percentile(np.abs(core), 95)) * 1.4,
+              (rate_cap * 2.5) if rate_cap else 0.0, 30.0)
+    peak = float(np.max(np.abs(gw)))
+    ax.set_ylim(-lim, lim)
+    if peak > lim * 1.05:
+        ax.text(0.01, 0.04, f"axis clipped — apogee tumble peaks {peak:.0f}°/s",
+                transform=ax.transAxes, ha="left", va="bottom", fontsize=8, color="0.4")
+
+
 def analyze(flight: Flight) -> AnalysisResult:
     result = AnalysisResult(name="roll_pid", title="Roll PID Tracking & Tuning")
     recs = flight.records
@@ -420,71 +447,96 @@ def analyze(flight: Flight) -> AnalysisResult:
             if -0.2 <= wt <= eject_t + 0.2:
                 ax.axvline(wt, color="gray", linestyle=":", lw=0.8)
 
-    # 2) Control timeline — launch → ejection (roll rate + servo command)
-    fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+    # Launch → ejection window (shared by the figures below).
     t_lo, t_hi = -0.2, eject_t + 0.2
     win = (t_imu >= t_lo) & (t_imu <= t_hi)
     win_c = (t_ns >= t_lo) & (t_ns <= t_hi)
-    axes[0].plot(t_imu[win], g[win], color="tab:green", lw=0.9)
-    axes[0].axhline(0, color="k", lw=0.5)
-    axes[0].set_ylabel("Roll rate (deg/s)")
-    axes[0].set_title("Roll control — launch → ejection")
-    axes[0].grid(True, alpha=0.3)
-    # Clip the rate axis to in-flight magnitudes so the apogee tumble spike
-    # doesn't crush the controlled-flight detail.
-    gw = g[win]
-    core = gw[t_imu[win] <= eject_t - 0.4]
-    core = core if core.size else gw
-    if core.size:
-        lim = max(float(np.percentile(np.abs(core), 99)) * 1.3, 30.0)
-        peak = float(np.max(np.abs(gw))) if gw.size else 0.0
-        axes[0].set_ylim(-lim, lim)
-        if peak > lim:
-            axes[0].text(0.01, 0.04, f"axis clipped — apogee tumble peaks {peak:.0f}°/s",
-                         transform=axes[0].transAxes, ha="left", va="bottom", fontsize=8,
-                         color="0.4")
-    _mark_events(axes[0], with_labels=True)
-    axes[0].legend(loc="upper right", fontsize=8)
-    axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
-    axes[1].axhline(0, color="k", lw=0.5)
-    axes[1].set_xlabel("Time since launch (s)")
-    axes[1].set_ylabel("Roll cmd (deg)")
-    axes[1].grid(True, alpha=0.3)
-    _mark_events(axes[1])
-    fig.tight_layout()
-    result.figures.append(fig)
+    rate_cap = _as_float(rc_cfg.get("rate_cap_dps"))
 
-    # 3) Roll-angle tracking vs profile plan (launch → ejection)
+    # 2) Control timeline — launch → ejection (roll rate + servo command).
+    #    For angle-profile flights this is folded into the 4-panel tracking
+    #    figure below, so only render it standalone for rate-only flights.
+    if not has_angle_profile:
+        fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+        axes[0].plot(t_imu[win], g[win], color="tab:green", lw=0.9)
+        axes[0].axhline(0, color="k", lw=0.5)
+        axes[0].set_ylabel("Roll rate (deg/s)")
+        axes[0].set_title("Roll control — launch → ejection")
+        axes[0].grid(True, alpha=0.3)
+        _clip_rate_axis(axes[0], t_imu[win], g[win], eject_t, rate_cap)
+        _mark_events(axes[0], with_labels=True)
+        axes[0].legend(loc="upper right", fontsize=8)
+        axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
+        axes[1].axhline(0, color="k", lw=0.5)
+        axes[1].set_xlabel("Time since launch (s)")
+        axes[1].set_ylabel("Roll cmd (deg)")
+        axes[1].grid(True, alpha=0.3)
+        _mark_events(axes[1])
+        fig.tight_layout()
+        result.figures.append(fig)
+
+    # 3) Roll-angle tracking vs profile plan + control activity (launch → ejection)
     if has_angle_profile and track_tw is not None and track_tw.size > 5:
-        fig, axes = plt.subplots(2, 1, figsize=(12, 7), sharex=True)
+        fig, axes = plt.subplots(4, 1, figsize=(12, 12), sharex=True)
+
+        # Panel 0 — roll angle: target vs actual (both wrapped ±180)
         _shade_segments(axes[0], track_tw, track_is_ang)
         axes[0].plot(track_tw, track_tgt, color="tab:orange", lw=2.2, label="profile target")
         axes[0].plot(track_tw, track_act, color="tab:green", lw=1.4, label="actual roll (quaternion)")
-        axes[0].set_ylabel("Roll angle (deg, wrapped ±180)")
+        axes[0].set_ylabel("Roll angle\n(deg, wrapped ±180)")
         axes[0].set_ylim(-189, 189)
         axes[0].set_yticks([-180, -90, 0, 90, 180])
         axes[0].set_title("Roll angle tracking vs profile plan (launch → ejection)")
         axes[0].grid(True, alpha=0.3)
-        # Annotate each angle waypoint with its absolute commanded target.
         for (wt, wa, wn) in wps:
             if not wn and 0 <= wt <= eject_t:
                 axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
                                  color="tab:orange", ha="left", va="bottom",
                                  xytext=(2, 2), textcoords="offset points")
-        _mark_events(axes[0])
-        axes[0].legend(loc="lower left", fontsize=8)
+        _mark_events(axes[0], with_labels=True)
+        axes[0].legend(loc="upper left", fontsize=8, ncol=2)
 
-        _shade_segments(axes[1], track_tw, track_is_ang)
+        # Panel 1 — tracking error
+        _shade_segments(axes[1], track_tw, track_is_ang, label=None)
         axes[1].axhline(0, color="k", lw=0.5)
         axes[1].plot(track_tw, track_err, color="tab:red", lw=1.1)
-        axes[1].set_ylabel("Tracking error (deg)")
-        axes[1].set_xlabel("Time since launch (s)")
+        axes[1].set_ylabel("Tracking error\n(deg)")
         axes[1].grid(True, alpha=0.3)
         _mark_events(axes[1])
         if np.isfinite(angle_rms):
             axes[1].text(0.99, 0.05, f"RMS {angle_rms:.1f}°   peak {angle_peak:.1f}°",
                          transform=axes[1].transAxes, ha="right", va="bottom", fontsize=9,
                          bbox=dict(boxstyle="round", fc="white", ec="0.7", alpha=0.85))
+
+        # Panel 2 — roll rate (gyro X), with the outer-loop rate cap for reference
+        _shade_segments(axes[2], track_tw, track_is_ang, label=None)
+        axes[2].axhline(0, color="k", lw=0.5)
+        axes[2].plot(t_imu[win], g[win], color="tab:green", lw=0.9, label="roll rate (gyro)")
+        axes[2].set_ylabel("Roll rate\n(deg/s)")
+        axes[2].grid(True, alpha=0.3)
+        _clip_rate_axis(axes[2], t_imu[win], g[win], eject_t, rate_cap)
+        if rate_cap is not None:
+            axes[2].axhline(rate_cap, color="tab:blue", ls=":", lw=1.0,
+                            label=f"rate cap ±{rate_cap:g}°/s")
+            axes[2].axhline(-rate_cap, color="tab:blue", ls=":", lw=1.0)
+        _mark_events(axes[2])
+        axes[2].legend(loc="upper right", fontsize=8)
+
+        # Panel 3 — roll command (PID output → servo), with saturation limits
+        _shade_segments(axes[3], track_tw, track_is_ang, label=None)
+        axes[3].axhline(0, color="k", lw=0.5)
+        axes[3].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9, label="roll cmd")
+        axes[3].set_ylabel("Roll cmd\n(deg)")
+        axes[3].set_xlabel("Time since launch (s)")
+        axes[3].grid(True, alpha=0.3)
+        cmin, cmax = _as_float(rc_cfg.get("cmd_limit_min_deg")), _as_float(rc_cfg.get("cmd_limit_max_deg"))
+        if cmax is not None:
+            axes[3].axhline(cmax, color="tab:purple", ls=":", lw=1.0, label="cmd limit")
+        if cmin is not None:
+            axes[3].axhline(cmin, color="tab:purple", ls=":", lw=1.0)
+        _mark_events(axes[3])
+        axes[3].legend(loc="upper right", fontsize=8)
+
         fig.tight_layout()
         result.figures.append(fig)
 

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -40,6 +40,14 @@ _K_PLANT_FALLBACK = 200.0                   # deg/s² per deg deflection
 _F_TARGET_HZ = 2.0                          # target closed-loop crossover
 _PM_TARGET_DEG = 50.0                       # target phase margin
 
+# Per-flight launch→ejection window trims (seconds since launch), keyed by .bin
+# stem. Some flights tumble well before apogee; capping the window keeps the
+# roll-tracking plots (and error stats) clean. The actual apogee is still
+# reported in the metrics.
+_WINDOW_TRIM_S: dict[str, float] = {
+    "flight_20260614_150808": 9.0,  # Rolly Polly III — tumble onset ~9s, apogee 10.27s
+}
+
 
 def _moving_average(arr: np.ndarray, window: int) -> np.ndarray:
     if _HAS_SCIPY:
@@ -180,7 +188,7 @@ def _clip_rate_axis(ax, tw, gw, eject_t, rate_cap=None):
     peak = float(np.max(np.abs(gw)))
     ax.set_ylim(-lim, lim)
     if peak > lim * 1.05:
-        ax.text(0.01, 0.04, f"axis clipped — apogee tumble peaks {peak:.0f}°/s",
+        ax.text(0.01, 0.04, f"axis clipped — peak |rate| {peak:.0f}°/s",
                 transform=ax.transAxes, ha="left", va="bottom", fontsize=8, color="0.4")
 
 
@@ -309,6 +317,11 @@ def analyze(flight: Flight) -> AnalysisResult:
                    else float(min(t_control_on + 6.0, t_imu[-1])))
     eject_t = float(min(eject_t, t_imu[-1]))
 
+    # Optional per-flight trim of the plot/analysis window (drop the messy
+    # pre-apogee tumble at the end). eject_t stays the real apogee for metrics.
+    trim_t = _WINDOW_TRIM_S.get(flight.bin_path.stem)
+    win_end = float(min(eject_t, trim_t)) if trim_t is not None else eject_t
+
     burnout_t = flight.sidecar.get("burnout_time_s")
     burnout_t = float(burnout_t) if burnout_t not in (None, "") else None
 
@@ -316,7 +329,7 @@ def analyze(flight: Flight) -> AnalysisResult:
     angle_rms = angle_peak = float("nan")
     if has_angle_profile:
         roll_act = _quat_roll_deg(*(get_array(ns, k) for k in ("q0", "q1", "q2", "q3")))
-        wmask = (t_ns >= 0.0) & (t_ns <= eject_t + 0.05) & np.isfinite(roll_act)
+        wmask = (t_ns >= 0.0) & (t_ns <= win_end + 0.05) & np.isfinite(roll_act)
         track_tw = t_ns[wmask]
         act_w = roll_act[wmask]
         tq = [_profile_target(wps, float(tt)) for tt in track_tw]
@@ -399,6 +412,8 @@ def analyze(flight: Flight) -> AnalysisResult:
         metrics["profile_plan"] = "; ".join(
             f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
         metrics["eject_time_s"]         = round(eject_t, 2)
+        if win_end < eject_t - 1e-6:
+            metrics["plot_window_trimmed_s"] = f"[0, {win_end:g}] (apogee {eject_t:.2f}s)"
         metrics["angle_track_rms_deg"]  = round(angle_rms, 1)  if np.isfinite(angle_rms)  else "—"
         metrics["angle_track_peak_deg"] = round(angle_peak, 1) if np.isfinite(angle_peak) else "—"
     result.metrics = metrics
@@ -434,21 +449,22 @@ def analyze(flight: Flight) -> AnalysisResult:
     fig.tight_layout()
     result.figures.append(fig)
 
-    # Event markers shared by the launch→eject figures.
+    # Event markers shared by the launch→eject figures (within the plotted window).
     def _mark_events(ax, with_labels=False):
         ax.axvline(t_control_on, color="red", linestyle="--", lw=1.0,
                    label=(f"control on ({t_control_on:.2f}s)" if with_labels else None))
-        if burnout_t is not None and -0.2 <= burnout_t <= eject_t + 0.2:
+        if burnout_t is not None and -0.2 <= burnout_t <= win_end + 0.2:
             ax.axvline(burnout_t, color="tab:purple", linestyle="--", lw=1.0,
                        label=(f"burnout ({burnout_t:.2f}s)" if with_labels else None))
-        ax.axvline(eject_t, color="black", linestyle="--", lw=1.0,
-                   label=(f"apogee/eject ({eject_t:.2f}s)" if with_labels else None))
+        if eject_t <= win_end + 0.2:
+            ax.axvline(eject_t, color="black", linestyle="--", lw=1.0,
+                       label=(f"apogee/eject ({eject_t:.2f}s)" if with_labels else None))
         for (wt, _, _) in wps:
-            if -0.2 <= wt <= eject_t + 0.2:
+            if -0.2 <= wt <= win_end + 0.2:
                 ax.axvline(wt, color="gray", linestyle=":", lw=0.8)
 
-    # Launch → ejection window (shared by the figures below).
-    t_lo, t_hi = -0.2, eject_t + 0.2
+    # Launch → ejection window (shared by the figures below), trimmed if configured.
+    t_lo, t_hi = -0.2, win_end + 0.2
     win = (t_imu >= t_lo) & (t_imu <= t_hi)
     win_c = (t_ns >= t_lo) & (t_ns <= t_hi)
     rate_cap = _as_float(rc_cfg.get("rate_cap_dps"))
@@ -463,7 +479,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].set_ylabel("Roll rate (deg/s)")
         axes[0].set_title("Roll control — launch → ejection")
         axes[0].grid(True, alpha=0.3)
-        _clip_rate_axis(axes[0], t_imu[win], g[win], eject_t, rate_cap)
+        _clip_rate_axis(axes[0], t_imu[win], g[win], win_end, rate_cap)
         _mark_events(axes[0], with_labels=True)
         axes[0].legend(loc="upper right", fontsize=8)
         axes[1].plot(t_ns[win_c], cmd[win_c], color="tab:orange", lw=0.9)
@@ -489,7 +505,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].set_title("Roll angle tracking vs profile plan (launch → ejection)")
         axes[0].grid(True, alpha=0.3)
         for (wt, wa, wn) in wps:
-            if not wn and 0 <= wt <= eject_t:
+            if not wn and 0 <= wt <= win_end:
                 axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
                                  color="tab:orange", ha="left", va="bottom",
                                  xytext=(2, 2), textcoords="offset points")
@@ -514,7 +530,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[2].plot(t_imu[win], g[win], color="tab:green", lw=0.9, label="roll rate (gyro)")
         axes[2].set_ylabel("Roll rate\n(deg/s)")
         axes[2].grid(True, alpha=0.3)
-        _clip_rate_axis(axes[2], t_imu[win], g[win], eject_t, rate_cap)
+        _clip_rate_axis(axes[2], t_imu[win], g[win], win_end, rate_cap)
         if rate_cap is not None:
             axes[2].axhline(rate_cap, color="tab:blue", ls=":", lw=1.0,
                             label=f"rate cap ±{rate_cap:g}°/s")

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -154,7 +154,8 @@ final class ActiveRocketSyncer: ObservableObject {
         device.sendServoControlConfig(enabled: profile.servoControlEnabled)
         device.sendGainScheduleConfig(enabled: profile.gainScheduleEnabled)
         device.sendRollControlConfig(useAngleControl: profile.useAngleControl,
-                                     rollDelayMs: profile.rollDelayMs)
+                                     rollDelayMs: profile.rollDelayMs,
+                                     rateCapDps: profile.rateCapDps)
         device.sendRollProfile(waypoints: profile.rollWaypoints.map {
             (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
         })

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -658,16 +658,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
-    func sendRollControlConfig(useAngleControl: Bool, rollDelayMs: UInt16) {
+    func sendRollControlConfig(useAngleControl: Bool, rollDelayMs: UInt16, rateCapDps: Float) {
         var payload = Data()
         payload.append(useAngleControl ? 0x01 : 0x00)
         payload.append(0x00)
         var delay = rollDelayMs
         payload.append(Data(bytes: &delay, count: 2))
+        var cap = rateCapDps                      // outer-loop angle→rate cap (deg/s), LE float
+        payload.append(Data(bytes: &cap, count: 4))
         sendRawCommand(31, payload: payload)
         if var cfg = rocketConfig {
             cfg.useAngleControl = useAngleControl
             cfg.rollDelayMs = rollDelayMs
+            cfg.rateCapDps = rateCapDps
             rocketConfig = cfg
         }
     }
@@ -1269,6 +1272,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             cfg.gainScheduleEnabled = dict["gs"] as? Bool ?? cfg.gainScheduleEnabled
             cfg.useAngleControl = dict["ac"] as? Bool ?? cfg.useAngleControl
             cfg.rollDelayMs = UInt16(dict["rdly"] as? Int ?? Int(cfg.rollDelayMs))
+            cfg.rateCapDps = parseFloat(dict["rcap"]) ?? cfg.rateCapDps
             cfg.guidanceEnabled = dict["ge"] as? Bool ?? cfg.guidanceEnabled
             cfg.cameraType = UInt8(dict["camt"] as? Int ?? Int(cfg.cameraType))
             cfg.loraFreqMHz = parseFloat(dict["lf"])

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -98,6 +98,7 @@ struct RocketConfig {
     var gainScheduleEnabled: Bool = true
     var useAngleControl: Bool = false
     var rollDelayMs: UInt16 = 0
+    var rateCapDps: Float = 60
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2
     var loraFreqMHz: Float? = nil

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -84,6 +84,7 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var gainScheduleEnabled: Bool = true
     var useAngleControl: Bool = false
     var rollDelayMs: UInt16 = 0
+    var rateCapDps: Float = 60          // outer-loop angle→rate cap (deg/s)
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2          // 0=None, 1=GoPro, 2=RunCam
 
@@ -174,6 +175,7 @@ extension RocketProfile {
         gainScheduleEnabled = try c.decodeIfPresent(Bool.self, forKey: .gainScheduleEnabled) ?? defaults.gainScheduleEnabled
         useAngleControl = try c.decodeIfPresent(Bool.self, forKey: .useAngleControl) ?? defaults.useAngleControl
         rollDelayMs = try c.decodeIfPresent(UInt16.self, forKey: .rollDelayMs) ?? defaults.rollDelayMs
+        rateCapDps = try c.decodeIfPresent(Float.self, forKey: .rateCapDps) ?? defaults.rateCapDps
         guidanceEnabled = try c.decodeIfPresent(Bool.self, forKey: .guidanceEnabled) ?? defaults.guidanceEnabled
         cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -42,6 +42,7 @@ struct SettingsView: View {
     @State private var sPidMinCmd = ""
     @State private var sPidMaxCmd = ""
     @State private var sRollDelayMs = ""
+    @State private var sRateCapDps = ""
 
     // Roll waypoints edited as strings; committed to the profile on change.
     @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
@@ -107,6 +108,7 @@ struct SettingsView: View {
         case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax
         case pidKp, pidKi, pidKd, pidMin, pidMax
         case rollDelay
+        case rateCap
         case wpTime(Int), wpAngle(Int)
         case pyroValue(Int)   // ch index 0..3
     }
@@ -117,7 +119,7 @@ struct SettingsView: View {
         switch field {
         case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax: return .servo
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
-        case .rollDelay: return .rollControl
+        case .rollDelay, .rateCap: return .rollControl
         case .wpTime, .wpAngle: return .rollWaypoints
         case .pyroValue: return .pyro
         case nil: return nil
@@ -541,6 +543,19 @@ struct SettingsView: View {
             Text("Milliseconds after launch before any roll control activates. Keeps fins neutral during initial boost.")
                 .font(.caption).foregroundColor(.secondary)
 
+            HStack {
+                Text("Rate Cap")
+                Spacer()
+                TextField("60", text: $sRateCapDps)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 80)
+                    .focused($focusedField, equals: .rateCap)
+                Text("\u{00B0}/s").foregroundColor(.secondary)
+            }
+            Text("Max roll rate the angle controller commands while slewing toward a profile angle (Track Profile mode). Higher = faster turns.")
+                .font(.caption).foregroundColor(.secondary)
+
             if profile.useAngleControl {
                 rollWaypointEditor
             }
@@ -706,6 +721,7 @@ struct SettingsView: View {
         sPidMinCmd = formatDecimal(Double(p.pidMinCmd))
         sPidMaxCmd = formatDecimal(Double(p.pidMaxCmd))
         sRollDelayMs = formatInt(Double(p.rollDelayMs))
+        sRateCapDps = formatInt(Double(p.rateCapDps))
         rollWaypoints = p.rollWaypoints.map {
             (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg), mode: $0.mode.rawValue)
         }
@@ -876,10 +892,14 @@ struct SettingsView: View {
 
     private func applyRollControlConfig() {
         let delayMs = UInt16(clamping: Int(Double(sRollDelayMs) ?? Double(profile.rollDelayMs)))
+        let rateCap = max(0, Float(sRateCapDps) ?? profile.rateCapDps)
         let useAngle = profile.useAngleControl
-        updateProfile { $0.rollDelayMs = delayMs }
+        updateProfile {
+            $0.rollDelayMs = delayMs
+            $0.rateCapDps = rateCap
+        }
         if device.isConnected {
-            device.sendRollControlConfig(useAngleControl: useAngle, rollDelayMs: delayMs)
+            device.sendRollControlConfig(useAngleControl: useAngle, rollDelayMs: delayMs, rateCapDps: rateCap)
         }
         showApplied($rollControlApplied)
     }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1617,8 +1617,9 @@ typedef struct __attribute__((packed))
     uint8_t  use_angle_control;   // 0 = rate-only (null roll), 1 = cascaded angle control w/ profile
     uint8_t  _pad;
     uint16_t roll_delay_ms;       // ms after launch before any roll control activates
+    float    kp_angle_rate_cap_dps;  // outer-loop angle→rate command cap (deg/s); <=0 keeps firmware default
 } RollControlConfigData;
-static_assert(sizeof(RollControlConfigData) == 4, "RollControlConfigData must be 4 bytes");
+static_assert(sizeof(RollControlConfigData) == 8, "RollControlConfigData must be 8 bytes");
 
 // --- Flight settings snapshot (#165) ---
 // One-shot snapshot of the rocket's runtime settings, emitted FC→OC over I2S

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1591,7 +1591,7 @@ static constexpr uint8_t MAX_ROLL_WAYPOINTS = 8;
 // holds indefinitely if this is the last waypoint).
 enum RollSegmentMode : uint8_t
 {
-    ROLL_SEG_ANGLE     = 0,  // interpolate to next waypoint's angle (cascaded angle PID)
+    ROLL_SEG_ANGLE     = 0,  // hold next waypoint's absolute angle, shortest path (cascaded angle PID)
     ROLL_SEG_NULL_RATE = 1,  // hold roll rate = 0 (rate-only inner PID); angle field ignored
 };
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4382,12 +4382,17 @@ static void loop_fc()
                     memcpy(&rc, cfg_payload, sizeof(rc));
                     use_angle_control = (rc.use_angle_control != 0);
                     roll_delay_ms     = rc.roll_delay_ms;
-                    ESP_LOGI(TAG, "[ROLL CFG] angle_ctrl=%s delay=%u ms",
+                    // Outer-loop rate cap: a positive, sane value overrides the
+                    // firmware default; <=0 (or garbage) leaves it unchanged.
+                    if (rc.kp_angle_rate_cap_dps > 0.0f && rc.kp_angle_rate_cap_dps <= 2000.0f)
+                        kp_angle_rate_cap_dps = rc.kp_angle_rate_cap_dps;
+                    ESP_LOGI(TAG, "[ROLL CFG] angle_ctrl=%s delay=%u ms rate_cap=%.0f dps",
                                   use_angle_control ? "ON" : "OFF",
-                                  (unsigned)roll_delay_ms);
+                                  (unsigned)roll_delay_ms, (double)kp_angle_rate_cap_dps);
                     prefs.begin("servo", false);
                     prefs.putBool("ac", use_angle_control);
                     prefs.putUShort("rdly", roll_delay_ms);
+                    prefs.putFloat("rcap", kp_angle_rate_cap_dps);
                     prefs.end();
                     ESP_LOGI(TAG, "[ROLL CFG] Saved to NVS");
                 }

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -917,11 +917,15 @@ static void servicePyroChannels(uint32_t now_ms)
     }
 }
 
-// ── Roll profile interpolation ────────────────────────────────────────────────
+// ── Roll profile lookup ─────────────────────────────────────────────────────
 // Returns the desired (angle, mode) for the current flight time.
 // Mode is the segment mode of the waypoint that STARTS the current segment.
-// Linear interpolation of angle between consecutive waypoints (ROLL_SEG_ANGLE
-// segments); ROLL_SEG_NULL_RATE segments instead null roll rate to 0 in the
+// Within a ROLL_SEG_ANGLE segment the controller is commanded straight to the
+// segment's DESTINATION (next waypoint's) absolute angle and takes the shortest
+// path there — no ramp. (Previously the setpoint was linearly interpolated
+// between waypoints, but sweeping it through intermediate angles flipped the
+// command direction at the ±180° error wrap mid-maneuver; see the roll-control
+// flight analysis.) ROLL_SEG_NULL_RATE segments null roll rate to 0 in the
 // inner loop and ignore the angle field. Before WP1 or after WPn we hold that
 // waypoint's mode and angle.
 // If no waypoints are loaded, defaults to NULL_RATE / 0 deg.
@@ -957,23 +961,15 @@ static RollProfileQuery roll_profile_query(float t_flight_s)
         out.mode      = roll_profile.waypoints[n - 1].mode;
         return out;
     }
-    // Inside profile -- find the segment [i, i+1)
+    // Inside profile -- find the active segment [i, i+1). No ramp: command the
+    // segment's DESTINATION (next waypoint's) absolute angle directly and let
+    // controlAngle take the shortest path to it.
     for (uint8_t i = 0; i < n - 1; ++i)
     {
         if (t_flight_s < roll_profile.waypoints[i + 1].time_s)
         {
-            const float t0 = roll_profile.waypoints[i].time_s;
-            const float t1 = roll_profile.waypoints[i + 1].time_s;
-            const float a0 = roll_profile.waypoints[i].angle_deg;
-            const float a1 = roll_profile.waypoints[i + 1].angle_deg;
-            out.mode = roll_profile.waypoints[i].mode;
-            if (t1 <= t0)
-            {
-                out.angle_deg = a0;  // guard against duplicate timestamps
-                return out;
-            }
-            const float frac = (t_flight_s - t0) / (t1 - t0);
-            out.angle_deg = a0 + frac * (a1 - a0);
+            out.angle_deg = roll_profile.waypoints[i + 1].angle_deg;
+            out.mode      = roll_profile.waypoints[i].mode;
             return out;
         }
     }


### PR DESCRIPTION
Outcome of debugging the 2026-06-14 BARC roll-control flights (RP II / RP III). Three related pieces:

## Analysis tooling (`Data_Analysis/flight_report/modules/roll_pid.py`)
- Surfaces the flown PID gains + roll-control setup from the #165 settings snapshot (were showing "—").
- New roll-angle-vs-profile tracking figure (launch→ejection): quaternion-derived actual roll vs the commanded plan, tracking error, roll rate (with the rate-cap reference), and servo command (zoomed, airspeed overlay); finer time grid + labeled phase transitions.
- General barometric ejection detection (cuts the window 0.25 s before the charge spike) instead of a hard-coded trim.
- Overlays the reconstructed outer-loop commanded rate so the rate-cap saturation and the ±180° wrap flip are visible; flags when a profile ramp exceeds the rate cap.

## Firmware (`flight_computer`)
- **No-ramp roll profile:** `roll_profile_query` now commands the segment's destination absolute angle directly and lets `controlAngle` take the shortest path, instead of linearly interpolating (which swept through 180° and flipped the command mid-maneuver). Reference stays absolute.
- **App-configurable outer-loop rate cap:** `RollControlConfigData` extended with `kp_angle_rate_cap_dps`; the `ROLL_CTRL_CONFIG` handler applies and persists it to NVS (was compile-time only).

## iOS app (`TinkerRocketApp`)
- `rateCapDps` added to the rocket profile + BLE config; self-applying "Rate Cap" field in the Roll Control settings; encoded in `sendRollControlConfig` (cmd 31 payload 4→8 bytes).

## Verification (local)
- Firmware builds clean on **ESP-IDF v6.0.1** (esp32p4).
- iOS app builds clean (`xcodebuild`, iOS Simulator).
- **342/342 C++ host tests pass** (incl. struct-size + wire-code checks); `check_ble_command_ids.py` PASS (roll cfg cmd 31, no collision with orientation cmd 34).
- Python report tests pass (3/3).
- Integrates current `main` (orientation PR #238) — merged with no conflicts.

## Before flying
- The no-ramp behavior and the rate cap are **flight-behavior changes** — bench/sim-validate (BLE config round-trip + roll response) before flight.
- `RollControlConfigData` grew 4→8 bytes, so **firmware and app must be updated together**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
