### PR TITLE
fc(apogee): health-aware adaptive quorum + baro descent backstop (#257)

### DIFF
--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -309,6 +309,29 @@ TEST_F(EKFTest, Quat2Euler_KnownAngles) {
     EXPECT_NEAR(orient[1], 0.0f, 0.2f); // pitch
 }
 
+// ── #257/#265: EKF health signal (isHealthy) ──
+TEST_F(EKFTest, IsHealthy_TrueWhenConverged) {
+    ekf.init(makeStationaryIMU(0), makeStationaryGNSS(0), makeStationaryMag(0));
+    for (uint32_t i = 1; i <= 50; ++i) {
+        uint32_t t = i * 2000;  // 2 ms steps
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+    EXPECT_TRUE(ekf.isHealthy());
+}
+
+// A non-finite IMU sample drives the quaternion to NaN; isHealthy() must report
+// the filter unhealthy so #257 excludes the EKF voters (and #265 stows the fins).
+TEST_F(EKFTest, IsHealthy_FalseOnNonFiniteInput) {
+    ekf.init(makeStationaryIMU(0), makeStationaryGNSS(0), makeStationaryMag(0));
+    ekf.update(true, makeStationaryIMU(2000), makeStationaryGNSS(2000), makeStationaryMag(2000));
+    ASSERT_TRUE(ekf.isHealthy());   // healthy before the fault
+
+    EkfIMUData bad = makeStationaryIMU(4000);
+    bad.gyro_x = NAN;               // non-finite gyro → quaternion propagates to NaN
+    ekf.update(true, bad, makeStationaryGNSS(4000), makeStationaryMag(4000));
+    EXPECT_FALSE(ekf.isHealthy()) << "EKF must report unhealthy after a non-finite update";
+}
+
 TEST_F(EKFTest, LargeTimestepStability) {
     ekf.init(makeStationaryIMU(0), makeStationaryGNSS(0), makeStationaryMag(0));
 

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -24,11 +24,11 @@ protected:
     void callFlight(float alt, float acc_mag, float vel_u, float roll_rate = 0.0f,
                     float gps_alt = 0.0f, bool new_gps = false,
                     float pitch_rad = 1.57f, bool burnout = false, bool baro_lockout = false,
-                    float gps_vel_u = 0.0f) {
+                    float gps_vel_u = 0.0f, bool ekf_healthy = true, bool baro_healthy = true) {
         float pos[3] = {0, 0, alt};
         float vel[3] = {0, 0, vel_u};
         kc.kinematicChecks(alt, acc_mag, pos, vel, roll_rate, true, gps_alt, new_gps,
-                           pitch_rad, burnout, baro_lockout, gps_vel_u);
+                           pitch_rad, burnout, baro_lockout, gps_vel_u, ekf_healthy, baro_healthy);
     }
 };
 
@@ -242,6 +242,7 @@ TEST_F(KinematicChecksTest, Reset_ClearsAll) {
     EXPECT_FALSE(kc.gps_apogee_flag);
     EXPECT_FALSE(kc.pitch_apogee_flag);
     EXPECT_FALSE(kc.apogee_flag);
+    EXPECT_FALSE(kc.apogee_backstop_flag);
     EXPECT_FLOAT_EQ(kc.max_altitude, 0.0f);
     EXPECT_FLOAT_EQ(kc.max_speed, 0.0f);
 }
@@ -402,4 +403,96 @@ TEST_F(KinematicChecksTest, Landing_SubflagsResetOnApogeeRisingEdge) {
         << "gps_stationary_flag should reset on apogee rising edge";
     EXPECT_FALSE(kc.baro_stable_flag)
         << "baro_stable_flag should reset on apogee rising edge";
+}
+
+// ── #257: health-aware adaptive quorum + Layer-2 baro descent backstop ──
+
+// EKF demonstrably unhealthy → velocity + pitch voters excluded, so the primary
+// vote is starved.  A healthy baro that has dropped > APOGEE_BACKSTOP_DROP_M
+// (30 m) below the peak while descending must still fire apogee via Layer 2 —
+// the rocket must not come in ballistic just because the EKF died.
+TEST_F(KinematicChecksTest, Apogee_EKFUnhealthy_BaroBackstopFires) {
+    kc.launch_flag = true;
+
+    // Seed the baro KF at a 140 m apogee, then pin the running peak.
+    for (int i = 0; i < 250; i++) {
+        setMockMillis(i * 2);
+        callFlight(140.0f, 9.81f, 0.0f, 0.0f, 0.0f, false, 1.0f, true);
+    }
+    ASSERT_GT(kc.alt_est, 130.0f);     // KF converged near the apogee
+    kc.max_altitude = 140.0f;
+
+    // Descend ~0.5 m/call (inside the baro rate-gate) with the EKF UNHEALTHY
+    // and baro healthy.  The backstop must stay silent until > 30 m below the
+    // peak, then latch apogee.
+    uint32_t t = 600;
+    float alt = 140.0f;
+    bool fired_too_high = false;
+    for (int i = 0; i < 160; i++, t += 2) {
+        alt -= 0.5f;
+        setMockMillis(t);
+        callFlight(alt, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f, true,
+                   false, 0.0f, /*ekf_healthy=*/false, /*baro_healthy=*/true);
+        if (kc.apogee_flag && (140.0f - kc.alt_est) < 28.0f) fired_too_high = true;
+    }
+    EXPECT_TRUE(kc.apogee_flag)          << "backstop should fire once > 30 m below peak";
+    EXPECT_TRUE(kc.apogee_backstop_flag) << "Layer-2 backstop should be the firing path";
+    EXPECT_FALSE(fired_too_high)         << "backstop must not fire < 30 m below the peak";
+}
+
+// False-positive guard: the EKF flagged unhealthy DURING ascent must not fire
+// apogee.  The vote is starved and the backstop stays silent because altitude
+// is rising (never 30 m below the peak).
+TEST_F(KinematicChecksTest, Apogee_NoFalsePositive_AscentWithUnhealthyEKF) {
+    for (int i = 0; i < 80; i++) {                       // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 250; i++) {                      // long ascent, worst case
+        setMockMillis(200 + i * 2);
+        callFlight(40.0f + i * 1.0f, 5.0f, 10.0f, 0.0f, 0.0f, false, 1.0f, true,
+                   false, 0.0f, /*ekf_healthy=*/false, /*baro_healthy=*/true);
+    }
+    EXPECT_FALSE(kc.apogee_flag)          << "no apogee during ascent even with EKF unhealthy";
+    EXPECT_FALSE(kc.apogee_backstop_flag);
+}
+
+// Baro flagged unhealthy → excluded; a healthy EKF (velocity + pitch) must
+// still carry the vote (floor of 2 = both EKF voters).  This is the
+// mach-lockout-equivalent path, now also reachable on a baro fault.
+TEST_F(KinematicChecksTest, Apogee_BaroUnhealthy_EKFVotersCarry) {
+    for (int i = 0; i < 80; i++) {                       // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 50; i++) {                       // ascent, burnout latches
+        setMockMillis(200 + i * 2);
+        callFlight(80.0f + i, 5.0f, 10.0f, 0.0f, 0.0f, false, 1.0f, true);
+    }
+    for (int i = 0; i < 40; i++) {                       // descent, baro UNHEALTHY
+        setMockMillis(300 + i * 2);
+        callFlight(130.0f - i * 2, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f, true,
+                   false, 0.0f, /*ekf_healthy=*/true, /*baro_healthy=*/false);
+    }
+    EXPECT_TRUE(kc.apogee_flag)           << "EKF vel+pitch should carry when baro unhealthy";
+    EXPECT_FALSE(kc.apogee_backstop_flag) << "primary vote fired, not the backstop";
+}
+
+// With NO healthy sensor there is nothing to detect apogee from, so apogee
+// stays false (documented blind case — beyond recovery's reach).
+TEST_F(KinematicChecksTest, Apogee_BothUnhealthy_NoFire) {
+    for (int i = 0; i < 80; i++) {                       // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 120; i++) {                      // descend, both unhealthy
+        setMockMillis(200 + i * 2);
+        callFlight(130.0f - i, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f, true,
+                   false, 0.0f, /*ekf_healthy=*/false, /*baro_healthy=*/false);
+    }
+    EXPECT_FALSE(kc.apogee_flag);
+    EXPECT_FALSE(kc.apogee_backstop_flag);
 }

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -260,6 +260,9 @@ void GpsInsEKF::update(bool use_ahrs_acc,
 // ─── Time Update (prediction) ───────────────────────────────────────
 
 void GpsInsEKF::timeUpdate() {
+    // #257/#265: age out the post-divergence unhealthy window one sample/cycle.
+    if (unhealthy_cooldown_ > 0) unhealthy_cooldown_--;
+
     // Compute DCM from current (pre-propagation) quaternion
     float T_NED2B[3][3];
     Quat2DCM(T_NED2B, quat_BL_);
@@ -516,8 +519,15 @@ void GpsInsEKF::stabilizeP() {
         P_MAX_ABIAS, P_MAX_ABIAS, P_MAX_ABIAS,
         P_MAX_GBIAS, P_MAX_GBIAS, P_MAX_GBIAS
     };
+    // Cooldown (in timeUpdate cycles) for which isHealthy() reports the filter
+    // unhealthy after a genuine divergence, giving it time to re-converge before
+    // consumers (#257 apogee voters, #265 servo gate) trust it again.
+    constexpr uint16_t EKF_UNHEALTHY_COOLDOWN = 500;
     for (int i = 0; i < 15; i++) {
         if (!std::isfinite(P_[i][i]) || P_[i][i] < P_MIN_DIAG) {
+            // A non-finite covariance is a genuine divergence (vs a benign
+            // underflow below P_MIN_DIAG) — flag the filter unhealthy (#257/#265).
+            if (!std::isfinite(P_[i][i])) unhealthy_cooldown_ = EKF_UNHEALTHY_COOLDOWN;
             // Zero the whole row and column so correlation terms can't carry
             // NaN forward even if this diagonal was non-finite.
             for (int j = 0; j < 15; j++) { P_[i][j] = 0.0f; P_[j][i] = 0.0f; }

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -135,6 +135,17 @@ public:
     void getVelEst(float (&r)[3]) const { r[0]=vEst_NED_mps_[0]; r[1]=vEst_NED_mps_[1]; r[2]=vEst_NED_mps_[2]; }
     void getQuaternion(float (&r)[4]) const { r[0]=quat_BL_[0]; r[1]=quat_BL_[1]; r[2]=quat_BL_[2]; r[3]=quat_BL_[3]; }
 
+    /// EKF health for downstream consumers (#257 apogee voter exclusion, #265
+    /// servo-stow gate).  v1 signal: the quaternion + velocity estimate are
+    /// finite AND stabilizeP() has not had to repair a non-finite covariance
+    /// within the last divergence-cooldown window.  Conservative — covariance-
+    /// magnitude thresholds are deferred until tuned against flight logs.
+    bool isHealthy() const {
+        for (int i = 0; i < 4; ++i) if (!std::isfinite(quat_BL_[i]))      return false;
+        for (int i = 0; i < 3; ++i) if (!std::isfinite(vEst_NED_mps_[i])) return false;
+        return unhealthy_cooldown_ == 0;
+    }
+
     void getCovPos(float (&r)[3]) const { r[0]=P_[0][0]; r[1]=P_[1][1]; r[2]=P_[2][2]; }
     void getCovVel(float (&r)[3]) const { r[0]=P_[3][3]; r[1]=P_[4][4]; r[2]=P_[5][5]; }
     void getCovOrient(float (&r)[3]) const { r[0]=P_[6][6]; r[1]=P_[7][7]; r[2]=P_[8][8]; }
@@ -249,6 +260,11 @@ private:
     uint32_t timeWeekPrev_;
     uint32_t baroTimePrev_ = 0;
     float euler_BL_rad_[3];
+
+    // #257/#265 health: counts down (one per timeUpdate) after stabilizeP()
+    // repairs a non-finite covariance — a genuine divergence — keeping
+    // isHealthy() false while the filter re-converges.
+    uint16_t unhealthy_cooldown_ = 0;
 
     // Kalman matrices
     float quat_BL_[4];

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -36,6 +36,14 @@ constexpr uint8_t  GPS_APOGEE_COUNT_HI      = 4;
 // (#237/#242), so the old altitude-below-peak test fired wildly off.
 constexpr float    GPS_VEL_APOGEE_DESCENT_MPS = 1.0f;
 
+// Layer-2 apogee backstop (#257). When the primary vote can't reach quorum
+// (e.g. an unhealthy EKF leaves < 2 healthy voters), a healthy + mach-unlocked
+// baro that has dropped this far below the running peak while still descending
+// is unambiguously "past apogee", independent of the EKF/IMU.  Altitude-
+// relative (not time-based), so it is rocket-agnostic; ~30 m past apogee is
+// ~24 m/s, fine for a drogue.  Reuses the APOGEE_COUNT_HI/MAX debounce.
+constexpr float    APOGEE_BACKSTOP_DROP_M     = 30.0f;
+
 // Landing slow-detector hysteresis (#166). Slow detectors evaluate inside
 // the 1 Hz landing_check_dt gate, so HI=4 → 4 s to fire (matches the
 // original ``landing_checks > 4`` first-fire timing).
@@ -65,6 +73,7 @@ TR_KinematicChecks::TR_KinematicChecks()
     gps_apogee_flag = false;
     pitch_apogee_flag = false;
     apogee_flag = false;
+    apogee_backstop_flag = false;
     launch_count = 0;
     max_altitude = 0.0f;
     max_speed = 0.0f;
@@ -74,6 +83,7 @@ TR_KinematicChecks::TR_KinematicChecks()
     apogee_count = 0;
     vel_apogee_count_ = 0;
     pitch_apogee_count_ = 0;
+    backstop_descent_count_ = 0;
     impact_seen_count = 0;
     impact_flag = false;
     baro_stable_flag = false;
@@ -121,6 +131,7 @@ void TR_KinematicChecks::reset()
     gps_apogee_flag = false;
     pitch_apogee_flag = false;
     apogee_flag = false;
+    apogee_backstop_flag = false;
     launch_count = 0;
     max_altitude = 0.0f;
     max_speed = 0.0f;
@@ -129,6 +140,7 @@ void TR_KinematicChecks::reset()
     apogee_count = 0;
     vel_apogee_count_ = 0;
     pitch_apogee_count_ = 0;
+    backstop_descent_count_ = 0;
     impact_seen_count = 0;
     impact_flag = false;
     baro_stable_flag = false;
@@ -165,7 +177,9 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                                          float pitch_rad,
                                          bool  burnout_detected,
                                          bool  baro_locked_out,
-                                         float gps_vel_u)
+                                         float gps_vel_u,
+                                         bool  ekf_healthy,
+                                         bool  baro_healthy)
 {
     // Snapshot apogee_flag so the rising-edge reset below sees the
     // state *before* this tick's apogee voting fires (#192).
@@ -443,18 +457,29 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         if (pitch_apogee_count_ >= APOGEE_COUNT_HI)     pitch_apogee_flag = true;
         else if (pitch_apogee_count_ == 0)              pitch_apogee_flag = false;
 
-        // --- Dynamic N-1 of N voting (vel + baro + pitch; GPS excluded #237) ---
+        // --- Dynamic N-1 of N voting with health-aware quorum (#237/#257) ---
+        // Only HEALTHY voters count toward `available`, so a positively-faulted
+        // voter (dead baro, diverged EKF) no longer *raises* the bar via
+        // `available - 1` — the healthy voters become sufficient.  The
+        // `passed >= 2` floor is kept, so we never fire on fewer than two
+        // concurring voters during ascent.  Velocity and pitch are both
+        // EKF-derived, so an unhealthy EKF excludes BOTH (no double-counting a
+        // single sick filter).  With < 2 healthy voters the vote cannot fire —
+        // the Layer-2 baro backstop below covers that degraded case.
         if (!apogee_flag)
         {
             uint8_t available = 0;
             uint8_t passed = 0;
 
-            // Velocity — always available
-            available++;
-            if (vel_u_apogee_flag) passed++;
+            // Velocity (EKF) — available only when the EKF is healthy
+            if (ekf_healthy)
+            {
+                available++;
+                if (vel_u_apogee_flag) passed++;
+            }
 
-            // Baro — excluded during mach lockout
-            if (!baro_locked_out)
+            // Baro — excluded during mach lockout or when baro is unhealthy
+            if (!baro_locked_out && baro_healthy)
             {
                 available++;
                 if (alt_apogee_flag) passed++;
@@ -467,16 +492,47 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
             // still computed + logged as a diagnostic, just excluded from the
             // vote so it can't move pyro timing.
 
-            // Pitch — always available
-            available++;
-            if (pitch_apogee_flag) passed++;
+            // Pitch (EKF) — available only when the EKF is healthy
+            if (ekf_healthy)
+            {
+                available++;
+                if (pitch_apogee_flag) passed++;
+            }
 
-            // N-1 of N with minimum 2 confirmations required.
-            // 3 available → need 2.  2 available (mach lockout) → need 2.
+            // N-1 of N, floor of 2 concurring.  3 healthy → need 2; 2 healthy
+            // → need both; < 2 healthy → cannot fire (see Layer-2 backstop).
             if (available >= 2 && passed >= 2 && passed >= (available - 1))
             {
                 apogee_flag = true;
             }
+        }
+
+        // --- Layer 2: baro-only descent backstop (#257) ---
+        // Last-resort net for the degraded case where the primary vote cannot
+        // reach quorum (e.g. an unhealthy EKF leaves < 2 healthy voters).  A
+        // healthy, mach-unlocked baro that has fallen >= APOGEE_BACKSTOP_DROP_M
+        // below the running peak while still descending is unambiguously past
+        // apogee — a condition unreachable during a normal boost, so there is
+        // no false-positive exposure.  alt_est / d_alt_est_ come from the
+        // baro-only KF, so this still works with a dead EKF (and dead IMU).
+        // Latches apogee_flag exactly like the vote, enabling the full
+        // drogue + main sequence; apogee_backstop_flag records that Layer 2
+        // (not the vote) was the path that fired, for post-flight diagnostics.
+        if (baro_healthy && !baro_locked_out &&
+            alt_est > 15.0f &&
+            alt_est <= max_altitude - APOGEE_BACKSTOP_DROP_M &&
+            d_alt_est_ < 0.0f)
+        {
+            if (backstop_descent_count_ < APOGEE_COUNT_MAX) backstop_descent_count_++;
+        }
+        else if (backstop_descent_count_ > 0)
+        {
+            backstop_descent_count_--;
+        }
+        if (backstop_descent_count_ >= APOGEE_COUNT_HI && !apogee_flag)
+        {
+            apogee_flag = true;
+            apogee_backstop_flag = true;
         }
     } // end burnout gate
 

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -24,7 +24,9 @@ public:
                          float pitch_rad = 1.57f,
                          bool  burnout_detected = false,
                          bool  baro_locked_out = false,
-                         float gps_vel_u = 0.0f);
+                         float gps_vel_u = 0.0f,
+                         bool  ekf_healthy = true,
+                         bool  baro_healthy = true);
 
     bool launch_flag;
     bool alt_landed_flag;       // Voted master landed
@@ -33,6 +35,7 @@ public:
     bool gps_apogee_flag;       // Test 3: GPS altitude decreasing
     bool pitch_apogee_flag;     // Test 4: pitch below horizontal
     bool apogee_flag;           // Combined voted result
+    bool apogee_backstop_flag;  // Layer-2 baro descent backstop fired (#257)
     // Landing sub-detector flags (#166) — exposed for diagnostics/logging.
     bool impact_flag;           // High-G ground impact (one-shot latch)
     bool baro_stable_flag;      // palt low and stable
@@ -53,6 +56,7 @@ private:
     uint8_t apogee_count;          // baro apogee leaky counter
     uint8_t vel_apogee_count_;     // velocity apogee leaky counter
     uint8_t pitch_apogee_count_;   // pitch apogee leaky counter
+    uint8_t backstop_descent_count_; // #257 Layer-2 descent backstop leaky counter
     uint16_t impact_seen_count;
     // Landing sub-detector leaky counters (#166).
     uint8_t baro_stable_count_;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -863,12 +863,13 @@ static void servicePyroChannels(uint32_t now_ms)
     if (!pyro_apogee_detected && kinematics.apogee_flag) {
         pyro_apogee_detected = true;
         pyro_apogee_time_ms  = now_ms;
-        ESP_LOGI(TAG, "[PYRO] Apogee detected at t=%lu ms (vel=%d baro=%d gps=%d pitch=%d)",
+        ESP_LOGI(TAG, "[PYRO] Apogee detected at t=%lu ms (vel=%d baro=%d gps=%d pitch=%d backstop=%d)",
                  (unsigned long)now_ms,
                  kinematics.vel_u_apogee_flag,
                  kinematics.alt_apogee_flag,
                  kinematics.gps_apogee_flag,
-                 kinematics.pitch_apogee_flag);
+                 kinematics.pitch_apogee_flag,
+                 kinematics.apogee_backstop_flag);
     }
 
     bool just_fired[4]  = { false, false, false, false };
@@ -4805,6 +4806,20 @@ static void loop_fc()
         // semantics as if the evaluator had consumed them.
         if (rocket_state != MAG_CALIBRATION)
         {
+            // #257: per-sensor health for the adaptive apogee quorum + Layer-2
+            // backstop.  baro_healthy = last sample finite and in a plausible
+            // range (the range test also rejects NaN/Inf, which compare false)
+            // and not stale — have_bmp_si latches once (#259) so it is not a
+            // freshness signal by itself.  ekf_healthy = filter initialized and
+            // reporting no recent divergence (TR_GpsInsEKF::isHealthy()).
+            constexpr uint32_t BARO_STALE_TIMEOUT_US = 500000u;  // 0.5 s -> dead
+            const bool baro_healthy =
+                have_bmp_si &&
+                bmp_latest_si.pressure > 25000.0f &&   // BMP585 valid 30-125 kPa;
+                bmp_latest_si.pressure < 125000.0f &&  // 25 kPa floor = margin below spec
+                (uint32_t)(time_us() - bmp_latest_si.time_us) < BARO_STALE_TIMEOUT_US;
+            const bool ekf_healthy = ekf_initialized && ekf.isHealthy();
+
             kinematics.kinematicChecks(pressure_altitude_m,
                                        accel_norm,
                                        imu_pos,
@@ -4816,7 +4831,9 @@ static void loop_fc()
                                        imu_rpy[1],
                                        burnout_detected,
                                        mach_locked_out,
-                                       (float)gnss_latest_si.vel_u);
+                                       (float)gnss_latest_si.vel_u,
+                                       ekf_healthy,
+                                       baro_healthy);
         }
         bmp_new_for_kf = false;
         gps_new_for_kc = false;


### PR DESCRIPTION
## Problem
The apogee vote (`TR_KinematicChecks`) counted a *faulted* voter (dead baro, diverged EKF) in the quorum denominator, so a dead voter didn't abstain — it *raised the bar* via `passed >= available - 1`, forcing the healthy voters to carry it. Combined with the fact that velocity + pitch are both EKF-derived, an unhealthy EKF during baro mach-lockout could make apogee unreachable (#262). And there was no fallback at all if the vote couldn't reach quorum.

## Approach
Two layers + a shared health foundation (rocket-agnostic, no time-based deploy — see #257 discussion):

**Layer 1 — health-aware adaptive quorum.** Only *healthy* voters count toward `available`, so a positively-faulted voter no longer raises the bar. `kinematicChecks()` gains `ekf_healthy` / `baro_healthy` params; an unhealthy EKF excludes **both** velocity and pitch (one filter, one opinion); an unhealthy/mach-locked baro excludes the baro voter. The `passed >= 2` floor is kept — we never fire on fewer than two concurring voters during ascent.

**Layer 2 — baro-only descent backstop.** For the degraded case where the vote can't reach quorum (e.g. EKF dead → < 2 healthy voters), a healthy, mach-unlocked baro that has fallen **≥ 30 m below the running peak while descending** latches apogee independently of the EKF/IMU (`alt_est` is from the baro-only KF). Altitude-relative, not time-based, so it's rocket-agnostic and unreachable during a normal boost (no false-positive). `apogee_backstop_flag` records when Layer 2 (vs the vote) fired.

**Shared health foundation.** `GpsInsEKF::isHealthy()` — false when the quaternion/velocity is non-finite or for a ~500-cycle cooldown after `stabilizeP()` repairs a non-finite covariance (a genuine divergence, distinguished from a benign underflow). Conservative v1; covariance-magnitude thresholds deferred until tuned against flight logs. `baro_healthy` (in `main.cpp`) = last BMP585 sample within its valid **25–125 kPa** range (the range test also rejects NaN/Inf) and not stale.

## Verification
- **Host gtests:** `test_kinematic_checks` 24/24 (4 new #257 scenarios: EKF-dead→backstop, no-false-positive-on-ascent, baro-dead→EKF-carries, both-dead→no-fire) + `test_ekf` 19/19 (2 new isHealthy cases).
- **Firmware:** `flight_computer` builds clean (IDF v6, esp32p4).
- **Simulated flight (this firmware):** apogee detection is **identical to the prior logic within ~13 ms** on healthy data — master fired via the vote (velocity + baro) at 5 m below the 458 m peak, the backstop did not engage (vote fired well above its 30 m threshold), and zero false sub-flags during boost. No regression to nominal detection.

## Follow-ups (consume this foundation; left open)
- #265 — wire `ekf.isHealthy()` into the servo-stow gate + a sticky `ekf_diverged` flag.
- #259 — apply baro/IMU staleness to burnout detection and the baro KF.

Closes #257. Part of the pre-flight review tracking issue #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
