### PR TITLE
fc(apogee): drop unreliable GPS from the apogee vote (#237, #242)

### DIFF
--- a/Data_Analysis/replay_kinematic_checks.py
+++ b/Data_Analysis/replay_kinematic_checks.py
@@ -113,6 +113,7 @@ def replay(binary_path: str) -> dict:
     latest_vel = (0.0, 0.0, 0.0)
     latest_roll_rate: float = 0.0
     latest_gps_alt: float = 0.0
+    latest_gps_vel_u: float = 0.0
     latest_pitch_rad: float = math.pi / 2
     burnout: bool = False
     mach_locked_out: bool = False
@@ -160,6 +161,7 @@ def replay(binary_path: str) -> dict:
 
         if kind == "gnss":
             latest_gps_alt = float(r["alt_m"])
+            latest_gps_vel_u = float(r["vel_u"])
             new_gps = True
             # Record GPS pass-state at GPS sample time (separate axis since
             # GPS is much slower than IMU and shouldn't be smeared along it).
@@ -194,6 +196,7 @@ def replay(binary_path: str) -> dict:
             roll_rate=latest_roll_rate,
             new_baro=new_baro,
             gps_altitude=latest_gps_alt,
+            gps_vel_u=latest_gps_vel_u,
             new_gps=new_gps,
             pitch_rad=latest_pitch_rad,
             burnout_detected=burnout,

--- a/Data_Analysis/sim_kinematic_checks.py
+++ b/Data_Analysis/sim_kinematic_checks.py
@@ -58,6 +58,9 @@ APOGEE_COUNT_MAX     = 10
 APOGEE_COUNT_HI      = 6        # baro/pitch/vel latch-on threshold
 GPS_APOGEE_COUNT_MAX = 8
 GPS_APOGEE_COUNT_HI  = 4
+# GPS apogee now fires on sustained Doppler descent faster than this m/s
+# (#237/#242): GPS velocity is real-time, GPS position lags ~4 s.
+GPS_VEL_APOGEE_DESCENT_MPS = 1.0
 
 # CHANGED (5): Landing sub-detector hysteresis thresholds.
 # Slow detectors evaluated at 1 Hz inside the existing landing_check_dt
@@ -213,6 +216,7 @@ class KinematicChecks:
         burnout_detected: bool,
         baro_locked_out: bool,
         now_ms: int,
+        gps_vel_u: float = 0.0,
     ) -> None:
         self._now_ms = now_ms
 
@@ -411,9 +415,12 @@ class KinematicChecks:
             elif self.apogee_count == 0:
                 self.alt_apogee_flag = False
 
-            # ─ Test 3: GPS (CHANGED (4): leaky counter; same HI=4) ─
-            if new_gps and self.gps_available_ and gps_altitude > 15.0:
-                gps_pass = gps_altitude < self.max_gps_altitude_ - 10.0
+            # ─ Test 3: GPS Doppler vertical velocity (descending), #237/#242 ─
+            # GPS position lags ~4 s & dives during boost; Doppler velocity is
+            # real-time, so descending vel_u tracks true apogee.  No altitude
+            # gate (that lag is the bug); fresh-fix gated; post-burnout only.
+            if new_gps and self.gps_available_:
+                gps_pass = gps_vel_u < -GPS_VEL_APOGEE_DESCENT_MPS
                 self.last_gps_pass = gps_pass
                 if gps_pass:
                     self.gps_apogee_count_ = min(GPS_APOGEE_COUNT_MAX,
@@ -450,10 +457,8 @@ class KinematicChecks:
                     available += 1
                     if self.alt_apogee_flag: passed += 1
 
-                if (self.gps_available_
-                        and (self._now_ms - self.last_gps_time_ms_) < 5000):
-                    available += 1
-                    if self.gps_apogee_flag: passed += 1
+                # GPS — NOT a voter (#237/#242): unreliable during boost on
+                # this hardware; gps_apogee_flag is computed + logged, excluded.
 
                 available += 1
                 if self.pitch_apogee_flag: passed += 1

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -23,11 +23,12 @@ protected:
     // Helper: call with flight-like data
     void callFlight(float alt, float acc_mag, float vel_u, float roll_rate = 0.0f,
                     float gps_alt = 0.0f, bool new_gps = false,
-                    float pitch_rad = 1.57f, bool burnout = false, bool baro_lockout = false) {
+                    float pitch_rad = 1.57f, bool burnout = false, bool baro_lockout = false,
+                    float gps_vel_u = 0.0f) {
         float pos[3] = {0, 0, alt};
         float vel[3] = {0, 0, vel_u};
         kc.kinematicChecks(alt, acc_mag, pos, vel, roll_rate, true, gps_alt, new_gps,
-                           pitch_rad, burnout, baro_lockout);
+                           pitch_rad, burnout, baro_lockout, gps_vel_u);
     }
 };
 
