### PR TITLE
fc(sensors): treat a stale IMU as unavailable for burnout + control (#259)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5088,7 +5088,18 @@ static void loop_fc()
                 // hysteresis (#197) reject boost vibration.  Logic is shared
                 // with the host unit test via BurnoutDetector.h.
                 const uint32_t t_since_launch_ms = now_ms - launch_time_millis;
-                if (have_ism6_si &&
+
+                // #259: treat the IMU as unavailable when its last sample is
+                // stale.  have_ism6_si latches on first read and never clears,
+                // so without this a mid-flight IMU dropout would feed a frozen
+                // accel into burnout detection (miss / false burnout) and frozen
+                // gyro/velocity into roll control.  (Baro staleness is already
+                // handled by baro_healthy / the bmp_new_for_kf KF gate.)
+                constexpr uint32_t IMU_STALE_TIMEOUT_US = 100000u;  // 0.1 s (~1 kHz IMU)
+                const bool ism6_fresh = have_ism6_si &&
+                    (uint32_t)(time_us() - ism6_latest_si.time_us) < IMU_STALE_TIMEOUT_US;
+
+                if (ism6_fresh &&
                     tr::burnoutDetectStep(burnout_detected, burnout_neg_count,
                                           ism6_latest_si.low_g_acc_x,
                                           t_since_launch_ms,
@@ -5107,7 +5118,7 @@ static void loop_fc()
                         // Hold fins neutral until delay/settle elapses
                         servo_control.control(0.0f);
                     }
-                    else if (have_ism6_si)
+                    else if (ism6_fresh)   // #259: stale IMU -> neutral-hold branch below
                     {
                         float speed = sqrtf(imu_vel[0]*imu_vel[0] +
                                             imu_vel[1]*imu_vel[1] +


### PR DESCRIPTION
## Problem
`have_ism6_si` latches true on the first IMU sample and never clears. So a mid-flight IMU dropout would feed a **frozen accelerometer** into burnout detection (a stuck-positive sample misses burnout; a stuck-negative one false-triggers it) and **frozen gyro/velocity** into roll control — both gated only by the latching flag.

## Fix
Add a freshness check and gate the two in-flight consumers on it instead of `have_ism6_si`:

```cpp
constexpr uint32_t IMU_STALE_TIMEOUT_US = 100000u;  // 0.1 s (~100 missed samples @ ~1 kHz)
const bool ism6_fresh = have_ism6_si &&
    (uint32_t)(time_us() - ism6_latest_si.time_us) < IMU_STALE_TIMEOUT_US;
```

- **Burnout detector** → gated on `ism6_fresh` (stale IMU stops burnout updates rather than acting on a frozen accel).
- **INFLIGHT control branch** → gated on `ism6_fresh`; a stale IMU now falls to the existing neutral-hold branch.

This complements the EKF-health work: **#265** routes control to gyro rate-null when the *EKF* is unhealthy; this routes it to neutral when the *IMU itself* is dead.

**Baro side needed no change** — #257's `baro_healthy` gates the apogee baro voter, and the baro KF only ingests fresh samples via the `bmp_new_for_kf` gate.

## Verification
- `flight_computer` **builds clean** (IDF v6, esp32p4).
- The main-loop gating isn't host-unit-testable (same as #256/#265); **transparent on healthy data** (the IMU is always fresh), so no SIL regression.

Completes the sensor/EKF-health-foundation consumers alongside #257 (foundation) and #265 (servo gate). Closes #259. Part of the pre-flight review tracking issue #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
