### PR TITLE
fc: relax servos on pad/post-land + sequential boot wiggle (cut idle current & pad power spikes)

### DIFF
--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -128,7 +128,22 @@ void TR_ServoControl::stowControl() {
     setPulse(0);
 }
 
+void TR_ServoControl::idle() {
+    // Already relaxed — don't re-issue the duty writes every loop tick.
+    if (is_idle_) return;
+    // 0% duty holds the GPIO low for the whole period: no rising edge, so the
+    // servo sees no pulse train and (if it honours signal loss) relaxes.  We
+    // stay inside the normal LEDC duty API rather than ledc_stop(), so the next
+    // setPulse()/setServoAngles() resumes pulses through the identical path.
+    for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
+        ledc_set_duty(LEDC_MODE, LEDC_CHANNELS[i], 0);
+        ledc_update_duty(LEDC_MODE, LEDC_CHANNELS[i]);
+    }
+    is_idle_ = true;
+}
+
 void TR_ServoControl::setServoAngles(const float angles[4]) {
+    is_idle_ = false;  // commanding a pulse resumes PWM after idle()
     for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
         // Clamp to the command limit (max deflection), then map via the physical
         // fin calibration (#267) so the fin reaches the commanded *physical* angle
@@ -154,6 +169,7 @@ int TR_ServoControl::saturateCommand(int command) {
 
 void TR_ServoControl::setPulse(int base_pulse_us) {
     // base_pulse_us is computed from control(), 0 means “centre”
+    is_idle_ = false;  // commanding a pulse resumes PWM after idle()
     for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
         // compute final pulse for this servo by adding its bias
         int pulse_us;

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -112,16 +112,23 @@ void TR_ServoControl::setFinCalibration(float finMinDeg, float finMaxDeg) {
 }
 
 void TR_ServoControl::wiggle() {
-    // sweep through min/mid/max for all servos
-    //for (int i = 0; i < 4; ++i) {
-        setPulse(((servo_min_us + servo_max_us) / 2)); // mid
-        delay(1250);
-        setPulse(servo_min_us); // min
-        delay(1500);
-        setPulse(servo_max_us); // max
-        delay(1500);
-        setPulse(((servo_min_us + servo_max_us) / 2)); // back to mid
-    //}
+    // Boot "servos alive" check.  Wiggle each servo individually, in order
+    // 0->1->2->3, so only ONE servo draws movement (inrush) current at a time.
+    // Sweeping all four at once stacked four inrush spikes on the shared rail,
+    // which could sag it enough to brown out the camera on the pad — a
+    // bandaid for that, until the next PCB's servo-power MOSFET.  Each servo
+    // returns to centre before the next begins; the others hold their
+    // begin()-set centre while one sweeps.
+    const int mid = (servo_min_us + servo_max_us) / 2;
+    constexpr int kSettleMs = 350;  // ample for an 8 g servo to traverse + be seen
+    for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
+        setPulseChannel(i, servo_min_us);  // min
+        delay(kSettleMs);
+        setPulseChannel(i, servo_max_us);  // max
+        delay(kSettleMs);
+        setPulseChannel(i, mid);           // back to centre
+        delay(kSettleMs);
+    }
 }
 
 void TR_ServoControl::stowControl() {
@@ -167,28 +174,34 @@ int TR_ServoControl::saturateCommand(int command) {
     return command;
 }
 
-void TR_ServoControl::setPulse(int base_pulse_us) {
-    // base_pulse_us is computed from control(), 0 means “centre”
+void TR_ServoControl::setPulseChannel(int channel, int base_pulse_us) {
+    // Drive a single servo channel.  base_pulse_us is the nominal pulse, 0
+    // meaning “centre”; the per-servo bias is applied here exactly as setPulse
+    // does, so driving one channel matches driving all.
+    if (channel < 0 || channel >= LEDC_CHANNEL_COUNT) return;
     is_idle_ = false;  // commanding a pulse resumes PWM after idle()
+
+    int pulse_us = (base_pulse_us == 0) ? servo_mid_us_[channel]
+                                        : base_pulse_us + servo_bias_us_[channel];
+    pulse_us = saturateCommand(pulse_us);
+
+    uint32_t max_duty = (1u << LEDC_RESOLUTION) - 1;
+    uint32_t duty     = (static_cast<uint32_t>(pulse_us)
+                        * static_cast<uint32_t>(servo_hz)
+                        * max_duty) / 1000000u;
+    ledc_set_duty(LEDC_MODE, LEDC_CHANNELS[channel], duty);
+    ledc_update_duty(LEDC_MODE, LEDC_CHANNELS[channel]);
+
+    // record last command from servo0’s perspective
+    if (channel == 0) roll_cmd_us = pulse_us;
+}
+
+void TR_ServoControl::setPulse(int base_pulse_us) {
+    // base_pulse_us is computed from control(), 0 means “centre”.  Drive all
+    // four channels (intentionally simultaneous — the flight control path
+    // updates every servo each tick).
     for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
-        // compute final pulse for this servo by adding its bias
-        int pulse_us;
-        if (base_pulse_us == 0) {
-            pulse_us = servo_mid_us_[i];
-        } else {
-            pulse_us = base_pulse_us + servo_bias_us_[i];
-        }
-        pulse_us = saturateCommand(pulse_us);
-
-        uint32_t max_duty = (1u << LEDC_RESOLUTION) - 1;
-        uint32_t duty     = (static_cast<uint32_t>(pulse_us)
-                            * static_cast<uint32_t>(servo_hz)
-                            * max_duty) / 1000000u;
-        ledc_set_duty(LEDC_MODE, LEDC_CHANNELS[i], duty);
-        ledc_update_duty(LEDC_MODE, LEDC_CHANNELS[i]);
-
-        // record last command from servo0’s perspective
-        if (i == 0) roll_cmd_us = pulse_us;
+        setPulseChannel(i, base_pulse_us);
     }
 }
 

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -35,6 +35,15 @@ public:
     void wiggle();
     // return servos to centre
     void stowControl();
+    // Relax the servos by stopping the PWM pulse train (0% duty -> output held
+    // low, no servo pulses).  A digital servo that honours signal loss goes
+    // limp and stops drawing holding current; one that latches keeps holding.
+    // Idempotent — only touches the hardware on the first call after a drive.
+    // Any drive command (control*/setServoAngles/stowControl/setPulse) resumes
+    // PWM automatically, so call wake() implicitly just by commanding a pulse.
+    void idle();
+    // True while the pulse train is stopped via idle().
+    bool isIdle() const { return is_idle_; }
     // set each servo to an individual angle (degrees), bypassing PID
     void setServoAngles(const float angles[4]);
     // last computed roll command (deg)
@@ -155,6 +164,11 @@ private:
 
     // Previous gain schedule scale factor (for I-term reset on large changes)
     float prev_gain_scale_ = 1.0f;
+
+    // True while idle() has stopped the pulse train.  Cleared by any drive
+    // (setPulse/setServoAngles), which re-asserts a real duty and so resumes
+    // PWM without an explicit wake step.
+    bool is_idle_ = false;
 
     // LEDC channels/timers for four servos
     static constexpr int LEDC_CHANNEL_COUNT = 4;

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -121,6 +121,9 @@ public:
 private:
     // update all four servos to a single nominal pulse
     void setPulse(int base_pulse_us);
+    // drive ONE servo channel to a nominal pulse (bias applied); used by
+    // setPulse() and by wiggle() to sequence the servos one at a time
+    void setPulseChannel(int channel, int base_pulse_us);
     int  saturateCommand(int command);
     // Map a physical fin angle (deg) to a servo pulse (us) via the fin
     // calibration (fin_min_deg_->servo_min_us, fin_max_deg_->servo_max_us). #267

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -232,6 +232,17 @@ struct config
     static constexpr bool USE_SERVO_CONTROL = true;
     static constexpr bool SERVO_WIGGLE_ON_BOOT = true;
 
+    // Relax the servos (stop the PWM pulse train) whenever we're sitting on the
+    // pad in READY/PRELAUNCH and after LANDED.  The digital PTK 7308 servos hold
+    // position stiffly and draw ~150 mA each while a valid pulse train is
+    // present; cutting the pulses lets them go limp so the pad/post-flight idle
+    // draw collapses to the servos' quiescent current.  PWM (and full holding
+    // torque) resumes automatically the instant control commands them at launch.
+    // NOTE: only saves current if the servo actually relaxes on signal loss —
+    // some digital servos latch their last position regardless.  The future
+    // servo-power MOSFET is the guaranteed fix; this is the interim lever.
+    static constexpr bool SERVO_RELAX_ON_PAD = true;
+
     // EKF pad heading: compass heading of board Z+ (deg, 0=North, 90=East)
     static constexpr float PAD_HEADING_DEG = 0.0f;
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5188,6 +5188,13 @@ static void loop_fc()
             }
             case READY:
             {
+                // Relax the servos on the pad: cut the pulse train so the
+                // digital servos stop drawing ~150 mA of holding current while
+                // we wait for GNSS/launch.  Re-asserted each tick (idempotent);
+                // PWM resumes automatically when INFLIGHT first commands a pulse.
+                if (servo_enabled && config::SERVO_RELAX_ON_PAD)
+                    servo_control.idle();
+
                 const bool gnss_ready = gnss_started &&
                                         (now_ms > valid_gnss_start_millis + 3000U) &&
                                         have_gnss_si &&
@@ -5206,6 +5213,12 @@ static void loop_fc()
             }
             case PRELAUNCH:
             {
+                // Stay relaxed through the pad wait; the INFLIGHT control path
+                // re-drives (and so re-energises) the servos the instant
+                // launch_flag flips below.
+                if (servo_enabled && config::SERVO_RELAX_ON_PAD)
+                    servo_control.idle();
+
                 if (kinematics.launch_flag)
                 {
                     rocket_state = INFLIGHT;
@@ -5589,7 +5602,13 @@ static void loop_fc()
                     clearFlightSnapshot();  // prevent stale recovery on next boot
                     if (servo_enabled)
                     {
-                        servo_control.stowControl();
+                        // Relax post-flight to stop the idle holding current
+                        // (the MOSFET-less interim of the pad relax); otherwise
+                        // hold centre as before.
+                        if (config::SERVO_RELAX_ON_PAD)
+                            servo_control.idle();
+                        else
+                            servo_control.stowControl();
                     }
                     // Reset guidance state
                     guidance.reset();


### PR DESCRIPTION
Two related flight-computer power changes for the current (MOSFET-less) servo rail. Both are interim bandaids until the next PCB adds a servo-power MOSFET.

## 1. Relax servos on the pad + post-land (`0c8c132`)
The digital PTK 7308 servos hold position stiffly whenever a valid pulse train is present, drawing ~150 mA each (~600 mA for four) while the rocket sits armed on the pad — pure waste before launch. The LEDC PWM ran continuously from `begin()` with no path that ever stopped it.

- New `TR_ServoControl::idle()` drives all four channels to 0% duty (output held low, no pulses) so a servo that honours signal loss goes limp. Stays inside the normal LEDC duty API (not `ledc_stop`), so any drive command resumes PWM through the identical path — `is_idle_` guard makes it idempotent.
- `main.cpp` relaxes the servos each tick in READY/PRELAUNCH and once on LANDED entry, gated by new `config::SERVO_RELAX_ON_PAD` (default on).
- INFLIGHT re-energizes automatically at launch detect (the roll-control delay already commands neutral), so full holding torque is restored before any roll/guidance authority is needed.

**Bench-confirmed:** idle current drops on the 4-servo configuration — these servos do relax on signal loss.

## 2. Sequential boot wiggle (`c2f188d`)
The boot "servos alive" wiggle drove all four servos through min/max at once, stacking four movement-inrush spikes on the shared rail — a suspected cause of the camera failing to start when servos are present on the pad.

- Sweep each servo individually in order 0→1→2→3; only one draws inrush at a time, others hold centre, each returns to centre before the next.
- New `setPulseChannel()` drives a single channel; `setPulse()` delegates to it (flight path unchanged). Per-servo settle trimmed to 350 ms so total boot wiggle stays ~4 s.

## Verification
- Builds clean (IDF v6.0, exit 0, 81% flash free).
- Pad behaviour bench-tested: power draw goes down on the 4-servo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)