### PR TITLE
fix(fc): center fins for genuine neutral holds instead of running the roll PID (#270)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5144,8 +5144,11 @@ static void loop_fc()
             }
             else if (servo_enabled)
             {
-                // EKF not yet initialized — hold neutral and log why
-                servo_control.control(0.0f);
+                // EKF not yet initialized — hold neutral and log why.  #270:
+                // centre the fins (no PID) and reset the integral, so nothing
+                // leaks into the "neutral" output or into control once it starts.
+                servo_control.stowControl();
+                servo_control.resetPID();
                 static uint32_t gt_wait_print_ms = 0;
                 if (now_ms - gt_wait_print_ms >= 2000U)
                 {
@@ -5353,8 +5356,12 @@ static void loop_fc()
                     // Delay roll control activation after launch if configured
                     if (reboot_recovery || t_since_launch_ms < roll_delay_ms)
                     {
-                        // Hold fins neutral until delay/settle elapses
-                        servo_control.control(0.0f);
+                        // Hold fins neutral until delay/settle elapses.  #270:
+                        // centre the fins (no PID) and reset the integral — the
+                        // pre-roll_delay window must not accumulate an offset that
+                        // would jerk the fins when roll control activates.
+                        servo_control.stowControl();
+                        servo_control.resetPID();
                     }
                     else if (ism6_fresh)   // #259: stale IMU -> neutral-hold branch below
                     {
@@ -5554,8 +5561,12 @@ static void loop_fc()
                     }
                     else
                     {
-                        // IMU data lost mid-flight — hold fins at neutral (0° command)
-                        servo_control.control(0.0f);
+                        // IMU data lost mid-flight — hold fins at neutral.  #270:
+                        // centre the fins (no PID) and reset the integral, so a
+                        // stale pre-loss integral can't deflect them and control
+                        // resumes clean if the IMU recovers.
+                        servo_control.stowControl();
+                        servo_control.resetPID();
                     }
                 }
                 const bool landing_conditions =


### PR DESCRIPTION
## Summary
Fixes #270. Three "hold fins neutral" branches called `servo_control.control(0.0f)`, which runs `pid.computePID()` and converts the output to a pulse — it does **not** center the fins. Each tick integrates the `(setpoint − 0)` error, so accumulated integral deflects the "neutral" fins and leaks into control when it resumes, contrary to the comment.

## Change
Replaced all three with `stowControl()` (→ `setPulse(0)` = centered, no PID) + `resetPID()` (→ `pid.reset()`, clears the integral) — the idiom already used at the other neutral-hold sites in this file:
- **pre-roll_delay window** (`t_since_launch < roll_delay` / reboot recovery): the worst case — old code integrated for the whole `roll_delay` (default 500 ms) and jerked the fins the instant roll control activated. Now holds true neutral; control starts from zero.
- **IMU-lost mid-flight branch**: a stale pre-loss integral no longer deflects the neutral fins; control resumes clean if the IMU recovers.
- **EKF-not-initialized ground-test hold**: same fix for consistency.

In-flight holds **center** (not `idle()`/relax) — fins must hold neutral against the airstream, not flop.

## Verification
flight_computer builds clean (esp32-p4, IDF v6.0). Bench-observable: with servos enabled, the pre-roll-delay / IMU-lost holds sit centered with no creep (vs. the old PID-driven drift). Control-output cleanup only — does not touch apogee/recovery logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
