### PR TITLE
fix(fc): re-enable GPS as an apogee voter (fresh-gated) + N-2 quorum for non-EKF diversity (#262)

### DIFF
--- a/Data_Analysis/flight_report/modules/kinematic_checks.py
+++ b/Data_Analysis/flight_report/modules/kinematic_checks.py
@@ -96,11 +96,14 @@ def _replay(records):
     latest_vel = (0.0, 0.0, 0.0)
     latest_roll_rate = 0.0
     latest_gps_alt = 0.0
+    latest_gps_vel_u = 0.0
     latest_pitch_rad = math.pi / 2
     burnout = False
     mach_locked_out = False
     new_baro = False
     new_gps = False
+    gvu_t: list[float] = []   # GNSS Doppler vert-velocity (for true-apogee xing)
+    gvu_v: list[float] = []
 
     sim_fires: dict[str, float] = {}
     raw_palt_t: list[float] = []
@@ -127,8 +130,11 @@ def _replay(records):
             continue
         if kind == "gnss":
             latest_gps_alt = float(r["alt_m"])
+            latest_gps_vel_u = float(r["vel_u"])
             new_gps = True
             gps_pass_t.append((t_us - t0_us) / 1e6)
+            gvu_t.append((t_us - t0_us) / 1e6)
+            gvu_v.append(latest_gps_vel_u)
             continue
         if kind == "ns":
             latest_pos = (r["e_pos"], r["n_pos"], r["u_pos"])
@@ -157,6 +163,7 @@ def _replay(records):
             roll_rate=latest_roll_rate,
             new_baro=new_baro,
             gps_altitude=latest_gps_alt,
+            gps_vel_u=latest_gps_vel_u,
             new_gps=new_gps,
             pitch_rad=latest_pitch_rad,
             burnout_detected=burnout,
@@ -205,7 +212,32 @@ def _replay(records):
         "gps_periods":   _periods(gps_pass_t, gps_pass_v),
         "max_altitude":  float(kc.max_altitude),
         "max_speed":     float(kc.max_speed),
+        # True apogee = GNSS Doppler vertical-velocity zero-crossing (after
+        # ascent).  Trusted over the raw-baro peak, which lags GNSS by 0.3-1.3 s
+        # and is spike-prone (#112).  None when there is no usable GNSS.
+        "true_apogee_t": _gnss_vel_zero_apogee(gvu_t, gvu_v),
     }
