### PR TITLE
iOS fixes: restore build, direction arrow, map freeze + GNSS analyzer

### DIFF
--- a/Data_Analysis/analyze_bs_gnss.py
+++ b/Data_Analysis/analyze_bs_gnss.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Quantify 'bad' GNSS packets in a base-station CSV log.
+
+The base station logs one row per *received* LoRa packet:
+  time_ms,state,num_sats,pdop,lat,lon,alt_m,h_acc,...,rssi,snr,next_ch,rx_freq_mhz,seq,gap,event
+
+Position is blanked to NaN by the BS when num_sats==0 or ECEF is all-zero
+(base_station/main.cpp ~3242, #95). This script measures how often that
+happens and tries to explain it (pre-fix? corrupt link? anomaly?).
+
+Usage: python3 analyze_bs_gnss.py <base_station_log.csv>
+"""
+import sys, csv
+from collections import Counter
+
+def is_blank(v):
+    if v is None: return True
+    s = v.strip().lower()
+    return s in ("", "nan", "-nan", "inf", "-inf")
+
+def fnum(v):
+    try: return float(v)
+    except (TypeError, ValueError): return None
+
+def main(path):
+    rows = []
+    with open(path, newline="") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            # Skip EVENT rows (no telemetry payload) and malformed rows.
+            if row.get("state", "").strip().upper() == "EVENT":
+                continue
+            if is_blank(row.get("num_sats")):
+                continue
+            rows.append(row)
+
+    n = len(rows)
+    if n == 0:
+        print("No telemetry rows found."); return
+
+    sats = [int(float(x["num_sats"])) for x in rows]
+    lat_blank = [is_blank(x.get("lat")) for x in rows]
+    rssi = [fnum(x.get("rssi")) for x in rows]
+
+    zero_sat   = sum(1 for s in sats if s == 0)
+    pos_blank  = sum(1 for b in lat_blank if b)
+    # The anomaly to watch for: position blanked while sats look healthy.
+    anomaly = [(i, sats[i]) for i in range(n) if lat_blank[i] and sats[i] > 0]
+    # Expected: position blanked because there genuinely were 0 sats.
+    blank_zerosat = sum(1 for i in range(n) if lat_blank[i] and sats[i] == 0)
+
+    print(f"file: {path}")
+    print(f"total telemetry packets: {n}")
+    print()
+    print("=== num_sats ===")
+    print(f"  packets with num_sats == 0 : {zero_sat:5d}  ({100*zero_sat/n:.2f}%)")
+    print(f"  min / median / max sats    : {min(sats)} / {sorted(sats)[n//2]} / {max(sats)}")
+    hist = Counter(sats)
+    print("  histogram (sats: count):")
+    for s in sorted(hist):
+        bar = "#" * min(60, hist[s])
+        print(f"    {s:3d}: {hist[s]:5d} {bar}")
+    print()
+    print("=== blanked position (lat == nan) ===")
+    print(f"  total blanked              : {pos_blank:5d}  ({100*pos_blank/n:.2f}%)")
+    print(f"  blanked WITH 0 sats (exp.) : {blank_zerosat:5d}")
+    print(f"  blanked WITH >0 sats (!!)  : {len(anomaly):5d}   <-- anomaly: sats look fine but no position")
+    if anomaly:
+        print(f"     example (row#, sats): {anomaly[:10]}")
+    print()
+
+    # Where do the bad packets sit? Front-loaded (pre-fix warmup) or scattered?
+    bad_idx = [i for i in range(n) if lat_blank[i]]
+    if bad_idx:
+        first_good = next((i for i in range(n) if not lat_blank[i]), None)
+        after_first_good = sum(1 for i in bad_idx if first_good is not None and i > first_good)
+        print("=== distribution ===")
+        print(f"  first valid-position packet at row: {first_good}")
+        print(f"  blanked packets AFTER first good fix: {after_first_good}  "
+              f"(pre-fix warmup explains {pos_blank - after_first_good})")
+        good_rssi = [rssi[i] for i in range(n) if not lat_blank[i] and rssi[i] is not None]
+        badf_rssi = [rssi[i] for i in bad_idx if first_good is not None and i > first_good and rssi[i] is not None]
+        if good_rssi and badf_rssi:
+            print(f"  mean RSSI  good={sum(good_rssi)/len(good_rssi):.1f}  "
+                  f"bad-after-fix={sum(badf_rssi)/len(badf_rssi):.1f}  "
+                  f"(much weaker bad => LoRa corruption)")
+    print()
+
+    # Dropped LoRa packets via sequence gaps (separate from blanked position).
+    seqs = [int(float(x["seq"])) for x in rows if not is_blank(x.get("seq"))]
+    if len(seqs) > 1:
+        drops = sum(max(0, seqs[i+1]-seqs[i]-1) for i in range(len(seqs)-1)
+                    if seqs[i+1] >= seqs[i])
+        print("=== LoRa link ===")
+        print(f"  seq range {min(seqs)}..{max(seqs)}, received {len(seqs)}, "
+              f"missing (seq gaps) ~{drops}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__); sys.exit(1)
+    main(sys.argv[1])

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -99,6 +99,8 @@ struct RocketConfig {
     var useAngleControl: Bool = false
     var rollDelayMs: UInt16 = 0
     var rateCapDps: Float = 60
+    var kpAngle: Float = 2.0               // outer angle-loop P-gain (cascaded angle control)
+    var integralSepThreshold: Float = 40   // PID integral-separation anti-windup threshold (deg/s); 0 disables
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2
     var imuOrientSetting: UInt8? = nil   // 0xFF auto / 0..23 manual (nil = not reported)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -388,7 +388,8 @@ struct ConnectedDashboardView: View {
                 telemetry: device.telemetry,
                 bleRSSI: device.connectedRSSI,
                 isBaseStation: device.isBaseStation,
-                locationManager: device.isBaseStation ? locationManager : nil
+                locationManager: device.isBaseStation ? locationManager : nil,
+                rocketFix: device.isBaseStation ? device.lastValidRocketFix : nil
             )
 
             // BatteryView shows BS battery (always live) + rocket battery.
@@ -2031,6 +2032,7 @@ struct SignalStrengthView: View {
     let bleRSSI: Int?
     let isBaseStation: Bool
     var locationManager: LocationManager? = nil
+    var rocketFix: LastValidRocketFix? = nil
     @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
 
     var body: some View {
@@ -2039,20 +2041,22 @@ struct SignalStrengthView: View {
                 .font(.headline)
 
             HStack(spacing: 30) {
-                // Direction arrow (base station only)
+                // Direction arrow (base station only). Uses the latched
+                // lastValidRocketFix (same source as MapView) rather than
+                // telemetry.latitude — relay frames frequently arrive with
+                // lat/lon = nil (#140), so reading the live frame left the
+                // arrow blank on almost every render.
                 if isBaseStation, let locMgr = locationManager,
-                   let rocketLat = telemetry.latitude,
-                   let rocketLon = telemetry.longitude,
-                   !rocketLat.isNaN && !rocketLon.isNaN,
+                   let fix = rocketFix,
                    let phoneLoc = locMgr.userLocation {
 
                     let dist = LocationManager.haversineDistance(
                         lat1: phoneLoc.latitude, lon1: phoneLoc.longitude,
-                        lat2: rocketLat, lon2: rocketLon
+                        lat2: fix.latitude, lon2: fix.longitude
                     )
                     let bear = LocationManager.bearing(
                         lat1: phoneLoc.latitude, lon1: phoneLoc.longitude,
-                        lat2: rocketLat, lon2: rocketLon
+                        lat2: fix.latitude, lon2: fix.longitude
                     )
                     let arrowAngle = bear - locMgr.heading
 
@@ -2075,6 +2079,22 @@ struct SignalStrengthView: View {
                             .font(.system(.caption, design: .monospaced))
                             .foregroundColor(.primary)
 
+                        Text("Rocket")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                } else if isBaseStation, let locMgr = locationManager {
+                    // Say why the arrow is hidden instead of showing nothing:
+                    // distinguishes "phone has no fix yet" from "rocket has no
+                    // latched GPS fix yet".
+                    VStack(spacing: 6) {
+                        Image(systemName: "location.slash")
+                            .font(.system(size: 44))
+                            .foregroundColor(.secondary)
+                        Text(locMgr.userLocation == nil ? "No phone GPS" : "Waiting for\nrocket fix")
+                            .font(.caption2)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(.secondary)
                         Text("Rocket")
                             .font(.caption2)
                             .foregroundColor(.secondary)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -206,6 +206,16 @@ struct DashboardView: View {
             fleet.activeDevice?.flightAnnouncer = flightAnnouncer
             if fleet.isConnected, let dev = fleet.activeDevice {
                 syncer.attach(device: dev, store: profileStore)
+                // Already-connected case: .onChange(of: fleet.isConnected) only
+                // fires on a *transition*, so when the dashboard appears with a
+                // live base-station link already up (auto-reconnect, app relaunch,
+                // or connected on another screen) location updates were never
+                // started — leaving the direction-to-rocket arrow blank despite a
+                // good rocket GNSS fix. Start them here too, matching the onChange
+                // path and DriftCastView's onAppear.
+                if dev.isBaseStation {
+                    locationManager.startUpdates()
+                }
             }
         }
         .onChange(of: fleet.isConnected) { connected in

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -206,16 +206,6 @@ struct DashboardView: View {
             fleet.activeDevice?.flightAnnouncer = flightAnnouncer
             if fleet.isConnected, let dev = fleet.activeDevice {
                 syncer.attach(device: dev, store: profileStore)
-                // Already-connected case: .onChange(of: fleet.isConnected) only
-                // fires on a *transition*, so when the dashboard appears with a
-                // live base-station link already up (auto-reconnect, app relaunch,
-                // or connected on another screen) location updates were never
-                // started — leaving the direction-to-rocket arrow blank despite a
-                // good rocket GNSS fix. Start them here too, matching the onChange
-                // path and DriftCastView's onAppear.
-                if dev.isBaseStation {
-                    locationManager.startUpdates()
-                }
             }
         }
         .onChange(of: fleet.isConnected) { connected in
@@ -230,11 +220,9 @@ struct DashboardView: View {
             if !connected && !fleet.isScanning {
                 fleet.startScanning()
             }
-            if connected, let dev = fleet.activeDevice, dev.isBaseStation {
-                locationManager.startUpdates()
-            } else if !connected {
-                locationManager.stopUpdates()
-            }
+            // Phone-location lifecycle is driven from ConnectedDashboardView,
+            // which observes the device — fleet.isConnected flips before the
+            // device's type resolves, so it's the wrong signal to gate on here.
         }
         .sheet(item: $activeSheet) { sheet in
             Group {
@@ -304,6 +292,18 @@ struct ConnectedDashboardView: View {
     var body: some View {
         // Active rocket profile summary + sync status (#132).
         ActiveRocketHeader(device: device)
+            // Phone-location lifecycle lives here, on the view that actually
+            // @ObservedObject's the device. deviceType (→ isBaseStation) resolves
+            // a beat after connect, and BLEFleet doesn't forward child-device
+            // changes, so the outer DashboardView never sees it. Start phone GPS
+            // once the active device identifies as a base station; stop otherwise
+            // and on teardown (disconnect / leaving the dashboard).
+            .onAppear { if device.isBaseStation { locationManager.startUpdates() } }
+            .onChange(of: device.isBaseStation) { isBaseStation in
+                if isBaseStation { locationManager.startUpdates() }
+                else { locationManager.stopUpdates() }
+            }
+            .onDisappear { locationManager.stopUpdates() }
 
         // Device chip bar (multi-device) or simple status (single device)
         if fleet.devices.count > 1 {
@@ -2084,19 +2084,16 @@ struct SignalStrengthView: View {
                             .foregroundColor(.secondary)
                     }
                 } else if isBaseStation, let locMgr = locationManager {
-                    // Say why the arrow is hidden instead of showing nothing:
-                    // distinguishes "phone has no fix yet" from "rocket has no
-                    // latched GPS fix yet".
+                    // Say why the arrow is hidden instead of showing nothing.
+                    // "phone" = app hasn't received a phone location yet (NOT a
+                    // signal-quality problem); "rocket" = no GPS fix latched yet.
                     VStack(spacing: 6) {
                         Image(systemName: "location.slash")
                             .font(.system(size: 44))
                             .foregroundColor(.secondary)
-                        Text(locMgr.userLocation == nil ? "No phone GPS" : "Waiting for\nrocket fix")
+                        Text(locMgr.userLocation == nil ? "Getting phone\nlocation…" : "Waiting for\nrocket GPS")
                             .font(.caption2)
                             .multilineTextAlignment(.center)
-                            .foregroundColor(.secondary)
-                        Text("Rocket")
-                            .font(.caption2)
                             .foregroundColor(.secondary)
                     }
                 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift
@@ -79,7 +79,10 @@ struct RocketMapView: UIViewRepresentable {
         let centerDelta = abs(mapView.region.center.latitude - region.center.latitude) +
                           abs(mapView.region.center.longitude - region.center.longitude)
         if centerDelta > 0.0001 && !context.coordinator.userIsInteracting {
-            mapView.setRegion(region, animated: true)
+            // Snap large jumps (e.g. the first center from the default location
+            // to the rocket); an animated cross-region setRegion streams tiles
+            // along the whole path and visibly hitches. Animate small re-centers.
+            mapView.setRegion(region, animated: centerDelta < 1.0)
         }
     }
 
@@ -110,8 +113,16 @@ struct RocketMapView: UIViewRepresentable {
         }
 
         func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
-            parent.region = mapView.region
             userIsInteracting = false
+            // Defer the binding write to the next runloop so we never mutate
+            // SwiftUI state during a view-update pass. updateUIView calls
+            // setRegion(), which feeds back here; writing parent.region inline
+            // triggers "Modifying state during view update" and a re-render
+            // churn that freezes the map. Async breaks the cycle while still
+            // tracking the map (so user pans aren't snapped back).
+            DispatchQueue.main.async { [weak self] in
+                self?.parent.region = mapView.region
+            }
         }
 
         func mapView(_ mapView: MKMapView,


### PR DESCRIPTION
Batch of fixes from a bench-testing session. Restores the iOS build (main is currently red for iOS) and fixes the rocket-direction arrow and a map freeze.

## Changes

- **Restore iOS build** — the roll-control merge (`66053b4`) added `kpAngle`/`integralSepThreshold` to `RocketProfile`, `SettingsView`, `ActiveRocketSyncer`, and `BLEDevice`, but not to the `RocketConfig` struct they assign to, so the app no longer compiled. Adds the two fields (defaults 2.0 / 40). `ios-tests.yml` has been red on main since that merge.
- **Direction-to-rocket arrow** now shows on a base-station connection:
  - Phone location is started from `ConnectedDashboardView` (which `@ObservedObject`s the device) instead of the outer `DashboardView` — `fleet.isConnected` flips before the device type resolves, and the fleet doesn't forward child-device changes, so `startUpdates()` was effectively never called.
  - Arrow reads the latched `lastValidRocketFix` (same source as the map) instead of per-frame `telemetry.latitude`, which can be nil on relay frames.
  - Adds a placeholder ("Getting phone location…" / "Waiting for rocket GPS") when the arrow can't render, instead of showing nothing.
- **Map freeze on open** — defers the coordinator's region write-back (it was mutating SwiftUI state during a view-update pass → "Modifying state during view update" + re-render churn), and snaps large region jumps instead of an animated cross-region `setRegion` that streamed tiles the whole way.
- **Tooling** — `Data_Analysis/analyze_bs_gnss.py` quantifies bad / 0-sat GNSS packets from a base-station CSV. A bench sample measured 0 bad packets, confirming 0-sat frames shouldn't occur with a healthy fix.

## Still open

Live read-back of the new roll gains through the OC + base-station firmware remains a separate task — see #253.

## Testing

- `xcodebuild build` clean for iphonesimulator.
- Bench-verified on device: arrow points at the rocket with distance; map opens without freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
