### PR TITLE
oc(log): keep the flush task draining after a NAND write failure (#271)

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -2025,7 +2025,17 @@ void TR_LogToFlash::flushRingToNand()
 
             if (!ok)
             {
+                // #271: a persistent write failure (flight region full or a
+                // bad-block run) must NOT wedge the drain.  The staged page was
+                // already popped from the ring (:ringPop above) and can't be
+                // recovered, so drop it and keep going: rewind current_file_bytes
+                // (this page never reached NAND) and reset page_buf_idx so the
+                // next flushRingToNand computes need>0 and keeps draining —
+                // instead of need==0 -> chunk==0 -> break, forever, which dropped
+                // the entire rest of the flight as ring overruns.
                 nand_prog_fail++;
+                current_file_bytes -= chunk_target;
+                page_buf_idx = 0;
                 return;
             }
             nand_bytes_written += chunk_target;


### PR DESCRIPTION
Closes #271.

## Bug (CRITICAL — flight-data recorder)
On the first persistent NAND write failure (flight region full or a bad-block
run), `flushRingToNand` did `nand_prog_fail++; return;` with `page_buf_idx`
still `== chunk_target`. Every later call then computed
`need = chunk_target - page_buf_idx == 0` → `chunk == 0` → `break`, so the
flush task drained **nothing forever**: the entire remainder of the flight
(apogee + descent) was lost as ring overruns. The page's bytes were also
already popped from the ring, and `current_file_bytes` (the reported file size)
over-counted them.

## Fix
In the `!ok` branch:
- `page_buf_idx = 0` — so the next `flushRingToNand` computes `need > 0` and
  keeps draining instead of wedging.
- `current_file_bytes -= chunk_target` — that page never reached NAND; don't
  count it toward the file size.

The staged page is unrecoverable (already popped), so we accept the one-page
loss and keep logging everything after it — a transient bad block recovers on
the next write; a truly-full region degrades gracefully instead of wedging.
`nand_prog_fail` already increments and is already surfaced via `getStats()`
(the OC logs it), so suggested-fix #3 is in place.

## Verification
- OC builds clean (IDF v6.0).
- Traced against region-full (keeps draining, accurate counters), transient
  bad block (recovers, one-page loss), and no-underflow (`current_file_bytes ≥
  chunk_target` at the failure point).
- No host harness for `TR_LogToFlash` (LFS + NAND/SPI deps the host build
  lacks). Bench regression — fill the flight region or force a write failure
  and confirm logging continues past it — to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)