### PR TITLE
fc(launch): accel-only launch fallback when the baro is invalid (#258)

### DIFF
--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -65,6 +65,42 @@ TEST_F(KinematicChecksTest, Launch_BriefSpike_NoTrigger) {
     EXPECT_FALSE(kc.launch_flag);
 }
 
+// ── #258: accel-only launch fallback when the baro is invalid ──
+
+// Baro invalid (dead) -> d_alt_est_ never confirms a climb.  Sustained >3 g for
+// >500 samples must still latch launch so recovery arms (a missed launch = no
+// pyro arming = ballistic).  callFlight's last arg is baro_healthy.
+TEST_F(KinematicChecksTest, Launch_DeadBaro_AccelOnlyFallbackFires) {
+    for (int i = 0; i < 600; i++) {
+        setMockMillis(i * 2);
+        // flat altitude (no climb), ~3.5 g, baro UNHEALTHY
+        callFlight(0.0f, 35.0f, 0.0f, 0.0f, 0.0f, false, 1.57f, false, false, 0.0f,
+                   /*ekf_healthy=*/true, /*baro_healthy=*/false);
+    }
+    EXPECT_TRUE(kc.launch_flag);
+}
+
+// Baro invalid but only ~300 samples of >3 g (< 500) -> fallback must NOT fire.
+TEST_F(KinematicChecksTest, Launch_DeadBaro_ShortHighG_NoLaunch) {
+    for (int i = 0; i < 300; i++) {
+        setMockMillis(i * 2);
+        callFlight(0.0f, 35.0f, 0.0f, 0.0f, 0.0f, false, 1.57f, false, false, 0.0f,
+                   true, /*baro_healthy=*/false);
+    }
+    EXPECT_FALSE(kc.launch_flag);
+}
+
+// Explicit goal: accel must NOT decide launch while the baro is VALID.
+// Static-fire / clamped case — healthy baro shows no climb, sustained >3 g.
+TEST_F(KinematicChecksTest, Launch_HealthyBaro_HighGNoClimb_NoLaunch) {
+    for (int i = 0; i < 600; i++) {
+        setMockMillis(i * 2);
+        callFlight(0.0f, 35.0f, 0.0f, 0.0f, 0.0f, false, 1.57f, false, false, 0.0f,
+                   true, /*baro_healthy=*/true);
+    }
+    EXPECT_FALSE(kc.launch_flag);
+}
+
 TEST_F(KinematicChecksTest, MaxAltitude_SpikeRejection) {
     // Per #142, max_altitude tracks the KF-smoothed altitude (alt_est)
     // rather than the raw pressure_altitude so individual noise spikes

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -36,6 +36,15 @@ constexpr uint8_t  GPS_APOGEE_COUNT_HI      = 4;
 // (#237/#242), so the old altitude-below-peak test fired wildly off.
 constexpr float    GPS_VEL_APOGEE_DESCENT_MPS = 1.0f;
 
+// Launch accel-only fallback (#258): when the baro is INVALID, latch launch on
+// sustained high-G alone.  Deliberately a much higher bar than the baro-
+// confirmed path (3 g vs 2 g, 500 vs 50 samples) so handling/transport can't
+// fake it — a missed launch means recovery never arms (ballistic), so we
+// over-confirm.  Gated on !baro_healthy, so accel never decides launch while
+// the baro is valid.
+constexpr float    LAUNCH_ACCEL_FALLBACK_MS2   = 30.0f;  // ~3 g
+constexpr uint16_t LAUNCH_ACCEL_FALLBACK_COUNT = 500;    // sustained samples
+
 // Layer-2 apogee backstop (#257). When the primary vote can't reach quorum
 // (e.g. an unhealthy EKF leaves < 2 healthy voters), a healthy + mach-unlocked
 // baro that has dropped this far below the running peak while still descending
@@ -75,6 +84,7 @@ TR_KinematicChecks::TR_KinematicChecks()
     apogee_flag = false;
     apogee_backstop_flag = false;
     launch_count = 0;
+    launch_count_hi = 0;
     max_altitude = 0.0f;
     max_speed = 0.0f;
     landing_check_time = 0;
@@ -133,6 +143,7 @@ void TR_KinematicChecks::reset()
     apogee_flag = false;
     apogee_backstop_flag = false;
     launch_count = 0;
+    launch_count_hi = 0;
     max_altitude = 0.0f;
     max_speed = 0.0f;
     landing_check_time = 0;
@@ -242,14 +253,31 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         if (acc_mag > 20.0)
         {
             launch_count++;
+            // Separate sustained-high-G counter for the accel-only fallback.
+            if (acc_mag > LAUNCH_ACCEL_FALLBACK_MS2) launch_count_hi++;
+            else                                     launch_count_hi = 0;
+
             if (launch_count > 50 && d_alt_est_ > 1.0)
             {
+                // Primary: accel + baro-confirmed climb (fast).
+                launch_flag = true;
+            }
+            else if (!baro_healthy &&
+                     launch_count_hi > LAUNCH_ACCEL_FALLBACK_COUNT)
+            {
+                // #258 accel-only fallback — ONLY when the baro is invalid.
+                // On a healthy baro this branch is unreachable (the primary
+                // latches first), so accel never decides launch unless the baro
+                // can't.  Half a second of sustained >3 g with a dead baro is an
+                // unambiguous boost; latching here is what keeps recovery from
+                // never arming (ballistic) on a baro failure.
                 launch_flag = true;
             }
         }
         else
         {
             launch_count = 0;
+            launch_count_hi = 0;
         }
     }
 

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -50,6 +50,7 @@ public:
 private:
 
     uint16_t launch_count;
+    uint16_t launch_count_hi;   // #258 sustained-high-G counter for the accel-only launch fallback
     uint32_t landing_check_time;
     float landing_look_back_alt;
     uint32_t landing_check_dt;


### PR DESCRIPTION
## Problem
Launch is latched only when `acc_mag > 20` for 50 samples **AND** `d_alt_est_ > 1.0` from the baro KF. A dead / frozen / mis-referenced BMP585 leaves `d_alt_est_` ≈ 0, so `launch_flag` never sets → **no `NSF_LAUNCH` logging trigger, no apogee detection, no recovery**. The entire flight — and its recovery — is lost on a sensor that isn't even in the recovery-critical path. (A missed launch means the pyros never arm → ballistic.)

## Fix
Add an **accel-only fallback**, gated **explicitly on `!baro_healthy`** (the #257 health signal, already a `kinematicChecks` param):

```cpp
if (acc_mag > 20.0) {
    launch_count++;
    if (acc_mag > LAUNCH_ACCEL_FALLBACK_MS2) launch_count_hi++; else launch_count_hi = 0;
    if (launch_count > 50 && d_alt_est_ > 1.0)                       launch_flag = true;  // primary
    else if (!baro_healthy && launch_count_hi > LAUNCH_ACCEL_FALLBACK_COUNT) launch_flag = true;  // #258
}
```

- **High bar:** sustained **>3 g (30 m/s²) for 500 samples** — its own counter, separate from the 2 g primary — so handling/transport can't fake it.
- **Explicit goal:** accel decides launch *only* when the baro is invalid. On a healthy baro the fallback is structurally unreachable (the primary latches first), so a static-fire / clamped vehicle with a valid baro and no climb will **not** false-launch.

## Verification
- **Host gtests 27/27** — 3 new (`Launch_DeadBaro_AccelOnlyFallbackFires`, `Launch_DeadBaro_ShortHighG_NoLaunch`, `Launch_HealthyBaro_HighGNoClimb_NoLaunch`) + the existing launch/apogee/landing suite, no regression.
- `flight_computer` **builds clean** (IDF v6, esp32p4). The `kinematicChecks` signature is unchanged (`baro_healthy` was already a param from #257).

Closes #258. Part of the pre-flight review tracking issue #298. Motivates the sensor health scorecard (#303 — surfacing this to the operator pre-launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
