### PR TITLE
oc(flightlog): MRAM dirty-boot recovery, dead force_format removal, bad-block gap (#274, #275, #276)

### DIFF
--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -1594,6 +1594,128 @@ TEST(TRFlightLogBrownout, TornLastPageReverts) {
     EXPECT_EQ(fl2.index().at(0).final_bytes, 9u * (NAND_PAGE_SIZE - sizeof(PageHeader)));
 }
 
+TEST(TRFlightLogBrownout, BadBlockMidFlightRecoversOneCleanFlight) {
+    // #276: a flight that hits BOTH a runtime bad block and a brownout must
+    // recover as ONE flight with the correct length (count of valid pages, not
+    // the physical span of the highest-seq page) and read back with no interior
+    // 0xFF garbage — recovery spans the bad block, the read walks over it.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    uint32_t start_block = 0;
+
+    constexpr uint32_t BLOCK0_PAGES    = NAND_PAGES_PER_BLK;  // fills block 0
+    constexpr uint32_t AFTER_GAP_PAGES = 30;                  // lands in block 2
+    constexpr uint32_t VALID_PAGES = BLOCK0_PAGES + AFTER_GAP_PAGES;  // 94
+
+    {
+        TR_FlightLog fl;
+        ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+        uint32_t id = 0;
+        ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+        start_block = fl.activeStartBlock();
+
+        std::vector<uint8_t> payload(PAYLOAD_PER_PAGE, 0xA5);
+        // Fill block 0 (seq 0..63).
+        for (uint32_t i = 0; i < BLOCK0_PAGES; ++i) {
+            ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+        }
+        // Poison the first page of block 1: the whole block is marked BAD and
+        // writePage skips to block 2 — a physical-page gap mid-flight.
+        nand.injectProgramFailOnce(start_block + 1, 0);
+        for (uint32_t i = 0; i < AFTER_GAP_PAGES; ++i) {
+            ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+        }
+        // No finalizeFlight() — simulate the brownout.
+    }
+    EXPECT_TRUE(nand.isBlockBad(start_block + 1));
+
+    // Reboot -> brownout recovery.
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+
+    // ONE recovered flight spanning the bad block, not two split halves.
+    ASSERT_EQ(fl2.index().size(), 1u);
+    const auto& e = fl2.index().at(0);
+    EXPECT_EQ(e.start_block, start_block);
+    EXPECT_EQ(e.n_blocks, 3u);  // physical span blocks 0,1,2 (bad block kept)
+
+    // Length is the valid-page count (94), NOT the physical span (158) that
+    // would fold block 1's 64 skipped pages in as 0xFF garbage.
+    EXPECT_EQ(e.final_bytes, VALID_PAGES * PAYLOAD_PER_PAGE);
+
+    // Block states: 0 and 2 allocated, 1 bad, the reserved tail freed.
+    EXPECT_EQ(fl2.bitmap().get(start_block + 0), BLOCK_ALLOCATED);
+    EXPECT_EQ(fl2.bitmap().get(start_block + 1), BLOCK_BAD);
+    EXPECT_EQ(fl2.bitmap().get(start_block + 2), BLOCK_ALLOCATED);
+    EXPECT_EQ(fl2.bitmap().get(start_block + 3), BLOCK_FREE);
+
+    // Every logical page reads back the written 0xA5 with no 0xFF gap — the read
+    // walks over the bad block instead of hopping into it.
+    for (uint32_t p = 0; p < VALID_PAGES; ++p) {
+        std::vector<uint8_t> out(PAYLOAD_PER_PAGE, 0x00);
+        size_t out_len = 0;
+        ASSERT_EQ(fl2.readFlightPage(e.filename, p * PAYLOAD_PER_PAGE,
+                                     out.data(), out.size(), out_len),
+                  Status::Ok) << "page " << p;
+        ASSERT_EQ(out_len, PAYLOAD_PER_PAGE) << "page " << p;
+        for (uint8_t b : out) ASSERT_EQ(b, 0xA5u) << "garbage at page " << p;
+    }
+
+    // One past the last valid page is clean EOF (no trailing garbage).
+    std::vector<uint8_t> tail(PAYLOAD_PER_PAGE, 0x00);
+    size_t tail_len = 123;
+    ASSERT_EQ(fl2.readFlightPage(e.filename, VALID_PAGES * PAYLOAD_PER_PAGE,
+                                 tail.data(), tail.size(), tail_len),
+              Status::Ok);
+    EXPECT_EQ(tail_len, 0u);
+}
+
+TEST(TRFlightLogFinalize, BadBlockMidFlightKeepsAllDataAndBlocks) {
+    // #276 sibling (finalize path): a finalized flight (no brownout) that hit a
+    // runtime bad block must size n_blocks from the physical span. Sizing the
+    // trim from the logical byte count frees the post-gap block (data loss) and
+    // shrinks the readable range — readFlightPage would EOF early.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    const uint32_t start_block = fl.activeStartBlock();
+
+    constexpr uint32_t BLOCK0_PAGES    = NAND_PAGES_PER_BLK;
+    constexpr uint32_t AFTER_GAP_PAGES = 30;
+    constexpr uint32_t VALID_PAGES = BLOCK0_PAGES + AFTER_GAP_PAGES;  // 94
+
+    std::vector<uint8_t> payload(PAYLOAD_PER_PAGE, 0x5A);
+    for (uint32_t i = 0; i < BLOCK0_PAGES; ++i)
+        ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+    nand.injectProgramFailOnce(start_block + 1, 0);
+    for (uint32_t i = 0; i < AFTER_GAP_PAGES; ++i)
+        ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+
+    ASSERT_EQ(fl.finalizeFlight("flight.bin", VALID_PAGES * PAYLOAD_PER_PAGE),
+              Status::Ok);
+
+    const FlightIndexEntry* e = fl.index().findByFilename("flight.bin");
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->n_blocks, 3u);  // physical span (0,1,2), not ceil(94/64)=2
+    EXPECT_EQ(e->final_bytes, VALID_PAGES * PAYLOAD_PER_PAGE);
+    // The block holding post-gap data must NOT have been freed by the trim.
+    EXPECT_EQ(fl.bitmap().get(start_block + 2), BLOCK_ALLOCATED);
+
+    // All pages read back clean — no early EOF into the (would-be) freed region.
+    for (uint32_t p = 0; p < VALID_PAGES; ++p) {
+        std::vector<uint8_t> out(PAYLOAD_PER_PAGE, 0x00);
+        size_t out_len = 0;
+        ASSERT_EQ(fl.readFlightPage("flight.bin", p * PAYLOAD_PER_PAGE,
+                                    out.data(), out.size(), out_len),
+                  Status::Ok) << "page " << p;
+        ASSERT_EQ(out_len, PAYLOAD_PER_PAGE) << "page " << p;
+        for (uint8_t b : out) ASSERT_EQ(b, 0x5Au) << "garbage at page " << p;
+    }
+}
+
 // ================================================================
 // TR_NandBackend_esp — Stage 1 stub is not yet wired to real hardware.
 // These tests only verify the class satisfies the interface; Stage 2 will

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -110,8 +110,16 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
         }
         // Found the start of an orphaned run. Walk forward.
         const uint32_t run_start = b;
