### PR TITLE
app(csv): fix parse crash on rows with more fields than header (#236)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
@@ -144,8 +144,12 @@ class CSVParser {
                     columns[col].append(.nan)
                 }
             }
-            // Pad if row has fewer columns than header
-            for col in fields.count..<columnCount {
+            // Pad short rows.  min() guards over-long rows (more fields than the
+            // header — e.g. garbled LoRa telemetry like "166.65.5" splitting into
+            // extra fields): bare `fields.count..<columnCount` traps with
+            // "Range requires lowerBound <= upperBound" when fields.count >
+            // columnCount (#236).  Extra fields were already consumed above.
+            for col in min(fields.count, columnCount)..<columnCount {
                 columns[col].append(.nan)
             }
         }

--- a/TinkerRocketApp/TinkerRocketAppTests/CSVParserTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/CSVParserTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// #236: `CSVParser.parse` trapped with "Range requires lowerBound <=
+/// upperBound" on LoRa logs whose corrupted-telemetry rows have MORE comma
+/// fields than the header (e.g. a garbled value like "166.65.5" splitting into
+/// extra fields).  The padding loop `fields.count..<columnCount` inverted when
+/// `fields.count > columnCount`.  Parsing must be crash-proof and column-aligned.
+final class CSVParserTests: XCTestCase {
+
+    private func parse(_ csv: String) throws -> FlightCSVData {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("csvtest-\(UUID().uuidString).csv")
+        try csv.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        return try CSVParser.parse(url: url)
+    }
+
+    /// The exact #236 crash: a row with MORE fields than the header.
+    func testParse_RowWithExtraFields_DoesNotTrap() throws {
+        let data = try parse("a,b,c\n1,2,3\n4,5,6,7,8\n9,10,11\n")
+        XCTAssertEqual(data.rowCount, 3)
+        // Every column stays aligned (one value per row); extra fields ignored.
+        XCTAssertEqual(data.columns["a"], [1.0, 4.0, 9.0])
+        XCTAssertEqual(data.columns["b"], [2.0, 5.0, 10.0])
+        XCTAssertEqual(data.columns["c"], [3.0, 6.0, 11.0])
+    }
+
+    /// Rows with FEWER fields than the header still pad with NaN.
+    func testParse_RowWithMissingFields_PadsNaN() throws {
+        let data = try parse("a,b,c\n1,2,3\n4,5\n")
+        XCTAssertEqual(data.rowCount, 2)
+        XCTAssertEqual(data.columns["a"], [1.0, 4.0])
+        XCTAssertEqual(data.columns["b"], [2.0, 5.0])
+        XCTAssertEqual(data.columns["c"]?[0], 3.0)
+        XCTAssertEqual(data.columns["c"]?.count, 2)
+        XCTAssertTrue(data.columns["c"]?[1].isNaN ?? false)   // padded
+    }
+
+    /// Mirrors the real LoRa shape: 36-col header with a 38-field garbled row.
+    func testParse_LoRaShapedGarbledRow_DoesNotTrap() throws {
+        let header  = (0..<36).map { "c\($0)" }.joined(separator: ",")
+        let good    = (0..<36).map { "\($0)"  }.joined(separator: ",")
+        let garbled = good + ",166.65.5,extra"   // 38 fields
+        let data = try parse("\(header)\n\(good)\n\(garbled)\n")
+        XCTAssertEqual(data.rowCount, 2)
+        XCTAssertEqual(data.columns["c0"], [0.0, 0.0])
+        XCTAssertEqual(data.columns["c35"]?.count, 2)        // all columns aligned
+    }
+}


### PR DESCRIPTION
## Summary
The real cause of the LoRa-plot crash (#236): `CSVParser.parse` traps with `Range requires lowerBound <= upperBound` when a data row has **more comma fields than the header**. The padding loop `for col in fields.count..<columnCount` becomes an inverted `Range<Int>` (e.g. `38..<36`) and traps during *parse*, before charting.

Confirmed from the debugger backtrace + the 6/14 10:50 log (`lora_20260614_145041.csv`), which has corrupted-telemetry rows with **37–42 fields** vs the 36-column header — garbled values like `166.65.5` that split into extra comma fields.

(#247's `safeDomain` chart-domain hardening was a legitimate robustness improvement but the wrong layer — the crash is upstream in the parser.)

Closes #236.

## Fix
`min(fields.count, columnCount)..<columnCount` — extra fields are already consumed by the first loop, so the pad range is correctly empty rather than inverted. Every column still gets exactly one value per row, so columns stay aligned.

## Tests
`CSVParserTests` parses an over-long row (`4,5,6,7,8` into a 3-col header), a short row (pads NaN), and a 36-col-header / 38-field LoRa-shaped garbled row (`...,166.65.5,extra`) — asserting no trap and column alignment. Verified locally: `xcodebuild test` on iPhone 17 Pro — **TEST SUCCEEDED**, 3/3. This deterministically reproduces the crash, so it's a true regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
