### PR TITLE
fix(oc): #297 low-severity cluster — INA230 calibrate guard, cmd_ring drop counter, I2C timeout units

### DIFF
--- a/tinkerrocket-idf/components/TR_INA230/TR_INA230.cpp
+++ b/tinkerrocket-idf/components/TR_INA230/TR_INA230.cpp
@@ -104,6 +104,11 @@ TR_INA230Status TR_INA230::setCalibration(uint16_t cal)
 
 TR_INA230Status TR_INA230::calibrate(float r_shunt_ohm, float current_lsb_A)
 {
+    // #297: guard the divide — a zero/negative LSB or shunt yields inf/NaN and a
+    // bogus calibration that would read a flat 0 A while still reporting OK.
+    if (current_lsb_A <= 0.0f || r_shunt_ohm <= 0.0f)
+        return TR_INA230_ERROR;
+
     _current_lsb_A = current_lsb_A;
 
     // CAL = 0.00512 / (Current_LSB * R_SHUNT)   (Equation 1)
@@ -245,7 +250,7 @@ TR_INA230Status TR_INA230::writeRegister(uint8_t reg, uint16_t value)
     buf[1] = (uint8_t)(value >> 8);    // MSByte
     buf[2] = (uint8_t)(value & 0xFF);  // LSByte
 
-    esp_err_t err = i2c_master_transmit(_dev, buf, 3, pdMS_TO_TICKS(I2C_TIMEOUT_MS));
+    esp_err_t err = i2c_master_transmit(_dev, buf, 3, I2C_TIMEOUT_MS /* #297: IDF-v6 i2c_master_* takes ms, not ticks */);
     return (err == ESP_OK) ? TR_INA230_OK : TR_INA230_ERROR;
 }
 
@@ -253,7 +258,7 @@ TR_INA230Status TR_INA230::readRegister(uint8_t reg, uint16_t *value)
 {
     uint8_t data[2] = {0, 0};
     esp_err_t err = i2c_master_transmit_receive(_dev, &reg, 1, data, 2,
-                                                 pdMS_TO_TICKS(I2C_TIMEOUT_MS));
+                                                 I2C_TIMEOUT_MS /* #297: IDF-v6 i2c_master_* takes ms, not ticks */);
     if (err != ESP_OK) return TR_INA230_ERROR;
     *value = ((uint16_t)data[0] << 8) | data[1];
     return TR_INA230_OK;

--- a/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17205G/TR_MAX17205G.cpp
@@ -28,7 +28,7 @@ bool TR_MAX17205G::readReg(uint8_t reg, uint16_t& value)
     if (_dev == nullptr) return false;
     uint8_t buf[2] = {};
     esp_err_t err = i2c_master_transmit_receive(_dev, &reg, 1, buf, 2,
-                                                pdMS_TO_TICKS(I2C_TIMEOUT_MS));
+                                                I2C_TIMEOUT_MS /* #297: IDF-v6 i2c_master_* takes ms, not ticks */);
     if (err != ESP_OK) return false;
     value = ((uint16_t)buf[1] << 8) | buf[0];  // Little-endian on the wire
     return true;
@@ -40,7 +40,7 @@ bool TR_MAX17205G::writeReg(uint8_t reg, uint16_t value)
     uint8_t buf[3] = { reg,
                        (uint8_t)(value & 0xFF),
                        (uint8_t)((value >> 8) & 0xFF) };
-    return i2c_master_transmit(_dev, buf, 3, pdMS_TO_TICKS(I2C_TIMEOUT_MS)) == ESP_OK;
+    return i2c_master_transmit(_dev, buf, 3, I2C_TIMEOUT_MS /* #297: IDF-v6 i2c_master_* takes ms, not ticks */) == ESP_OK;
 }
 
 // ---------------------------------------------------------------------------

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1028,6 +1028,7 @@ static constexpr size_t CMD_RING_SIZE = 1024;
 static uint8_t cmd_ring[CMD_RING_SIZE];
 static size_t cmd_head = 0;
 static size_t cmd_tail = 0;
