### PR TITLE
feat(app): flash-space bar (used/reserved/free) for rocket + base station

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -65,6 +65,11 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// the file_ops characteristic behind a 0xCB discriminator (#132).
     @Published var sensorCalStatus: SensorCalStatus?
 
+    /// Latest flash-space stats: rocketStorage on a direct rocket link (0xCC),
+    /// bsStorage on a base-station link (0xCD). Each is shown by its own bar.
+    @Published var rocketStorage: RocketStorageStats?
+    @Published var bsStorage: BaseStationStorageStats?
+
     /// Set once per connected-session after the first-time-seen base station
     /// has auto-picked and pushed a quiet channel.  Gates the auto-pick so it
     /// only runs once per session; cleared on disconnect so that a BS reboot
@@ -1311,6 +1316,8 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 case 0xAA: parseScanResult(data)
                 case 0xCA: parseMagCalStatus(data)     // issue #96
                 case 0xCB: parseSensorCalStatus(data)  // issue #132
+                case 0xCC: parseRocketStorageStats(data)
+                case 0xCD: parseBaseStationStorageStats(data)
                 case 0x7B:                              // '{' → JSON object
                     if let s = OTAStatusUpdate.parse(data) {
                         otaStatus = s
@@ -1557,6 +1564,20 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             return
         }
         sensorCalStatus = status
+    }
+
+    private func parseRocketStorageStats(_ data: Data) {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 15, bytes[0] == 0xCC,
+              let stats = RocketStorageStats.decode(Array(bytes[1...])) else { return }
+        rocketStorage = stats
+    }
+
+    private func parseBaseStationStorageStats(_ data: Data) {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 27, bytes[0] == 0xCD,
+              let stats = BaseStationStorageStats.decode(Array(bytes[1...])) else { return }
+        bsStorage = stats
     }
 
     private func parseScanResult(_ data: Data) {

--- a/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
@@ -1,0 +1,84 @@
+//
+//  StorageStats.swift
+//  TinkerRocketApp
+//
+//  Decoded flash-space stats for the storage bar. Two frames arrive on the
+//  file_ops characteristic, each behind a discriminator byte:
+//    0xCC  RocketStorageStats        (rocket NAND flight log — direct rocket link)
+//    0xCD  BaseStationStorageStats   (base station's own filesystem — BS link)
+//  Wire layouts mirror RocketStorageStatsData / BaseStationStorageStatsData in
+//  RocketComputerTypes.h — keep both in sync.
+//
+
+import Foundation
+
+/// Rocket NAND flight-log usage, in 128 KB blocks (wire = 14 bytes, LE packed):
+///   [0..1] u16 flight_region_blocks  [2..3] u16 used  [4..5] u16 free
+///   [6..7] u16 bad  [8..9] u16 system  [10..11] u16 flight_count
+///   [12] u8 block_size_kb  [13] u8 flags(bit0=initialized)
+struct RocketStorageStats: Equatable {
+    let flightRegionBlocks: Int
+    let usedBlocks: Int
+    let freeBlocks: Int
+    let badBlocks: Int
+    let systemBlocks: Int
+    let flightCount: Int
+    let blockSizeKB: Int
+    let initialized: Bool
+
+    private var blockBytes: Int { blockSizeKB * 1024 }
+    /// Full managed chip = flight region + fixed system overhead.
+    var totalBytes: Int { (flightRegionBlocks + systemBlocks) * blockBytes }
+    var usedBytes: Int { usedBlocks * blockBytes }
+    /// Reserved = bad blocks + fixed system overhead (LFS + metadata).
+    var reservedBytes: Int { (badBlocks + systemBlocks) * blockBytes }
+    var freeBytes: Int { freeBlocks * blockBytes }
+
+    /// Decode the payload *after* the 0xCC discriminator byte.
+    static func decode(_ bytes: [UInt8]) -> RocketStorageStats? {
+        guard bytes.count >= 14 else { return nil }
+        func u16(_ o: Int) -> Int {
+            Int(bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: o, as: UInt16.self)
+            })
+        }
+        return RocketStorageStats(
+            flightRegionBlocks: u16(0), usedBlocks: u16(2), freeBlocks: u16(4),
+            badBlocks: u16(6), systemBlocks: u16(8), flightCount: u16(10),
+            blockSizeKB: Int(bytes[12]), initialized: (bytes[13] & 0x01) != 0)
+    }
+}
+
+/// Base-station filesystem usage, in bytes (wire = 26 bytes, LE packed):
+///   [0..7] u64 total  [8..15] u64 used  [16..23] u64 free
+///   [24] u8 backend(0=SPIFFS,1=SD,2=ext-NAND)  [25] u8 flags(bit0=mounted)
+struct BaseStationStorageStats: Equatable {
+    let totalBytes: Int
+    let usedBytes: Int
+    let freeBytes: Int
+    let backend: Int
+    let mounted: Bool
+
+    /// FS overhead the data accounting doesn't attribute to used or free.
+    var reservedBytes: Int { max(0, totalBytes - usedBytes - freeBytes) }
+    var backendName: String {
+        switch backend {
+        case 0:  return "Internal flash"
+        case 2:  return "External NAND"
+        default: return "SD card"
+        }
+    }
+
+    /// Decode the payload *after* the 0xCD discriminator byte.
+    static func decode(_ bytes: [UInt8]) -> BaseStationStorageStats? {
+        guard bytes.count >= 26 else { return nil }
+        func u64(_ o: Int) -> Int {
+            Int(truncatingIfNeeded: bytes.withUnsafeBufferPointer {
+                UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: o, as: UInt64.self)
+            })
+        }
+        return BaseStationStorageStats(
+            totalBytes: u64(0), usedBytes: u64(8), freeBytes: u64(16),
+            backend: Int(bytes[24]), mounted: (bytes[25] & 0x01) != 0)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -871,6 +871,90 @@ struct BatteryView: View {
     }
 }
 
