### PR TITLE
fc(guidance): log commanded pitch/yaw fin deflections + guidance flight analysis tooling

### DIFF
--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -77,6 +77,7 @@ MSG_END_FLIGHT        = 0xA8
 MSG_IIS2MDC           = 0xD1  # new-PCB IIS2MDC magnetometer raw frame
 MSG_LOG_BUFFER_STATS  = 0xE2  # OC self-emitted ring-buffer snapshot (~1 Hz)
 MSG_LORA              = 0xF1
+MSG_GUIDANCE_TELEM    = 0xCA  # GuidanceTelemData, ~10 Hz during guided coast
 
 MSG_NAMES = {
     MSG_OUT_STATUS_QUERY: "OUT_STATUS_QUERY",
@@ -91,6 +92,7 @@ MSG_NAMES = {
     MSG_END_FLIGHT:       "EndFlight",
     MSG_LOG_BUFFER_STATS: "LogBufferStats",
     MSG_LORA:             "LoRa",
+    MSG_GUIDANCE_TELEM:   "Guidance",
 }
 
 # Expected payload sizes for validation.  A tuple lists every valid size
@@ -108,6 +110,7 @@ MSG_EXPECTED_LEN = {
     MSG_END_FLIGHT:        None,
     MSG_LOG_BUFFER_STATS:  28,    # LogBufferStatsData
     MSG_LORA:              49,
+    MSG_GUIDANCE_TELEM:    (15, 19),  # legacy (mislabeled) / current (+fin cmds)
 }
 
 # Struct formats (little-endian, packed)
@@ -133,6 +136,15 @@ FMT_STATUS_QUERY = '<B H H hh B hhh'
 FMT_STATUS_QUERY_B2R = '<BB hhhh'  # b2r_code, b2r_mode, quat×10000 (payload[16:26])
 # LogBufferStatsData: 28 bytes (time_us + 6× uint32 ring counters)
 FMT_LOG_BUFFER_STATS = '<I IIIIII'
+# GuidanceTelemData (GUIDANCE_TELEM_MSG 0xCA). Current 19-byte layout:
+#   time_us, accel_cmd_n/e (m/s² ×100), lateral_offset (cm), los_angle (deg ×100),
+#   closing_vel (m/s ×100), pitch_fin_cmd/yaw_fin_cmd (deg ×100), guid_flags.
+# Legacy 15-byte logs have the same first five i16 (under misleading old names)
+# but NO fin-command fields — they are decoded as None.
+FMT_GUIDANCE_19 = '<I hhhhhhh B'
+FMT_GUIDANCE_15 = '<I hhhhh B'  # legacy: time, accel_n, accel_e, lateral, los, closing, flags
+GUID_FLAG_ACTIVE  = (1 << 0)
+GUID_FLAG_BURNOUT = (1 << 1)
 
 SYNC = b'\xAA\x55\xAA\x55'
 
@@ -291,6 +303,7 @@ def parse_binary_file(filepath):
         "NonSensor":      [],
         "POWER":          [],
         "LogBufferStats": [],
+        "Guidance":       [],
     }
 
     config = {
@@ -557,6 +570,32 @@ def parse_binary_file(filepath):
                     "ring_overruns":          fields[4],
                     "ring_drop_oldest_bytes": fields[5],
                     "ring_bad_sof_clears":    fields[6],
+                })
+
+            elif msg_type == MSG_GUIDANCE_TELEM and msg_len in (15, 19):
+                # PN guidance telemetry, ~10 Hz during guided coast.
+                # See GuidanceTelemData in RocketComputerTypes.h.
+                if msg_len == 19:
+                    fields = struct.unpack(FMT_GUIDANCE_19, payload)
+                    pitch_fin_cmd = fields[6] / 100.0  # deg
+                    yaw_fin_cmd   = fields[7] / 100.0  # deg
+                    gflags        = fields[8]
+                else:  # 15-byte legacy log (no fin-command fields)
+                    fields = struct.unpack(FMT_GUIDANCE_15, payload)
+                    pitch_fin_cmd = None
+                    yaw_fin_cmd   = None
+                    gflags        = fields[6]
+                records["Guidance"].append({
+                    "time_us":        fields[0],
+                    "accel_cmd_n":    fields[1] / 100.0,  # m/s²
+                    "accel_cmd_e":    fields[2] / 100.0,  # m/s²
+                    "lateral_offset": fields[3] / 100.0,  # cm → m
+                    "los_angle":      fields[4] / 100.0,  # deg
+                    "closing_vel":    fields[5] / 100.0,  # m/s
+                    "pitch_fin_cmd":  pitch_fin_cmd,      # deg (None on legacy)
+                    "yaw_fin_cmd":    yaw_fin_cmd,        # deg (None on legacy)
+                    "active":         bool(gflags & GUID_FLAG_ACTIVE),
+                    "burnout":        bool(gflags & GUID_FLAG_BURNOUT),
                 })
 
         except struct.error:
