### PR TITLE
oc(log): surface flight-log storage health + reclaim NAND without deleting

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -154,6 +154,7 @@ struct TelemetryData: Codable {
     var magHealth:  SensorHealth { shState(6) }   // advisory only — never gates go/no-go
     var gnssHealth: SensorHealth { shState(8) }
     var battHealth: SensorHealth { shState(10) }
+    var storageHealth: SensorHealth { shState(20) }   // #281/#278: flight-log NAND — BAD = full/failing, won't record
     func pyroHealth(channel: Int) -> SensorHealth {   // channel 1...4; .na = not configured
         guard (1...4).contains(channel) else { return .na }
         return shState(12 + (channel - 1) * 2)
@@ -172,6 +173,9 @@ struct TelemetryData: Codable {
             SensorHealthRow(name: "Battery", state: battHealth),
             SensorHealthRow(name: "Mag",     state: magHealth),
         ]
+        if storageHealth != .na {   // OC-reported only; absent on older firmware / BS self-frames
+            rows.append(SensorHealthRow(name: "Storage", state: storageHealth))
+        }
         for ch in 1...4 where pyroHealth(channel: ch) != .na {
             rows.append(SensorHealthRow(name: "Pyro \(ch)", state: pyroHealth(channel: ch)))
         }
@@ -179,9 +183,11 @@ struct TelemetryData: Codable {
     }
 
     // Go/no-go rollup (#303).  Red = a hard fault waiting won't fix (baro/IMU/
-    // battery BAD, or a configured pyro with no continuity).  Green needs every
-    // required item OK — including EKF initialized/converged and a GNSS fix.
-    // Mag is advisory and never gates.  Amber = anything in between.
+    // battery BAD, a full/failing flight-log store, or a configured pyro with no
+    // continuity).  Green needs every required item OK — including EKF
+    // initialized/converged and a GNSS fix.  Mag is advisory and never gates.
+    // Storage is OC-reported: absent (N/A) on older firmware → ignored, not red.
+    // Amber = anything in between.
     enum FlightReadiness { case unknown, ready, caution, notReady
         var label: String {
             switch self { case .unknown:  return "Waiting for telemetry…"
@@ -192,10 +198,11 @@ struct TelemetryData: Codable {
     }
     var flightReadiness: FlightReadiness {
         guard hasSensorHealth else { return .unknown }
-        let hardFault = [baroHealth, imuHealth, battHealth].contains(.bad)
+        let hardFault = [baroHealth, imuHealth, battHealth, storageHealth].contains(.bad)
             || (1...4).contains { pyroHealth(channel: $0) == .bad }
         if hardFault { return .notReady }
         var mustBeOK = [baroHealth, imuHealth, battHealth, ekfHealth, gnssHealth]
+        if storageHealth != .na { mustBeOK.append(storageHealth) }   // #281/#278: low/full space gates green
         for ch in 1...4 where pyroHealth(channel: ch) != .na { mustBeOK.append(pyroHealth(channel: ch)) }
         return mustBeOK.allSatisfy { $0 == .ok } ? .ready : .caution
     }

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -119,12 +119,12 @@ final class TelemetryDataTests: XCTestCase {
 
     /// Pack a "h" bitfield from per-item states.  Shifts mirror
     /// RocketComputerTypes.h SH_*_SHIFT (baro 0, imu 2, ekf 4, mag 6, gnss 8,
-    /// batt 10, pyro1..4 at 12/14/16/18).
+    /// batt 10, pyro1..4 at 12/14/16/18, storage 20).
     private func pack(baro: SH = .na, imu: SH = .na, ekf: SH = .na, mag: SH = .na,
-                      gnss: SH = .na, batt: SH = .na,
+                      gnss: SH = .na, batt: SH = .na, storage: SH = .na,
                       p1: SH = .na, p2: SH = .na, p3: SH = .na, p4: SH = .na) -> Int {
         baro.rawValue | (imu.rawValue << 2) | (ekf.rawValue << 4) | (mag.rawValue << 6)
-            | (gnss.rawValue << 8) | (batt.rawValue << 10)
+            | (gnss.rawValue << 8) | (batt.rawValue << 10) | (storage.rawValue << 20)
             | (p1.rawValue << 12) | (p2.rawValue << 14) | (p3.rawValue << 16) | (p4.rawValue << 18)
     }
     private func decode(health: Int) throws -> TelemetryData {
@@ -142,6 +142,7 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(try decode(health: 1 << 8).gnssHealth, .ok)       // gnss
         XCTAssertEqual(try decode(health: 1 << 10).battHealth, .ok)      // battery
         XCTAssertEqual(try decode(health: 1 << 18).pyroHealth(channel: 4), .ok)  // pyro4
+        XCTAssertEqual(try decode(health: 1 << 20).storageHealth, .ok)   // storage (#281/#278)
         // A single field set leaves everything else N/A (no bleed).
         let onlyGnss = try decode(health: 1 << 8)
         XCTAssertEqual(onlyGnss.baroHealth, .na)
@@ -188,6 +189,27 @@ final class TelemetryDataTests: XCTestCase {
         // A configured-but-untested pyro is amber too.
         let pyro = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok, p1: .deg))
         XCTAssertEqual(pyro.flightReadiness, .caution)
+    }
+
+    /// Flight-log storage (#281/#278): BAD (full/failing NAND) is a hard fault —
+    /// the silent log-loss that motivated the verdict must read "do not fly".
+    /// DEGRADED (low space) gates green down to amber; N/A (older firmware) is
+    /// ignored so it can't strand the go/no-go.  A reported state adds a card row.
+    func testReadiness_Storage() throws {
+        let full = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok, storage: .bad))
+        XCTAssertEqual(full.storageHealth, .bad)
+        XCTAssertEqual(full.flightReadiness, .notReady)
+        let low = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, gnss: .ok, batt: .ok, storage: .deg))
+        XCTAssertEqual(low.flightReadiness, .caution)
+        let ok = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, mag: .ok, gnss: .ok, batt: .ok, storage: .ok))
+        XCTAssertEqual(ok.flightReadiness, .ready)
+        XCTAssertEqual(ok.sensorHealthRows.count, 7)         // 6 core + Storage
+        XCTAssertTrue(ok.sensorHealthRows.contains { $0.name == "Storage" })
+        // N/A storage (older firmware / BS frame) is ignored: no row, still green.
+        let naStor = try decode(health: pack(baro: .ok, imu: .ok, ekf: .ok, mag: .ok, gnss: .ok, batt: .ok))
+        XCTAssertEqual(naStor.storageHealth, .na)
+        XCTAssertEqual(naStor.flightReadiness, .ready)
+        XCTAssertFalse(naStor.sensorHealthRows.contains { $0.name == "Storage" })
     }
 
     /// Mag is advisory — BAD mag with everything else OK still recommends fly.

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -31,6 +31,37 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(Vec3i16),         6u);
 }
 
