### PR TITLE
fc(health): pre-launch sensor health scorecard + go/no-go (#303)

### DIFF
--- a/Data_Analysis/analyze_ekf_cov.py
+++ b/Data_Analysis/analyze_ekf_cov.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Replay a (stationary-bench) flight log through the EKF and report the
+CONVERGED attitude/velocity covariance.
+
+Used to set the #303 sensor-health scorecard thresholds
+config::EKF_ATT_VAR_OK / EKF_VEL_VAR_OK from real numbers instead of guesses.
+The firmware EKF bit reads OK when fmaxf(getCovOrient) < EKF_ATT_VAR_OK and
+fmaxf(getCovVel) < EKF_VEL_VAR_OK, so this prints the worst-of-3-axes variance
+the replayed filter (same TR_GpsInsEKF.cpp) settles to.
+
+Usage: python analyze_ekf_cov.py <binary_file>
+"""
+import sys, math
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent))
+from plot_flight_data_mini import parse_binary_file, get_array, pressure_to_altitude
+from tinkerrocket_sim._ekf import GpsInsEKF, IMUData, GNSSDataLLA, MagData, BaroData
+
+G = 9.80665
+DEG2RAD = math.pi / 180.0
+RAD2DEG = 180.0 / math.pi
+LOW_G_SAT = 15.5 * G
+
+
+def main(binpath):
+    records, stats, config = parse_binary_file(binpath)
+    nmag = len(records.get("MMC5983MA", [])) + len(records.get("IIS2MDC", []))
+    print(f"Frames: {stats['good_crc']:,} good, {stats['bad_crc']} bad CRC")
+    print(f"IMU {len(records['ISM6HG256']):,}  GNSS {len(records['GNSS']):,}  "
+          f"Baro {len(records['BMP585']):,}  Mag {nmag:,}")
+
+    ev = []
+    for r in records["ISM6HG256"]:        ev.append((r["time_us"], "imu", r))
+    for r in records["GNSS"]:             ev.append((r["time_us"], "gnss", r))
+    for r in records["BMP585"]:           ev.append((r["time_us"], "baro", r))
+    for r in records.get("MMC5983MA", []): ev.append((r["time_us"], "mag", r))
+    for r in records.get("IIS2MDC", []):   ev.append((r["time_us"], "mag", r))
+    ev.sort(key=lambda e: e[0])
+    t0 = records["ISM6HG256"][0]["time_us"]
+
+    ekf = GpsInsEKF()
+    init = False
+    latest_gnss = None
+    latest_mag = None
+    gnss_counter = 0
+    baro_ref = None
+    baro_samp = []
+    baro_off = 0.0
+    baro_off_set = False
+    max_sats = 0
+
+    t = []
+    covP = []
+    covV = []
+    covO = []
+    n_imu = 0
+
+    for time_us, etype, rec in ev:
+        if etype == "gnss":
+            max_sats = max(max_sats, rec.get("num_sats", 0))
+            if rec.get("num_sats", 0) >= 4 and (latest_gnss is None or
+                    rec["second"] != latest_gnss["second"] or
+                    rec["milli_sec"] != latest_gnss["milli_sec"]):
+                latest_gnss = rec
+                gnss_counter += 1
+        elif etype == "mag":
+            latest_mag = rec
+        elif etype == "baro":
+            if baro_ref is None:
+                baro_samp.append(rec["pressure_pa"])
+                if len(baro_samp) >= 20:
+                    baro_ref = float(np.mean(baro_samp))
+                continue
+            if not baro_off_set and latest_gnss is not None:
+                baro_off = latest_gnss["alt_m"]
+                baro_off_set = True
+            balt = pressure_to_altitude(rec["pressure_pa"], baro_ref) + baro_off
+            if init:
+                b = BaroData(); b.time_us = time_us; b.altitude_m = balt
+                ekf.baro_meas_update(b)
+        elif etype == "imu":
+            if latest_gnss is None:
+                continue
+            lx, ly, lz = rec["low_acc_x"], rec["low_acc_y"], rec["low_acc_z"]
+            if abs(lx) > LOW_G_SAT or abs(ly) > LOW_G_SAT or abs(lz) > LOW_G_SAT:
+                ax, ay, az = rec["high_acc_x"], rec["high_acc_y"], rec["high_acc_z"]
+            else:
+                ax, ay, az = lx, ly, lz
+            imu = IMUData(); imu.time_us = time_us
+            imu.acc_x = ax; imu.acc_y = -ay; imu.acc_z = -az
+            imu.gyro_x = rec["gyro_x"]; imu.gyro_y = -rec["gyro_y"]; imu.gyro_z = -rec["gyro_z"]
+            g = GNSSDataLLA(); g.time_us = gnss_counter
+            g.lat_rad = latest_gnss["lat"] * DEG2RAD
+            g.lon_rad = latest_gnss["lon"] * DEG2RAD
+            g.alt_m = latest_gnss["alt_m"]
+            g.vel_n_mps = latest_gnss["vel_n"]; g.vel_e_mps = latest_gnss["vel_e"]
+            g.vel_d_mps = -latest_gnss["vel_u"]
+            m = MagData()
+            if latest_mag is not None:
+                m.time_us = latest_mag["time_us"]
+                m.mag_x = latest_mag["mag_x"]; m.mag_y = -latest_mag["mag_y"]; m.mag_z = -latest_mag["mag_z"]
+            if not init:
+                ekf.init_lla(imu, g, m); init = True; continue
+            ekf.update_lla(True, imu, g, m)   # stationary bench → AHRS accel always
+            n_imu += 1
+            if n_imu % 20 == 0:
+                t.append((time_us - t0) / 1e6)
+                covP.append(ekf.get_cov_pos())
+                covV.append(ekf.get_cov_vel())
+                covO.append(ekf.get_cov_orient())
+
+    t = np.array(t); covP = np.array(covP); covV = np.array(covV); covO = np.array(covO)
+    if len(t) < 5:
+        print(f"\nNot enough converged samples (max_sats={max_sats}). Aborting.")
+        return
+    print(f"replayed {n_imu:,} IMU updates  |  {len(t)} cov samples  |  "
+          f"duration {t[-1]:.1f}s  |  max sats {max_sats}")
+
+    k = max(1, int(len(t) * 0.7))   # converged = last 30% of a stationary run
+
+    def report(name, seg, unit, ang=False):
+        worst = seg.max(axis=1)
+        med, p95, mx = np.median(worst), np.percentile(worst, 95), worst.max()
+        s = (f"\n{name} (worst-of-3-axes variance, converged t>{t[k]:.0f}s):\n"
+             f"  median={med:.3e}  p95={p95:.3e}  max={mx:.3e}  [{unit}^2]")
+        if ang:
+            s += (f"\n  -> 1sigma: median={math.sqrt(med)*RAD2DEG:.2f}deg  "
+                  f"p95={math.sqrt(p95)*RAD2DEG:.2f}deg  max={math.sqrt(mx)*RAD2DEG:.2f}deg")
+        else:
+            s += (f"\n  -> 1sigma: median={math.sqrt(med):.3g}  "
+                  f"p95={math.sqrt(p95):.3g}  max={math.sqrt(mx):.3g} {unit}")
+        s += (f"\n  per-axis median var: [{np.median(seg[:,0]):.3e}, "
+              f"{np.median(seg[:,1]):.3e}, {np.median(seg[:,2]):.3e}]")
+        print(s)
+
+    report("ATTITUDE  (getCovOrient -> EKF_ATT_VAR_OK)", covO, "rad", ang=True)
+    report("VELOCITY  (getCovVel    -> EKF_VEL_VAR_OK)", covV, "m/s")
+    report("POSITION  (getCovPos)", covP, "m")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/Data_Analysis/analyze_pyro_apogee.py
+++ b/Data_Analysis/analyze_pyro_apogee.py
@@ -18,6 +18,7 @@ MSG_NON_SENSOR = 0xA5
 # <I hhhhh iii iii BB h B B
 #  time_us(4), q0-q3+roll_cmd(5*2=10), e/n/u_pos(3*4=12), e/n/u_vel(3*4=12),
 #  flags(1), rocket_state(1), baro_alt_rate_dmps(2), pyro_status(1), apogee_flags(1) = 44
+FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'  # +uint32 sensor_health (#303)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'
 FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'
@@ -114,7 +115,11 @@ def parse(filepath):
         stats["frames"] += 1
 
         if msg_type == MSG_NON_SENSOR:
-            if msg_len == 44:
+            if msg_len == 48:
+                fields = struct.unpack(FMT_NONSENSOR_48, payload)
+                pyro_status = fields[15]
+                apogee_flags = fields[16]
+            elif msg_len == 44:
                 fields = struct.unpack(FMT_NONSENSOR_44, payload)
                 pyro_status = fields[15]
                 apogee_flags = fields[16]

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -127,6 +127,7 @@ FMT_POWER = '<I Hhh'
 FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'     # legacy (no pyro_status)
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'  # +pyro_status byte (#34)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'  # +apogee_flags byte (#142/#143)
+FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'  # +uint32 sensor_health (#303)
 # OutStatusQueryData: 16 bytes (v2) / 26 bytes (v3, +b2r orientation)
 FMT_STATUS_QUERY = '<B H H hh B hhh'
 FMT_STATUS_QUERY_B2R = '<BB hhhh'  # b2r_code, b2r_mode, quat×10000 (payload[16:26])
@@ -456,8 +457,12 @@ def parse_binary_file(filepath):
                     "raw_z":    fields[3],
                 })
 
-            elif msg_type == MSG_NON_SENSOR and msg_len in (42, 43, 44):
-                if msg_len == 44:
+            elif msg_type == MSG_NON_SENSOR and msg_len in (42, 43, 44, 48):
+                if msg_len == 48:
+                    fields = struct.unpack(FMT_NONSENSOR_48, payload)
+                    pyro_status = fields[15]
+                    apogee_flags_b = fields[16]
+                elif msg_len == 44:
                     fields = struct.unpack(FMT_NONSENSOR_44, payload)
                     pyro_status = fields[15]
                     apogee_flags_b = fields[16]

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -134,6 +134,72 @@ struct TelemetryData: Codable {
                           default: return false }
     }
 
+    // ── Sensor health scorecard (#303) ────────────────────────────────────
+    // Packed "h" bitfield: FC sets sensors + EKF, OC sets battery.  2 bits per
+    // item; layout mirrors RocketComputerTypes.h (SH_*_SHIFT).  0 = nothing
+    // reported (older firmware or a BS self-frame) → card hidden.
+    var sensor_health: Int = 0
+    enum SensorHealth: Int { case na = 0, ok = 1, degraded = 2, bad = 3
+        var label: String {
+            switch self { case .na: return "N/A"; case .ok: return "OK"
+                          case .degraded: return "DEGRADED"; case .bad: return "BAD" }
+        }
+    }
+    private func shState(_ shift: Int) -> SensorHealth {
+        SensorHealth(rawValue: (sensor_health >> shift) & 0x3) ?? .na
+    }
+    var baroHealth: SensorHealth { shState(0) }
+    var imuHealth:  SensorHealth { shState(2) }
+    var ekfHealth:  SensorHealth { shState(4) }   // health + init + orientation residual
+    var magHealth:  SensorHealth { shState(6) }   // advisory only — never gates go/no-go
+    var gnssHealth: SensorHealth { shState(8) }
+    var battHealth: SensorHealth { shState(10) }
+    func pyroHealth(channel: Int) -> SensorHealth {   // channel 1...4; .na = not configured
+        guard (1...4).contains(channel) else { return .na }
+        return shState(12 + (channel - 1) * 2)
+    }
+    var hasSensorHealth: Bool { sensor_health != 0 }
+
+    // Rows for the pre-launch health card.  Core sensors always shown; a pyro
+    // channel appears only when configured for the flight (state != .na).
+    struct SensorHealthRow: Identifiable { let name: String; let state: SensorHealth; var id: String { name } }
+    var sensorHealthRows: [SensorHealthRow] {
+        var rows = [
+            SensorHealthRow(name: "Baro",    state: baroHealth),
+            SensorHealthRow(name: "IMU",     state: imuHealth),
+            SensorHealthRow(name: "EKF",     state: ekfHealth),
+            SensorHealthRow(name: "GNSS",    state: gnssHealth),
+            SensorHealthRow(name: "Battery", state: battHealth),
+            SensorHealthRow(name: "Mag",     state: magHealth),
+        ]
+        for ch in 1...4 where pyroHealth(channel: ch) != .na {
+            rows.append(SensorHealthRow(name: "Pyro \(ch)", state: pyroHealth(channel: ch)))
+        }
+        return rows
+    }
+
+    // Go/no-go rollup (#303).  Red = a hard fault waiting won't fix (baro/IMU/
+    // battery BAD, or a configured pyro with no continuity).  Green needs every
+    // required item OK — including EKF initialized/converged and a GNSS fix.
+    // Mag is advisory and never gates.  Amber = anything in between.
+    enum FlightReadiness { case unknown, ready, caution, notReady
+        var label: String {
+            switch self { case .unknown:  return "Waiting for telemetry…"
+                          case .ready:    return "Ready to fly"
+                          case .caution:  return "Not ready — check sensors"
+                          case .notReady: return "Do not fly" }
+        }
+    }
+    var flightReadiness: FlightReadiness {
+        guard hasSensorHealth else { return .unknown }
+        let hardFault = [baroHealth, imuHealth, battHealth].contains(.bad)
+            || (1...4).contains { pyroHealth(channel: $0) == .bad }
+        if hardFault { return .notReady }
+        var mustBeOK = [baroHealth, imuHealth, battHealth, ekfHealth, gnssHealth]
+        for ch in 1...4 where pyroHealth(channel: ch) != .na { mustBeOK.append(pyroHealth(channel: ch)) }
+        return mustBeOK.allSatisfy { $0 == .ok } ? .ready : .caution
+    }
+
     // Short JSON keys → Swift property names (saves ~150 bytes in BLE payload)
     enum CodingKeys: String, CodingKey {
         case soc
@@ -173,6 +239,7 @@ struct TelemetryData: Codable {
         // cam/log/bslog).  Bit layout mirrors TR_BLE_To_APP.cpp.
         case flight_status_bits = "fs"
         case pyro_status_bits = "ps"  // packed bitfield: b0=armed (global), then (cont,fired) per channel 1..4
+        case sensor_health = "h"      // #303 scorecard: 2 bits/sensor, see RocketComputerTypes.h
         case source_rocket_id = "rid"
         case source_unit_name = "run"
         case data_status = "ds"        // #95
@@ -221,6 +288,7 @@ struct TelemetryData: Codable {
         bs_log_silence_remaining_s = try c.decodeIfPresent(UInt16.self, forKey: .bs_log_silence_remaining_s)
         flight_status_bits = try c.decodeIfPresent(Int.self, forKey: .flight_status_bits) ?? 0
         pyro_status_bits = try c.decodeIfPresent(Int.self, forKey: .pyro_status_bits) ?? 0
+        sensor_health = try c.decodeIfPresent(Int.self, forKey: .sensor_health) ?? 0
         source_rocket_id = try c.decodeIfPresent(Int.self, forKey: .source_rocket_id)
         source_unit_name = try c.decodeIfPresent(String.self, forKey: .source_unit_name)
         // #95: missing "ds" → .live (older firmware doesn't emit it)

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -150,7 +150,7 @@ struct TelemetryData: Codable {
     }
     var baroHealth: SensorHealth { shState(0) }
     var imuHealth:  SensorHealth { shState(2) }
-    var ekfHealth:  SensorHealth { shState(4) }   // health + init + orientation residual
+    var ekfHealth:  SensorHealth { shState(4) }   // filter health: init + isHealthy + covariance converged
     var magHealth:  SensorHealth { shState(6) }   // advisory only — never gates go/no-go
     var gnssHealth: SensorHealth { shState(8) }
     var battHealth: SensorHealth { shState(10) }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -428,6 +428,14 @@ struct ConnectedDashboardView: View {
                             isBaseStation: device.isBaseStation)
                 .opacity(showRocketViews ? staleOpacity : 1.0)
 
+            // Pre-launch sensor health scorecard + go/no-go (#303), sitting just
+            // above the pyro channels.  Only shown once the rocket reports a
+            // scorecard ("h" present → hasSensorHealth).
+            if showRocketViews && device.telemetry.hasSensorHealth {
+                HealthCardView(telemetry: device.telemetry)
+                    .opacity(staleOpacity)
+            }
+
             if !device.isBaseStation {
                 PyroChannelsView(device: device)
             }
@@ -613,6 +621,89 @@ struct RocketStateView: View {
         .padding()
         .frame(maxWidth: .infinity)
         .background(stateColor.opacity(0.1))
+        .cornerRadius(10)
+    }
+}
+
+/// Pre-launch sensor health scorecard + go/no-go recommendation (#303).
+/// Driven by the packed "h" bitfield (FC sensors/EKF + OC battery); the parent
+/// only renders it once the rocket actually reports a scorecard.  The rollup
+/// rule lives in TelemetryData.flightReadiness — EKF-init and a GNSS fix gate
+/// green, configured pyros must have continuity, and mag is advisory.
+struct HealthCardView: View {
+    let telemetry: TelemetryData
+
+    private func color(for state: TelemetryData.SensorHealth) -> Color {
+        switch state {
+        case .ok:       return .green
+        case .degraded: return .orange
+        case .bad:      return .red
+        case .na:       return .gray
+        }
+    }
+    private var readinessColor: Color {
+        switch telemetry.flightReadiness {
+        case .ready:    return .green
+        case .caution:  return .orange
+        case .notReady: return .red
+        case .unknown:  return .gray
+        }
+    }
+    private var readinessIcon: String {
+        switch telemetry.flightReadiness {
+        case .ready:    return "checkmark.seal.fill"
+        case .caution:  return "exclamationmark.triangle.fill"
+        case .notReady: return "xmark.octagon.fill"
+        case .unknown:  return "hourglass"
+        }
+    }
+
+    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 8)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Sensor Health")
+                .font(.headline)
+
+            // Go/no-go recommendation banner.
+            HStack(spacing: 10) {
+                Image(systemName: readinessIcon)
+                    .font(.title2)
+                    .foregroundColor(readinessColor)
+                Text(telemetry.flightReadiness.label)
+                    .font(.system(.title3, design: .default).weight(.semibold))
+                    .foregroundColor(readinessColor)
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(readinessColor.opacity(0.12))
+            .cornerRadius(8)
+
+            // Per-sensor chips — core sensors always, configured pyros appended.
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                ForEach(telemetry.sensorHealthRows) { row in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(color(for: row.state))
+                            .frame(width: 8, height: 8)
+                        Text(row.name)
+                            .font(.caption)
+                        Spacer(minLength: 2)
+                        Text(row.state.label)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundColor(color(for: row.state))
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(color(for: row.state).opacity(0.10))
+                    .cornerRadius(6)
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
         .cornerRadius(10)
     }
 }

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -111,4 +111,100 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(telemetry.pitch), 0.0, accuracy: 1e-3)
         XCTAssertEqual(try XCTUnwrap(telemetry.yaw), 0.0, accuracy: 1e-3)
     }
+
+    // MARK: - Sensor health scorecard (#303)
+
+    /// Per-item state, matching firmware SensorHealthState (NA/OK/DEGRADED/BAD).
+    private enum SH: Int { case na = 0, ok = 1, deg = 2, bad = 3 }
+
+    /// Pack a "h" bitfield from per-item states.  Shifts mirror
+    /// RocketComputerTypes.h SH_*_SHIFT (baro 0, imu 2, ekf 4, mag 6, gnss 8,
+    /// batt 10, pyro1..4 at 12/14/16/18).
+    private func pack(baro: SH = .na, imu: SH = .na, ekf: SH = .na, mag: SH = .na,
+                      gnss: SH = .na, batt: SH = .na,
+                      p1: SH = .na, p2: SH = .na, p3: SH = .na, p4: SH = .na) -> Int {
+        baro.rawValue | (imu.rawValue << 2) | (ekf.rawValue << 4) | (mag.rawValue << 6)
+            | (gnss.rawValue << 8) | (batt.rawValue << 10)
+            | (p1.rawValue << 12) | (p2.rawValue << 14) | (p3.rawValue << 16) | (p4.rawValue << 18)
+    }
+    private func decode(health: Int) throws -> TelemetryData {
+        try JSONDecoder().decode(TelemetryData.self,
+                                 from: "{\"h\":\(health)}".data(using: .utf8)!)
+    }
+
+    /// Raw-int bit positions, pinned independently of `pack` so a systematic
+    /// shift error can't hide behind a matching bug in the test helper.
+    func testSensorHealth_BitPositions() throws {
+        XCTAssertEqual(try decode(health: 1 << 0).baroHealth, .ok)       // baro
+        XCTAssertEqual(try decode(health: 1 << 2).imuHealth, .ok)        // imu
+        XCTAssertEqual(try decode(health: 1 << 4).ekfHealth, .ok)        // ekf
+        XCTAssertEqual(try decode(health: 1 << 6).magHealth, .ok)        // mag
+        XCTAssertEqual(try decode(health: 1 << 8).gnssHealth, .ok)       // gnss
+        XCTAssertEqual(try decode(health: 1 << 10).battHealth, .ok)      // battery
+        XCTAssertEqual(try decode(health: 1 << 18).pyroHealth(channel: 4), .ok)  // pyro4
+        // A single field set leaves everything else N/A (no bleed).
+        let onlyGnss = try decode(health: 1 << 8)
+        XCTAssertEqual(onlyGnss.baroHealth, .na)
+        XCTAssertEqual(onlyGnss.pyroHealth(channel: 1), .na)
+        // BAD encodes as 0b11 in-place (verifies the 2-bit mask).
+        XCTAssertEqual(try decode(health: 3 << 4).ekfHealth, .bad)
+    }
+
+    /// Missing "h" (older firmware / BS self-frame) → no scorecard, unknown.
+    func testSensorHealth_MissingKey_Unknown() throws {
+        let t = try JSONDecoder().decode(TelemetryData.self, from: "{}".data(using: .utf8)!)
+        XCTAssertEqual(t.sensor_health, 0)
+        XCTAssertFalse(t.hasSensorHealth)
+        XCTAssertEqual(t.flightReadiness, .unknown)
+    }
+
+    /// Everything OK incl. EKF + GNSS, no pyros configured → green.
+    func testReadiness_AllOK_Ready() throws {
+        let t = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, mag: .ok, gnss: .ok, batt: .ok))
+        XCTAssertTrue(t.hasSensorHealth)
+        XCTAssertEqual(t.flightReadiness, .ready)
+        XCTAssertEqual(t.sensorHealthRows.count, 6)            // 6 core, no pyros
+    }
+
+    /// Hard faults waiting won't fix → red "do not fly".
+    func testReadiness_HardFaults_NotReady() throws {
+        let baro = try decode(health: pack(baro: .bad, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok))
+        XCTAssertEqual(baro.flightReadiness, .notReady)
+        let batt = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .bad))
+        XCTAssertEqual(batt.flightReadiness, .notReady)
+        // A configured pyro with no continuity is a hard fault.
+        let pyro = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok, p1: .bad))
+        XCTAssertEqual(pyro.pyroHealth(channel: 1), .bad)
+        XCTAssertEqual(pyro.flightReadiness, .notReady)
+    }
+
+    /// EKF not converged or GNSS without a fix gate green down to amber, but
+    /// aren't hard faults (you wait them out).
+    func testReadiness_EkfOrGnssNotOK_Caution() throws {
+        let ekf = try decode(health: pack(baro: .ok, imu: .ok, ekf: .deg, gnss: .ok, batt: .ok))
+        XCTAssertEqual(ekf.flightReadiness, .caution)
+        let gnss = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .bad, batt: .ok))
+        XCTAssertEqual(gnss.flightReadiness, .caution)        // no fix → amber, not red
+        // A configured-but-untested pyro is amber too.
+        let pyro = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok, p1: .deg))
+        XCTAssertEqual(pyro.flightReadiness, .caution)
+    }
+
+    /// Mag is advisory — BAD mag with everything else OK still recommends fly.
+    func testReadiness_MagAdvisory_DoesNotGate() throws {
+        let t = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, mag: .bad, gnss: .ok, batt: .ok))
+        XCTAssertEqual(t.magHealth, .bad)
+        XCTAssertEqual(t.flightReadiness, .ready)
+    }
+
+    /// Unconfigured pyros (N/A) are ignored; configured ones add a card row.
+    func testSensorHealthRows_OnlyConfiguredPyros() throws {
+        let none = try decode(health: pack(baro: .ok, imu: .ok))
+        XCTAssertFalse(none.sensorHealthRows.contains { $0.name.hasPrefix("Pyro") })
+        let two = try decode(health: pack(baro: .ok, imu: .ok, p1: .ok, p3: .bad))
+        XCTAssertEqual(two.sensorHealthRows.count, 6 + 2)
+        XCTAssertTrue(two.sensorHealthRows.contains { $0.name == "Pyro 1" })
+        XCTAssertTrue(two.sensorHealthRows.contains { $0.name == "Pyro 3" })
+        XCTAssertFalse(two.sensorHealthRows.contains { $0.name == "Pyro 2" })
+    }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -26,7 +26,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(MMC5983MAData),  16u);
     EXPECT_EQ(sizeof(POWERData),      10u);
     EXPECT_EQ(sizeof(NonSensorData),  48u);  // #303: +uint32 sensor_health (4 B)
-    EXPECT_EQ(sizeof(LoRaData),       62u);  // 5-byte routing header (incl. 16-bit seq) + 57-byte payload
+    EXPECT_EQ(sizeof(LoRaData),       66u);  // #303: +uint32 sensor_health (4 B)
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -25,7 +25,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(ISM6HG256Data),  22u);
     EXPECT_EQ(sizeof(MMC5983MAData),  16u);
     EXPECT_EQ(sizeof(POWERData),      10u);
-    EXPECT_EQ(sizeof(NonSensorData),  44u);  // #142/#143: +1 apogee_flags byte
+    EXPECT_EQ(sizeof(NonSensorData),  48u);  // #303: +uint32 sensor_health (4 B)
     EXPECT_EQ(sizeof(LoRaData),       62u);  // 5-byte routing header (incl. 16-bit seq) + 57-byte payload
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1230,6 +1230,10 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
         if (ps != 0) { addInt("ps", (int)ps); }
     }
 
+    // Sensor health scorecard bitfield (#303): 2 bits/sensor, NA/OK/DEGRADED/BAD.
+    // Omitted when zero (nothing reported) to save MTU; iOS unpacks per SH_*_SHIFT.
+    if (data.sensor_health != 0) { addInt("h", (int)data.sensor_health); }
+
     // Source rocket identity (base station relay only)
     if (data.source_rocket_id > 0) {
         addInt("rid", data.source_rocket_id);

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -90,6 +90,10 @@ public:
         bool pyro_cont[4];      // true = continuity OK (load present, closed)
         bool pyro_fired[4];
 
+        // Per-sensor health scorecard (#303): 2 bits/sensor, NA/OK/DEGRADED/BAD.
+        // Layout in RocketComputerTypes.h (SH_*_SHIFT). 0 = nothing reported.
+        uint32_t sensor_health;
+
         // Source rocket identity (base station only — for multi-rocket demux)
         uint8_t source_rocket_id;       // 0 = not set (direct connection)
         const char* source_unit_name;   // nullptr = not set

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1102,6 +1102,15 @@ static inline uint32_t shSet(uint32_t field, uint8_t shift, SensorHealthState st
 static inline uint8_t shGet(uint32_t field, uint8_t shift) {
     return (uint8_t)((field >> shift) & 0x3u);
 }
+// Battery verdict from pack voltage (2S Li-ion).  The OC owns this — the FC
+// never reads the pack — so both OC downlink paths (LoRa relay + direct BLE)
+// classify here to keep the thresholds in one place.  NaN/implausible -> NA.
+static inline SensorHealthState shBatteryState(float voltage) {
+    if (!(voltage == voltage) || voltage < 1.0f) return SH_NA;  // NaN or no reading
+    if (voltage >= 7.0f) return SH_OK;
+    if (voltage >= 6.6f) return SH_DEGRADED;
+    return SH_BAD;
+}
 
 static constexpr uint8_t NSF_ALT_LANDED   = (1u << 0);
 static constexpr uint8_t NSF_ALT_APOGEE   = (1u << 1);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1299,10 +1299,12 @@ typedef struct __attribute__((packed))
 
     int16_t speed;           // m/s
 
+    uint32_t sensor_health;  // #303 scorecard bitfield (see SH_*_SHIFT)
+
 } LoRaData;
 
-static_assert(sizeof(LoRaData) == 62,
-              "LoRaData must be 62 bytes (5-byte routing header incl. 16-bit seq + 57-byte telemetry payload)");
+static_assert(sizeof(LoRaData) == 66,
+              "LoRaData must be 66 bytes (62 + uint32 sensor_health, #303)");
 
 static constexpr uint8_t LORA_LAUNCH      = (1u << 0);  // bit 0
 static constexpr uint8_t LORA_VEL_APOGEE  = (1u << 1);  // bit 1
@@ -1356,6 +1358,7 @@ typedef struct
     float   yaw;                    // int16_t      : -180 to 180
     float   q0, q1, q2, q3;        // quaternion   : -1 to 1
     float   speed;                  // 1 m/s        : 0 to 4000
+    uint32_t sensor_health;         // #303 scorecard bitfield (see SH_*_SHIFT)
 } LoRaDataSI;
 
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1068,10 +1068,40 @@ typedef struct __attribute__((packed))
         bit 3–7: reserved
     */
 
+    // Sensor health scorecard (#303): 2 bits per item (SensorHealthState), see
+    // the SH_*_SHIFT positions below — incl. a state per pyro channel.  FC fills
+    // baro/IMU/EKF/mag/GNSS/pyro×4; the OC ORs in the battery bits before relay.
+    uint32_t sensor_health;
+
 } NonSensorData;
 
-static_assert(sizeof(NonSensorData) == 44,
-              "NonSensorData must be 44 bytes");
+static_assert(sizeof(NonSensorData) == 48,
+              "NonSensorData must be 48 bytes");
+
+// ── Sensor health scorecard (#303) ──────────────────────────────────────────
+// 2 bits per item packed into NonSensorData.sensor_health (FC→OC) and
+// LoRaData.sensor_health (OC→BS), a uint32.  Surfaced to the operator pre-launch
+// on iOS (BLE JSON key "h").  Mirror this encoding in the iOS app's
+// TelemetryData.  Per pyro channel so the operator sees each configured charge.
+enum SensorHealthState : uint8_t { SH_NA = 0, SH_OK = 1, SH_DEGRADED = 2, SH_BAD = 3 };
+// Bit shift (×2) per item within the 32-bit field.
+static constexpr uint8_t SH_BARO_SHIFT = 0;
+static constexpr uint8_t SH_IMU_SHIFT  = 2;
+static constexpr uint8_t SH_EKF_SHIFT  = 4;   // EKF health + init + orientation residual
+static constexpr uint8_t SH_MAG_SHIFT  = 6;
+static constexpr uint8_t SH_GNSS_SHIFT = 8;
+static constexpr uint8_t SH_BATT_SHIFT = 10;  // set by the OC from POWERData
+// Per pyro channel.  SH_NA = channel not configured for this flight (ignored by
+// the operator's go/no-go); OK = continuity present; DEGRADED = configured but
+// continuity not yet tested; BAD = configured, tested, no continuity.
+static constexpr uint8_t SH_PYRO_SHIFT[4] = { 12, 14, 16, 18 };
+// bits 20-31 reserved
+static inline uint32_t shSet(uint32_t field, uint8_t shift, SensorHealthState st) {
+    return (field & ~(uint32_t)(0x3u << shift)) | ((uint32_t)st << shift);
+}
+static inline uint8_t shGet(uint32_t field, uint8_t shift) {
+    return (uint8_t)((field >> shift) & 0x3u);
+}
 
 static constexpr uint8_t NSF_ALT_LANDED   = (1u << 0);
 static constexpr uint8_t NSF_ALT_APOGEE   = (1u << 1);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1087,7 +1087,7 @@ enum SensorHealthState : uint8_t { SH_NA = 0, SH_OK = 1, SH_DEGRADED = 2, SH_BAD
 // Bit shift (×2) per item within the 32-bit field.
 static constexpr uint8_t SH_BARO_SHIFT = 0;
 static constexpr uint8_t SH_IMU_SHIFT  = 2;
-static constexpr uint8_t SH_EKF_SHIFT  = 4;   // EKF health + init + orientation residual
+static constexpr uint8_t SH_EKF_SHIFT  = 4;   // EKF filter health: init + isHealthy + covariance converged
 static constexpr uint8_t SH_MAG_SHIFT  = 6;
 static constexpr uint8_t SH_GNSS_SHIFT = 8;
 static constexpr uint8_t SH_BATT_SHIFT = 10;  // set by the OC from POWERData

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -481,6 +481,8 @@ void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
         float sp = clampf(in.speed, 0.f, 4000.f);
         out.speed = (int16_t)lroundf(sp);
     }
+
+    out.sensor_health = in.sensor_health;  // #303 raw bitfield, no encoding
 }
 
 void SensorConverter::unpackLoRa(const LoRaData& in, LoRaDataSI& out)
@@ -537,6 +539,7 @@ void SensorConverter::unpackLoRa(const LoRaData& in, LoRaDataSI& out)
     out.q3 = (float)in.q3 / 10000.0f;
 
     out.speed = (float)in.speed;
+    out.sensor_health = in.sensor_health;  // #303
 
     // Not transmitted in LoRaData (superset fields)
     out.base_station_voltage = 0.0f;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1100,6 +1100,10 @@ static void buildBLETelemetry(const LoRaDataSI& lora, float rssi, float snr,
     out.gdop = lora.pdop;
     out.num_sats = (int)lora.num_sats;
 
+    // Sensor health scorecard bitfield (#303) — relayed straight from the
+    // FC/OC LoRa downlink; iOS unpacks the 2-bit-per-sensor states.
+    out.sensor_health = lora.sensor_health;
+
     // State
     out.state = rocketStateToString(lora.rocket_state);
 

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -216,6 +216,17 @@ struct config
     static constexpr float    GNSS_MAX_VEL_INIT_MPS = 2.0f;  // max velocity magnitude for EKF init
     static constexpr uint8_t  GNSS_MIN_SATS_INIT    = 5;     // minimum sats for EKF init (stricter)
 
+    // EKF scorecard health (#303): the filter counts as "converged" when its
+    // worst-axis attitude and velocity covariance sit below these.  stabilizeP()
+    // caps the diagonals at P_MAX_ATT=10 (~180° σ) and P_MAX_VEL=1e4 (~100 m/s σ),
+    // so a diverged filter pins at the cap while isHealthy() (NaN-only) still
+    // reads true — these bars catch that.  Chosen well below the caps but loose
+    // enough to pass a stationary bench (where heading/yaw is weakly observable),
+    // and robust to the half-angle attitude convention.  PROVISIONAL — validate
+    // against converged values from a bench log via Data_Analysis/replay_flight_ekf.py.
+    static constexpr float    EKF_ATT_VAR_OK        = 1.0f;   // rad², worst attitude axis
+    static constexpr float    EKF_VEL_VAR_OK        = 25.0f;  // (m/s)², worst velocity axis (~5 m/s σ)
+
     // Barometer spike rejection: max altitude change (m) between consecutive
     // BMP585 samples before the reading is rejected.  At 500 Hz a 5 m jump
     // implies >2500 m/s — far beyond any model rocket — so real flight data

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -219,13 +219,14 @@ struct config
     // EKF scorecard health (#303): the filter counts as "converged" when its
     // worst-axis attitude and velocity covariance sit below these.  stabilizeP()
     // caps the diagonals at P_MAX_ATT=10 (~180° σ) and P_MAX_VEL=1e4 (~100 m/s σ),
-    // so a diverged filter pins at the cap while isHealthy() (NaN-only) still
-    // reads true — these bars catch that.  Chosen well below the caps but loose
-    // enough to pass a stationary bench (where heading/yaw is weakly observable),
-    // and robust to the half-angle attitude convention.  PROVISIONAL — validate
-    // against converged values from a bench log via Data_Analysis/replay_flight_ekf.py.
-    static constexpr float    EKF_ATT_VAR_OK        = 1.0f;   // rad², worst attitude axis
-    static constexpr float    EKF_VEL_VAR_OK        = 25.0f;  // (m/s)², worst velocity axis (~5 m/s σ)
+    // so a diverged filter pins at the cap while isHealthy() (NaN-only) still reads
+    // true — these bars catch that.  Tuned from a 34 s stationary bench run
+    // (Data_Analysis/analyze_ekf_cov.py, replay through this same EKF): converged
+    // worst-axis attitude settled to ~0.01–0.028 rad² (1σ ~6–9.5°) and velocity to
+    // ~0.03–1.0 (m/s)² (1σ ~0.2–1 m/s).  Bars sit a few× above that — pass a
+    // converged filter, flag one that hasn't converged or is pinned at the cap.
+    static constexpr float    EKF_ATT_VAR_OK        = 0.1f;   // rad²,  worst attitude axis (~18° 1σ)
+    static constexpr float    EKF_VEL_VAR_OK        = 4.0f;   // (m/s)², worst velocity axis (~2 m/s 1σ)
 
     // Barometer spike rejection: max altitude change (m) between consecutive
     // BMP585 samples before the reading is rejected.  At 500 Hz a 5 m jump

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5559,13 +5559,23 @@ static void loop_fc()
             }
             sh = shSet(sh, SH_IMU_SHIFT, imu_st);
 
-            // EKF / attitude — BAD until initialized; DEGRADED if unhealthy (#265)
-            // or the orientation residual is large / thrust-axis mismatch (#238).
+            // EKF — the FILTER's own health, not the board-orientation auto-detect
+            // (#238): that residual is a mounting-config signal that reads large off
+            // the vertical pad and says nothing about the Kalman state.  BAD until
+            // initialized; DEGRADED if diverging (isHealthy()'s NaN-repair cooldown)
+            // or the covariance hasn't converged — stabilizeP() pins the diagonals
+            // at P_MAX_* on divergence, which a finite isHealthy() can't see, so we
+            // check the worst attitude + velocity variance directly.  OK = converged.
             SensorHealthState ekf_st = SH_BAD;
             if (ekf_initialized) {
-                const bool orient_ok = (b2r_active_residual_cdeg < 1000) &&  // < 10 deg
-                                       !orient_thrust_mismatch;
-                ekf_st = (ekf.isHealthy() && orient_ok) ? SH_OK : SH_DEGRADED;
+                float covO[3], covV[3];
+                ekf.getCovOrient(covO);
+                ekf.getCovVel(covV);
+                const float att_var = fmaxf(covO[0], fmaxf(covO[1], covO[2]));
+                const float vel_var = fmaxf(covV[0], fmaxf(covV[1], covV[2]));
+                const bool converged = att_var < config::EKF_ATT_VAR_OK &&
+                                       vel_var < config::EKF_VEL_VAR_OK;
+                ekf_st = (ekf.isHealthy() && converged) ? SH_OK : SH_DEGRADED;
             }
             sh = shSet(sh, SH_EKF_SHIFT, ekf_st);
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5573,16 +5573,16 @@ static void loop_fc()
             sh = shSet(sh, SH_MAG_SHIFT,
                        (have_iis2mdc_si || have_mmc_si) ? SH_OK : SH_NA);
 
-            // GNSS — 3D fix + sats + horizontal accuracy.
+            // GNSS — OK needs a 3D fix + enough sats (+ horizontal accuracy,
+            // but only when that gate is enabled: config::GNSS_MAX_HACC_M == 0
+            // is a "disabled" sentinel, so comparing against it would make OK
+            // unreachable).  DEGRADED = 3D fix but marginal; BAD = no 3D fix.
             SensorHealthState gnss_st = SH_BAD;
-            if (have_gnss_si) {
-                if (gnss_latest_si.fix_mode >= 3U &&
-                    gnss_latest_si.num_sats >= config::GNSS_MIN_SATS &&
-                    gnss_latest_si.horizontal_accuracy < config::GNSS_MAX_HACC_M) {
-                    gnss_st = SH_OK;
-                } else if (gnss_latest_si.fix_mode >= 3U) {
-                    gnss_st = SH_DEGRADED;   // 3D fix but marginal sats/accuracy
-                }
+            if (have_gnss_si && gnss_latest_si.fix_mode >= 3U) {
+                const bool hacc_ok = (config::GNSS_MAX_HACC_M <= 0.0f) ||
+                                     (gnss_latest_si.horizontal_accuracy < config::GNSS_MAX_HACC_M);
+                gnss_st = (gnss_latest_si.num_sats >= config::GNSS_MIN_SATS && hacc_ok)
+                          ? SH_OK : SH_DEGRADED;
             }
             sh = shSet(sh, SH_GNSS_SHIFT, gnss_st);
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5534,6 +5534,74 @@ static void loop_fc()
             non_sensor_data.pyro_status = ps;
         }
 
+        // Sensor health scorecard (#303): pack 2-bit verdicts for the operator's
+        // pre-launch go/no-go (surfaced on iOS).  FC fills all but battery, which
+        // the OC ORs in from POWERData before the LoRa relay.
+        {
+            uint32_t sh = 0;
+            const uint32_t now_us_h = time_us();
+
+            // Baro — in BMP585 range + fresh (mirrors #257 baro_healthy).
+            SensorHealthState baro_st = SH_BAD;
+            if (have_bmp_si) {
+                const bool fresh = (uint32_t)(now_us_h - bmp_latest_si.time_us) < 500000u;
+                const bool inrange = bmp_latest_si.pressure > 25000.0f &&
+                                     bmp_latest_si.pressure < 125000.0f;
+                baro_st = inrange ? (fresh ? SH_OK : SH_DEGRADED) : SH_BAD;
+            }
+            sh = shSet(sh, SH_BARO_SHIFT, baro_st);
+
+            // IMU — present + fresh (mirrors #259 ism6_fresh).
+            SensorHealthState imu_st = SH_BAD;
+            if (have_ism6_si) {
+                const bool fresh = (uint32_t)(now_us_h - ism6_latest_si.time_us) < 100000u;
+                imu_st = fresh ? SH_OK : SH_DEGRADED;
+            }
+            sh = shSet(sh, SH_IMU_SHIFT, imu_st);
+
+            // EKF / attitude — BAD until initialized; DEGRADED if unhealthy (#265)
+            // or the orientation residual is large / thrust-axis mismatch (#238).
+            SensorHealthState ekf_st = SH_BAD;
+            if (ekf_initialized) {
+                const bool orient_ok = (b2r_active_residual_cdeg < 1000) &&  // < 10 deg
+                                       !orient_thrust_mismatch;
+                ekf_st = (ekf.isHealthy() && orient_ok) ? SH_OK : SH_DEGRADED;
+            }
+            sh = shSet(sh, SH_EKF_SHIFT, ekf_st);
+
+            // Mag — present (cal-residual refinement is a follow-up; amber-only).
+            sh = shSet(sh, SH_MAG_SHIFT,
+                       (have_iis2mdc_si || have_mmc_si) ? SH_OK : SH_NA);
+
+            // GNSS — 3D fix + sats + horizontal accuracy.
+            SensorHealthState gnss_st = SH_BAD;
+            if (have_gnss_si) {
+                if (gnss_latest_si.fix_mode >= 3U &&
+                    gnss_latest_si.num_sats >= config::GNSS_MIN_SATS &&
+                    gnss_latest_si.horizontal_accuracy < config::GNSS_MAX_HACC_M) {
+                    gnss_st = SH_OK;
+                } else if (gnss_latest_si.fix_mode >= 3U) {
+                    gnss_st = SH_DEGRADED;   // 3D fix but marginal sats/accuracy
+                }
+            }
+            sh = shSet(sh, SH_GNSS_SHIFT, gnss_st);
+
+            // Per-channel pyro (#303): only configured channels matter.  Carried
+            // in sensor_health because LoRaData has no pyro_status, so on a
+            // base-station relay this is the only pyro signal.
+            for (int i = 0; i < 4; ++i) {
+                SensorHealthState pst = SH_NA;              // not configured -> ignored
+                if (pyroChEnabled(i)) {
+                    pst = !cont_known[i] ? SH_DEGRADED      // configured, not yet tested
+                        : (cont_state[i] ? SH_OK : SH_BAD); // continuity present / none
+                }
+                sh = shSet(sh, SH_PYRO_SHIFT[i], pst);
+            }
+
+            // Battery bits (12-13) left N/A — the OC fills them from POWERData.
+            non_sensor_data.sensor_health = sh;
+        }
+
         if ((logic_now_us - last_non_sensor_tx_time_us) >= non_sensor_tx_period_us)
         {
             last_non_sensor_tx_time_us = logic_now_us;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2338,6 +2338,17 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
         lora.voltage = power_si.voltage;
         lora.current = power_si.current;
         lora.soc = power_si.soc;
+
+        // #303: relay the FC's health verdicts and OR in the battery state (the
+        // FC leaves battery N/A — only the OC reads POWERData).  2S-pack
+        // thresholds; tunable, and #272 may refine the low-voltage policy.
+        uint32_t sh = latest_non_sensor_valid ? latest_non_sensor.sensor_health : 0u;
+        const float v = power_si.voltage;
+        SensorHealthState batt = (v < 1.0f)  ? SH_NA       // no/implausible reading
+                               : (v >= 7.0f) ? SH_OK       // 2S pack healthy
+                               : (v >= 6.6f) ? SH_DEGRADED
+                                             : SH_BAD;
+        lora.sensor_health = shSet(sh, SH_BATT_SHIFT, batt);
     }
 
     lora.pressure_alt = pressure_alt_m;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2343,12 +2343,7 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
         // FC leaves battery N/A — only the OC reads POWERData).  2S-pack
         // thresholds; tunable, and #272 may refine the low-voltage policy.
         uint32_t sh = latest_non_sensor_valid ? latest_non_sensor.sensor_health : 0u;
-        const float v = power_si.voltage;
-        SensorHealthState batt = (v < 1.0f)  ? SH_NA       // no/implausible reading
-                               : (v >= 7.0f) ? SH_OK       // 2S pack healthy
-                               : (v >= 6.6f) ? SH_DEGRADED
-                                             : SH_BAD;
-        lora.sensor_health = shSet(sh, SH_BATT_SHIFT, batt);
+        lora.sensor_health = shSet(sh, SH_BATT_SHIFT, shBatteryState(power_si.voltage));
     }
 
     lora.pressure_alt = pressure_alt_m;
@@ -3898,6 +3893,18 @@ static void printStats()
     ble_telem.q2 = (float)latest_non_sensor.q2 / 10000.0f;
     ble_telem.q3 = (float)latest_non_sensor.q3 / 10000.0f;
     ble_telem.roll_cmd = (float)latest_non_sensor.roll_cmd / 100.0f;
+    // Sensor health scorecard (#303) — direct-BLE path (no LoRa hop): take the
+    // FC's bits and fold in the OC-owned battery verdict.  The FC never reads the
+    // pack, so without this the operator would see battery = N/A on a direct link.
+    {
+        uint32_t sh = latest_non_sensor.sensor_health;
+        if (latest_power_valid) {
+            POWERDataSI p = {};
+            sensor_converter.convertPowerData(latest_power_raw, p);
+            sh = shSet(sh, SH_BATT_SHIFT, shBatteryState(p.voltage));
+        }
+        ble_telem.sensor_health = sh;
+    }
     ble_telem.rssi = NAN;  // LoRa RSSI only meaningful on base station (continuous RX)
     ble_telem.snr = NAN;
     ble_telem.bs_soc = NAN;      // No base station battery


### PR DESCRIPTION
Surfaces per-sensor health to the operator before launch, end to end:
FC computes a packed bitfield → OC relays it over LoRa (+ battery) → BS/OC emit
it in the BLE telemetry JSON → the iOS dashboard shows a health card and a
go/no-go recommendation. Closes #303.

## Wire format
`uint32 sensor_health`, 2 bits/item (NA/OK/DEGRADED/BAD), laid out in
`RocketComputerTypes.h` (`SH_*_SHIFT`): baro, IMU, EKF, mag, GNSS, battery, and
4 per-channel pyro. Carried in `NonSensorData` (44→48 B) and `LoRaData`
(62→66 B); static_asserts + the host type test updated.

## Layers
- **FC** — computes the bitfield each cycle (baro range/fresh, IMU fresh, EKF
  filter health, mag presence, GNSS fix/sats, per-configured-pyro continuity).
- **OC** — relays the FC bits and folds in the battery verdict (the FC never
  reads the pack); shared `shBatteryState()` keeps the 2S thresholds in one
  place for both the LoRa-relay and direct-BLE paths.
- **BS/OC BLE** — `TelemetryData.sensor_health` + compact `"h"` JSON field,
  bounded by the existing per-field MTU guard.
- **iOS** — decodes `"h"`, renders `HealthCardView` (per-sensor chips, only
  configured pyros shown), and a `flightReadiness` rollup: red on a hard fault
  (baro/IMU/battery BAD or a configured pyro with no continuity), green only
  when every required item is OK incl. EKF converged + a GNSS fix, mag advisory.

## Follow-up fixes (from review + bench data)
- **GNSS OK was unreachable** — the OK gate compared `h_acc < GNSS_MAX_HACC_M`,
  but that constant is `0` (a "disabled" sentinel), so it was always false.
- **EKF health now reflects the filter, not board orientation** — the bit had
  gated on the #238 mounting-residual, which reads large off the vertical pad
  and says nothing about the Kalman state (it pinned the EKF at DEGRADED on the
  bench). Now: initialized + `isHealthy()` + covariance converged. This also
  closes a gap where a diverged-but-`stabilizeP`-capped filter passed the
  NaN-only `isHealthy()`.
- **Thresholds tuned from a 34 s stationary bench replay** (new
  `Data_Analysis/analyze_ekf_cov.py`): converged worst-axis attitude ~6–9.5°,
  velocity ~0.2–1 m/s → `EKF_ATT_VAR_OK=0.1`, `EKF_VEL_VAR_OK=4.0`.

## Validation
- FC / OC / BS build clean (IDF v6.0).
- Host C++ suite 356/356 (incl. updated struct-size test).
- iOS app + 7 new `TelemetryDataTests` (bit positions, every rollup verdict,
  mag-advisory, configured-pyro rows) pass on the iOS 26.4 simulator.
- Bench `.bin` replayed through the EKF to set the covariance thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)