### PR TITLE
app(announcer): callout direction from rate sign, not apogee flag (#235)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
@@ -323,6 +323,18 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
         }
     }
 
+    /// Direction word for a SIGNED altitude rate, or nil within the deadband
+    /// (near-level → omit direction).  Single source of truth so a callout's
+    /// spoken direction can never contradict the rate's sign.  #235: "climbing"
+    /// was announced during descent because the word came from the apogee-phase
+    /// flag (`alt_apo`, which clears below ~15 m AGL near landing) instead of
+    /// the rate.
+    static func climbDescendWord(forRate rate: Float, deadband: Float = 1.0) -> String? {
+        if rate >  deadband { return "climbing" }
+        if rate < -deadband { return "descending" }
+        return nil
+    }
+
     private func checkPeriodicAltitude(_ telemetry: TelemetryData) {
         let now = Date()
         guard now.timeIntervalSince(lastAltitudeAnnounceTime) >= Self.altitudeInterval else { return }
@@ -330,10 +342,13 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
 
         lastAltitudeAnnounceTime = now
         let altStr = UnitFormatter.spokenAltitude(Double(alt))
-        // Only include climb rate after burnout — during powered flight the
-        // rate changes too rapidly and isn't meaningful to announce.
-        if burnoutAnnounced, let rate = telemetry.altitude_rate, abs(rate) > 1.0 {
-            announce("\(altStr), climbing \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
+        // Only include the vertical rate after burnout — during powered flight
+        // it changes too rapidly to be meaningful.  The direction word comes
+        // from the rate's sign (#235), never the apogee phase, so it can't
+        // contradict the motion (e.g. "climbing" while descending near landing).
+        if burnoutAnnounced, let rate = telemetry.altitude_rate,
+           let word = Self.climbDescendWord(forRate: rate) {
+            announce("\(altStr), \(word) \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
         } else {
             announce(altStr)
         }
@@ -347,8 +362,9 @@ class FlightAnnouncer: NSObject, ObservableObject, AVSpeechSynthesizerDelegate, 
         lastDescentAnnounceTime = now
 
         let altStr = UnitFormatter.spokenAltitude(Double(alt))
-        if let rate = telemetry.altitude_rate, abs(rate) > 1.0 {
-            announce("\(altStr), descending \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
+        if let rate = telemetry.altitude_rate,
+           let word = Self.climbDescendWord(forRate: rate) {
+            announce("\(altStr), \(word) \(UnitFormatter.spokenSpeed(Double(abs(rate))))")
         } else {
             announce(altStr)
         }

--- a/TinkerRocketApp/TinkerRocketAppTests/FlightAnnouncerDispatchTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/FlightAnnouncerDispatchTests.swift
@@ -108,3 +108,46 @@ final class FlightAnnouncerDispatchTests: XCTestCase {
                        "Non-relayed frames should not populate remoteRockets")
     }
 }
+
+/// #235: the altitude-rate callout's direction word must follow the SIGN of the
+/// rate, never the apogee-phase flag — so "climbing" is never spoken while
+/// descending (the original bug, which surfaced below ~15 m AGL when `alt_apo`
+/// cleared near landing and the pre-apogee branch re-fired).
+final class FlightAnnouncerWordingTests: XCTestCase {
+
+    func testWord_MatchesRateSign() {
+        XCTAssertEqual(FlightAnnouncer.climbDescendWord(forRate: 80),   "climbing")
+        XCTAssertEqual(FlightAnnouncer.climbDescendWord(forRate: 1.5),  "climbing")
+        XCTAssertEqual(FlightAnnouncer.climbDescendWord(forRate: -30),  "descending")
+        XCTAssertEqual(FlightAnnouncer.climbDescendWord(forRate: -1.5), "descending")
+    }
+
+    func testWord_OmittedWithinDeadband() {
+        XCTAssertNil(FlightAnnouncer.climbDescendWord(forRate: 0))
+        XCTAssertNil(FlightAnnouncer.climbDescendWord(forRate: 0.5))
+        XCTAssertNil(FlightAnnouncer.climbDescendWord(forRate: -0.5))
+        XCTAssertNil(FlightAnnouncer.climbDescendWord(forRate: 1.0),   "boundary is strict (> deadband)")
+        XCTAssertNil(FlightAnnouncer.climbDescendWord(forRate: -1.0))
+    }
+
+    /// Sweep a synthetic ascent → apogee → descent → near-ground profile; the
+    /// direction word must never contradict the sign of the rate.
+    func testWord_NeverContradictsRate_AcrossFlightProfile() {
+        let rates: [Float] = [80, 40, 12, 5, 1.5, 0.4, 0, -0.4, -1.5, -8, -20, -6, -3, -2]
+        for r in rates {
+            let word = FlightAnnouncer.climbDescendWord(forRate: r)
+            if r > 1.0 {
+                XCTAssertEqual(word, "climbing", "rate \(r) m/s should read 'climbing'")
+            } else if r < -1.0 {
+                XCTAssertEqual(word, "descending", "rate \(r) m/s should read 'descending'")
+            } else {
+                XCTAssertNil(word, "near-level rate \(r) m/s should omit the direction word")
+            }
+            // The cardinal #235 guarantee: never "climbing" while descending.
+            if r < 0 {
+                XCTAssertNotEqual(word, "climbing",
+                                  "must never say 'climbing' at a negative rate (\(r) m/s)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The altitude-rate voice callout announced **"climbing" during descent** near landing. The direction word came from the apogee phase, not the rate: `checkPeriodicAltitude` hardcoded "climbing", `checkDescentCallout` hardcoded "descending", and both discarded the sign via `abs(rate)`. The two were switched by `telemetry.alt_apo` — the firmware's *live* "baro-altitude-decreasing" voter (`TR_KinematicChecks` Test 2), whose gate requires `alt_est > 15 m`. So below ~15 m AGL near landing `alt_apo` clears, the pre-apogee branch re-fires, and it says "climbing" while the rocket is still falling.

Closes #235.

## Fix
A single source of truth — `FlightAnnouncer.climbDescendWord(forRate:)` — picks the word from the **signed** rate (1 m/s deadband; omitted near level), used by both callouts. The spoken direction can no longer contradict the motion, regardless of which phase branch fires.

## Tests
New `FlightAnnouncerWordingTests` sweeps an ascent → apogee → descent → near-ground rate profile and asserts the word never contradicts the rate sign (never "climbing" at a negative rate), plus the deadband boundaries. Existing `FlightAnnouncerDispatchTests` (#138) stay green.

Verified locally: `xcodebuild test` on iPhone 17 Pro — **TEST SUCCEEDED**, 7/7 FlightAnnouncer tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
