### PR TITLE
fc(recovery): decouple burnout/apogee detection from servo_enabled (#256)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -265,11 +265,15 @@ target_include_directories(test_bs_log_policy PRIVATE
 target_link_libraries(test_bs_log_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_log_policy)
 
-# ---------- test_burnout_detector (#197) ----------
-# Hysteresis-based burnout detector lives inline in
-# flight_computer/main/main.cpp; test reimplements the small state
-# machine and asserts behavior matches spec. See test file header.
+# ---------- test_burnout_detector (#197/#256) ----------
+# Detector logic is shared with the firmware via
+# components/TR_KinematicChecks/BurnoutDetector.h — the test exercises the
+# real code, not a mirror.
 add_executable(test_burnout_detector test_burnout_detector.cpp)
+target_include_directories(test_burnout_detector PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_KinematicChecks
+)
 target_link_libraries(test_burnout_detector GTest::gtest_main)
 gtest_discover_tests(test_burnout_detector)
 

--- a/tests_cpp/test_burnout_detector.cpp
+++ b/tests_cpp/test_burnout_detector.cpp
@@ -1,40 +1,33 @@
-// Tests for the burnout-detector hysteresis added in #197.
-//
-// The detector itself lives inline in the flight_computer main loop at
-// tinkerrocket-idf/projects/flight_computer/main/main.cpp:3860 (search
-// for "Burnout detection").  Extracting the logic to a shared component
-// is a deliberate follow-up — for now this test reimplements the small
-// state machine and verifies it matches the spec.  If main.cpp diverges
-// from this reference, this test will pass while the firmware is wrong;
-// the next refactor should consolidate to a single source of truth.
+// Tests for the post-launch burnout-detector hysteresis (#197), exercising the
+// REAL firmware logic in
+// tinkerrocket-idf/components/TR_KinematicChecks/BurnoutDetector.h (no longer a
+// hand-copied mirror).  The flight loop calls the same tr::burnoutDetectStep()
+// unconditionally — independent of roll/servo control (#256) — so these tests
+// are the single source of truth for the detector's behavior.
 
 #include <gtest/gtest.h>
 #include <cstdint>
+#include "BurnoutDetector.h"
 
 namespace {
 
 // Mirror of config::BURNOUT_NEG_HYSTERESIS in
 // tinkerrocket-idf/projects/flight_computer/main/config.h.
 constexpr uint16_t BURNOUT_NEG_HYSTERESIS = 50;
-// 200 ms launch lockout — pre-existing, unchanged by #197.
-constexpr uint32_t LAUNCH_LOCKOUT_MS = 200;
+// 200 ms launch lockout, owned by BurnoutDetector.h.
+constexpr uint32_t LAUNCH_LOCKOUT_MS = tr::kBurnoutLaunchLockoutMs;
 
+// Thin test wrapper over the real detector step so the existing cases read
+// unchanged; fired_at_ms is captured from the single rising-edge return.
 struct BurnoutDetector {
     bool     detected  = false;
     uint16_t neg_count = 0;
     uint32_t fired_at_ms = 0;
 
-    // Mirror of the inline detector at main.cpp:3860.
     void update(float body_ax, uint32_t t_since_launch_ms) {
-        if (detected) return;
-        if (t_since_launch_ms <= LAUNCH_LOCKOUT_MS) return;
-        if (body_ax < 0.0f) {
-            if (++neg_count >= BURNOUT_NEG_HYSTERESIS) {
-                detected = true;
-                fired_at_ms = t_since_launch_ms;
-            }
-        } else {
-            neg_count = 0;
+        if (tr::burnoutDetectStep(detected, neg_count, body_ax,
+                                  t_since_launch_ms, BURNOUT_NEG_HYSTERESIS)) {
+            fired_at_ms = t_since_launch_ms;
         }
     }
 };
@@ -146,4 +139,28 @@ TEST(BurnoutDetector, RIM66Profile_FiresAtRealCutoff) {
     EXPECT_TRUE(kd.detected);
     // Fire time should be at sample-50 of the negative run.
     EXPECT_EQ(kd.fired_at_ms, 250 + 2000 + BURNOUT_NEG_HYSTERESIS - 1);
+}
+
+// #256 regression: burnout detection must depend ONLY on the IMU sample and
+// time-since-launch — never on roll/servo control state.  The shared step
+// function takes no control-mode input, so a flight with roll control disabled
+// detects burnout byte-identically to one with it enabled.  (In the firmware
+// tr::burnoutDetectStep() is called above `if (servo_enabled)`; apogee + pyro
+// recovery depend on the burnout it latches — so gating it behind servo
+// control silently disables recovery.)
+TEST(BurnoutDetector, Issue256_DetectionIndependentOfControlMode) {
+    auto run_to_burnout = []() {
+        BurnoutDetector kd;
+        uint32_t t = 250;  // past lockout
+        for (int i = 0; i < 2000; ++i, ++t) kd.update(75.0f, t);                    // boost
+        for (int i = 0; i < BURNOUT_NEG_HYSTERESIS; ++i, ++t) kd.update(-7.0f, t);  // cutoff
+        return kd;
+    };
+    // Two notional flights with identical IMU history — e.g. servos enabled vs
+    // disabled — must reach identical detector state.
+    BurnoutDetector roll_on  = run_to_burnout();
+    BurnoutDetector roll_off = run_to_burnout();
+    EXPECT_TRUE(roll_on.detected);
+    EXPECT_TRUE(roll_off.detected);
+    EXPECT_EQ(roll_on.fired_at_ms, roll_off.fired_at_ms);
 }

--- a/tinkerrocket-idf/components/TR_KinematicChecks/BurnoutDetector.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/BurnoutDetector.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+
+// Single source of truth for the post-launch burnout (motor-cutoff) detector
+// (#197).  Pure, dependency-free logic so the host unit test
+// (tests_cpp/test_burnout_detector.cpp) exercises the *real* firmware code
+// instead of a hand-copied mirror that can silently diverge.
+//
+// #256: burnout detection MUST run independently of roll/servo control.
+// Apogee detection (TR_KinematicChecks) is gated on burnout_detected, and
+// drogue/main deployment is gated on apogee — so if this step is ever skipped
+// (e.g. trapped behind `if (servo_enabled)`), recovery silently never fires.
+// Callers must invoke it from the flight loop unconditionally.
+
+namespace tr {
+
+// Post-launch lockout: ignore the first 200 ms so boost vibration / pad
+// transients can't trip the detector.  Strictly-greater comparison, i.e.
+// t == 200 ms is still locked out, t == 201 ms is live.
+inline constexpr uint32_t kBurnoutLaunchLockoutMs = 200;
+
+// Advance the burnout detector by one IMU sample.
+//
+//   detected, neg_count : caller-owned latching state (persist across calls).
+//   body_ax_mps2        : forward-axis (FRD body-X) specific force; goes
+//                         negative once the motor stops thrusting.
+//   t_since_launch_ms   : milliseconds since launch was latched.
+//   neg_hysteresis      : consecutive negative samples required to latch
+//                         (config::BURNOUT_NEG_HYSTERESIS).
+//
+// Returns true exactly once — on the rising edge that latches burnout — so the
+// caller can stamp the burnout time and log.  Once `detected` is true the
+// function is a no-op and returns false.
+inline bool burnoutDetectStep(bool& detected, uint16_t& neg_count,
+                              float body_ax_mps2, uint32_t t_since_launch_ms,
+                              uint16_t neg_hysteresis)
+{
+    if (detected) return false;
+    if (t_since_launch_ms <= kBurnoutLaunchLockoutMs) return false;
+    if (body_ax_mps2 < 0.0f) {
+        if (++neg_count >= neg_hysteresis) {
+            detected = true;
+            return true;
+        }
+    } else {
+        neg_count = 0;
+    }
+    return false;
+}
+
+} // namespace tr

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -13,6 +13,7 @@
 #include <TR_GpsInsEKF.h>
 #include <TR_GeoMag.h>
 #include <TR_KinematicChecks.h>
+#include <BurnoutDetector.h>      // shared burnout detector (#197/#256)
 #include <TR_MagCalibrator.h>
 #include <TR_ServoControl_ledc_mult.h>
 #include <TR_GuidancePN.h>
@@ -5057,10 +5058,33 @@ static void loop_fc()
                     ESP_LOGI(TAG, "[RECOVERY] Servo settle complete, control resumed");
                 }
 
+                // --- Burnout detection — runs independently of servo/roll
+                // control (#256) ---
+                // Apogee detection (TR_KinematicChecks) is gated on
+                // burnout_detected, and drogue/main deployment is gated on
+                // apogee, so this MUST NOT live inside `if (servo_enabled)` —
+                // otherwise recovery silently never fires when roll control is
+                // disabled.  Hoisted above the servo block (and ahead of the
+                // roll-delay branch, so a non-zero ROLL_CONTROL_DELAY_MS can't
+                // suppress it either).  Body-X accel (forward axis in FRD) goes
+                // negative after motor burnout; the 200 ms lockout + N-sample
+                // hysteresis (#197) reject boost vibration.  Logic is shared
+                // with the host unit test via BurnoutDetector.h.
+                const uint32_t t_since_launch_ms = now_ms - launch_time_millis;
+                if (have_ism6_si &&
+                    tr::burnoutDetectStep(burnout_detected, burnout_neg_count,
+                                          ism6_latest_si.low_g_acc_x,
+                                          t_since_launch_ms,
+                                          config::BURNOUT_NEG_HYSTERESIS))
+                {
+                    burnout_time_ms = now_ms;
+                    ESP_LOGI(TAG, "[GUID] Burnout detected at T+%lu ms",
+                                  (unsigned long)t_since_launch_ms);
+                }
+
                 if (servo_enabled)
                 {
                     // Delay roll control activation after launch if configured
-                    const uint32_t t_since_launch_ms = now_ms - launch_time_millis;
                     if (reboot_recovery || t_since_launch_ms < roll_delay_ms)
                     {
                         // Hold fins neutral until delay/settle elapses
@@ -5071,31 +5095,6 @@ static void loop_fc()
                         float speed = sqrtf(imu_vel[0]*imu_vel[0] +
                                             imu_vel[1]*imu_vel[1] +
                                             imu_vel[2]*imu_vel[2]);
-
-                        // --- Burnout detection ---
-                        // Body-X accel (forward axis in FRD) goes negative when
-                        // decelerating after motor burnout.  Wait at least 200ms
-                        // after launch to avoid false triggers from vibration.
-                        // Require N consecutive negative samples (#197) so a
-                        // single vibration cycle or wind gust can't trip it.
-                        if (!burnout_detected && t_since_launch_ms > 200)
-                        {
-                            float body_ax = ism6_latest_si.low_g_acc_x;
-                            if (body_ax < 0.0f)
-                            {
-                                if (++burnout_neg_count >= config::BURNOUT_NEG_HYSTERESIS)
-                                {
-                                    burnout_detected = true;
-                                    burnout_time_ms = now_ms;
-                                    ESP_LOGI(TAG, "[GUID] Burnout detected at T+%lu ms",
-                                                  (unsigned long)t_since_launch_ms);
-                                }
-                            }
-                            else
-                            {
-                                burnout_neg_count = 0;
-                            }
-                        }
 
                         // --- Guided coast mode (PN guidance) ---
                         // Active only during coast when guidance is enabled and EKF is valid.


### PR DESCRIPTION
## Problem
With roll/servo control disabled (`servo_enabled == false`), the flight computer would **silently never fire any pyro charge** — drogue or main — and go ballistic. `servo_enabled` goes false when the app sends `SERVO_CTRL_DISABLE` or when servo pins aren't configured; it's NVS-persisted and defaults to `USE_SERVO_CONTROL = true`, which is what masked this.

## Root cause
Burnout detection was nested inside the INFLIGHT `if (servo_enabled)` block, so `burnout_detected` never latched with control off. Apogee detection (`TR_KinematicChecks`) gates on `burnout_detected`, and drogue/main deployment gates on apogee — so the whole recovery chain was transitively gated on servo control.

The coupling was **incidental, not an intended interlock**: the `[GUID]`-tagged detector was authored as a guidance concern (coast/PN guidance begins at burnout) and lived in the guidance block; the recovery path later took a dependency on its output and inherited the gate. Audited all 21 `servo_enabled` uses — this was the only non-servo logic trapped behind the flag (e.g. `pyroSafeAll()`/`clearFlightSnapshot()` at LANDED and `kinematics.reset()` at MAG_CAL already sit outside their `servo_enabled` guards).

## Fix
- **Hoist** burnout detection above `if (servo_enabled)` (it only reads the accelerometer). This also moves it ahead of the roll-delay branch, so a non-zero `ROLL_CONTROL_DELAY_MS` can no longer suppress it either (a second latent coupling).
- **Factor** the detector into `TR_KinematicChecks/BurnoutDetector.h` (`tr::burnoutDetectStep`) as a single source of truth shared by firmware and host test. `test_burnout_detector.cpp` previously reimplemented a hand-copied "mirror" that — per its own comment — "will pass while the firmware is wrong"; it now exercises the real code.
- Add `Issue256_DetectionIndependentOfControlMode` regression test.

## Verification
- Host gtest: **10/10** — the 9 existing cases now run against the shared detector (proving the factoring is behavior-identical), plus the new #256 case.
- `flight_computer` builds clean on **IDF v6 / esp32p4**.

## Pre-flight bench check (recommended)
SIL/sim flight with `servo_en=false` in NVS → confirm pyro still fires.

Closes #256. Part of the pre-flight review tracking issue #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
