### PR TITLE
analysis(gnss): fix gnss_to_enu — rotate ECEF delta into local ENU

### DIFF
--- a/Data_Analysis/plot_flight_data_legacy.py
+++ b/Data_Analysis/plot_flight_data_legacy.py
@@ -438,9 +438,18 @@ def gnss_to_enu(gnss_records):
 
     # First valid point as origin
     i0 = int(np.argmax(valid))
-    E = x - x[i0]
-    N = y - y[i0]
-    U = z - z[i0]
+    dx, dy, dz = x - x[i0], y - y[i0], z - z[i0]
+
+    # Rotate the ECEF delta into the local ENU frame at the reference fix.
+    # Without this rotation the raw ECEF X/Y/Z deltas are not E/N/U, and
+    # vertical motion (apogee altitude) leaks into the horizontal ground track.
+    lat0 = np.deg2rad(lat[i0])
+    lon0 = np.deg2rad(lon[i0])
+    sla, cla = np.sin(lat0), np.cos(lat0)
+    slo, clo = np.sin(lon0), np.cos(lon0)
+    E = -slo * dx + clo * dy
+    N = -sla * clo * dx - sla * slo * dy + cla * dz
+    U = cla * clo * dx + cla * slo * dy + sla * dz
 
     # NaN-out invalid points
     E[~valid] = np.nan

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -763,9 +763,19 @@ def gnss_to_enu(gnss_records):
     x, y, z = lla_to_ecef(lat, lon, alt)
 
     i0 = int(np.argmax(valid))
-    E = x - x[i0]
-    N = y - y[i0]
-    U = z - z[i0]
+    dx, dy, dz = x - x[i0], y - y[i0], z - z[i0]
+
+    # Rotate the ECEF delta into the local ENU frame at the reference fix.
+    # WITHOUT this rotation the raw ECEF X/Y/Z deltas are not E/N/U — most
+    # visibly, vertical motion (apogee altitude) leaks into the horizontal
+    # ground track, manufacturing a bogus 100 m+ excursion.
+    lat0 = np.deg2rad(lat[i0])
+    lon0 = np.deg2rad(lon[i0])
+    sla, cla = np.sin(lat0), np.cos(lat0)
+    slo, clo = np.sin(lon0), np.cos(lon0)
+    E = -slo * dx + clo * dy
+    N = -sla * clo * dx - sla * slo * dy + cla * dz
+    U = cla * clo * dx + cla * slo * dy + sla * dz
 
     E[~valid] = np.nan
     N[~valid] = np.nan


### PR DESCRIPTION
Found while validating a flight against video ground truth: the report GPS ground track showed a ~100 m south / 20 m east out-and-back loop that contradicted a consistent ~20 m SSW flight.

**Bug:** gnss_to_enu() converts lat/lon/alt to ECEF and then labels the raw ECEF X/Y/Z deltas directly as East/North/Up — no ECEF→ENU rotation. ECEF axes are not local E/N/U, so vertical motion (apogee altitude) leaks into the horizontal ground track. The report N tracked −altitude almost exactly; the 100 m loop was the 110 m climb/descent bleeding into the horizontal plane.

**Fix:** apply the standard ECEF→ENU rotation at the reference fix.

**Verified** on a flight log: corrected E/N now match a flat-earth lat/lon conversion to <0.1 m, U holds the true 109 m apogee, and the GPS ground track shows the real ~30 m-south track landing ~21 m SW (matches video) instead of the artifact. Fixes plot_gps_ground_track / gps_enu_2d / gps_enu_3d / nav_vs_gps; same fix applied to the standalone copy in plot_flight_data_legacy.py.

The GNSS data itself was fine all along — only the plot conversion was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)