### PR TITLE
Configurable PN guidance + overhead mode, fin layout, and control-mode/orientation UI

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -171,7 +171,8 @@ final class ActiveRocketSyncer: ObservableObject {
                                   targetAlt: profile.pnTargetAltM)
         device.sendFinConfig(ringMode: profile.finRingMode,
                              servoAtSlot: profile.finServoAtSlot,
-                             reverse: profile.finReverse)
+                             reverse: profile.finReverse,
+                             rollReverse: profile.finRollReverse)
         device.sendCameraConfig(cameraType: profile.cameraType)
         device.sendImuOrientationConfig(profile.imuOrientSetting)
         device.sendSoundConfig(enabled: profile.soundsEnabled)

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -169,6 +169,9 @@ final class ActiveRocketSyncer: ObservableObject {
                                   targetMode: profile.pnTargetMode,
                                   targetE: profile.pnTargetE, targetN: profile.pnTargetN,
                                   targetAlt: profile.pnTargetAltM)
+        device.sendFinConfig(ringMode: profile.finRingMode,
+                             servoAtSlot: profile.finServoAtSlot,
+                             reverse: profile.finReverse)
         device.sendCameraConfig(cameraType: profile.cameraType)
         device.sendImuOrientationConfig(profile.imuOrientSetting)
         device.sendSoundConfig(enabled: profile.soundsEnabled)

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -162,7 +162,13 @@ final class ActiveRocketSyncer: ObservableObject {
         device.sendRollProfile(waypoints: profile.rollWaypoints.map {
             (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
         })
-        device.sendGuidanceConfig(enabled: profile.guidanceEnabled)
+        device.sendGuidanceConfig(enabled: profile.guidanceEnabled,
+                                  navGain: profile.pnNavGain, maxAccel: profile.pnMaxAccel,
+                                  accelToFin: profile.pnAccelToFin, maxFinDeg: profile.pnMaxFinDeg,
+                                  minSpeed: profile.pnMinSpeed, coastDelayMs: profile.pnCoastDelayMs,
+                                  targetMode: profile.pnTargetMode,
+                                  targetE: profile.pnTargetE, targetN: profile.pnTargetN,
+                                  targetAlt: profile.pnTargetAltM)
         device.sendCameraConfig(cameraType: profile.cameraType)
         device.sendImuOrientationConfig(profile.imuOrientSetting)
         device.sendSoundConfig(enabled: profile.soundsEnabled)

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -760,13 +760,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         if var cfg = rocketConfig { cfg.guidanceEnabled = enabled; rocketConfig = cfg }
     }
 
-    /// Fin layout (FinConfigData = 17 bytes, cmd 66). Derives each servo's CONTROL
+    /// Fin layout (FinConfigData = 18 bytes, cmd 66). Derives each servo's CONTROL
     /// azimuth from the ring slot it occupies (slot azimuths {0,90,180,270} for "+"
-    /// or {45,135,225,315} for "×"), then sends 4 LE floats + a per-servo reverse
-    /// bitmask. The ring GUI's nose-down view is a rendering choice and does not
-    /// change these control-frame azimuths.
-    func sendFinConfig(ringMode: UInt8, servoAtSlot: [Int], reverse: [Bool]) {
-        guard servoAtSlot.count == 4, reverse.count == 4 else { return }
+    /// or {45,135,225,315} for "×"), then sends 4 LE floats + a per-servo tilt-reverse
+    /// bitmask + an independent per-servo roll-reverse bitmask. The ring GUI's nose-down
+    /// view is a rendering choice and does not change these control-frame azimuths.
+    func sendFinConfig(ringMode: UInt8, servoAtSlot: [Int], reverse: [Bool], rollReverse: [Bool]) {
+        guard servoAtSlot.count == 4, reverse.count == 4, rollReverse.count == 4 else { return }
         let slotAz: [Float] = ringMode == 1 ? [45, 135, 225, 315] : [0, 90, 180, 270]
         var az: [Float] = [0, 90, 180, 270]            // per servo index (0=servo 1)
         for slot in 0..<4 {
@@ -778,7 +778,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         var mask: UInt8 = 0
         for i in 0..<4 where reverse[i] { mask |= (UInt8(1) << UInt8(i)) }
         payload.append(mask)
-        sendRawCommand(66, payload: payload)           // FinConfigData = 17 bytes
+        var rollMask: UInt8 = 0
+        for i in 0..<4 where rollReverse[i] { rollMask |= (UInt8(1) << UInt8(i)) }
+        payload.append(rollMask)
+        sendRawCommand(66, payload: payload)           // FinConfigData = 18 bytes
     }
 
     func sendCameraConfig(cameraType: UInt8) {

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -737,6 +737,29 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendRawCommand(32, payload: Data([enabled ? 0x01 : 0x00]))
     }
 
+    /// Full PN guidance config (GuidanceConfigData = 36 bytes, cmd 65). Floats
+    /// LE in struct order, then coast_delay(u16), enable(u8), target_mode(u8).
+    func sendGuidanceConfig(enabled: Bool, navGain: Float, maxAccel: Float, accelToFin: Float,
+                            maxFinDeg: Float, minSpeed: Float, coastDelayMs: UInt16,
+                            targetMode: UInt8, targetE: Float, targetN: Float, targetAlt: Float) {
+        var payload = Data()
+        var ng = navGain, ma = maxAccel, a2f = accelToFin, mf = maxFinDeg, ms = minSpeed
+        var te = targetE, tn = targetN, ta = targetAlt
+        payload.append(Data(bytes: &ng,  count: 4))
+        payload.append(Data(bytes: &ma,  count: 4))
+        payload.append(Data(bytes: &a2f, count: 4))
+        payload.append(Data(bytes: &mf,  count: 4))
+        payload.append(Data(bytes: &ms,  count: 4))
+        payload.append(Data(bytes: &te,  count: 4))
+        payload.append(Data(bytes: &tn,  count: 4))
+        payload.append(Data(bytes: &ta,  count: 4))
+        var cd = coastDelayMs; payload.append(Data(bytes: &cd, count: 2))
+        payload.append(enabled ? 0x01 : 0x00)
+        payload.append(targetMode)
+        sendRawCommand(65, payload: payload)   // GuidanceConfigData = 36 bytes
+        if var cfg = rocketConfig { cfg.guidanceEnabled = enabled; rocketConfig = cfg }
+    }
+
     func sendCameraConfig(cameraType: UInt8) {
         sendRawCommand(33, payload: Data([cameraType]))
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -760,6 +760,27 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         if var cfg = rocketConfig { cfg.guidanceEnabled = enabled; rocketConfig = cfg }
     }
 
+    /// Fin layout (FinConfigData = 17 bytes, cmd 66). Derives each servo's CONTROL
+    /// azimuth from the ring slot it occupies (slot azimuths {0,90,180,270} for "+"
+    /// or {45,135,225,315} for "×"), then sends 4 LE floats + a per-servo reverse
+    /// bitmask. The ring GUI's nose-down view is a rendering choice and does not
+    /// change these control-frame azimuths.
+    func sendFinConfig(ringMode: UInt8, servoAtSlot: [Int], reverse: [Bool]) {
+        guard servoAtSlot.count == 4, reverse.count == 4 else { return }
+        let slotAz: [Float] = ringMode == 1 ? [45, 135, 225, 315] : [0, 90, 180, 270]
+        var az: [Float] = [0, 90, 180, 270]            // per servo index (0=servo 1)
+        for slot in 0..<4 {
+            let servo = servoAtSlot[slot]              // 1-4
+            if servo >= 1 && servo <= 4 { az[servo - 1] = slotAz[slot] }
+        }
+        var payload = Data()
+        for i in 0..<4 { var a = az[i]; payload.append(Data(bytes: &a, count: 4)) }
+        var mask: UInt8 = 0
+        for i in 0..<4 where reverse[i] { mask |= (UInt8(1) << UInt8(i)) }
+        payload.append(mask)
+        sendRawCommand(66, payload: payload)           // FinConfigData = 17 bytes
+    }
+
     func sendCameraConfig(cameraType: UInt8) {
         sendRawCommand(33, payload: Data([cameraType]))
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -132,7 +132,8 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     // +pitch, 2 right/+yaw, 3 bottom, 4 left) so an unconfigured rocket is unchanged.
     var finRingMode: UInt8 = 0                              // 0 = "+" on-axis, 1 = "×" 45°
     var finServoAtSlot: [Int] = [1, 2, 3, 4]               // servo (1-4) at slot 0..3
-    var finReverse: [Bool] = [false, false, false, false]  // per-servo (1-4) reverse
+    var finReverse: [Bool] = [false, false, false, false]  // per-servo (1-4) tilt (pitch/yaw) reverse
+    var finRollReverse: [Bool] = [false, false, false, false]  // per-servo (1-4) roll reverse (independent)
 
     // MARK: PID
     // Defaults match the FC factory config (#267): kp=0.12 reproduces the flown
@@ -249,6 +250,8 @@ extension RocketProfile {
         finServoAtSlot = finSlots.count == 4 ? finSlots : defaults.finServoAtSlot
         let finRev = try c.decodeIfPresent([Bool].self, forKey: .finReverse) ?? defaults.finReverse
         finReverse = finRev.count == 4 ? finRev : defaults.finReverse
+        let finRollRev = try c.decodeIfPresent([Bool].self, forKey: .finRollReverse) ?? defaults.finRollReverse
+        finRollReverse = finRollRev.count == 4 ? finRollRev : defaults.finRollReverse
 
         pidKp = try c.decodeIfPresent(Float.self, forKey: .pidKp) ?? defaults.pidKp
         pidKi = try c.decodeIfPresent(Float.self, forKey: .pidKi) ?? defaults.pidKi

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -104,7 +104,7 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     /// manual board→rocket code. Manual fixes the roll clocking the control
     /// surfaces need — required for roll-controlled/guided flights with an
     /// off-axis board; optional for non-controlled flights.
-    var imuOrientSetting: UInt8 = 0xFF
+    var imuOrientSetting: UInt8 = 0   // default: manual identity (+X nose/up); 0xFF = pad auto-detect
 
     // MARK: Servo
     var servoBias1: Int16 = 85

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -124,6 +124,16 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var finMinDeg: Float = -60.0
     var finMaxDeg: Float = 60.0
 
+    // MARK: Fin layout
+    // Servo→fin mapping + ring orientation, sent as FinConfigData (cmd 66): each
+    // servo's CONTROL azimuth (deg) + a reverse bitmask. finServoAtSlot[s] is the
+    // servo (1-4) at ring slot s; slot control azimuths are {0,90,180,270} ("+")
+    // or {45,135,225,315} ("×"). Defaults reproduce the firmware "+" (servo 1 top/
+    // +pitch, 2 right/+yaw, 3 bottom, 4 left) so an unconfigured rocket is unchanged.
+    var finRingMode: UInt8 = 0                              // 0 = "+" on-axis, 1 = "×" 45°
+    var finServoAtSlot: [Int] = [1, 2, 3, 4]               // servo (1-4) at slot 0..3
+    var finReverse: [Bool] = [false, false, false, false]  // per-servo (1-4) reverse
+
     // MARK: PID
     // Defaults match the FC factory config (#267): kp=0.12 reproduces the flown
     // physical roll authority on the corrected 1:1 fin-angle scale; ki is a small
@@ -234,6 +244,11 @@ extension RocketProfile {
         servoMaxUs = try c.decodeIfPresent(Int16.self, forKey: .servoMaxUs) ?? defaults.servoMaxUs
         finMinDeg = try c.decodeIfPresent(Float.self, forKey: .finMinDeg) ?? defaults.finMinDeg
         finMaxDeg = try c.decodeIfPresent(Float.self, forKey: .finMaxDeg) ?? defaults.finMaxDeg
+        finRingMode = try c.decodeIfPresent(UInt8.self, forKey: .finRingMode) ?? defaults.finRingMode
+        let finSlots = try c.decodeIfPresent([Int].self, forKey: .finServoAtSlot) ?? defaults.finServoAtSlot
+        finServoAtSlot = finSlots.count == 4 ? finSlots : defaults.finServoAtSlot
+        let finRev = try c.decodeIfPresent([Bool].self, forKey: .finReverse) ?? defaults.finReverse
+        finReverse = finRev.count == 4 ? finRev : defaults.finReverse
 
         pidKp = try c.decodeIfPresent(Float.self, forKey: .pidKp) ?? defaults.pidKp
         pidKi = try c.decodeIfPresent(Float.self, forKey: .pidKi) ?? defaults.pidKi

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -87,6 +87,18 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var rateCapDps: Float = 60          // outer-loop angle→rate cap (deg/s)
     var kpAngle: Float = 2.0            // outer angle-loop P-gain (cascaded angle control)
     var guidanceEnabled: Bool = false
+    // PN guidance params. Defaults MUST equal config.h (PN_*); pushed on connect,
+    // they override the FC, so a mismatch silently re-tunes guidance.
+    var pnNavGain: Float = 5.0          // config::PN_NAV_GAIN
+    var pnMaxAccel: Float = 20.0        // config::PN_MAX_ACCEL_MPS2
+    var pnAccelToFin: Float = 4.0       // config::PN_ACCEL_TO_FIN_DEG
+    var pnMaxFinDeg: Float = 15.0       // config::PN_MAX_FIN_DEG
+    var pnMinSpeed: Float = 15.0        // config::PN_MIN_SPEED_MPS
+    var pnCoastDelayMs: UInt16 = 0      // config::PN_COAST_DELAY_MS
+    var pnTargetAltM: Float = 600.0     // config::PN_TARGET_ALT_M
+    var pnTargetMode: UInt8 = 0         // GUIDE_TARGET_OVERHEAD (Phase 1: locked)
+    var pnTargetE: Float = 0
+    var pnTargetN: Float = 0
     var cameraType: UInt8 = 2          // 0=None, 1=GoPro, 2=RunCam
     /// IMU mounting orientation: 0xFF = auto (pad-gravity detect), 0..23 =
     /// manual board→rocket code. Manual fixes the roll clocking the control
@@ -200,6 +212,16 @@ extension RocketProfile {
         rateCapDps = try c.decodeIfPresent(Float.self, forKey: .rateCapDps) ?? defaults.rateCapDps
         kpAngle = try c.decodeIfPresent(Float.self, forKey: .kpAngle) ?? defaults.kpAngle
         guidanceEnabled = try c.decodeIfPresent(Bool.self, forKey: .guidanceEnabled) ?? defaults.guidanceEnabled
+        pnNavGain = try c.decodeIfPresent(Float.self, forKey: .pnNavGain) ?? defaults.pnNavGain
+        pnMaxAccel = try c.decodeIfPresent(Float.self, forKey: .pnMaxAccel) ?? defaults.pnMaxAccel
+        pnAccelToFin = try c.decodeIfPresent(Float.self, forKey: .pnAccelToFin) ?? defaults.pnAccelToFin
+        pnMaxFinDeg = try c.decodeIfPresent(Float.self, forKey: .pnMaxFinDeg) ?? defaults.pnMaxFinDeg
+        pnMinSpeed = try c.decodeIfPresent(Float.self, forKey: .pnMinSpeed) ?? defaults.pnMinSpeed
+        pnCoastDelayMs = try c.decodeIfPresent(UInt16.self, forKey: .pnCoastDelayMs) ?? defaults.pnCoastDelayMs
+        pnTargetAltM = try c.decodeIfPresent(Float.self, forKey: .pnTargetAltM) ?? defaults.pnTargetAltM
+        pnTargetMode = try c.decodeIfPresent(UInt8.self, forKey: .pnTargetMode) ?? defaults.pnTargetMode
+        pnTargetE = try c.decodeIfPresent(Float.self, forKey: .pnTargetE) ?? defaults.pnTargetE
+        pnTargetN = try c.decodeIfPresent(Float.self, forKey: .pnTargetN) ?? defaults.pnTargetN
         cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
         imuOrientSetting = try c.decodeIfPresent(UInt8.self, forKey: .imuOrientSetting) ?? defaults.imuOrientSetting
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
@@ -1,0 +1,210 @@
+//
+//  FinLayoutView.swift
+//  TinkerRocketApp
+//
+//  Rocket-settings editor for the servo→fin mapping + ring orientation (FinConfigData,
+//  cmd 66).  A nose-down ring (looking from the nose aft: +Z up, +Y right) where each
+//  servo sits at a fin position; the ring is "+" (on-axis) or "×" (45°); each fin can be
+//  reversed; and a servo jog (reuses the servo-test path) confirms deflection direction
+//  on the bench.  Pure presentation: values in, edit closures out — the parent owns the
+//  profile and sends the config.
+//
+
+import SwiftUI
+
+struct FinLayoutView: View {
+    let device: BLEDevice
+    let ringMode: UInt8            // 0 = "+", 1 = "×"
+    let servoAtSlot: [Int]         // servo (1-4) at ring slot 0..3
+    let reverse: [Bool]            // per-servo (1-4) reverse
+    let canJog: Bool
+    let onSetRingMode: (UInt8) -> Void
+    let onSetServoAtSlot: ([Int]) -> Void
+    let onSetReverse: ([Bool]) -> Void
+
+    @State private var selectedSlot: Int = 0
+
+    /// Control azimuth (deg) of each ring slot — the firmware convention
+    /// (θ=0 top/+pitch, 90 +yaw, …); the nose-down view is rendering only.
+    private var slotAzimuths: [Double] {
+        ringMode == 1 ? [45, 135, 225, 315] : [0, 90, 180, 270]
+    }
+    private var selectedServo: Int {
+        servoAtSlot.indices.contains(selectedSlot) ? servoAtSlot[selectedSlot] : 1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Picker("Orientation", selection: ringModeBinding) {
+                Text("+ on axes").tag(0)
+                Text("× 45°").tag(1)
+            }
+            .pickerStyle(.segmented)
+
+            ring
+                .frame(height: 230)
+                .frame(maxWidth: .infinity)
+
+            Text("Viewed from the nose, looking aft · +Z up, +Y right · tap a fin")
+                .font(.caption2).foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Divider()
+            selectedFinEditor
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: Ring
+
+    private var ring: some View {
+        GeometryReader { geo in
+            let cx = geo.size.width / 2
+            let cy = geo.size.height / 2
+            let r = min(cx, cy) - 26
+            ZStack {
+                Circle()
+                    .stroke(Color.secondary.opacity(0.6), lineWidth: 1.5)
+                    .frame(width: 2 * r, height: 2 * r)
+                    .position(x: cx, y: cy)
+                Circle().fill(Color.secondary.opacity(0.5))
+                    .frame(width: 7, height: 7).position(x: cx, y: cy)
+
+                // Axis labels: +Z top, +Y right, −Z bottom, −Y left (nose-down).
+                ForEach(0..<4, id: \.self) { i in
+                    Text(["+Z", "+Y", "−Z", "−Y"][i])
+                        .font(.caption2).foregroundColor(.secondary)
+                        .position(point(clockwiseDeg: Double(i) * 90, radius: r + 16, cx: cx, cy: cy))
+                }
+
+                ForEach(0..<4, id: \.self) { slot in
+                    finMarker(slot: slot, r: r, cx: cx, cy: cy)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func finMarker(slot: Int, r: CGFloat, cx: CGFloat, cy: CGFloat) -> some View {
+        let scrA = (360 - slotAzimuths[slot]).truncatingRemainder(dividingBy: 360)  // nose-down mirror
+        let sel = slot == selectedSlot
+        let servo = servoAtSlot.indices.contains(slot) ? servoAtSlot[slot] : slot + 1
+        let bladeCenter = point(clockwiseDeg: scrA, radius: r, cx: cx, cy: cy)
+        let badgeCenter = point(clockwiseDeg: scrA, radius: r - 22, cx: cx, cy: cy)
+
+        Rectangle()
+            .fill(sel ? Color.accentColor : Color.secondary)
+            .frame(width: 6, height: 26)
+            .rotationEffect(.degrees(scrA))
+            .position(bladeCenter)
+
+        Button { selectedSlot = slot } label: {
+            Text("\(servo)")
+                .font(.headline)
+                .foregroundColor(sel ? Color.white : Color.primary)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(sel ? Color.accentColor : Color(.secondarySystemBackground)))
+                .overlay(Circle().stroke(sel ? Color.accentColor : Color.secondary, lineWidth: 1.5))
+        }
+        .buttonStyle(.plain)
+        .position(badgeCenter)
+    }
+
+    // MARK: Selected-fin editor
+
+    private var selectedFinEditor: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(slotName(selectedSlot)).font(.subheadline).fontWeight(.semibold)
+                Spacer()
+                Text("drives: \(mixDescription(selectedSlot))")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+
+            HStack {
+                Text("Servo here")
+                Spacer()
+                Picker("", selection: servoBinding) {
+                    ForEach(1...4, id: \.self) { Text("\($0)").tag($0) }
+                }
+                .pickerStyle(.segmented).frame(width: 170)
+            }
+
+            Toggle("Reverse (mirrored servo)", isOn: reverseBinding)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Jog servo \(selectedServo) to confirm direction")
+                    .font(.caption).foregroundColor(.secondary)
+                HStack(spacing: 8) {
+                    Button { jog(-10) } label: { Label("−10°", systemImage: "minus") }
+                    Button { jogStop() } label: { Label("Stop", systemImage: "stop.fill") }
+                    Button { jog(10) } label: { Label("+10°", systemImage: "plus") }
+                }
+                .buttonStyle(.bordered)
+                .disabled(!canJog)
+                if !canJog {
+                    Text("Connect and power on the rocket to jog the servos.")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: Bindings
+
+    private var ringModeBinding: Binding<Int> {
+        Binding(get: { Int(ringMode) }, set: { onSetRingMode(UInt8($0)) })
+    }
+    private var servoBinding: Binding<Int> {
+        Binding(get: { selectedServo }, set: { newServo in
+            guard servoAtSlot.indices.contains(selectedSlot) else { return }
+            var slots = servoAtSlot
+            if let other = slots.firstIndex(of: newServo) { slots[other] = slots[selectedSlot] }
+            slots[selectedSlot] = newServo
+            onSetServoAtSlot(slots)
+        })
+    }
+    private var reverseBinding: Binding<Bool> {
+        Binding(get: { reverse.indices.contains(selectedServo - 1) ? reverse[selectedServo - 1] : false },
+                set: { newVal in
+            guard reverse.indices.contains(selectedServo - 1) else { return }
+            var rev = reverse
+            rev[selectedServo - 1] = newVal
+            onSetReverse(rev)
+        })
+    }
+
+    // MARK: Jog (reuses the servo-test path)
+
+    private func jog(_ deg: Double) {
+        let idx = selectedServo - 1
+        guard idx >= 0 && idx < 4 else { return }
+        var angles = [0.0, 0.0, 0.0, 0.0]
+        // Apply the per-servo reverse so the jog reflects the controller's "+".
+        angles[idx] = (reverse.indices.contains(idx) && reverse[idx]) ? -deg : deg
+        device.sendServoTestAngles(angles)
+    }
+    private func jogStop() { device.sendServoTestStop() }
+
+    // MARK: Geometry + labels
+
+    private func point(clockwiseDeg deg: Double, radius: CGFloat, cx: CGFloat, cy: CGFloat) -> CGPoint {
+        let a = deg * .pi / 180
+        return CGPoint(x: cx + radius * CGFloat(sin(a)), y: cy - radius * CGFloat(cos(a)))
+    }
+    private func slotName(_ slot: Int) -> String {
+        let plus  = ["Top · +Z", "Left · −Y", "Bottom · −Z", "Right · +Y"]
+        let cross = ["Upper-left", "Lower-left", "Lower-right", "Upper-right"]
+        let names = ringMode == 1 ? cross : plus
+        return names.indices.contains(slot) ? names[slot] : "Fin"
+    }
+    private func mixDescription(_ slot: Int) -> String {
+        let th = slotAzimuths[slot] * .pi / 180
+        let c = cos(th), s = sin(th)
+        var parts: [String] = []
+        if abs(c) > 0.05 { parts.append("pitch \(c > 0 ? "+" : "−")") }
+        if abs(s) > 0.05 { parts.append("yaw \(s > 0 ? "+" : "−")") }
+        parts.append("roll +")
+        return parts.joined(separator: " · ")
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
@@ -16,11 +16,13 @@ struct FinLayoutView: View {
     let device: BLEDevice
     let ringMode: UInt8            // 0 = "+", 1 = "×"
     let servoAtSlot: [Int]         // servo (1-4) at ring slot 0..3
-    let reverse: [Bool]            // per-servo (1-4) reverse
+    let reverse: [Bool]            // per-servo (1-4) tilt (pitch/yaw) reverse
+    let rollReverse: [Bool]        // per-servo (1-4) roll reverse (independent)
     let canJog: Bool
     let onSetRingMode: (UInt8) -> Void
     let onSetServoAtSlot: ([Int]) -> Void
     let onSetReverse: ([Bool]) -> Void
+    let onSetRollReverse: ([Bool]) -> Void
 
     @State private var selectedSlot: Int = 0
 
@@ -130,7 +132,8 @@ struct FinLayoutView: View {
                 .pickerStyle(.segmented).frame(width: 170)
             }
 
-            Toggle("Reverse (mirrored servo)", isOn: reverseBinding)
+            Toggle("Reverse pitch/yaw (tilt)", isOn: reverseBinding)
+            Toggle("Reverse roll", isOn: rollReverseBinding)
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Jog servo \(selectedServo) to confirm direction")
@@ -173,6 +176,15 @@ struct FinLayoutView: View {
             onSetReverse(rev)
         })
     }
+    private var rollReverseBinding: Binding<Bool> {
+        Binding(get: { rollReverse.indices.contains(selectedServo - 1) ? rollReverse[selectedServo - 1] : false },
+                set: { newVal in
+            guard rollReverse.indices.contains(selectedServo - 1) else { return }
+            var rev = rollReverse
+            rev[selectedServo - 1] = newVal
+            onSetRollReverse(rev)
+        })
+    }
 
     // MARK: Jog (reuses the servo-test path)
 
@@ -200,11 +212,14 @@ struct FinLayoutView: View {
     }
     private func mixDescription(_ slot: Int) -> String {
         let th = slotAzimuths[slot] * .pi / 180
-        let c = cos(th), s = sin(th)
+        let servo = servoAtSlot.indices.contains(slot) ? servoAtSlot[slot] : slot + 1
+        let tilt = (reverse.indices.contains(servo - 1) && reverse[servo - 1]) ? -1.0 : 1.0
+        let rollS = (rollReverse.indices.contains(servo - 1) && rollReverse[servo - 1]) ? -1.0 : 1.0
+        let c = cos(th) * tilt, s = sin(th) * tilt
         var parts: [String] = []
         if abs(c) > 0.05 { parts.append("pitch \(c > 0 ? "+" : "−")") }
         if abs(s) > 0.05 { parts.append("yaw \(s > 0 ? "+" : "−")") }
-        parts.append("roll +")
+        parts.append("roll \(rollS > 0 ? "+" : "−")")
         return parts.joined(separator: " · ")
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -45,6 +45,7 @@ struct SettingsView: View {
     @State private var sPidMaxCmd = ""
     @State private var sRollDelayMs = ""
     @State private var savedRollUsesAngle: Bool? = nil
+    @State private var savedOrientCode: UInt8? = nil
     @State private var sRateCapDps = ""
     @State private var sKpAngle = ""
     @State private var sIntegralSep = ""
@@ -552,12 +553,30 @@ struct SettingsView: View {
         }
 
         Section("IMU Mounting") {
-            Picker("Orientation", selection: imuOrientBinding) {
-                Text("Auto-detect").tag(255)
-                ForEach(0..<24, id: \.self) { code in
-                    Text("Nose \(FlightSettingsData.b2rName(code: UInt8(code)))").tag(code)
-                }
+            Picker("Mode", selection: orientModeBinding) {
+                Text("Manual").tag(0)
+                Text("Pad auto-detect").tag(1)
             }
+            .pickerStyle(.segmented)
+
+            if profile.imuOrientSetting != 0xFF {
+                Picker("Nose axis", selection: noseAxisBinding) {
+                    ForEach(0..<6, id: \.self) { i in
+                        Text(["+X", "-X", "+Y", "-Y", "+Z", "-Z"][i]).tag(i)
+                    }
+                }
+                Picker("Fin clocking", selection: clockingBinding) {
+                    ForEach(0..<4, id: \.self) { i in
+                        Text(["0\u{00B0}", "90\u{00B0}", "180\u{00B0}", "270\u{00B0}"][i]).tag(i)
+                    }
+                }
+                Text("Which board axis points at the nose (up on the pad). Manual also fixes the fin clocking (quarter-turns about the nose) \u{2014} required for roll-controlled or guided flight.")
+                    .font(.caption).foregroundColor(.secondary)
+            } else {
+                Text("Detects the nose axis from gravity on the pad. It can\u{2019}t observe fin clocking, so this is fine only for non-controlled flights \u{2014} not roll or guidance.")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+
             if !device.imuOrientationName.isEmpty {
                 HStack {
                     Text("Active on rocket")
@@ -566,21 +585,45 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                 }
             }
-            Text(profile.imuOrientSetting == 0xFF
-                ? "Auto detects which board axis points at the nose from gravity on the pad. Fine for non-controlled flights."
-                : "Manual mounting also fixes the fin clocking (rNN = quarter-turns about the nose) — required for roll-controlled or guided flights when the board is mounted off-axis.")
-                .font(.caption).foregroundColor(.secondary)
         }
     }
 
-    private var imuOrientBinding: Binding<Int> {
+    // Board→rocket orientation: 0xFF = pad auto-detect, else code = axis*4 + clock.
+    private var orientModeBinding: Binding<Int> {
         Binding(
-            get: { Int(profile.imuOrientSetting) },
+            get: { profile.imuOrientSetting == 0xFF ? 1 : 0 },
             set: { newValue in
-                let v = UInt8(clamping: newValue)
+                let v: UInt8
+                if newValue == 1 {
+                    if profile.imuOrientSetting != 0xFF { savedOrientCode = profile.imuOrientSetting }
+                    v = 0xFF
+                } else {
+                    v = savedOrientCode ?? 0
+                }
                 updateProfile { $0.imuOrientSetting = v }
                 if device.isConnected { device.sendImuOrientationConfig(v) }
             })
+    }
+    private var noseAxisBinding: Binding<Int> {
+        Binding(
+            get: { profile.imuOrientSetting == 0xFF ? 0 : Int(profile.imuOrientSetting) / 4 },
+            set: { axis in
+                let clock = profile.imuOrientSetting == 0xFF ? 0 : Int(profile.imuOrientSetting) % 4
+                setOrientCode(axis: axis, clock: clock)
+            })
+    }
+    private var clockingBinding: Binding<Int> {
+        Binding(
+            get: { profile.imuOrientSetting == 0xFF ? 0 : Int(profile.imuOrientSetting) % 4 },
+            set: { clock in
+                let axis = profile.imuOrientSetting == 0xFF ? 0 : Int(profile.imuOrientSetting) / 4
+                setOrientCode(axis: axis, clock: clock)
+            })
+    }
+    private func setOrientCode(axis: Int, clock: Int) {
+        let v = UInt8(clamping: axis * 4 + clock)
+        updateProfile { $0.imuOrientSetting = v }
+        if device.isConnected { device.sendImuOrientationConfig(v) }
     }
 
     @ViewBuilder

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -663,7 +663,7 @@ struct SettingsView: View {
                     .focused($focusedField, equals: .guidTargetAlt)
                 Text("m").foregroundColor(.secondary)
             }
-            Text("Aim-point altitude above the pad. Set above expected apogee so guidance steers up-and-over the pad through the whole coast.")
+            Text("Aim-point altitude above the pad. Set near (or modestly above) expected apogee \u{2014} aiming far above weakens guidance (it reaches closest-approach early).")
                 .font(.caption).foregroundColor(.secondary)
 
             HStack {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -658,12 +658,14 @@ struct SettingsView: View {
                 ringMode: profile.finRingMode,
                 servoAtSlot: profile.finServoAtSlot,
                 reverse: profile.finReverse,
+                rollReverse: profile.finRollReverse,
                 canJog: device.isConnected && !device.isBaseStation && device.telemetry.pwr_pin_on,
                 onSetRingMode: { m in updateProfile { $0.finRingMode = m }; applyFinConfig() },
                 onSetServoAtSlot: { s in updateProfile { $0.finServoAtSlot = s }; applyFinConfig() },
-                onSetReverse: { r in updateProfile { $0.finReverse = r }; applyFinConfig() }
+                onSetReverse: { r in updateProfile { $0.finReverse = r }; applyFinConfig() },
+                onSetRollReverse: { r in updateProfile { $0.finRollReverse = r }; applyFinConfig() }
             )
-            Text("Map each servo to its fin, set the ring orientation (+ on axes or \u{00D7} at 45\u{00B0}), and reverse any mirrored servo. On the bench, jog each servo to confirm it deflects the way the ring shows.")
+            Text("Map each servo to its fin and set the ring orientation (+ on axes or \u{00D7} at 45\u{00B0}). If a fin's tilt is backwards in ground test, flip Reverse pitch/yaw; if its roll is backwards, flip Reverse roll. Jog each servo on the bench to confirm direction.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -1099,7 +1101,8 @@ struct SettingsView: View {
         if device.isConnected {
             device.sendFinConfig(ringMode: profile.finRingMode,
                                  servoAtSlot: profile.finServoAtSlot,
-                                 reverse: profile.finReverse)
+                                 reverse: profile.finReverse,
+                                 rollReverse: profile.finRollReverse)
         }
         showApplied($finApplied)
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -44,6 +44,7 @@ struct SettingsView: View {
     @State private var sPidMinCmd = ""
     @State private var sPidMaxCmd = ""
     @State private var sRollDelayMs = ""
+    @State private var savedRollUsesAngle: Bool? = nil
     @State private var sRateCapDps = ""
     @State private var sKpAngle = ""
     @State private var sIntegralSep = ""
@@ -384,8 +385,12 @@ struct SettingsView: View {
                 .font(.caption).foregroundColor(.secondary)
         }
 
-        rollControlSection
-        guidanceSection
+        controlModeSection
+        if profile.guidanceEnabled {
+            guidanceSection
+        } else {
+            rollControlSection
+        }
         finLayoutSection
     }
 
@@ -579,6 +584,20 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private var controlModeSection: some View {
+        Section(header: Text("Control Mode")) {
+            Picker("Mode", selection: controlModeBinding) {
+                Text("Roll Control").tag(0)
+                Text("Guidance").tag(1)
+            }
+            .pickerStyle(.segmented)
+            Text(profile.guidanceEnabled
+                ? "PN guidance steers pitch/yaw toward the target. Roll is rate-nulled \u{2014} the profile is ignored."
+                : "The roll controller holds the airframe (null roll, or track a roll-angle profile). No guidance.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
     private var rollControlSection: some View {
         Section(header: configHeader("Roll Control", applied: rollControlApplied)) {
             Picker("Mode", selection: angleControlBinding) {
@@ -672,8 +691,9 @@ struct SettingsView: View {
 
     private var guidanceSection: some View {
         Section(header: configHeader("PN Guidance", applied: guidanceApplied)) {
-            Toggle("Enable Guidance", isOn: bind(\.guidanceEnabled) { _ in applyGuidanceConfig() })
-            Text("Proportional-navigation steering. Engages with roll control at its initiation delay after launch (not after burnout). Phase 1 target: directly over the launch pad (overhead).")
+            Text("Roll axis is rate-nulled (held at zero spin) \u{2014} the roll profile is not followed in Guidance mode.")
+                .font(.caption).foregroundColor(.secondary)
+            Text("Proportional-navigation steering toward the target. Engages with roll control at its initiation delay after launch (not after burnout). Phase 1 target: directly over the launch pad (overhead).")
                 .font(.caption).foregroundColor(.secondary)
 
             HStack {
@@ -852,6 +872,28 @@ struct SettingsView: View {
             get: { profile.useAngleControl },
             set: { newValue in
                 updateProfile { $0.useAngleControl = newValue }
+                applyRollControlConfig()
+            })
+    }
+
+    /// Top-level control mode: 0 = Roll Control, 1 = Guidance.  Derived from
+    /// guidanceEnabled.  Guidance forces useAngleControl=false so roll is rate-nulled
+    /// in every phase (the profile is never followed); switching back to Roll Control
+    /// restores the prior roll sub-mode (Null Roll / Track Profile).
+    private var controlModeBinding: Binding<Int> {
+        Binding(
+            get: { profile.guidanceEnabled ? 1 : 0 },
+            set: { newValue in
+                if newValue == 1 {
+                    savedRollUsesAngle = profile.useAngleControl
+                    updateProfile { $0.guidanceEnabled = true; $0.useAngleControl = false }
+                } else {
+                    updateProfile {
+                        $0.guidanceEnabled = false
+                        if let prev = savedRollUsesAngle { $0.useAngleControl = prev }
+                    }
+                }
+                applyGuidanceConfig()
                 applyRollControlConfig()
             })
     }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -384,9 +384,9 @@ struct SettingsView: View {
                 .font(.caption).foregroundColor(.secondary)
         }
 
-        finLayoutSection
         rollControlSection
         guidanceSection
+        finLayoutSection
     }
 
     @ViewBuilder
@@ -673,7 +673,7 @@ struct SettingsView: View {
     private var guidanceSection: some View {
         Section(header: configHeader("PN Guidance", applied: guidanceApplied)) {
             Toggle("Enable Guidance", isOn: bind(\.guidanceEnabled) { _ in applyGuidanceConfig() })
-            Text("Proportional-navigation steering during coast. Phase 1 target: directly over the launch pad (overhead).")
+            Text("Proportional-navigation steering. Engages with roll control at its initiation delay after launch (not after burnout). Phase 1 target: directly over the launch pad (overhead).")
                 .font(.caption).foregroundColor(.secondary)
 
             HStack {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -66,6 +66,7 @@ struct SettingsView: View {
     @State private var pidApplied = false
     @State private var rollControlApplied = false
     @State private var guidanceApplied = false
+    @State private var finApplied = false
     @State private var pyroApplied = false
 
     // LoRa TX power (BS only) — hydrated from rocketConfig, debounced send.
@@ -383,6 +384,7 @@ struct SettingsView: View {
                 .font(.caption).foregroundColor(.secondary)
         }
 
+        finLayoutSection
         rollControlSection
         guidanceSection
     }
@@ -645,6 +647,23 @@ struct SettingsView: View {
             }
 
             Text("Stored in the rocket profile. Persists across reboots.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    private var finLayoutSection: some View {
+        Section(header: configHeader("Fin Layout", applied: finApplied)) {
+            FinLayoutView(
+                device: device,
+                ringMode: profile.finRingMode,
+                servoAtSlot: profile.finServoAtSlot,
+                reverse: profile.finReverse,
+                canJog: device.isConnected && !device.isBaseStation && device.telemetry.pwr_pin_on,
+                onSetRingMode: { m in updateProfile { $0.finRingMode = m }; applyFinConfig() },
+                onSetServoAtSlot: { s in updateProfile { $0.finServoAtSlot = s }; applyFinConfig() },
+                onSetReverse: { r in updateProfile { $0.finReverse = r }; applyFinConfig() }
+            )
+            Text("Map each servo to its fin, set the ring orientation (+ on axes or \u{00D7} at 45\u{00B0}), and reverse any mirrored servo. On the bench, jog each servo to confirm it deflects the way the ring shows.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -1074,6 +1093,15 @@ struct SettingsView: View {
                                          kpAngle: kpAngle, integralSepThreshold: iwind)
         }
         showApplied($rollControlApplied)
+    }
+
+    private func applyFinConfig() {
+        if device.isConnected {
+            device.sendFinConfig(ringMode: profile.finRingMode,
+                                 servoAtSlot: profile.finServoAtSlot,
+                                 reverse: profile.finReverse)
+        }
+        showApplied($finApplied)
     }
 
     private func applyGuidanceConfig() {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -47,6 +47,13 @@ struct SettingsView: View {
     @State private var sRateCapDps = ""
     @State private var sKpAngle = ""
     @State private var sIntegralSep = ""
+    @State private var sPnTargetAlt = ""
+    @State private var sPnNavGain = ""
+    @State private var sPnMaxAccel = ""
+    @State private var sPnAccelToFin = ""
+    @State private var sPnMaxFin = ""
+    @State private var sPnMinSpeed = ""
+    @State private var sPnCoastDelay = ""
 
     // Roll waypoints edited as strings; committed to the profile on change.
     @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
@@ -58,6 +65,7 @@ struct SettingsView: View {
     @State private var servoApplied = false
     @State private var pidApplied = false
     @State private var rollControlApplied = false
+    @State private var guidanceApplied = false
     @State private var pyroApplied = false
 
     // LoRa TX power (BS only) — hydrated from rocketConfig, debounced send.
@@ -115,17 +123,19 @@ struct SettingsView: View {
         case rateCap
         case kpAngle
         case integralSep
+        case guidTargetAlt, guidNavGain, guidMaxAccel, guidAccelToFin, guidMaxFin, guidMinSpeed, guidCoastDelay
         case wpTime(Int), wpAngle(Int)
         case pyroValue(Int)   // ch index 0..3
     }
 
-    private enum EditGroup { case servo, pid, rollControl, rollWaypoints, pyro }
+    private enum EditGroup { case servo, pid, rollControl, guidance, rollWaypoints, pyro }
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
         case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax, .finMin, .finMax: return .servo
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay, .rateCap, .kpAngle, .integralSep: return .rollControl
+        case .guidTargetAlt, .guidNavGain, .guidMaxAccel, .guidAccelToFin, .guidMaxFin, .guidMinSpeed, .guidCoastDelay: return .guidance
         case .wpTime, .wpAngle: return .rollWaypoints
         case .pyroValue: return .pyro
         case nil: return nil
@@ -137,6 +147,7 @@ struct SettingsView: View {
         case .servo: applyServoConfig()
         case .pid: applyPIDConfig()
         case .rollControl: applyRollControlConfig()
+        case .guidance: applyGuidanceConfig()
         case .rollWaypoints: applyRollProfile()
         case .pyro: applyPyroConfig()
         }
@@ -373,6 +384,7 @@ struct SettingsView: View {
         }
 
         rollControlSection
+        guidanceSection
     }
 
     @ViewBuilder
@@ -637,6 +649,74 @@ struct SettingsView: View {
         }
     }
 
+    private var guidanceSection: some View {
+        Section(header: configHeader("PN Guidance", applied: guidanceApplied)) {
+            Toggle("Enable Guidance", isOn: bind(\.guidanceEnabled) { _ in applyGuidanceConfig() })
+            Text("Proportional-navigation steering during coast. Phase 1 target: directly over the launch pad (overhead).")
+                .font(.caption).foregroundColor(.secondary)
+
+            HStack {
+                Text("Target Altitude")
+                Spacer()
+                TextField("600", text: $sPnTargetAlt)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidTargetAlt)
+                Text("m").foregroundColor(.secondary)
+            }
+            Text("Aim-point altitude above the pad. Set above expected apogee so guidance steers up-and-over the pad through the whole coast.")
+                .font(.caption).foregroundColor(.secondary)
+
+            HStack {
+                Text("Nav Gain (N)")
+                Spacer()
+                TextField("5", text: $sPnNavGain)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidNavGain)
+            }
+            HStack {
+                Text("Max Accel")
+                Spacer()
+                TextField("20", text: $sPnMaxAccel)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidMaxAccel)
+                Text("m/s\u{00B2}").foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Accel\u{2192}Fin")
+                Spacer()
+                TextField("4", text: $sPnAccelToFin)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidAccelToFin)
+            }
+            HStack {
+                Text("Max Fin")
+                Spacer()
+                TextField("15", text: $sPnMaxFin)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidMaxFin)
+                Text("deg").foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Min Speed")
+                Spacer()
+                TextField("15", text: $sPnMinSpeed)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidMinSpeed)
+                Text("m/s").foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Coast Delay")
+                Spacer()
+                TextField("0", text: $sPnCoastDelay)
+                    .keyboardType(.numberPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidCoastDelay)
+                Text("ms").foregroundColor(.secondary)
+            }
+            Text("Nav gain = PN aggressiveness (3\u{2013}5). Min speed gates guidance off below useful fin authority; coast delay waits after burnout before engaging. Stored in the rocket profile.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
     @ViewBuilder
     private var rollWaypointEditor: some View {
         Text("Each waypoint defines the START of a segment. Angle interpolates the target roll angle to the next waypoint; Null Rate holds zero roll rate (angle ignored) for the segment.")
@@ -798,6 +878,13 @@ struct SettingsView: View {
         sRateCapDps = formatInt(Double(p.rateCapDps))
         sKpAngle = formatDecimal(Double(p.kpAngle))
         sIntegralSep = formatInt(Double(p.integralSepThreshold))
+        sPnTargetAlt = formatInt(Double(p.pnTargetAltM))
+        sPnNavGain = formatDecimal(Double(p.pnNavGain))
+        sPnMaxAccel = formatDecimal(Double(p.pnMaxAccel))
+        sPnAccelToFin = formatDecimal(Double(p.pnAccelToFin))
+        sPnMaxFin = formatDecimal(Double(p.pnMaxFinDeg))
+        sPnMinSpeed = formatDecimal(Double(p.pnMinSpeed))
+        sPnCoastDelay = formatInt(Double(p.pnCoastDelayMs))
         rollWaypoints = p.rollWaypoints.map {
             (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg), mode: $0.mode.rawValue)
         }
@@ -987,6 +1074,30 @@ struct SettingsView: View {
                                          kpAngle: kpAngle, integralSepThreshold: iwind)
         }
         showApplied($rollControlApplied)
+    }
+
+    private func applyGuidanceConfig() {
+        let navGain    = max(0, Float(sPnNavGain)    ?? profile.pnNavGain)
+        let maxAccel   = max(0, Float(sPnMaxAccel)   ?? profile.pnMaxAccel)
+        let accelToFin = max(0, Float(sPnAccelToFin) ?? profile.pnAccelToFin)
+        let maxFin     = max(0, Float(sPnMaxFin)     ?? profile.pnMaxFinDeg)
+        let minSpeed   = max(0, Float(sPnMinSpeed)   ?? profile.pnMinSpeed)
+        let coastDelay = UInt16(clamping: Int(Double(sPnCoastDelay) ?? Double(profile.pnCoastDelayMs)))
+        let targetAlt  = max(0, Float(sPnTargetAlt)  ?? profile.pnTargetAltM)
+        updateProfile {
+            $0.pnNavGain = navGain; $0.pnMaxAccel = maxAccel; $0.pnAccelToFin = accelToFin
+            $0.pnMaxFinDeg = maxFin; $0.pnMinSpeed = minSpeed; $0.pnCoastDelayMs = coastDelay
+            $0.pnTargetAltM = targetAlt
+        }
+        if device.isConnected {
+            device.sendGuidanceConfig(enabled: profile.guidanceEnabled,
+                                      navGain: navGain, maxAccel: maxAccel, accelToFin: accelToFin,
+                                      maxFinDeg: maxFin, minSpeed: minSpeed, coastDelayMs: coastDelay,
+                                      targetMode: profile.pnTargetMode,
+                                      targetE: profile.pnTargetE, targetN: profile.pnTargetN,
+                                      targetAlt: targetAlt)
+        }
+        showApplied($guidanceApplied)
     }
 
     private func applyRollProfile() {

--- a/tests_cpp/test_control_mixer.cpp
+++ b/tests_cpp/test_control_mixer.cpp
@@ -181,3 +181,88 @@ TEST_F(ControlMixerTest, Reset_ClearsAllState) {
     EXPECT_FLOAT_EQ(mixer.getPitchFinCmd(), 0.0f);
     EXPECT_FLOAT_EQ(mixer.getYawFinCmd(), 0.0f);
 }
+
+// ─── Configurable fin layout (servo→azimuth + reverse) ───────────────────────
+
+// REGRESSION: with no setFinLayout call (default {0,90,180,270} + mask 0),
+// mixToFins must reproduce the legacy hardcoded "+" mix exactly:
+//   d0=+pitch+roll  d1=+yaw+roll  d2=-pitch+roll  d3=-yaw+roll
+TEST_F(ControlMixerTest, MixToFins_DefaultReproducesHardcodedPlus) {
+    float d[4];
+    mixer.mixToFins(0.0f, 2.0f, 0.0f, MAX_FIN, d);          // pure pitch
+    EXPECT_NEAR(d[0],  2.0f, 1e-4f);
+    EXPECT_NEAR(d[1],  0.0f, 1e-4f);
+    EXPECT_NEAR(d[2], -2.0f, 1e-4f);
+    EXPECT_NEAR(d[3],  0.0f, 1e-4f);
+
+    mixer.mixToFins(0.0f, 0.0f, 3.0f, MAX_FIN, d);          // pure yaw
+    EXPECT_NEAR(d[0],  0.0f, 1e-4f);
+    EXPECT_NEAR(d[1],  3.0f, 1e-4f);
+    EXPECT_NEAR(d[2],  0.0f, 1e-4f);
+    EXPECT_NEAR(d[3], -3.0f, 1e-4f);
+
+    mixer.mixToFins(4.0f, 0.0f, 0.0f, MAX_FIN, d);          // pure roll → common
+    for (int i = 0; i < 4; i++) EXPECT_NEAR(d[i], 4.0f, 1e-4f);
+
+    mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);          // combined
+    EXPECT_NEAR(d[0],  2.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[1],  3.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[2], -2.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[3], -3.0f + 1.0f, 1e-4f);
+}
+
+TEST_F(ControlMixerTest, SetFinLayout_DefaultAzimuthsMatchHardcode) {
+    const float az[4] = {0.0f, 90.0f, 180.0f, 270.0f};
+    mixer.setFinLayout(az, 0);
+    float d[4];
+    mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);
+    EXPECT_NEAR(d[0],  2.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[1],  3.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[2], -2.0f + 1.0f, 1e-4f);
+    EXPECT_NEAR(d[3], -3.0f + 1.0f, 1e-4f);
+}
+
+// "×" layout: every fin shares pitch AND yaw at cos/sin(45°)=±0.707.
+TEST_F(ControlMixerTest, SetFinLayout_CrossSharesPitchAndYaw) {
+    const float az[4] = {45.0f, 135.0f, 225.0f, 315.0f};
+    mixer.setFinLayout(az, 0);
+    const float k = 0.70710678f;
+    float d[4];
+    mixer.mixToFins(0.0f, 1.0f, 0.0f, MAX_FIN, d);          // pitch → cos(az)
+    EXPECT_NEAR(d[0],  k, 1e-4f);
+    EXPECT_NEAR(d[1], -k, 1e-4f);
+    EXPECT_NEAR(d[2], -k, 1e-4f);
+    EXPECT_NEAR(d[3],  k, 1e-4f);
+
+    mixer.mixToFins(0.0f, 0.0f, 1.0f, MAX_FIN, d);          // yaw → sin(az)
+    EXPECT_NEAR(d[0],  k, 1e-4f);
+    EXPECT_NEAR(d[1],  k, 1e-4f);
+    EXPECT_NEAR(d[2], -k, 1e-4f);
+    EXPECT_NEAR(d[3], -k, 1e-4f);
+
+    mixer.mixToFins(2.0f, 0.0f, 0.0f, MAX_FIN, d);          // roll still common
+    for (int i = 0; i < 4; i++) EXPECT_NEAR(d[i], 2.0f, 1e-4f);
+}
+
+// A reverse bit negates that servo's whole deflection (mirrored mount).
+TEST_F(ControlMixerTest, SetFinLayout_ReverseNegatesFin) {
+    const float az[4] = {0.0f, 90.0f, 180.0f, 270.0f};
+    mixer.setFinLayout(az, 0x02);                            // reverse servo 1
+    float d[4];
+    mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);
+    EXPECT_NEAR(d[0],   2.0f + 1.0f,  1e-4f);                // unchanged
+    EXPECT_NEAR(d[1], -(3.0f + 1.0f), 1e-4f);                // fully negated
+    EXPECT_NEAR(d[2],  -2.0f + 1.0f,  1e-4f);                // unchanged
+    EXPECT_NEAR(d[3],  -3.0f + 1.0f,  1e-4f);                // unchanged
+    EXPECT_EQ(mixer.getFinReverseMask(), 0x02);
+    EXPECT_NEAR(mixer.getFinAzimuthDeg(1), 90.0f, 1e-4f);
+}
+
+TEST_F(ControlMixerTest, MixToFins_Clamps) {
+    float d[4];
+    mixer.mixToFins(100.0f, 100.0f, 100.0f, MAX_FIN, d);
+    for (int i = 0; i < 4; i++) {
+        EXPECT_LE(d[i],  MAX_FIN);
+        EXPECT_GE(d[i], -MAX_FIN);
+    }
+}

--- a/tests_cpp/test_control_mixer.cpp
+++ b/tests_cpp/test_control_mixer.cpp
@@ -213,7 +213,7 @@ TEST_F(ControlMixerTest, MixToFins_DefaultReproducesHardcodedPlus) {
 
 TEST_F(ControlMixerTest, SetFinLayout_DefaultAzimuthsMatchHardcode) {
     const float az[4] = {0.0f, 90.0f, 180.0f, 270.0f};
-    mixer.setFinLayout(az, 0);
+    mixer.setFinLayout(az, 0, 0);
     float d[4];
     mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);
     EXPECT_NEAR(d[0],  2.0f + 1.0f, 1e-4f);
@@ -225,7 +225,7 @@ TEST_F(ControlMixerTest, SetFinLayout_DefaultAzimuthsMatchHardcode) {
 // "×" layout: every fin shares pitch AND yaw at cos/sin(45°)=±0.707.
 TEST_F(ControlMixerTest, SetFinLayout_CrossSharesPitchAndYaw) {
     const float az[4] = {45.0f, 135.0f, 225.0f, 315.0f};
-    mixer.setFinLayout(az, 0);
+    mixer.setFinLayout(az, 0, 0);
     const float k = 0.70710678f;
     float d[4];
     mixer.mixToFins(0.0f, 1.0f, 0.0f, MAX_FIN, d);          // pitch → cos(az)
@@ -244,18 +244,32 @@ TEST_F(ControlMixerTest, SetFinLayout_CrossSharesPitchAndYaw) {
     for (int i = 0; i < 4; i++) EXPECT_NEAR(d[i], 2.0f, 1e-4f);
 }
 
-// A reverse bit negates that servo's whole deflection (mirrored mount).
-TEST_F(ControlMixerTest, SetFinLayout_ReverseNegatesFin) {
+// A tilt-reverse bit negates only that servo's pitch/yaw response; roll is untouched.
+TEST_F(ControlMixerTest, SetFinLayout_ReverseNegatesTiltOnly) {
     const float az[4] = {0.0f, 90.0f, 180.0f, 270.0f};
-    mixer.setFinLayout(az, 0x02);                            // reverse servo 1
+    mixer.setFinLayout(az, 0x02, 0);                         // tilt-reverse servo 1
     float d[4];
     mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);
-    EXPECT_NEAR(d[0],   2.0f + 1.0f,  1e-4f);                // unchanged
-    EXPECT_NEAR(d[1], -(3.0f + 1.0f), 1e-4f);                // fully negated
-    EXPECT_NEAR(d[2],  -2.0f + 1.0f,  1e-4f);                // unchanged
-    EXPECT_NEAR(d[3],  -3.0f + 1.0f,  1e-4f);                // unchanged
+    EXPECT_NEAR(d[0],  2.0f + 1.0f, 1e-4f);                  // unchanged
+    EXPECT_NEAR(d[1], -3.0f + 1.0f, 1e-4f);                  // yaw negated, roll kept (+1)
+    EXPECT_NEAR(d[2], -2.0f + 1.0f, 1e-4f);                  // unchanged
+    EXPECT_NEAR(d[3], -3.0f + 1.0f, 1e-4f);                  // unchanged
     EXPECT_EQ(mixer.getFinReverseMask(), 0x02);
     EXPECT_NEAR(mixer.getFinAzimuthDeg(1), 90.0f, 1e-4f);
+}
+
+// A roll-reverse bit negates only that servo's roll response; pitch/yaw is untouched.
+// This is the #fin-roll fix: a servo can have its tilt and roll signs set independently.
+TEST_F(ControlMixerTest, SetFinLayout_RollReverseNegatesRollOnly) {
+    const float az[4] = {0.0f, 90.0f, 180.0f, 270.0f};
+    mixer.setFinLayout(az, 0, 0x02);                         // roll-reverse servo 1
+    float d[4];
+    mixer.mixToFins(1.0f, 2.0f, 3.0f, MAX_FIN, d);
+    EXPECT_NEAR(d[0], 2.0f + 1.0f, 1e-4f);                   // unchanged
+    EXPECT_NEAR(d[1], 3.0f - 1.0f, 1e-4f);                   // yaw kept, roll negated (−1)
+    EXPECT_NEAR(d[2], -2.0f + 1.0f, 1e-4f);                  // unchanged
+    EXPECT_NEAR(d[3], -3.0f + 1.0f, 1e-4f);                  // unchanged
+    EXPECT_EQ(mixer.getFinRollReverseMask(), 0x02);
 }
 
 TEST_F(ControlMixerTest, MixToFins_Clamps) {

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -99,6 +99,13 @@ TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
     EXPECT_EQ(offsetof(GuidanceConfigData, target_mode),      35u);
 }
 
+TEST(RocketComputerTypes, FinConfigData_Layout) {
+    // Wire struct relayed app→OC→BS→FC; size is hardcoded in the relay paths.
+    EXPECT_EQ(sizeof(FinConfigData), 17u);
+    EXPECT_EQ(offsetof(FinConfigData, azimuth_deg),  0u);
+    EXPECT_EQ(offsetof(FinConfigData, reverse_mask), 16u);
+}
+
 TEST(RocketComputerTypes, MaxPayload_CoversAllTypes) {
     // MAX_PAYLOAD must be >= every packed struct that can be a frame payload
     EXPECT_GE(MAX_PAYLOAD, sizeof(GNSSData));

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -101,9 +101,10 @@ TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
 
 TEST(RocketComputerTypes, FinConfigData_Layout) {
     // Wire struct relayed app→OC→BS→FC; size is hardcoded in the relay paths.
-    EXPECT_EQ(sizeof(FinConfigData), 17u);
-    EXPECT_EQ(offsetof(FinConfigData, azimuth_deg),  0u);
-    EXPECT_EQ(offsetof(FinConfigData, reverse_mask), 16u);
+    EXPECT_EQ(sizeof(FinConfigData), 18u);
+    EXPECT_EQ(offsetof(FinConfigData, azimuth_deg),       0u);
+    EXPECT_EQ(offsetof(FinConfigData, reverse_mask),      16u);
+    EXPECT_EQ(offsetof(FinConfigData, roll_reverse_mask), 17u);
 }
 
 TEST(RocketComputerTypes, MaxPayload_CoversAllTypes) {

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -83,6 +83,22 @@ TEST(RocketComputerTypes, PyroConfigData_FourChannelLayout) {
     EXPECT_EQ(offsetof(PyroConfigData, ch4_trigger_value), 20u);
 }
 
+TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
+    // 8 floats (32) + u16 coast_delay (2) + 2 u8 (2) = 36, naturally aligned (no pad).
+    EXPECT_EQ(sizeof(GuidanceConfigData), 36u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, nav_gain),         0u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, max_accel_mps2),   4u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, accel_to_fin_deg), 8u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, max_fin_deg),      12u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, min_speed_mps),    16u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, target_e_m),       20u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, target_n_m),       24u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, target_alt_m),     28u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, coast_delay_ms),   32u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, enable),           34u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, target_mode),      35u);
+}
+
 TEST(RocketComputerTypes, MaxPayload_CoversAllTypes) {
     // MAX_PAYLOAD must be >= every packed struct that can be a frame payload
     EXPECT_GE(MAX_PAYLOAD, sizeof(GNSSData));

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.cpp
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.cpp
@@ -118,20 +118,24 @@ void TR_ControlMixer::getFinDeflections(float deflections[4]) const
     }
 }
 
-void TR_ControlMixer::setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask)
+void TR_ControlMixer::setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask,
+                                   uint8_t roll_reverse_mask)
 {
     constexpr float DEG2RAD = 0.01745329252f;
-    fin_reverse_mask_ = reverse_mask;
+    fin_reverse_mask_      = reverse_mask;
+    fin_roll_reverse_mask_ = roll_reverse_mask;
     for (int i = 0; i < 4; ++i) {
         fin_azimuth_deg_[i] = azimuth_deg[i];
         float c = cosf(azimuth_deg[i] * DEG2RAD);
         float s = sinf(azimuth_deg[i] * DEG2RAD);
         if (fabsf(c) < 1e-6f) c = 0.0f;   // snap cardinal angles to exact 0 / ±1
         if (fabsf(s) < 1e-6f) s = 0.0f;
-        float sign = (reverse_mask & (1u << i)) ? -1.0f : 1.0f;
-        pitch_mix_[i] = sign * c;
-        yaw_mix_[i]   = sign * s;
-        roll_mix_[i]  = sign;
+        // Tilt (pitch/yaw) and roll signs are independent — see FinConfigData.
+        float tilt_sign = (reverse_mask      & (1u << i)) ? -1.0f : 1.0f;
+        float roll_sign = (roll_reverse_mask & (1u << i)) ? -1.0f : 1.0f;
+        pitch_mix_[i] = tilt_sign * c;
+        yaw_mix_[i]   = tilt_sign * s;
+        roll_mix_[i]  = roll_sign;
     }
 }
 

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.cpp
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.cpp
@@ -1,10 +1,6 @@
 #include "TR_ControlMixer.h"
 #include <algorithm>
-
-// Static constexpr member definitions (required pre-C++17 for ODR-use)
-constexpr float TR_ControlMixer::PITCH_MIX[4];
-constexpr float TR_ControlMixer::YAW_MIX[4];
-constexpr float TR_ControlMixer::ROLL_MIX[4];
+#include <cmath>
 
 TR_ControlMixer::TR_ControlMixer()
     : pitch_rate_pid_(0.04f, 0.001f, 0.0003f, 15.0f, -15.0f),
@@ -106,9 +102,9 @@ void TR_ControlMixer::update(float pitch_angle_cmd_deg,
 
     // --- Mix into 4 fin deflections ---
     for (int i = 0; i < 4; ++i) {
-        float d = PITCH_MIX[i] * pitch_fin_cmd_
-                + YAW_MIX[i]   * yaw_fin_cmd_
-                + ROLL_MIX[i]  * roll_cmd_deg;
+        float d = pitch_mix_[i] * pitch_fin_cmd_
+                + yaw_mix_[i]   * yaw_fin_cmd_
+                + roll_mix_[i]  * roll_cmd_deg;
 
         // Per-fin deflection clamp
         deflections_[i] = constrain(d, -max_fin_deg_, max_fin_deg_);
@@ -119,6 +115,34 @@ void TR_ControlMixer::getFinDeflections(float deflections[4]) const
 {
     for (int i = 0; i < 4; ++i) {
         deflections[i] = deflections_[i];
+    }
+}
+
+void TR_ControlMixer::setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask)
+{
+    constexpr float DEG2RAD = 0.01745329252f;
+    fin_reverse_mask_ = reverse_mask;
+    for (int i = 0; i < 4; ++i) {
+        fin_azimuth_deg_[i] = azimuth_deg[i];
+        float c = cosf(azimuth_deg[i] * DEG2RAD);
+        float s = sinf(azimuth_deg[i] * DEG2RAD);
+        if (fabsf(c) < 1e-6f) c = 0.0f;   // snap cardinal angles to exact 0 / ±1
+        if (fabsf(s) < 1e-6f) s = 0.0f;
+        float sign = (reverse_mask & (1u << i)) ? -1.0f : 1.0f;
+        pitch_mix_[i] = sign * c;
+        yaw_mix_[i]   = sign * s;
+        roll_mix_[i]  = sign;
+    }
+}
+
+void TR_ControlMixer::mixToFins(float roll_cmd_deg, float pitch_fin_cmd, float yaw_fin_cmd,
+                                float max_fin_deg, float out_deflections[4]) const
+{
+    for (int i = 0; i < 4; ++i) {
+        float d = pitch_mix_[i] * pitch_fin_cmd
+                + yaw_mix_[i]   * yaw_fin_cmd
+                + roll_mix_[i]  * roll_cmd_deg;
+        out_deflections[i] = constrain(d, -max_fin_deg, max_fin_deg);
     }
 }
 

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.h
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.h
@@ -53,11 +53,13 @@ public:
     float getPitchFinCmd() const { return pitch_fin_cmd_; }
     float getYawFinCmd()   const { return yaw_fin_cmd_; }
 
-    /// Configure the fin→servo mix from per-servo control azimuths (deg) and a
-    /// reverse bitmask (bit i ⇒ servo i deflection negated, for a mirrored mount).
-    /// Recomputes the pitch/yaw/roll mix coefficients used by both update() and
-    /// mixToFins().  Defaults {0,90,180,270} + mask 0 reproduce the cruciform "+".
-    void setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask);
+    /// Configure the fin→servo mix from per-servo control azimuths (deg), a tilt
+    /// reverse bitmask (bit i ⇒ negate servo i pitch/yaw response) and a roll reverse
+    /// bitmask (bit i ⇒ negate its roll response, independently).  Recomputes the
+    /// pitch/yaw/roll mix coefficients used by both update() and mixToFins().  Defaults
+    /// {0,90,180,270} + masks 0 reproduce the cruciform "+".
+    void setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask,
+                      uint8_t roll_reverse_mask);
 
     /// Allocate a (roll,pitch,yaw) fin command to the 4 servos using the configured
     /// fin layout, each clamped to ±max_fin_deg.  Stateless allocation (no PID state) —
@@ -69,6 +71,7 @@ public:
     /// Flown fin layout — for the telemetry / flight-log snapshot.
     float   getFinAzimuthDeg(int i) const { return (i >= 0 && i < 4) ? fin_azimuth_deg_[i] : 0.0f; }
     uint8_t getFinReverseMask() const { return fin_reverse_mask_; }
+    uint8_t getFinRollReverseMask() const { return fin_roll_reverse_mask_; }
 
     /// Reset all PID internal state.
     void reset();
@@ -106,13 +109,15 @@ private:
     //   deflection_i = pitch_mix_[i]·pitch + yaw_mix_[i]·yaw + roll_mix_[i]·roll
     // Default reproduces the legacy "+" (servo 0 top/+pitch, 1 right/+yaw, 2 bottom,
     // 3 left).  Reconfigured at runtime by setFinLayout() from the rocket's fin
-    // azimuth + reverse config: pitch_mix_[i]=sign·cos(az_i), yaw_mix_[i]=sign·
-    // sin(az_i), roll_mix_[i]=sign, with sign=-1 if servo i is reversed.
+    // azimuth + reverse config: pitch_mix_[i]=tilt·cos(az_i), yaw_mix_[i]=tilt·
+    // sin(az_i) (tilt=-1 if servo i tilt-reversed), roll_mix_[i]=roll (roll=-1 if
+    // servo i roll-reversed) — tilt and roll signs are independent.
     float   pitch_mix_[4] = { +1.0f,  0.0f, -1.0f,  0.0f };
     float   yaw_mix_[4]   = {  0.0f, +1.0f,  0.0f, -1.0f };
     float   roll_mix_[4]  = { +1.0f, +1.0f, +1.0f, +1.0f };
     float   fin_azimuth_deg_[4] = { 0.0f, 90.0f, 180.0f, 270.0f };
     uint8_t fin_reverse_mask_ = 0;
+    uint8_t fin_roll_reverse_mask_ = 0;
 };
 
 #endif // TR_CONTROL_MIXER_H

--- a/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.h
+++ b/tinkerrocket-idf/components/TR_ControlMixer/TR_ControlMixer.h
@@ -53,6 +53,23 @@ public:
     float getPitchFinCmd() const { return pitch_fin_cmd_; }
     float getYawFinCmd()   const { return yaw_fin_cmd_; }
 
+    /// Configure the fin→servo mix from per-servo control azimuths (deg) and a
+    /// reverse bitmask (bit i ⇒ servo i deflection negated, for a mirrored mount).
+    /// Recomputes the pitch/yaw/roll mix coefficients used by both update() and
+    /// mixToFins().  Defaults {0,90,180,270} + mask 0 reproduce the cruciform "+".
+    void setFinLayout(const float azimuth_deg[4], uint8_t reverse_mask);
+
+    /// Allocate a (roll,pitch,yaw) fin command to the 4 servos using the configured
+    /// fin layout, each clamped to ±max_fin_deg.  Stateless allocation (no PID state) —
+    /// the FC roll / ground-test / coast-guidance paths all call this so every mix
+    /// site shares one layout.
+    void mixToFins(float roll_cmd_deg, float pitch_fin_cmd, float yaw_fin_cmd,
+                   float max_fin_deg, float out_deflections[4]) const;
+
+    /// Flown fin layout — for the telemetry / flight-log snapshot.
+    float   getFinAzimuthDeg(int i) const { return (i >= 0 && i < 4) ? fin_azimuth_deg_[i] : 0.0f; }
+    uint8_t getFinReverseMask() const { return fin_reverse_mask_; }
+
     /// Reset all PID internal state.
     void reset();
 
@@ -85,14 +102,17 @@ private:
 
     void applyGainSchedule(float speed_mps);
 
-    // Cruciform mixing coefficients (looking from rear, FRD body frame):
-    //   Servo 0 (top/0deg)    -> pitch +1, yaw  0, roll +1
-    //   Servo 1 (right/90deg) -> pitch  0, yaw +1, roll +1
-    //   Servo 2 (bottom/180deg)-> pitch -1, yaw  0, roll +1
-    //   Servo 3 (left/270deg) -> pitch  0, yaw -1, roll +1
-    static constexpr float PITCH_MIX[4] = { +1.0f,  0.0f, -1.0f,  0.0f };
-    static constexpr float YAW_MIX[4]   = {  0.0f, +1.0f,  0.0f, -1.0f };
-    static constexpr float ROLL_MIX[4]  = { +1.0f, +1.0f, +1.0f, +1.0f };
+    // Cruciform mixing coefficients (control/FRD body frame, looking from rear):
+    //   deflection_i = pitch_mix_[i]·pitch + yaw_mix_[i]·yaw + roll_mix_[i]·roll
+    // Default reproduces the legacy "+" (servo 0 top/+pitch, 1 right/+yaw, 2 bottom,
+    // 3 left).  Reconfigured at runtime by setFinLayout() from the rocket's fin
+    // azimuth + reverse config: pitch_mix_[i]=sign·cos(az_i), yaw_mix_[i]=sign·
+    // sin(az_i), roll_mix_[i]=sign, with sign=-1 if servo i is reversed.
+    float   pitch_mix_[4] = { +1.0f,  0.0f, -1.0f,  0.0f };
+    float   yaw_mix_[4]   = {  0.0f, +1.0f,  0.0f, -1.0f };
+    float   roll_mix_[4]  = { +1.0f, +1.0f, +1.0f, +1.0f };
+    float   fin_azimuth_deg_[4] = { 0.0f, 90.0f, 180.0f, 270.0f };
+    uint8_t fin_reverse_mask_ = 0;
 };
 
 #endif // TR_CONTROL_MIXER_H

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1546,6 +1546,8 @@ static constexpr uint8_t ORIENT_CONFIG_PENDING = 0xED;  // OC→FC: payload foll
 static constexpr uint8_t ORIENT_CONFIG_MSG     = 0xEE;  // 1-byte ImuOrientConfigData
 static constexpr uint8_t GUIDANCE_CONFIG_PENDING = 0xEF;  // OC→FC: payload follows as GUIDANCE_CONFIG_MSG
 static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceConfigData
+static constexpr uint8_t FIN_CONFIG_PENDING      = 0xF2;  // OC→FC: payload follows as FIN_CONFIG_MSG
+static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 17-byte FinConfigData
 
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
@@ -1671,6 +1673,19 @@ typedef struct __attribute__((packed))
     uint8_t  target_mode;       // GUIDE_TARGET_OVERHEAD / _POINT
 } GuidanceConfigData;
 static_assert(sizeof(GuidanceConfigData) == 36, "GuidanceConfigData must be 36 bytes");
+
+// App-configurable fin→servo mix.  azimuth_deg[i] is the CONTROL azimuth of the fin
+// driven by servo i: deflection_i = sign_i · (roll + pitch·cos(az_i) + yaw·sin(az_i)),
+// where sign_i = -1 if bit i of reverse_mask is set (mirrored servo) else +1.  The
+// defaults {0,90,180,270} + mask 0 reproduce the legacy hardcoded "+" mix exactly
+// (servo 0 = top/+pitch, 1 = right/+yaw, 2 = bottom, 3 = left).  The app derives these
+// from the ring GUI (servo placement + +/× orientation + per-fin reverse).
+typedef struct __attribute__((packed))
+{
+    float   azimuth_deg[4];  // per-servo fin control azimuth (deg)
+    uint8_t reverse_mask;    // bit i set ⇒ servo i deflection negated (mirrored mount)
+} FinConfigData;
+static_assert(sizeof(FinConfigData) == 17, "FinConfigData must be 17 bytes");
 
 typedef struct __attribute__((packed))
 {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1547,7 +1547,7 @@ static constexpr uint8_t ORIENT_CONFIG_MSG     = 0xEE;  // 1-byte ImuOrientConfi
 static constexpr uint8_t GUIDANCE_CONFIG_PENDING = 0xEF;  // OC→FC: payload follows as GUIDANCE_CONFIG_MSG
 static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceConfigData
 static constexpr uint8_t FIN_CONFIG_PENDING      = 0xF2;  // OC→FC: payload follows as FIN_CONFIG_MSG
-static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 17-byte FinConfigData
+static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 18-byte FinConfigData
 
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
@@ -1675,17 +1675,22 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(GuidanceConfigData) == 36, "GuidanceConfigData must be 36 bytes");
 
 // App-configurable fin→servo mix.  azimuth_deg[i] is the CONTROL azimuth of the fin
-// driven by servo i: deflection_i = sign_i · (roll + pitch·cos(az_i) + yaw·sin(az_i)),
-// where sign_i = -1 if bit i of reverse_mask is set (mirrored servo) else +1.  The
-// defaults {0,90,180,270} + mask 0 reproduce the legacy hardcoded "+" mix exactly
-// (servo 0 = top/+pitch, 1 = right/+yaw, 2 = bottom, 3 = left).  The app derives these
-// from the ring GUI (servo placement + +/× orientation + per-fin reverse).
+// driven by servo i:
+//   deflection_i = tilt_i·(pitch·cos(az_i) + yaw·sin(az_i)) + roll_i·roll
+// tilt_i = -1 if bit i of reverse_mask is set (flips that fin's pitch/yaw response);
+// roll_i = -1 if bit i of roll_reverse_mask is set (flips its roll response).  The two
+// are INDEPENDENT: a fin's tilt and roll directions don't always share a sign in real
+// hardware (e.g. a linkage that mirrors pitch/yaw but not the roll moment), so one bit
+// can't express both.  Both masks 0 + azimuths {0,90,180,270} reproduce the legacy
+// hardcoded "+" mix (servo 0 = top/+pitch, 1 = right/+yaw, 2 = bottom, 3 = left).  The
+// app derives all of this from the ring GUI.
 typedef struct __attribute__((packed))
 {
-    float   azimuth_deg[4];  // per-servo fin control azimuth (deg)
-    uint8_t reverse_mask;    // bit i set ⇒ servo i deflection negated (mirrored mount)
+    float   azimuth_deg[4];     // per-servo fin control azimuth (deg)
+    uint8_t reverse_mask;       // bit i ⇒ negate servo i pitch/yaw (tilt) response
+    uint8_t roll_reverse_mask;  // bit i ⇒ negate servo i roll response (independent)
 } FinConfigData;
-static_assert(sizeof(FinConfigData) == 17, "FinConfigData must be 17 bytes");
+static_assert(sizeof(FinConfigData) == 18, "FinConfigData must be 18 bytes");
 
 typedef struct __attribute__((packed))
 {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1544,6 +1544,8 @@ static constexpr uint8_t FC_IDENTITY         = 0xEC;
 // roll clocking survives power cycles without the app connected.
 static constexpr uint8_t ORIENT_CONFIG_PENDING = 0xED;  // OC→FC: payload follows as ORIENT_CONFIG_MSG
 static constexpr uint8_t ORIENT_CONFIG_MSG     = 0xEE;  // 1-byte ImuOrientConfigData
+static constexpr uint8_t GUIDANCE_CONFIG_PENDING = 0xEF;  // OC→FC: payload follows as GUIDANCE_CONFIG_MSG
+static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceConfigData
 
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
@@ -1646,6 +1648,29 @@ typedef struct __attribute__((packed))
     float max_cmd;
 } PIDConfigData;
 static_assert(sizeof(PIDConfigData) == 20, "PIDConfigData must be 20 bytes");
+
+// PN guidance target mode (which point the rocket steers toward).
+static constexpr uint8_t GUIDE_TARGET_OVERHEAD = 0;  // directly over the pad: (0,0,target_alt)
+static constexpr uint8_t GUIDE_TARGET_POINT    = 1;  // configured point: (target_e,target_n,target_alt)
+
+// App-configurable PN guidance.  Floats first so every field is naturally aligned
+// inside the packed struct (no internal padding) -> sizeof == 36.  ENU meters are
+// relative to the launch pad, matching the FC's imu_pos frame (no conversion).
+typedef struct __attribute__((packed))
+{
+    float    nav_gain;          // PN navigation constant N (3-5)
+    float    max_accel_mps2;    // lateral accel command clamp (m/s^2)
+    float    accel_to_fin_deg;  // accel (m/s^2) -> fin (deg) scale
+    float    max_fin_deg;       // per-fin deflection clamp in guided mode (deg)
+    float    min_speed_mps;     // airspeed gate below which guidance is inactive
+    float    target_e_m;        // POINT: East rel. pad (m); OVERHEAD: ignored (0)
+    float    target_n_m;        // POINT: North rel. pad (m); OVERHEAD: ignored (0)
+    float    target_alt_m;      // target altitude above pad (m), both modes
+    uint16_t coast_delay_ms;    // delay after burnout before guidance engages (ms)
+    uint8_t  enable;            // 0/1 runtime guidance master enable
+    uint8_t  target_mode;       // GUIDE_TARGET_OVERHEAD / _POINT
+} GuidanceConfigData;
+static_assert(sizeof(GuidanceConfigData) == 36, "GuidanceConfigData must be 36 bytes");
 
 typedef struct __attribute__((packed))
 {

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3756,6 +3756,17 @@ static void loop_bs()
             ESP_LOGI(TAG, "[BLE->UPLINK] Servo config relayed");
         }
     }
+    else if (ble_cmd == 65)
+    {
+        // Full guidance config: relay to OutComputer via LoRa uplink
+        const uint8_t* payload = ble_app.getCommandPayload();
+        size_t payload_len = ble_app.getCommandPayloadLength();
+        if (payload_len >= sizeof(GuidanceConfigData))
+        {
+            buildUplinkPacket(65, payload, sizeof(GuidanceConfigData));
+            ESP_LOGI(TAG, "[BLE->UPLINK] Guidance config relayed");
+        }
+    }
     else if (ble_cmd == 13)
     {
         // PID config: cache locally + relay to OutComputer via LoRa uplink

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3767,6 +3767,17 @@ static void loop_bs()
             ESP_LOGI(TAG, "[BLE->UPLINK] Guidance config relayed");
         }
     }
+    else if (ble_cmd == 66)
+    {
+        // Full fin layout: relay to OutComputer via LoRa uplink
+        const uint8_t* payload = ble_app.getCommandPayload();
+        size_t payload_len = ble_app.getCommandPayloadLength();
+        if (payload_len >= sizeof(FinConfigData))
+        {
+            buildUplinkPacket(66, payload, sizeof(FinConfigData));
+            ESP_LOGI(TAG, "[BLE->UPLINK] Fin layout relayed");
+        }
+    }
     else if (ble_cmd == 13)
     {
         // PID config: cache locally + relay to OutComputer via LoRa uplink

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -323,12 +323,14 @@ struct config
     // FIN_AZIMUTH_n_DEG = control azimuth of servo n: deflection_n = sign_n·(roll
     // + pitch·cos(az_n) + yaw·sin(az_n)).  Defaults reproduce the legacy "+"
     // (servo 0 top/+pitch, 1 right/+yaw, 2 bottom, 3 left).  Bit n of
-    // FIN_REVERSE_MASK negates servo n (mirrored mount).
+    // FIN_REVERSE_MASK bit n negates servo n's pitch/yaw (tilt) response;
+    // FIN_ROLL_REVERSE_MASK bit n independently negates its roll response.
     static constexpr float   FIN_AZIMUTH_0_DEG = 0.0f;
     static constexpr float   FIN_AZIMUTH_1_DEG = 90.0f;
     static constexpr float   FIN_AZIMUTH_2_DEG = 180.0f;
     static constexpr float   FIN_AZIMUTH_3_DEG = 270.0f;
-    static constexpr uint8_t FIN_REVERSE_MASK  = 0;
+    static constexpr uint8_t FIN_REVERSE_MASK      = 0;
+    static constexpr uint8_t FIN_ROLL_REVERSE_MASK = 0;
     // Minimum airspeed for guidance (below this, fins have no authority)
     static constexpr float PN_MIN_SPEED_MPS = 15.0f;
     // Delay after burnout before engaging guidance (ms)

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -323,6 +323,12 @@ struct config
     static constexpr float PN_MIN_SPEED_MPS = 15.0f;
     // Delay after burnout before engaging guidance (ms)
     static constexpr uint16_t PN_COAST_DELAY_MS = 0;
+    // Guided-mode accel(m/s^2) -> fin(deg) scale (coast path; was an inline literal)
+    static constexpr float PN_ACCEL_TO_FIN_DEG = 4.0f;
+    // Target mode + point (ENU m rel. pad). OVERHEAD (0) = directly over pad (E=N=0).
+    static constexpr uint8_t PN_TARGET_MODE = 0;  // GUIDE_TARGET_OVERHEAD
+    static constexpr float   PN_TARGET_E_M  = 0.0f;
+    static constexpr float   PN_TARGET_N_M  = 0.0f;
 
     // ### Burnout Detection ###
     // Consecutive samples of negative body-X accel required to latch

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -319,6 +319,16 @@ struct config
     static constexpr float PN_YAW_KD = 0.0003f;
     // Max individual fin deflection in guided mode (deg)
     static constexpr float PN_MAX_FIN_DEG = 15.0f;
+    // Fin→servo layout (cruciform mix shared by roll / ground-test / guidance).
+    // FIN_AZIMUTH_n_DEG = control azimuth of servo n: deflection_n = sign_n·(roll
+    // + pitch·cos(az_n) + yaw·sin(az_n)).  Defaults reproduce the legacy "+"
+    // (servo 0 top/+pitch, 1 right/+yaw, 2 bottom, 3 left).  Bit n of
+    // FIN_REVERSE_MASK negates servo n (mirrored mount).
+    static constexpr float   FIN_AZIMUTH_0_DEG = 0.0f;
+    static constexpr float   FIN_AZIMUTH_1_DEG = 90.0f;
+    static constexpr float   FIN_AZIMUTH_2_DEG = 180.0f;
+    static constexpr float   FIN_AZIMUTH_3_DEG = 270.0f;
+    static constexpr uint8_t FIN_REVERSE_MASK  = 0;
     // Minimum airspeed for guidance (below this, fins have no authority)
     static constexpr float PN_MIN_SPEED_MPS = 15.0f;
     // Delay after burnout before engaging guidance (ms)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2383,7 +2383,8 @@ static void setup_fc()
         prefs.getFloat("fa2", config::FIN_AZIMUTH_2_DEG),
         prefs.getFloat("fa3", config::FIN_AZIMUTH_3_DEG),
     };
-    uint8_t fin_rev = prefs.getUChar("frv", config::FIN_REVERSE_MASK);
+    uint8_t fin_rev  = prefs.getUChar("frv",  config::FIN_REVERSE_MASK);
+    uint8_t fin_rrev = prefs.getUChar("frrv", config::FIN_ROLL_REVERSE_MASK);
     prefs.end();
     ESP_LOGI(TAG, "Roll: kp_angle=%.2f rate_cap=%.0f iwindup=%.0f dps",
                   (double)kp_angle_outer, (double)kp_angle_rate_cap_dps,
@@ -2410,10 +2411,10 @@ static void setup_fc()
         control_mixer.enableGainSchedule(config::GAIN_SCHEDULE_V_REF,
                                          config::GAIN_SCHEDULE_V_MIN);
     }
-    control_mixer.setFinLayout(fin_az, fin_rev);
-    ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X",
+    control_mixer.setFinLayout(fin_az, fin_rev, fin_rrev);
+    ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X rollrev=0x%X",
                   (double)fin_az[0], (double)fin_az[1], (double)fin_az[2], (double)fin_az[3],
-                  (unsigned)fin_rev);
+                  (unsigned)fin_rev, (unsigned)fin_rrev);
 
     // Restore high-g accelerometer bias from NVS (namespace "cal")
     prefs.begin("cal", false);  // read-write (creates namespace on first boot)
@@ -3225,7 +3226,11 @@ static void loop_fc()
             // horizontal prep self-corrects; latched by leaving READY/
             // PRELAUNCH at launch).  During boost, the thrust direction
             // cross-checks whatever was latched.
-            if (rocket_state == READY || rocket_state == PRELAUNCH)
+            // Tilting the board during a bench ground test must NOT re-trigger the
+            // pad orientation auto-detect — it would keep re-racking the board→rocket
+            // frame mid-test (the fins then chase a moving reference).  Freeze the
+            // estimator while ground_test_active; it resumes when the test stops.
+            if ((rocket_state == READY || rocket_state == PRELAUNCH) && !ground_test_active)
             {
                 if (orient_estimator.update(ism6_latest_si.time_us,
                                             acc_x, acc_y, acc_z,
@@ -4914,17 +4919,19 @@ static void loop_fc()
                     for (int i = 0; i < 4; ++i)
                         if (!(f.azimuth_deg[i] >= -360.0f && f.azimuth_deg[i] <= 360.0f)) ok = false;
                     if (ok) {
-                        control_mixer.setFinLayout(f.azimuth_deg, f.reverse_mask);
-                        ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X",
+                        control_mixer.setFinLayout(f.azimuth_deg, f.reverse_mask,
+                                                   f.roll_reverse_mask);
+                        ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X rollrev=0x%X",
                                       (double)f.azimuth_deg[0], (double)f.azimuth_deg[1],
                                       (double)f.azimuth_deg[2], (double)f.azimuth_deg[3],
-                                      (unsigned)f.reverse_mask);
+                                      (unsigned)f.reverse_mask, (unsigned)f.roll_reverse_mask);
                         prefs.begin("servo", false);
                         prefs.putFloat("fa0", f.azimuth_deg[0]);
                         prefs.putFloat("fa1", f.azimuth_deg[1]);
                         prefs.putFloat("fa2", f.azimuth_deg[2]);
                         prefs.putFloat("fa3", f.azimuth_deg[3]);
-                        prefs.putUChar("frv", f.reverse_mask);
+                        prefs.putUChar("frv",  f.reverse_mask);
+                        prefs.putUChar("frrv", f.roll_reverse_mask);
                         prefs.end();
                         ESP_LOGI(TAG, "[FIN CFG] Saved to NVS");
                     } else {

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -349,6 +349,18 @@ static TR_ControlMixer control_mixer;
 static TR_PID roll_rate_pid_standalone(config::KP, config::KI, config::KD,
                                        config::MAX_CMD, config::MIN_CMD);
 static bool guidance_enabled = config::GUIDANCE_ENABLED;
+// Runtime-tunable PN guidance params (seeded from config::, overridden by NVS / the
+// app's GuidanceConfigData push). Phase 1 uses OVERHEAD (target_e/n forced 0).
+static float    pn_nav_gain       = config::PN_NAV_GAIN;
+static float    pn_max_accel      = config::PN_MAX_ACCEL_MPS2;
+static float    pn_accel_to_fin   = config::PN_ACCEL_TO_FIN_DEG;
+static float    pn_max_fin_deg    = config::PN_MAX_FIN_DEG;
+static float    pn_min_speed      = config::PN_MIN_SPEED_MPS;
+static uint16_t pn_coast_delay_ms = config::PN_COAST_DELAY_MS;
+static uint8_t  pn_target_mode    = config::PN_TARGET_MODE;
+static float    pn_target_e       = config::PN_TARGET_E_M;
+static float    pn_target_n       = config::PN_TARGET_N_M;
+static float    pn_target_alt     = config::PN_TARGET_ALT_M;
 static bool burnout_detected = false;
 static uint32_t burnout_time_ms = 0;
 // Consecutive-sample hysteresis for burnout detection (#197). Prevents
@@ -2354,6 +2366,16 @@ static void setup_fc()
     integral_sep_threshold_dps = prefs.getFloat("iwind", config::INTEGRAL_SEP_THRESHOLD_DPS);
     applyRollPidSepThreshold(integral_sep_threshold_dps);  // #268: both roll PIDs
     guidance_enabled        = prefs.getBool("guid_en", config::GUIDANCE_ENABLED);
+    pn_nav_gain       = prefs.getFloat("gng", config::PN_NAV_GAIN);
+    pn_max_accel      = prefs.getFloat("gma", config::PN_MAX_ACCEL_MPS2);
+    pn_accel_to_fin   = prefs.getFloat("gaf", config::PN_ACCEL_TO_FIN_DEG);
+    pn_max_fin_deg    = prefs.getFloat("gmf", config::PN_MAX_FIN_DEG);
+    pn_min_speed      = prefs.getFloat("gms", config::PN_MIN_SPEED_MPS);
+    pn_coast_delay_ms = prefs.getUShort("gcd", config::PN_COAST_DELAY_MS);
+    pn_target_mode    = prefs.getUChar("gtm", config::PN_TARGET_MODE);
+    pn_target_e       = prefs.getFloat("gte", config::PN_TARGET_E_M);
+    pn_target_n       = prefs.getFloat("gtn", config::PN_TARGET_N_M);
+    pn_target_alt     = prefs.getFloat("gta", config::PN_TARGET_ALT_M);
     prefs.end();
     ESP_LOGI(TAG, "Roll: kp_angle=%.2f rate_cap=%.0f iwindup=%.0f dps",
                   (double)kp_angle_outer, (double)kp_angle_rate_cap_dps,
@@ -2369,9 +2391,8 @@ static void setup_fc()
 #endif
 
     // Configure guidance and control mixer
-    guidance.configure(config::PN_NAV_GAIN,
-                       config::PN_MAX_ACCEL_MPS2,
-                       config::PN_TARGET_ALT_M);
+    // OVERHEAD: target = (0,0,pn_target_alt); the 3-arg form keeps horizontal at (0,0).
+    guidance.configure(pn_nav_gain, pn_max_accel, pn_target_alt);
     control_mixer.configure(config::PN_PITCH_KP, config::PN_PITCH_KI, config::PN_PITCH_KD,
                             config::PN_YAW_KP,   config::PN_YAW_KI,   config::PN_YAW_KD,
                             config::PN_MAX_FIN_DEG,
@@ -4815,6 +4836,56 @@ static void loop_fc()
                     ESP_LOGW(TAG, "[ROLL CFG] readConfigFrame failed");
                 }
             }
+            else if (out_pending_command == GUIDANCE_CONFIG_PENDING)
+            {
+                delay_ms(1);
+                uint8_t cfg_payload[sizeof(GuidanceConfigData)];
+                size_t  cfg_len = 0;
+                if (readConfigFrame(GUIDANCE_CONFIG_MSG, sizeof(GuidanceConfigData),
+                                    cfg_payload, sizeof(cfg_payload), cfg_len)
+                    && cfg_len >= sizeof(GuidanceConfigData))
+                {
+                    GuidanceConfigData g;
+                    memcpy(&g, cfg_payload, sizeof(g));
+                    guidance_enabled = (g.enable != 0);
+                    // Positive/sane values override; out-of-range leaves the default.
+                    if (g.nav_gain         > 0.0f && g.nav_gain         <= 20.0f)  pn_nav_gain     = g.nav_gain;
+                    if (g.max_accel_mps2   > 0.0f && g.max_accel_mps2   <= 200.0f) pn_max_accel    = g.max_accel_mps2;
+                    if (g.accel_to_fin_deg > 0.0f && g.accel_to_fin_deg <= 100.0f) pn_accel_to_fin = g.accel_to_fin_deg;
+                    if (g.max_fin_deg      > 0.0f && g.max_fin_deg      <= 60.0f)  pn_max_fin_deg  = g.max_fin_deg;
+                    if (g.min_speed_mps   >= 0.0f && g.min_speed_mps   <= 200.0f)  pn_min_speed    = g.min_speed_mps;
+                    if (g.target_alt_m     > 0.0f)                                 pn_target_alt   = g.target_alt_m;
+                    pn_coast_delay_ms = g.coast_delay_ms;
+                    pn_target_mode    = g.target_mode;
+                    // OVERHEAD forces horizontal (0,0) so a stale POINT push can't pollute it.
+                    pn_target_e = (g.target_mode == GUIDE_TARGET_POINT) ? g.target_e_m : 0.0f;
+                    pn_target_n = (g.target_mode == GUIDE_TARGET_POINT) ? g.target_n_m : 0.0f;
+                    // Phase 1: OVERHEAD via the 3-arg form (horizontal stays 0,0).
+                    guidance.configure(pn_nav_gain, pn_max_accel, pn_target_alt);
+                    ESP_LOGI(TAG, "[GUID CFG] en=%s N=%.1f maxA=%.0f a2f=%.1f maxFin=%.0f minV=%.0f mode=%u alt=%.0f",
+                                  guidance_enabled ? "ON" : "OFF", (double)pn_nav_gain,
+                                  (double)pn_max_accel, (double)pn_accel_to_fin, (double)pn_max_fin_deg,
+                                  (double)pn_min_speed, (unsigned)pn_target_mode, (double)pn_target_alt);
+                    prefs.begin("servo", false);
+                    prefs.putBool("guid_en", guidance_enabled);
+                    prefs.putFloat("gng", pn_nav_gain);
+                    prefs.putFloat("gma", pn_max_accel);
+                    prefs.putFloat("gaf", pn_accel_to_fin);
+                    prefs.putFloat("gmf", pn_max_fin_deg);
+                    prefs.putFloat("gms", pn_min_speed);
+                    prefs.putUShort("gcd", pn_coast_delay_ms);
+                    prefs.putUChar("gtm", pn_target_mode);
+                    prefs.putFloat("gte", pn_target_e);
+                    prefs.putFloat("gtn", pn_target_n);
+                    prefs.putFloat("gta", pn_target_alt);
+                    prefs.end();
+                    ESP_LOGI(TAG, "[GUID CFG] Saved to NVS");
+                }
+                else
+                {
+                    ESP_LOGW(TAG, "[GUID CFG] readConfigFrame failed");
+                }
+            }
             else if (out_pending_command == SERVO_REPLAY_PENDING)
             {
                 if (isCommandLockoutState(rocket_state)) {
@@ -5225,8 +5296,8 @@ static void loop_fc()
                             burnout_detected &&
                             ekf_initialized &&
                             ekf_ctrl_healthy &&   // #265: don't fly guidance on a diverged EKF
-                            (now_ms - burnout_time_ms >= config::PN_COAST_DELAY_MS) &&
-                            (speed > config::PN_MIN_SPEED_MPS) &&
+                            (now_ms - burnout_time_ms >= pn_coast_delay_ms) &&
+                            (speed > pn_min_speed) &&
                             !guidance.isCpaReached();
 
                         if (coast_guidance_active)
@@ -5286,7 +5357,7 @@ static void loop_fc()
                             float pitch_accel = a_body_down;   // sign verified in sim
                             float yaw_accel   = a_body_right;
 
-                            float accel_to_fin_deg = 4.0f;  // tuned in sim
+                            float accel_to_fin_deg = pn_accel_to_fin;  // app/NVS-tunable (was inline 4.0)
                             float pitch_fin = accel_to_fin_deg * pitch_accel;
                             float yaw_fin   = accel_to_fin_deg * yaw_accel;
 
@@ -5295,7 +5366,7 @@ static void loop_fc()
                                 config::ROLL_RATE_SET_POINT, -roll_rate_dps);
 
                             // Mix to 4 fins: pitch differential + yaw differential + roll common
-                            float max_fin = config::PN_MAX_FIN_DEG;
+                            float max_fin = pn_max_fin_deg;
                             float deflections[4];
                             deflections[0] = constrain(+pitch_fin + roll_fin_cmd, -max_fin, max_fin);  // top
                             deflections[1] = constrain(+yaw_fin   + roll_fin_cmd, -max_fin, max_fin);  // right

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5342,15 +5342,18 @@ static void loop_fc()
                             ekf_ctrl_healthy_prev = ekf_ctrl_healthy;
                         }
 
-                        // --- Guided coast mode (PN guidance) ---
-                        // Active only during coast when guidance is enabled and EKF is valid.
-                        // Stops at closest point of approach (CPA) or when speed drops.
+                        // --- Guided mode (PN guidance) ---
+                        // Shares roll-control initiation timing: this whole branch is
+                        // gated by t_since_launch_ms >= roll_delay_ms above, so guidance
+                        // engages WITH roll control (at the roll-control delay after
+                        // launch), NOT after burnout.  Set roll_delay_ms to ~burn time to
+                        // keep guidance post-boost.  Still needs a healthy EKF + airspeed
+                        // (pn_min_speed) and stops at closest point of approach (CPA).
+                        // (pn_coast_delay_ms / burnout are no longer gates here.)
                         const bool coast_guidance_active =
                             guidance_enabled &&
-                            burnout_detected &&
                             ekf_initialized &&
                             ekf_ctrl_healthy &&   // #265: don't fly guidance on a diverged EKF
-                            (now_ms - burnout_time_ms >= pn_coast_delay_ms) &&
                             (speed > pn_min_speed) &&
                             !guidance.isCpaReached();
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2376,6 +2376,14 @@ static void setup_fc()
     pn_target_e       = prefs.getFloat("gte", config::PN_TARGET_E_M);
     pn_target_n       = prefs.getFloat("gtn", config::PN_TARGET_N_M);
     pn_target_alt     = prefs.getFloat("gta", config::PN_TARGET_ALT_M);
+    // Fin→servo layout (servo azimuth + reverse), shared by every mix site.
+    float fin_az[4] = {
+        prefs.getFloat("fa0", config::FIN_AZIMUTH_0_DEG),
+        prefs.getFloat("fa1", config::FIN_AZIMUTH_1_DEG),
+        prefs.getFloat("fa2", config::FIN_AZIMUTH_2_DEG),
+        prefs.getFloat("fa3", config::FIN_AZIMUTH_3_DEG),
+    };
+    uint8_t fin_rev = prefs.getUChar("frv", config::FIN_REVERSE_MASK);
     prefs.end();
     ESP_LOGI(TAG, "Roll: kp_angle=%.2f rate_cap=%.0f iwindup=%.0f dps",
                   (double)kp_angle_outer, (double)kp_angle_rate_cap_dps,
@@ -2402,6 +2410,10 @@ static void setup_fc()
         control_mixer.enableGainSchedule(config::GAIN_SCHEDULE_V_REF,
                                          config::GAIN_SCHEDULE_V_MIN);
     }
+    control_mixer.setFinLayout(fin_az, fin_rev);
+    ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X",
+                  (double)fin_az[0], (double)fin_az[1], (double)fin_az[2], (double)fin_az[3],
+                  (unsigned)fin_rev);
 
     // Restore high-g accelerometer bias from NVS (namespace "cal")
     prefs.begin("cal", false);  // read-write (creates namespace on first boot)
@@ -4886,6 +4898,44 @@ static void loop_fc()
                     ESP_LOGW(TAG, "[GUID CFG] readConfigFrame failed");
                 }
             }
+            else if (out_pending_command == FIN_CONFIG_PENDING)
+            {
+                delay_ms(1);
+                uint8_t cfg_payload[sizeof(FinConfigData)];
+                size_t  cfg_len = 0;
+                if (readConfigFrame(FIN_CONFIG_MSG, sizeof(FinConfigData),
+                                    cfg_payload, sizeof(cfg_payload), cfg_len)
+                    && cfg_len >= sizeof(FinConfigData))
+                {
+                    FinConfigData f;
+                    memcpy(&f, cfg_payload, sizeof(f));
+                    // Reject garbage azimuths (range check also rejects NaN/Inf).
+                    bool ok = true;
+                    for (int i = 0; i < 4; ++i)
+                        if (!(f.azimuth_deg[i] >= -360.0f && f.azimuth_deg[i] <= 360.0f)) ok = false;
+                    if (ok) {
+                        control_mixer.setFinLayout(f.azimuth_deg, f.reverse_mask);
+                        ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X",
+                                      (double)f.azimuth_deg[0], (double)f.azimuth_deg[1],
+                                      (double)f.azimuth_deg[2], (double)f.azimuth_deg[3],
+                                      (unsigned)f.reverse_mask);
+                        prefs.begin("servo", false);
+                        prefs.putFloat("fa0", f.azimuth_deg[0]);
+                        prefs.putFloat("fa1", f.azimuth_deg[1]);
+                        prefs.putFloat("fa2", f.azimuth_deg[2]);
+                        prefs.putFloat("fa3", f.azimuth_deg[3]);
+                        prefs.putUChar("frv", f.reverse_mask);
+                        prefs.end();
+                        ESP_LOGI(TAG, "[FIN CFG] Saved to NVS");
+                    } else {
+                        ESP_LOGW(TAG, "[FIN CFG] rejected out-of-range azimuth");
+                    }
+                }
+                else
+                {
+                    ESP_LOGW(TAG, "[FIN CFG] readConfigFrame failed");
+                }
+            }
             else if (out_pending_command == SERVO_REPLAY_PENDING)
             {
                 if (isCommandLockoutState(rocket_state)) {
@@ -5051,13 +5101,10 @@ static void loop_fc()
                 // would stay zero otherwise.
                 last_external_roll_cmd_deg = roll_fin_cmd;
 
-                // 4-fin cruciform mixing
+                // 4-fin mix via the configured fin layout (servo→azimuth + reverse)
                 float max_fin = config::PN_MAX_FIN_DEG;
                 float deflections[4];
-                deflections[0] = constrain(+pitch_fin + roll_fin_cmd, -max_fin, max_fin); // top
-                deflections[1] = constrain(+yaw_fin   + roll_fin_cmd, -max_fin, max_fin); // right
-                deflections[2] = constrain(-pitch_fin + roll_fin_cmd, -max_fin, max_fin); // bottom
-                deflections[3] = constrain(-yaw_fin   + roll_fin_cmd, -max_fin, max_fin); // left
+                control_mixer.mixToFins(roll_fin_cmd, pitch_fin, yaw_fin, max_fin, deflections);
                 servo_control.setServoAngles(deflections);
 
                 // Periodic debug output (1 Hz)
@@ -5365,13 +5412,10 @@ static void loop_fc()
                             float roll_fin_cmd = roll_rate_pid_standalone.computePID(
                                 config::ROLL_RATE_SET_POINT, -roll_rate_dps);
 
-                            // Mix to 4 fins: pitch differential + yaw differential + roll common
+                            // 4-fin mix via the configured fin layout (servo→azimuth + reverse)
                             float max_fin = pn_max_fin_deg;
                             float deflections[4];
-                            deflections[0] = constrain(+pitch_fin + roll_fin_cmd, -max_fin, max_fin);  // top
-                            deflections[1] = constrain(+yaw_fin   + roll_fin_cmd, -max_fin, max_fin);  // right
-                            deflections[2] = constrain(-pitch_fin + roll_fin_cmd, -max_fin, max_fin);  // bottom
-                            deflections[3] = constrain(-yaw_fin   + roll_fin_cmd, -max_fin, max_fin);  // left
+                            control_mixer.mixToFins(roll_fin_cmd, pitch_fin, yaw_fin, max_fin, deflections);
                             servo_control.setServoAngles(deflections);
                             guidance_active = true;
                         }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1143,6 +1143,7 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == SERVO_REPLAY_PENDING ||
            cmd == ROLL_CTRL_CONFIG_PENDING ||
            cmd == GUIDANCE_CONFIG_PENDING ||
+           cmd == FIN_CONFIG_PENDING ||
            cmd == PYRO_CONFIG_PENDING ||
            cmd == ORIENT_CONFIG_PENDING ||
            cmd == PYRO_CONT_TEST ||
@@ -1578,6 +1579,8 @@ static bool isKnownMessageType(uint8_t type)
         case ROLL_CTRL_CONFIG_MSG:
         case GUIDANCE_CONFIG_PENDING:
         case GUIDANCE_CONFIG_MSG:
+        case FIN_CONFIG_PENDING:
+        case FIN_CONFIG_MSG:
         case GUIDANCE_ENABLE:
         case GUIDANCE_DISABLE:
         case GUIDANCE_TELEM_MSG:
@@ -2952,6 +2955,15 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         pending_config_msg_type = GUIDANCE_CONFIG_MSG;
         setPendingCommand(GUIDANCE_CONFIG_PENDING);
         ESP_LOGI("LORA", "UPLINK Guidance config queued for RocketComputer");
+    }
+    else if (cmd == 66 && payload_len >= sizeof(FinConfigData))
+    {
+        // Full fin layout from BaseStation: relay to FC
+        memcpy(pending_config_data, payload, sizeof(FinConfigData));
+        pending_config_data_len = sizeof(FinConfigData);
+        pending_config_msg_type = FIN_CONFIG_MSG;
+        setPendingCommand(FIN_CONFIG_PENDING);
+        ESP_LOGI("LORA", "UPLINK Fin layout queued for RocketComputer");
     }
     else if (cmd == LORA_CMD_CHANNEL_SET && payload_len >= 5)
     {
@@ -5500,6 +5512,20 @@ static void loop_oc()
                 pending_config_msg_type = GUIDANCE_CONFIG_MSG;
                 setPendingCommand(GUIDANCE_CONFIG_PENDING);
                 ESP_LOGI("BLE", "Guidance config queued for RocketComputer");
+            }
+        }
+        else if (ble_cmd == 66)
+        {
+            // Full fin layout (FinConfigData): relay the whole struct to the FC
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= sizeof(FinConfigData))
+            {
+                memcpy(pending_config_data, payload, sizeof(FinConfigData));
+                pending_config_data_len = sizeof(FinConfigData);
+                pending_config_msg_type = FIN_CONFIG_MSG;
+                setPendingCommand(FIN_CONFIG_PENDING);
+                ESP_LOGI("BLE", "Fin layout queued for RocketComputer");
             }
         }
         else if (ble_cmd == 33)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1142,6 +1142,7 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == ROLL_PROFILE_PENDING ||
            cmd == SERVO_REPLAY_PENDING ||
            cmd == ROLL_CTRL_CONFIG_PENDING ||
+           cmd == GUIDANCE_CONFIG_PENDING ||
            cmd == PYRO_CONFIG_PENDING ||
            cmd == ORIENT_CONFIG_PENDING ||
            cmd == PYRO_CONT_TEST ||
@@ -1575,6 +1576,8 @@ static bool isKnownMessageType(uint8_t type)
         case SERVO_REPLAY_STOP:
         case ROLL_CTRL_CONFIG_PENDING:
         case ROLL_CTRL_CONFIG_MSG:
+        case GUIDANCE_CONFIG_PENDING:
+        case GUIDANCE_CONFIG_MSG:
         case GUIDANCE_ENABLE:
         case GUIDANCE_DISABLE:
         case GUIDANCE_TELEM_MSG:
@@ -2940,6 +2943,15 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         cfg_guidance_en = enabled;
         setPendingCommand(enabled ? GUIDANCE_ENABLE : GUIDANCE_DISABLE);
         ESP_LOGI("LORA", "UPLINK Guidance: %s", enabled ? "ENABLE" : "DISABLE");
+    }
+    else if (cmd == 65 && payload_len >= sizeof(GuidanceConfigData))
+    {
+        // Full guidance config from BaseStation: relay to FC
+        memcpy(pending_config_data, payload, sizeof(GuidanceConfigData));
+        pending_config_data_len = sizeof(GuidanceConfigData);
+        pending_config_msg_type = GUIDANCE_CONFIG_MSG;
+        setPendingCommand(GUIDANCE_CONFIG_PENDING);
+        ESP_LOGI("LORA", "UPLINK Guidance config queued for RocketComputer");
     }
     else if (cmd == LORA_CMD_CHANNEL_SET && payload_len >= 5)
     {
@@ -5474,6 +5486,20 @@ static void loop_oc()
                 prefs.putBool("en", enabled);
                 prefs.end();
                 ESP_LOGI("BLE", "Guidance: %s", enabled ? "ENABLE" : "DISABLE");
+            }
+        }
+        else if (ble_cmd == 65)
+        {
+            // Full guidance config (GuidanceConfigData): relay the whole struct to the FC
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= sizeof(GuidanceConfigData))
+            {
+                memcpy(pending_config_data, payload, sizeof(GuidanceConfigData));
+                pending_config_data_len = sizeof(GuidanceConfigData);
+                pending_config_msg_type = GUIDANCE_CONFIG_MSG;
+                setPendingCommand(GUIDANCE_CONFIG_PENDING);
+                ESP_LOGI("BLE", "Guidance config queued for RocketComputer");
             }
         }
         else if (ble_cmd == 33)

