### PR TITLE
app: BLE resilience, pyro fire-guard, tolerant telemetry decode, dead-view cleanup (#290-294)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -74,7 +74,7 @@ class BLEFleet: NSObject, ObservableObject {
 
     // Reconnection state
     private var reconnectAttempts: Int = 0
-    private let maxReconnectAttempts = 3
+    private let maxReconnectAttempts = 8   // #291: was 3 (~7 s); raised for flight dropouts
     private var lastPeripheralIdentifier: UUID?
     private var userInitiatedDisconnect = false
     private var reconnectingPeripheral: CBPeripheral?
@@ -202,6 +202,11 @@ extension BLEFleet: CBCentralManagerDelegate {
             if let p = reconnectingPeripheral, p.state == .connected {
                 print("[BLE] Restored peripheral still connected — resuming")
                 let device = BLEDevice(peripheral: p, name: p.name ?? "Restored")
+                // #290: mirror the didConnect path. Without the fleet backref,
+                // fleet?.recordRocketFix() no-ops, so lastValidRocketFix never
+                // populates and the map marker / direction arrow / landing anchor
+                // stay blank for the whole restored session.
+                device.fleet = self
                 device.onConnect()
                 devices.append(device)
                 activeDeviceID = p.identifier
@@ -308,7 +313,8 @@ extension BLEFleet: CBCentralManagerDelegate {
         if reconnectAttempts < maxReconnectAttempts {
             reconnectAttempts += 1
             statusMessage = "Reconnecting (\(reconnectAttempts)/\(maxReconnectAttempts))..."
-            let delay = pow(2.0, Double(reconnectAttempts - 1))
+            // #291: cap the backoff — 2^(n-1) blows up fast once the cap is raised.
+            let delay = min(8.0, pow(2.0, Double(reconnectAttempts - 1)))
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
                 guard let self = self, self.device(for: peripheral) == nil else { return }
                 // Retain across the reconnect attempt too (#173).
@@ -316,12 +322,16 @@ extension BLEFleet: CBCentralManagerDelegate {
                 self.centralManager.connect(peripheral, options: nil)
             }
         } else {
+            // #291: don't abandon the flight after a handful of tries. CB
+            // connect() has no timeout — it completes whenever the peripheral
+            // returns to range — so leave a connect pending AND fall back to
+            // scanning so a returning device re-pairs automatically, instead of
+            // the old dead-end ("Disconnected" + cleared list).
             reconnectAttempts = 0
-            statusMessage = "Disconnected"
-            discoveredDevices = []
-            if devices.isEmpty {
-                UIApplication.shared.isIdleTimerDisabled = false
-            }
+            statusMessage = "Searching for \(peripheral.name ?? "rocket")…"
+            connectingPeripherals[peripheral.identifier] = peripheral
+            centralManager.connect(peripheral, options: nil)
+            startScanning()
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -260,6 +260,19 @@ struct TelemetryData: Codable {
     // Custom decoder: non-optional fields with defaults need decodeIfPresent
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        // #293: tolerate a high-value field emitted as a float or string instead
+        // of an int — firmware-contract drift on one field would otherwise throw
+        // and the catch discards the WHOLE telemetry frame. Mirrors the defensive
+        // config decode. Float fields already accept int JSON, so only the ints
+        // below need this.
+        func flexInt(_ key: CodingKeys) -> Int? {
+            if let i = try? c.decodeIfPresent(Int.self, forKey: key) { return i }
+            if let d = try? c.decodeIfPresent(Double.self, forKey: key) { return Int(d) }
+            if let s = try? c.decodeIfPresent(String.self, forKey: key) {
+                return Int(s) ?? Double(s).map { Int($0) }
+            }
+            return nil
+        }
         soc = try c.decodeIfPresent(Float.self, forKey: .soc)
         current = try c.decodeIfPresent(Float.self, forKey: .current)
         voltage = try c.decodeIfPresent(Float.self, forKey: .voltage)
@@ -297,15 +310,15 @@ struct TelemetryData: Codable {
         bs_voltage = try c.decodeIfPresent(Float.self, forKey: .bs_voltage)
         bs_current = try c.decodeIfPresent(Float.self, forKey: .bs_current)
         bs_log_silence_remaining_s = try c.decodeIfPresent(UInt16.self, forKey: .bs_log_silence_remaining_s)
-        flight_status_bits = try c.decodeIfPresent(Int.self, forKey: .flight_status_bits) ?? 0
-        pyro_status_bits = try c.decodeIfPresent(Int.self, forKey: .pyro_status_bits) ?? 0
+        flight_status_bits = flexInt(.flight_status_bits) ?? 0   // #293: tolerant
+        pyro_status_bits = flexInt(.pyro_status_bits) ?? 0       // #293: tolerant
         sensor_health = try c.decodeIfPresent(Int.self, forKey: .sensor_health) ?? 0
         source_rocket_id = try c.decodeIfPresent(Int.self, forKey: .source_rocket_id)
         source_unit_name = try c.decodeIfPresent(String.self, forKey: .source_unit_name)
         // #95: missing "ds" → .live (older firmware doesn't emit it)
         let dsRaw = try c.decodeIfPresent(Int.self, forKey: .data_status) ?? 0
         data_status = DataStatus(rawValue: dsRaw) ?? .live
-        data_age_ms = try c.decodeIfPresent(UInt32.self, forKey: .data_age_ms) ?? 0
+        data_age_ms = UInt32(clamping: flexInt(.data_age_ms) ?? 0)   // #293: tolerant
     }
 
     // Default memberwise init (for creating empty telemetry)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1530,50 +1530,6 @@ struct StatusBadge: View {
     }
 }
 
-struct RocketDirectionView: View {
-    let telemetry: TelemetryData
-    @ObservedObject var locationManager: LocationManager
-    @AppStorage("unitSystem") private var unitSystem: UnitSystem = .metric
-
-    var body: some View {
-        if let rocketLat = telemetry.latitude,
-           let rocketLon = telemetry.longitude,
-           !rocketLat.isNaN && !rocketLon.isNaN,
-           let phoneLoc = locationManager.userLocation {
-
-            let dist = LocationManager.haversineDistance(
-                lat1: phoneLoc.latitude, lon1: phoneLoc.longitude,
-                lat2: rocketLat, lon2: rocketLon
-            )
-            let bear = LocationManager.bearing(
-                lat1: phoneLoc.latitude, lon1: phoneLoc.longitude,
-                lat2: rocketLat, lon2: rocketLon
-            )
-            // Arrow rotation: bearing relative to phone's compass heading
-            let arrowAngle = bear - locationManager.heading
-
-            VStack(spacing: 8) {
-                Text("Rocket Direction")
-                    .font(.headline)
-
-                Image(systemName: "location.north.fill")
-                    .font(.system(size: 64))
-                    .foregroundColor(.blue)
-                    .rotationEffect(.degrees(arrowAngle))
-                    .animation(.easeOut(duration: 0.3), value: arrowAngle)
-
-                Text(UnitFormatter.distance(dist, system: unitSystem))
-                    .font(.title2)
-                    .fontWeight(.semibold)
-            }
-            .padding()
-            .frame(maxWidth: .infinity)
-            .background(Color(.systemGray6))
-            .cornerRadius(10)
-        }
-    }
-}
-
 // MARK: - Pyro Channels
 
 struct PyroChannelsView: View {

--- a/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
@@ -112,6 +112,16 @@ struct PyroTestView: View {
                 }
                 // Fire at T-0
                 if secondsRemaining <= 0 {
+                    // #292: re-check the link at the fire instant. sendPyroFire
+                    // silently no-ops when disconnected, so without this the UI
+                    // would advance to recording and report success for a command
+                    // that was never sent.
+                    guard device.isConnected else {
+                        errorMessage = "Link lost before fire — no fire command sent"
+                        state = .done
+                        ticker.stop()
+                        return
+                    }
                     device.sendPyroFire(channel: UInt8(channel))
                     state = .recording
                     recordSecondsRemaining = 5


### PR DESCRIPTION
Five iOS-app reliability fixes from the pre-flight review, all build-verified on the simulator (no rocket hardware).

## #290 (HIGH) — restore the fleet backref after BLE state-restoration
CoreBluetooth state-restoration (background BLE) rebuilt the `BLEDevice` without setting `device.fleet`, so `fleet?.recordRocketFix()` no-op'd — `lastValidRocketFix` never populated and the map marker / direction arrow / distance / landing anchor stayed blank for the restored session. Set `device.fleet = self` in the restoration branch, mirroring `didConnect`.

## #291 (HIGH) — don't give up reconnecting mid-flight
Auto-reconnect gave up after 3 attempts (~7 s) and dead-ended to "Disconnected" + cleared the list — a dropout during boost/descent lost telemetry + recording for the rest of the flight. Raised the cap to 8, capped the backoff at 8 s, and on exhaustion keep a connect pending (CB `connect()` has no timeout) + fall back to scanning, so a returning device re-pairs automatically.

## #292 — re-check the link at the pyro fire instant
The test-fire countdown called `sendPyroFire()` unconditionally at T-0; it no-ops when disconnected, so a mid-countdown drop showed a phantom success. Guard on `device.isConnected` at T-0; abort with a clear message if the link is gone.

## #293 — tolerant telemetry decode (defense-in-depth)
Strict `decodeIfPresent` throws out the whole frame on any numeric type mismatch. Firmware emits fs/ps/age as integers today (confirmed `addInt`/`addUint`), so this hardens against future drift: a `flexInt` coercion (int → float → string) on `flight_status_bits` / `pyro_status_bits` / `data_age_ms`.

## #294 — delete dead RocketDirectionView
Keyed off per-frame `telemetry.latitude` (nil on BS-relay frames, the #140 hazard), but only ever defined, never instantiated. Deleted.

## Verification
App **BUILD SUCCEEDED** with all five. #294 confirmed unreferenced; #293 firmware contract confirmed. The BLE-behavior confirmations (#290 restore, #291 out-of-range re-link, #292 mid-pyro drop) are quick phone-only checks — the code mirrors the working paths / adds explicit guards.

Closes #290
Closes #291
Closes #292
Closes #293
Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