+
+
+def _gnss_vel_zero_apogee(t, vu):
+    """Apogee = descending GNSS Doppler vert-velocity zero-crossing, gated to
+    after the vehicle clearly ascended (vu>10 m/s) so on-pad noise is skipped.
+    A 5-sample median de-spikes vu first."""
+    if len(t) < 6:
+        return None
+    half = 2
+    sm = [sorted(vu[max(0, i - half):min(len(vu), i + half + 1)])[
+              (min(len(vu), i + half + 1) - max(0, i - half)) // 2]
+          for i in range(len(vu))]
+    ascended = False
+    for i in range(1, len(sm)):
+        if sm[i - 1] > 10.0:
+            ascended = True
+        if ascended and sm[i - 1] >= 0.0 and sm[i] < 0.0:
+            denom = sm[i - 1] - sm[i]
+            f = (sm[i - 1] / denom) if denom else 0.0
+            return float(t[i - 1] + f * (t[i] - t[i - 1]))
+    return None
 
 
 # Map sim flag name -> logged flag name produced by logged_flag_times()
@@ -252,11 +284,19 @@ def _plot_apogee_voting(res, title_suffix=""):
         ax_alt.plot(t_raw, v_raw, color="lightgray", lw=0.7, label="raw palt")
     ax_alt.plot(t_sim, v_sim, color="black", lw=0.9, label="KF alt_est")
 
-    # True apogee = peak of raw palt
+    # True apogee = GNSS Doppler vel=0 (trusted).  Fall back to the raw-baro
+    # peak only when there is no GNSS; show the baro peak separately so its
+    # lag vs GNSS (#112) is visible rather than mistaken for the truth.
+    true_t = res.get("true_apogee_t")
+    if true_t is not None:
+        ax_alt.axvline(true_t, color="black", ls=":", lw=1.4,
+                       label=f"true apogee (GNSS v=0) {true_t:.2f}s")
     if v_raw:
         peak_idx = max(range(len(v_raw)), key=lambda i: v_raw[i])
-        ax_alt.axvline(t_raw[peak_idx], color="dimgray", ls=":", lw=0.8,
-                       label=f"true apogee {t_raw[peak_idx]:.2f}s")
+        baro_pk_t = t_raw[peak_idx]
+        ax_alt.axvline(baro_pk_t, color="dimgray", ls=":", lw=0.8,
+                       label=("baro peak (lags)" if true_t is not None
+                              else "true apogee") + f" {baro_pk_t:.2f}s")
 
     # Sub-detector fire markers
     fire_marker = {"vel": "s", "baro": "^", "gps": "o", "pitch": "*"}

--- a/Data_Analysis/sim_kinematic_checks.py
+++ b/Data_Analysis/sim_kinematic_checks.py
@@ -61,6 +61,9 @@ GPS_APOGEE_COUNT_HI  = 4
 # GPS apogee now fires on sustained Doppler descent faster than this m/s
 # (#237/#242): GPS velocity is real-time, GPS position lags ~4 s.
 GPS_VEL_APOGEE_DESCENT_MPS = 1.0
+# Max age of the last GPS fix for GPS to count as an apogee voter (#262) —
+# tight, because boost-to-apogee is ~6-8 s and GPS runs ~18 Hz; mirrors firmware.
+GPS_APOGEE_FRESH_MS = 500
 
 # CHANGED (5): Landing sub-detector hysteresis thresholds.
 # Slow detectors evaluated at 1 Hz inside the existing landing_check_dt
@@ -445,7 +448,10 @@ class KinematicChecks:
             elif self.pitch_apogee_count_ == 0:
                 self.pitch_apogee_flag = False
 
-            # N-1 of N voting (TRKC.cpp:264) — master still latches once true.
+            # Dynamic vote (TRKC.cpp) — master latches once true.  NOTE: this
+            # port does not model the firmware's ekf_healthy/baro_healthy quorum
+            # (#237/#257) nor the Layer-2 baro backstop; voters are always
+            # "available" here, which matches the firmware on a healthy flight.
             if not self.apogee_flag:
                 available = 0
                 passed = 0
@@ -457,13 +463,23 @@ class KinematicChecks:
                     available += 1
                     if self.alt_apogee_flag: passed += 1
 
-                # GPS — NOT a voter (#237/#242): unreliable during boost on
-                # this hardware; gps_apogee_flag is computed + logged, excluded.
+                # GPS (Doppler) — non-EKF voter on a fresh fix (#262).  Re-added
+                # after the GNSS dynamic-model change fixed the boost corruption
+                # that forced its exclusion; restores non-EKF diversity during
+                # mach lockout / degraded EKF.  5 s freshness gate, as firmware.
+                if (self.gps_available_
+                        and (self._now_ms - self.last_gps_time_ms_) < GPS_APOGEE_FRESH_MS):
+                    available += 1
+                    if self.gps_apogee_flag: passed += 1
 
                 available += 1
                 if self.pitch_apogee_flag: passed += 1
 
-                if available >= 2 and passed >= 2 and passed >= (available - 1):
+                # Floor of 2 concurring, then N-1 of N, relaxed to N-2 once > 3
+                # voters so adding GPS as a 4th voter keeps 2-of-4 (== old 2-of-3)
+                # instead of demanding 3-of-4 and delaying apogee (#262).
+                need = (available - 2) if available > 3 else (available - 1)
+                if available >= 2 and passed >= 2 and passed >= need:
                     self.apogee_flag = True
 
         # ── Apogee rising edge: reset landing sub-flag counters (#192) ──

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -181,26 +181,125 @@ TEST_F(KinematicChecksTest, Apogee_WithBurnout_DetectsApogee) {
     EXPECT_TRUE(kc.apogee_flag);
 }
 
-// #237/#242: GPS apogee is computed + logged but is NOT a voter — on RP III the
-// GPS solution is corrupted during boost (vel_u noise to -38 m/s while climbing,
-// fix=3), so a GPS-only "apogee" must never fire the master.
-TEST_F(KinematicChecksTest, Apogee_GPSExcludedFromVote) {
+// #262: GPS is now a voter (re-enabled after the GNSS dynamic-model fix), but a
+// single concurring sensor must still never fire the master — the floor-of-2
+// quorum holds.  Drive ONLY GPS descending (others say still-ascending): the
+// flag is computed, but apogee must not latch on one voter.
+TEST_F(KinematicChecksTest, Apogee_GPSAlone_BelowQuorumFloor) {
     for (int i = 0; i < 80; i++) {           // launch
         setMockMillis(i * 2);
         callFlight(0.5f * i, 25.0f, 10.0f);
     }
     ASSERT_TRUE(kc.launch_flag);
 
-    // Post-burnout, drive ONLY GPS "descending" (gps_vel_u = -10) while the real
-    // detectors say still-ascending: EKF velocity +10, altitude climbing, nose up.
     for (int i = 0; i < 60; i++) {
         setMockMillis(200 + i * 2);
         callFlight(/*alt*/100.0f + i, /*acc*/5.0f, /*vel_u*/10.0f, /*roll*/0.0f,
                    /*gps_alt*/0.0f, /*new_gps*/true, /*pitch*/1.0f, /*burnout*/true,
                    /*baro_lockout*/false, /*gps_vel_u*/-10.0f);
     }
-    EXPECT_TRUE(kc.gps_apogee_flag)  << "GPS apogee flag should still be computed";
-    EXPECT_FALSE(kc.apogee_flag)     << "GPS must NOT vote the master apogee (#237)";
+    EXPECT_TRUE(kc.gps_apogee_flag)  << "GPS apogee flag should be computed";
+    EXPECT_FALSE(kc.apogee_flag)     << "one voter (GPS) must not meet the 2-concurring floor";
+}
+
+// #262: N-2-when-N>3 quorum.  With all four voters available, exactly TWO
+// concurring must fire (== the old 2-of-3) — NOT three.  Isolate the quorum
+// arithmetic with deterministic voters: vel (EKF v<0) and GPS (Doppler descent)
+// pass; pitch is held nose-up and baro is held at constant altitude (so it is
+// AVAILABLE — not locked, healthy — but never < peak-5, so it does not pass).
+// Under the old strict N-1 this 2-of-4 would have demanded a 3rd voter.
+TEST_F(KinematicChecksTest, Apogee_N2Quorum_TwoOfFourFires) {
+    for (int i = 0; i < 80; i++) {           // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 60; i++) {
+        setMockMillis(200 + i * 2);
+        callFlight(/*alt*/100.0f /*constant → baro available, not passing*/, 5.0f,
+                   /*vel_u*/-10.0f /*descending → vel passes*/, 0.0f,
+                   /*gps_alt*/100.0f, /*new_gps*/true,
+                   /*pitch*/1.0f /*nose-up → NOT passing*/, /*burnout*/true,
+                   /*baro_lockout*/false, /*gps_vel_u*/-10.0f /*GPS passes*/);
+    }
+    EXPECT_TRUE(kc.vel_u_apogee_flag);
+    EXPECT_TRUE(kc.gps_apogee_flag);
+    EXPECT_FALSE(kc.alt_apogee_flag) << "constant-alt baro is available but must not pass";
+    EXPECT_FALSE(kc.pitch_apogee_flag);
+    EXPECT_TRUE(kc.apogee_flag) << "2 of 4 concurring must fire under N-2 (would need 3 under N-1)";
+}
+
+// #262 CORE: during mach-lockout (baro excluded) a single EKF-voter fault would
+// sink the old 2-of-2 {vel,pitch}.  With GPS restored as a non-EKF voter the
+// vote becomes 2-of-3 {vel,gps,pitch}, so pitch+GPS carry it.  Here EKF velocity
+// is faulted (reads +5 while truly descending), pitch + GPS agree on descent.
+TEST_F(KinematicChecksTest, Apogee_GPSRescuesMachLockout_OneEKFFault) {
+    for (int i = 0; i < 80; i++) {           // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 60; i++) {           // mach-locked descent, faulted vel
+        setMockMillis(200 + i * 2);
+        callFlight(/*alt*/100.0f, 5.0f, /*vel_u*/+5.0f /*FAULT: says ascending*/,
+                   0.0f, /*gps_alt*/100.0f, /*new_gps*/true,
+                   /*pitch*/-0.5f /*descending*/, /*burnout*/true,
+                   /*baro_lockout*/true, /*gps_vel_u*/-10.0f /*descending*/);
+    }
+    EXPECT_FALSE(kc.vel_u_apogee_flag) << "faulted EKF velocity must not pass";
+    EXPECT_TRUE(kc.gps_apogee_flag);
+    EXPECT_TRUE(kc.pitch_apogee_flag);
+    EXPECT_TRUE(kc.apogee_flag) << "GPS+pitch (2-of-3) must carry during lockout (#262)";
+}
+
+// Companion: identical lockout + faulted-vel scenario but with NO GPS fix — the
+// vote falls back to 2-of-2 {vel,pitch} and CANNOT fire (the pre-#262 failure).
+TEST_F(KinematicChecksTest, Apogee_MachLockout_OneEKFFault_NoGPS_DoesNotFire) {
+    for (int i = 0; i < 80; i++) {           // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    for (int i = 0; i < 60; i++) {           // same as above, but new_gps=false
+        setMockMillis(200 + i * 2);
+        callFlight(/*alt*/100.0f, 5.0f, /*vel_u*/+5.0f, 0.0f, /*gps_alt*/0.0f,
+                   /*new_gps*/false, /*pitch*/-0.5f, /*burnout*/true,
+                   /*baro_lockout*/true, /*gps_vel_u*/0.0f);
+    }
+    EXPECT_TRUE(kc.pitch_apogee_flag);
+    EXPECT_FALSE(kc.apogee_flag) << "without GPS, lockout+vel-fault leaves 1-of-2 — no fire";
+}
+
+// #262 freshness gate: a GPS apogee flag latched from earlier fixes must NOT
+// keep voting once the fix goes stale (> GPS_APOGEE_FRESH_MS).  Phase 1 latches
+// gps_apogee_flag (pitch not yet passing → no fire).  Phase 2 stops GPS updates
+// and lets the clock pass the freshness window while pitch starts passing: GPS
+// is now stale, so the vote is only {vel,pitch}=1 and must not fire.
+TEST_F(KinematicChecksTest, Apogee_StaleGPS_DoesNotVote) {
+    for (int i = 0; i < 80; i++) {           // launch
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 10.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+    int t = 200;
+    for (int i = 0; i < 40; i++) {           // Phase 1: latch GPS (pitch nose-up)
+        setMockMillis(t); t += 2;
+        callFlight(/*alt*/100.0f, 5.0f, /*vel_u*/+5.0f, 0.0f, /*gps_alt*/100.0f,
+                   /*new_gps*/true, /*pitch*/1.0f, /*burnout*/true,
+                   /*baro_lockout*/true, /*gps_vel_u*/-10.0f);
+    }
+    ASSERT_TRUE(kc.gps_apogee_flag);
+    ASSERT_FALSE(kc.apogee_flag);
+    // Phase 2: no more GPS; jump past the freshness window; pitch now passes.
+    t += 700;                                 // > GPS_APOGEE_FRESH_MS (500) since last fix
+    for (int i = 0; i < 40; i++) {
+        setMockMillis(t); t += 2;
+        callFlight(/*alt*/100.0f, 5.0f, /*vel_u*/+5.0f, 0.0f, /*gps_alt*/0.0f,
+                   /*new_gps*/false, /*pitch*/-0.5f /*now descending*/, /*burnout*/true,
+                   /*baro_lockout*/true, /*gps_vel_u*/0.0f);
+    }
+    EXPECT_TRUE(kc.pitch_apogee_flag);
+    EXPECT_FALSE(kc.apogee_flag) << "stale GPS must not count — only pitch passes (1-of-2)";
 }
 
 TEST_F(KinematicChecksTest, Landing_StableAlt) {

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -35,6 +35,12 @@ constexpr uint8_t  GPS_APOGEE_COUNT_HI      = 4;
 // *velocity* is real-time; GPS *position* lags ~4 s and dives during boost
 // (#237/#242), so the old altitude-below-peak test fired wildly off.
 constexpr float    GPS_VEL_APOGEE_DESCENT_MPS = 1.0f;
+// Max age of the last GPS fix for GPS to count as an apogee voter (#262).
+// Deliberately tight — boost-to-apogee is only ~6-8 s and GPS runs ~18 Hz
+// (~55 ms/fix, worst observed gap ~136 ms), so a fix older than this is stale
+// for an apogee decision (a 5 s-old fix would be from the launch rail).  Much
+// tighter than the landing vote's 5 s gate, which is a slower ground event.
+constexpr uint32_t GPS_APOGEE_FRESH_MS     = 500;
 
 // Launch accel-only fallback (#258): when the baro is INVALID, latch launch on
 // sustained high-G alone.  Deliberately a much higher bar than the baro-
@@ -513,12 +519,22 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                 if (alt_apogee_flag) passed++;
             }
 
-            // GPS — NOT a voter (#237/#242).  GPS apogee is unreliable during
-            // boost on this hardware (RP III: position AND Doppler velocity
-            // corrupted — vel_u noise to -38 m/s while climbing — at fix=3 with
-            // good reported accuracy), so it false-fires.  gps_apogee_flag is
-            // still computed + logged as a diagnostic, just excluded from the
-            // vote so it can't move pyro timing.
+            // GPS (Doppler) — non-EKF voter, available on a FRESH fix (#262).
+            // Re-enabled after the GNSS dynamic-model change fixed the boost
+            // corruption that originally forced its exclusion (#237/#242): the
+            // detector is post-burnout only, velocity-based (no laggy-altitude
+            // gate), and requires GPS_APOGEE_COUNT_HI sustained descending
+            // samples, so a transient can't fire it.  Being non-EKF, it restores
+            // voter diversity exactly when the EKF voters and/or baro are at
+            // risk — baro mach-locked-out (the #262 common-mode case) or a
+            // degraded EKF.  Same 5 s freshness gate as the landing vote.
+            const bool gps_fresh = gps_available_ &&
+                                   (millis() - last_gps_time_ms_) < GPS_APOGEE_FRESH_MS;
+            if (gps_fresh)
+            {
+                available++;
+                if (gps_apogee_flag) passed++;
+            }
 
             // Pitch (EKF) — available only when the EKF is healthy
             if (ekf_healthy)
@@ -527,9 +543,17 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                 if (pitch_apogee_flag) passed++;
             }
 
-            // N-1 of N, floor of 2 concurring.  3 healthy → need 2; 2 healthy
-            // → need both; < 2 healthy → cannot fire (see Layer-2 backstop).
-            if (available >= 2 && passed >= 2 && passed >= (available - 1))
+            // Quorum: a floor of 2 concurring voters, then N-1 of N — but relax
+            // to N-2 once there are > 3 voters (#262).  Adding GPS as a 4th voter
+            // under a strict N-1 would turn the nominal 2-of-3 into 3-of-4 and
+            // *delay* apogee (observed +0.56 s in flight replay); N-2-when-N>3
+            // keeps 4-voter sensitivity at 2-of-4 (== the old 2-of-3) while the
+            // 2-concurring floor still bars any single-sensor trigger.  Three or
+            // fewer voters (incl. the mach-lockout case: vel+gps+pitch) stay at
+            // N-1 → 2-of-3, with GPS supplying the non-EKF diversity.
+            const uint8_t need = (available > 3) ? (uint8_t)(available - 2)
+                                                 : (uint8_t)(available - 1);
+            if (available >= 2 && passed >= 2 && passed >= need)
             {
                 apogee_flag = true;
             }


### PR DESCRIPTION
## Summary
Fixes #262. During transonic baro mach-lockout the apogee vote collapses to vel+pitch — both EKF-derived — so a common-mode EKF fault can sink both voters and apogee is missed until the baro backstop unlocks well into descent. This restores a non-EKF voter in that window by re-enabling GPS Doppler vertical velocity, now that the GNSS dynamic-model change has cleaned up the boost corruption (#237/#242) that originally forced GPS out of the vote.

## Change (firmware + Python port, in lockstep)
- **GPS un-excluded as an apogee voter**, available only on a **fresh fix**: `gps_available_ && (now − last_fix) < GPS_APOGEE_FRESH_MS` (**500 ms**). Tight on purpose — boost-to-apogee is ~6–8 s and GPS runs ~18 Hz (~55 ms/fix), so a 5 s-old fix (the landing vote's gate) would be launch-rail stale. The detector itself is unchanged (post-burnout, Doppler-only, 1 m/s descent, HI=4 debounce); only its availability changed.
- **Quorum relaxed N−1 → floor-2 / N−2-when-N>3.** Adding GPS as a 4th voter under strict N−1 would turn the nominal 2-of-3 into 3-of-4 and *delay* apogee (+0.56 s in replay). N−2-when-N>3 keeps 4-voter sensitivity at 2-of-4 (== old 2-of-3) while the 2-concurring floor still bars any single-sensor trigger. ≤3 voters (incl. mach-lockout's vel+gps+pitch) stay at N−1 → 2-of-3, GPS supplying the non-EKF diversity.

## Report tooling
- Feed `gps_vel_u` into the replay — it was omitted, so the report's GPS voting row was silently inert. The GPS detector now fires in replay and matches the firmware's logged flag.
- True-apogee marker = GNSS Doppler vel=0 crossing, not the raw-baro argmax (baro lags GNSS 0.3–1.3 s, #112, and argmax grabbed spikes). Baro peak still drawn, labeled as lagging.

## Tests
New gtest coverage in `test_kinematic_checks.cpp` (replaces the obsolete "GPS excluded" test): single-voter floor, N−2 2-of-4 fire, the #262 lockout-rescue (pitch+GPS carry when vel is faulted), the without-GPS companion (does *not* fire), and the stale-GPS gate. **Full tests_cpp suite: 375/375 pass.**

## Validation
- flight_computer builds clean (esp32-p4, IDF v6.0).
- **Bench SIL simulated flight** (real `TR_KinematicChecks` binary): behavioral replay confirms the flown firmware ran this code (logged master apogee 8.18 s matches the new port, not the old 8.94 s). GPS was the deciding 2nd voter; with pitch never firing in the 1-D sim, the change fired apogee **0.77 s earlier** than the old logic (8.18 vs 8.94 s) and closer to true apogee (GNSS vel=0 at 7.96 s: +0.22 s vs +0.99 s). No false/premature fire.

## Caveat
All validation flights were subsonic, so the **mach-lockout path itself is covered by the gtest and by-construction, not yet by flight data** — needs a transonic flight to exercise live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
