### PR TITLE
fc/app(servo): physical fin-angle calibration + gain retune + app inputs (#267)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -147,7 +147,8 @@ final class ActiveRocketSyncer: ObservableObject {
         device.sendServoConfig(
             biases: [profile.servoBias1, profile.servoBias2,
                      profile.servoBias3, profile.servoBias4],
-            hz: profile.servoHz, minUs: profile.servoMinUs, maxUs: profile.servoMaxUs)
+            hz: profile.servoHz, minUs: profile.servoMinUs, maxUs: profile.servoMaxUs,
+            finMinDeg: profile.finMinDeg, finMaxDeg: profile.finMaxDeg)
         device.sendPIDConfig(
             kp: profile.pidKp, ki: profile.pidKi, kd: profile.pidKd,
             minCmd: profile.pidMinCmd, maxCmd: profile.pidMaxCmd)

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -611,7 +611,8 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
-    func sendServoConfig(biases: [Int16], hz: Int16, minUs: Int16, maxUs: Int16) {
+    func sendServoConfig(biases: [Int16], hz: Int16, minUs: Int16, maxUs: Int16,
+                         finMinDeg: Float, finMaxDeg: Float) {
         var payload = Data()
         for i in 0..<4 {
             var b: Int16 = i < biases.count ? biases[i] : 0
@@ -620,6 +621,9 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         var h = hz;  payload.append(Data(bytes: &h, count: 2))
         var mn = minUs; payload.append(Data(bytes: &mn, count: 2))
         var mx = maxUs; payload.append(Data(bytes: &mx, count: 2))
+        // #267: fin-angle calibration (physical deg at min/max pulse) — 14 -> 22 bytes
+        var fmn = finMinDeg; payload.append(Data(bytes: &fmn, count: 4))
+        var fmx = finMaxDeg; payload.append(Data(bytes: &fmx, count: 4))
         sendRawCommand(12, payload: payload)
         if var cfg = rocketConfig {
             cfg.servoBias1 = biases.count > 0 ? biases[0] : 0

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -786,6 +786,8 @@ nonisolated struct ServoSettings: Codable, Sendable {
     let frequency_hz: Int
     let min_pulse_us: Int
     let max_pulse_us: Int
+    let fin_min_deg: Double?   // #267: physical fin angle at min_pulse_us (nil pre-v3)
+    let fin_max_deg: Double?   // #267: physical fin angle at max_pulse_us (nil pre-v3)
 
     init(from raw: FlightSettingsData) {
         enabled = raw.servoEnabled
@@ -793,6 +795,8 @@ nonisolated struct ServoSettings: Codable, Sendable {
         frequency_hz = Int(raw.servo_hz)
         min_pulse_us = Int(raw.servo_min_us)
         max_pulse_us = Int(raw.servo_max_us)
+        fin_min_deg = raw.fin_min_deg.map { sigFig($0) }
+        fin_max_deg = raw.fin_max_deg.map { sigFig($0) }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -100,17 +100,25 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var servoBias3: Int16 = 0
     var servoBias4: Int16 = 0
     var servoHz: Int16 = 333
-    var servoMinUs: Int16 = 1250
-    var servoMaxUs: Int16 = 1750
+    // #267: full-travel range. 1000us = fin -60deg, 2000us = +60deg (the servo's
+    // mechanical limit). MUST match config.h SERVO_MIN_US/MAX_US + the firmware
+    // setFinCalibration endpoints, or the commanded-vs-physical fin angle is wrong
+    // (e.g. 1250/1750 would only reach +/-30deg at a +/-60deg command).
+    var servoMinUs: Int16 = 1000
+    var servoMaxUs: Int16 = 2000
 
     // MARK: PID
-    // Defaults: RollyPolly III SIL tune (#170). KI raised for fin-misalignment
-    // rejection, made safe by the integral-separation anti-windup below.
-    var pidKp: Float = 0.02
-    var pidKi: Float = 0.03
+    // Defaults match the FC factory config (#267): kp=0.12 reproduces the flown
+    // physical roll authority on the corrected 1:1 fin-angle scale; ki is a small
+    // bench-tunable seed (SIL roll plant unvalidated). MinCmd/MaxCmd are the max
+    // command deflection (+/-20deg), well inside the +/-60deg mechanical limit.
+    // MUST stay in sync with config.h KP/KI/MIN_CMD/MAX_CMD -- this profile is
+    // pushed on connect (ActiveRocketSyncer) and OVERRIDES the firmware defaults.
+    var pidKp: Float = 0.12
+    var pidKi: Float = 0.01
     var pidKd: Float = 0.0
-    var pidMinCmd: Float = -10.0
-    var pidMaxCmd: Float = 10.0
+    var pidMinCmd: Float = -20.0
+    var pidMaxCmd: Float = 20.0
     var integralSepThreshold: Float = 40   // PID integral-separation anti-windup threshold (deg/s); 0 disables
 
     // MARK: Roll profile

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -106,6 +106,11 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     // (e.g. 1250/1750 would only reach +/-30deg at a +/-60deg command).
     var servoMinUs: Int16 = 1000
     var servoMaxUs: Int16 = 2000
+    // #267: physical fin angle (deg) the servo reaches at servoMinUs / servoMaxUs.
+    // Fin bolts directly to the servo arm (1:1), so this is the servo's mechanical
+    // travel. Sent with the servo config; the FC maps commanded fin-deg across it.
+    var finMinDeg: Float = -60.0
+    var finMaxDeg: Float = 60.0
 
     // MARK: PID
     // Defaults match the FC factory config (#267): kp=0.12 reproduces the flown
@@ -205,6 +210,8 @@ extension RocketProfile {
         servoHz = try c.decodeIfPresent(Int16.self, forKey: .servoHz) ?? defaults.servoHz
         servoMinUs = try c.decodeIfPresent(Int16.self, forKey: .servoMinUs) ?? defaults.servoMinUs
         servoMaxUs = try c.decodeIfPresent(Int16.self, forKey: .servoMaxUs) ?? defaults.servoMaxUs
+        finMinDeg = try c.decodeIfPresent(Float.self, forKey: .finMinDeg) ?? defaults.finMinDeg
+        finMaxDeg = try c.decodeIfPresent(Float.self, forKey: .finMaxDeg) ?? defaults.finMaxDeg
 
         pidKp = try c.decodeIfPresent(Float.self, forKey: .pidKp) ?? defaults.pidKp
         pidKi = try c.decodeIfPresent(Float.self, forKey: .pidKi) ?? defaults.pidKi

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -23,7 +23,7 @@ enum MessageType: UInt8 {
     case h3lis331 = 0xA9   // Legacy-only high-G accelerometer (10B)
     case cameraStart = 0xAA
     case cameraStop = 0xAB
-    case flightSettings = 0xE1  // FlightSettingsData (188B v1 / 200B v2) — runtime settings snapshot at launch (#165)
+    case flightSettings = 0xE1  // FlightSettingsData (188B v1 / 200B v2 / 208B v3) — runtime settings snapshot at launch (#165)
     case iis2mdc = 0xD1    // IIS2MDC magnetometer (new Mini PCB rev, 10B)
     case lora = 0xF1
 }
@@ -164,6 +164,11 @@ nonisolated struct FlightSettingsData {
     // v2 tail: board→rocket mounting orientation, appended at fixed offset
     // 188 after the full v1 layout. nil on v1 frames (pre-orientation
     // firmware, which always assumed the +X-nose mounting).
+    // v3 tail: fin-angle calibration (#267), appended at offset 200. nil on
+    // pre-v3 frames.
+    let fin_min_deg: Float?
+    let fin_max_deg: Float?
+
     let b2r_code: UInt8?
     let b2r_mode: UInt8?            // 0 default, 1 manual, 2 auto-snap, 3 auto-exact
     let b2r_residual_deg: Float?    // auto-snap residual angle
@@ -278,6 +283,16 @@ nonisolated struct FlightSettingsData {
             b2r_mode = nil
             b2r_residual_deg = nil
             b2r_quat = nil
+        }
+
+        // v3 fin-angle calibration tail at fixed offset 200 (#267).
+        if version >= 3 && data.count >= 208 {
+            var o = 200
+            fin_min_deg = data.readFloat32LE(at: &o)
+            fin_max_deg = data.readFloat32LE(at: &o)
+        } else {
+            fin_min_deg = nil
+            fin_max_deg = nil
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -36,6 +36,8 @@ struct SettingsView: View {
     @State private var sServoHz = ""
     @State private var sServoMinUs = ""
     @State private var sServoMaxUs = ""
+    @State private var sFinMinDeg = ""
+    @State private var sFinMaxDeg = ""
     @State private var sPidKp = ""
     @State private var sPidKi = ""
     @State private var sPidKd = ""
@@ -107,7 +109,7 @@ struct SettingsView: View {
     // MARK: - Focus-driven self-apply (#144)
 
     private enum EditField: Hashable {
-        case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax
+        case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax, finMin, finMax
         case pidKp, pidKi, pidKd, pidMin, pidMax
         case rollDelay
         case rateCap
@@ -121,7 +123,7 @@ struct SettingsView: View {
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
-        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax: return .servo
+        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax, .finMin, .finMax: return .servo
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay, .rateCap, .kpAngle, .integralSep: return .rollControl
         case .wpTime, .wpAngle: return .rollWaypoints
@@ -338,12 +340,16 @@ struct SettingsView: View {
             stringRow("Kp", text: $sPidKp, field: .pidKp, decimal: true)
             stringRow("Ki", text: $sPidKi, field: .pidKi, decimal: true)
             stringRow("Kd", text: $sPidKd, field: .pidKd, decimal: true)
-            stringRow("Min Cmd", text: $sPidMinCmd, field: .pidMin, unit: "deg")
-            stringRow("Max Cmd", text: $sPidMaxCmd, field: .pidMax, unit: "deg")
+            Text("Roll-rate-null PID, in fin-degrees per deg/s of roll-rate error. Kp sets roll authority, Ki slowly cancels a steady fin-misalignment spin, Kd is normally 0.")
+                .font(.caption).foregroundColor(.secondary)
+            stringRow("Min Deflection", text: $sPidMinCmd, field: .pidMin, unit: "deg")
+            stringRow("Max Deflection", text: $sPidMaxCmd, field: .pidMax, unit: "deg")
+            Text("Hard clamp on commanded fin deflection (\u{00B1} max deflection). Stay inside the servo's mechanical fin-angle range set in the Servo section below.")
+                .font(.caption).foregroundColor(.secondary)
             Toggle("Velocity Gain Scheduling", isOn: bind(\.gainScheduleEnabled) {
                 device.sendGainScheduleConfig(enabled: $0)
             })
-            Text("Scales PID gains with (V_ref/V)\u{00B2}. Disable for fixed gains at all speeds.")
+            Text("Scales the gains by (V_ref/V)\u{00B2} so fin authority stays roughly constant as speed changes. Disable for fixed gains at all speeds.")
                 .font(.caption).foregroundColor(.secondary)
         }
 
@@ -355,11 +361,15 @@ struct SettingsView: View {
             stringRow("Servo 2", text: $sBias2, field: .bias2)
             stringRow("Servo 3", text: $sBias3, field: .bias3)
             stringRow("Servo 4", text: $sBias4, field: .bias4)
-            Text("Microsecond offset per servo to trim mechanical misalignment.")
+            Text("Per-servo pulse offset (\u{00B5}s) to trim mechanical misalignment so a zero command holds the fin straight.")
                 .font(.caption).foregroundColor(.secondary)
             stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
             stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
             stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
+            stringRow("Min Fin Angle", text: $sFinMinDeg, field: .finMin, unit: "deg")
+            stringRow("Max Fin Angle", text: $sFinMaxDeg, field: .finMax, unit: "deg")
+            Text("Fin-angle calibration: the physical fin deflection at Min/Max Pulse \u{2014} the servo's mechanical travel (fin bolts 1:1 to the arm). The controller maps a commanded fin angle onto the pulse that produces it, so e.g. 1000/2000\u{00B5}s = \u{2212}60/+60\u{00B0}.")
+                .font(.caption).foregroundColor(.secondary)
         }
 
         rollControlSection
@@ -777,6 +787,8 @@ struct SettingsView: View {
         sServoHz = formatInt(Double(p.servoHz))
         sServoMinUs = formatInt(Double(p.servoMinUs))
         sServoMaxUs = formatInt(Double(p.servoMaxUs))
+        sFinMinDeg = formatDecimal(Double(p.finMinDeg))
+        sFinMaxDeg = formatDecimal(Double(p.finMaxDeg))
         sPidKp = formatDecimal(Double(p.pidKp))
         sPidKi = formatDecimal(Double(p.pidKi))
         sPidKd = formatDecimal(Double(p.pidKd))
@@ -887,13 +899,17 @@ struct SettingsView: View {
         let hz = Int16(clamping: Int(parseDouble(sServoHz, fallback: Double(profile.servoHz)).rounded()))
         let mn = Int16(clamping: Int(parseDouble(sServoMinUs, fallback: Double(profile.servoMinUs)).rounded()))
         let mx = Int16(clamping: Int(parseDouble(sServoMaxUs, fallback: Double(profile.servoMaxUs)).rounded()))
+        let fmn = Float(parseDouble(sFinMinDeg, fallback: Double(profile.finMinDeg)))
+        let fmx = Float(parseDouble(sFinMaxDeg, fallback: Double(profile.finMaxDeg)))
 
         updateProfile {
             $0.servoBias1 = b1; $0.servoBias2 = b2; $0.servoBias3 = b3; $0.servoBias4 = b4
             $0.servoHz = hz; $0.servoMinUs = mn; $0.servoMaxUs = mx
+            $0.finMinDeg = fmn; $0.finMaxDeg = fmx
         }
         if device.isConnected {
-            device.sendServoConfig(biases: [b1, b2, b3, b4], hz: hz, minUs: mn, maxUs: mx)
+            device.sendServoConfig(biases: [b1, b2, b3, b4], hz: hz, minUs: mn, maxUs: mx,
+                                   finMinDeg: fmn, finMaxDeg: fmx)
         }
         showApplied($servoApplied)
     }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -790,7 +790,7 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
 // by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
 // here so a struct edit can't silently desync the cross-language decode.
 TEST(RocketComputerTypes, FlightSettingsData_Layout) {
-    EXPECT_EQ(sizeof(FlightSettingsData), 200u);  // v2: +12 for b2r orientation
+    EXPECT_EQ(sizeof(FlightSettingsData), 208u);  // v2: +12 b2r orientation; v3: +8 fin cal
     EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
 
     EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
@@ -831,6 +831,11 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
     EXPECT_EQ(offsetof(FlightSettingsData, b2r_mode),          189u);
     EXPECT_EQ(offsetof(FlightSettingsData, b2r_residual_cdeg), 190u);
     EXPECT_EQ(offsetof(FlightSettingsData, b2r_q),             192u);
+
+    // v3 fin-angle calibration tail (#267) — appended after b2r_q (192 + 8 = 200)
+    // so v1/v2 parsers decode their prefix unchanged.
+    EXPECT_EQ(offsetof(FlightSettingsData, fin_min_deg),       200u);
+    EXPECT_EQ(offsetof(FlightSettingsData, fin_max_deg),       204u);
 }
 
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1632,8 +1632,10 @@ typedef struct __attribute__((packed))
     int16_t hz;           // PWM frequency
     int16_t min_us;       // Minimum pulse width
     int16_t max_us;       // Maximum pulse width
+    float   fin_min_deg;  // #267: physical fin angle (deg) at min_us pulse
+    float   fin_max_deg;  // #267: physical fin angle (deg) at max_us pulse
 } ServoConfigData;
-static_assert(sizeof(ServoConfigData) == 14, "ServoConfigData must be 14 bytes");
+static_assert(sizeof(ServoConfigData) == 22, "ServoConfigData must be 22 bytes");
 
 typedef struct __attribute__((packed))
 {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1728,7 +1728,8 @@ static_assert(sizeof(RollControlConfigData) == 16, "RollControlConfigData must b
 struct __attribute__((packed)) FlightSettingsData
 {
     // v2: appended board→rocket mounting orientation (b2r_* fields).
-    static constexpr uint8_t VERSION = 2;
+    // v3: appended fin-angle calibration (fin_min_deg/fin_max_deg, #267).
+    static constexpr uint8_t VERSION = 3;
 
     // flags bit positions
     static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only
@@ -1795,8 +1796,13 @@ struct __attribute__((packed)) FlightSettingsData
     uint8_t  b2r_mode;            // ORIENT_MODE_*
     int16_t  b2r_residual_cdeg;   // auto-snap residual, centi-deg
     int16_t  b2r_q[4];            // board→rocket quaternion ×10000
+
+    // Fin-angle calibration that actually flew (v3+, #267): physical fin
+    // deflection (deg) at servo_min_us / servo_max_us.
+    float    fin_min_deg;
+    float    fin_max_deg;
 };
-static_assert(sizeof(FlightSettingsData) == 200, "FlightSettingsData layout check");
+static_assert(sizeof(FlightSettingsData) == 208, "FlightSettingsData layout check");
 
 // --- Log Buffer Stats Data (OC self-emitted, ~1 Hz while logging) -----------
 // Snapshot of the OC's ring-buffer health written into the flight log so the

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -27,6 +27,8 @@ TR_ServoControl::TR_ServoControl(uint8_t servo_pin_1,
       roll_cmd_us(min_us),
       min_cmd(min_cmd_in),
       max_cmd(max_cmd_in),
+      fin_min_deg_(min_cmd_in),
+      fin_max_deg_(max_cmd_in),
       kp_base(kp),
       ki_base(ki),
       kd_base(kd),
@@ -85,14 +87,28 @@ void TR_ServoControl::control(float roll_rate) {
     roll_cmd_deg = pid.computePID(pid_setpoint, roll_rate);
     roll_cmd_deg = constrain(roll_cmd_deg, min_cmd, max_cmd);
 
-    // normalise to [0..1]
-    float span_deg = max_cmd - min_cmd;
-    float norm     = (roll_cmd_deg - min_cmd) / span_deg;
-    // convert to pulse (centre bias and servo range)
-    int base_pulse = servo_min_us + static_cast<int>(norm * (servo_max_us - servo_min_us));
+    // Map the commanded fin angle (deg) to a servo pulse via the physical
+    // fin calibration (#267) — NOT the command-clamp span.
+    int base_pulse = usFromFinDeg(roll_cmd_deg);
     base_pulse     = saturateCommand(base_pulse);
     // drive all servos
     setPulse(base_pulse);
+}
+
+// #267: physical fin-angle (deg) -> servo pulse (us).  The line is defined by
+// (fin_min_deg_ -> servo_min_us) and (fin_max_deg_ -> servo_max_us), so a
+// commanded fin angle produces the pulse that yields that physical deflection,
+// independent of the roll command clamp.
+int TR_ServoControl::usFromFinDeg(float fin_deg) const {
+    float span_deg = fin_max_deg_ - fin_min_deg_;
+    if (span_deg == 0.0f) return (servo_min_us + servo_max_us) / 2;
+    float norm = (fin_deg - fin_min_deg_) / span_deg;
+    return servo_min_us + static_cast<int>(norm * (servo_max_us - servo_min_us));
+}
+
+void TR_ServoControl::setFinCalibration(float finMinDeg, float finMaxDeg) {
+    fin_min_deg_ = finMinDeg;
+    fin_max_deg_ = finMaxDeg;
 }
 
 void TR_ServoControl::wiggle() {
@@ -113,15 +129,12 @@ void TR_ServoControl::stowControl() {
 }
 
 void TR_ServoControl::setServoAngles(const float angles[4]) {
-    float span_deg = max_cmd - min_cmd;
-    if (span_deg <= 0.0f) return;
-
     for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
+        // Clamp to the command limit (max deflection), then map via the physical
+        // fin calibration (#267) so the fin reaches the commanded *physical* angle
+        // — no longer truncated to / scaled by the roll-PID clamp.
         float angle = constrain(angles[i], min_cmd, max_cmd);
-        float norm = (angle - min_cmd) / span_deg;
-        int pulse_us = servo_min_us
-                     + static_cast<int>(norm * (servo_max_us - servo_min_us))
-                     + servo_bias_us_[i];
+        int pulse_us = usFromFinDeg(angle) + servo_bias_us_[i];
         pulse_us = saturateCommand(pulse_us);
 
         uint32_t max_duty = (1u << LEDC_RESOLUTION) - 1;

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -54,6 +54,14 @@ public:
     // during large transients (e.g. a roll kick) to prevent windup.
     void setPIDIntegralSeparationThreshold(float threshold);
 
+    // Physical fin-angle <-> servo-pulse calibration (#267): the fin angle (deg)
+    // at servo_min_us and at servo_max_us.  Decouples the deg->us scale from the
+    // command clamp (min_cmd/max_cmd) so a commanded fin angle maps to the pulse
+    // that produces that *physical* deflection.
+    void setFinCalibration(float finMinDeg, float finMaxDeg);
+    float getFinMinDeg() const { return fin_min_deg_; }
+    float getFinMaxDeg() const { return fin_max_deg_; }
+
     // Reset PID internal state (for replay / test sessions)
     void resetPID();
 
@@ -105,6 +113,9 @@ private:
     // update all four servos to a single nominal pulse
     void setPulse(int base_pulse_us);
     int  saturateCommand(int command);
+    // Map a physical fin angle (deg) to a servo pulse (us) via the fin
+    // calibration (fin_min_deg_->servo_min_us, fin_max_deg_->servo_max_us). #267
+    int  usFromFinDeg(float fin_deg) const;
 
     // arrays for each servo pin, bias and mid positions
     uint8_t servo_pin_[4];
@@ -123,6 +134,11 @@ private:
     int   roll_cmd_us;
     float min_cmd;
     float max_cmd;
+    // Fin angle (deg) at servo_min_us / servo_max_us — the physical us<->deg
+    // calibration (#267).  Defaults to min_cmd/max_cmd (legacy behaviour) until
+    // setFinCalibration() is called with the real airframe values.
+    float fin_min_deg_;
+    float fin_max_deg_;
 
     // Base PID gains (used as reference for gain scheduling)
     float kp_base;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3749,10 +3749,10 @@ static void loop_bs()
         // Servo config: cache locally + relay to OutComputer via LoRa uplink
         const uint8_t* payload = ble_app.getCommandPayload();
         size_t payload_len = ble_app.getCommandPayloadLength();
-        if (payload_len >= 14)
+        if (payload_len >= sizeof(ServoConfigData))
         {
             cacheServoConfig(payload, payload_len);
-            buildUplinkPacket(12, payload, 14);
+            buildUplinkPacket(12, payload, sizeof(ServoConfigData));
             ESP_LOGI(TAG, "[BLE->UPLINK] Servo config relayed");
         }
     }

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -179,8 +179,16 @@ struct config
     static constexpr float KP = 0.02f;
     static constexpr float KI = 0.03f;
     static constexpr float KD = 0.0f;
-    static constexpr float MIN_CMD = -10.0f;
-    static constexpr float MAX_CMD = 10.0f;
+    static constexpr float MIN_CMD = -20.0f;   // max commanded fin deflection (deg); app-tunable via PIDConfigData min/max
+    static constexpr float MAX_CMD = 20.0f;
+    // #267 servo fin-angle calibration: the physical fin deflection (deg) at
+    // SERVO_MIN_US and SERVO_MAX_US.  The fin is bolted directly to the servo arm
+    // (1:1), so the full 1000-2000us travel = +/-60 deg of fin.  Kept separate
+    // from the command clamp above so a commanded fin angle maps to the pulse
+    // that produces that *physical* deflection (was: ±cmd stretched over full
+    // travel -> 6x over-deflection).
+    static constexpr float FIN_MIN_DEG = -60.0f;
+    static constexpr float FIN_MAX_DEG = 60.0f;
     // 1-pole LP filter cutoff on the PID D-term. The raw backward-difference
     // derivative amplifies sample-to-sample gyro noise (≈1 dps Δ / 2 ms =
     // 500 dps/s "rate") into visible servo flutter even when the rocket is

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -170,14 +170,17 @@ struct config
     static constexpr int SERVO_MAX_US = 2000;
 
     static constexpr float ROLL_RATE_SET_POINT = 0.0f;
-    // Tuned for RollyPolly III via SIL (#170), 2026-06. KI raised ~30x for
-    // fin-misalignment rejection — only safe because integral-separation
-    // anti-windup (INTEGRAL_SEP_THRESHOLD_DPS) freezes the integrator during
-    // the launch transient. Validated vs the 6/14 flight + robustness and
-    // servo-lag sweeps. (Prior RP IV 2026-03-08 tune: Kp=0.04, Ki=0.001,
-    // Kd=0.0003.) Runtime-overridable via NVS "kp"/"ki"/"kd" / the app.
-    static constexpr float KP = 0.02f;
-    static constexpr float KI = 0.03f;
+    // #267 retune for the corrected fin-angle calibration.  The old command-kp
+    // hid a fixed PHYSICAL roll authority: 6/14 flew 0.04 cmd-kp x3 scale, #170
+    // flew 0.02 cmd-kp x6 scale -> both ~0.12 physical kp.  Now command ==
+    // physical fin-deg (1:1), so KP=0.12 reproduces that flown authority, and it
+    // sits in the SIL crisp-roll-null band.  KI dropped to a small seed: the
+    // FLOWN ki was ~0, high ki winds up on transients, and the SIL roll plant
+    // (Cl_p) isn't validated enough to pin it -> KI is a BENCH/FLIGHT-tune knob,
+    // raise it if a steady roll persists.  (Prior #170 SIL tune: 0.02/0.03;
+    // RP IV 2026-03-08: 0.04/0.001/0.0003.)  Runtime-overridable via NVS / app.
+    static constexpr float KP = 0.12f;
+    static constexpr float KI = 0.01f;
     static constexpr float KD = 0.0f;
     static constexpr float MIN_CMD = -20.0f;   // max commanded fin deflection (deg); app-tunable via PIDConfigData min/max
     static constexpr float MAX_CMD = 20.0f;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1474,6 +1474,8 @@ static void buildFlightSettings(FlightSettingsData& s)
     s.servo_hz     = (int16_t)servo_control.getServoHz();
     s.servo_min_us = (int16_t)servo_control.getServoMinUs();
     s.servo_max_us = (int16_t)servo_control.getServoMaxUs();
+    s.fin_min_deg  = servo_control.getFinMinDeg();
+    s.fin_max_deg  = servo_control.getFinMaxDeg();
 
     s.camera_type = runtime_camera_type;
     s.pyro        = pyro_config;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2606,6 +2606,9 @@ static void setup_fc()
     if (servoPinsValid())
     {
         servo_control.begin();
+        // #267: apply the physical fin-angle <-> pulse calibration so commanded
+        // fin degrees map to real deflection (not the command-clamp span).
+        servo_control.setFinCalibration(config::FIN_MIN_DEG, config::FIN_MAX_DEG);
         if (nvs_servo_timing_changed)
         {
             servo_control.setServoTiming(nvs_servo_hz, nvs_servo_min, nvs_servo_max);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2272,6 +2272,8 @@ static void setup_fc()
     int16_t nvs_servo_hz  = config::SERVO_HZ;
     int16_t nvs_servo_min = config::SERVO_MIN_US;
     int16_t nvs_servo_max = config::SERVO_MAX_US;
+    float   nvs_fin_min_deg = config::FIN_MIN_DEG;
+    float   nvs_fin_max_deg = config::FIN_MAX_DEG;
     bool nvs_servo_timing_changed = false;
 
     prefs.begin("servo", false);  // read-write (creates namespace on first boot)
@@ -2284,6 +2286,8 @@ static void setup_fc()
         nvs_servo_hz  = prefs.getShort("hz",  config::SERVO_HZ);
         nvs_servo_min = prefs.getShort("min", config::SERVO_MIN_US);
         nvs_servo_max = prefs.getShort("max", config::SERVO_MAX_US);
+        nvs_fin_min_deg = prefs.getFloat("fmin", config::FIN_MIN_DEG);
+        nvs_fin_max_deg = prefs.getFloat("fmax", config::FIN_MAX_DEG);
         nvs_servo_timing_changed = (nvs_servo_hz  != config::SERVO_HZ ||
                                      nvs_servo_min != config::SERVO_MIN_US ||
                                      nvs_servo_max != config::SERVO_MAX_US);
@@ -2608,7 +2612,8 @@ static void setup_fc()
         servo_control.begin();
         // #267: apply the physical fin-angle <-> pulse calibration so commanded
         // fin degrees map to real deflection (not the command-clamp span).
-        servo_control.setFinCalibration(config::FIN_MIN_DEG, config::FIN_MAX_DEG);
+        // From NVS if the app has set it, else the config default.
+        servo_control.setFinCalibration(nvs_fin_min_deg, nvs_fin_max_deg);
         if (nvs_servo_timing_changed)
         {
             servo_control.setServoTiming(nvs_servo_hz, nvs_servo_min, nvs_servo_max);
@@ -3644,7 +3649,7 @@ static void loop_fc()
             else if (out_pending_command == SERVO_CONFIG_PENDING)
             {
                 delay_ms(1);  // let slave TX FIFO settle
-                uint8_t cfg_payload[14];
+                uint8_t cfg_payload[sizeof(ServoConfigData)];
                 size_t  cfg_len = 0;
                 if (readConfigFrame(SERVO_CONFIG_MSG, sizeof(ServoConfigData),
                                     cfg_payload, sizeof(cfg_payload), cfg_len)
@@ -3652,10 +3657,11 @@ static void loop_fc()
                 {
                     ServoConfigData cfg;
                     memcpy(&cfg, cfg_payload, sizeof(cfg));
-                    ESP_LOGI(TAG, "[SERVO CFG] bias=[%d,%d,%d,%d] hz=%d min=%d max=%d",
+                    ESP_LOGI(TAG, "[SERVO CFG] bias=[%d,%d,%d,%d] hz=%d min=%d max=%d fin=[%.1f,%.1f]",
                                   cfg.bias_us[0], cfg.bias_us[1],
                                   cfg.bias_us[2], cfg.bias_us[3],
-                                  cfg.hz, cfg.min_us, cfg.max_us);
+                                  cfg.hz, cfg.min_us, cfg.max_us,
+                                  cfg.fin_min_deg, cfg.fin_max_deg);
 
                     for (int i = 0; i < 4; ++i)
                     {
@@ -3664,10 +3670,13 @@ static void loop_fc()
                     if (rocket_state != INFLIGHT)
                     {
                         servo_control.setServoTiming(cfg.hz, cfg.min_us, cfg.max_us);
+                        // #267: apply fin-angle calibration (skip a degenerate span)
+                        if (cfg.fin_max_deg != cfg.fin_min_deg)
+                            servo_control.setFinCalibration(cfg.fin_min_deg, cfg.fin_max_deg);
                     }
                     else
                     {
-                        ESP_LOGW(TAG, "[SERVO CFG] Hz/min/max deferred (INFLIGHT)");
+                        ESP_LOGW(TAG, "[SERVO CFG] Hz/min/max/fin deferred (INFLIGHT)");
                     }
 
                     prefs.begin("servo", false);
@@ -3678,6 +3687,8 @@ static void loop_fc()
                     prefs.putShort("hz", cfg.hz);
                     prefs.putShort("min", cfg.min_us);
                     prefs.putShort("max", cfg.max_us);
+                    prefs.putFloat("fmin", cfg.fin_min_deg);
+                    prefs.putFloat("fmax", cfg.fin_max_deg);
                     prefs.end();
                     ESP_LOGI(TAG, "[SERVO CFG] Saved to NVS");
                 }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2887,11 +2887,11 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
                      lora_hop_disabled ? "DISABLED" : "ENABLED");
         }
     }
-    else if (cmd == 12 && payload_len >= 14)
+    else if (cmd == 12 && payload_len >= sizeof(ServoConfigData))
     {
         // Servo config from BaseStation: relay to FlightComputer + cache
-        memcpy(pending_config_data, payload, 14);
-        pending_config_data_len = 14;
+        memcpy(pending_config_data, payload, sizeof(ServoConfigData));
+        pending_config_data_len = sizeof(ServoConfigData);
         pending_config_msg_type = SERVO_CONFIG_MSG;
         setPendingCommand(SERVO_CONFIG_PENDING);
         cacheServoConfig(payload, payload_len);
@@ -5329,13 +5329,13 @@ static void loop_oc()
         }
         else if (ble_cmd == 12)
         {
-            // Servo configuration: [bias1:2][bias2:2][bias3:2][bias4:2][hz:2][min:2][max:2] = 14 bytes
+            // Servo config: [bias1:2][bias2:2][bias3:2][bias4:2][hz:2][min:2][max:2][fin_min:4][fin_max:4] = 22 bytes
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
-            if (plen >= 14)
+            if (plen >= sizeof(ServoConfigData))
             {
-                memcpy(pending_config_data, payload, 14);
-                pending_config_data_len = 14;
+                memcpy(pending_config_data, payload, sizeof(ServoConfigData));
+                pending_config_data_len = sizeof(ServoConfigData);
                 pending_config_msg_type = SERVO_CONFIG_MSG;
                 setPendingCommand(SERVO_CONFIG_PENDING);
                 cacheServoConfig(payload, plen);


### PR DESCRIPTION
Closes #267.

## The bug
The roll-PID command (deg) → servo pulse (µs) mapping stretched the command clamp `[min_cmd, max_cmd]` across the **full** `[servo_min_us, servo_max_us]` travel. With a 1000–2000µs servo that sweeps ±60° of fin and a ±10° command clamp, a commanded 10° fin produced **60° of physical deflection — 6× over.** The gains were entangled with this wrong scale (6/14 flew 0.04 cmd-kp ×3, #170 flew 0.02 cmd-kp ×6 — both ~0.12 *physical* kp).

## The fix (6 commits, layered)
1. **`fc(servo)` calibration** — separate fin-angle calibration (physical fin deg at min/max pulse) from the command clamp; a commanded fin angle now maps to the pulse that produces that *physical* deflection (1:1, fin bolts to the servo arm).
2. **`fc(roll)` gain retune** — `kp 0.12, ki 0.01` (from 0.02/0.03). kp=0.12 reproduces the flown *physical* roll authority on the corrected 1:1 scale (scale-invariant argument, cross-checked in the 6-DOF SIL crisp-null band). ki is a small bench-tunable seed (the SIL roll plant / Cl_p isn't validated enough to pin it; flown ki was ~0).
3. **`app(roll)` default sync** — the app pushes the active profile on connect, so its old defaults (servo 1250/1750, kp 0.02/ki 0.03, clamp ±10) would have *overridden* the firmware. Defaults now match the FC config.
4. **`fc/oc/bs(servo)` protocol** — `ServoConfigData` 14→22 bytes carries `fin_min_deg/fin_max_deg`; the FC applies + persists them to NVS (loads at boot), OC/BS relay the full payload over I2C/LoRa. `sizeof()`-based copies replace hardcoded `14`s.
5. **`app(servo)` inputs + labels** — editable "Min/Max Fin Angle" rows; "Min/Max Cmd" renamed "Min/Max Deflection"; captions added across PID + servo so every control is self-explanatory.
6. **`fc/app(servo)` log completeness** — `FlightSettingsData` v2→v3 (200→208B, appended at tail) records the flown fin calibration; app decodes + exports it (config-export-completeness rule).

## Verification
- **Builds clean:** flight_computer, out_computer, base_station (IDF v6.0, all `static_assert(sizeof==22/208)` pass), iOS app (xcodebuild). `tools/check_ble_command_ids.py` PASS (no new command IDs).
- **Firmware sim flight** (458 m, 62.9 s): clean run, no crash/NaN; config applied + logged correctly in v3 (`fin −60/+60`, `kp 0.12`, `ki 0.01`, `±20` clamp, `1000/2000µs`); roll command respects the ±20 clamp; calibration math sane. (Roll *stabilization* isn't testable in the 1D no-roll firmware sim — tuned in the 6-DOF SIL; confirm on the bench.)

## Bench note
Flash **FC + OC together** (protocol moved in lockstep); BS too if configuring via the ground station. An existing saved app profile keeps old values — set servo 1000/2000, fin −60/+60, PID 0.12/0.01, deflection ±20 in the GUI (new profiles default to these). First bench check: command a fin angle, confirm it physically reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
