### PR TITLE
fc(ekf): proper Kalman magnetometer heading fusion + GPS/WMM true-north declination

### DIFF
--- a/Data_Analysis/replay_flight_ekf.py
+++ b/Data_Analysis/replay_flight_ekf.py
@@ -40,7 +40,11 @@ def build_event_list(records):
         events.append((r["time_us"], "gnss", r))
     for r in records["BMP585"]:
         events.append((r["time_us"], "baro", r))
-    for r in records["MMC5983MA"]:
+    # Magnetometer: old PCB logs MMC5983MA, new PCB logs IIS2MDC. Both carry
+    # mag_x/y/z (µT) post-parse, so the "mag" handler is identical.
+    for r in records.get("MMC5983MA", []):
+        events.append((r["time_us"], "mag", r))
+    for r in records.get("IIS2MDC", []):
         events.append((r["time_us"], "mag", r))
     events.sort(key=lambda e: e[0])
     return events

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -84,6 +84,19 @@ target_include_directories(test_ekf PRIVATE
 target_link_libraries(test_ekf GTest::gtest_main)
 gtest_discover_tests(test_ekf)
 
+# ---------- test_geomag ----------
+# WMM2025 magnetic-declination model (TR_GeoMag), validated against the
+# official NOAA WMM2025_TestValues.txt reference declinations.
+add_executable(test_geomag test_geomag.cpp
+    ${LIB_DIR}/TR_GeoMag/TR_GeoMag.cpp
+)
+target_include_directories(test_geomag PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_GeoMag
+)
+target_link_libraries(test_geomag GTest::gtest_main)
+gtest_discover_tests(test_geomag)
+
 # ---------- test_kinematic_checks ----------
 add_executable(test_kinematic_checks test_kinematic_checks.cpp
     ${LIB_DIR}/TR_KinematicChecks/TR_KinematicChecks.cpp

--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -37,6 +37,38 @@ static EkfMagData makeStationaryMag(uint32_t time_us) {
     return mag;
 }
 
+// Nose-up (vertical) fixtures physically consistent with the EKF's init
+// attitude (quat = [0.707,0,0.707,0] → body-X = up).  Specific force points
+// up along the nose (+X).  FRD body mag for an Earth field of (22 N, 0 E,
+// 42 D) µT (magnetic north) rotated into the nose-up body frame → heading ≈ 0.
+static EkfIMUData makeNoseUpIMU(uint32_t time_us) {
+    EkfIMUData imu;
+    imu.time_us = time_us;
+    imu.acc_x = 9.807; imu.acc_y = 0.0; imu.acc_z = 0.0;   // specific force up = +X (nose)
+    imu.gyro_x = 0.0; imu.gyro_y = 0.0; imu.gyro_z = 0.0;
+    return imu;
+}
+static EkfMagData makeNoseUpMag(uint32_t time_us) {
+    EkfMagData mag;
+    mag.time_us = time_us;
+    mag.mag_x = -42.0; mag.mag_y = 0.0; mag.mag_z = 22.0;
+    return mag;
+}
+
+// Hamilton quaternion product (scalar-first) and geodesic angle (deg) —
+// singularity-safe heading comparison (Euler yaw is gimbal-locked at vertical).
+static void tqMul(const float a[4], const float b[4], float o[4]) {
+    o[0] = a[0]*b[0] - a[1]*b[1] - a[2]*b[2] - a[3]*b[3];
+    o[1] = a[0]*b[1] + a[1]*b[0] + a[2]*b[3] - a[3]*b[2];
+    o[2] = a[0]*b[2] - a[1]*b[3] + a[2]*b[0] + a[3]*b[1];
+    o[3] = a[0]*b[3] + a[1]*b[2] - a[2]*b[1] + a[3]*b[0];
+}
+static float tqGeodesicDeg(const float a[4], const float b[4]) {
+    float d = std::fabs(a[0]*b[0] + a[1]*b[1] + a[2]*b[2] + a[3]*b[3]);
+    if (d > 1.0f) d = 1.0f;
+    return 2.0f * std::acos(d) * 180.0f / (float)M_PI;
+}
+
 class EKFTest : public ::testing::Test {
 protected:
     GpsInsEKF ekf;
@@ -129,6 +161,46 @@ TEST_F(EKFTest, StationaryVelocityAccuracy) {
     for (int i = 0; i < 3; i++) {
         EXPECT_NEAR(vel[i], 0.0f, 0.5f); // < 0.5 m/s for stationary
     }
+}
+
+// Heading fusion must CONVERGE while nose-vertical — the exact case the old
+// Mahony correction (cos²(pitch) → 0 at vertical) could not handle.
+TEST_F(EKFTest, MagHeadingConvergesWhenVertical) {
+    ekf.init(makeNoseUpIMU(0), makeStationaryGNSS(0), makeNoseUpMag(0));
+    uint32_t t = 0;
+    for (int i = 0; i < 2000; i++) { t += 2000;
+        ekf.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t)); }
+    float q_ref[4]; ekf.getQuaternion(q_ref);
+
+    // Inject a 50° heading error (rotation about NED-down), then reopen the
+    // attitude covariance so the filter has room to correct it.
+    const float a = 50.0f * (float)M_PI / 180.0f;
+    const float qyaw[4] = { std::cos(a/2), 0.0f, 0.0f, std::sin(a/2) };  // about NED +Z (down)
+    float q_err[4]; tqMul(qyaw, q_ref, q_err);
+    ekf.setQuaternion(q_err[0], q_err[1], q_err[2], q_err[3]);
+    for (int i = 6; i < 9; i++) ekf.inflateCovDiag(i, 1.0f);
+    EXPECT_GT(tqGeodesicDeg(q_err, q_ref), 30.0f);     // error really was injected
+
+    for (int i = 0; i < 6000; i++) { t += 2000;
+        ekf.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t)); }
+    float q_fin[4]; ekf.getQuaternion(q_fin);
+    EXPECT_LT(tqGeodesicDeg(q_fin, q_ref), 8.0f);      // heading converged back
+}
+
+// Heading fusion must be STABLE (no drift) while stationary nose-vertical —
+// the symptom we observed (±180° roll/yaw cycling) must not recur.
+TEST_F(EKFTest, MagHeadingStableVertical) {
+    ekf.init(makeNoseUpIMU(0), makeStationaryGNSS(0), makeNoseUpMag(0));
+    uint32_t t = 0;
+    for (int i = 0; i < 2000; i++) { t += 2000;
+        ekf.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t)); }
+    float q_a[4]; ekf.getQuaternion(q_a);
+    for (int i = 0; i < 4000; i++) { t += 2000;
+        ekf.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t)); }
+    float q_b[4]; ekf.getQuaternion(q_b);
+    EXPECT_LT(tqGeodesicDeg(q_a, q_b), 2.0f);          // no heading drift over 8 s
+    float n = std::sqrt(q_b[0]*q_b[0] + q_b[1]*q_b[1] + q_b[2]*q_b[2] + q_b[3]*q_b[3]);
+    EXPECT_NEAR(n, 1.0f, 0.01f);
 }
 
 TEST_F(EKFTest, SetQuaternion_ResetsAttCovariance) {

--- a/tests_cpp/test_geomag.cpp
+++ b/tests_cpp/test_geomag.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "TR_GeoMag.h"
+#include <cmath>
+
+// Validation against the official NOAA WMM2025_TestValues.txt (field 5 =
+// declination, deg).  A representative spread of epochs / latitudes /
+// longitudes, including a near-pole point and a large-declination point.
+namespace {
+struct TV { double year, alt_km, lat_deg, lon_deg, dec_deg; };
+constexpr TV kTests[] = {
+    {2025.0, 28,  89, -121,  -99.77},   // near north pole
+    {2025.0, 65,  43,   93,    0.50},
+    {2025.0, 51, -33,  109,   -5.49},
+    {2025.0, 18,   0,   21,    1.29},
+    {2025.5, 63,  26,   81,    0.51},
+    {2026.0, 69,  23,   63,    1.17},
+    {2026.5, 12, -79,  115, -137.58},   // large declination, high south lat
+    {2027.5, 16,  66, -178,    0.37},
+    {2028.0, 95,  14,   65,   -0.51},
+    {2029.5, 33,  17,    5,    0.89},
+};
+constexpr double D2R = M_PI / 180.0;
+constexpr double R2D = 180.0 / M_PI;
+}  // namespace
+
+TEST(GeoMagTest, DeclinationMatchesNOAAReference) {
+    for (const auto& tv : kTests) {
+        float dec_rad = TR_GeoMag::declinationRad(
+            tv.lat_deg * D2R, tv.lon_deg * D2R, tv.alt_km * 1000.0, tv.year);
+        double dec_deg = dec_rad * R2D;
+        // Declination wraps at ±180; compare on the circle.
+        double err = std::remainder(dec_deg - tv.dec_deg, 360.0);
+        EXPECT_NEAR(err, 0.0, 0.1)
+            << "year=" << tv.year << " lat=" << tv.lat_deg
+            << " lon=" << tv.lon_deg << " got=" << dec_deg
+            << " expected=" << tv.dec_deg;
+    }
+}

--- a/tinkerrocket-idf/components/TR_GeoMag/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_GeoMag/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "TR_GeoMag.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat)

--- a/tinkerrocket-idf/components/TR_GeoMag/TR_GeoMag.cpp
+++ b/tinkerrocket-idf/components/TR_GeoMag/TR_GeoMag.cpp
@@ -1,0 +1,269 @@
+// ─── World Magnetic Model 2025 — declination evaluation ─────────────────────
+//
+// Spherical-harmonic field evaluation adapted from the NOAA/NCEI reference
+// implementation (geomag70.c, public domain).  Degree/order 12.  Returns
+// magnetic declination only.  See TR_GeoMag.h for provenance and the 2030.0
+// expiry.
+
+#include "TR_GeoMag.h"
+
+#include <cmath>
+
+namespace TR_GeoMag {
+
+namespace {
+
+constexpr int    MAXORD = 12;
+constexpr double A_WGS84 = 6378.137;        // semi-major axis (km)
+constexpr double B_WGS84 = 6356.7523142;    // semi-minor axis (km)
+constexpr double RE_GEO  = 6371.2;          // geomagnetic reference radius (km)
+
+// WMM2025 Gauss coefficients (Schmidt semi-normalized), epoch 2025.0.
+// One row per term: { n, m, g_nm (nT), h_nm (nT), gdot (nT/yr), hdot (nT/yr) }.
+struct Coef { int n, m; double g, h, gd, hd; };
+constexpr Coef WMM2025[] = {
+    { 1, 0, -29351.8,     0.0,  12.0,   0.0},
+    { 1, 1,  -1410.8,  4545.4,   9.7, -21.5},
+    { 2, 0,  -2556.6,     0.0, -11.6,   0.0},
+    { 2, 1,   2951.1, -3133.6,  -5.2, -27.7},
+    { 2, 2,   1649.3,  -815.1,  -8.0, -12.1},
+    { 3, 0,   1361.0,     0.0,  -1.3,   0.0},
+    { 3, 1,  -2404.1,   -56.6,  -4.2,   4.0},
+    { 3, 2,   1243.8,   237.5,   0.4,  -0.3},
+    { 3, 3,    453.6,  -549.5, -15.6,  -4.1},
+    { 4, 0,    895.0,     0.0,  -1.6,   0.0},
+    { 4, 1,    799.5,   278.6,  -2.4,  -1.1},
+    { 4, 2,     55.7,  -133.9,  -6.0,   4.1},
+    { 4, 3,   -281.1,   212.0,   5.6,   1.6},
+    { 4, 4,     12.1,  -375.6,  -7.0,  -4.4},
+    { 5, 0,   -233.2,     0.0,   0.6,   0.0},
+    { 5, 1,    368.9,    45.4,   1.4,  -0.5},
+    { 5, 2,    187.2,   220.2,   0.0,   2.2},
+    { 5, 3,   -138.7,  -122.9,   0.6,   0.4},
+    { 5, 4,   -142.0,    43.0,   2.2,   1.7},
+    { 5, 5,     20.9,   106.1,   0.9,   1.9},
+    { 6, 0,     64.4,     0.0,  -0.2,   0.0},
+    { 6, 1,     63.8,   -18.4,  -0.4,   0.3},
+    { 6, 2,     76.9,    16.8,   0.9,  -1.6},
+    { 6, 3,   -115.7,    48.8,   1.2,  -0.4},
+    { 6, 4,    -40.9,   -59.8,  -0.9,   0.9},
+    { 6, 5,     14.9,    10.9,   0.3,   0.7},
+    { 6, 6,    -60.7,    72.7,   0.9,   0.9},
+    { 7, 0,     79.5,     0.0,  -0.0,   0.0},
+    { 7, 1,    -77.0,   -48.9,  -0.1,   0.6},
+    { 7, 2,     -8.8,   -14.4,  -0.1,   0.5},
+    { 7, 3,     59.3,    -1.0,   0.5,  -0.8},
+    { 7, 4,     15.8,    23.4,  -0.1,   0.0},
+    { 7, 5,      2.5,    -7.4,  -0.8,  -1.0},
+    { 7, 6,    -11.1,   -25.1,  -0.8,   0.6},
+    { 7, 7,     14.2,    -2.3,   0.8,  -0.2},
+    { 8, 0,     23.2,     0.0,  -0.1,   0.0},
+    { 8, 1,     10.8,     7.1,   0.2,  -0.2},
+    { 8, 2,    -17.5,   -12.6,   0.0,   0.5},
+    { 8, 3,      2.0,    11.4,   0.5,  -0.4},
+    { 8, 4,    -21.7,    -9.7,  -0.1,   0.4},
+    { 8, 5,     16.9,    12.7,   0.3,  -0.5},
+    { 8, 6,     15.0,     0.7,   0.2,  -0.6},
+    { 8, 7,    -16.8,    -5.2,  -0.0,   0.3},
+    { 8, 8,      0.9,     3.9,   0.2,   0.2},
+    { 9, 0,      4.6,     0.0,  -0.0,   0.0},
+    { 9, 1,      7.8,   -24.8,  -0.1,  -0.3},
+    { 9, 2,      3.0,    12.2,   0.1,   0.3},
+    { 9, 3,     -0.2,     8.3,   0.3,  -0.3},
+    { 9, 4,     -2.5,    -3.3,  -0.3,   0.3},
+    { 9, 5,    -13.1,    -5.2,   0.0,   0.2},
+    { 9, 6,      2.4,     7.2,   0.3,  -0.1},
+    { 9, 7,      8.6,    -0.6,  -0.1,  -0.2},
+    { 9, 8,     -8.7,     0.8,   0.1,   0.4},
+    { 9, 9,    -12.9,    10.0,  -0.1,   0.1},
+    {10, 0,     -1.3,     0.0,   0.1,   0.0},
+    {10, 1,     -6.4,     3.3,   0.0,   0.0},
+    {10, 2,      0.2,     0.0,   0.1,  -0.0},
+    {10, 3,      2.0,     2.4,   0.1,  -0.2},
+    {10, 4,     -1.0,     5.3,  -0.0,   0.1},
+    {10, 5,     -0.6,    -9.1,  -0.3,  -0.1},
+    {10, 6,     -0.9,     0.4,   0.0,   0.1},
+    {10, 7,      1.5,    -4.2,  -0.1,   0.0},
+    {10, 8,      0.9,    -3.8,  -0.1,  -0.1},
+    {10, 9,     -2.7,     0.9,  -0.0,   0.2},
+    {10,10,     -3.9,    -9.1,  -0.0,  -0.0},
+    {11, 0,      2.9,     0.0,   0.0,   0.0},
+    {11, 1,     -1.5,     0.0,  -0.0,  -0.0},
+    {11, 2,     -2.5,     2.9,   0.0,   0.1},
+    {11, 3,      2.4,    -0.6,   0.0,  -0.0},
+    {11, 4,     -0.6,     0.2,   0.0,   0.1},
+    {11, 5,     -0.1,     0.5,  -0.1,  -0.0},
+    {11, 6,     -0.6,    -0.3,   0.0,  -0.0},
+    {11, 7,     -0.1,    -1.2,  -0.0,   0.1},
+    {11, 8,      1.1,    -1.7,  -0.1,  -0.0},
+    {11, 9,     -1.0,    -2.9,  -0.1,   0.0},
+    {11,10,     -0.2,    -1.8,  -0.1,   0.0},
+    {11,11,      2.6,    -2.3,  -0.1,   0.0},
+    {12, 0,     -2.0,     0.0,   0.0,   0.0},
+    {12, 1,     -0.2,    -1.3,   0.0,  -0.0},
+    {12, 2,      0.3,     0.7,  -0.0,   0.0},
+    {12, 3,      1.2,     1.0,  -0.0,  -0.1},
+    {12, 4,     -1.3,    -1.4,  -0.0,   0.1},
+    {12, 5,      0.6,    -0.0,  -0.0,  -0.0},
+    {12, 6,      0.6,     0.6,   0.1,  -0.0},
+    {12, 7,      0.5,    -0.1,  -0.0,  -0.0},
+    {12, 8,     -0.1,     0.8,   0.0,   0.0},
+    {12, 9,     -0.4,     0.1,   0.0,  -0.0},
+    {12,10,     -0.2,    -1.0,  -0.1,  -0.0},
+    {12,11,     -1.3,     0.1,  -0.0,   0.0},
+    {12,12,     -0.7,     0.2,  -0.1,  -0.1},
+};
+
+// Schmidt-renormalized coefficients (filled once).  g[n][m], h[n][m] and the
+// secular-variation rates.  k/fn/fm are the Legendre-recursion constants.
+struct Model {
+    double g[MAXORD + 1][MAXORD + 1] = {};
+    double h[MAXORD + 1][MAXORD + 1] = {};
+    double gd[MAXORD + 1][MAXORD + 1] = {};
+    double hd[MAXORD + 1][MAXORD + 1] = {};
+    double k[MAXORD + 1][MAXORD + 1] = {};
+    double fn[MAXORD + 1] = {};
+    double fm[MAXORD + 1] = {};
+    bool   ready = false;
+};
+
+Model& model() {
+    static Model M;
+    if (M.ready) return M;
+
+    // Load raw coefficients into [n][m].
+    for (const Coef& c : WMM2025) {
+        M.g[c.n][c.m]  = c.g;   M.h[c.n][c.m]  = c.h;
+        M.gd[c.n][c.m] = c.gd;  M.hd[c.n][c.m] = c.hd;
+    }
+
+    // Schmidt semi-normalization for the geomag70 Legendre recursion.
+    // snorm[n][m] carries the normalization factor; coefficients are scaled by
+    // it, and k[n][m] are the recursion constants.
+    double snorm[MAXORD + 1][MAXORD + 1] = {};
+    snorm[0][0] = 1.0;
+    for (int n = 1; n <= MAXORD; n++) {
+        snorm[n][0] = snorm[n - 1][0] * (double)(2 * n - 1) / (double)n;
+        int j = 2;
+        for (int m = 0; m <= n; m++) {
+            M.k[n][m] = (double)(((n - 1) * (n - 1)) - (m * m)) /
+                        (double)((2 * n - 1) * (2 * n - 3));
+            if (m > 0) {
+                double flnmj = (double)((n - m + 1) * j) / (double)(n + m);
+                snorm[n][m] = snorm[n][m - 1] * std::sqrt(flnmj);
+                j = 1;
+                M.h[n][m]  *= snorm[n][m];
+                M.hd[n][m] *= snorm[n][m];
+            }
+            M.g[n][m]  *= snorm[n][m];
+            M.gd[n][m] *= snorm[n][m];
+        }
+        M.fn[n] = (double)(n + 1);
+        M.fm[n] = (double)n;
+    }
+    M.k[1][1] = 0.0;
+    M.ready = true;
+    return M;
+}
+
+}  // namespace
+
+float declinationRad(double lat_rad, double lon_rad, double alt_m, double decimal_year) {
+    const Model& M = model();
+
+    // Clamp the epoch to the model's valid range (extrapolation only degrades).
+    double t = decimal_year;
+    if (t < WMM_VALID_MIN) t = WMM_VALID_MIN;
+    if (t > WMM_VALID_MAX) t = WMM_VALID_MAX;
+    const double dt = t - WMM_EPOCH;
+
+    const double glat = lat_rad;        // already radians
+    const double alt_km = alt_m / 1000.0;
+
+    const double srlon = std::sin(lon_rad), crlon = std::cos(lon_rad);
+    const double srlat = std::sin(glat),   crlat = std::cos(glat);
+    const double srlat2 = srlat * srlat, crlat2 = crlat * crlat;
+
+    // Geodetic → geocentric spherical coordinates.
+    const double a2 = A_WGS84 * A_WGS84, b2 = B_WGS84 * B_WGS84;
+    const double c2 = a2 - b2, a4 = a2 * a2, b4 = b2 * b2, c4 = a4 - b4;
+    const double q  = std::sqrt(a2 - c2 * srlat2);
+    const double q1 = alt_km * q;
+    const double q2 = ((q1 + a2) / (q1 + b2)) * ((q1 + a2) / (q1 + b2));
+    const double ct = srlat / std::sqrt(q2 * crlat2 + srlat2);   // cos(colatitude)
+    const double st = std::sqrt(1.0 - ct * ct);                  // sin(colatitude)
+    const double r  = std::sqrt(alt_km * alt_km + 2.0 * q1 +
+                                (a4 - c4 * srlat2) / (q * q));
+    const double d  = std::sqrt(a2 * crlat2 + b2 * srlat2);
+    const double ca = (alt_km + d) / r;                          // cos(geocentric-geodetic)
+    const double sa = c2 * srlat * crlat / (r * d);              // sin(geocentric-geodetic)
+
+    double sp[MAXORD + 1], cp[MAXORD + 1];
+    sp[0] = 0.0; cp[0] = 1.0;
+    sp[1] = srlon; cp[1] = crlon;
+    for (int m = 2; m <= MAXORD; m++) {
+        sp[m] = sp[1] * cp[m - 1] + cp[1] * sp[m - 1];
+        cp[m] = cp[1] * cp[m - 1] - sp[1] * sp[m - 1];
+    }
+
+    // Associated Legendre values (snorm) + derivatives (dp), rebuilt each call.
+    double snorm[MAXORD + 1][MAXORD + 1] = {};
+    double dp[MAXORD + 1][MAXORD + 1] = {};
+    double pp[MAXORD + 1] = {};
+    snorm[0][0] = 1.0; pp[0] = 1.0; dp[0][0] = 0.0;
+
+    const double aor = RE_GEO / r;
+    double ar = aor * aor;
+    double br = 0.0, bt = 0.0, bp = 0.0, bpp = 0.0;
+
+    for (int n = 1; n <= MAXORD; n++) {
+        ar *= aor;
+        for (int m = 0; m <= n; m++) {
+            // Schmidt Legendre recursion (geomag70).
+            if (n == m) {
+                snorm[n][m] = st * snorm[n - 1][m - 1];
+                dp[n][m] = st * dp[n - 1][m - 1] + ct * snorm[n - 1][m - 1];
+            } else if (n == 1 && m == 0) {
+                snorm[n][m] = ct * snorm[n - 1][m];
+                dp[n][m] = ct * dp[n - 1][m] - st * snorm[n - 1][m];
+            } else {  // n > 1 && n != m
+                if (m > n - 2) { snorm[n - 2][m] = 0.0; dp[n - 2][m] = 0.0; }
+                snorm[n][m] = ct * snorm[n - 1][m] - M.k[n][m] * snorm[n - 2][m];
+                dp[n][m] = ct * dp[n - 1][m] - st * snorm[n - 1][m] -
+                           M.k[n][m] * dp[n - 2][m];
+            }
+
+            // Time-adjusted coefficients.
+            const double gt = M.g[n][m] + dt * M.gd[n][m];
+            const double ht = M.h[n][m] + dt * M.hd[n][m];
+
+            const double par = ar * snorm[n][m];
+            double temp1, temp2;
+            if (m == 0) { temp1 = gt * cp[m];              temp2 = gt * sp[m]; }
+            else        { temp1 = gt * cp[m] + ht * sp[m]; temp2 = gt * sp[m] - ht * cp[m]; }
+
+            bt -= ar * temp1 * dp[n][m];
+            bp += M.fm[m] * temp2 * par;
+            br += M.fn[n] * temp1 * par;
+
+            // North-geographic-pole limit (st → 0): use the L'Hôpital branch.
+            if (st == 0.0 && m == 1) {
+                if (n == 1) pp[n] = pp[n - 1];
+                else        pp[n] = ct * pp[n - 1] - M.k[n][m] * pp[n - 2];
+                bpp += M.fm[m] * temp2 * (ar * pp[n]);
+            }
+        }
+    }
+
+    if (st == 0.0) bp = bpp;
+    else           bp /= st;
+
+    // Spherical → geodetic field components (North, East).  Declination needs
+    // only the horizontal pair.
+    const double bx = -bt * ca - br * sa;   // geodetic north
+    const double by = bp;                   // east
+
+    return (float)std::atan2(by, bx);       // declination, radians (east +)
+}
+
+}  // namespace TR_GeoMag

--- a/tinkerrocket-idf/components/TR_GeoMag/TR_GeoMag.h
+++ b/tinkerrocket-idf/components/TR_GeoMag/TR_GeoMag.h
@@ -1,0 +1,32 @@
+#pragma once
+// ─── World Magnetic Model 2025 — magnetic declination from GPS position ──────
+//
+// Computes magnetic declination (the angle from true north to magnetic north)
+// so the EKF heading-only magnetometer update can output a TRUE-north heading.
+// Declination only — the heading update needs nothing else from the field.
+//
+// Coefficients: NOAA/NCEI WMM2025, epoch 2025.0, Schmidt semi-normalized.
+//   Source : https://www.ncei.noaa.gov/products/world-magnetic-model
+//   Valid  : 2025.0 – 2030.0.
+//
+// ⚠  MODEL EXPIRES 2030.0.  Refresh the coefficient table from the next WMM
+//    release (WMMyyyy.COF) before then; declination drifts otherwise.
+//
+// Off the flight-loop hot path: evaluate once when a good GPS fix is acquired,
+// cache the result, and feed it to GpsInsEKF::setDeclination().
+
+#include <compat.h>
+
+namespace TR_GeoMag {
+
+// Magnetic declination (radians, EAST-positive) at a geodetic position.
+//   lat_rad, lon_rad : geodetic latitude / longitude (radians)
+//   alt_m            : geodetic altitude above the WGS84 ellipsoid (metres)
+//   decimal_year     : e.g. 2026.45; clamped to the model's valid range.
+float declinationRad(double lat_rad, double lon_rad, double alt_m, double decimal_year);
+
+constexpr double WMM_EPOCH     = 2025.0;
+constexpr double WMM_VALID_MIN = 2025.0;
+constexpr double WMM_VALID_MAX = 2030.0;
+
+}  // namespace TR_GeoMag

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -198,8 +198,10 @@ void GpsInsEKF::updateCore(bool use_ahrs_acc,
     // 8. Accelerometer gravity reference update
     if (accel_valid) accelMeasUpdate(aMeas);
 
-    // 9. Magnetometer heading update (needs valid accel for gravity direction)
-    if (mag_valid && accel_valid) magHeadingUpdate(aMeas, magMeas);
+    // 9. Magnetometer heading update — scalar Kalman, yaw-only (needs valid
+    //    accel for the gravity/level reference; accel owns roll/pitch, mag owns
+    //    heading, so the two are complementary, not competing).
+    if (mag_valid && accel_valid) magMeasUpdate(aMeas, magMeas);
 
     // 10. GNSS measurement update
     if ((gnss_time_us - timeWeekPrev_) > 0) {
@@ -659,84 +661,125 @@ void GpsInsEKF::accelMeasUpdate(const float aMeas[3]) {
     stabilizeP();
 }
 
-// ─── Magnetometer Heading Update ─────────────────────────────────────
+// ─── Magnetometer Heading Update (heading-only scalar Kalman) ────────
+//
+// Fuses a tilt-compensated magnetic-heading measurement into the 15-state
+// error covariance, correcting ONLY yaw (rotation about NED-down).  Unlike
+// the retired Mahony correction, the measurement — a tilt-compensated atan2
+// heading — stays well-defined at every attitude including nose-vertical, so
+// there is no cos²(pitch) blind spot.  The accelerometer owns roll/pitch and
+// the magnetometer owns heading; their measurement Jacobians are orthogonal in
+// the attitude block, so the two updates are complementary, not competing.
 
-void GpsInsEKF::magHeadingUpdate(const float aMeas[3], const float magMeas[3]) {
-    // Proportional heading correction ported from Mahony mag logic.
-    // No covariance update — simple, stateless correction.
+void GpsInsEKF::magMeasUpdate(const float aMeas[3], const float magMeas[3]) {
+    // Body-down unit vector from the current attitude (= aGrav_B / G); this is
+    // both the leveling reference and the heading-error axis (H below).
+    float T_NED2B[3][3];
+    Quat2DCM(T_NED2B, quat_BL_);
+    const float d[3] = { T_NED2B[0][2], T_NED2B[1][2], T_NED2B[2][2] };
 
-    float q0l = quat_BL_[0], q1l = quat_BL_[1], q2l = quat_BL_[2], q3l = quat_BL_[3];
+    // ── Measured magnetic heading: tilt-compensate the body mag with the
+    //    accelerometer (independent of the quaternion's yaw → no circularity).
+    const float aN = std::sqrt(aMeas[0]*aMeas[0] + aMeas[1]*aMeas[1] + aMeas[2]*aMeas[2]);
+    if (aN < 0.01f) return;
+    // Down direction in body = -accel/|accel| (specific force at rest opposes
+    // modeled gravity-in-body; same sign convention as accelMeasUpdate).
+    const float dmx = -aMeas[0]/aN, dmy = -aMeas[1]/aN, dmz = -aMeas[2]/aN;
+    // Roll/pitch from the measured down vector (FRD): d = (-sθ, sφcθ, cφcθ).
+    const float roll  = std::atan2(dmy, dmz);
+    const float pitch = std::atan2(-dmx, std::sqrt(dmy*dmy + dmz*dmz));
+    const float sr = std::sin(roll),  cr = std::cos(roll);
+    const float sp = std::sin(pitch), cp = std::cos(pitch);
+    // Tilt-compensated horizontal field (level frame), standard e-compass.
+    const float mx = magMeas[0], my = magMeas[1], mz = magMeas[2];
+    const float Xh = mx*cp + my*sr*sp + mz*cr*sp;   // north-ish
+    const float Yh = my*cr - mz*sr;                 // east-ish
+    if (Xh*Xh + Yh*Yh < 9.0f) return;               // |B_horiz| < 3 µT: heading
+                                                    // unobservable (polar/vertical field)
+    const float psi_meas = std::atan2(-Yh, Xh) + declination_rad_;   // TRUE heading
 
-    // Normalize accel (gravity direction)
-    float ax = aMeas[0], ay = aMeas[1], az = aMeas[2];
-    float aNorm = std::sqrt(ax*ax + ay*ay + az*az);
-    if (aNorm < 0.01f) return;
-    float inv_aNorm = 1.0f / aNorm;
-    ax *= inv_aNorm; ay *= inv_aNorm; az *= inv_aNorm;
+    // ── Predicted heading (yaw) from the state quaternion (true-NED frame).
+    //    Computed from T_NED2B directly (euler_BL_rad_ is a cycle stale here).
+    const float psi_pred = std::atan2(T_NED2B[0][1], T_NED2B[0][0]);
 
-    // Normalize mag
-    float mx = magMeas[0], my = magMeas[1], mz = magMeas[2];
-    float mNorm = std::sqrt(mx*mx + my*my + mz*mz);
-    if (mNorm < 0.01f) return;
-    float inv_mNorm = 1.0f / mNorm;
-    mx *= inv_mNorm; my *= inv_mNorm; mz *= inv_mNorm;
+    // ── Scalar innovation, wrapped to (-π, π] (≤2 iters: inputs are bounded).
+    float y = psi_meas - psi_pred;
+    while (y >  (float)M_PI) y -= 2.0f * (float)M_PI;
+    while (y < -(float)M_PI) y += 2.0f * (float)M_PI;
 
-    // Pre-compute quaternion products
-    float q0q0=q0l*q0l, q0q1=q0l*q1l, q0q2=q0l*q2l, q0q3=q0l*q3l;
-    float q1q1=q1l*q1l, q1q2=q1l*q2l, q1q3=q1l*q3l;
-    float q2q2=q2l*q2l, q2q3=q2l*q3l;
+    // ── H (1×15): ∂ψ_pred/∂(δθ/2) in the body-frame error state.  ∂ψ/∂δθ is
+    //    the body-down axis d (yaw is rotation about NED-down); the factor 2
+    //    accounts for the half-angle attitude error xk[6..8] = δθ/2 (matching
+    //    accelMeasUpdate's -2·skew).  Nonzero only in cols 6,7,8.
+    const float H6 = 2.0f*d[0], H7 = 2.0f*d[1], H8 = 2.0f*d[2];
 
-    // Estimated gravity direction in body frame (half-vectors, Mahony convention)
-    float halfvx = q1q3 - q0q2;
-    float halfvy = q0q1 + q2q3;
-    float halfvz = q0q0 - 0.5f + q3l*q3l;
+    // S = H P Hᵀ + R_mag_  (only the attitude block contributes)
+    float HP[15];
+    for (int j = 0; j < 15; j++)
+        HP[j] = H6*P_[6][j] + H7*P_[7][j] + H8*P_[8][j];
+    const float S = HP[6]*H6 + HP[7]*H7 + HP[8]*H8 + R_mag_;
+    if (!(S > 1e-9f)) return;            // |H|=2 ⇒ S ≥ R_mag_ at any attitude; NaN-safe
+    const float S_inv = 1.0f / S;
 
-    // Rotate mag to NED frame to find reference field direction
-    float hx = 2*(mx*(0.5f-q2q2-q3l*q3l) + my*(q1q2-q0q3) + mz*(q1q3+q0q2));
-    float hy = 2*(mx*(q1q2+q0q3) + my*(0.5f-q1q1-q3l*q3l) + mz*(q2q3-q0q1));
-    float bx = std::sqrt(hx*hx + hy*hy);
-    float bz = 2*(mx*(q1q3-q0q2) + my*(q2q3+q0q1) + mz*(0.5f-q1q1-q2q2));
+    // K = P Hᵀ S⁻¹  (15×1)
+    float K[15];
+    for (int i = 0; i < 15; i++)
+        K[i] = (P_[i][6]*H6 + P_[i][7]*H7 + P_[i][8]*H8) * S_inv;
 
-    // Expected mag field direction in body frame (from reference [bx, 0, bz])
-    float halfwx = bx*(0.5f-q2q2-q3l*q3l) + bz*(q1q3-q0q2);
-    float halfwy = bx*(q1q2-q0q3) + bz*(q0q1+q2q3);
-    float halfwz = bx*(q0q2+q1q3) + bz*(0.5f-q1q1-q2q2);
+    // State correction xk = K y
+    float xk[15];
+    for (int i = 0; i < 15; i++) xk[i] = K[i] * y;
 
-    // Mag error: cross product of measured vs expected
-    float halfex = my*halfwz - mz*halfwy;
-    float halfey = mz*halfwx - mx*halfwz;
-    float halfez = mx*halfwy - my*halfwx;
-
-    // Project onto gravity axis (heading-only correction)
-    float grav_mag2 = halfvx*halfvx + halfvy*halfvy + halfvz*halfvz;
-    if (grav_mag2 > 0.01f) {
-        float proj = (halfex*halfvx + halfey*halfvy + halfez*halfvz) / grav_mag2;
-        halfex = proj * halfvx;
-        halfey = proj * halfvy;
-        halfez = proj * halfvz;
+    double Rew, Rns;
+    EarthRad(pEst_D_rrm_[0], &Rew, &Rns);
+    pEst_D_rrm_[2] -= xk[2];
+    pEst_D_rrm_[0] += xk[0] / (Rns + pEst_D_rrm_[2]);
+    pEst_D_rrm_[1] += xk[1] / ((Rew + pEst_D_rrm_[2]) * std::cos(pEst_D_rrm_[0]));
+    for (int i = 0; i < 3; i++) {
+        vEst_NED_mps_[i] += xk[i + 3];
+        aBias_mps2_[i]   += xk[i + 9];
+        wBias_rps_[i]    += xk[i + 12];
     }
 
-    // Scale by cos²(pitch) to avoid gimbal-lock corruption near vertical
-    {
-        float cross_sq = halfvy*halfvy + halfvz*halfvz;
-        float cos2_pitch = (grav_mag2 > 0.01f) ? (cross_sq / grav_mag2) : 1.0f;
-        halfex *= cos2_pitch;
-        halfey *= cos2_pitch;
-        halfez *= cos2_pitch;
-    }
+    // Quaternion correction (body-frame δθ, left-multiply — same convention as
+    // accel/baro/GNSS updates)
+    float quatDelta[4] = {1.0f, xk[6], xk[7], xk[8]};
+    normalizeQuaternion(quatDelta, quatDelta);
+    float qTemp[4];
+    multiplyQuaternions(quat_BL_, quatDelta, qTemp);
+    for (int i = 0; i < 4; i++) quat_BL_[i] = qTemp[i];
 
-    // Apply proportional correction to quaternion via first-order kinematics.
-    // Correction rate: omega = magKp_ * [halfex, halfey, halfez]
-    // Quaternion update: q += 0.5 * dt * Omega(omega) * q
-    float hw[3] = {0.5f * magKp_ * halfex * dt_s_,
-                    0.5f * magKp_ * halfey * dt_s_,
-                    0.5f * magKp_ * halfez * dt_s_};
-    float qw = quat_BL_[0], qx = quat_BL_[1], qy = quat_BL_[2], qz = quat_BL_[3];
-    quat_BL_[0] = qw - qx*hw[0] - qy*hw[1] - qz*hw[2];
-    quat_BL_[1] = qx + qw*hw[0] + qy*hw[2] - qz*hw[1];
-    quat_BL_[2] = qy + qw*hw[1] - qx*hw[2] + qz*hw[0];
-    quat_BL_[3] = qz + qw*hw[2] + qx*hw[1] - qy*hw[0];
-    normalizeQuaternion(quat_BL_, quat_BL_);
+    // Joseph form: P = (I-KH) P (I-KH)ᵀ + K R Kᵀ.  H is sparse — nonzero only
+    // in cols {6,7,8} with values {H6,H7,H8}.
+    float Hrow[15] = {};
+    Hrow[6] = H6; Hrow[7] = H7; Hrow[8] = H8;
+
+    float I_KH[15][15];
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            I_KH[i][j] = (i == j ? 1.0f : 0.0f) - K[i] * Hrow[j];
+
+    float P_new[15][15] = {};
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            for (int k = 0; k < 15; k++)
+                P_new[i][j] += I_KH[i][k] * P_[k][j];
+
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++) {
+            float sum = 0;
+            for (int k = 0; k < 15; k++) sum += P_new[i][k] * I_KH[j][k];
+            P_[i][j] = sum + K[i] * R_mag_ * K[j];
+        }
+
+    // Symmetrize P
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j <= i; j++) {
+            float s = 0.5f * (P_[i][j] + P_[j][i]);
+            P_[i][j] = s; P_[j][i] = s;
+        }
+
+    stabilizeP();
 }
 
 // ─── Measurement Update (GNSS correction) ───────────────────────────

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -8,8 +8,10 @@
 // Unified EKF architecture (Mahony AHRS removed):
 //   - Quaternion propagation via gyro in timeUpdate()
 //   - Accelerometer gravity-reference measurement update (accelMeasUpdate)
-//   - Magnetometer proportional heading correction (magHeadingUpdate)
-//   - cos²(pitch) gating on magnetometer and GNSS attitude corrections
+//   - Magnetometer heading-only scalar Kalman update (magMeasUpdate):
+//     tilt-compensated, true-north via magnetic declination, well-conditioned
+//     at any attitude including vertical (no cos²(pitch) blind spot)
+//   - cos⁴(pitch) gating on GNSS velocity-derived attitude correction only
 //   - Specific force magnitude gating (0.5g–1.5g) during thrust/free-fall
 //   - Consistent FRD body frame / NED world frame convention
 
@@ -105,6 +107,12 @@ public:
     void setGpsNoiseScale(float scale) { gpsNoiseScale_ = scale; }
     float getGpsNoiseScale() const { return gpsNoiseScale_; }
 
+    /// Magnetic declination (radians, EAST-positive) added to the measured
+    /// magnetic heading so the filter tracks TRUE north.  0 = magnetic north.
+    /// Set once from GPS lat/lon/date via the World Magnetic Model.
+    void setDeclination(float dec_rad) { declination_rad_ = dec_rad; }
+    float getDeclination() const { return declination_rad_; }
+
     /// Inject known position (lat_rad, lon_rad, alt_m) and reset pos covariance.
     void setPosition(double lat_rad, double lon_rad, double alt_m) {
         pEst_D_rrm_[0] = lat_rad; pEst_D_rrm_[1] = lon_rad; pEst_D_rrm_[2] = alt_m;
@@ -186,7 +194,7 @@ private:
     void timeUpdate();
     void measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]);
     void accelMeasUpdate(const float aMeas[3]);
-    void magHeadingUpdate(const float aMeas[3], const float magMeas[3]);
+    void magMeasUpdate(const float aMeas[3], const float magMeas[3]);
 
     // Numerical safety net: floor P diagonals at a tiny positive value and
     // cap them at the per-state P_MAX_* values. Call after every path that
@@ -269,8 +277,12 @@ private:
     // Accel gravity-reference measurement noise variance (sigma m/s²)^2
     float R_accel_ = 0.25f;
 
-    // Mag heading proportional gain
-    float magKp_ = 1.0f;
+    // Mag heading-only Kalman measurement noise variance (rad²; ~3° sigma)
+    float R_mag_ = 0.0027f;
+
+    // Magnetic declination (rad, EAST-positive); added to the measured magnetic
+    // heading to yield a true-north heading.  Set from GPS+WMM at fix; 0 until.
+    float declination_rad_ = 0.0f;
 
     // P diagonal clamping — prevents float32 overflow when states are
     // unobservable (e.g. no GPS fix on bench).  Caps are well above

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -21,6 +21,7 @@ idf_component_register(
         TR_Sensor_Data_Converter
         TR_Orientation
         TR_GpsInsEKF
+        TR_GeoMag
         TR_KinematicChecks
         TR_MagCalibrator
         TR_ServoControl_ledc_mult

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -174,6 +174,11 @@ struct config
     // EKF pad heading: compass heading of board Z+ (deg, 0=North, 90=East)
     static constexpr float PAD_HEADING_DEG = 0.0f;
 
+    // Magnetic declination fallback (deg, EAST-positive) used until a good GPS
+    // fix lets TR_GeoMag (WMM2025) compute the true value from lat/lon/date.
+    // 0 = the EKF heading tracks MAGNETIC north until the WMM value is set.
+    static constexpr float MAGNETIC_DECLINATION_DEG = 0.0f;
+
     // GNSS quality gates — layered rejection of bad fixes
     // Note: h_acc is uint8_t (max 255). Many receivers report 255 = "unknown".
     // Set thresholds to 0 to disable h_acc gating when receiver doesn't populate it.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -11,6 +11,7 @@
 #include <TR_Sensor_Data_Converter.h>
 #include <TR_Orientation.h>
 #include <TR_GpsInsEKF.h>
+#include <TR_GeoMag.h>
 #include <TR_KinematicChecks.h>
 #include <TR_MagCalibrator.h>
 #include <TR_ServoControl_ledc_mult.h>
@@ -3294,6 +3295,33 @@ static void loop_fc()
                         ESP_LOGI(TAG, "[EKF] Init: acc=(%.2f,%.2f,%.2f) heading=%.1f deg",
                                       ekf_imu.acc_x, ekf_imu.acc_y, ekf_imu.acc_z,
                                       (double)config::PAD_HEADING_DEG);
+                    }
+
+                    // Magnetic declination → true-north heading.  Computed once
+                    // here (off the flight-loop hot path) from the averaged pad
+                    // position + GPS date via WMM2025; falls back to the config
+                    // constant if the GNSS date is implausible.
+                    {
+                        float decl_deg = config::MAGNETIC_DECLINATION_DEG;
+                        const uint16_t yr = gnss_latest_si.year;
+                        if (yr >= 2020 && yr <= 2035) {
+                            static const int mdays[12] =
+                                {31,28,31,30,31,30,31,31,30,31,30,31};
+                            int doy = gnss_latest_si.day;
+                            for (int mo = 1; mo < gnss_latest_si.month && mo <= 12; mo++)
+                                doy += mdays[mo - 1];
+                            const bool leap = (yr % 4 == 0 && (yr % 100 != 0 || yr % 400 == 0));
+                            if (leap && gnss_latest_si.month > 2) doy += 1;
+                            const double decimal_year =
+                                (double)yr + (double)(doy - 1) / (leap ? 366.0 : 365.0);
+                            const float decl_rad = TR_GeoMag::declinationRad(
+                                ref_lat_rad, ref_lon_rad, ref_alt_m, decimal_year);
+                            decl_deg = decl_rad * (180.0f / (float)M_PI);
+                        }
+                        ekf.setDeclination(decl_deg * ((float)M_PI / 180.0f));
+                        ESP_LOGI(TAG, "[EKF] Declination %.2f deg (WMM2025, %u-%02u-%02u)",
+                                      (double)decl_deg, gnss_latest_si.year,
+                                      gnss_latest_si.month, gnss_latest_si.day);
                     }
                     ekf_initialized = true;
                 }


### PR DESCRIPTION
## Why

On the pad the rocket stands vertical, and the old magnetometer fusion (`magHeadingUpdate`, a stateless Mahony nudge) scaled its heading correction by `cos²(pitch)` — which goes to ~0 when vertical, exactly when heading is *most* observable from the horizontal field. So heading was left to free-run on the gyro on the pad, and near the Euler pitch=90° singularity that showed up as the roll/yaw "drift & cycle" in telemetry. There was also no absolute (true-north) reference — heading was only relatively stabilized.

## What

Replace the Mahony correction with a **proper heading-only scalar Kalman update** fused through the existing 15-state error covariance, and add **true-north declination from GPS via the World Magnetic Model**.

**`magMeasUpdate` (TR_GpsInsEKF)** — scalar Kalman, mirrors `baroMeasUpdate` (no matrix inverse):
- Tilt-compensated magnetic heading from accel (level reference) + mag, plus `declination_rad_` for true north.
- Corrects **only yaw**: `H[6..8] = +2·(body-down)` in the attitude block (factor 2 = half-angle attitude error; + sign because ∂yaw/∂δθ = body-down). `|H|=2` ⇒ `S ≥ R_mag` at any attitude — **no vertical blind spot**.
- Accel keeps owning roll/pitch (orthogonal H), so the two updates are complementary, not competing. Retires `magHeadingUpdate` + `magKp_` + the `cos²(pitch)` logic.

**`TR_GeoMag` (new component)** — WMM2025 magnetic declination from geodetic lat/lon/alt + date (degree-12 spherical harmonics, official NOAA coefficients, epoch 2025.0, expires 2030.0). Evaluated **once at GPS fix** (off the flight-loop hot path); `config::MAGNETIC_DECLINATION_DEG` fallback (default 0 = magnetic) until then.

**Replay tooling** — `replay_flight_ekf.py` now feeds the new-PCB IIS2MDC mag (previously MMC-only), so new-board logs replay with a magnetometer.

## Verification

- **Host tests (345/345 pass).** New EKF tests: heading **converges from a 50° error while nose-vertical** and **stays stable** — the exact case the old path failed (gimbal-safe quaternion-geodesic checks). New `test_geomag` validates declination against 10 official NOAA `WMM2025_TestValues.txt` points (<0.1°).
- **Builds clean on ESP32-P4 / ESP-IDF v6.0.1** (82% app partition free).
- **Hardware bench (3 vertical holds across 2 runs):** held near-vertical for 18 s / 23 s / 32 s → heading drift ≈0°/s, quaternion spread <3°, **zero cycling**. Mag healthy (in-gate), GPS-fixed (true-north applied).
- **Reference-EKF replay** of the 6/14 flights runs cleanly end-to-end (the `.bin`s don't retain the long cycling pad — that lived only in LoRa telemetry — so the bench data is the definitive regression evidence).

## Timing

The mag update is a single scalar Kalman step (no matrix inverse) and runs inside `ekf.update()`, so the existing `[TIMING] ekf: avg/max us` log already measures it; no new hot-path cost of note.

## Notes
- Absolute heading accuracy depends on a hard-iron mag calibration; an uncalibrated mag fails the 15–80 µT gate → no mag (graceful, never a wrong heading).
- WMM coefficients expire 2030.0 (documented in `TR_GeoMag.h` for refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
