### PR TITLE
oc(power): report USB-bench power — lower INA230 validity floor 5.5->3.0 V (#272)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -722,12 +722,15 @@ static void updateEulerFromNonSensor()
 // Uses triggered mode: fires one conversion (~0.7ms with 1 avg × 332us × 2ch),
 // polls CVRF for completion, reads results, then INA returns to power-down.
 // Called inline from the main loop at ~100 Hz.
-// 2S pack bus-voltage window we trust from the INA230.  A real pack — even
-// sagging hard under boost — sits well inside this; a dropped/failed read (0 V)
-// or a stuck/garbage value falls outside.  Wide on purpose: it rejects only
-// *failed* reads.  A genuinely low pack stays valid and is flagged DEGRADED/BAD
-// by the scorecard's shBatteryState (#272/#303).
-static constexpr float   POWER_BUS_V_MIN      = 5.5f;
+// Plausible bus-voltage window from the INA230 — accept any real powered-board
+// reading and reject only a *failed* read.  The floor sits below USB (~5.2 V) so
+// USB-bench power is still reported: the operator wants to see the actual reading
+// (and knows it's USB) rather than have it suppressed to N/A, even though 5 V reads
+// BAD on the 2S scorecard.  A dropped/failed read (0 V — the failure sentinel
+// readINA230Power passes on I2C error / CVRF timeout) or NaN/+-Inf falls below the
+// floor and is rejected.  Flight pack is 2S (6.6-8.4 V); shBatteryState classifies
+// the reading's health (#272/#303).
+static constexpr float   POWER_BUS_V_MIN      = 3.0f;   // below USB; still rejects 0 V failed reads
 static constexpr float   POWER_BUS_V_MAX      = 9.0f;
 // Invalidate cached power (-> battery N/A on the scorecard) only after this many
 // consecutive bad reads, so a one-off glitch holds last-good instead of flickering.


### PR DESCRIPTION
Refines #272 (no issue to close).

## Why
The #272 INA230 validity floor of 5.5 V rejected the ~5.2 V **USB rail** as implausible, which suppressed all power telemetry and dropped the scorecard battery to N/A during USB-powered bench work. The operator wants to *see* the actual reading on the bench (and knows it's USB), not have it hidden.

## Change
Lower `POWER_BUS_V_MIN` 5.5 → **3.0 V**:
- A real powered-board reading (USB ~5 V, or a 2S pack at 6.6–8.4 V) is reported.
- A **failed** read still falls below the floor and is rejected — `0 V` is the sentinel `readINA230Power` passes on an I2C error / CVRF timeout, and `NaN`/`±Inf` fail the finite range — so #272's anti-garbage behavior (→ battery N/A after `POWER_BAD_READ_LIMIT` consecutive bad reads) is preserved.

## Note
On USB the scorecard battery reads **BAD** (5 V is below the 2S-empty threshold, and voltage alone can't distinguish USB from a deeply-dead pack). That's truthful; the real OK/DEGRADED/BAD verdict returns on the 2S flight pack.

## Verification
- OC builds clean (IDF v6.0). One-constant change; no struct/wire impact.
- Bench: on USB, voltage/current report (~5.2 V, SoC 0%); pull the INA230 → battery still goes N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
