### PR TITLE
analysis(guidance): report measured guidance-telem rate, not hardcoded 10 Hz

### DIFF
--- a/Data_Analysis/report_guidance_flight.py
+++ b/Data_Analysis/report_guidance_flight.py
@@ -66,8 +66,10 @@ def summarize(recs, stats, t_launch, meta):
         print("\nNO guidance frames in this log.")
         return
     tg = _arr(g, "time_us") / 1e6 - t_launch
+    dt = np.diff(tg)
+    rate_hz = (1.0 / np.median(dt)) if len(dt) and np.median(dt) > 0 else float("nan")
     print(f"\nGuidance active: T+{tg.min():.2f} .. T+{tg.max():.2f} s "
-          f"({tg.max()-tg.min():.2f} s, {len(g)} frames @ ~10 Hz)")
+          f"({tg.max()-tg.min():.2f} s, {len(g)} frames @ ~{rate_hz:.0f} Hz)")
     if meta:
         d = meta.get("settings", {}).get("roll_control", {}).get("delay_ms")
         if d is not None:


### PR DESCRIPTION
Small follow-up to #325. report_guidance_flight.py printed a fixed "~10 Hz" in its text summary, now stale after guidance telemetry moved to 500 Hz. Compute the actual rate from frame timestamps (median 1/dt).

Verified on the first 500 Hz flight log: now prints "1356 frames @ ~497 Hz" (was "~10 Hz"). Saved PNG was already correct (the label is console-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)