+static uint32_t cmd_ring_drop_count = 0;  // #297: bytes dropped-oldest on overflow (visibility; CRC still rejects the corrupted result)
 
 static inline size_t cmdLen()
 {
@@ -1039,7 +1040,10 @@ static inline void cmdPush(uint8_t b)
     cmd_ring[cmd_head] = b;
     cmd_head = (cmd_head + 1U) % CMD_RING_SIZE;
     if (cmd_head == cmd_tail)
-        cmd_tail = (cmd_tail + 1U) % CMD_RING_SIZE;
+    {
+        cmd_tail = (cmd_tail + 1U) % CMD_RING_SIZE;  // drop oldest on overflow
+        cmd_ring_drop_count++;                       // #297
+    }
 }
 static inline uint8_t cmdPeek(size_t i)
 {
@@ -3779,9 +3783,10 @@ static void printStats()
     ESP_LOGI("OC", "i2c raw reads/bytes=%lu/%llu",
                   (unsigned long)raw_i2c_reads,
                   (unsigned long long)raw_i2c_bytes);
-    ESP_LOGI("OC", "i2c raw_rx=%.1f KB/s | ring_drops=%lu | parser_drops resync/len/crc=%llu/%llu/%lu",
+    ESP_LOGI("OC", "i2c raw_rx=%.1f KB/s | ring_drops=%lu | cmd_drops=%lu | parser_drops resync/len/crc=%llu/%llu/%lu",
                   (double)raw_rx_kbs,
                   (unsigned long)rx_ring_overflow_drops,
+                  (unsigned long)cmd_ring_drop_count,
                   (unsigned long long)parser_resync_drops,
                   (unsigned long long)parser_len_drops,
                   (unsigned long)frames_bad_crc);
@@ -4684,10 +4689,19 @@ static void setup_oc()
                                 INA230_ConvTime::CT_332us,
                                 INA230_ConvTime::CT_332us,
                                 INA230_Mode::POWER_DOWN);
-        ina230.calibrate(INA230_R_SHUNT_OHM, INA230_CURRENT_LSB_A);
-        ina230.enableConversionReadyAlert(true);  // enable CVRF bit for polling
-        ina230_ok = true;
-        ESP_LOGI("PWR", "INA230 OK (triggered mode, CVRF polling)");
+        // #297: gate ina230_ok on a successful calibrate so a bad calibration
+        // (guarded divide returns ERROR) can't leave us reading a flat 0 A with
+        // an "OK" status.
+        if (ina230.calibrate(INA230_R_SHUNT_OHM, INA230_CURRENT_LSB_A) == TR_INA230_OK)
+        {
+            ina230.enableConversionReadyAlert(true);  // enable CVRF bit for polling
+            ina230_ok = true;
+            ESP_LOGI("PWR", "INA230 OK (triggered mode, CVRF polling)");
+        }
+        else
+        {
+            ESP_LOGW("PWR", "INA230 calibrate failed — battery monitoring disabled");
+        }
     }
     else
     {


### PR DESCRIPTION
## Summary
Group 1 of the #297 low-severity roundup — the Out-Computer items.

- **INA230 `calibrate()`** — guard the `0.00512 / (lsb * shunt)` divide (zero/negative → ERROR instead of inf/NaN → a bogus cal that reads flat 0 A with OK status), and **gate `ina230_ok` on the calibrate return** at the caller (was unconditional).
- **`cmd_ring` drop counter** — add `cmd_ring_drop_count`, incremented on the silent drop-oldest overflow, surfaced in the OC `[STATS]` line (`cmd_drops=N`). CRC already rejects the corrupted result; this just makes it observable (rx_ring already had a counter).
- **I2C timeout units** — drop the `pdMS_TO_TICKS()` wrap around the millisecond timeout arg of the IDF-v6 `i2c_master_transmit/receive` calls in `TR_INA230` + `TR_MAX17205G` (4 sites). Identity at `CONFIG_FREERTOS_HZ=1000` today, but would silently shrink the timeout if the tick rate changed. (BQ27Z746 already passes ms directly.)

**Not changed (also #297):**
- Duplicated SoC tables — already consolidated; only one table remains.
- rx_ring ISR drop → BLE `frames_drop` — deferred: `rx_ring_overflow_drops` is a **byte** count and `frames_drop` is a **frame** count, so folding it in would mislead the GUI; the ISR drops are already in the serial `[STATS]` and the `.bin` LogBufferStats.

## Verification
`TR_INA230` / `TR_MAX17205G` are shared by OC + BS — both build clean (IDF v6.0). No behavior change except the new guards/counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