--- a/tinkerrocket-sim/scripts/run_closed_loop.py
+++ b/tinkerrocket-sim/scripts/run_closed_loop.py
@@ -97,6 +97,8 @@ GUIDANCE_MODE = 'pn'            # 'pn' = proportional nav, 'attitude' = point-at
 PN_NAV_GAIN = 5.0               # navigation constant (3-5 typical)
 PN_MAX_TILT_DEG = 15.0          # max body tilt command (deg)
 PN_MAX_ACCEL_MPS2 = 20.0        # max lateral accel command (m/s^2)
+PN_TARGET_ALT_M = 600.0         # OVERHEAD aim-point altitude above pad (matches FC)
+PN_ACCEL_TO_FIN_DEG = 4.0       # accel->fin scale (reconciled to FC config::PN_ACCEL_TO_FIN_DEG)
 PN_BLEND_RADIUS_M = 200.0       # PD blend radius (m) — large = always PD mode
 PN_KP_POS = 0.8                 # PD position gain (s^-2)
 PN_KD_VEL = 1.5                 # PD velocity gain (s^-1)
@@ -647,6 +649,8 @@ if __name__ == "__main__":
         pn_nav_gain=PN_NAV_GAIN,
         pn_max_tilt_deg=PN_MAX_TILT_DEG,
         pn_max_accel_mps2=PN_MAX_ACCEL_MPS2,
