### PR TITLE
attitude: plot FC gimbal-lock-free roll + fix NonSensor parsers (#295, #296)

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -57,7 +57,7 @@ MSG_EXPECTED_LEN = {
     MSG_ISM6HG256:        22,
     MSG_BMP585:           12,
     MSG_MMC5983MA:        16,
-    MSG_NON_SENSOR:       40,
+    MSG_NON_SENSOR:       (42, 43, 44, 48),
     MSG_POWER:            10,
     MSG_START_LOGGING:    None,
     MSG_END_FLIGHT:       None,
@@ -66,7 +66,12 @@ MSG_EXPECTED_LEN = {
 
 FMT_ISM6       = '<I hhh hhh hhh'
 FMT_BMP585     = '<I i I'
-FMT_NONSENSOR  = '<I hhhh iii iii BB h'
+# Mirror the central parser (plot_flight_data_mini): 5 leading int16 are the
+# quaternion q0..q3 + roll_cmd, NOT Euler roll/pitch/yaw (#295). Per-length FMTs.
+FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'
+FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'
+FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'
+FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'
 FMT_STATUS_QUERY = '<B H H hh B hhh'
 
 ROCKET_STATES = {
@@ -218,23 +223,42 @@ def parse_file(filepath):
                 })
 
             elif msg_type == MSG_NON_SENSOR:
-                fields = struct.unpack(FMT_NONSENSOR, payload)
-                flags = fields[11]
+                # #295: 5 leading int16 are the quaternion q0..q3 + roll_cmd
+                # (centideg); the old layout's 4 Euler int16 are gone. Pick the
+                # FMT by length and derive Euler from the quaternion, mirroring
+                # plot_flight_data_mini.parse_binary_file.
+                if msg_len == 48:
+                    fields = struct.unpack(FMT_NONSENSOR_48, payload)
+                elif msg_len == 44:
+                    fields = struct.unpack(FMT_NONSENSOR_44, payload)
+                elif msg_len == 43:
+                    fields = struct.unpack(FMT_NONSENSOR_43, payload)
+                else:
+                    fields = struct.unpack(FMT_NONSENSOR_42, payload)
+                q0, q1, q2, q3 = (fields[1] / 10000.0, fields[2] / 10000.0,
+                                  fields[3] / 10000.0, fields[4] / 10000.0)
+                roll  = math.degrees(math.atan2(2*(q0*q1 + q2*q3),
+                                                1 - 2*(q1*q1 + q2*q2)))
+                pitch = math.degrees(math.asin(max(-1.0, min(1.0,
+                                                2*(q0*q2 - q3*q1)))))
+                yaw   = math.degrees(math.atan2(2*(q0*q3 + q1*q2),
+                                                1 - 2*(q2*q2 + q3*q3)))
+                flags = fields[12]
                 nonsensor.append({
                     "time_us":       fields[0],
-                    "roll":          fields[1] / 100.0,
-                    "pitch":         fields[2] / 100.0,
-                    "yaw":           fields[3] / 100.0,
-                    "roll_cmd":      fields[4] / 100.0,
-                    "e_pos":         fields[5] / 100.0,
-                    "n_pos":         fields[6] / 100.0,
-                    "u_pos":         fields[7] / 100.0,
-                    "e_vel":         fields[8] / 100.0,
-                    "n_vel":         fields[9] / 100.0,
-                    "u_vel":         fields[10] / 100.0,
+                    "roll":          roll,
+                    "pitch":         pitch,
+                    "yaw":           yaw,
+                    "roll_cmd":      fields[5] / 100.0,
+                    "e_pos":         fields[6] / 100.0,
+                    "n_pos":         fields[7] / 100.0,
+                    "u_pos":         fields[8] / 100.0,
+                    "e_vel":         fields[9] / 100.0,
+                    "n_vel":         fields[10] / 100.0,
+                    "u_vel":         fields[11] / 100.0,
                     "flags":         flags,
-                    "rocket_state":  fields[12],
-                    "baro_alt_rate": fields[13] * 0.1,
+                    "rocket_state":  fields[13],
+                    "baro_alt_rate": fields[14] * 0.1,
                     "alt_landed":    bool(flags & NSF_ALT_LANDED),
                     "alt_apogee":    bool(flags & NSF_ALT_APOGEE),
                     "vel_apogee":    bool(flags & NSF_VEL_APOGEE),
@@ -298,11 +322,12 @@ def print_section(title):
 
 
 def main():
-    filepath = (
-        "/Users/christianpedersen/Documents/Hobbies/Model Rockets/"
-        "TestFlights/2026_03_08/Raw Downloads/Goblin Flight 2 F52/"
-        "flight_20260308_190239.bin"
-    )
+    # Take the log path from the CLI (the old hardcoded path was dead, so the
+    # tool couldn't be run on a real file).
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} <flight_log.bin>", file=sys.stderr)
+        sys.exit(1)
+    filepath = sys.argv[1]
 
     print(f"Parsing: {filepath}")
     ism6, bmp585, nonsensor, stats, config = parse_file(filepath)

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -131,6 +131,12 @@ FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'     # legacy (no pyro_status)
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'  # +pyro_status byte (#34)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'  # +apogee_flags byte (#142/#143)
 FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'  # +uint32 sensor_health (#303)
+# #296: lengths we know how to decode. An unrecognized NonSensor length means the
+# struct grew without updating this parser — warn loudly (once each) below instead
+# of silently dropping every record (the #227 failure shape). Add the new length
+# + a FMT_NONSENSOR_<len> when NonSensorData grows.
+NONSENSOR_KNOWN_LENS = (42, 43, 44, 48)
+_warned_nonsensor_lens = set()
 # OutStatusQueryData: 16 bytes (v2) / 26 bytes (v3, +b2r orientation)
 FMT_STATUS_QUERY = '<B H H hh B hhh'
 FMT_STATUS_QUERY_B2R = '<BB hhhh'  # b2r_code, b2r_mode, quat×10000 (payload[16:26])
@@ -470,7 +476,7 @@ def parse_binary_file(filepath):
                     "raw_z":    fields[3],
                 })
 
-            elif msg_type == MSG_NON_SENSOR and msg_len in (42, 43, 44, 48):
+            elif msg_type == MSG_NON_SENSOR and msg_len in NONSENSOR_KNOWN_LENS:
                 if msg_len == 48:
                     fields = struct.unpack(FMT_NONSENSOR_48, payload)
                     pyro_status = fields[15]
@@ -547,6 +553,19 @@ def parse_binary_file(filepath):
                     "reboot_recovery":    bool(apogee_flags_b & NSF2_REBOOT_RECOVERY),
                     "guidance_enabled":   bool(apogee_flags_b & NSF2_GUIDANCE_ENABLED),
                 })
