### PR TITLE
oc: flight-log + I2C observability/resilience batch (#278, #277, #280, #279)

### DIFF
--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -1670,6 +1670,45 @@ TEST(TRFlightLogBrownout, BadBlockMidFlightRecoversOneCleanFlight) {
     EXPECT_EQ(tail_len, 0u);
 }
 
+TEST(TRFlightLogBrownout, RecoveryDefersWhenTimeBudgetExceeded) {
+    // #277: an over-budget recovery pass stops at a run boundary, leaving the
+    // orphaned range for the next boot rather than scanning to completion and
+    // risking the app's 180 s power-on watchdog. Exercised with an injected clock.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+
+    {  // Crash a flight -> one orphaned ALLOCATED run at flight_region_start.
+        TR_FlightLog fl;
+        ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+        uint32_t id = 0;
+        ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+        uint8_t payload[64] = {0};
+        for (int i = 0; i < 10; ++i)
+            ASSERT_EQ(fl.writeFrame(payload, sizeof(payload)), Status::Ok);
+        // no finalizeFlight() — leaves the range orphaned
+    }
+
+    // Reboot with a clock that advances past the budget on the first check.
+    static uint32_t fake_now;
+    fake_now = 0;
+    {
+        TR_FlightLog fl2;
+        TR_FlightLog::Config cfg;
+        cfg.recovery_budget_ms = 1000;
+        cfg.now_ms = []() -> uint32_t { fake_now += 2000; return fake_now; };
+        ASSERT_EQ(fl2.begin(nand, cfg, &store), Status::Ok);
+        EXPECT_EQ(fl2.index().size(), 0u);  // budget hit before any run -> deferred
+        EXPECT_EQ(fl2.bitmap().get(TR_FlightLog::Config{}.flight_region_start),
+                  BLOCK_ALLOCATED);                 // run left orphaned for next boot
+    }
+
+    // Reboot within budget (default now_ms -> 0 on host) -> recovers normally.
+    TR_FlightLog fl3;
+    ASSERT_EQ(fl3.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    ASSERT_EQ(fl3.index().size(), 1u);
+    EXPECT_NE(std::strstr(fl3.index().at(0).filename, "recovered"), nullptr);
+}
+
 TEST(TRFlightLogFinalize, BadBlockMidFlightKeepsAllDataAndBlocks) {
     // #276 sibling (finalize path): a finalized flight (no brownout) that hit a
     // runtime bad block must size n_blocks from the physical span. Sizing the

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -5,6 +5,13 @@
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <esp_timer.h>
+#include <esp_log.h>
+#define FL_LOGW(...) ESP_LOGW("FLTLOG", __VA_ARGS__)
+#define FL_LOGI(...) ESP_LOGI("FLTLOG", __VA_ARGS__)
+#else
+#define FL_LOGW(...) ((void)0)
+#define FL_LOGI(...) ((void)0)
 #endif
 
 #include <cstdio>
@@ -33,6 +40,17 @@ bool page_is_all_ones(const uint8_t* page) {
 inline void yield_to_scheduler() {
 #ifdef ESP_PLATFORM
     vTaskDelay(1);  // ~10 ms; allows IDLE to run and resets the watchdog
+#endif
+}
+
+// Monotonic milliseconds since boot for the recovery time budget (#277). On
+// host / in tests there is no wall clock, so this returns 0 and the budget is
+// inert unless a test injects a clock via Config::now_ms.
+inline uint32_t monotonic_ms() {
+#ifdef ESP_PLATFORM
+    return static_cast<uint32_t>(esp_timer_get_time() / 1000);
+#else
+    return 0;
 #endif
 }
 
@@ -102,8 +120,27 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
     bool index_dirty  = false;
     bool bitmap_dirty = false;
 
+    // #277: progress + a wall-clock budget so a near-full chip's scan is visible
+    // and can't approach the app's 180 s power-on watchdog.
+    auto now = [&]() -> uint32_t { return cfg_.now_ms ? cfg_.now_ms() : monotonic_ms(); };
+    const uint32_t t0            = now();
+    const uint32_t region_blocks = static_cast<uint32_t>(cfg_.flight_region_end -
+                                                          cfg_.flight_region_start);
+    uint32_t blocks_scanned = 0;
+
     uint32_t b = cfg_.flight_region_start;
     while (b < cfg_.flight_region_end) {
+        // Budget is checked only at run boundaries: each run is scanned to
+        // completion (a partial scan would synthesize a wrong-length entry), so
+        // an over-budget pass leaves the remaining orphaned runs for next boot.
+        if (cfg_.recovery_budget_ms != 0 && now() - t0 > cfg_.recovery_budget_ms) {
+            FL_LOGW("recovery: %lu ms budget hit at block %lu/%lu — deferring the "
+                    "rest to next boot",
+                    (unsigned long)cfg_.recovery_budget_ms,
+                    (unsigned long)(b - cfg_.flight_region_start),
+                    (unsigned long)region_blocks);
+            break;
+        }
         if (bitmap_.get(b) != BLOCK_ALLOCATED || is_in_index(b)) {
             ++b;
             continue;
@@ -134,6 +171,11 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
         bool     saw_any             = false;
 
         for (uint32_t i = 0; i < run_len; ++i) {
+            if (++blocks_scanned % 256 == 0) {
+                FL_LOGI("recovery: scanned %lu/%lu blocks (%lu ms)",
+                        (unsigned long)blocks_scanned, (unsigned long)region_blocks,
+                        (unsigned long)(now() - t0));
+            }
             const uint32_t blk = run_start + i;
             if (bitmap_.get(blk) == BLOCK_BAD) continue;
 

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -28,6 +28,14 @@ public:
         uint16_t flight_region_start = 32;    // first block owned by this layer
         uint16_t flight_region_end   = 1020;  // one past last flight block
         uint16_t metadata_blocks[4]  = {1020, 1021, 1022, 1023};
+        // #277: wall-clock cap on one brownout-recovery pass so a chip with many
+        // large orphaned ranges can't scan for minutes and look hung past the
+        // app's 180 s power-on watchdog. Checked at run boundaries (never
+        // mid-run), so any unscanned runs simply defer to the next boot. 0 = off.
+        uint32_t recovery_budget_ms  = 90000;  // 90 s, comfortably under 180 s
+        // Monotonic-ms source for the budget; nullptr uses the built-in source
+        // (esp_timer on hardware, 0 on host so the budget is inert in tests).
+        uint32_t (*now_ms)()         = nullptr;
     };
 
     TR_FlightLog() = default;

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -262,8 +262,26 @@ void TR_I2C_Interface::slaveTxTask(void *arg)
         }
 
         uint32_t written = 0;
-        i2c_slave_write(self->_slave_dev, local, static_cast<uint32_t>(len),
-                        &written, SLAVE_TX_WRITE_TIMEOUT_MS);
+        esp_err_t werr = i2c_slave_write(self->_slave_dev, local,
+                                         static_cast<uint32_t>(len), &written,
+                                         SLAVE_TX_WRITE_TIMEOUT_MS);
+        // #280: surface a chronically failing serve. The status was discarded,
+        // so a TX that timed out every poll looked identical to a healthy one.
+        self->_tx_writes++;
+        if (werr != ESP_OK || written != len)
+        {
+            const uint32_t fails = ++self->_tx_write_fails;
+            // Rate-limit on the per-poll TX path: shout on the first failure,
+            // then every 256th, so a stuck serve stays visible without flooding.
+            if (fails == 1 || (fails % 256) == 0)
+            {
+                ESP_LOGW(TAG, "slave TX write failed: %s, wrote %lu/%lu B "
+                              "(fails=%lu of %lu serves)",
+                         esp_err_to_name(werr), (unsigned long)written,
+                         (unsigned long)len, (unsigned long)fails,
+                         (unsigned long)self->_tx_writes);
+            }
+        }
     }
 }
 

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -261,6 +261,15 @@ void TR_I2C_Interface::slaveTxTask(void *arg)
             len = 1;
         }
 
+        // #279: flush any residue left in the driver TX FIFO by a previous
+        // short/aborted read before staging this response. Otherwise a 232 B
+        // snapshot read that the FC cuts short can leave bytes the next 96 B
+        // status poll clocks out as stale — and the FC status path has no SOF
+        // rescan to recover. All driver TX-FIFO ops stay in this one task, so no
+        // lock is needed; the reset must precede the write (after it would wipe
+        // the response we just staged).
+        i2c_slave_reset_tx_fifo(self->_slave_dev);
+
         uint32_t written = 0;
         esp_err_t werr = i2c_slave_write(self->_slave_dev, local,
                                          static_cast<uint32_t>(len), &written,

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
@@ -114,6 +114,12 @@ private:
     static constexpr size_t SLAVE_TX_BUF_SIZE = 256;
     uint8_t _tx_buf[SLAVE_TX_BUF_SIZE];
     volatile size_t _tx_len;
+
+    // #280: slave-TX serve diagnostics. i2c_slave_write's status was discarded,
+    // so a serve that timed out every poll was indistinguishable from a healthy
+    // one. Counted in slaveTxTask, surfaced via a rate-limited ESP_LOGW.
+    uint32_t _tx_writes      = 0;  // total i2c_slave_write calls
+    uint32_t _tx_write_fails = 0;  // non-OK or short writes
 };
 
 #endif

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -104,6 +104,7 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
     bytes_received = 0;
     frames_received = 0;
     frames_dropped = 0;
+    drop_warned_ = false;
     recovery_performed = false;
     recovery_bytes = 0;
     file_open = false;
@@ -274,6 +275,19 @@ bool TR_LogToFlash::enqueueFrame(const uint8_t* frame, size_t len)
     if (!ringPush(frame, static_cast<uint32_t>(len)))
     {
         frames_dropped++;
+        // #278: the ring rejected the NEWEST frame (in-flight drop-newest). It's
+        // counted in frames_dropped / telemetry frames_drop, but warn loudly the
+        // first time so a truncated flight can't look healthy in the moment.
+        if (!drop_warned_)
+        {
+            drop_warned_ = true;
+            ESP_LOGW(TAG, "RING FULL in flight: dropped NEWEST frame (%lu B); log "
+                          "truncates at the tail (received=%lu, highwater=%lu). "
+                          "Further drops counted in frames_dropped.",
+                     static_cast<unsigned long>(len),
+                     static_cast<unsigned long>(frames_received),
+                     static_cast<unsigned long>(rb_highwater));
+        }
         return false;
     }
     return true;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -367,6 +367,7 @@ private:
     uint64_t bytes_received = 0;
     uint32_t frames_received = 0;
     uint32_t frames_dropped = 0;
+    bool     drop_warned_ = false;  // #278: one-shot loud warning on first in-flight drop
 
     // startup recovery
     bool recovery_performed = false;


### PR DESCRIPTION
Four small OC-side observability/resilience fixes from the pre-flight code review, batched on one branch. All OC firmware; #277 is gtest-covered, the rest build clean + bench-observable.

## #278 — warn on the first in-flight ring drop
In flight, when the NAND ring fills, `processFrame` drops the **newest** frame and bumps `frames_dropped` but logged nothing — a truncated flight looked healthy live. Now a one-shot `ESP_LOGW` (frame size / received / highwater) fires on the first drop. (`drop_warned_` flag rather than `== 1` because the increment is outside `push_mutex_`.)

## #277 — recovery time budget + progress log
`scanForBrownoutRecovery` had no wall-clock cap and emitted nothing, so a near-full chip could scan for tens of seconds and look hung vs the 180 s app watchdog. Adds a progress log every 256 blocks + `Config.recovery_budget_ms` (default 90 s), checked **at run boundaries** (never mid-run, which would forge a wrong-length entry) so an over-budget pass defers the remaining runs to the next boot. Host-safe (`monotonic_ms` + no-op log macros); clock injectable via `Config.now_ms` for the new gtest.

## #280 — surface failing I2C slave-TX serves
`slaveTxTask` discarded `i2c_slave_write`'s `esp_err_t` + byte count, so a serve timing out every poll looked healthy. Now counts writes/failures and `ESP_LOGW`s the first failure then every 256th (rate-limited on the per-poll path).

## #279 — flush the I2C TX FIFO before each serve
The 232 B snapshot and 96 B status poll share the 256 B TX ring; a short snapshot read at boot recovery could leave residue the next status poll clocks out stale (the FC status path has no SOF rescan). Now calls `i2c_slave_reset_tx_fifo()` before each `i2c_slave_write` (in the TX task, before — not after — the write).

## Verification
- OC firmware builds clean (esp32s3) at HEAD.
- Host gtests: **100/100** (`test_tr_flightlog_core`, incl. the new `RecoveryDefersWhenTimeBudgetExceeded`).
- Bench checks are observational (the new logs, `frames_drop` / `ring_highwater`, `i2c_query_ok/fail`).

Closes #278
Closes #277
Closes #280
Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
