### PR TITLE
fc/oc(safety): LANDED is terminal until reboot — no re-arm/log/pyro (#317)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -235,6 +235,12 @@ static bool bmp_new_for_kf = false; // Set when new BMP sample arrives, cleared 
 
 // --- Flight logic state ---
 static RocketState rocket_state = INITIALIZATION;
+// #317: latched true once a flight reaches LANDED. Makes LANDED terminal until a
+// hardware reboot — no re-arm, no second flight cycle, no re-armed pyros, and the
+// OC won't open a new log. Matches the real-world use case (you don't re-fly
+// immediately) and prevents ever re-arming anything dangerous unexpectedly.
+// Cleared only at boot (static init) and on sim-completion re-arm.
+static bool post_flight_lockout = false;
 
 // Issue #216 — predicate used to gate ground-test / pyro-fire / servo-test
 // BLE commands.  We reject these from INFLIGHT (a launched rocket should
@@ -870,6 +876,9 @@ static void initPyroPins()
 // Caller MUST hold pyro_spinlock.
 static void pyroSetArmLocked(bool want_high)
 {
+    // #317: once a flight has landed, never re-arm the pyro rail until a hardware
+    // reboot — only disarm requests are honored.
+    if (post_flight_lockout) want_high = false;
     if (pyro_arm_pin_state == want_high) return;
     gpio_set_level((gpio_num_t)config::PYRO_ARM_PIN, want_high ? 1 : 0);
     pyro_arm_pin_state = want_high;
@@ -5155,6 +5164,12 @@ static void loop_fc()
             // Servo replay: driven by I2C command handler, skip state machine
         }
         else
+        {
+        // #317: once a flight has landed, the computer is terminal until a
+        // hardware reboot. Force LANDED so any transition a command or a
+        // ground-handling re-trigger of launch-detect tries to make is overridden
+        // (no re-arm, no second flight).
+        if (post_flight_lockout) rocket_state = LANDED;
         switch (rocket_state)
         {
             case INITIALIZATION:
@@ -5569,6 +5584,7 @@ static void loop_fc()
                 if (!landed_actions_done)
                 {
                     landed_actions_done = true;
+                    post_flight_lockout = true;  // #317: LANDED is terminal until reboot
                     pyroSafeAll();
                     clearFlightSnapshot();  // prevent stale recovery on next boot
                     if (servo_enabled)
@@ -5629,6 +5645,7 @@ static void loop_fc()
                 break;
             }
         }
+        }
 
         // ---- Auto-return to READY after sim completes ----
         {
@@ -5641,6 +5658,7 @@ static void loop_fc()
                 // READY -> PRELAUNCH transition on stale data.
                 pyroSafeAll();
                 rocket_state = READY;
+                post_flight_lockout = false;  // #317: sim re-arm is legitimate
                 ground_pressure_found = false;
                 out_ready = false;
                 end_flight_sent = false;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4819,9 +4819,16 @@ static void loop_oc()
         // Launch-triggered logging: start when NSF_LAUNCH appears in NonSensorData
         {
             static bool prev_ns_launch = false;
+            // #317: once the vehicle has reported LANDED, refuse to start a new
+            // flight log until a reboot. Post-flight ground handling can re-trip
+            // the FC launch-detect and would otherwise open a bogus session that
+            // only closes on power-off (-> a junk recovered_*.bin full of ground
+            // data). Reset only by an OC reboot.
+            static bool oc_landed_lockout = false;
+            if (latest_rocket_state == LANDED) oc_landed_lockout = true;
             const bool ns_launch = latest_non_sensor_valid &&
                                    nsFlagSet(latest_non_sensor.flags, NSF_LAUNCH);
-            if (ns_launch && !prev_ns_launch)
+            if (ns_launch && !prev_ns_launch && !oc_landed_lockout)
             {
                 // Mirror the cmd 23 lifecycle so a launch detected without a
                 // prior PRELAUNCH transition still gets a flightlog flight


### PR DESCRIPTION
Makes the post-flight LANDED state a hard lockout until a hardware reboot — the root fix for #317's bogus `flight_recovered_N.bin` ground sessions, and a broader flight-safety invariant.

## The bug (#317)
After a flight finalizes, ground handling (the 17 g bumps in the evidence) could re-trip the launch detector; the OC opened a **new** log on the `NSF_LAUNCH` rising edge; with no `END_FLIGHT` it streamed minutes of stationary ground data until power-off → next boot's recovery synthesized it as a "recovered" flight (43 MB of junk in one case, larger than the prealloc).

## The fix — LANDED is terminal until reboot
One latch (`post_flight_lockout`, set on LANDED entry, cleared only at boot + sim-completion re-arm) enforces it everywhere:
- **FC** (`flight_computer`): `rocket_state` is forced to `LANDED` at the state-machine top, so any transition a command or a re-triggered launch-detect tries is overridden (no second flight cycle); `pyroSetArmLocked` honors only *disarm* once locked (the pyro rail can't re-arm post-flight).
- **OC** (`out_computer`): independent backstop — once it's seen `rocket_state == LANDED` it refuses to open a new flight log even if `NSF_LAUNCH` re-rises.

A reboot is the only path back to `READY` — matching the real-world flow (you don't re-fly immediately, and nothing dangerous re-arms unexpectedly). SIL is unaffected (the sim-completion re-arm clears the latch).

## Verification
- FC builds clean (esp32p4), OC builds clean (esp32s3).
- Behavior is bench-confirmable: after a flight + a hard bump, no log opens and pyros stay safe; a reboot returns to normal `READY`.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
