### PR TITLE
refactor(bs): name the app<->BS BLE command IDs instead of bare literals (#287)

### DIFF
--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -229,6 +229,34 @@ static constexpr uint8_t LORA_CMD_HOP_PAUSE       = 16;   // uplink cmd: park on
 static constexpr uint16_t LORA_HOP_PAUSE_MAX_MS   = 60000; // server-side cap on cmd 16 duration
 static constexpr uint8_t LORA_CMD_SET_HOP_DISABLED = 17;  // uplink cmd: 1 byte payload, 0=hopping enabled (default), 1=disabled (fixed-frequency mode for diagnostics, #106)
 
+// ── App ↔ Base Station BLE command IDs (#287) ─────────────────────────────
+// The command byte the iOS app sends to the *base station* on the BLE command
+// characteristic.  Promoted from bare literals in the BS dispatch so a renumber
+// is greppable and tools/check_ble_command_ids.py resolves them to numbers.
+// This is the BS command space; the app↔Out-Computer space is INDEPENDENT and
+// may reuse the same number for a different meaning (e.g. 50 = relay-to-rocket
+// here, but mag-cal-start on the OC — that overlap is correct).  Some are
+// relayed verbatim to the rocket (camera/logging/sim/servo-test); their value
+// happens to equal the OC's inner command number.  LORA_CMD_SET_HOP_DISABLED
+// (17, above) doubles as the BS hop-disable BLE command and is reused as-is.
+static constexpr uint8_t BLE_BS_CMD_CAMERA_TOGGLE     = 1;
+static constexpr uint8_t BLE_BS_CMD_FILE_LIST         = 2;
+static constexpr uint8_t BLE_BS_CMD_FILE_DELETE       = 3;
+static constexpr uint8_t BLE_BS_CMD_FILE_DOWNLOAD     = 4;
+static constexpr uint8_t BLE_BS_CMD_SIM_CONFIG        = 5;
+static constexpr uint8_t BLE_BS_CMD_SIM_START         = 6;
+static constexpr uint8_t BLE_BS_CMD_SIM_STOP          = 7;
+static constexpr uint8_t BLE_BS_CMD_TIME_SYNC         = 9;
+static constexpr uint8_t BLE_BS_CMD_LORA_RECONFIG     = 10;
+static constexpr uint8_t BLE_BS_CMD_CONFIG_READBACK   = 20;
+static constexpr uint8_t BLE_BS_CMD_LOGGING_TOGGLE    = 23;
+static constexpr uint8_t BLE_BS_CMD_SERVO_TEST_ANGLES = 24;
+static constexpr uint8_t BLE_BS_CMD_SERVO_TEST_STOP   = 25;
+static constexpr uint8_t BLE_BS_CMD_SET_UNIT_NAME     = 40;
+static constexpr uint8_t BLE_BS_CMD_SET_NETWORK_ID    = 41;
+static constexpr uint8_t BLE_BS_CMD_RELAY_TO_ROCKET   = 50;
+static constexpr uint8_t BLE_BS_CMD_FREQ_SCAN         = 60;
+
 // Minimum SNR (dB) for an RX packet to be considered trustworthy at the
 // given spreading factor.  Bench-confirmed in #90 follow-up: a CRC-
 // passing decode at -12.8 dB SNR on SF8 (sensitivity -10 dB) was a

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3604,19 +3604,19 @@ static void loop_bs()
     }
 
     uint8_t ble_cmd = ble_app.getCommand();
-    if (ble_cmd == 2)
+    if (ble_cmd == BLE_BS_CMD_FILE_LIST)
     {
         handleFileListCommand();
     }
-    else if (ble_cmd == 3)
+    else if (ble_cmd == BLE_BS_CMD_FILE_DELETE)
     {
         handleDeleteCommand();
     }
-    else if (ble_cmd == 4)
+    else if (ble_cmd == BLE_BS_CMD_FILE_DOWNLOAD)
     {
         handleDownloadCommand();
     }
-    else if (ble_cmd == 1)
+    else if (ble_cmd == BLE_BS_CMD_CAMERA_TOGGLE)
     {
         // Camera toggle: send desired state (inverse of last known) so LoRa
         // retries are idempotent — won't toggle back and forth on the rocket.
@@ -3624,7 +3624,7 @@ static void loop_bs()
         buildUplinkPacket(1, &desired, 1);
         ESP_LOGI(TAG, "[BLE->UPLINK] Camera %s", desired ? "START" : "STOP");
     }
-    else if (ble_cmd == 23)
+    else if (ble_cmd == BLE_BS_CMD_LOGGING_TOGGLE)
     {
         // Logging toggle: starts/stops BOTH rocket flash recording (via LoRa
         // uplink) and base station SD card logging simultaneously.
@@ -3659,7 +3659,7 @@ static void loop_bs()
             }
         }
     }
-    else if (ble_cmd == 24)
+    else if (ble_cmd == BLE_BS_CMD_SERVO_TEST_ANGLES)
     {
         // Servo test angles: relay 8-byte payload to OutComputer via LoRa uplink
         const uint8_t* payload = ble_app.getCommandPayload();
@@ -3670,13 +3670,13 @@ static void loop_bs()
             ESP_LOGI(TAG, "[BLE->UPLINK] Servo test angles");
         }
     }
