### PR TITLE
sim(guidance): RollyPolly III + F67 guidance flight; engage on shared activation delay

### DIFF
--- a/tinkerrocket-sim/scripts/run_closed_loop.py
+++ b/tinkerrocket-sim/scripts/run_closed_loop.py
@@ -12,6 +12,7 @@ import numpy as np
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from tinkerrocket_sim.rocket.definition import RocketDefinition, MotorConfig, from_ork
+from tinkerrocket_sim.rocket.motor_db import find_motor
 from tinkerrocket_sim.simulation.closed_loop_sim import run_closed_loop, SimConfig
 
 
@@ -21,9 +22,18 @@ from tinkerrocket_sim.simulation.closed_loop_sim import run_closed_loop, SimConf
 
 # --- Rocket source ---
 # Option 1: Load from OpenRocket .ork file (motor thrust data from motors/*.eng)
+# The 67mm Guidance Testbed IS RollyPolly III — 4 fins + 4 fin tabs, CFD-derived
+# aero — the same airframe flown for roll control.
 ORK_FILE = "rockets/67mm Guidance Testbed.ork"
 # Option 2: Set to None to use the manual definition in make_rocket() below
 # ORK_FILE = None
+
+# --- Motor override ---
+# When set, replace the .ork's default motor with this designation looked up
+# from motors/*.eng (RASP thrust curve). Set to None to keep the .ork motor.
+# F67C = AeroTech F67 (Classic); the "-4" ejection delay is irrelevant to the
+# powered+coast guidance sim (no ejection modeled), so the F67C curve is used.
+MOTOR_OVERRIDE = "F67C"
 
 # --- PID gains (inner rate loop) — flight-proven from Rolly Poly IV ---
 KP = 0.04                  # proportional gain
@@ -177,6 +187,25 @@ def load_rocket():
         print(f"  Motor: {rd.motor.designation} ({len(rd.motor.thrust_times)} thrust points)")
     else:
         rd = make_rocket_manual()
+
+    # --- Motor override (replace .ork default with a motors/*.eng curve) ---
+    if MOTOR_OVERRIDE:
+        eng = find_motor(MOTOR_OVERRIDE)
+        if eng is None:
+            raise SystemExit(f"MOTOR_OVERRIDE='{MOTOR_OVERRIDE}' not found in motors/*.eng")
+        rd.motor.thrust_times = np.array(eng.thrust_times, dtype=float)
+        rd.motor.thrust_forces = np.array(eng.thrust_forces, dtype=float)
+        rd.motor.total_mass = eng.total_mass
+        rd.motor.propellant_mass = eng.propellant_mass
+        rd.motor.designation = eng.designation
+        print(f"  Motor override: {eng.designation} "
+              f"(burn {rd.motor.burn_time:.2f}s, peak {max(eng.thrust_forces):.1f}N, "
+              f"prop {eng.propellant_mass*1e3:.0f}g)")
+
+    # RollyPolly III is a 4-TAB vehicle (4 fins × 1 tab); the FinTabConfig
+    # default is n_tabs=3 and the sim_config.yaml override isn't applied on this
+    # .ork load path, so set it explicitly for correct roll authority.
+    rd.fin_tabs.n_tabs = 4
 
     # Apply disturbance (not in .ork file)
     rd.roll_disturbance_torque = ROLL_DISTURBANCE_NM

--- a/tinkerrocket-sim/scripts/run_closed_loop.py
+++ b/tinkerrocket-sim/scripts/run_closed_loop.py
@@ -56,6 +56,10 @@ KP_ANGLE = 5.0             # outer angle loop gain: (deg/s rate cmd) per (deg an
 
 # --- Control ---
 CONTROL_ENABLED = True      # False = passive flight (no fin tab actuation)
+# Activation delay (ms after launch) before fin control engages — the app's
+# "Activation Delay" (firmware roll_delay_ms / BLE), SHARED by roll control and
+# guidance. Guidance engages at launch + this delay, NOT at burnout.
+ROLL_DELAY_MS = 250
 ROLL_DISTURBANCE_NM = 0.002  # constant roll torque disturbance (N-m)
 
 # --- Gain scheduling — V_ref=50 gives 1.73x at 38 m/s, 0.51x at 70 m/s ---
@@ -122,7 +126,7 @@ PN_YAW_KI = 0.002
 PN_YAW_KD = 0.0004
 PN_MAX_FIN_DEG = 20.0           # per-fin max deflection (deg)
 PN_MIN_SPEED_MPS = 10.0         # min speed for guidance (m/s)
-PN_COAST_DELAY_S = 0.0          # delay after burnout (s)
+PN_COAST_DELAY_S = 0.0          # LEGACY (no longer a gate); use ROLL_DELAY_MS
 PN_GAIN_V_REF = 50.0            # pitch/yaw gain-schedule V_ref (m/s)
 PN_GAIN_V_MIN = 25.0            # pitch/yaw gain-schedule V_min (m/s)
 
@@ -660,6 +664,7 @@ if __name__ == "__main__":
         mag_rate=MAG_RATE,
         gnss_rate=GNSS_RATE,
         control_enabled=CONTROL_ENABLED,
