### PR TITLE
fc(camera): fix RunCam wiring + record control — resolves #234

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -103,9 +103,13 @@ struct config
     static constexpr bool USE_GOPRO = (CAMERA_TYPE == 1);
     static constexpr bool USE_RUNCAM = (CAMERA_TYPE == 2);
 
-    // GoPro pins & timing
-    static constexpr int8_t CAM_PWR_PIN = 30;        // powers on camera
-    static constexpr int8_t CAM_SHUTTER_PIN = 31;    // GoPro shutter pulse
+    // GoPro pins & timing.  DEAD on this PCB: USE_GOPRO is false (CAMERA_TYPE=2,
+    // RunCam) so the setup() block that drives these never runs.  J6 carries the
+    // camera power gate on pin 32 and the RunCam UART on 30/31 — there is no
+    // separate GoPro shutter line.  Revisit these numbers before ever setting
+    // CAMERA_TYPE=1 on this hardware.
+    static constexpr int8_t CAM_PWR_PIN = 30;        // powers on camera (GoPro path, unused)
+    static constexpr int8_t CAM_SHUTTER_PIN = 31;    // GoPro shutter pulse (unused)
     static constexpr uint16_t GOPRO_PULSE_MS = 120;
 
     // Time to keep the camera rolling after LANDED before issuing the stop.
@@ -114,10 +118,20 @@ struct config
     // (which saturated i2s_tx_queue and dropped END_FLIGHT; see #141).
     static constexpr uint32_t CAMERA_STOP_DELAY_MS = 30000;  // 30 s
 
-    // RunCam UART pins & settings
-    static constexpr int8_t RUNCAM_RX_PIN = 31;      // FC receives from RunCam
-    static constexpr int8_t RUNCAM_TX_PIN = 32;      // FC sends to RunCam
-    static constexpr int8_t RUNCAM_PWR_PIN = 30;     // powers on RunCam
+    // RunCam UART + power pins.
+    // J6 mapping verified against the board schematic (#234):
+    //   pin 32 = CAM_ACT  → PMPB14XNX gate = camera POWER (R42 holds it off when
+    //                        the pin is low/floating)
+    //   pin 30 = Camera_TX → FC receives  (RX)
+    //   pin 31 = Camera_RX → FC transmits (TX)
+    // These were previously rotated (RX=31/TX=32/PWR=30), which put the UART TX
+    // on the power gate (pin 32).  A UART TX line idles HIGH, so the camera was
+    // powered on and auto-recording from boot, uncontrollably, while the firmware
+    // toggled a dead pin (30): the root cause of #234 (records on power-up,
+    // ignores app commands, overheats from continuous recording).
+    static constexpr int8_t RUNCAM_RX_PIN = 30;      // FC receives from RunCam (Camera_TX)
+    static constexpr int8_t RUNCAM_TX_PIN = 31;      // FC sends to RunCam (Camera_RX)
+    static constexpr int8_t RUNCAM_PWR_PIN = 32;     // camera power gate (CAM_ACT)
     static constexpr uint32_t RUNCAM_BAUD = 115200;
 
     // ### Pyro Channel Pins ###

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -119,18 +119,19 @@ struct config
     static constexpr uint32_t CAMERA_STOP_DELAY_MS = 30000;  // 30 s
 
     // RunCam UART + power pins.