@@ -1265,6 +1304,65 @@ def plot_roll_cmd_gyro(records, t0_global):
     return fig
 
 
+def plot_guidance(records, t0_global):
+    """PN guidance telemetry (GUIDANCE_TELEM_MSG, ~10 Hz during guided coast).
+
+    Top: commanded pre-mix fin deflections (pitch/yaw) — the guidance analogue
+    of roll_cmd — plus the roll command from NonSensor for context.
+    Bottom: guidance internals (LOS angle, lateral offset, closing velocity).
+    """
+    g = records["Guidance"]
+    if not g:
+        return None
+
+    t = (get_array(g, "time_us") - t0_global) / 1e6
+    has_fin = g[0].get("pitch_fin_cmd") is not None
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 9), sharex=True)
+
+    # --- Top: commanded fin deflections ---
+    if has_fin:
+        ax1.scatter(t, get_array(g, "pitch_fin_cmd"), s=DOT_SIZE, alpha=0.6,
+                    color='tab:red', label="Pitch fin cmd (deg)")
+        ax1.scatter(t, get_array(g, "yaw_fin_cmd"), s=DOT_SIZE, alpha=0.6,
+                    color='tab:green', label="Yaw fin cmd (deg)")
+    else:
+        ax1.text(0.5, 0.5, "No fin-command fields (legacy 15-byte log)",
+                 transform=ax1.transAxes, ha='center', va='center',
+                 color='gray', fontsize=11)
+    ns = records["NonSensor"]
+    if ns:
+        t_ns = (get_array(ns, "time_us") - t0_global) / 1e6
+        ax1.scatter(t_ns, get_array(ns, "roll_cmd"), s=8, alpha=0.3,
+                    color='tab:orange', label="Roll cmd (deg)")
+    ax1.set_ylabel("Commanded deflection (deg)")
+    ax1.set_title("Guidance commanded fin deflections")
+    ax1.legend(loc='upper right')
+    ax1.grid(True, alpha=0.3)
+
+    # --- Bottom: guidance internals ---
+    ax2.scatter(t, get_array(g, "los_angle"), s=DOT_SIZE, alpha=0.6,
+                color='tab:blue', label="LOS angle (deg)")
+    ax2.scatter(t, get_array(g, "lateral_offset"), s=DOT_SIZE, alpha=0.6,
+                color='tab:purple', label="Lateral offset (m)")
+    ax2.set_xlabel("Time (s)")
+    ax2.set_ylabel("LOS angle (deg) / offset (m)")
+    ax2.grid(True, alpha=0.3)
+    # Closing velocity on a separate right-hand axis (different scale).
+    ax2b = ax2.twinx()
+    ax2b.scatter(t, get_array(g, "closing_vel"), s=8, alpha=0.3,
+                 color='tab:gray', label="Closing vel (m/s)")
+    ax2b.set_ylabel("Closing velocity (m/s)", color='tab:gray')
+    ax2b.tick_params(axis='y', labelcolor='tab:gray')
+    l1, lab1 = ax2.get_legend_handles_labels()
+    l2, lab2 = ax2b.get_legend_handles_labels()
+    ax2.legend(l1 + l2, lab1 + lab2, loc='upper right')
+    ax2.set_title("Guidance internals (LOS / offset / closing velocity)")
+
+    fig.tight_layout()
+    return fig
+
+
 def plot_nav_altitude(records, t0_global):
     """Nav filter altitude (u_pos) and baro alt rate."""
     ns = records["NonSensor"]