+        roll_delay_s=ROLL_DELAY_MS / 1000.0,
         pid_kp=KP,
         pid_ki=KI,
         pid_kd=KD,

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -54,6 +54,12 @@ class SimConfig:
     pid_kd: float = 0.0003
     roll_setpoint_dps: float = 0.0  # desired roll rate in deg/s (constant mode)
     control_enabled: bool = True
+    # Activation delay (s after launch) before fin control engages. SHARED by
+    # roll control AND guidance, mirroring the firmware: both live in the same
+    # post-delay branch gated by `t_since_launch_ms >= roll_delay_ms` (FC
+    # main.cpp). This is the app's "Activation Delay" (BLE roll_delay_ms);
+    # guidance engages at launch+delay, NOT at burnout.
+    roll_delay_s: float = 0.25
 
     # Roll angle profile: list of (time_s, angle_deg) waypoints, or None
     # When set, a cascaded controller tracks angle → rate → fin tab
@@ -149,7 +155,10 @@ class SimConfig:
     # Guided mode limits
     pn_max_fin_deg: float = 15.0
     pn_min_speed_mps: float = 15.0
-    pn_coast_delay_s: float = 0.0   # delay after burnout before guidance activates
+    # LEGACY — no longer a guidance gate. The firmware dropped the post-burnout
+    # "coast delay" in favour of the shared activation delay (roll_delay_s); kept
+    # only so callers passing it don't break. See roll_delay_s above.
+    pn_coast_delay_s: float = 0.0
     pn_target_alt_m: float = 600.0      # OVERHEAD aim-point altitude above pad (matches FC config::PN_TARGET_ALT_M)
     pn_accel_to_fin_deg: float = 4.0    # accel->fin scale; reconciled to the FC's config::PN_ACCEL_TO_FIN_DEG (was 5.0)
 
@@ -596,17 +605,22 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                         sim.rocket.roll_disturbance_torque = 0.0
 
                 # --- Determine if guided coast is active ---
+                # Mirrors the firmware: guidance engages once past the shared
+                # activation delay (launch+roll_delay_s), gated only by airspeed
+                # and not-yet-CPA — NOT by burnout (FC main.cpp comment: "burnout
+                # are no longer gates here").
                 guidance_active = False
                 if (config.guidance_enabled and guidance is not None and
-                        burnout_detected and
+                        t >= config.roll_delay_s and
                         not guidance_cpa_reached and
-                        t >= burnout_time + config.pn_coast_delay_s and
                         speed > config.pn_min_speed_mps):
                     guidance_active = True
 
-                # PID control: use EKF roll rate estimate
-                # Roll control starts at t=0.5s; full guidance after burnout
-                if config.control_enabled and speed > 5.0 and t > 0.5:
+                # Fin control (roll + guidance) engages after the shared
+                # activation delay, matching the firmware neutral-hold gate
+                # `t_since_launch_ms >= roll_delay_ms`. speed > 5 is a rail-
+                # clearance floor.
+                if config.control_enabled and speed > 5.0 and t >= config.roll_delay_s:
                     rot_rate = ekf.get_rot_rate_est()
                     roll_rate_dps = math.degrees(rot_rate[0])
 


### PR DESCRIPTION
## Summary
Sets up the Python 6-DOF closed-loop sim to fly a guidance flight on the RollyPolly III (67mm Guidance Testbed) airframe with an AeroTech F67 — a short test flight — and aligns guidance activation with the firmware.

### F67 motor + fin-tab fix (`65eb937`)
- Add a `MOTOR_OVERRIDE` knob to `run_closed_loop.py`: replace the `.ork`'s default motor with a `motors/*.eng` RASP curve (here `F67C`). The `.ork` default for this airframe is F50T/G74W and there was no way to pick a motor without editing the `.ork`.
- Fix fin-tab count to **4**. RollyPolly III is a 4-tab vehicle, but `FinTabConfig` defaults to `n_tabs=3` and the `sim_config.yaml` override is not applied on the `from_ork()` load path, so roll authority was modeled with 3 tabs.

### Activation-delay gating (`85fb641`)
- The sim engaged guidance at burnout + `pn_coast_delay_s` and started roll control at a hardcoded `t > 0.5s`. Firmware instead gates **both** roll control and guidance on the shared activation delay (`t_since_launch_ms >= roll_delay_ms`, the app's "Activation Delay"), **not** burnout.
- Add `SimConfig.roll_delay_s` (shared by roll + guidance) and gate both on `t >= roll_delay_s` (t=0 is launch). Expose `ROLL_DELAY_MS=250` in `run_closed_loop.py`. `pn_coast_delay_s` is retained as a no-op for compatibility.

## Verification
- Headless guidance flight (RollyPolly III + F67): apogee 196 m, max 63 m/s; F67 override loads (burn 1.46 s, peak 68.7 N); guidance engages at **t=0.251 s** (launch + 250 ms) instead of burnout (1.33 s); apogee unchanged by the gating change; clean LOS-to-CPA guidance plot.
- Guidance + 6-DOF unit tests pass (17).

Note: the `_guidance`/`_ekf` pybind extensions build from `tinkerrocket-idf/components/` (TR_GuidancePN is a submodule); no firmware behavior changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