-    // J6 mapping verified against the board schematic (#234):
-    //   pin 32 = CAM_ACT  → PMPB14XNX gate = camera POWER (R42 holds it off when
-    //                        the pin is low/floating)
-    //   pin 30 = Camera_TX → FC receives  (RX)
-    //   pin 31 = Camera_RX → FC transmits (TX)
-    // These were previously rotated (RX=31/TX=32/PWR=30), which put the UART TX
-    // on the power gate (pin 32).  A UART TX line idles HIGH, so the camera was
-    // powered on and auto-recording from boot, uncontrollably, while the firmware
-    // toggled a dead pin (30): the root cause of #234 (records on power-up,
-    // ignores app commands, overheats from continuous recording).
-    static constexpr int8_t RUNCAM_RX_PIN = 30;      // FC receives from RunCam (Camera_TX)
-    static constexpr int8_t RUNCAM_TX_PIN = 31;      // FC sends to RunCam (Camera_RX)
+    //   pin 32 = CAM_ACT → PMPB14XNX gate = camera POWER (R42 holds it off when
+    //                      low) — CONFIRMED, camera powers on/off correctly.
+    // The UART pair (30/31) is under bench verification (#234).  The schematic's
+    // Camera_TX/RX labels were ambiguous as to FC side; the first orientation
+    // (RX=30/TX=31) powered fine but the GET_DEVICE_INFO probe got no reply and
+    // record was unreliable, so we are testing the swapped orientation:
+    //   pin 31 = FC receives (RX) ← Camera_TX
+    //   pin 30 = FC transmits (TX) → Camera_RX
+    // (The original firmware had the whole set rotated RX=31/TX=32/PWR=30, which
+    // put the UART TX on the power gate — idle-high auto-powered/-recorded the
+    // camera at boot: the root cause of #234.)
+    static constexpr int8_t RUNCAM_RX_PIN = 31;      // FC receives from RunCam (Camera_TX)
+    static constexpr int8_t RUNCAM_TX_PIN = 30;      // FC sends to RunCam (Camera_RX)
     static constexpr int8_t RUNCAM_PWR_PIN = 32;     // camera power gate (CAM_ACT)
     static constexpr uint32_t RUNCAM_BAUD = 115200;
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1968,7 +1968,16 @@ static inline void serviceCameraStart(uint32_t now_ms)
     if ((int32_t)(now_ms - camera_start_due_ms) < 0) return;
     // WaitingForBoot elapsed — camera should now accept UART.
     ESP_LOGI(TAG, "RunCam boot wait elapsed — probing over UART");
-    runCamQueryDeviceInfo();
+    const bool alive = runCamQueryDeviceInfo();
+    // The camera boots to IDLE — it does not auto-record on a clean power-up
+    // (the old assumption only held because the UART-idle glitch kept it
+    // powered continuously; see #234).  So we must explicitly command the
+    // record start here.  Power-button toggle: idle -> recording, the mirror
+    // of the stop toggle in serviceCameraStop().  Sent regardless of the probe
+    // result — if only the RX wire is bad the TX toggle still lands.
+    sendRunCamToggle();
+    ESP_LOGI(TAG, "RunCam record START toggle sent (probe %s)",
+             alive ? "OK" : "no-reply");
     camera_start_phase = CameraStartPhase::Idle;
 }
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1728,6 +1728,13 @@ static const uint8_t RUNCAM_PWR_CMD[] = {0xCC, 0x01, 0x01, 0xE7};
 static constexpr uart_port_t RUNCAM_UART_PORT = UART_NUM_2;
 static bool runcam_uart_ready = false;
 
+// RCDEVICE feature bitfield from GET_DEVICE_INFO (0 until a probe succeeds).
+// Bit 0x40 = explicit START_RECORDING support, which we prefer over the
+// power-button toggle: on the bench unit the toggle only blips the LED without
+// holding record, whereas START_RECORDING holds it (#234).
+static constexpr uint16_t RUNCAM_FEAT_START_RECORDING = 0x0040;
+static uint16_t runcam_features = 0;
+
 static void initRunCam()
 {
     if (!config::USE_RUNCAM)
@@ -1857,6 +1864,7 @@ static bool runCamQueryDeviceInfo()
         ESP_LOGI(TAG, "RunCam ALIVE — protocol v%u, feature bytes "
                       "0x%02X 0x%02X (LE=0x%04X BE=0x%04X)",
                  resp[1], resp[2], resp[3], feat_le, feat_be);
+        runcam_features = feat_le;
         return true;
     }
 
@@ -1971,13 +1979,24 @@ static inline void serviceCameraStart(uint32_t now_ms)
     const bool alive = runCamQueryDeviceInfo();
     // The camera boots to IDLE — it does not auto-record on a clean power-up
     // (the old assumption only held because the UART-idle glitch kept it
