### PR TITLE
fix(app): choose connected-device screen by positive role, not fail-open (#330)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -317,7 +317,16 @@ struct ConnectedDashboardView: View {
             )
         }
 
-        if !device.isBaseStation && !device.telemetry.pwr_pin_on {
+        if device.deviceType == .unknown {
+            // --- Role not yet known (#330): neutral "identifying" state.
+            //     The connected-device view used to fail *open* to the rocket
+            //     Power-On screen for anything not positively a base station,
+            //     so `.unknown` (name parse miss, or the window before
+            //     config_identity "dt" resolves) wrongly showed a rocket UI.
+            //     Drive the screen off a *positive* role instead, with an
+            //     explicit identifying state for the unresolved case.
+            IdentifyingDeviceView(deviceName: device.displayName)
+        } else if device.deviceType == .rocket && !device.telemetry.pwr_pin_on {
             // --- Powered OFF (rocket only): show battery + power on button ---
             BatteryView(telemetry: device.telemetry, isBaseStation: false)
 
@@ -468,6 +477,35 @@ struct ConnectedDashboardView: View {
 }
 
 // MARK: - Component Views
+
+/// Neutral placeholder shown while a connected device's role is still
+/// `.unknown` (#330) — i.e. its advertised name didn't parse to a role and
+/// the `config_identity` "dt" readback hasn't arrived yet.  This replaces the
+/// old fail-open behaviour where any non-base-station device (including the
+/// not-yet-identified state) landed on the rocket "Power On" screen.  As soon
+/// as the role resolves to .rocket or .baseStation the parent re-renders into
+/// the appropriate screen, so this is normally only visible for a beat.
+struct IdentifyingDeviceView: View {
+    let deviceName: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+            Text("Identifying device…")
+                .font(.headline)
+            if !deviceName.isEmpty {
+                Text(deviceName)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(10)
+    }
+}
 
 struct ConnectionStatusView: View {
     let isConnected: Bool


### PR DESCRIPTION
Closes #330.

## Problem
The connected-device view chose between the rocket **Power On** screen and the full dashboard with one negative check:

```swift
if !device.isBaseStation && !device.telemetry.pwr_pin_on { /* rocket Power-On screen */ }
```

`isBaseStation` is true only when a device is *positively* `deviceType == .baseStation`, and `deviceType` defaults to `.unknown`. So **any device not yet positively a base station fell into the rocket branch** — including `.unknown`, which happens when the advertised name doesn't parse to a role, or when we render before the `config_identity` "dt" readback resolves. With the fleet auto-promoting the first connected device to active, the first thing an operator saw after connecting *anything* was the rocket pre-powered-on screen.

## Fix
Drive the screen off a **positive** role (`Views/DashboardView.swift`):

- `.unknown` → new neutral `IdentifyingDeviceView` ("Identifying device…") instead of a rocket-specific UI. Resolves to the correct screen as soon as the role lands (name parse or `dt` = `R`/`B`), so it's normally on screen only briefly.
- `.rocket && !pwr_pin_on` → Power-On screen (was `!isBaseStation`).
- else (base station, or a powered-on rocket) → full dashboard, **unchanged**.

The Power-On screen is intentionally **not** freshness-gated: it exists precisely when telemetry is minimal (rocket off), so a SYNCING/STALE gate there would hide the button and strand the operator.

## Acceptance (from #330)
- Connecting a base station shows the base-station dashboard, never the rocket Power-On screen. ✅ (`.baseStation` → else branch)
- A device whose role isn't known yet shows a neutral "identifying" state. ✅
- A powered-off rocket still shows the Power-On screen. ✅ (`.rocket && !pwr_pin_on`)

## Test
iOS build + full test suite green (iPhone 17 / OS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
