### PR TITLE
fix(bs): storage bar — use real FAT sector size (fs->ssize), not hardcoded 512

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -789,8 +789,11 @@ static bool bsQueryStorage(uint64_t& total, uint64_t& used)
     FATFS* fs = nullptr;
     DWORD free_clust = 0;
     if (f_getfree("0:", &free_clust, &fs) != FR_OK || fs == nullptr) return false;
-    total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
-    const uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
+    // Use the real sector size (fs->ssize), NOT a hardcoded 512: the external
+    // NAND mounts FAT with 4096-byte sectors (CONFIG_FATFS_SECTOR_4096), so a
+    // hardcoded 512 under-reported total/free/used by 8x (512 MB read as ~57 MB).
+    total = (uint64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
+    const uint64_t free_bytes = (uint64_t)free_clust * fs->csize * fs->ssize;
     used = (total > free_bytes) ? (total - free_bytes) : 0;
     return true;
 }
@@ -2717,8 +2720,8 @@ static void setup_bs()
             DWORD free_clust;
             if (f_getfree("0:", &free_clust, &fs) == FR_OK)
             {
-                uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * 512;
-                uint64_t free_bytes = (uint64_t)free_clust * fs->csize * 512;
+                uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
+                uint64_t free_bytes = (uint64_t)free_clust * fs->csize * fs->ssize;
                 uint64_t used = total - free_bytes;
                 ESP_LOGI(TAG, "SD card mounted: %llu MB total, %llu MB used, %llu MB free",
                          (unsigned long long)(total / (1024 * 1024)),


### PR DESCRIPTION
## What
The base-station storage bar reported **57 MB free on a 512 MB NAND**, with "Used 0.1 MB" despite ~0.96 MB of actual log files. Root cause: `bsQueryStorage()` (and the SD-mount boot log) computed FAT bytes as `clusters * csize * 512`, but the external NAND mounts FAT with **4096-byte sectors** (`CONFIG_FATFS_SECTOR_4096`). So total/free/used were all under-reported by exactly **8×** (4096 ÷ 512).

## Fix
Use the real sector size `fs->ssize` instead of the hardcoded `512`, in all four spots (the `bsQueryStorage()` helper that feeds the app bar + the boot-log calc). `fs->ssize` is valid here because IDF keeps `FF_MIN_SS = MIN(512, 4096) = 512 ≠ FF_MAX_SS = 4096`, so the field is compiled into the FATFS struct.

## It reconciles at 8×
| Shown | ×8 = reality |
|---|---|
| 57.4 MB total | **459 MB** (512 MB NAND − Dhara FTL/FAT overhead) |
| 57.3 MB free | **458 MB** |
| 0.1 MB used | **0.80 MB** ≈ the ~0.96 MB of actual logs |

## Scope / impact
Display-only — the FAT and logging were always healthy (the bar just did the math with the wrong sector size). Isolated to the BS; the rocket's 128 MB reads correctly. In the new #318/#321 storage-reporting code, caught on the bench.

## Verification
- BS builds clean (esp32s3, IDF v6.0): `base_station.bin`.
- Bench-confirm pending: reflash BS, the bar should read ~458 MB free and "Used" should match the log totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
