### PR TITLE
Guided-flight EKF fusion fixes + tilt-limit gate + station-keep

### DIFF
--- a/Data_Analysis/replay_flight_ekf.py
+++ b/Data_Analysis/replay_flight_ekf.py
@@ -279,30 +279,19 @@ def replay(binary_file, plot_dir=None, align_baro=True):
 
             if not ekf_initialized:
                 ekf.init_lla(imu_d, gnss_d, mag_d)
-
-                # Pad heading init from accel + known heading
-                g_mag = math.sqrt(imu_d.acc_x**2 + imu_d.acc_y**2 +
-                                  imu_d.acc_z**2)
-                if g_mag > 0.1:
-                    pitch_rad = math.asin(max(-1, min(1, imu_d.acc_x / g_mag)))
-                    if abs(pitch_rad) > math.radians(80.0):
-                        roll_rad = 0.0
-                    else:
-                        roll_rad = math.atan2(-imu_d.acc_y, -imu_d.acc_z)
-                    # Use 0° heading (north) as default — we don't know actual heading
-                    yaw_rad = 0.0
-                    cy = math.cos(yaw_rad/2); sy = math.sin(yaw_rad/2)
-                    cp = math.cos(pitch_rad/2); sp = math.sin(pitch_rad/2)
-                    cr = math.cos(roll_rad/2); sr = math.sin(roll_rad/2)
-                    qw = cr*cp*cy + sr*sp*sy
-                    qx = sr*cp*cy - cr*sp*sy
-                    qy = cr*sp*cy + sr*cp*sy
-                    qz = cr*cp*sy - sr*sp*cy
-                    ekf.set_quaternion(qw, qx, qy, qz)
-
+                # FIDELITY FIX: pad attitude (INCLUDING heading) now comes from
+                # init_lla, which derives heading from the magnetometer — exactly
+                # as the firmware does. Previously this overrode it with yaw=0
+                # ("we don't know actual heading"), which discarded the mag-based
+                # pad heading and made the replay structurally unable to reproduce
+                # the firmware's rail-heading error (the root cause of the guided
+                # miss). With this removed the replay starts where the vehicle
+                # actually started.
                 ekf_initialized = True
-                print(f"  EKF initialized at t={t_rel:.2f}s  "
-                      f"pitch={math.degrees(pitch_rad):.1f}°")
+                q = ekf.get_quaternion()
+                yaw0 = math.degrees(math.atan2(2*(q[0]*q[3]+q[1]*q[2]),
+                                               1 - 2*(q[2]**2 + q[3]**2)))
+                print(f"  EKF initialized at t={t_rel:.2f}s  yaw(mag)={yaw0:.0f}°")
                 continue
 
             # Determine use_ahrs_acc based on flight phase
@@ -551,6 +540,10 @@ def replay(binary_file, plot_dir=None, align_baro=True):
         "accel_bias": accel_bias,
         "pad_alt": pad_alt,
         "ekf_alt_range": (float(ekf_u.min()), float(ekf_u.max())),