@@ -142,6 +143,28 @@ TEST_F(KinematicChecksTest, Apogee_WithBurnout_DetectsApogee) {
         callFlight(alt, 5.0f, -10.0f, 0.0f, alt, true, -0.2f, true);
     }
     EXPECT_TRUE(kc.apogee_flag);
+}
+
+// #237/#242: GPS apogee is computed + logged but is NOT a voter — on RP III the
+// GPS solution is corrupted during boost (vel_u noise to -38 m/s while climbing,
+// fix=3), so a GPS-only "apogee" must never fire the master.
+TEST_F(KinematicChecksTest, Apogee_GPSExcludedFromVote) {
+    for (int i = 0; i < 80; i++) {           // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+
+    // Post-burnout, drive ONLY GPS "descending" (gps_vel_u = -10) while the real
+    // detectors say still-ascending: EKF velocity +10, altitude climbing, nose up.
+    for (int i = 0; i < 60; i++) {
+        setMockMillis(200 + i * 2);
+        callFlight(/*alt*/100.0f + i, /*acc*/5.0f, /*vel_u*/10.0f, /*roll*/0.0f,
+                   /*gps_alt*/0.0f, /*new_gps*/true, /*pitch*/1.0f, /*burnout*/true,
+                   /*baro_lockout*/false, /*gps_vel_u*/-10.0f);
+    }
+    EXPECT_TRUE(kc.gps_apogee_flag)  << "GPS apogee flag should still be computed";
+    EXPECT_FALSE(kc.apogee_flag)     << "GPS must NOT vote the master apogee (#237)";
 }
 
 TEST_F(KinematicChecksTest, Landing_StableAlt) {

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -31,6 +31,10 @@ constexpr uint8_t  APOGEE_COUNT_MAX         = 10;
 constexpr uint8_t  APOGEE_COUNT_HI          = 6;
 constexpr uint8_t  GPS_APOGEE_COUNT_MAX     = 8;
 constexpr uint8_t  GPS_APOGEE_COUNT_HI      = 4;
+// GPS apogee fires on sustained Doppler descent faster than this (m/s).  GPS
+// *velocity* is real-time; GPS *position* lags ~4 s and dives during boost
+// (#237/#242), so the old altitude-below-peak test fired wildly off.
+constexpr float    GPS_VEL_APOGEE_DESCENT_MPS = 1.0f;
 
 // Landing slow-detector hysteresis (#166). Slow detectors evaluate inside
 // the 1 Hz landing_check_dt gate, so HI=4 → 4 s to fire (matches the
@@ -160,7 +164,8 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                                          bool  new_gps,
                                          float pitch_rad,
                                          bool  burnout_detected,
-                                         bool  baro_locked_out)
+                                         bool  baro_locked_out,
+                                         float gps_vel_u)
 {
     // Snapshot apogee_flag so the rising-edge reset below sees the
     // state *before* this tick's apogee voting fires (#192).
@@ -360,15 +365,11 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         }
     }
 
