### PR TITLE
fix(bs): skip the periodic telemetry push when the RX path already sent this loop (#289)

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3073,6 +3073,12 @@ static void setup_bs()
 
 static void loop_bs()
 {
+    // #289: set when the RX path sends a (fresh) telemetry notification this
+    // iteration, so the periodic battery push below can skip a redundant second
+    // notify — two back-to-back sends double the notify pressure exactly when
+    // the queue may be full, making an RX-path drop more likely.
+    bool rx_sent_telem_this_iter = false;
+
     // Service LoRa (complete any pending TX before checking for RX)
     lora_comms.service();
     lora_comms.pollDio1();          // Fallback if DIO1 interrupt doesn't fire
@@ -3464,6 +3470,7 @@ static void loop_bs()
                     ble_telem.source_unit_name = tracked_rockets[slot].unit_name;
                 }
                 ble_app.sendTelemetry(ble_telem);
+                rx_sent_telem_this_iter = true;   // #289
                 maybeMarkOtaValid();
             }
         }
@@ -3571,8 +3578,15 @@ static void loop_bs()
                 buildBLETelemetry(empty, NAN, NAN, NAN, NAN, NAN, ble_telem);
                 ble_telem.data_status = TR_BLE_To_APP::TelemetryData::DataStatus::SYNCING;
             }
-            ble_app.sendTelemetry(ble_telem);
-            maybeMarkOtaValid();
+            // #289: skip this push if the RX path already sent a fresher frame
+            // this iteration — the periodic push exists to keep BS stats/liveness
+            // current when no packet arrived, so it's redundant right after a
+            // fresh decode.  The battery read above still runs every period.
+            if (!rx_sent_telem_this_iter)
+            {
+                ble_app.sendTelemetry(ble_telem);
+                maybeMarkOtaValid();
+            }
 
             // Flash-space stats for the app's storage bar (every ~5 s).
             static uint32_t last_bs_storage_ms = 0;


### PR DESCRIPTION
## Summary
Fixes #289. The BS sends telemetry on a fresh LoRa decode (RX path) and again from the periodic battery block every `PWR_UPDATE_PERIOD_MS`. When a packet arrives AND the 2 s timer fires in the same `loop_bs()` iteration, two notifications go out back-to-back — doubling notify pressure exactly when the queue may be full, raising the chance the RX-path frame is the one dropped by `notify_data`'s 3-retry cap (compounds the MTU-drop concern).

## Change
Add an iteration-scoped flag (`rx_sent_telem_this_iter`) set by the RX-path send, and gate **only** the periodic `sendTelemetry` on it. The periodic battery read + flash-space stats still run every period; just the redundant second notify is skipped (the RX frame is fresher and already carries the BS stats). Same task, no reentrancy.

## Verification
base_station builds clean (esp32s3, IDF v6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