+// Flash-space card: a segmented used / reserved / free bar for the connected
+// device — rocket NAND on a direct rocket link, base-station FS on a BS link
+// (v1: each device reports its own; no rocket-over-LoRa plumbing).
+struct StorageBarView: View {
+    @ObservedObject var device: BLEDevice
+
+    var body: some View {
+        Group {
+            if device.isBaseStation {
+                if let s = device.bsStorage, s.totalBytes > 0 {
+                    card(title: "Base Station Storage", subtitle: s.backendName,
+                         used: s.usedBytes, reserved: s.reservedBytes, free: s.freeBytes,
+                         total: s.totalBytes)
+                }
+            } else if let s = device.rocketStorage, s.initialized {
+                card(title: "Rocket Storage",
+                     subtitle: "\(s.flightCount) flight\(s.flightCount == 1 ? "" : "s")",
+                     used: s.usedBytes, reserved: s.reservedBytes, free: s.freeBytes,
+                     total: s.totalBytes)
+            }
+        }
+    }
+
+    private func card(title: String, subtitle: String,
+                      used: Int, reserved: Int, free: Int, total: Int) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title).font(.headline)
+                Spacer()
+                Text(subtitle).font(.caption).foregroundColor(.secondary)
+            }
+            StorageSegmentBar(used: used, reserved: reserved, free: free, total: total)
+            HStack(spacing: 14) {
+                legend(.orange, "Used", used)
+                if reserved > 0 { legend(Color(.systemGray2), "Reserved", reserved) }
+                legend(.green, "Free", free)
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
+        .cornerRadius(10)
+    }
+
+    private func legend(_ color: Color, _ label: String, _ bytes: Int) -> some View {
+        HStack(spacing: 5) {
+            RoundedRectangle(cornerRadius: 2).fill(color).frame(width: 10, height: 10)
+            Text("\(label) \(StorageBarView.fmt(bytes))")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    static func fmt(_ bytes: Int) -> String {
+        let f = ByteCountFormatter()
+        f.allowedUnits = [.useMB, .useGB]
+        f.countStyle = .binary
+        return f.string(fromByteCount: Int64(bytes))
+    }
+}
+
+struct StorageSegmentBar: View {
+    let used: Int
+    let reserved: Int
+    let free: Int
+    let total: Int
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let t = CGFloat(max(total, 1))
+            HStack(spacing: 0) {
+                Color.orange.frame(width: w * CGFloat(used) / t)
+                Color(.systemGray2).frame(width: w * CGFloat(reserved) / t)
+                Color.green.frame(width: w * CGFloat(free) / t)
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(height: 14)
+        .clipShape(Capsule())
+        .overlay(Capsule().stroke(Color(.systemGray4), lineWidth: 0.5))
+    }
+}
+
 /// Stripped-down BatteryView used while the BS hasn't caught the rocket yet
 /// (#95).  Hides the rocket row entirely (its values would be empty/cached)
 /// and shows only the live BS battery row, so the operator still has a

--- a/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
@@ -26,6 +26,10 @@ struct FileManagerView: View {
                     .foregroundColor(.secondary)
                     .padding()
             } else {
+                // Flash-space usage for this device's log storage (rocket NAND
+                // on a rocket link, base-station filesystem on a BS link).
+                StorageBarView(device: device)
+
                 // Header with refresh button
                 HStack {
                     VStack(alignment: .leading) {
@@ -194,6 +198,7 @@ struct FileManagerView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .navigationTitle(device.isBaseStation ? "LoRa Logs" : "Flights")
         .brandedToolbar()
         .onAppear {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -979,6 +979,29 @@ void TR_BLE_To_APP::sendSensorCalStatus(const uint8_t* status_bytes, size_t len)
     }
 }
 
+void TR_BLE_To_APP::sendStorageStats(uint8_t marker, const uint8_t* bytes, size_t len)
+{
+    if (!device_connected_ || bytes == nullptr || len == 0) return;
+    // marker (0xCC rocket / 0xCD base station) + packed struct; cap defensively.
+    constexpr size_t MAX_PAYLOAD = 64;
+    if (len > MAX_PAYLOAD) len = MAX_PAYLOAD;
+
+    uint8_t buf[1 + MAX_PAYLOAD];
+    buf[0] = marker;
+    memcpy(&buf[1], bytes, len);
+
+    int rc = notify_data(conn_handle_, file_ops_val_handle_, buf, 1 + len);
+    if (rc != 0)
+    {
+        static uint32_t fail_count = 0;
+        if ((fail_count++ % 32) == 0)
+        {
+            ESP_LOGW(BLE_TAG, "Storage-stats notify failed, rc=%d (count=%lu)",
+                     rc, (unsigned long)fail_count);
+        }
+    }
+}
+
 void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
                                    size_t len, bool eof)
 {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -177,6 +177,11 @@ public:
     // Sibling discriminator to mag cal's 0xCA.
     void sendSensorCalStatus(const uint8_t* status_bytes, size_t len);
 
+    // Send a flash-space stats frame for the storage bar on the file-ops
+    // characteristic.  Format: [0]=marker (0xCC rocket / 0xCD base station)
+    // [1..]=packed struct LE bytes (RocketStorageStatsData / BaseStationStorageStatsData).
+    void sendStorageStats(uint8_t marker, const uint8_t* bytes, size_t len);
+
     // Get pending download filename (empty if none)
     // Clears the filename after reading
     String getDownloadFilename();

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -905,6 +905,40 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(SensorCalStatusData) == 19,
               "SensorCalStatusData must be 19 bytes");
 
+// OC→app flash-space stats for the rocket NAND flight log.  Rides the file_ops
+// characteristic behind a 0xCC discriminator (sibling of the 0xCB sensor-cal
+// frame).  All counts are 128 KB NAND blocks; the app derives bytes and the
+// used / reserved / free bar: total = flight_region + system, used = used_blocks,
+// reserved = bad + system, free = free_blocks.  Accurate on a DIRECT rocket link.
+typedef struct __attribute__((packed))
+{
+    uint16_t flight_region_blocks;  // total blocks the flight layer manages (~988)
+    uint16_t used_blocks;           // ALLOCATED (finalized + active flights)
+    uint16_t free_blocks;           // FREE
+    uint16_t bad_blocks;            // BAD (unusable)
+    uint16_t system_blocks;         // LFS + metadata blocks (fixed overhead)
+    uint16_t flight_count;          // entries in the flight index
+    uint8_t  block_size_kb;         // NAND block size in KB (128)
+    uint8_t  flags;                 // bit0 = flight log initialized
+} RocketStorageStatsData;
+static_assert(sizeof(RocketStorageStatsData) == 14,
+              "RocketStorageStatsData must be 14 bytes");
+
+// BS→app flash-space stats for the base station's own log filesystem.  Rides the
+// file_ops characteristic behind a 0xCD discriminator.  Bytes (not blocks) since
+// the backend may be SD/FAT (GB) or SPIFFS (MB).  reserved is FS overhead =
+// total - used - free (often ~0).  Accurate on a base-station link.
+typedef struct __attribute__((packed))
+{
+    uint64_t total_bytes;
+    uint64_t used_bytes;
+    uint64_t free_bytes;
+    uint8_t  backend;   // 0 = SPIFFS, 1 = SD/FAT, 2 = ext-NAND/FAT
+    uint8_t  flags;     // bit0 = filesystem mounted
+} BaseStationStorageStatsData;
+static_assert(sizeof(BaseStationStorageStatsData) == 26,
+              "BaseStationStorageStatsData must be 26 bytes");
+
 // MMC5983MA centered-counts offset (legacy path).  Stored in NVS as
 // int32_t in the same 18-bit signed centered-counts space as
 // mmc5983ma_centered_counts() returns.  Subtracted before scaling to µT.

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -774,6 +774,27 @@ static void renameOpenLogIfSequential()
 
 static uint32_t log_write_count = 0;  // Tracks calls for periodic flash check
 
+// Query the active log filesystem (SPIFFS or FAT) for total/used bytes.
+// Returns true if a backend is mounted and the query succeeded.
+static bool bsQueryStorage(uint64_t& total, uint64_t& used)
+{
+    total = 0; used = 0;
+    if (using_internal_flash)
+    {
+        size_t t = 0, u = 0;
+        if (esp_spiffs_info(SPIFFS_PARTITION_LABEL, &t, &u) != ESP_OK) return false;
+        total = t; used = u;
+        return true;
+    }
+    FATFS* fs = nullptr;
+    DWORD free_clust = 0;
+    if (f_getfree("0:", &free_clust, &fs) != FR_OK || fs == nullptr) return false;
+    total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
+    const uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
+    used = (total > free_bytes) ? (total - free_bytes) : 0;
+    return true;
+}
+
 static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                           double lat, double lon, double alt,
                           float rx_freq_mhz, int32_t observed_gap)
@@ -784,26 +805,7 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
     if (++log_write_count % 100 == 0)
     {
         uint64_t total = 0, used = 0;
-        if (using_internal_flash)
-        {
-            size_t t = 0, u = 0;
-            if (esp_spiffs_info(SPIFFS_PARTITION_LABEL, &t, &u) == ESP_OK)
-            {
-                total = t;
-                used  = u;
-            }
-        }
-        else
-        {
-            FATFS* fs;
-            DWORD free_clust;
-            if (f_getfree("0:", &free_clust, &fs) == FR_OK)
-            {
-                total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
-                uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
-                used = total - free_bytes;
-            }
-        }
+        bsQueryStorage(total, used);
         if (total > 0 && used > (total * 9 / 10))
         {
             ESP_LOGW(TAG, "[LOG] %s nearly full! %llu/%llu bytes (%.0f%%)",
@@ -3578,6 +3580,23 @@ static void loop_bs()
             }
             ble_app.sendTelemetry(ble_telem);
             maybeMarkOtaValid();
+
+            // Flash-space stats for the app's storage bar (every ~5 s).
+            static uint32_t last_bs_storage_ms = 0;
+            const uint32_t now_bs = millis();
+            if (now_bs - last_bs_storage_ms >= 5000U)
+            {
+                last_bs_storage_ms = now_bs;
+                BaseStationStorageStatsData bss = {};
+                uint64_t total = 0, used = 0;
+                const bool mounted = bsQueryStorage(total, used);
+                bss.total_bytes = total;
+                bss.used_bytes  = used;
+                bss.free_bytes  = (total > used) ? (total - used) : 0;
+                bss.backend = using_internal_flash ? 0 : (using_external_flash ? 2 : 1);
+                bss.flags   = mounted ? 0x01 : 0x00;
+                ble_app.sendStorageStats(0xCD, reinterpret_cast<const uint8_t*>(&bss), sizeof(bss));
+            }
         }
     }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3612,6 +3612,33 @@ static void printStats()
     TR_LogToFlashStats s = {};
     logger.getStats(s);
 
+    // Flash-space stats for the app's storage bar (every ~3 s on a live BLE
+    // link).  Same flightlog accounting as ocStorageHealth(); accurate on a
+    // direct rocket connection.
+    if (ble_app.isConnected())
+    {
+        static uint32_t last_storage_stats_ms = 0;
+        const uint32_t now_ss = millis();
+        if (now_ss - last_storage_stats_ms >= 3000U)
+        {
+            last_storage_stats_ms = now_ss;
+            RocketStorageStatsData rss = {};
+            if (flightlog.isInitialized())
+            {
+                const auto& fcfg = flightlog.config();
+                rss.flight_region_blocks = (uint16_t)(fcfg.flight_region_end - fcfg.flight_region_start);
+                rss.used_blocks   = (uint16_t)flightlog.bitmap().countInState(tr_flightlog::BLOCK_ALLOCATED);
+                rss.free_blocks   = (uint16_t)flightlog.bitmap().countInState(tr_flightlog::BLOCK_FREE);
+                rss.bad_blocks    = (uint16_t)flightlog.bitmap().countInState(tr_flightlog::BLOCK_BAD);
+                rss.system_blocks = (uint16_t)(fcfg.flight_region_start + 4u);  // LFS region + 4 metadata
+                rss.flight_count  = (uint16_t)flightlog.index().size();
+                rss.block_size_kb = (uint8_t)(tr_flightlog::NAND_BLOCK_SIZE / 1024u);
+                rss.flags         = 0x01;  // initialized
+            }
+            ble_app.sendStorageStats(0xCC, reinterpret_cast<const uint8_t*>(&rss), sizeof(rss));
+        }
+    }
+
     // Capture GNSS timestamp for the active log file (when available)
     if (s.logging_active && latest_gnss_valid && latest_gnss_si.year > 2000)
     {


### PR DESCRIPTION
## What
A flash-space card with a segmented **used / reserved / free** bar at the top of the on-device file view (`FileManagerView` — "Flights" for the rocket, "LoRa Logs" for the base station). Each device reports its own storage: the **rocket NAND flight log** on a direct rocket link, the **base station's own filesystem** on a base-station link (v1 — no rocket-over-LoRa plumbing).

## How
- **Wire**: two low-rate file-ops binary frames behind discriminators **0xCC** (rocket) / **0xCD** (base station) — mirrors the existing sensor-cal/mag-cal frames, so **no new BLE command id** and no id-registry/gtest churn. Struct sizes locked by `static_assert` (14 B / 26 B).
- **OC** builds the rocket struct from `flightlog.bitmap().countInState(...)` + `config()` + `index()` (the `ocStorageHealth()` accounting), sends every ~3 s on a live link.
- **BS** sends its FS total/used/free + backend every ~5 s, via a refactored `bsQueryStorage()` helper.
- **App**: `StorageStats.swift` decoders; `BLEDevice` `@Published rocketStorage/bsStorage` + parse; `StorageBarView` + `StorageSegmentBar` atop `FileManagerView`, gated on `isBaseStation` like the battery card.
- `reserved` = bad blocks + LFS/metadata (rocket) or FS overhead (base station).

## Verified
- OC + BS firmware build clean (esp32s3); iOS **BUILD SUCCEEDED**.
- **On hardware** (screenshot): Used 0 · Reserved 4.5 MB · Free 128 MB — exactly right (4.5 MB = LFS + metadata, 128 MB ≈ full chip). End-to-end OC→app decode confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
