### PR TITLE
fix(sim): hold LANDED terminal in sim — re-arm on sim start, not end (#317)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5647,18 +5647,24 @@ static void loop_fc()
         }
         }
 
-        // ---- Auto-return to READY after sim completes ----
+        // ---- Re-arm on a NEW sim run, NOT when a sim ends (#317) ----
+        // A sim flight that reaches LANDED must STAY landed — terminal, exactly
+        // like real hardware — so the sim faithfully reproduces and can validate
+        // the post-flight lockout. Re-arm on the RISING edge of sim-active (the
+        // deliberate start of a new run, the sim's equivalent of a reboot), never
+        // on the falling edge. When a sim ends we do nothing: the FC holds the
+        // state it reached (LANDED if it flew) and the lockout stays in force.
         {
             const bool curr_sim_active = sensor_collector.isSimActive();
-            if (prev_sim_active && !curr_sim_active)
+            if (!prev_sim_active && curr_sim_active)
             {
-                // Sim just finished — reset state machine so user can run another sim.
-                // Must also reset GNSS state: the sim injected synthetic GNSS
-                // (fix=3, sats=12) which would otherwise cause an immediate
-                // READY -> PRELAUNCH transition on stale data.
+                // New sim run — reset state machine for a fresh flight. Also
+                // resets GNSS state: the sim injects synthetic GNSS (fix=3,
+                // sats=12); a stale copy would otherwise immediately re-trip
+                // READY -> PRELAUNCH on the new run.
                 pyroSafeAll();
                 rocket_state = READY;
-                post_flight_lockout = false;  // #317: sim re-arm is legitimate
+                post_flight_lockout = false;  // #317: a deliberate new sim run re-arms
                 ground_pressure_found = false;
                 out_ready = false;
                 end_flight_sent = false;
@@ -5687,7 +5693,7 @@ static void loop_fc()
                 reboot_recovery = false;
                 reboot_recovery_telem = false;
                 clearFlightSnapshot();
-                ESP_LOGI(TAG, "[STATE] Sim complete -> READY");
+                ESP_LOGI(TAG, "[STATE] Sim start -> READY (re-armed for new run)");
             }
             prev_sim_active = curr_sim_active;
         }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4823,9 +4823,22 @@ static void loop_oc()
             // flight log until a reboot. Post-flight ground handling can re-trip
             // the FC launch-detect and would otherwise open a bogus session that
             // only closes on power-off (-> a junk recovered_*.bin full of ground
-            // data). Reset only by an OC reboot.
+            // data). Reset by an OC reboot, or by a sim re-arm — the FC leaving
+            // LANDED, which is impossible in a real flight (terminal lockout).
             static bool oc_landed_lockout = false;
-            if (latest_rocket_state == LANDED) oc_landed_lockout = true;
+            static RocketState prev_rs_lockout = INITIALIZATION;
+            if (latest_rocket_state == LANDED)
+            {
+                oc_landed_lockout = true;
+            }
+            else if (prev_rs_lockout == LANDED)
+            {
+                // #317 sim re-arm: the FC only leaves LANDED on a deliberate new
+                // sim run (real flight is terminal), so clear the lockout to match
+                // the FC's sim-start re-arm and let the new sim flight log.
+                oc_landed_lockout = false;
+            }
+            prev_rs_lockout = latest_rocket_state;
             const bool ns_launch = latest_non_sensor_valid &&
                                    nsFlagSet(latest_non_sensor.flags, NSF_LAUNCH);
             if (ns_launch && !prev_ns_launch && !oc_landed_lockout)


### PR DESCRIPTION
## What
In **sim mode**, a flight that reached LANDED would re-arm the moment the sim ended (`isSimActive` falling edge): `LANDED → READY → PRELAUNCH`. That diverged from real hardware (where LANDED is terminal until reboot) on the exact behaviour #317 guards — and made the lockout **impossible to validate in sim**, since a re-launch was never blocked.

## Fix
- **FC** ([main.cpp:5650](tinkerrocket-idf/projects/flight_computer/main/main.cpp)): re-arm on the **rising** edge of `isSimActive` (a deliberate new sim run — the sim's equivalent of a reboot) instead of the falling edge. A landed sim flight now **stays LANDED**; the lockout holds and can be observed/tested.
- **OC** ([main.cpp:4827](tinkerrocket-idf/projects/out_computer/main/main.cpp)): clear `oc_landed_lockout` when the FC **leaves** LANDED. A real flight is terminal in LANDED, so that transition only happens on a sim re-arm — safe, and it keeps FC + OC in lockstep so a re-armed sim still logs.

## Safety
**Real flight is unchanged.** The re-arm path is gated behind `isSimActive()`, which is always false in a real flight, so it is physically unreachable without an injected sim. LANDED remains terminal-until-reboot on hardware.

## New sim behaviour
- Sim flight lands → FC + OC **stay LANDED**; a re-launch attempt is blocked (no new log, pyros safe) — the #317 behaviour, now testable.
- Start a fresh sim → FC + OC re-arm together, new flight logs normally.

## Verification
- FC (esp32p4) + OC (esp32s3) build clean, IDF v6.0.
- Bench-confirm pending: run a sim, confirm it holds LANDED + blocks re-launch; start a new sim, confirm it re-arms and logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
