### PR TITLE
fix(bs): reject oversized uplink payloads instead of silently truncating them (#286)

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1377,13 +1377,23 @@ static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payloa
                               uint8_t target_rid = 0xFF,
                               uint8_t retries = config::UPLINK_RETRIES)
 {
+    // #286: reject (do NOT truncate) an oversized payload.  Truncating would
+    // send a malformed command with a wrong-but-consistent length and no error
+    // surfaced.  Checked first so a rejected command also leaves any
+    // already-pending uplink untouched.
+    constexpr size_t kMaxUplinkPayload = sizeof(uplink_buf) - 6 - 1;  // header + 1 B slack = 33
+    if (payload_len > kMaxUplinkPayload)
+    {
+        ESP_LOGE(TAG, "[UPLINK] cmd=%u payload %u B exceeds max %u — REJECTED, not queued",
+                 cmd, (unsigned)payload_len, (unsigned)kMaxUplinkPayload);
+        return;
+    }
+
     if (uplink_pending)
     {
         ESP_LOGW(TAG, "[UPLINK] Discarding pending cmd=%u, replacing with cmd=%u",
                  uplink_buf[4], cmd);
     }
-
-    if (payload_len > 33) payload_len = 33;  // 40-byte buf − 6-byte header − 1 byte slack
     // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
     uplink_buf[0] = config::UPLINK_SYNC_BYTE;  // 0xCA
     uplink_buf[1] = network_id;


### PR DESCRIPTION
## Summary
Fixes #286. `buildUplinkPacket` did `if (payload_len > 33) payload_len = 33;` then wrote that truncated length into the packet — a too-long command (a cmd-50 relay, or any future longer command) went out shortened with a wrong-but-consistent length, delivering a malformed command to the rocket with **no error surfaced**.

## Change
Reject instead of truncate: log `ESP_LOGE` and `return` without queuing when the payload exceeds the buffer's capacity. Two refinements:
- **Limit derived from the buffer** — `sizeof(uplink_buf) - 6 (header) - 1 (slack)` (= 33), so it tracks the buffer if it's ever resized rather than a magic number.
- **Check moved to the top** of the function, so a rejected oversized command also leaves any already-pending uplink untouched (the old order would hit the "discarding pending" path first).

All fixed-size callers send ≤27 B; only the app-driven cmd-50 relay can exceed the cap, and it now fails loudly (and visibly unconfirmed, per #285) instead of corrupting the command.

## Verification
base_station builds clean (esp32s3, IDF v6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