+        // Span BLOCK_BAD blocks as well as ALLOCATED ones. A block that failed
+        // to program mid-flight is marked BAD and skipped to the next block by
+        // writePage — it's an interior gap in ONE flight, not a boundary between
+        // flights. Stopping the run at it would split the flight into two
+        // same-named flight_recovered_<id>.bin entries with the data torn in
+        // half (#276). The bad block is skipped when scanning pages (below) and
+        // walked over on read (readFlightPage). Recovery runs every boot, so two
+        // distinct un-indexed flights never coexist to be wrongly merged here.
         while (b < cfg_.flight_region_end &&
-               bitmap_.get(b) == BLOCK_ALLOCATED &&
+               (bitmap_.get(b) == BLOCK_ALLOCATED || bitmap_.get(b) == BLOCK_BAD) &&
                !is_in_index(b)) {
             ++b;
         }
@@ -119,9 +127,10 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
 
         // Scan the run for pages with valid PageHeader CRC. Track the highest
         // seq_number + associated flight_id.
-        int32_t  last_good_page_rel = -1;   // logical page index within the run
+        int32_t  last_good_page_rel = -1;   // physical page index within the run
         uint32_t last_seq            = 0;
         uint32_t last_flight_id      = 0;
+        uint32_t valid_pages         = 0;   // #276: count of magic+CRC pages
         bool     saw_any             = false;
 
         for (uint32_t i = 0; i < run_len; ++i) {
@@ -145,6 +154,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
                 // First page looked valid; handle it below along with the rest.
                 if (hdr0.crc32 == page_crc(page))
                 {
+                    ++valid_pages;
                     if (!saw_any || hdr0.seq_number > last_seq) {
                         last_seq           = hdr0.seq_number;
                         last_flight_id     = hdr0.flight_id;
@@ -161,6 +171,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
                 std::memcpy(&hdr, page, sizeof(hdr));
                 if (hdr.magic != FPAG_MAGIC) continue;
                 if (hdr.crc32 != page_crc(page)) continue;
+                ++valid_pages;
 
                 if (!saw_any || hdr.seq_number > last_seq) {
                     last_seq           = hdr.seq_number;
@@ -186,6 +197,13 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
         // NOT NAND_PAGE_SIZE (2048), or the downloader walks past the last real
         // page into PageHeader/0xFF bytes (corrupt tail, size ~0.8% too large).
         constexpr uint32_t PAYLOAD_PER_PAGE = NAND_PAGE_SIZE - sizeof(PageHeader);
+        // #276: length is the count of *valid* pages actually present, NOT the
+        // physical span of the highest-seq page. If the flight hit a bad block
+        // mid-write, writePage marked it BAD and skipped to the next block, so
+        // the span over-counts by the skipped block(s) — deriving bytes from it
+        // injects interior 0xFF garbage and the wrong length. The physical span
+        // (used_pages) still sizes the block range to keep allocated; the gap is
+        // walked on read (readFlightPage).
         const uint32_t used_pages  = static_cast<uint32_t>(last_good_page_rel + 1);
         uint32_t used_blocks = (used_pages + NAND_PAGES_PER_BLK - 1) / NAND_PAGES_PER_BLK;
         if (used_blocks > run_len) used_blocks = run_len;
@@ -198,7 +216,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
                       static_cast<unsigned long>(last_flight_id));
         entry.start_block = static_cast<uint16_t>(run_start);
         entry.n_blocks    = static_cast<uint16_t>(used_blocks);  // trimmed; was run_len (full ~32 MB)
-        entry.final_bytes = used_pages * PAYLOAD_PER_PAGE;
+        entry.final_bytes = valid_pages * PAYLOAD_PER_PAGE;
 
         Status st = index_.append(entry);
         if (st != Status::Ok) return st;
@@ -395,10 +413,19 @@ Status TR_FlightLog::finalizeFlight(const char* filename, uint32_t final_bytes) 
     // shorter — without trimming, the bitmap caps out at floor(region / 32MB)
     // simultaneous flights regardless of their actual size. Round up to cover
     // any partial trailing page.
+    // Size the kept range to cover BOTH the logical length (final_bytes) AND the
+    // PHYSICAL span actually consumed (active_next_page_). They match for a
+    // normal flight; a runtime bad block makes the physical span larger
+    // (writePage marked it BAD and skipped ahead), so trimming by the logical
+    // count alone would free post-gap blocks that still hold data (silent loss +
+    // reuse) and shrink n_blocks below the span readFlightPage walks (#276).
+    // final_bytes stays the logical byte length.
     constexpr uint32_t PAYLOAD_PER_PAGE = NAND_PAGE_SIZE - sizeof(PageHeader);
-    const uint32_t used_pages = (final_bytes == 0) ? 0
+    const uint32_t logical_pages = (final_bytes == 0) ? 0
         : (final_bytes + PAYLOAD_PER_PAGE - 1) / PAYLOAD_PER_PAGE;
-    uint32_t used_blocks = (used_pages + NAND_PAGES_PER_BLK - 1) / NAND_PAGES_PER_BLK;
+    const uint32_t span_pages = (active_next_page_ > logical_pages)
+                                    ? active_next_page_ : logical_pages;
+    uint32_t used_blocks = (span_pages + NAND_PAGES_PER_BLK - 1) / NAND_PAGES_PER_BLK;
     if (used_blocks > active_n_blocks_) used_blocks = active_n_blocks_;
 
     FlightIndexEntry entry{};
@@ -475,8 +502,25 @@ Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
 
     const uint32_t logical_page = offset / PAYLOAD_PER_PAGE;
     const uint32_t byte_in_pl   = offset % PAYLOAD_PER_PAGE;
-    const uint32_t abs_block    = entry->start_block + logical_page / NAND_PAGES_PER_BLK;
-    const uint32_t page_in_blk  = logical_page % NAND_PAGES_PER_BLK;
+
+    // Map the logical payload page to a physical (block, page). Pages are laid
+    // down sequentially, but a block that failed to program mid-flight was
+    // marked BLOCK_BAD and skipped whole at write time (writePage), leaving a
+    // physical gap. Walk the entry's blocks skipping BLOCK_BAD ones so logical
+    // page L lands on the L-th *valid* page instead of hopping into a 0xFF gap
+    // and returning interior garbage (#276). Gaps are block-aligned and recorded
+    // in the bitmap, so this stays O(blocks) with no extra NAND reads.
+    const uint32_t end_block = entry->start_block + entry->n_blocks;
+    uint32_t abs_block  = entry->start_block;
+    uint32_t pages_left = logical_page;
+    while (abs_block < end_block && bitmap_.get(abs_block) == BLOCK_BAD) ++abs_block;
+    while (pages_left >= NAND_PAGES_PER_BLK) {
+        pages_left -= NAND_PAGES_PER_BLK;
+        ++abs_block;
+        while (abs_block < end_block && bitmap_.get(abs_block) == BLOCK_BAD) ++abs_block;
+    }
+    if (abs_block >= end_block) return Status::Ok;  // logical page past the data
+    const uint32_t page_in_blk = pages_left;
 
     uint8_t page[NAND_PAGE_SIZE];
     if (!nand_->readPage(abs_block, page_in_blk, page)) return Status::BackendFailed;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -1599,6 +1599,11 @@ void TR_LogToFlash::closeLogSession()
 // Dirty flag persistence (LittleFS marker file, replaces MRAM persist state)
 // ============================================================================
 
+// #274: sentinel written to the MRAM dirty marker (cfg.dirty_marker_addr) while a
+// sink-mode log session is open and cleared on a clean close. It lives in the
+// non-volatile MRAM, so a surviving copy on the next boot flags unflushed ring data.
+static constexpr uint32_t kMramDirtyMagic = 0x52443274u;
+
 void TR_LogToFlash::markDirty()
 {
     // Sink mode (issue #50 Stage 2c-3c): the "dirty" marker file exists so
@@ -1609,7 +1614,19 @@ void TR_LogToFlash::markDirty()
     // block 0/1 superblock metadata for no gain ("Bad block at 0x1 /
     // Superblock 0x1 has become unwritable" warnings on chips that have been
     // reformatted many times during development).
-    if (cfg.write_sink != nullptr) return;
+    if (cfg.write_sink != nullptr)
+    {
+        // #274: sink mode skips the LittleFS marker (superblock churn) but sets a
+        // non-volatile MRAM marker, so a dirty boot is still detected and the
+        // surviving ring can be replayed through the sink.
+        if (use_mram_ && cfg.dirty_marker_addr != 0)
+        {
+            const uint32_t magic = kMramDirtyMagic;
+            mramRawWrite(cfg.dirty_marker_addr,
+                         reinterpret_cast<const uint8_t*>(&magic), sizeof(magic));
+        }
+        return;
+    }
 
     lfs_file_t f;
     int err = lfs_file_open(&lfs, &f, "/.dirty",
@@ -1625,7 +1642,17 @@ void TR_LogToFlash::markDirty()
 void TR_LogToFlash::clearDirty()
 {
     // See markDirty() — symmetric skip in sink mode.
-    if (cfg.write_sink != nullptr) return;
+    if (cfg.write_sink != nullptr)
+    {
+        // #274: clear the non-volatile MRAM dirty marker on a clean close.
+        if (use_mram_ && cfg.dirty_marker_addr != 0)
+        {
+            const uint32_t zero = 0;
+            mramRawWrite(cfg.dirty_marker_addr,
+                         reinterpret_cast<const uint8_t*>(&zero), sizeof(zero));
+        }
+        return;
+    }
 
     lfs_remove(&lfs, "/.dirty");
 }
@@ -1634,6 +1661,45 @@ bool TR_LogToFlash::checkDirtyOnStartup()
 {
     struct lfs_info info;
     return (lfs_stat(&lfs, "/.dirty", &info) >= 0);
+}
+
+bool TR_LogToFlash::checkMramDirty()
+{
+    if (!use_mram_ || cfg.dirty_marker_addr == 0) return false;
+    uint32_t magic = 0;
+    if (!mramRawRead(cfg.dirty_marker_addr,
+                     reinterpret_cast<uint8_t*>(&magic), sizeof(magic)))
+        return false;
+    return magic == kMramDirtyMagic;
+}
+
+// #274: replay the entire surviving MRAM ring through the write_sink. The sink
+// consumes (NAND_PAGE_SIZE - 16)-byte chunks (it prepends a 16-byte PageHeader),
+// exactly like flushRingToNand; the ring is dumped raw and the downstream parser
+// handles SOF framing / CRC / stale + partial frames (parity with the legacy LFS
+// dump). The caller must have opened a destination flight on the sink first.
+// Returns the number of bytes handed to the sink.
+uint32_t TR_LogToFlash::drainMramToSink()
+{
+    if (!use_mram_ || cfg.write_sink == nullptr) return 0;
+    constexpr uint32_t kChunk = NAND_PAGE_SIZE - 16u;   // 2032; matches flushRingToNand
+    uint8_t buf[kChunk];
+    uint32_t total = 0;
+    for (uint32_t off = 0; off < ring_size_; off += kChunk)
+    {
+        const uint32_t n = (ring_size_ - off < kChunk) ? (ring_size_ - off) : kChunk;
+        if (!mramRawRead(off, buf, n)) break;
+        if (!cfg.write_sink(cfg.write_sink_ctx, buf, n)) break;  // sink full / failed
+        total += n;
+    }
+    return total;
+}
+
+void TR_LogToFlash::finishMramRecovery()
+{
+    clearRing();
+    clearDirty();   // clears the MRAM marker (sink mode)
+    pending_mram_recovery_ = false;
 }
 
 void TR_LogToFlash::clearRing()
@@ -1849,14 +1915,17 @@ uint32_t TR_LogToFlash::scanBadBlocksAtBoot()
 
 void TR_LogToFlash::runStartupRecovery()
 {
-    if (!checkDirtyOnStartup())
+    const bool lfs_dirty  = checkDirtyOnStartup();   // LittleFS marker (non-sink)
+    const bool mram_dirty = checkMramDirty();        // #274: MRAM marker (sink mode)
+
+    if (!lfs_dirty && !mram_dirty)
     {
         clearRing();
         if (cfg.debug) ESP_LOGI(TAG, "Clean startup, no recovery needed.");
         return;
     }
 
-    // Previous session was interrupted (dirty flag present).
+    // Previous session was interrupted (a dirty marker is present).
     if (!use_mram_)
     {
         // RAM ring is volatile — nothing to recover.
@@ -1864,6 +1933,18 @@ void TR_LogToFlash::runStartupRecovery()
         clearDirty();
         if (cfg.debug) ESP_LOGW(TAG, "Dirty startup — RAM ring volatile, data lost.");
         return;
+    }
+
+    // #274: in sink mode the unflushed MRAM ring must be replayed THROUGH the
+    // sink into a NAND flight — but the sink (TR_FlightLog) isn't initialized yet
+    // at begin() time. Defer: preserve the ring + marker and let the OC drive
+    // drainMramToSink() once flightlog.begin() has run.
+    if (cfg.write_sink != nullptr && mram_dirty)
+    {
+        pending_mram_recovery_ = true;
+        if (cfg.debug)
+            ESP_LOGW(TAG, "Dirty startup (sink) — MRAM ring preserved for deferred recovery.");
+        return;   // do NOT clearRing / clearDirty here
     }
 
     // MRAM ring survived the reset — drain it into a recovery file.

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -15,7 +15,6 @@ struct TR_LogToFlashConfig
     uint8_t spi_mode_nand = SPI_MODE0;
     uint32_t ring_buffer_size = 65536;  // RAM ring buffer size (bytes)
     bool debug = false;
-    bool force_format = false;  // Erase entire NAND before mount (recovery from corruption)
 
     // LittleFS block-count. Defaults to the full chip for backward compat.
     // When sharing the NAND with TR_FlightLog (issue #50 Stage 2c) the caller

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -51,6 +51,12 @@ struct TR_LogToFlashConfig
     uint32_t spi_hz_mram = 40'000'000;
     uint8_t spi_mode_mram = SPI_MODE0;
     uint32_t mram_size = 131072;        // 128 KB (MR25H10)
+
+    // #274: absolute MRAM address of the 4-byte sink-mode "dirty" marker, in the
+    // caller's reserved region above mram_size. 0 = disabled. When set, markDirty
+    // writes a magic here instead of the LittleFS marker (no superblock churn), so
+    // a dirty boot is detected and the surviving ring replayed through the sink.
+    uint32_t dirty_marker_addr = 0;
 };
 
 struct TR_LogToFlashStats
@@ -184,6 +190,14 @@ public:
     bool mramRawWrite(uint32_t addr, const uint8_t* data, uint32_t len);
     bool mramRawRead(uint32_t addr, uint8_t* out, uint32_t len);
     bool isMramEnabled() const { return use_mram_; }
+
+    // #274 MRAM-ring recovery (sink mode). begin() sets "pending" if the previous
+    // session was dirty and the non-volatile ring survived; the OC then opens a
+    // recovered flight, calls drainMramToSink() to replay the ring through the
+    // write_sink, and finishMramRecovery() to clear the ring + the dirty marker.
+    bool hasPendingMramRecovery() const { return pending_mram_recovery_; }
+    uint32_t drainMramToSink();   // dump the whole ring through write_sink; returns bytes sunk
+    void finishMramRecovery();    // clearRing() + clear the dirty marker
 
 private:
     // --- NAND ---
@@ -359,6 +373,7 @@ private:
     bool recovery_performed = false;
     uint32_t recovery_bytes = 0;
     char recovery_filename[64] = {};
+    bool pending_mram_recovery_ = false;  // #274: dirty sink-mode boot — ring preserved for deferred replay
 
     // LittleFS filesystem
     lfs_t lfs;
@@ -456,6 +471,7 @@ private:
     void markDirty();           // Write LittleFS marker file on log start
     void clearDirty();          // Remove LittleFS marker file on log close
     bool checkDirtyOnStartup(); // Check if previous session was dirty
+    bool checkMramDirty();      // #274: read the sink-mode MRAM dirty marker
     void clearRing();
     // Internal variant: caller holds push_mutex_. Used by ringPush()'s
     // drop-oldest fallback so it doesn't re-acquire the mutex it already

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -46,6 +46,11 @@ struct config
     // reads on the same mutex never observe a partial write).
     static constexpr uint32_t SNAPSHOT_REGION_SIZE = 1024;
     static constexpr uint32_t SNAPSHOT_REGION_BASE = MRAM_SIZE - SNAPSHOT_REGION_SIZE;
+    // #274: 4-byte sink-mode "dirty" marker, parked at the free top of the
+    // snapshot region (FlightSnapshot uses ~232 B up from SNAPSHOT_REGION_BASE).
+    // Set while a log session is open; a surviving magic on the next boot means
+    // an unclean shutdown left unflushed frames in the non-volatile MRAM ring.
+    static constexpr uint32_t MRAM_DIRTY_MARKER_ADDR = MRAM_SIZE - 16;
 
     // --- SPI speeds/modes ---
     static constexpr uint32_t SPI_HZ_NAND = 40'000'000;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4106,48 +4106,17 @@ void initPeripherals()
     // chunk the flush task drains from the ring is routed through
     // flightlogWriteSink → flightlog.writeFrame(), which wraps it in a
     // PageHeader (CRC32 + seq + flight_id) and programs one NAND page
-    // directly. First boot of this firmware under the shrunk layout force-
-    // formats (wipes any legacy flight_*.bin); subsequent boots skip the
-    // wipe via the NVS "lfs_shrunk" marker.
+    // directly.
     log_cfg.lfs_block_count = 32;
     log_cfg.write_sink = flightlogWriteSink;
     log_cfg.write_sink_ctx = &flightlog;
     log_cfg.flush_task_hook = flightlogFlushTaskHook;
     log_cfg.dirty_marker_addr = config::MRAM_DIRTY_MARKER_ADDR;  // #274: sink-mode dirty marker
 
-    bool lfs_wipe_pending = false;
-    {
-        Preferences fl_prefs;
-        bool already_shrunk = false;
-        if (fl_prefs.begin("flightlog", /*readOnly=*/true))
-        {
-            already_shrunk = fl_prefs.getBool("lfs_shrunk", false);
-            fl_prefs.end();
-        }
-        if (!already_shrunk)
-        {
-            log_cfg.force_format = true;
-            lfs_wipe_pending = true;
-            ESP_LOGW("FLIGHTLOG", "First boot of shrunk-LFS firmware — will wipe legacy flight files");
-        }
-    }
-
     if (!logger.begin(SPI, log_cfg))
     {
         ESP_LOGE("PWR", "TR_LogToFlash begin failed");
         return;
-    }
-
-    // Record the shrunk-layout marker so subsequent boots skip the force_format.
-    if (lfs_wipe_pending)
-    {
-        Preferences fl_prefs;
-        if (fl_prefs.begin("flightlog", /*readOnly=*/false))
-        {
-            fl_prefs.putBool("lfs_shrunk", true);
-            fl_prefs.end();
-            ESP_LOGI("FLIGHTLOG", "Recorded shrunk-LFS marker in NVS");
-        }
     }
 
     // --- TR_FlightLog begin (issue #50) -------------------------------------

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4113,6 +4113,7 @@ void initPeripherals()
     log_cfg.write_sink = flightlogWriteSink;
     log_cfg.write_sink_ctx = &flightlog;
     log_cfg.flush_task_hook = flightlogFlushTaskHook;
+    log_cfg.dirty_marker_addr = config::MRAM_DIRTY_MARKER_ADDR;  // #274: sink-mode dirty marker
 
     bool lfs_wipe_pending = false;
     {
@@ -4169,6 +4170,31 @@ void initPeripherals()
             ESP_LOGE("FLIGHTLOG", "begin failed: %s",
                      tr_flightlog::to_string(st));
         }
+    }
+
+    // #274: if the previous session left unflushed frames in the non-volatile
+    // MRAM ring (dirty sink-mode boot), replay the surviving ring through the
+    // sink into a recovered flight so the touchdown data isn't wiped. Runs after
+    // flightlog.begin() (the sink needs an allocated flight) and before the flush
+    // task / normal logging start — the sink writes synchronously.
+    if (logger.hasPendingMramRecovery())
+    {
+        uint32_t fid = 0;
+        if (flightlog.prepareFlight(fid) == tr_flightlog::Status::Ok)
+        {
+            const uint32_t bytes = logger.drainMramToSink();
+            char name[40];
+            snprintf(name, sizeof(name), "flight_mram_recovered_%lu.bin",
+                     (unsigned long)fid);
+            const auto fst = flightlog.finalizeFlight(name, bytes);
+            ESP_LOGW("FLIGHTLOG", "#274: MRAM recovery -> %s (%lu B): %s",
+                     name, (unsigned long)bytes, tr_flightlog::to_string(fst));
+        }
+        else
+        {
+            ESP_LOGE("FLIGHTLOG", "#274: MRAM recovery — prepareFlight failed (no space?)");
+        }
+        logger.finishMramRecovery();
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
Three related OC flight-log fixes from the pre-flight review, stacked on one branch. All are OC firmware (`out_computer`); #274 is bench-validated and #276 is gtest-covered.

## #274 — recover the MRAM ring on a dirty sink-mode boot
On an unclean shutdown the non-volatile MRAM log ring still held unflushed frames (the last seconds before touchdown), but sink-mode boot cleared it without draining → silent loss. A 4-byte dirty marker (parked at the top of the MRAM snapshot region) is now set while a session is open; a surviving magic on the next boot drains the whole ring to a recovery file before clearing.
- **Bench-validated**: dirty reboot → ~1.87 s of valid frames recovered (data previously wiped).

## #275 — delete the dead force_format / false first-boot-wipe
OC main set `force_format` and logged *"will wipe legacy flight files"*, but `TR_LogToFlash::begin()` never read it — the wipe never happened. The `lfs_shrunk` NVS marker only gated this dead path. Removed the flag, the first-boot detection + marker-write blocks, and the misleading log. Behaviorally inert; the LFS→32-block migration is already handled by reformat-on-mount-fail + the fresh TR_FlightLog bitmap.

## #276 — handle a bad-block page gap on every flight path
A flight that hit a runtime bad block (writePage marks it BAD, skips to the next block, scattering valid pages across the gap) was mishandled three ways:
- **Recovery** stopped the run-walk at `BLOCK_BAD` → split the flight into two same-named `recovered_<id>.bin` halves, and over-counted the length from the physical span.
- **Finalize** (no brownout) sized `n_blocks` from the logical byte count → the trim **freed post-gap blocks still holding data** (silent loss + reuse on next prepare).
- **Read** mapped logical→physical contiguously → interior `0xFF` garbage in the download.

Fixed in `TR_FlightLog`: recovery spans `BLOCK_BAD` (one flight) + sets length from the count of valid pages; finalize sizes from `max(logical, physical span)`; `readFlightPage` walks the entry's blocks skipping `BLOCK_BAD` (O(blocks), no extra NAND reads, no-bad-block path unchanged). Two new regression tests (recovery + finalize).

## Verification
- OC firmware builds clean (esp32s3) at HEAD.
- Host gtests: **99/99 pass** (`test_tr_flightlog_core`, incl. the two new bad-block tests).
- #274 bench-validated; a clean SIL ascent shows no regression on the normal logging path (these changes are dormant there — they fire only on dirty-reboot recovery / runtime bad block).

Closes #274
Closes #275
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