+        pn_target_alt_m=PN_TARGET_ALT_M,
+        pn_accel_to_fin_deg=PN_ACCEL_TO_FIN_DEG,
         pn_blend_radius_m=PN_BLEND_RADIUS_M,
         pn_kp_pos=PN_KP_POS,
         pn_kd_vel=PN_KD_VEL,

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -150,6 +150,8 @@ class SimConfig:
     pn_max_fin_deg: float = 15.0
     pn_min_speed_mps: float = 15.0
     pn_coast_delay_s: float = 0.0   # delay after burnout before guidance activates
+    pn_target_alt_m: float = 600.0      # OVERHEAD aim-point altitude above pad (matches FC config::PN_TARGET_ALT_M)
+    pn_accel_to_fin_deg: float = 4.0    # accel->fin scale; reconciled to the FC's config::PN_ACCEL_TO_FIN_DEG (was 5.0)
 
     # Gain scheduling for pitch/yaw (separate from roll)
     pn_gain_V_ref: float = 50.0
@@ -257,7 +259,7 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         guidance = GuidancePN()
         guidance.configure(
             config.pn_nav_gain, config.pn_max_accel_mps2,
-            600.0)  # target alt above apogee
+            config.pn_target_alt_m)  # OVERHEAD: aim straight up over the pad
 
         control_mixer = ControlMixer()
         control_mixer.configure(
@@ -633,7 +635,7 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                         # 4. PN guidance via C++ library (TR_GuidancePN)
                         #    Same textbook 3D PN (Yanushevsky Ch.2, eq 1.11/2.23)
                         #    Library outputs ENU acceleration commands.
-                        target_alt = 600.0
+                        target_alt = config.pn_target_alt_m
 
                         guid_active = guidance.update(
                             [float(pos_e), float(pos_n), float(pos_u)],
@@ -696,7 +698,7 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
 
                             # Direct accel → fin deflection (bypass PID)
                             # Scale: deg of fin per m/s² of accel command
-                            accel_to_fin_deg = 5.0  # tunable
+                            accel_to_fin_deg = config.pn_accel_to_fin_deg  # reconciled to FC (was 5.0)
                             pitch_fin = accel_to_fin_deg * pitch_accel
                             yaw_fin = accel_to_fin_deg * yaw_accel
 


### PR DESCRIPTION
## Summary

Makes the flight-control pipeline app-configurable and adds an overhead "steer back over the pad" guidance mode, plus a configurable fin→servo layout and the UI to drive both. All cross-layer config follows the established FC↔OC↔BS↔app relay pattern (packed struct + `static_assert` + layout gtest + full-`sizeof` relays + `ActiveRocketSyncer` push-on-connect).

### PN guidance (app-configurable + overhead)
- `GuidanceConfigData` wire struct (app cmd 65, msg ids `0xEF`/`0xF0`) relayed app→BS→OC→FC; runtime + NVS-backed nav gain, max accel, accel→fin, min speed, max fin, target altitude, and target mode.
- **Overhead** target mode: steers toward (0,0,target_alt) over the pad (a special case of the drift-cast/reverse-cast idea, chosen as the simpler starting point).
- SIL-validated (config-driven target alt + accel→fin; overhead reduces lateral offset toward the pad).

### Configurable fin layout
- Runtime servo→fin azimuth mix in `TR_ControlMixer` (`setFinLayout` / `mixToFins`), routed through **every** FC mix site. `FinConfigData` (app cmd 66, msg ids `0xF2`/`0xF3`).
- Default azimuths `{0,90,180,270}` reproduce the legacy hardcoded "+" mix **exactly** — gtest-guarded regression.
- **Independent** per-fin **tilt** (pitch/yaw) and **roll** reverse — a servo reversed for tilt no longer flips its roll (found on the bench).
- Ring GUI (nose-down view: +Z up, +Y right) with servo placement, +/× orientation, per-fin reverse, and a servo jog (reuses the servo-test path) to confirm deflection direction on the bench.

### Control behavior + UI
- Guidance engages at the **roll-control launch delay** (shared initiation timing), not after burnout. `roll_delay_ms` is the single start knob — set ≈ burn time to keep guidance post-boost.
- Single **Control Mode** switch (Roll Control ↔ Guidance, mutually exclusive); Guidance rate-nulls roll and never follows the roll profile.
- **IMU Mounting** Manual/Pad switch, default **manual +X-up** (aligns with `config::BOARD_TO_ROCKET_ORIENT`; the app no longer overrides the FC to auto on connect). Manual fixes the fin clocking that gravity can't observe — required for roll/guided flight.
- Ground test freezes the pad orientation auto-detect so tilting the board to exercise the guidance fins doesn't re-rack the board→rocket frame mid-test.

## Verification
- C++ gtests: `test_control_mixer` (default == hardcode regression, × split, independent tilt/roll reverse) + `test_rocket_computer_types` (`FinConfigData` 18 B layout) pass.
- FC / OC / BS firmware compile (ESP-IDF v6.0); iOS app builds (`xcodebuild`).
- Bench-iterated: fin direction confirm via servo jog + ground-test tilt.

## Deferred
- Record the flown guidance/fin params in `FlightSettingsData` (analysis-completeness).
- DriftCast point/cast/reverse-cast target modes (`target_mode`/E/N reserved in the struct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