-    // ### GPS altitude tracking ###
-    // Track max GPS altitude from launch onwards (raw MSL — relative
-    // tracking means absolute value doesn't matter).
-    // #166: the 100 m spike-reject window was removed.  On big flights where
-    // GPS lost lock through boost (Eagle Claw 5/17/26), the post-recovery
-    // sample legitimately differs from the pad fix by hundreds of metres,
-    // and the gate permanently rejected those updates — leaving the GPS
-    // apogee detector silent for the entire flight.  Boost-phase dropout is
-    // common, so the gate did more harm than good.
+    // ### GPS freshness tracking ###
+    // Mark GPS available + stamp the last fix for the voting staleness gate.
+    // max_gps_altitude_ is still tracked (cheap, kept for diagnostics) but the
+    // GPS apogee test no longer uses it — it fires on Doppler velocity now
+    // (#237/#242), which is real-time, unlike the ~4 s-lagging GPS position.
     if (new_gps && launch_flag)
     {
         gps_available_ = true;
@@ -411,10 +412,16 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         if (apogee_count >= APOGEE_COUNT_HI)            alt_apogee_flag = true;
         else if (apogee_count == 0)                     alt_apogee_flag = false;
 
-        // --- Test 3: GPS altitude (GPS altitude decreasing) ---
-        if (new_gps && gps_available_ && gps_altitude > 15.0f)
+        // --- Test 3: GPS Doppler vertical velocity (descending) ---
+        // Was "GPS altitude below running max", but GPS *position* lags ~4 s
+        // and dives during boost (#242) — firing this wildly off (III at
+        // T+3.6 s, II at T+9.9 s vs true apogee #237).  GPS *velocity*
+        // (Doppler) is real-time, so a sustained descent tracks true apogee.
+        // Gated only on a fresh fix — NO gps-altitude gate, since that lag is
+        // the bug.  Post-burnout only, so an ascent excursion can't fire it.
+        if (new_gps && gps_available_)
         {
-            const bool gps_pass = (gps_altitude < max_gps_altitude_ - 10.0f);
+            const bool gps_pass = (gps_vel_u < -GPS_VEL_APOGEE_DESCENT_MPS);
             if (gps_pass) {
                 if (gps_apogee_count_ < GPS_APOGEE_COUNT_MAX) gps_apogee_count_++;
             } else {
@@ -436,7 +443,7 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         if (pitch_apogee_count_ >= APOGEE_COUNT_HI)     pitch_apogee_flag = true;
         else if (pitch_apogee_count_ == 0)              pitch_apogee_flag = false;
 
-        // --- Dynamic N-1 of N voting ---
+        // --- Dynamic N-1 of N voting (vel + baro + pitch; GPS excluded #237) ---
         if (!apogee_flag)
         {
             uint8_t available = 0;
@@ -453,20 +460,19 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                 if (alt_apogee_flag) passed++;
             }
 
-            // GPS — excluded if stale (>5s since last fix)
-            if (gps_available_ &&
-                (millis() - last_gps_time_ms_ < 5000))
-            {
-                available++;
-                if (gps_apogee_flag) passed++;
-            }
+            // GPS — NOT a voter (#237/#242).  GPS apogee is unreliable during
+            // boost on this hardware (RP III: position AND Doppler velocity
+            // corrupted — vel_u noise to -38 m/s while climbing — at fix=3 with
+            // good reported accuracy), so it false-fires.  gps_apogee_flag is
+            // still computed + logged as a diagnostic, just excluded from the
+            // vote so it can't move pyro timing.
 
             // Pitch — always available
             available++;
             if (pitch_apogee_flag) passed++;
 
             // N-1 of N with minimum 2 confirmations required.
-            // 4 available → need 3.  3 available → need 2.  2 available → need 2.
+            // 3 available → need 2.  2 available (mach lockout) → need 2.
             if (available >= 2 && passed >= 2 && passed >= (available - 1))
             {
                 apogee_flag = true;

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -23,7 +23,8 @@ public:
                          bool  new_gps = false,
                          float pitch_rad = 1.57f,
                          bool  burnout_detected = false,
-                         bool  baro_locked_out = false);
+                         bool  baro_locked_out = false,
+                         float gps_vel_u = 0.0f);
 
     bool launch_flag;
     bool alt_landed_flag;       // Voted master landed

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4765,7 +4765,8 @@ static void loop_fc()
                                        gps_new_for_kc,
                                        imu_rpy[1],
                                        burnout_detected,
-                                       mach_locked_out);
+                                       mach_locked_out,
+                                       (float)gnss_latest_si.vel_u);
         }
         bmp_new_for_kf = false;
         gps_new_for_kc = false;


### PR DESCRIPTION
## Summary
GPS apogee fired wildly off on the 6/14 Rolly Polly flights (replay-confirmed against the logs): **III at T+3.6 s (~7 s early)**, **II at T+9.9 s (~3 s late)** vs true apogee ~10 s / ~6.5 s.

**Root cause (#242):** the GPS solution is **corrupted during boost** — position lags ~4 s and dives (−31 m AGL while climbing), and Doppler **velocity hits −38 m/s noise while still ascending**, all at `fix_mode=3` with good reported `h_acc`/`v_acc`. So neither GPS altitude nor GPS velocity is usable for apogee on III, and **no GPS-data gate** separates that corruption from a real descent (III has 31 ascent samples below −5 m/s — *more* negative than the real −10 m/s post-apogee descent).

The EKF-velocity, baro, and pitch detectors fire apogee correctly on **both** flights.

## Fix
- **Remove `gps_apogee_flag` from the N-1 apogee vote** — it can no longer move pyro timing. Master apogee now rides on EKF-velocity + baro + pitch and fires **at true apogee** on both flights (II 6.54 s, III 10.03 s), vs the old 6.84 / 11.06 that waited for the 3rd-of-4 vote.
- **Keep `gps_apogee_flag` computed + logged** as a diagnostic, switched from the lagging altitude-below-peak to Doppler velocity (real-time where GPS is healthy, e.g. II).
- Mirrored in the Python port (`sim_kinematic_checks.py` / `replay_kinematic_checks.py`) — replay reproduces firmware exactly.

## Validation
- **Replay on the real II + III logs** (the test bench): master apogee now II 6.54 s / III 10.03 s — at true apogee, with the GPS false votes (early/late) no longer able to touch it.
- New gtest `Apogee_GPSExcludedFromVote`: a GPS-only "apogee" fires its flag but cannot fire the master. **20/20 kinematic gtests pass.**
- FC firmware build (IDF v6.0.1): green.

Closes #237. Resolves the apogee half of #242 (the ~4 s position lag itself is a u-blox characteristic under boost; a dynamic-model readback + a `Data_Analysis` lag check remain as #242 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
