### PR TITLE
fc(mag): IIS2MDC sensor→board rotation +90° (validated heading) + status-query propagation

### DIFF
--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -43,7 +43,7 @@ ISM6_HIGH_G_FS_G  = 256    # ±256 g
 ISM6_GYRO_FS_DPS  = 4000   # ±4000 dps
 ISM6_ROT_Z_DEG    = -45.0  # sensor → board frame rotation about +Z
 MMC_ROT_Z_DEG     = 180.0  # sensor → board frame rotation about +Z (old-PCB MMC5983MA)
-IIS2MDC_ROT_Z_DEG = 0.0    # sensor → board frame rotation about +Z (new-PCB IIS2MDC)
+IIS2MDC_ROT_Z_DEG = 90.0   # sensor → board frame rotation about +Z (new-PCB IIS2MDC, #204)
 
 def ism6_scales(low_g_fs=ISM6_LOW_G_FS_G, high_g_fs=ISM6_HIGH_G_FS_G,
                 gyro_fs=ISM6_GYRO_FS_DPS):
@@ -389,6 +389,9 @@ def parse_binary_file(filepath):
                         config["b2r_mode"] = b2r[1]
                         config["b2r_quat"] = (b2r[2] / 10000.0, b2r[3] / 10000.0,
                                               b2r[4] / 10000.0, b2r[5] / 10000.0)
