### PR TITLE
fix(bs): count LoRa RX bad-length drops so they're visible in [STATS] (#288)

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -251,6 +251,15 @@ bool TR_LoRa_Comms::readPacket(uint8_t* buf, size_t maxLen, size_t& len)
     const size_t pkt_len = radio_->getPacketLength();
     if (pkt_len == 0 || pkt_len > maxLen)
     {
+        // #288: count the drop so a stuck/garbage length field is visible in
+        // [STATS] instead of vanishing silently.  Implausible in practice
+        // (maxLen 256 vs ~62 B real packets), so a nonzero count is a signal.
+        stats_.rx_len_drop++;
+        if (debug_)
+        {
+            ESP_LOGW(TAG, "LoRa RX bad length %u (max %u), dropped",
+                     (unsigned)pkt_len, (unsigned)maxLen);
+        }
         // Restart RX for next packet
         (void)radio_->startReceive();
         return false;

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -39,6 +39,7 @@ public:
         uint32_t tx_fail = 0;
         uint32_t rx_count = 0;
         uint32_t rx_crc_fail = 0;
+        uint32_t rx_len_drop = 0;  // #288: RX dropped for bad length (0 or > maxLen)
         uint32_t isr_count = 0;
         uint32_t tx_watchdog_fires = 0;  // tx_ongoing_ force-cleared by watchdog (#105)
         float last_rssi = 0.0f;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1278,10 +1278,11 @@ static void printStats()
         snprintf(last_pkt_str, sizeof(last_pkt_str), "never");
     }
 
-    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | low-SNR drop: %lu | ISR: %lu | rx_mode: %d | TX wdog: %lu | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
+    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | len drop: %lu | low-SNR drop: %lu | ISR: %lu | rx_mode: %d | TX wdog: %lu | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
              (unsigned long)ls.rx_count,
              (double)rx_hz,
              (unsigned long)ls.rx_crc_fail,
+             (unsigned long)ls.rx_len_drop,
              (unsigned long)lora_low_snr_drops,
              (unsigned long)ls.isr_count,
              (int)ls.rx_mode,


### PR DESCRIPTION
## Summary
Fixes #288. `readPacket` dropped packets with `pkt_len == 0 || pkt_len > maxLen` by restarting RX and returning false **without** incrementing any counter, so a stuck/garbage length field was invisible in the `[STATS]` line. The happy path is already robust (length validated before `readData`, CRC mismatch counted) — this is a visibility gap, not a crash.

## Change
- Add `Stats::rx_len_drop`.
- Increment it in the bad-length branch (plus a debug-gated warn).
- Surface it in the BS `[STATS]` line as `len drop: N`, next to `CRC fail`.

An oversized packet is implausible (`maxLen` 256 vs ~62 B real packets), so any nonzero count is a real signal worth seeing.

## Verification
`TR_LoRa_Comms` is shared by base_station + out_computer — both build clean (IDF v6.0); the `Stats` field is additive and OC's `readPacket` increments the counter harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