@@ -1623,6 +1721,7 @@ def main(filepath=BINARY_FILE, output_dir=OUTPUT_DIR, show_plots=SHOW_PLOTS,
         # --- Nav filter ---
         ("attitude",         lambda: plot_attitude(records, t0_global)),
         ("roll_cmd_gyro",    lambda: plot_roll_cmd_gyro(records, t0_global)),
+        ("guidance",         lambda: plot_guidance(records, t0_global)),
         ("nav_altitude",     lambda: plot_nav_altitude(records, t0_global)),
         ("nav_velocity",     lambda: plot_nav_velocity(records, t0_global)),
         ("rocket_state",     lambda: plot_rocket_state(records, t0_global)),

--- a/Data_Analysis/report_guidance_flight.py
+++ b/Data_Analysis/report_guidance_flight.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Guidance-flight report from a TinkerRocket .bin flight log.
+
+Decodes GUIDANCE_TELEM_MSG (0xCA) + NonSensor frames and produces a
+guidance-focused report: control output (pitch/yaw fin commands, roll command)
+and PN guidance parameters (LOS angle, closing velocity, lateral offset, accel
+commands), aligned to flight time (T=0 at launch). Loads the matching .json
+sidecar for apogee/burnout/config context when present.
+
+Usage:
+    python3 report_guidance_flight.py <flight.bin> [--out report.png]
+"""
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import plot_flight_data_mini as P  # noqa: E402
+
+
+def _arr(records, key):
+    return np.array([r[key] for r in records], dtype=float)
+
+
+def load_flight(bin_path):
+    recs, stats, _ = P.parse_binary_file(bin_path)
+    ns = recs["NonSensor"]
+    g = recs["Guidance"]
+    if not ns:
+        raise SystemExit("No NonSensor frames — cannot establish launch time.")
+
+    launched = [r for r in ns if r["launch"]]
+    t_launch = (launched[0]["time_us"] if launched else ns[0]["time_us"]) / 1e6
+
+    # Optional .json sidecar (apogee/burnout/config)
+    side = os.path.splitext(bin_path)[0] + ".json"
+    meta = {}
+    if os.path.exists(side):
+        with open(side) as f:
+            meta = json.load(f)
+    return recs, stats, t_launch, meta
+
+
+def summarize(recs, stats, t_launch, meta):
+    ns, g = recs["NonSensor"], recs["Guidance"]
+    print("=" * 64)
+    print("GUIDANCE FLIGHT REPORT")
+    print("=" * 64)
+    print(f"Frames: {stats['good_crc']} good CRC, {stats['bad_crc']} bad")
+    if meta:
+        settings = meta.get("settings", {})
+        rc = settings.get("roll_control", {})
+        print(f"FW: {settings.get('fw_git_sha','?')}"
+              f"{' (dirty)' if settings.get('fw_dirty') else ''} | "
+              f"guidance_enabled={rc.get('guidance_enabled')} | "
+              f"activation delay_ms={rc.get('delay_ms')}")
+        print(f"Apogee: {meta.get('max_altitude_m',0):.1f} m @ T+"
+              f"{meta.get('apogee_time_s',0):.2f} s | "
+              f"max speed {meta.get('max_speed_mps',0):.1f} m/s | "
+              f"burnout T+{meta.get('burnout_time_s',0):.2f} s")
+
+    if not g:
+        print("\nNO guidance frames in this log.")
+        return
+    tg = _arr(g, "time_us") / 1e6 - t_launch
+    print(f"\nGuidance active: T+{tg.min():.2f} .. T+{tg.max():.2f} s "
+          f"({tg.max()-tg.min():.2f} s, {len(g)} frames @ ~10 Hz)")
+    if meta:
+        d = meta.get("settings", {}).get("roll_control", {}).get("delay_ms")
+        if d is not None:
+            print(f"  -> engaged {tg.min()*1000:.0f} ms after launch "
+                  f"(activation delay = {d} ms; burnout at T+"
+                  f"{meta.get('burnout_time_s',0):.2f} s) "
+                  f"=> {'DURING boost' if tg.min() < meta.get('burnout_time_s',1e9) else 'post-burnout'}")
+    pf, yf = _arr(g, "pitch_fin_cmd"), _arr(g, "yaw_fin_cmd")
+    print(f"  pitch fin cmd: {pf.min():+.1f} .. {pf.max():+.1f} deg")
+    print(f"  yaw   fin cmd: {yf.min():+.1f} .. {yf.max():+.1f} deg")
+    print(f"  LOS angle:     {_arr(g,'los_angle').min():.2f} .. "
+          f"{_arr(g,'los_angle').max():.2f} deg")
+    print(f"  closing vel:   {_arr(g,'closing_vel').min():.1f} .. "
+          f"{_arr(g,'closing_vel').max():.1f} m/s")
+    print(f"  lateral offset:{_arr(g,'lateral_offset').min():.2f} .. "
+          f"{_arr(g,'lateral_offset').max():.2f} m")
+    amag = np.hypot(_arr(g, "accel_cmd_n"), _arr(g, "accel_cmd_e"))
+    print(f"  PN |accel cmd|:{amag.min():.1f} .. {amag.max():.1f} m/s^2")
+
+
+def make_report(recs, t_launch, meta, out_path):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    ns, g = recs["NonSensor"], recs["Guidance"]
+    t_ns = _arr(ns, "time_us") / 1e6 - t_launch
+    alt = _arr(ns, "u_pos")
+    spd = np.sqrt(_arr(ns, "e_vel")**2 + _arr(ns, "n_vel")**2 + _arr(ns, "u_vel")**2)
+    roll_cmd = _arr(ns, "roll_cmd")
+    roll = _arr(ns, "roll"); pitch = _arr(ns, "pitch"); yaw = _arr(ns, "yaw")
+
+    has_g = bool(g)
+    if has_g:
+        tg = _arr(g, "time_us") / 1e6 - t_launch
+        g0, g1 = tg.min(), tg.max()
+    t_apo = meta.get("apogee_time_s")
+    t_burn = meta.get("burnout_time_s")
+
+    def shade(ax):
+        if has_g:
+            ax.axvspan(g0, g1, color="tab:green", alpha=0.10,
+                       label="guidance active")
+        if t_burn:
+            ax.axvline(t_burn, color="gray", ls=":", lw=1)
+        if t_apo:
+            ax.axvline(t_apo, color="k", ls="--", lw=0.8)
+
+    # Limit the x-window to the interesting part (launch .. shortly past apogee)
+    x_hi = (t_apo + 2) if t_apo else t_ns.max()
+    m = (t_ns >= -0.5) & (t_ns <= x_hi)
+
+    fig, axes = plt.subplots(3, 2, figsize=(15, 12))
+    title = "Guidance Flight Report"
+    if meta:
+        title += (f"  —  apogee {meta.get('max_altitude_m',0):.0f} m, "
+                  f"act.delay {meta.get('settings',{}).get('roll_control',{}).get('delay_ms','?')} ms")
+    fig.suptitle(title, fontsize=14, fontweight="bold")
+
+    # (0,0) Flight context: altitude + speed
+    ax = axes[0, 0]; shade(ax)
+    ax.plot(t_ns[m], alt[m], color="tab:blue", label="Altitude (m)")
+    ax.set_ylabel("Altitude (m)", color="tab:blue"); ax.set_xlabel("T+ (s)")
+    axb = ax.twinx()
+    axb.plot(t_ns[m], spd[m], color="tab:red", alpha=0.6, label="Speed (m/s)")
+    axb.set_ylabel("Speed (m/s)", color="tab:red")
+    ax.set_title("Flight context (burnout ·, apogee --)")
+    ax.grid(True, alpha=0.3)
+
+    # (0,1) CONTROL OUTPUT: commanded fin deflections
+    ax = axes[0, 1]; shade(ax)
+    ax.plot(t_ns[m], roll_cmd[m], color="tab:orange", lw=1, alpha=0.8,
+            label="roll cmd (NonSensor)")
+    if has_g:
+        ax.plot(tg, _arr(g, "pitch_fin_cmd"), "o-", ms=3, color="tab:red",
+                label="pitch fin cmd")
+        ax.plot(tg, _arr(g, "yaw_fin_cmd"), "o-", ms=3, color="tab:green",
+                label="yaw fin cmd")
+    ax.set_ylabel("Commanded deflection (deg)"); ax.set_xlabel("T+ (s)")
+    ax.set_title("Control output — fin commands (pre-mix)")
+    ax.legend(loc="upper left", fontsize=8); ax.grid(True, alpha=0.3)
+
+    # (1,0) Guidance geometry: LOS angle + lateral offset
+    ax = axes[1, 0]; shade(ax)
+    if has_g:
+        ax.plot(tg, _arr(g, "los_angle"), "o-", ms=3, color="tab:blue",
+                label="LOS angle (deg)")
+        axb = ax.twinx()
+        axb.plot(tg, _arr(g, "lateral_offset"), "s-", ms=3, color="tab:purple",
+                 label="lateral offset (m)")
+        axb.set_ylabel("Lateral offset (m)", color="tab:purple")
+    ax.set_ylabel("LOS angle (deg)", color="tab:blue"); ax.set_xlabel("T+ (s)")
+    ax.set_title("Guidance geometry"); ax.grid(True, alpha=0.3)
+
+    # (1,1) Closing velocity + PN accel command magnitude (with saturation ref)
+    ax = axes[1, 1]; shade(ax)
+    if has_g:
+        amag = np.hypot(_arr(g, "accel_cmd_n"), _arr(g, "accel_cmd_e"))
+        ax.plot(tg, _arr(g, "closing_vel"), "o-", ms=3, color="tab:gray",
+                label="closing vel (m/s)")
+        axb = ax.twinx()
+        axb.plot(tg, amag, "o-", ms=3, color="tab:red",
+                 label="|PN accel cmd| (m/s²)")
+        axb.set_ylabel("|PN accel cmd| (m/s²)", color="tab:red")
+    ax.set_ylabel("Closing velocity (m/s)", color="tab:gray"); ax.set_xlabel("T+ (s)")
+    ax.set_title("Closing velocity & PN accel command"); ax.grid(True, alpha=0.3)
+
+    # (2,0) Attitude
+    ax = axes[2, 0]; shade(ax)
+    ax.plot(t_ns[m], roll[m], label="roll", alpha=0.8)
+    ax.plot(t_ns[m], pitch[m], label="pitch", alpha=0.8)
+    ax.plot(t_ns[m], yaw[m], label="yaw", alpha=0.8)
+    ax.set_ylabel("Euler angle (deg)"); ax.set_xlabel("T+ (s)")
+    ax.set_title("Attitude (NonSensor quaternion → Euler)")
+    ax.legend(loc="upper left", fontsize=8); ax.grid(True, alpha=0.3)
+
+    # (2,1) Fin commands zoomed to the guidance window
+    ax = axes[2, 1]
+    if has_g:
+        if t_burn:
+            ax.axvline(t_burn, color="gray", ls=":", lw=1, label="burnout")
+        ax.plot(tg, _arr(g, "pitch_fin_cmd"), "o-", ms=4, color="tab:red",
+                label="pitch fin cmd")
+        ax.plot(tg, _arr(g, "yaw_fin_cmd"), "o-", ms=4, color="tab:green",
+                label="yaw fin cmd")
+        ax.set_xlim(g0 - 0.1, g1 + 0.1)
+    ax.set_ylabel("Commanded deflection (deg)"); ax.set_xlabel("T+ (s)")
+    ax.set_title("Fin commands — guidance window (zoom)")
+    ax.legend(loc="upper left", fontsize=8); ax.grid(True, alpha=0.3)
+
+    fig.tight_layout(rect=[0, 0, 1, 0.97])
+    fig.savefig(out_path, dpi=130, bbox_inches="tight")
+    print(f"\nReport saved to {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Guidance flight report from a .bin log")
+    ap.add_argument("bin", help="path to flight .bin")
+    ap.add_argument("--out", default=None, help="output PNG path")
+    args = ap.parse_args()
+    out = args.out or (os.path.splitext(args.bin)[0] + "_guidance_report.png")
+
+    recs, stats, t_launch, meta = load_flight(args.bin)
+    summarize(recs, stats, t_launch, meta)
+    make_report(recs, t_launch, meta, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -130,6 +130,20 @@ TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
     EXPECT_EQ(offsetof(GuidanceConfigData, target_mode),      35u);
 }
 
+TEST(RocketComputerTypes, GuidanceTelemData_Layout) {
+    // Logged as GUIDANCE_TELEM_MSG (0xCA): u32 + 7 i16 + u8 = 19, packed.
+    EXPECT_EQ(sizeof(GuidanceTelemData), 19u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, time_us),            0u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, accel_cmd_n_cmps2),  4u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, accel_cmd_e_cmps2),  6u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, lateral_offset_cm),  8u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, los_angle_cdeg),     10u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, closing_vel_cmps),   12u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, pitch_fin_cmd_cdeg), 14u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, yaw_fin_cmd_cdeg),   16u);
+    EXPECT_EQ(offsetof(GuidanceTelemData, guid_flags),         18u);
+}
+
 TEST(RocketComputerTypes, FinConfigData_Layout) {
     // Wire struct relayed app→OC→BS→FC; size is hardcoded in the relay paths.
     EXPECT_EQ(sizeof(FinConfigData), 18u);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1930,18 +1930,26 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(LogBufferStatsData) == 28,
               "LogBufferStatsData must be 28 bytes");
 
-// --- Guidance Telemetry Data (sent at ~10 Hz during coast) ---
+// --- Guidance Telemetry Data (sent at ~10 Hz during guided coast) ---
+// Logged to the flight log as GUIDANCE_TELEM_MSG (0xCA). NOTE: the field
+// names prior to this struct's extension were misleading — pitch_cmd/yaw_cmd
+// actually held PN acceleration commands and pitch_fin/yaw_fin held the LOS
+// angle and closing velocity, NOT fin deflections. Fields are now named for
+// their true contents, and the genuinely-commanded pitch/yaw fin deflections
+// (the guidance analogue of NonSensorData.roll_cmd) are logged explicitly.
 typedef struct __attribute__((packed))
 {
-    uint32_t time_us;
-    int16_t  pitch_cmd_cdeg;    // guidance pitch command (centi-deg)
-    int16_t  yaw_cmd_cdeg;      // guidance yaw command (centi-deg)
-    int16_t  lateral_offset_cm; // lateral distance from pad vertical (cm)
-    int16_t  pitch_fin_cdeg;    // pitch fin command after PID (centi-deg)
-    int16_t  yaw_fin_cdeg;      // yaw fin command after PID (centi-deg)
-    uint8_t  guid_flags;        // bit 0: guidance_active, bit 1: burnout_detected
+    uint32_t time_us;            // FC monotonic time (us)
+    int16_t  accel_cmd_n_cmps2;  // PN acceleration command, North (m/s^2 x100)
+    int16_t  accel_cmd_e_cmps2;  // PN acceleration command, East  (m/s^2 x100)
+    int16_t  lateral_offset_cm;  // lateral distance from pad vertical (cm)
+    int16_t  los_angle_cdeg;     // line-of-sight angle to target (deg x100)
+    int16_t  closing_vel_cmps;   // closing velocity to target (m/s x100)
+    int16_t  pitch_fin_cmd_cdeg; // commanded pitch fin deflection, pre-mix (deg x100)
+    int16_t  yaw_fin_cmd_cdeg;   // commanded yaw fin deflection, pre-mix (deg x100)
+    uint8_t  guid_flags;         // bit 0: guidance_active, bit 1: burnout_detected
 } GuidanceTelemData;
-static_assert(sizeof(GuidanceTelemData) == 15, "GuidanceTelemData must be 15 bytes");
+static_assert(sizeof(GuidanceTelemData) == 19, "GuidanceTelemData must be 19 bytes");
 
 // --- Flight snapshot (#104 follow-up) ---
 // Periodic snapshot of FC flight state for crash recovery.  Sent FC→OC

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -361,6 +361,11 @@ static uint8_t  pn_target_mode    = config::PN_TARGET_MODE;
 static float    pn_target_e       = config::PN_TARGET_E_M;
 static float    pn_target_n       = config::PN_TARGET_N_M;
 static float    pn_target_alt     = config::PN_TARGET_ALT_M;
+// Last commanded pre-mix fin deflections from guidance, carried from the
+// guidance compute block to the ~10 Hz GuidanceTelemData emit. Only meaningful
+// while guidance_active (the only condition under which they are logged).
+static float    pn_last_pitch_fin_deg = 0.0f;
+static float    pn_last_yaw_fin_deg   = 0.0f;
 static bool burnout_detected = false;
 static uint32_t burnout_time_ms = 0;
 // Consecutive-sample hysteresis for burnout detection (#197). Prevents
@@ -5418,6 +5423,10 @@ static void loop_fc()
                             float pitch_fin = accel_to_fin_deg * pitch_accel;
                             float yaw_fin   = accel_to_fin_deg * yaw_accel;
 
+                            // Stash for the ~10 Hz GuidanceTelemData log frame.
+                            pn_last_pitch_fin_deg = pitch_fin;
+                            pn_last_yaw_fin_deg   = yaw_fin;
+
                             // Roll control: standalone PID
                             float roll_fin_cmd = roll_rate_pid_standalone.computePID(
                                 config::ROLL_RATE_SET_POINT, -roll_rate_dps);
@@ -5827,12 +5836,14 @@ static void loop_fc()
                 {
                     guid_telem_counter = 0;
                     GuidanceTelemData gtd = {};
-                    gtd.time_us = logic_now_us;
-                    gtd.pitch_cmd_cdeg    = (int16_t)lroundf(guidance.getAccelNorthCmd() * 100.0f);
-                    gtd.yaw_cmd_cdeg      = (int16_t)lroundf(guidance.getAccelEastCmd() * 100.0f);
-                    gtd.lateral_offset_cm = (int16_t)lroundf(guidance.getLateralOffset() * 100.0f);
-                    gtd.pitch_fin_cdeg    = (int16_t)lroundf(guidance.getLosAngleDeg() * 100.0f);
-                    gtd.yaw_fin_cdeg      = (int16_t)lroundf(guidance.getClosingVelocity() * 100.0f);
+                    gtd.time_us            = logic_now_us;
+                    gtd.accel_cmd_n_cmps2  = (int16_t)lroundf(guidance.getAccelNorthCmd() * 100.0f);
+                    gtd.accel_cmd_e_cmps2  = (int16_t)lroundf(guidance.getAccelEastCmd() * 100.0f);
+                    gtd.lateral_offset_cm  = (int16_t)lroundf(guidance.getLateralOffset() * 100.0f);
+                    gtd.los_angle_cdeg     = (int16_t)lroundf(guidance.getLosAngleDeg() * 100.0f);
+                    gtd.closing_vel_cmps   = (int16_t)lroundf(guidance.getClosingVelocity() * 100.0f);
+                    gtd.pitch_fin_cmd_cdeg = (int16_t)lroundf(pn_last_pitch_fin_deg * 100.0f);
+                    gtd.yaw_fin_cmd_cdeg   = (int16_t)lroundf(pn_last_yaw_fin_deg * 100.0f);
                     gtd.guid_flags = (guidance_active ? 1u : 0u) | (burnout_detected ? 2u : 0u);
                     uint8_t gtd_buf[sizeof(GuidanceTelemData)];
                     memcpy(gtd_buf, &gtd, sizeof(GuidanceTelemData));


### PR DESCRIPTION
## Summary
Makes guidance flights properly analyzable. A guidance flight's `GuidanceTelemData` (`GUIDANCE_TELEM_MSG` 0xCA, ~10 Hz during guided coast) was missing the commanded pitch/yaw fin deflections (the guidance analogue of `roll_cmd`), and five fields were mislabeled. No Python tooling decoded `0xCA` at all.

### Firmware (`8356091`)
- Log the genuinely-commanded **pre-mix pitch/yaw fin deflections** (carried from the guidance compute block via `pn_last_{pitch,yaw}_fin_deg`).
- Rename the misleading fields to their true contents: PN accel N/E, LOS angle, closing velocity (they were named `pitch_cmd`/`yaw_cmd`/`pitch_fin`/`yaw_fin` but held accel commands / LOS / closing velocity).
- Struct grows 15 → 19 bytes. OC relays it verbatim (length-agnostic `enqueueFrame`), so no relay change needed. Added a `GuidanceTelemData` layout gtest alongside the bumped `static_assert`.

### Analysis tooling (`c7b2217`, `1a9e6f6`)
- `plot_flight_data_mini.py`: decode `0xCA` (both the new 19-byte and legacy 15-byte layouts) + a `plot_guidance` panel.
- `report_guidance_flight.py`: new guidance-flight report generator from a `.bin` (control output + PN guidance params, flight-time aligned).

## Verification
- Host gtest `GuidanceTelemData_Layout` passes (19 bytes, offsets correct).
- FC firmware builds clean with IDF v6.
- Decoder round-trips synthesized 19B + 15B frames (valid CRC).
- **Validated on a real guidance flight log** (fw `1c3c678`-dirty, 122,336 frames, 0 bad CRC): new 19-byte frames decode with populated fin commands; decoded altitude matches the JSON sidecar; guidance engaged 601 ms after launch (= the flight's 500 ms activation delay, during boost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)