+// #281/#278: the flight-log storage verdict the OC folds into sensor_health.  A
+// full/failing NAND silently dropped the 2026-06-25 guided flight; these pin the
+// thresholds and the bit slot so the pre-launch go/no-go can trust them.
+TEST(RocketComputerTypes, StorageHealthVerdict) {
+    constexpr uint32_t PA = 256;  // prealloc_blocks — one flight's reservation
+    EXPECT_EQ(shStorageState(/*free=*/988, PA, /*write_fail=*/0), SH_OK);
+    EXPECT_EQ(shStorageState(2 * PA,       PA, 0), SH_OK);
+    EXPECT_EQ(shStorageState(2 * PA - 1,   PA, 0), SH_DEGRADED);  // room for <2 flights
+    EXPECT_EQ(shStorageState(PA,           PA, 0), SH_DEGRADED);
+    EXPECT_EQ(shStorageState(PA - 1,       PA, 0), SH_BAD);       // no room for next flight
+    EXPECT_EQ(shStorageState(0,            PA, 0), SH_BAD);
+    // A NAND write failure is BAD regardless of free space (full mid-flight /
+    // bad-block run) — even with the whole chip nominally free.
+    EXPECT_EQ(shStorageState(988,          PA, /*write_fail=*/1), SH_BAD);
+    EXPECT_EQ(shStorageState(0, /*prealloc=*/0, 0), SH_NA);       // logger not configured
+}
+
+TEST(RocketComputerTypes, StorageHealth_BitPosition) {
+    EXPECT_EQ(SH_STORAGE_SHIFT, 20u);
+    for (uint8_t other : {SH_BARO_SHIFT, SH_IMU_SHIFT, SH_EKF_SHIFT, SH_MAG_SHIFT,
+                          SH_GNSS_SHIFT, SH_BATT_SHIFT, SH_PYRO_SHIFT[0],
+                          SH_PYRO_SHIFT[1], SH_PYRO_SHIFT[2], SH_PYRO_SHIFT[3]}) {
+        EXPECT_NE(SH_STORAGE_SHIFT, other);   // clear of every other field
+    }
+    uint32_t f = shSet(0u, SH_STORAGE_SHIFT, SH_BAD);
+    EXPECT_EQ(shGet(f, SH_STORAGE_SHIFT), SH_BAD);
+    f = shSet(f, SH_PYRO_SHIFT[3], SH_OK);    // neighbouring field (shift 18) — no bleed
+    EXPECT_EQ(shGet(f, SH_STORAGE_SHIFT), SH_BAD);
+    EXPECT_EQ(shGet(f, SH_PYRO_SHIFT[3]), SH_OK);
+}
+
 TEST(RocketComputerTypes, NSF_FlagBits_NoOverlap) {
     // bits 0-6 used; bit 7 reserved post per-fire-arming refactor.
     uint8_t all = NSF_ALT_LANDED | NSF_ALT_APOGEE | NSF_VEL_APOGEE |

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -176,7 +176,7 @@ TEST(TRFlightLogScaffold, BeginAcceptsDefaultConfig) {
     TR_FlightLog::Config cfg;
     EXPECT_EQ(fl.begin(nand, cfg), Status::Ok);
     EXPECT_TRUE(fl.isInitialized());
-    EXPECT_EQ(fl.config().prealloc_blocks, 256);
+    EXPECT_EQ(fl.config().prealloc_blocks, 80);
 }
 
 TEST(TRFlightLogScaffold, BeginRejectsInvertedRegion) {
@@ -524,6 +524,34 @@ TEST(FlightIndexPersist, SaveThenLoadRoundTrip) {
     EXPECT_STREQ(loaded.at(1).filename, "flight_002.bin");
 }
 
+TEST(FlightIndexPersist, FullIndexRoundTripsAcrossPages) {
+    // At MAX_ENTRIES=128 the serialized snapshot is ~6.2 KB — several NAND pages
+    // — and is built in a heap buffer off the 4 KB stack (#281). Fill the index
+    // to capacity and confirm save/load round-trips every entry, including the
+    // last one (which lives on a later page).
+    FakeNandBackend nand;
+    FlightIndex idx;
+    for (size_t i = 0; i < FlightIndex::MAX_ENTRIES; ++i) {
+        char name[24];
+        std::snprintf(name, sizeof(name), "flight_%03zu.bin", i);
+        ASSERT_EQ(idx.append(makeEntry(static_cast<uint32_t>(i + 1), name,
+                                       static_cast<uint16_t>(32 + i), 1,
+                                       static_cast<uint32_t>(1000 + i))),
+                  Status::Ok);
+    }
+    ASSERT_EQ(idx.save(nand, META_A, META_B), Status::Ok);
+
+    FlightIndex loaded;
+    ASSERT_EQ(loaded.load(nand, META_A, META_B), Status::Ok);
+    ASSERT_EQ(loaded.size(), FlightIndex::MAX_ENTRIES);
+    EXPECT_EQ(loaded.at(0).flight_id, 1u);
+    EXPECT_STREQ(loaded.at(0).filename, "flight_000.bin");
+    EXPECT_EQ(loaded.at(FlightIndex::MAX_ENTRIES - 1).flight_id,
+              static_cast<uint32_t>(FlightIndex::MAX_ENTRIES));
+    EXPECT_EQ(loaded.at(FlightIndex::MAX_ENTRIES - 1).final_bytes,
+              static_cast<uint32_t>(1000 + FlightIndex::MAX_ENTRIES - 1));
+}
+
 TEST(FlightIndexPersist, SequenceIncrementsOnEachSave) {
     FakeNandBackend nand;
     FlightIndex idx;
@@ -666,7 +694,7 @@ TEST(TRFlightLogPrepare, FreshChipPicksRangeStart) {
     FakeNandBackend nand;
     MemoryBitmapStore store;
     TR_FlightLog fl;
-    TR_FlightLog::Config cfg;  // default prealloc_blocks = 256
+    TR_FlightLog::Config cfg;  // default prealloc_blocks = 80
     ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
 
     uint32_t flight_id = 0;
@@ -697,22 +725,23 @@ TEST(TRFlightLogPrepare, SkipsKnownBadBlocksWhenPicking) {
     MemoryBitmapStore store;
     TR_FlightLog fl;
     TR_FlightLog::Config cfg;
-    // Factory-bad a block partway through the first natural 256-block range.
-    nand.injectFactoryBadBlock(cfg.flight_region_start + 100);
+    // Factory-bad a block partway through the first natural prealloc-block range
+    // (must be < prealloc_blocks so it actually breaks the first candidate run).
+    nand.injectFactoryBadBlock(cfg.flight_region_start + 50);
 
     ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
     uint32_t flight_id = 0;
     ASSERT_EQ(fl.prepareFlight(flight_id), Status::Ok);
 
-    // The chosen start must be >= flight_region_start + 101 (first fresh free
+    // The chosen start must be >= flight_region_start + 51 (first fresh free
     // run after the bad block).
     // Walk the bitmap to find the chosen range.
     uint32_t first_alloc = 0;
     for (uint32_t b = 0; b < NAND_BLOCK_COUNT; ++b) {
         if (fl.bitmap().get(b) == BLOCK_ALLOCATED) { first_alloc = b; break; }
     }
-    EXPECT_EQ(first_alloc, cfg.flight_region_start + 101);
-    EXPECT_EQ(fl.bitmap().get(cfg.flight_region_start + 100), BLOCK_BAD);
+    EXPECT_EQ(first_alloc, cfg.flight_region_start + 51);
+    EXPECT_EQ(fl.bitmap().get(cfg.flight_region_start + 50), BLOCK_BAD);
 }
 
 TEST(TRFlightLogPrepare, NoSpaceWhenInsufficientContiguousFree) {
@@ -1489,9 +1518,16 @@ TEST(TRFlightLogBrownout, RecoversPartialFlightWithValidHeaders) {
 
     const auto& e = fl2.index().at(0);
     EXPECT_EQ(e.flight_id, expected_flight_id);
-    EXPECT_EQ(e.n_blocks, 256u);
-    // Last valid seq was 49; final_bytes = (49+1) * NAND_PAGE_SIZE.
-    EXPECT_EQ(e.final_bytes, 50u * NAND_PAGE_SIZE);
+    // 50 single-page frames -> 50 pages -> 1 block. The recovered entry is now
+    // TRIMMED to the blocks actually used (was the full prealloc), and the
+    // reserved-but-unused tail is returned to FREE — so a brownout flight no
+    // longer permanently holds its whole prealloc (#281 root cause).
+    EXPECT_EQ(e.n_blocks, 1u);
+    EXPECT_EQ(fl2.bitmap().get(e.start_block), BLOCK_ALLOCATED);
+    EXPECT_EQ(fl2.bitmap().get(e.start_block + e.n_blocks), BLOCK_FREE);  // tail freed
+    // #273: final_bytes uses PAYLOAD_PER_PAGE (2032), not NAND_PAGE_SIZE (2048),
+    // so the downloader stops at the last real page (clean tail, correct size).
+    EXPECT_EQ(e.final_bytes, 50u * (NAND_PAGE_SIZE - sizeof(PageHeader)));
     // Filename is synthesized — caller can rename later.
     EXPECT_NE(std::strstr(e.filename, "recovered"), nullptr);
 }
@@ -1553,8 +1589,9 @@ TEST(TRFlightLogBrownout, TornLastPageReverts) {
     TR_FlightLog fl2;
     ASSERT_EQ(fl2.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
     ASSERT_EQ(fl2.index().size(), 1u);
-    // Recovery should stop at seq=8 (last intact page); final_bytes = 9 pages.
-    EXPECT_EQ(fl2.index().at(0).final_bytes, 9u * NAND_PAGE_SIZE);
+    // Recovery should stop at seq=8 (last intact page); final_bytes = 9 pages
+    // of PAYLOAD_PER_PAGE (#273), not NAND_PAGE_SIZE.
+    EXPECT_EQ(fl2.index().at(0).final_bytes, 9u * (NAND_PAGE_SIZE - sizeof(PageHeader)));
 }
 
 // ================================================================

--- a/tinkerrocket-idf/components/TR_FlightLog/FlightIndex.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/FlightIndex.cpp
@@ -3,6 +3,8 @@
 #include "CRC.h"
 
 #include <cstring>
+#include <memory>
+#include <new>
 
 namespace tr_flightlog {
 
@@ -10,6 +12,21 @@ namespace {
 
 constexpr size_t serialized_size(size_t entry_count) {
     return sizeof(MetadataHeader) + entry_count * sizeof(FlightIndexEntry);
+}
+
+// Whole-page-aligned scratch for a full serialized snapshot, rounded up to a
+// NAND page so readPage/programPage (which always touch a full NAND_PAGE_SIZE)
+// never run past the buffer. Allocated on the HEAP per call (#281): the snapshot
+// is ~6 KB at MAX_ENTRIES=128 — too large for the 4 KB main-task stack — and the
+// callers (main at boot, flush task at finalize, BLE task at delete) each get
+// their own buffer, so there's no stack pressure and no cross-task shared-buffer
+// race. Returns a zero-filled buffer (pads the last page deterministically), or
+// nullptr on OOM (caller degrades gracefully — the data stays on NAND).
+constexpr size_t SNAPSHOT_BUF_BYTES =
+    ((FlightIndex::MAX_SERIALIZED_BYTES + NAND_PAGE_SIZE - 1) / NAND_PAGE_SIZE) * NAND_PAGE_SIZE;
+
+inline std::unique_ptr<uint8_t[]> allocSnapshotBuf() {
+    return std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[SNAPSHOT_BUF_BYTES]());
 }
 
 // CRC32 over everything after the crc32 field of MetadataHeader, through the
@@ -82,30 +99,29 @@ void FlightIndex::clear() {
 
 FlightIndex::SnapshotInfo FlightIndex::inspect(TR_NandBackend& nand, uint32_t block) const {
     SnapshotInfo info;
-    uint8_t page[NAND_PAGE_SIZE];
-    if (!nand.readPage(block, 0, page)) return info;
+    auto buf = allocSnapshotBuf();
+    if (!buf) return info;
+    if (!nand.readPage(block, 0, buf.get())) return info;
 
     MetadataHeader hdr;
-    std::memcpy(&hdr, page, sizeof(hdr));
+    std::memcpy(&hdr, buf.get(), sizeof(hdr));
     if (hdr.magic != META_MAGIC) return info;
     if (hdr.entry_count > MAX_ENTRIES) return info;
 
     const size_t total_bytes = serialized_size(hdr.entry_count);
     if (total_bytes > MAX_SERIALIZED_BYTES) return info;
 
-    // Read the full serialized blob, page by page.
-    uint8_t buf[MAX_SERIALIZED_BYTES];
-    size_t pages_needed = (total_bytes + NAND_PAGE_SIZE - 1) / NAND_PAGE_SIZE;
-    std::memcpy(buf, page, NAND_PAGE_SIZE);
+    // Read the remaining pages of the serialized blob (page 0 already in buf).
+    const size_t pages_needed = (total_bytes + NAND_PAGE_SIZE - 1) / NAND_PAGE_SIZE;
     for (size_t p = 1; p < pages_needed; ++p) {
         if (!nand.readPage(block, static_cast<uint32_t>(p),
-                           buf + p * NAND_PAGE_SIZE)) {
+                           buf.get() + p * NAND_PAGE_SIZE)) {
             return info;
         }
     }
 
     const uint32_t want_crc = hdr.crc32;
-    const uint32_t got_crc  = compute_crc(buf, total_bytes);
+    const uint32_t got_crc  = compute_crc(buf.get(), total_bytes);
     if (want_crc != got_crc) return info;
 
     info.valid       = true;
@@ -116,11 +132,12 @@ FlightIndex::SnapshotInfo FlightIndex::inspect(TR_NandBackend& nand, uint32_t bl
 
 Status FlightIndex::readSnapshot(TR_NandBackend& nand, uint32_t block) {
     clear();
-    uint8_t buf[MAX_SERIALIZED_BYTES];
-    if (!nand.readPage(block, 0, buf)) return Status::BackendFailed;
+    auto buf = allocSnapshotBuf();
+    if (!buf) return Status::BackendFailed;
+    if (!nand.readPage(block, 0, buf.get())) return Status::BackendFailed;
 
     MetadataHeader hdr;
-    std::memcpy(&hdr, buf, sizeof(hdr));
+    std::memcpy(&hdr, buf.get(), sizeof(hdr));
     if (hdr.magic != META_MAGIC) return Status::CrcMismatch;
     if (hdr.entry_count > MAX_ENTRIES) return Status::Error;
 
@@ -128,15 +145,15 @@ Status FlightIndex::readSnapshot(TR_NandBackend& nand, uint32_t block) {
     const size_t pages_needed = (total_bytes + NAND_PAGE_SIZE - 1) / NAND_PAGE_SIZE;
     for (size_t p = 1; p < pages_needed; ++p) {
         if (!nand.readPage(block, static_cast<uint32_t>(p),
-                           buf + p * NAND_PAGE_SIZE)) {
+                           buf.get() + p * NAND_PAGE_SIZE)) {
             return Status::BackendFailed;
         }
     }
-    if (compute_crc(buf, total_bytes) != hdr.crc32) return Status::CrcMismatch;
+    if (compute_crc(buf.get(), total_bytes) != hdr.crc32) return Status::CrcMismatch;
 
     count_         = hdr.entry_count;
     last_sequence_ = hdr.sequence;
-    std::memcpy(entries_, buf + sizeof(MetadataHeader),
+    std::memcpy(entries_, buf.get() + sizeof(MetadataHeader),
                 count_ * sizeof(FlightIndexEntry));
     return Status::Ok;
 }
@@ -162,7 +179,8 @@ Status FlightIndex::load(TR_NandBackend& nand,
 
 Status FlightIndex::writeSnapshot(TR_NandBackend& nand,
                                   uint32_t block, uint32_t sequence) const {
-    uint8_t buf[MAX_SERIALIZED_BYTES] = {};
+    auto buf = allocSnapshotBuf();   // zero-filled: pads the last page deterministically
+    if (!buf) return Status::BackendFailed;
     const size_t total_bytes = serialized_size(count_);
 
     MetadataHeader hdr;
@@ -170,17 +188,17 @@ Status FlightIndex::writeSnapshot(TR_NandBackend& nand,
     hdr.magic       = META_MAGIC;
     hdr.sequence    = sequence;
     hdr.entry_count = static_cast<uint32_t>(count_);
-    std::memcpy(buf, &hdr, sizeof(hdr));
-    std::memcpy(buf + sizeof(hdr), entries_,
+    std::memcpy(buf.get(), &hdr, sizeof(hdr));
+    std::memcpy(buf.get() + sizeof(hdr), entries_,
                 count_ * sizeof(FlightIndexEntry));
 
-    const uint32_t crc = compute_crc(buf, total_bytes);
-    std::memcpy(buf, &crc, sizeof(crc));
+    const uint32_t crc = compute_crc(buf.get(), total_bytes);
+    std::memcpy(buf.get(), &crc, sizeof(crc));
 
     const size_t pages_needed = (total_bytes + NAND_PAGE_SIZE - 1) / NAND_PAGE_SIZE;
     for (size_t p = 0; p < pages_needed; ++p) {
         if (!nand.programPage(block, static_cast<uint32_t>(p),
-                              buf + p * NAND_PAGE_SIZE)) {
+                              buf.get() + p * NAND_PAGE_SIZE)) {
             return Status::BackendFailed;
         }
     }

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -181,8 +181,15 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
             continue;
         }
 
-        // Synthesize a partial flight entry. final_bytes tracks the logical
-        // byte count of the data that actually got flushed to NAND.
+        // Synthesize a partial flight entry. final_bytes is the logical PAYLOAD
+        // byte count actually flushed to NAND — #273: PAYLOAD_PER_PAGE (2032),
+        // NOT NAND_PAGE_SIZE (2048), or the downloader walks past the last real
+        // page into PageHeader/0xFF bytes (corrupt tail, size ~0.8% too large).
+        constexpr uint32_t PAYLOAD_PER_PAGE = NAND_PAGE_SIZE - sizeof(PageHeader);
+        const uint32_t used_pages  = static_cast<uint32_t>(last_good_page_rel + 1);
+        uint32_t used_blocks = (used_pages + NAND_PAGES_PER_BLK - 1) / NAND_PAGES_PER_BLK;
+        if (used_blocks > run_len) used_blocks = run_len;
+
         FlightIndexEntry entry{};
         entry.magic       = FLGT_MAGIC;
         entry.flight_id   = last_flight_id;
@@ -190,13 +197,22 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
                       "flight_recovered_%lu.bin",
                       static_cast<unsigned long>(last_flight_id));
         entry.start_block = static_cast<uint16_t>(run_start);
-        entry.n_blocks    = static_cast<uint16_t>(run_len);
-        entry.final_bytes = static_cast<uint32_t>(
-            (last_good_page_rel + 1) * static_cast<int32_t>(NAND_PAGE_SIZE));
+        entry.n_blocks    = static_cast<uint16_t>(used_blocks);  // trimmed; was run_len (full ~32 MB)
+        entry.final_bytes = used_pages * PAYLOAD_PER_PAGE;
 
         Status st = index_.append(entry);
         if (st != Status::Ok) return st;
         index_dirty = true;
+
+        // Trim the unused tail of the recovered range back to FREE, exactly like
+        // finalizeFlight. Without this a brownout flight permanently holds its
+        // full prealloc — ~4 such flights fill the chip despite <10 MB of real
+        // data each (the 2026-06-25 silent log-loss / #281 root cause).
+        const uint32_t free_count = run_len - used_blocks;
+        if (free_count > 0) {
+            bitmap_.markFreeRange(run_start + used_blocks, free_count);
+            bitmap_dirty = true;
+        }
     }
 
     if (index_dirty) {

--- a/tinkerrocket-idf/components/TR_FlightLog/include/FlightIndex.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/FlightIndex.h
@@ -29,13 +29,16 @@ constexpr uint32_t META_MAGIC = 0x4154454D;  // 'META' little-endian
 // MAX_ENTRIES is conservative — practical chip usage is tens of flights.
 class FlightIndex {
 public:
-    // 64 entries × 48 B + 16 B header = 3088 B serialized. The serialize/
-    // deserialize helpers allocate this as a stack buffer, so it must comfortably
-    // fit the smallest task stack that calls begin()/save()/load() — that's the
-    // ESP-IDF main task at 4 KB default. 256 entries (the Stage 1 figure) put
-    // ~12 KB on the stack and crashed on the bench with the classic 0x55aa...
-    // canary smear. Chip capacity is ~8 full flights anyway; 64 is still ample.
-    static constexpr size_t MAX_ENTRIES = 64;
+    // 128 entries × 48 B + 16 B header ≈ 6.2 KB serialized. The serialize/
+    // deserialize helpers now allocate this scratch on the HEAP (page-aligned),
+    // not the stack, so the cap is no longer bounded by the 4 KB ESP-IDF
+    // main-task stack — raising it from 64 (#281) is safe. (256 entries on the
+    // stack put ~12 KB there and crashed on the bench with a 0x55aa canary
+    // smear; that hazard is gone now.) With recovered flights trimmed and a
+    // ~10 MB prealloc the chip holds ~12-30 real flights; 128 is comfortable
+    // headroom even for many short hops, and the OC surfaces index-near-full
+    // as a storage warning.
+    static constexpr size_t MAX_ENTRIES = 128;
     static constexpr size_t MAX_SERIALIZED_BYTES =
         sizeof(MetadataHeader) + MAX_ENTRIES * sizeof(FlightIndexEntry);
 

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -19,7 +19,11 @@ namespace tr_flightlog {
 class TR_FlightLog {
 public:
     struct Config {
-        uint16_t prealloc_blocks     = 256;   // 32 MB
+        // ~10 MB (~2.7 min at the ~64 KB/s log rate) covers the vast majority of
+        // flights without an overflow extend.  Was 256 (32 MB / ~8.5 min): with
+        // recovered flights now trimmed (scanForBrownoutRecovery) that headroom
+        // is pure waste/fragmentation, and a brownout flight no longer keeps it.
+        uint16_t prealloc_blocks     = 80;    // ~10 MB
         uint16_t extend_blocks       = 64;    // overflow step (~200 ms stall)
         uint16_t flight_region_start = 32;    // first block owned by this layer
         uint16_t flight_region_end   = 1020;  // one past last flight block

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1070,7 +1070,8 @@ typedef struct __attribute__((packed))
 
     // Sensor health scorecard (#303): 2 bits per item (SensorHealthState), see
     // the SH_*_SHIFT positions below — incl. a state per pyro channel.  FC fills
-    // baro/IMU/EKF/mag/GNSS/pyro×4; the OC ORs in the battery bits before relay.
+    // baro/IMU/EKF/mag/GNSS/pyro×4; the OC ORs in battery + flight-log storage
+    // before relay (both OC-owned — the FC reads neither).
     uint32_t sensor_health;
 
 } NonSensorData;
@@ -1095,7 +1096,11 @@ static constexpr uint8_t SH_BATT_SHIFT = 10;  // set by the OC from POWERData
 // the operator's go/no-go); OK = continuity present; DEGRADED = configured but
 // continuity not yet tested; BAD = configured, tested, no continuity.
 static constexpr uint8_t SH_PYRO_SHIFT[4] = { 12, 14, 16, 18 };
-// bits 20-31 reserved
+// Flight-log storage (#281 no-eviction / #278 silent drop): OC-owned, like
+// battery.  BAD = a full or write-failing NAND that will NOT record the flight
+// — the silent failure mode that lost the 2026-06-25 guided flight.
+static constexpr uint8_t SH_STORAGE_SHIFT = 20;
+// bits 22-31 reserved
 static inline uint32_t shSet(uint32_t field, uint8_t shift, SensorHealthState st) {
     return (field & ~(uint32_t)(0x3u << shift)) | ((uint32_t)st << shift);
 }
@@ -1110,6 +1115,24 @@ static inline SensorHealthState shBatteryState(float voltage) {
     if (voltage >= 7.0f) return SH_OK;
     if (voltage >= 6.6f) return SH_DEGRADED;
     return SH_BAD;
+}
+// Flight-log storage verdict (#281/#278).  The OC owns the NAND flight log; the
+// FC has no visibility, so the OC classifies here and ORs the bits into
+// sensor_health before relay (mirrors shBatteryState).  A full or write-failing
+// store silently dropped the 2026-06-25 flight — this surfaces it pre-launch.
+//   free_blocks     : BlockStateBitmap::countInState(BLOCK_FREE)
+//   prealloc_blocks : blocks one flight reserves (TR_FlightLog::Config)
+//   write_fail      : NAND program failures this session (nand_prog_fail)
+// BAD = won't record (writes failing, or no room for the next flight);
+// DEGRADED = room for fewer than 2 more flights; OK = ample room + healthy writes.
+static inline SensorHealthState shStorageState(uint32_t free_blocks,
+                                               uint32_t prealloc_blocks,
+                                               uint32_t write_fail) {
+    if (prealloc_blocks == 0) return SH_NA;          // logger not configured
+    if (write_fail > 0) return SH_BAD;               // NAND writes failing now
+    if (free_blocks < prealloc_blocks) return SH_BAD;        // no room for a flight
+    if (free_blocks < 2u * prealloc_blocks) return SH_DEGRADED;  // low space
+    return SH_OK;
 }
 
 static constexpr uint8_t NSF_ALT_LANDED   = (1u << 0);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -119,6 +119,20 @@ static bool flightlogWriteSink(void* ctx, const uint8_t* payload, size_t payload
     return fl->writeFrame(payload, payload_len) == tr_flightlog::Status::Ok;
 }
 
+// #281/#278: classify flight-log storage for the #303 scorecard.  A full or
+// write-failing NAND silently dropped the 2026-06-25 guided flight (recovery
+// surfaced the previous day's data); folding a verdict into sensor_health makes
+// it visible on the pre-launch go/no-go and the live downlink instead.
+static SensorHealthState ocStorageHealth()
+{
+    if (!flightlog.isInitialized()) return SH_NA;
+    TR_LogToFlashStats s = {};
+    logger.getStats(s);
+    const uint32_t free_blocks = flightlog.bitmap().countInState(tr_flightlog::BLOCK_FREE);
+    const uint32_t prealloc    = flightlog.config().prealloc_blocks;
+    return shStorageState(free_blocks, prealloc, s.nand_prog_fail);
+}
+
 // Stage 3b (issue #50): BLE file-ops re-backed on TR_FlightLog.
 // Fills up to `max_bytes` of the downloader's scratch buffer by issuing
 // successive readFlightPage calls (each one returns at most 2032 payload
@@ -2380,6 +2394,15 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
         lora.sensor_health = shSet(sh, SH_BATT_SHIFT, shBatteryState(power_si.voltage));
     }
 
+    // #281/#278: fold in the OC-owned flight-log storage verdict regardless of
+    // power validity, so a full/failing NAND surfaces even before the pack reads.
+    // Seed from the bits already assembled above (battery, when power was valid).
+    {
+        uint32_t sh = latest_power_valid ? lora.sensor_health
+                     : (latest_non_sensor_valid ? latest_non_sensor.sensor_health : 0u);
+        lora.sensor_health = shSet(sh, SH_STORAGE_SHIFT, ocStorageHealth());
+    }
+
     lora.pressure_alt = pressure_alt_m;
     lora.altitude_rate = pressure_alt_rate_mps;
     lora.max_alt = max_alt_m;
@@ -3955,6 +3978,7 @@ static void printStats()
             sensor_converter.convertPowerData(latest_power_raw, p);
             sh = shSet(sh, SH_BATT_SHIFT, shBatteryState(p.voltage));
         }
+        sh = shSet(sh, SH_STORAGE_SHIFT, ocStorageHealth());  // #281/#278
         ble_telem.sensor_health = sh;
     }
     ble_telem.rssi = NAN;  // LoRa RSSI only meaningful on base station (continuous RX)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -130,7 +130,14 @@ static SensorHealthState ocStorageHealth()
     logger.getStats(s);
     const uint32_t free_blocks = flightlog.bitmap().countInState(tr_flightlog::BLOCK_FREE);
     const uint32_t prealloc    = flightlog.config().prealloc_blocks;
-    return shStorageState(free_blocks, prealloc, s.nand_prog_fail);
+    SensorHealthState st = shStorageState(free_blocks, prealloc, s.nand_prog_fail);
+    // The flight index is a second, independent capacity limit (#281): once it's
+    // full, finalize can't record the flight even with free blocks. Fold it in.
+    const size_t used = flightlog.index().size();
+    const size_t cap  = tr_flightlog::FlightIndex::MAX_ENTRIES;
+    if (used >= cap) st = SH_BAD;
+    else if (used + 4 >= cap && st == SH_OK) st = SH_DEGRADED;
+    return st;
 }
 
 // Stage 3b (issue #50): BLE file-ops re-backed on TR_FlightLog.


### PR DESCRIPTION
## Why

A guided flight on **2026-06-25 was silently not recorded**: the NAND flight-log store was full, `prepareFlight` returned `NoSpace`, and the OC kept draining-and-discarding every frame while the pre-launch scorecard stayed all-green. Forensics on the recovered fragments showed the chip was full of **un-trimmed days-old ground data** (e.g. an 11.5 min / 43 MB June-23 ground "session" larger than a whole prealloc), and the post-flight summary reported a 3 m apogee computed from that stale data.

Root causes were a **silent failure** (no operator visibility) plus a **space leak** (brownout-recovered flights kept their full ~32 MB prealloc forever). This PR fixes both — and keeps the 128 MB chip holding many flights **without auto-deleting** anything.

## What changed

**1. Make a full/failing log visible (commit 1)**
- New `shStorageState(free_blocks, prealloc, write_fail)` verdict at the reserved `SH_STORAGE_SHIFT=20` slot of the #303 `sensor_health` scorecard: `BAD` = full/failing (won't record), `DEGRADED` = room for <2 flights, `OK` = ample.
- OC folds it into `sensor_health` on **both** downlinks (LoRa relay + direct BLE), mirroring the existing battery verdict — no FC change.
- iOS `TelemetryData`: a **Storage** row + go/no-go rollup (`BAD` → "Do not fly", `DEGRADED` → caution); shown only when reported, so older firmware is unaffected.

**2. Reclaim NAND without deleting (commit 2)**
- **Trim recovered flights** — `scanForBrownoutRecovery` now sets `n_blocks` to the blocks actually used and frees the reserved tail (mirroring `finalizeFlight`). A brownout flight no longer hogs its whole prealloc.
- **#273 size fix** — recovered `final_bytes` uses `PAYLOAD_PER_PAGE` (2032), not `NAND_PAGE_SIZE` (2048), so the downloader stops at the last real page (clean tail, correct size).
- **Shrink default `prealloc_blocks` 256 → 80** (~32 MB → ~10 MB ≈ 2.7 min at the measured ~64 KB/s log rate); `extend_blocks` still grows long flights on overflow.
- **Raise `FlightIndex` cap 64 → 128** — the serialize/deserialize scratch moved off the 4 KB main-task stack to a **page-aligned heap buffer** (the reason the cap was pinned at 64; also fixes a latent ~1 KB over-read). Each caller gets its own buffer — no shared-buffer race.
- OC storage verdict also flags **index-near-full** (a second, independent capacity limit).

No struct grows (reuses a reserved `sensor_health` bit); on-NAND index format stays backward compatible (≤64-entry snapshots still load). Existing bloated recovered entries are reclaimed by deleting them once in the app; future recovered flights self-trim.

## Validation (full arc)
- **97 flightlog host gtests** + the types/storage gtests pass — incl. trimmed-`n_blocks` + freed-tail + `PAYLOAD_PER_PAGE` recovery asserts, and a 128-entry save/load round-trip across pages.
- **OC firmware builds clean** (esp32s3); **iOS `TelemetryDataTests` pass**.
- **SIL flight** (457 m, fw `ee77488`): full flight captured + finalized cleanly, fit the new prealloc with no extend, zero in-flight gaps.
- **Real-hardware bench** (fw `ee77488`): clean finalize, **0 in-session overruns/drops, 0 gaps, 0 corruption**, ring drains to ~empty — the off-stack heap index buffer works on the actual ESP32 + NAND.

## Issues
- Closes #273 (recovered size / corrupt tail).
- Addresses #281 (index cap raised + surfaced) and #278 (silent drop now visible).
- Follow-ups: #315 (optional auto-evict oldest), #317 (why ground sessions get recorded at all). The firmware `coast_delay_ms` cleanup is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