+        # Horizontal velocity / position / heading for fusion-tuning analysis.
+        "ekf_vn": ekf_vn, "ekf_ve": ekf_ve, "ekf_lat": ekf_lat, "ekf_lon": ekf_lon,
+        "ekf_yaw": ekf_yaw,
+        "g_vn": g_vn, "g_ve": g_ve, "g_lat": g_lat, "g_lon": g_lon,
         "boost_start_rel": (boost_start - t0_us) / 1e6 if boost_start else None,
         "apogee_rel": (apogee_us - t0_us) / 1e6 if apogee_us else None,
         "plots": plots,

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -207,6 +207,30 @@ void GpsInsEKF::updateCore(bool use_ahrs_acc,
     if ((gnss_time_us - timeWeekPrev_) > 0) {
         timeWeekPrev_ = gnss_time_us;
         measUpdate(pMeas_D_rrm, vMeas_NED);
+        // 10b. GNSS course-over-ground heading aiding — only with enough
+        //      horizontal speed for a well-defined course (else it's noise).
+        const float vh_sq = vMeas_NED[0]*vMeas_NED[0] + vMeas_NED[1]*vMeas_NED[1];
+        if (vh_sq > (3.0f*3.0f)) velCourseHeadingUpdate(vMeas_NED);
+
+        // 10c. Accel-match heading aiding — differentiate the GNSS velocity to
+        //      a world horizontal acceleration (low-passed), then match it to
+        //      the body lateral specific force to observe the roll DOF.
+        if (haveGnssAccel_ && prevGnssSampleUs_ != 0) {
+            const float dtg = (float)(t_us - prevGnssSampleUs_) * 1e-6f;
+            if (dtg > 0.005f && dtg < 0.5f) {
+                const float aN_raw = (vMeas_NED[0] - prevGnssVel_NED_[0]) / dtg;
+                const float aE_raw = (vMeas_NED[1] - prevGnssVel_NED_[1]) / dtg;
+                const float lp = 0.3f;
+                gnssAccelLP_NE_[0] += lp * (aN_raw - gnssAccelLP_NE_[0]);
+                gnssAccelLP_NE_[1] += lp * (aE_raw - gnssAccelLP_NE_[1]);
+                accelMatchHeadingUpdate(aMeas, gnssAccelLP_NE_);
+            }
+        }
+        prevGnssVel_NED_[0] = vMeas_NED[0];
+        prevGnssVel_NED_[1] = vMeas_NED[1];
+        prevGnssVel_NED_[2] = vMeas_NED[2];
+        prevGnssSampleUs_   = t_us;
+        haveGnssAccel_      = true;
     }
 
     // 11. Recompute estimates with post-update quaternion and biases
@@ -792,6 +816,169 @@ void GpsInsEKF::magMeasUpdate(const float aMeas[3], const float magMeas[3]) {
     stabilizeP();
 }
 
+// ─── Heading update from GNSS velocity course ───────────────────────
+// Treats the horizontal velocity direction (course over ground) as a heading
+// measurement: at low angle of attack the velocity vector ≈ the nose direction.
+// Same scalar-heading Kalman as magMeasUpdate (H ∝ body-down d), but the
+// measurement comes from the GNSS velocity — independent of the mag and of the
+// attitude tilt-comp, so it has none of the in-flight circularity that
+// destabilized the mag update. NOTE: it observes the NOSE direction, so near
+// vertical it sees only ~sin(tilt) of an azimuth/roll error — weak when vertical.
+void GpsInsEKF::velCourseHeadingUpdate(const float vMeas_NED[3]) {
+    float T_NED2B[3][3];
+    Quat2DCM(T_NED2B, quat_BL_);
+    const float d[3] = { T_NED2B[0][2], T_NED2B[1][2], T_NED2B[2][2] };
+
+    const float psi_meas = std::atan2(vMeas_NED[1], vMeas_NED[0]);     // course (E,N)
+    const float psi_pred = std::atan2(T_NED2B[0][1], T_NED2B[0][0]);   // nose azimuth
+
+    float y = psi_meas - psi_pred;
+    while (y >  (float)M_PI) y -= 2.0f * (float)M_PI;
+    while (y < -(float)M_PI) y += 2.0f * (float)M_PI;
+
+    const float R_course = 0.05f;   // ~13° course noise (rad²)
+    const float H6 = 2.0f*d[0], H7 = 2.0f*d[1], H8 = 2.0f*d[2];
+
+    float HP[15];
+    for (int j = 0; j < 15; j++)
+        HP[j] = H6*P_[6][j] + H7*P_[7][j] + H8*P_[8][j];
+    const float S = HP[6]*H6 + HP[7]*H7 + HP[8]*H8 + R_course;
+    if (!(S > 1e-9f)) return;
+    const float S_inv = 1.0f / S;
+
+    float K[15];
+    for (int i = 0; i < 15; i++)
+        K[i] = (P_[i][6]*H6 + P_[i][7]*H7 + P_[i][8]*H8) * S_inv;
+
+    float xk[15];
+    for (int i = 0; i < 15; i++) xk[i] = K[i] * y;
+
+    double Rew, Rns;
+    EarthRad(pEst_D_rrm_[0], &Rew, &Rns);
+    pEst_D_rrm_[2] -= xk[2];
+    pEst_D_rrm_[0] += xk[0] / (Rns + pEst_D_rrm_[2]);
+    pEst_D_rrm_[1] += xk[1] / ((Rew + pEst_D_rrm_[2]) * std::cos(pEst_D_rrm_[0]));
+    for (int i = 0; i < 3; i++) {
+        vEst_NED_mps_[i] += xk[i + 3];
+        aBias_mps2_[i]   += xk[i + 9];
+        wBias_rps_[i]    += xk[i + 12];
+    }
+
+    float quatDelta[4] = {1.0f, xk[6], xk[7], xk[8]};
+    normalizeQuaternion(quatDelta, quatDelta);
+    float qTemp[4];
+    multiplyQuaternions(quat_BL_, quatDelta, qTemp);
+    for (int i = 0; i < 4; i++) quat_BL_[i] = qTemp[i];
+
+    float Hrow[15] = {}; Hrow[6] = H6; Hrow[7] = H7; Hrow[8] = H8;
+    float I_KH[15][15];
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            I_KH[i][j] = (i == j ? 1.0f : 0.0f) - K[i] * Hrow[j];
+    float P_new[15][15] = {};
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            for (int k = 0; k < 15; k++)
+                P_new[i][j] += I_KH[i][k] * P_[k][j];
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++) {
+            float sum = 0;
+            for (int k = 0; k < 15; k++) sum += P_new[i][k] * I_KH[j][k];
+            P_[i][j] = sum + K[i] * R_course * K[j];
+        }
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j <= i; j++) {
+            float s = 0.5f * (P_[i][j] + P_[j][i]);
+            P_[i][j] = s; P_[j][i] = s;
+        }
+    stabilizeP();
+}
+
+// ─── Heading update by body↔world lateral-acceleration matching ─────
+// The aero side force (AoA + fins) is measured in the BODY frame (accelerometer
+// lateral components) and in the WORLD frame (GNSS-derived horizontal accel).
+// They are the same force, so the azimuth between them IS the roll/heading —
+// the one DOF the velocity course cannot see near vertical (rolling the body
+// does not move the nose, but it does rotate the lateral force in the world).
+// Only the LATERAL body force is used (axial/nose component zeroed) so boost
+// thrust doesn't dominate; caller gates on a clear lateral force in both frames.
+void GpsInsEKF::accelMatchHeadingUpdate(const float aMeas[3], const float aWorldHoriz[2]) {
+    float T_NED2B[3][3];
+    Quat2DCM(T_NED2B, quat_BL_);
+    const float d[3] = { T_NED2B[0][2], T_NED2B[1][2], T_NED2B[2][2] };
+
+    // Rotate the body LATERAL specific force (0, a_y, a_z) into NED.
+    const float ay = aMeas[1], az = aMeas[2];
+    const float a_pred_N = T_NED2B[1][0]*ay + T_NED2B[2][0]*az;
+    const float a_pred_E = T_NED2B[1][1]*ay + T_NED2B[2][1]*az;
+    const float pred_h = std::sqrt(a_pred_N*a_pred_N + a_pred_E*a_pred_E);
+    const float meas_h = std::sqrt(aWorldHoriz[0]*aWorldHoriz[0] + aWorldHoriz[1]*aWorldHoriz[1]);
+    if (pred_h < 0.5f || meas_h < 0.5f) return;   // need a clear lateral force
+
+    const float psi_pred = std::atan2(a_pred_E, a_pred_N);
+    const float psi_meas = std::atan2(aWorldHoriz[1], aWorldHoriz[0]);
+    float y = psi_meas - psi_pred;
+    while (y >  (float)M_PI) y -= 2.0f * (float)M_PI;
+    while (y < -(float)M_PI) y += 2.0f * (float)M_PI;
+
+    const float R_am = 0.20f;   // ~26° (rad²) — GNSS-derived accel is noisy
+    const float H6 = 2.0f*d[0], H7 = 2.0f*d[1], H8 = 2.0f*d[2];
+
+    float HP[15];
+    for (int j = 0; j < 15; j++)
+        HP[j] = H6*P_[6][j] + H7*P_[7][j] + H8*P_[8][j];
+    const float S = HP[6]*H6 + HP[7]*H7 + HP[8]*H8 + R_am;
+    if (!(S > 1e-9f)) return;
+    const float S_inv = 1.0f / S;
+
+    float K[15];
+    for (int i = 0; i < 15; i++)
+        K[i] = (P_[i][6]*H6 + P_[i][7]*H7 + P_[i][8]*H8) * S_inv;
+
+    float xk[15];
+    for (int i = 0; i < 15; i++) xk[i] = K[i] * y;
+
+    double Rew, Rns;
+    EarthRad(pEst_D_rrm_[0], &Rew, &Rns);
+    pEst_D_rrm_[2] -= xk[2];
+    pEst_D_rrm_[0] += xk[0] / (Rns + pEst_D_rrm_[2]);
+    pEst_D_rrm_[1] += xk[1] / ((Rew + pEst_D_rrm_[2]) * std::cos(pEst_D_rrm_[0]));
+    for (int i = 0; i < 3; i++) {
+        vEst_NED_mps_[i] += xk[i + 3];
+        aBias_mps2_[i]   += xk[i + 9];
+        wBias_rps_[i]    += xk[i + 12];
+    }
+
+    float quatDelta[4] = {1.0f, xk[6], xk[7], xk[8]};
+    normalizeQuaternion(quatDelta, quatDelta);
+    float qTemp[4];
+    multiplyQuaternions(quat_BL_, quatDelta, qTemp);
+    for (int i = 0; i < 4; i++) quat_BL_[i] = qTemp[i];
+
+    float Hrow[15] = {}; Hrow[6] = H6; Hrow[7] = H7; Hrow[8] = H8;
+    float I_KH[15][15];
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            I_KH[i][j] = (i == j ? 1.0f : 0.0f) - K[i] * Hrow[j];
+    float P_new[15][15] = {};
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++)
+            for (int k = 0; k < 15; k++)
+                P_new[i][j] += I_KH[i][k] * P_[k][j];
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j < 15; j++) {
+            float sum = 0;
+            for (int k = 0; k < 15; k++) sum += P_new[i][k] * I_KH[j][k];
+            P_[i][j] = sum + K[i] * R_am * K[j];
+        }
+    for (int i = 0; i < 15; i++)
+        for (int j = 0; j <= i; j++) {
+            float s = 0.5f * (P_[i][j] + P_[j][i]);
+            P_[i][j] = s; P_[j][i] = s;
+        }
+    stabilizeP();
+}
+
 // ─── Measurement Update (GNSS correction) ───────────────────────────
 
 void GpsInsEKF::measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]) {
@@ -844,14 +1031,19 @@ void GpsInsEKF::measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]) {
     // vertical velocity lagging during high-g boost — reject the ENTIRE
     // pos+vel update, discarding the good horizontal-velocity correction so
     // horizontal velocity dead-reckons and runs away.  Test the position
-    // (3-DOF) and velocity (3-DOF) blocks independently; on a trip de-weight
-    // only that block (inflate its R) rather than dropping the whole
-    // measurement.  The marginal precision of each block is the inverse of
-    // that block of S.  chi²(3, 0.001) ≈ 16.27.
+    // (3-DOF) and velocity blocks independently; on a trip de-weight only that
+    // block (inflate its R) rather than dropping the whole measurement.  The
+    // velocity block is split further into horizontal (2-DOF) and vertical
+    // (1-DOF): the boost vertical-velocity lag is exactly the inconsistency
+    // that must not be allowed to de-weight the GOOD horizontal velocity — else
+    // horizontal velocity dead-reckons and snaps to GNSS position each fix (the
+    // sawtooth seen in guidance).  Marginal precision of each block is the
+    // inverse of that block of S.  chi²(0.001): 3-DOF≈16.27, 2≈13.82, 1≈10.83.
     {
-        static constexpr float CHI2_GATE_3DOF = 16.27f;
+        static constexpr float CHI2_GATE_3DOF = 16.27f;  // χ²(3, 0.001) — position
+        static constexpr float CHI2_GATE_2DOF = 13.82f;  // χ²(2, 0.001) — horiz velocity
+        static constexpr float CHI2_GATE_1DOF = 10.83f;  // χ²(1, 0.001) — vert  velocity
         float Spp[9] = { S[0],  S[1],  S[2],  S[6],  S[7],  S[8],  S[12], S[13], S[14] };
-        float Svv[9] = { S[21], S[22], S[23], S[27], S[28], S[29], S[33], S[34], S[35] };
         float Sinv3[9];
         // Huber-style soft de-weight: when a block's NIS exceeds the gate,
         // inflate that block's R by (NIS/gate) instead of rejecting it.  An
@@ -860,20 +1052,36 @@ void GpsInsEKF::measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]) {
         // fully discarded — so the filter can still recover after it has
         // drifted (e.g. a large reacquired-GNSS velocity innovation following
         // a GNSS gap keeps pulling the estimate back).
-        float infl_pos = 1.0f, infl_vel = 1.0f;
+        float infl_pos = 1.0f, infl_vh = 1.0f, infl_vd = 1.0f;
         if (invertMatrix3x3(Spp, Sinv3)) {
             float nis = 0.0f;
             for (int i=0;i<3;i++){ float r=0; for(int j=0;j<3;j++) r+=Sinv3[i*3+j]*y[j]; nis+=y[i]*r; }
             if (nis > CHI2_GATE_3DOF) infl_pos = nis / CHI2_GATE_3DOF;
         }
-        if (invertMatrix3x3(Svv, Sinv3)) {
-            float nis = 0.0f;
-            for (int i=0;i<3;i++){ float r=0; for(int j=0;j<3;j++) r+=Sinv3[i*3+j]*y[3+j]; nis+=y[3+i]*r; }
-            if (nis > CHI2_GATE_3DOF) infl_vel = nis / CHI2_GATE_3DOF;
+        // Horizontal velocity (vN, vE) — 2×2 innovation block, indices 3,4.
+        {
+            const float a = S[21], b = S[22], c = S[27], d = S[28];  // [[vN-vN,vN-vE],[vE-vN,vE-vE]]
+            const float det = a*d - b*c;
+            if (fabsf(det) > 1e-12f) {
+                const float yN = y[3], yE = y[4];
+                // NIS = yᵀ Sₕ⁻¹ y, with Sₕ⁻¹ = (1/det)[[d,-b],[-c,a]].
+                const float nis = (yN*(d*yN - b*yE) + yE*(a*yE - c*yN)) / det;
+                if (nis > CHI2_GATE_2DOF) infl_vh = nis / CHI2_GATE_2DOF;
+            }
         }
-        if (infl_pos > 1.0f || infl_vel > 1.0f) {
+        // Vertical velocity (vD) — 1×1 block, index 5. This is the term that
+        // lags in high-g boost; isolating it keeps that lag from de-weighting
+        // the horizontal velocity above.
+        {
+            const float Svd = S[35];
+            if (Svd > 1e-12f) {
+                const float nis = (y[5]*y[5]) / Svd;
+                if (nis > CHI2_GATE_1DOF) infl_vd = nis / CHI2_GATE_1DOF;
+            }
+        }
+        if (infl_pos > 1.0f || infl_vh > 1.0f || infl_vd > 1.0f) {
             R_scaled[0][0]*=infl_pos; R_scaled[1][1]*=infl_pos; R_scaled[2][2]*=infl_pos;
-            R_scaled[3][3]*=infl_vel; R_scaled[4][4]*=infl_vel; R_scaled[5][5]*=infl_vel;
+            R_scaled[3][3]*=infl_vh;  R_scaled[4][4]*=infl_vh;  R_scaled[5][5]*=infl_vd;
             for (int i=0;i<6;i++) for (int j=0;j<6;j++) {
                 float s=0.0f; for (int k=0;k<15;k++) s+=H_P[i][k]*H_T[k][j];
                 S[i*6+j]=s+R_scaled[i][j];

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -206,6 +206,16 @@ private:
     void measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]);
     void accelMeasUpdate(const float aMeas[3]);
     void magMeasUpdate(const float aMeas[3], const float magMeas[3]);
+    // Heading update from the GNSS velocity course (direction of travel ≈ nose
+    // heading at low AoA). Independent of mag/attitude tilt-comp (no
+    // circularity). Caller gates on sufficient horizontal speed.
+    void velCourseHeadingUpdate(const float vMeas_NED[3]);
+    // Heading update by matching the body-frame lateral specific force (aero
+    // side force from AoA/fins) against the GNSS-derived world horizontal
+    // acceleration. The rotation between the two frames IS the roll, so unlike
+    // the velocity course this observes the roll DOF directly — strongest near
+    // vertical with an active lateral force. aWorldHoriz = [aN, aE] (m/s²).
+    void accelMatchHeadingUpdate(const float aMeas[3], const float aWorldHoriz[2]);
 
     // Numerical safety net: floor P diagonals at a tiny positive value and
     // cap them at the per-state P_MAX_* values. Call after every path that
@@ -237,8 +247,19 @@ private:
     float wMarkovTau_s = 50.0f;
     float pNoiseSigma_NE_m = 3.0f;
     float pNoiseSigma_D_m = 6.0f;
-    float vNoiseSigma_NE_mps = 0.5f;
-    float vNoiseSigma_D_mps = 1.0f;
+    // GNSS Doppler velocity is better than the old values implied. Measured
+    // sample noise in benign coast: horizontal ~0.2 m/s, vertical ~0.28 m/s.
+    // The old 0.5 / 1.0 under-trusted it ~6×/13× in variance, so the filter
+    // dead-reckoned instead of using a good measurement. Tighten both to ~0.3
+    // (matched to the clean-case noise). The boost failure mode is NOT a uniform
+    // 1 m/s degradation and NOT loss of fix (stays 3D, 13 sats) — it is a large
+    // *systematic* corruption (~6 m/s vertical). That is exactly what the
+    // per-axis NIS gate in measUpdate() rejects (horizontal 2-DOF, vertical
+    // 1-DOF independently), so tight nominal R + the gate is the right model:
+    // trust the clean measurement, reject the corrupted one. Vertical position
+    // is also baro-anchored, so over-trusting vertical velocity is low risk.
+    float vNoiseSigma_NE_mps = 0.3f;
+    float vNoiseSigma_D_mps  = 0.3f;
 
     // Initial covariance
     static constexpr float pErrSigma_Init_m = 10.0f;
@@ -260,6 +281,14 @@ private:
     uint32_t timeWeekPrev_;
     uint32_t baroTimePrev_ = 0;
     float euler_BL_rad_[3];
+
+    // GNSS-acceleration estimate for accelMatchHeadingUpdate: previous GNSS
+    // velocity + sample time to difference, and a low-pass on the result
+    // (differencing 25 Hz velocity is noisy).
+    float    prevGnssVel_NED_[3] = {0,0,0};
+    uint32_t prevGnssSampleUs_   = 0;
+    bool     haveGnssAccel_      = false;
+    float    gnssAccelLP_NE_[2]  = {0,0};   // low-passed world horizontal accel
 
     // #257/#265 health: counts down (one per timeUpdate) after stabilizeP()
     // repairs a non-finite covariance — a genuine divergence — keeping

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -328,6 +328,15 @@ struct config
     static constexpr float PN_YAW_KD = 0.0003f;
     // Max individual fin deflection in guided mode (deg)
     static constexpr float PN_MAX_FIN_DEG = 15.0f;
+    // Tilt-limit safety gate: if the off-vertical angle of the nose (from EKF
+    // attitude) exceeds the phase limit, guidance is LATCHED off and the
+    // vehicle falls back to roll-only for the rest of the flight. Guidance has
+    // little authority once badly tilted (lateral accel ∝ q ∝ V², collapsing
+    // in coast) and a heading-error could push the wrong way, so a hard tilt
+    // ceiling is a safety floor. Boost limit is tighter (a vertical boost
+    // should stay near-vertical); coast allows more before giving up.
+    static constexpr float GUIDANCE_TILT_LIMIT_BOOST_DEG = 15.0f;
+    static constexpr float GUIDANCE_TILT_LIMIT_COAST_DEG = 20.0f;
     // Fin→servo layout (cruciform mix shared by roll / ground-test / guidance).
     // FIN_AZIMUTH_n_DEG = control azimuth of servo n: deflection_n = sign_n·(roll
     // + pitch·cos(az_n) + yaw·sin(az_n)).  Defaults reproduce the legacy "+"

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -375,6 +375,10 @@ static uint16_t burnout_neg_count = 0;
 static bool mach_locked_out = false;    // promoted from baro block for apogee voting
 static bool gps_new_for_kc = false;     // new GPS sample available for kinematic checks
 static bool guidance_active = false;
+// Tilt-limit safety latch: set true once the off-vertical tilt exceeds the
+// phase limit (config::GUIDANCE_TILT_LIMIT_*); guidance then stays roll-only
+// for the rest of the flight. Reset at re-arm alongside guidance.reset().
+static bool guidance_tilt_inhibited = false;
 static bool ground_test_active = false;
 // Last roll fin command (deg) produced by the ground-test / guidance paths
 // that bypass servo_control's internal PID. Used to populate
@@ -4527,6 +4531,7 @@ static void loop_fc()
             {
                 guidance_enabled = false;
                 guidance_active = false;
+                guidance_tilt_inhibited = false;   // clear tilt-limit latch
                 guidance.reset();
                 control_mixer.reset();
                 roll_rate_pid_standalone.reset();
@@ -5235,6 +5240,7 @@ static void loop_fc()
                     burnout_time_ms = 0;
                     burnout_neg_count = 0;
                     guidance_active = false;
+                    guidance_tilt_inhibited = false;   // clear tilt-limit latch
                     // Reset pyro channels on launch. ARM stays LOW until a
                     // channel's trigger fires (per-fire arming on new PCB).
                     pyro_apogee_detected = false;
@@ -5355,10 +5361,37 @@ static void loop_fc()
                         // keep guidance post-boost.  Still needs a healthy EKF + airspeed
                         // (pn_min_speed) and stops at closest point of approach (CPA).
                         // (pn_coast_delay_ms / burnout are no longer gates here.)
+                        // Tilt-limit safety gate: off-vertical angle of the nose
+                        // (body-X) from EKF attitude. Tilt is well-observed even
+                        // when heading is degraded (it's the gravity-aligned part
+                        // of the attitude), so the FC can trust its own estimate.
+                        // Latched: once tripped, guidance stays off for the flight.
+                        {
+                            float gq[4];
+                            ekf.getQuaternion(gq);
+                            // cos(tilt) = up-component of the nose in NED = -D row.
+                            float nose_up = -2.0f * (gq[1]*gq[3] - gq[0]*gq[2]);
+                            if (nose_up >  1.0f) nose_up =  1.0f;
+                            if (nose_up < -1.0f) nose_up = -1.0f;
+                            float tilt_deg = acosf(nose_up) * (180.0f / (float)M_PI);
+                            float tilt_limit = burnout_detected
+                                ? config::GUIDANCE_TILT_LIMIT_COAST_DEG
+                                : config::GUIDANCE_TILT_LIMIT_BOOST_DEG;
+                            if (guidance_enabled && !guidance_tilt_inhibited &&
+                                tilt_deg > tilt_limit) {
+                                guidance_tilt_inhibited = true;
+                                ESP_LOGW(TAG, "[GUID] tilt %.1f deg > %.0f limit (%s) "
+                                         "— guidance LATCHED off, roll-only for flight",
+                                         (double)tilt_deg, (double)tilt_limit,
+                                         burnout_detected ? "coast" : "boost");
+                            }
+                        }
+
                         const bool coast_guidance_active =
                             guidance_enabled &&
                             ekf_initialized &&
                             ekf_ctrl_healthy &&   // #265: don't fly guidance on a diverged EKF
+                            !guidance_tilt_inhibited &&  // tilt-limit safety latch
                             (speed > pn_min_speed) &&
                             !guidance.isCpaReached();
 

--- a/tinkerrocket-sim/cpp/guidance/guidance_bindings.cpp
+++ b/tinkerrocket-sim/cpp/guidance/guidance_bindings.cpp
@@ -12,6 +12,12 @@ PYBIND11_MODULE(_guidance, m) {
         .def("configure", &TR_GuidancePN::configure,
              py::arg("nav_gain"), py::arg("max_accel_mps2"),
              py::arg("target_alt_m"))
+        .def("configure_station_keep", &TR_GuidancePN::configureStationKeep,
+             py::arg("kp_pos_per_s2"), py::arg("kd_vel_per_s"),
+             py::arg("max_accel_mps2"))
+        .def("get_mode", [](const TR_GuidancePN& self) {
+            return static_cast<int>(self.getMode());
+        })
         .def("update", [](TR_GuidancePN& self,
                           std::array<float, 3> pos_enu,
                           std::array<float, 3> vel_ned,

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -118,6 +118,12 @@ class SimConfig:
     # (removes AHRS convergence error, isolates pure IMU integration drift)
     inject_truth_orientation_at_ignition: bool = False
 
+    # Heading-bias injection: at ignition, rotate the EKF attitude by this many
+    # degrees about the world vertical (NED-down). Mimics a corrupted pad-mag
+    # heading (e.g. steel launch rail) seeding a fixed heading error. Used to
+    # test whether the in-flight magnetometer update recovers it.
+    inject_heading_bias_deg: float = 0.0
+
     # Pad heading initialization: when set (not None), the EKF quaternion is
     # initialized from the accelerometer (pitch/roll) + this known heading.
     # Simulates real hardware where the board Z-axis points in a known direction
@@ -155,6 +161,11 @@ class SimConfig:
     # Guided mode limits
     pn_max_fin_deg: float = 15.0
     pn_min_speed_mps: float = 15.0
+    # Tilt-limit safety gate (mirrors FC config::GUIDANCE_TILT_LIMIT_*): if the
+    # off-vertical tilt from EKF attitude exceeds the phase limit, guidance is
+    # LATCHED off (roll-only) for the rest of the flight.
+    guidance_tilt_limit_boost_deg: float = 15.0
+    guidance_tilt_limit_coast_deg: float = 20.0
     # LEGACY — no longer a guidance gate. The firmware dropped the post-burnout
     # "coast delay" in favour of the shared activation delay (roll_delay_s); kept
     # only so callers passing it don't break. See roll_delay_s above.
@@ -266,9 +277,13 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         from tinkerrocket_sim._mixer import ControlMixer
 
         guidance = GuidancePN()
-        guidance.configure(
-            config.pn_nav_gain, config.pn_max_accel_mps2,
-            config.pn_target_alt_m)  # OVERHEAD: aim straight up over the pad
+        if config.guidance_mode == 'station_keep':
+            guidance.configure_station_keep(
+                config.pn_kp_pos, config.pn_kd_vel, config.pn_max_accel_mps2)
+        else:
+            guidance.configure(
+                config.pn_nav_gain, config.pn_max_accel_mps2,
+                config.pn_target_alt_m)  # OVERHEAD: aim straight up over the pad
 
         control_mixer = ControlMixer()
         control_mixer.configure(
@@ -319,6 +334,8 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
     fin_cmds = np.zeros(4)
     fin_actuals = np.zeros(4)
     guidance_active = False
+    guidance_tilt_inhibited = False  # tilt-limit safety latch (FC: guidance_tilt_inhibited)
+    guidance_tilt_trip_t = None      # time the latch tripped (for reporting/plots)
     burnout_detected = False
     burnout_time = None
     guidance_cpa_reached = False  # closest point of approach — stop guidance
@@ -327,6 +344,7 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
     ekf_initialized = False
     gnss_time_counter = 0
     truth_quat_injected = False
+    heading_bias_injected = False
 
     # Logging
     log_rows = []
@@ -575,6 +593,20 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                     ekf.set_velocity(vel[1], vel[0], -vel[2])
                     truth_quat_injected = True
 
+                # --- Heading-bias injection at ignition (rail-mag mimic) ---
+                if (config.inject_heading_bias_deg != 0.0 and
+                        not heading_bias_injected and t >= 0.0):
+                    dpsi = math.radians(config.inject_heading_bias_deg)
+                    qd = (math.cos(dpsi / 2.0), 0.0, 0.0, math.sin(dpsi / 2.0))  # about NED-down
+                    qe = ekf.get_quaternion()  # (w,x,y,z), FRD→NED
+                    # q_new = qd ⊗ qe (rotate body azimuth by dpsi in the world)
+                    w = qd[0]*qe[0] - qd[1]*qe[1] - qd[2]*qe[2] - qd[3]*qe[3]
+                    x = qd[0]*qe[1] + qd[1]*qe[0] + qd[2]*qe[3] - qd[3]*qe[2]
+                    y = qd[0]*qe[2] - qd[1]*qe[3] + qd[2]*qe[0] + qd[3]*qe[1]
+                    z = qd[0]*qe[3] + qd[1]*qe[2] - qd[2]*qe[1] + qd[3]*qe[0]
+                    ekf.set_quaternion(w, x, y, z)
+                    heading_bias_injected = True
+
                 # --- Baro measurement + Mach lockout ---
                 a_sound = atm.speed_of_sound(alt + config.ref_alt_m)
                 latest_mach = speed / a_sound if a_sound > 0 else 0.0
@@ -609,9 +641,30 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                 # activation delay (launch+roll_delay_s), gated only by airspeed
                 # and not-yet-CPA — NOT by burnout (FC main.cpp comment: "burnout
                 # are no longer gates here").
+                # Tilt-limit safety gate (mirrors FC main.cpp): off-vertical tilt
+                # of the nose from EKF attitude. Latched — once tripped, guidance
+                # stays roll-only for the rest of the flight. Only checked after
+                # launch+activation delay (the FC checks it inside the post-launch
+                # control block), so a pad-init attitude transient can't trip it.
+                if (config.guidance_enabled and not guidance_tilt_inhibited
+                        and t >= config.roll_delay_s):
+                    eq = ekf.get_quaternion()  # (q0,q1,q2,q3) body->NED
+                    nose_up = -2.0 * (eq[1]*eq[3] - eq[0]*eq[2])
+                    nose_up = max(-1.0, min(1.0, nose_up))
+                    tilt_deg = math.degrees(math.acos(nose_up))
+                    tilt_limit = (config.guidance_tilt_limit_coast_deg if burnout_detected
+                                  else config.guidance_tilt_limit_boost_deg)
+                    if tilt_deg > tilt_limit:
+                        guidance_tilt_inhibited = True
+                        guidance_tilt_trip_t = t
+                        print(f"  [GUID] tilt {tilt_deg:.1f} deg > {tilt_limit:.0f} "
+                              f"limit ({'coast' if burnout_detected else 'boost'}) "
+                              f"@t={t:.2f}s — guidance LATCHED off, roll-only")
+
                 guidance_active = False
                 if (config.guidance_enabled and guidance is not None and
                         t >= config.roll_delay_s and
+                        not guidance_tilt_inhibited and
                         not guidance_cpa_reached and
                         speed > config.pn_min_speed_mps):
                     guidance_active = True


### PR DESCRIPTION
Guidance/EKF work from debugging a guided flight whose horizontal position,
velocity, and guidance commands showed a ramp-and-snap sawtooth and an
uncorrected near-vertical heading. Four independent commits.

## Commits
1. **ekf: per-axis GNSS velocity gating, Doppler R retune, in-flight heading aids**
   - Splits the #174 velocity NIS gate into horizontal (2-DOF) + vertical
     (1-DOF) so the known boost vertical-velocity corruption (~6 m/s,
     systematic, fix stays 3D) no longer de-weights the *good* horizontal
     velocity — the cause of the dead-reckon-and-snap sawtooth.
   - Retunes GNSS Doppler R to the measured noise (horiz ~0.2, vert ~0.28 m/s;
     was 0.5/1.0, ~6x/13x too loose), letting the filter use a good
     measurement instead of dead-reckoning. The per-axis gate rejects the
     boost corruption, so tight nominal R is safe.
   - Adds two in-flight scalar heading updates (GNSS course; body-vs-world
     accel match) that work near vertical, where accel+mag are gated off.
2. **fc: latched tilt-limit guidance safety gate** — falls back to roll-only
   (latched) if EKF off-vertical tilt exceeds a per-phase limit (15 deg boost
   / 20 deg coast).
3. **sim: station-keep guidance, tilt gate, G80 + heading-bias harness** —
   closed-loop support; **bumps the TR_GuidancePN submodule** to add the
   station-keep PD law.
4. **analysis: fix replay EKF pad-heading init (use mag, not yaw=0)** — the
   replay discarded the firmware's mag heading; now it reproduces the flight.

## Validation
- A/B replay of the flight log (faithful after commit 4): horizontal sawtooth
  **0.12 -> 0.055 m (-54%)**, velocity self-consistency **88 -> ~100%**,
  vertical corruption gated per-axis (boost NIS ~500 vs gate 10.83).
- 19 EKF gtests pass. FC firmware builds clean (IDF v6.0). Rebased on current
  main (#334).

## Dependency
The submodule pointer references `Tinkerbug-Robotics/TR_GuidancePN@station-keep`
(pushed). CI clones the private submodule via token, so that branch must exist
remotely for CI — it does.

## Known follow-ups (not in this PR)
- Replay absolute heading still offset from firmware (no declination, raw PCB
  hard-iron) — faithful enough for velocity/sawtooth A/B, not absolute heading.
- Guidance control-authority vs wind, and inner-loop boost over-control, are
  open (separate from this nav/safety work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