+                    if fmt_ver >= 4 and msg_len >= 28:
+                        # v4 (#204): per-chip IIS2MDC sensor→board rotation
+                        config["iis2mdc_rot_z_deg"] = struct.unpack("<h", payload[26:28])[0] / 100.0
                     config_seen = True
 
             elif msg_type == MSG_GNSS:

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -417,9 +417,10 @@ nonisolated class CSVGenerator {
                let config = try? OutStatusQueryData(from: queryFrame.payload) {
                 converter.configureMiniRotation(
                     imuDeg: config.imuRotationDeg,
-                    magDeg: config.magRotationDeg
+                    magDeg: config.magRotationDeg,
+                    iisDeg: config.iisRotationDeg
                 )
-                print("[CSV] Mini rotation config: IMU=\(config.imuRotationDeg)° MAG=\(config.magRotationDeg)°")
+                print("[CSV] Mini rotation config: IMU=\(config.imuRotationDeg)° MAG=\(config.magRotationDeg)° IIS=\(config.iisRotationDeg.map { String($0) } ?? "n/a")°")
             } else {
                 print("[CSV] No statusQuery frame found — using default rotation (0°)")
             }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -26,6 +26,7 @@ nonisolated class SensorConverter {
     // Mini sensor-frame → board-frame rotation angles (configurable per device)
     private var ism6_rot_z_rad: Double = 0.0
     private var mmc_rot_z_rad: Double = 0.0
+    private var iis2mdc_rot_z_rad: Double = 0.0
 
     init() {
         // Calculate sensitivity values
@@ -49,9 +50,13 @@ nonisolated class SensorConverter {
 
     /// Configure Mini sensor rotation angles from status query data.
     /// Called when a 0xA0 (statusQuery) frame is found in the binary log.
-    func configureMiniRotation(imuDeg: Double, magDeg: Double) {
+    func configureMiniRotation(imuDeg: Double, magDeg: Double, iisDeg: Double? = nil) {
         ism6_rot_z_rad = imuDeg * .pi / 180.0
         mmc_rot_z_rad = magDeg * .pi / 180.0
+        // IIS2MDC (new PCB) has its own sensor→board rotation (#204).  Older
+        // logs (status query format_version < 4) don't carry it; fall back to
+        // the MMC value to preserve prior behavior on those.
+        iis2mdc_rot_z_rad = (iisDeg ?? magDeg) * .pi / 180.0
     }
 
     /// Configure Legacy sensor rotation.
@@ -195,9 +200,9 @@ nonisolated class SensorConverter {
 
     /// Convert IIS2MDC raw counts to MMC5983MADataSI (µT) so CSV writer
     /// stays unified between MMC and IIS2MDC boards.  IIS2MDC sensitivity
-    /// is 0.15 µT/LSB (datasheet 9.13).  Frame rotation reuses
-    /// mmc_rot_z_rad — only one mag rotation comes back in the status
-    /// query (mmc_rot_z_cdeg), applied to whichever mag chip is present.
+    /// is 0.15 µT/LSB (datasheet 9.13).  Applies the IIS2MDC-specific
+    /// sensor→board rotation (iis2mdc_rot_z_rad, from status query
+    /// iis2mdc_rot_z_cdeg, format_version >= 4 — #204), NOT the MMC's.
     func convertIIS2MDC(_ raw: IIS2MDCData) -> MMC5983MADataSI {
         let UT_PER_LSB = 0.15
 
@@ -205,8 +210,8 @@ nonisolated class SensorConverter {
         let my = Double(raw.mag_y) * UT_PER_LSB
         let mz = Double(raw.mag_z) * UT_PER_LSB
 
-        let c = cos(mmc_rot_z_rad)
-        let s = sin(mmc_rot_z_rad)
+        let c = cos(iis2mdc_rot_z_rad)
+        let s = sin(iis2mdc_rot_z_rad)
 
         // Sensor frame -> board frame, rotation about +Z.
         let mag_x = (mx * c) - (my * s)

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -47,6 +47,7 @@ nonisolated struct OutStatusQueryData {
     let ism6_rot_z_cdeg: Int16       // centi-degrees
     let mmc_rot_z_cdeg: Int16        // centi-degrees
     let format_version: UInt8
+    let iis2mdc_rot_z_cdeg: Int16?   // centi-degrees; format_version >= 4 (#204)
 
     init(from data: Data) throws {
         guard data.count >= 10 else {
@@ -60,12 +61,23 @@ nonisolated struct OutStatusQueryData {
         ism6_rot_z_cdeg = data.readInt16LE(at: &offset)
         mmc_rot_z_cdeg = data.readInt16LE(at: &offset)
         format_version = data.readUInt8(at: &offset)
+
+        // v4 (#204): per-chip IIS2MDC rotation appended after the b2r block.
+        // Byte offset 26 = ism6(1+2+2) + mmc(2) + ver(1) + hg_bias(6) + b2r(2+8).
+        if format_version >= 4 && data.count >= 28 {
+            var iisOffset = 26
+            iis2mdc_rot_z_cdeg = data.readInt16LE(at: &iisOffset)
+        } else {
+            iis2mdc_rot_z_cdeg = nil
+        }
     }
 
     /// IMU rotation in degrees
     var imuRotationDeg: Double { Double(ism6_rot_z_cdeg) / 100.0 }
-    /// Magnetometer rotation in degrees
+    /// Magnetometer (MMC5983MA) rotation in degrees
     var magRotationDeg: Double { Double(mmc_rot_z_cdeg) / 100.0 }
+    /// IIS2MDC rotation in degrees (format_version >= 4); nil on older logs
+    var iisRotationDeg: Double? { iis2mdc_rot_z_cdeg.map { Double($0) / 100.0 } }
 }
 
 // MARK: - Flight Settings Snapshot (176 bytes) — runtime config at launch (#165)

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -558,6 +558,7 @@ typedef struct __attribute__((packed))
     uint8_t  format_version;      // payload format version
                                   //   2 = has HG bias
                                   //   3 = has board→rocket orientation
+                                  //   4 = has IIS2MDC rotation
     int16_t  hg_bias_x_cmss;     // high-g bias X, centi-m/s² (0.01 m/s² units)
     int16_t  hg_bias_y_cmss;     // high-g bias Y, centi-m/s²
     int16_t  hg_bias_z_cmss;     // high-g bias Z, centi-m/s²
@@ -570,9 +571,15 @@ typedef struct __attribute__((packed))
     uint8_t  b2r_code;           // discrete orientation code (0 = +X nose)
     uint8_t  b2r_mode;           // ORIENT_MODE_* (how it was determined)
     int16_t  b2r_q[4];           // board→rocket quaternion ×10000
+
+    // Per-chip IIS2MDC magnetometer rotation (format_version >= 4, #204).
+    // New-PCB boards carry the IIS2MDC, whose sensor→board rotation differs
+    // from the MMC5983MA's (mmc_rot_z_cdeg).  Consumers must apply THIS to
+    // IIS2MDC data — using mmc_rot_z_cdeg gives a 180° (or worse) heading error.
+    int16_t  iis2mdc_rot_z_cdeg; // centi-deg
 } OutStatusQueryData;
-static_assert(sizeof(OutStatusQueryData) == 26,
-              "OutStatusQueryData must be 26 bytes");
+static_assert(sizeof(OutStatusQueryData) == 28,
+              "OutStatusQueryData must be 28 bytes");
 
 // ### Data Structures ###
 // Packed and unpacked data structures for each type ---

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -79,11 +79,13 @@ struct config
     // MMC5983MA -> board frame (deg), CCW positive about +Z.
     // Note: board frame: +X forward, +Y left, +Z up.
     static constexpr float MMC5983MA_ROT_Z_DEG = 180.0f;
-    // IIS2MDC -> board frame (deg). Default 0 deg (no rotation) until
-    // bench characterization confirms the chip's mounting on the new PCB
-    // rev. Adjust here when the EKF heading shows a fixed offset relative
-    // to the IMU's Z axis.
-    static constexpr float IIS2MDC_ROT_Z_DEG = 0.0f;
+    // IIS2MDC -> board frame (deg), CCW positive about +Z.
+    // +90 deg from bench characterization (#204): with board +X pointed
+    // true north the IIS2MDC reads Earth's horizontal field on its -Y axis
+    // (and on -X when board +X points east) -> chip +Y is parallel to
+    // board -X, a +90 deg sensor->board rotation.  Validated against two
+    // static logs (board+X -> N and board+X -> E, 2026-06-17).
+    static constexpr float IIS2MDC_ROT_Z_DEG = 90.0f;
 
     // Board -> rocket mounting orientation (TR_Orientation code, 0-23).
     // 0 = board +X toward the nose (the historical assumption).  Set to a

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2469,9 +2469,11 @@ static void setup_fc()
     out_status_query_data.ism6_gyro_fs_dps = config::ISM6_GYRO_FS_DPS;
     out_status_query_data.ism6_rot_z_cdeg = (int16_t)lroundf(config::ISM6HG256_ROT_Z_DEG * 100.0f);
     out_status_query_data.mmc_rot_z_cdeg = (int16_t)lroundf(config::MMC5983MA_ROT_Z_DEG * 100.0f);
+    out_status_query_data.iis2mdc_rot_z_cdeg = (int16_t)lroundf(config::IIS2MDC_ROT_Z_DEG * 100.0f);
     // v3: adds board→rocket orientation (b2r_* fields, filled by
     // applyBoardToRocketOrientation above and on any runtime change).
-    out_status_query_data.format_version = 3;
+    // v4: adds per-chip iis2mdc_rot_z_cdeg (#204).
+    out_status_query_data.format_version = 4;
 
     // NOTE: Do NOT drain the slave TX buffer here.  With the new
     // i2c_slave driver, reading when the slave has no TX data queued


### PR DESCRIPTION
## Summary
The new-PCB IIS2MDC magnetometer's sensor→board rotation (`IIS2MDC_ROT_Z_DEG`) was `0°` — an unvalidated placeholder. Bench heading validation (#204) shows the correct value is **+90°**: with board +X pointed true north the IIS2MDC reads Earth's horizontal field on its **−Y** axis (and **−X** when board +X points east) → chip +Y ∥ board −X, a +90° rotation. At 0° the EKF mag-heading reference (and CSV exports) were ~90° off.

Also threads the per-chip rotation through `OutStatusQueryData` (format_version **4**, new `iis2mdc_rot_z_cdeg`) so the iOS exporter and Python tooling apply the IIS2MDC's own rotation instead of the MMC5983MA's.

Closes #204.

## Validation (3 static bench logs, NJ, 2026-06-17)
| board +X → | horizontal field lands on | ✓ |
|---|---|---|
| true north | board **+X**, ~13° off-axis (= local declination) | ✅ |
| true east | board **+Y** (north is 90° left of +X) | ✅ |
| true north (post-flash, fixed fw + app) | board **+X**, ~13° off | ✅ |

`|B|` ≈ 43 µT and dip ≈ 65–68° throughout (consistent, healthy hard-iron cal).

### Why +90°, not −90°
The first pass read −90° from a CSV that *looked* chip-native. But the iOS `convertIIS2MDC` had been applying the **MMC5983MA's 180°** rotation, so that CSV was 180°-rotated from chip-native. Backing the 180° out flips the sign → **+90°**, confirmed four ways and across both orientations, then bench-confirmed after flashing.

## Changes
**Firmware**
- `config.h`: `IIS2MDC_ROT_Z_DEG` 0° → 90° (wired into the converter via `configureIIS2MDCRotationZ` → EKF mag).
- `OutStatusQueryData`: append `iis2mdc_rot_z_cdeg`, bump `format_version` 3 → 4 (struct 26 → 28 bytes; OC reads by `sizeof`, no change needed).
- FC fills the new field.

**App + analysis**
- iOS `convertIIS2MDC` applies the IIS2MDC-specific rotation (new `configureMiniRotation(iisDeg:)`), not the MMC's 180°; `OutStatusQueryData` decoder reads the v4 field (nil on older logs).
- Python parser reads `iis2mdc_rot_z` from the v4 status query; fallback constant → 90°.

## Verification
- FC firmware build (IDF v6.0.1): green.
- `OutStatusQueryData` `static_assert` → 28 bytes.
- iOS converter tests unaffected (zero-rotation default path).
- Python parses cleanly; v3 logs fall back to the default.
- Bench-confirmed (table above).

## Not in this PR
Pre-existing, separate bug: the **Python `parse_binary_file` misreads IIS2MDC raw values** (`|B|` ≈ 6.6× low, wrong axis split) — the iOS app reads the same frames correctly. Affects #240's report mag plots; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