-    // powered continuously; see #234).  So we must explicitly command the
-    // record start here.  Power-button toggle: idle -> recording, the mirror
-    // of the stop toggle in serviceCameraStop().  Sent regardless of the probe
-    // result — if only the RX wire is bad the TX toggle still lands.
-    sendRunCamToggle();
-    ESP_LOGI(TAG, "RunCam record START toggle sent (probe %s)",
-             alive ? "OK" : "no-reply");
+    // powered continuously; see #234).  So explicitly command record start.
+    // Prefer the deterministic START_RECORDING command when the camera advertises
+    // it (feature 0x40): the power-button toggle only blips the LED without
+    // holding record on the bench unit.  Fall back to the toggle otherwise.
+    if (runcam_features & RUNCAM_FEAT_START_RECORDING)
+    {
+        uint8_t rec[4] = {0xCC, 0x01, 0x03, 0x00};  // CAMERA_CONTROL: START_RECORDING
+        rec[3] = runCamCrc8(rec, 3);
+        uart_write_bytes(RUNCAM_UART_PORT, rec, sizeof(rec));
+        ESP_LOGI(TAG, "RunCam START_RECORDING sent (probe OK, feat 0x%04X)",
+                 runcam_features);
+    }
+    else
+    {
+        sendRunCamToggle();
+        ESP_LOGI(TAG, "RunCam record toggle sent (probe %s, no explicit-record feature)",
+                 alive ? "OK" : "no-reply");
+    }
     camera_start_phase = CameraStartPhase::Idle;
 }
 


### PR DESCRIPTION
## Summary
The RunCam never worked as intended because its pins were mis-assigned in `config.h` — and once that was corrected, the control logic needed two follow-on fixes. End result: the camera boots dark, records on the app's **Start**, and stops + powers down on **Stop**, reliably and repeatably. Resolves all three #234 findings.

## Root cause
`RUNCAM_TX_PIN` was assigned to **pin 32 — which is the camera power gate** (CAM_ACT → PMPB14XNX). A UART TX line idles HIGH, so the camera was powered on and auto-recording from boot, uncontrollably, while the firmware drove the real power pin as a dead GPIO. In effect the **TX and power assignments were swapped** (RX was coincidentally correct).

Confirmed against the board schematic and on the bench (`GET_DEVICE_INFO` now replies `cc 01 77 00 02`):

| signal | FC pin | was | now |
|---|---|---|---|
| camera power (CAM_ACT gate) | 32 | `RUNCAM_TX_PIN` (UART TX!) | `RUNCAM_PWR_PIN` |
| FC → Camera_RX (UART TX) | 30 | `RUNCAM_PWR_PIN` (dead GPIO) | `RUNCAM_TX_PIN` |
| FC ← Camera_TX (UART RX) | 31 | `RUNCAM_RX_PIN` ✓ | `RUNCAM_RX_PIN` ✓ |

(The UART orientation took a bench swap to settle — the schematic's `Camera_TX`/`Camera_RX` labels were ambiguous as to which FC side they meant.)

## How the three findings resolve
- **F1** — *records on power-up, app says off*: the UART-idle-high on the power gate is gone. Power is now a clean GPIO — off at boot (R42 holds the gate low), on only when commanded — so the app's recording state matches reality.
- **F2** — *ignores app commands*: the UART now actually reaches the camera (TX on `Camera_RX`) and the camera replies (RX from `Camera_TX`). Start issues the **explicit `START_RECORDING`** command — the camera advertises feature `0x40`, and the power-button toggle only blipped the LED without holding record. Deterministic, bench-verified each cycle.
- **F3** — *mid-flight shutoff*: root cause was *continuous recording from boot* (the camera could never be stopped) → thermal cutoff. It now records only when commanded and stops on command, so it's no longer recording through the entire prep + flight.

## Changes
- **`config.h`** — corrected the RunCam pin map (power 32, RX 31, TX 30); annotated the now-dead GoPro pins (`USE_GOPRO=false`).
- **`main.cpp`** — `serviceCameraStart` commands record start after the post-boot `GET_DEVICE_INFO` probe; chooses `START_RECORDING` when advertised (feature-gated via `runcam_features`), power-button toggle as fallback. Logic otherwise unchanged.

## Verification
- Builds clean (IDF v6.0).
- Bench: boots dark; Start → power on + holds recording; Stop → stops + powers down; repeatable across cycles. `GET_DEVICE_INFO` ALIVE (protocol v1, features `0x0077`).

## Follow-up (not blocking)
- F3's thermal behavior should be confirmed on the next flight. The *root cause* (uncontrolled continuous recording) is fixed; a long legitimate recording could still warrant heat-sinking — a separate hardware item if it recurs.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