-    else if (ble_cmd == 25)
+    else if (ble_cmd == BLE_BS_CMD_SERVO_TEST_STOP)
     {
         // Servo test stop: relay to OutComputer via LoRa uplink
         buildUplinkPacket(25, nullptr, 0);
         ESP_LOGI(TAG, "[BLE->UPLINK] Servo test stop");
     }
-    else if (ble_cmd == 5)
+    else if (ble_cmd == BLE_BS_CMD_SIM_CONFIG)
     {
         // Sim config: relay to OutComputer via LoRa uplink
         // Payload is 16 bytes: [mass_g:4][thrust_n:4][burn_s:4][descent_rate_mps:4]
@@ -3700,17 +3700,17 @@ static void loop_bs()
                      (double)mass_g, (double)thrust_n, (double)burn_s, (double)descent);
         }
     }
-    else if (ble_cmd == 6)
+    else if (ble_cmd == BLE_BS_CMD_SIM_START)
     {
         buildUplinkPacket(6, nullptr, 0);
         ESP_LOGI(TAG, "[BLE->UPLINK] Sim start");
     }
-    else if (ble_cmd == 7)
+    else if (ble_cmd == BLE_BS_CMD_SIM_STOP)
     {
         buildUplinkPacket(7, nullptr, 0);
         ESP_LOGI(TAG, "[BLE->UPLINK] Sim stop");
     }
-    else if (ble_cmd == 9)
+    else if (ble_cmd == BLE_BS_CMD_TIME_SYNC)
     {
         // Time sync from phone: [year_lo][year_hi][month][day][hour][minute][second]
         const uint8_t* payload = ble_app.getCommandPayload();
@@ -3735,7 +3735,7 @@ static void loop_bs()
             renameOpenLogIfSequential();
         }
     }
-    else if (ble_cmd == 10)
+    else if (ble_cmd == BLE_BS_CMD_LORA_RECONFIG)
     {
         // LoRa reconfiguration — transactional (issue #71).  The base
         // station relays the new config to every rocket on the OLD channel,
@@ -3794,13 +3794,13 @@ static void loop_bs()
             sendCurrentConfig();
         }
     }
-    else if (ble_cmd == 20)
+    else if (ble_cmd == BLE_BS_CMD_CONFIG_READBACK)
     {
         // Config readback request
         sendCurrentConfig();
     }
     // ---- Device Identity Commands ----
-    else if (ble_cmd == 40)
+    else if (ble_cmd == BLE_BS_CMD_SET_UNIT_NAME)
     {
         // Set unit name — payload is UTF-8 string, max 20 bytes
         const uint8_t* payload = ble_app.getCommandPayload();
@@ -3821,7 +3821,7 @@ static void loop_bs()
             ESP_LOGI(TAG, "[BLE] Unit name set: %s", unit_name);
         }
     }
-    else if (ble_cmd == 41)
+    else if (ble_cmd == BLE_BS_CMD_SET_NETWORK_ID)
     {
         // Set network_id — payload: [nid:1]
         const uint8_t* payload = ble_app.getCommandPayload();
@@ -3837,7 +3837,7 @@ static void loop_bs()
             ESP_LOGI(TAG, "[BLE] Network ID set: %u", (unsigned)network_id);
         }
     }
-    else if (ble_cmd == 50)
+    else if (ble_cmd == BLE_BS_CMD_RELAY_TO_ROCKET)
     {
         // Relay command to a specific rocket via LoRa uplink
         // Payload: [target_rid:1][inner_cmd:1][inner_payload:0..18]
@@ -3854,7 +3854,7 @@ static void loop_bs()
                      inner_cmd, target_rid, (unsigned)inner_len);
         }
     }
-    else if (ble_cmd == 60)
+    else if (ble_cmd == BLE_BS_CMD_FREQ_SCAN)
     {
         // Frequency scan (base-station radio, pre-launch collision avoidance).
         // Payload: [start_mhz f32][stop_mhz f32][step_khz u16][dwell_ms u16]


### PR DESCRIPTION
## Summary
Fixes #287. The base-station BLE dispatch matched the incoming command byte with bare integer literals (`ble_cmd == 1` … `== 60`). A renumber on one side silently shadows a branch, and the literals carry no meaning at the call site. (The inner LoRa cmds already used `LORA_CMD_*`.)

## Change
Promote all 17 to named constants (`BLE_BS_CMD_*`) in `RocketComputerTypes.h`, beside the existing `LORA_CMD_*` block, and use them in the dispatch. This is the **app↔BS** command space, kept explicitly separate from the independent **app↔OC** space (e.g. `50` = relay-to-rocket here, mag-cal-start on the OC). `tools/check_ble_command_ids.py` resolves names from that header, so the IDs are now greppable and CI-validated. `LORA_CMD_SET_HOP_DISABLED` (17) already doubled as a BS BLE command and is reused as-is.

**No behavior change** — same numeric values; the check script confirms each name resolves to its prior literal.

Note: the duplicate-shadowing *safety* was already enforced by `check_ble_command_ids.py` (wire-codes CI); this is the readability/drift-resistance half the issue also asked for. The inner `buildUplinkPacket(N, …)` relay literals are intentionally left alone to keep the change scoped to the dispatch.

## Verification
- `check_ble_command_ids.py` passes and resolves all 18 BS names to their prior values.
- base_station builds clean (esp32s3, IDF v6.0); shared-header gtest `test_rocket_computer_types` 72/72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