+
+            elif msg_type == MSG_NON_SENSOR:
+                # #296: NonSensor frame with an unrecognized length — the struct
+                # grew and NONSENSOR_KNOWN_LENS / FMT_NONSENSOR_* weren't updated.
+                # Warn loudly (once per length) rather than silently dropping every
+                # record like #227.
+                if msg_len not in _warned_nonsensor_lens:
+                    _warned_nonsensor_lens.add(msg_len)
+                    sys.stderr.write(
+                        f"WARNING: NonSensor frame length {msg_len} B not in "
+                        f"{NONSENSOR_KNOWN_LENS} — records dropped. Update "
+                        f"NONSENSOR_KNOWN_LENS + add FMT_NONSENSOR_{msg_len} after a "
+                        f"NonSensorData struct change.\n")
 
             elif msg_type == MSG_POWER:
                 fields = struct.unpack(FMT_POWER, payload)

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -405,12 +405,21 @@ nonisolated class SensorConverter {
     // MARK: - Mini NonSensor Conversion
 
     func convertNonSensor(_ raw: NonSensorData) -> NonSensorDataSI {
-        // Quaternion int16*10000 -> float, then derive Euler (ZYX convention)
+        // Quaternion int16*10000 -> float, then derive angles.
         let q0 = Double(raw.q0) / 10000.0
         let q1 = Double(raw.q1) / 10000.0
         let q2 = Double(raw.q2) / 10000.0
         let q3 = Double(raw.q3) / 10000.0
-        let roll  = atan2(2*(q0*q1 + q2*q3), 1 - 2*(q1*q1 + q2*q2)) * 180.0 / .pi
+        // Roll: body-Z definition matching the FC roll controller
+        // (flight_computer/main.cpp: actual_roll_deg = -atan2(z_east, z_north)).
+        // Stays well-defined when the rocket is vertical, unlike the ZYX-Euler
+        // roll which gimbal-locks and cycles near pitch ±90°. Keep in sync with
+        // TelemetryData.roll.
+        let zNorth = 2*(q1*q3 + q0*q2)
+        let zEast  = 2*(q2*q3 - q0*q1)
+        let roll  = -atan2(zEast, zNorth) * 180.0 / .pi
+        // Pitch/yaw stay ZYX-Euler: asin pitch is robust; yaw is the heading and
+        // is inherently undefined when vertical (no formula avoids that).
         let pitch = asin(max(-1, min(1, 2*(q0*q2 - q3*q1)))) * 180.0 / .pi
         let yaw   = atan2(2*(q0*q3 + q1*q2), 1 - 2*(q2*q2 + q3*q3)) * 180.0 / .pi
         let roll_cmd = Double(raw.roll_cmd) / 100.0

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -51,9 +51,13 @@ struct TelemetryData: Codable {
         guard let w = q0, let x = q1, let y = q2, let z = q3 else { return nil }
         let norm = w*w + x*x + y*y + z*z
         guard norm > 0.1 && norm < 2.0 else { return nil }
-        let sinr = 2.0 * (w * x + y * z)
-        let cosr = 1.0 - 2.0 * (x * x + y * y)
-        return atan2(sinr, cosr) * 180.0 / .pi
+        // Body-Z roll, matching the FC roll controller (flight_computer/main.cpp:
+        // actual_roll_deg = -atan2(z_east, z_north)). Stays well-defined when the
+        // rocket is vertical, unlike the ZYX-Euler roll which gimbal-locks and
+        // cycles near pitch ±90°. Keep in sync with SensorConverter.convertNonSensor.
+        let zNorth = 2.0 * (x * z + w * y)
+        let zEast  = 2.0 * (y * z - w * x)
+        return -atan2(zEast, zNorth) * 180.0 / .pi
     }
     var pitch: Float? {
         guard let w = q0, let x = q1, let y = q2, let z = q3 else { return nil }


### PR DESCRIPTION
Two no-bench fixes to how rocket attitude is parsed and plotted, verified entirely on a recorded log + the iOS simulator (no rocket hardware).

## app — plot the FC roll controller's roll (gimbal-lock-free)
The app derives attitude from the logged quaternion (the FC logs no Euler), but used the ZYX-Euler roll, which gimbal-locks and cycles near vertical (pitch ≈ 90°) — exactly the pad/boost phase. The FC's roll controller uses a body-Z roll instead: `roll = -atan2(z_east, z_north)` (flight_computer/main.cpp), well-defined when vertical. Swapped both display paths (`TelemetryData.roll` live, `SensorConverter.convertNonSensor` for downloaded logs/charts/CSV) to the FC formula. Pitch (`asin`) unchanged; yaw stays ZYX (heading is inherently undefined at vertical). Legacy pre-quaternion logs untouched (no quaternion to recompute).

## #295 — analyze_launch_detection.py NonSensor parsing
Length table said `MSG_NON_SENSOR = 40` (rejected every 44/48-byte frame) and `FMT_NONSENSOR` decoded 4 Euler int16 (pre-quaternion), so its NonSensor analysis was silently empty. Mirrored the central parser (per-length FMTs, 5 quaternion int16, derive Euler, remap indices) + took the log path from argv (the hardcoded default was dead).

## #296 — plot_flight_data_mini.py robustness
The central parser already handles 48 B, but the gate was a bare length set — the next struct growth would silently drop every NonSensor record (the #227 shape). Added `NONSENSOR_KNOWN_LENS` + a loud warning when a NonSensor frame's length isn't recognized.

## Verification (recorded 6/26 log + iOS simulator, no rocket hardware)
- App **BUILD SUCCEEDED**.
- Gimbal-lock fix on real data: first 2 s near vertical, new roll stdev **6.4°** vs ZYX **23.2°** (3.6× steadier).
- **#295**: tool parses **7687 NonSensor** (was 0), sane apogee/velocity, state analysis works, CLI-runnable.
- **#296**: forcing an unknown length drops records **and emits the warning**; central parser still parses 7687.

Note: the roll is now a different (better-behaved) angle than before near vertical, so historical plots will look different there — correctly so.

Closes #295
Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
