### PR TITLE
fc(guidance): log guidance telemetry at 500 Hz, lockstep with NonSensor

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -67,6 +67,15 @@ struct config
     static constexpr uint16_t MMC5983MA_UPDATE_RATE = 200;
     static constexpr uint16_t ISM6HG256_UPDATE_RATE = 960;
     static constexpr uint16_t NON_SENSOR_UPDATE_RATE = 500;
+    // Guidance telemetry (GUIDANCE_TELEM_MSG) log rate while guidance is active.
+    // Emitted from inside the NonSensor TX block, so it must divide
+    // NON_SENSOR_UPDATE_RATE; 500 = lockstep with NonSensor/roll_cmd (frames
+    // time-aligned 1:1). The guidance law recomputes at ISM6HG256_UPDATE_RATE
+    // (960 Hz), so values are fresh at any rate up to NON_SENSOR_UPDATE_RATE.
+    static constexpr uint16_t GUIDANCE_TELEM_RATE_HZ = 500;
+    static_assert(GUIDANCE_TELEM_RATE_HZ >= 1 &&
+                  GUIDANCE_TELEM_RATE_HZ <= NON_SENSOR_UPDATE_RATE,
+                  "GUIDANCE_TELEM_RATE_HZ must be in [1, NON_SENSOR_UPDATE_RATE]");
     // ISM6 full-scale configuration used by SensorConverter (and shared to OUT).
     static constexpr uint8_t ISM6_LOW_G_FS_G = 16;
     static constexpr uint16_t ISM6_HIGH_G_FS_G = 256;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5828,11 +5828,13 @@ static void loop_fc()
                                non_sensor_data_buffer,
                                SIZE_OF_NON_SENSOR_DATA);
 
-            // Send guidance telemetry at ~10 Hz during guided coast
+            // Send guidance telemetry during guided coast, at
+            // config::GUIDANCE_TELEM_RATE_HZ (500 = lockstep with NonSensor).
             if (guidance_active)
             {
                 static uint32_t guid_telem_counter = 0;
-                if (++guid_telem_counter >= (config::NON_SENSOR_UPDATE_RATE / 10))
+                if (++guid_telem_counter >=
+                    (config::NON_SENSOR_UPDATE_RATE / config::GUIDANCE_TELEM_RATE_HZ))
                 {
                     guid_telem_counter = 0;
                     GuidanceTelemData gtd = {};


### PR DESCRIPTION
## Summary
Raise guidance telemetry (`GUIDANCE_TELEM_MSG`) logging from a fixed ~10 Hz to **500 Hz**, lockstep with the NonSensor/`roll_cmd` stream.

The guidance law recomputes at the IMU rate (960 Hz) and `roll_cmd` is logged in `NonSensorData` at 500 Hz, but guidance telemetry was emitted only every `NON_SENSOR_UPDATE_RATE/10` = 50 NonSensor cycles = ~10 Hz. That left the command dynamics (e.g. the post-burnout fin-command transient seen on the last flight) coarsely sampled — 21 frames for the whole guidance window.

## Change
- Add `config::GUIDANCE_TELEM_RATE_HZ` (default **500**) with a `static_assert` bounding it to `[1, NON_SENSOR_UPDATE_RATE]`.
- Drive the emit divisor from it: `NON_SENSOR_UPDATE_RATE / GUIDANCE_TELEM_RATE_HZ`. At 500 it emits every NonSensor cycle, so `GuidanceTelemData` frames are **time-aligned 1:1 with NonSensor/`roll_cmd`** (trivially joinable on timestamp).

## Impact / safety
- **No struct/size change** — the OC relay (verbatim `enqueueFrame`), the `0xCA` flight-log decoder, and the report tooling are all unaffected (just ~50× more guidance frames during the guidance window).
- Emit is still gated on `guidance_active`, so the added I2S/NAND load is bounded to the guided-coast window. The I2S TX queue is 512-deep with graceful drop-counting (`i2s_tx_enqueue_drop`, logged in GAP DIAG); worth a post-flight glance at that counter, but it degrades gracefully (counted drops, no crash).
- Values are fresh at any rate up to 500 Hz (compute is 960 Hz).

## Verification
- FC firmware builds clean with IDF v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
