### PR TITLE
fix(ci): mark TR_GuidancePN submodule update=none so recursive clones skip it (#255)

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -28,9 +28,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
-          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
+
+      # TR_GuidancePN is marked `update = none` in .gitmodules so recursive
+      # clones (Xcode Cloud, casual `--recurse-submodules`) skip the private
+      # repo instead of failing on it (#255). On trusted branches the token is
+      # present and we want guidance coverage, so force the checkout here,
+      # overriding the `none` update mode. Forks / PRs without the token skip
+      # this step and guidance tests are simply not discovered
+      # (tests_cpp/CMakeLists.txt handles that gracefully).
+      - name: Check out private TR_GuidancePN (trusted branches only)
+        if: ${{ env.HAS_GUIDANCE_TOKEN == 'true' }}
+        env:
+          TR_GUIDANCEPN_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN }}
+        run: |
+          # Match actions/checkout's safe.directory exception for this manual
+          # submodule call (harmless on the non-container runner).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${TR_GUIDANCEPN_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
+            submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
 
       - name: Configure
         run: cmake -S tests_cpp -B tests_cpp/build -DCMAKE_BUILD_TYPE=Debug
@@ -46,9 +62,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
-          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
+
+      # See the cpp-tests job above — same private-submodule handling (#255).
+      - name: Check out private TR_GuidancePN (trusted branches only)
+        if: ${{ env.HAS_GUIDANCE_TOKEN == 'true' }}
+        env:
+          TR_GUIDANCEPN_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN }}
+        run: |
+          # Match actions/checkout's safe.directory exception for this manual
+          # submodule call (harmless on the non-container runner).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${TR_GUIDANCEPN_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
+            submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -10,6 +10,11 @@ on:
       - 'tinkerrocket-idf/**'
       - '.github/workflows/firmware-build.yml'
 
+# The `secrets` context isn't available in step-level `if:`, so surface the
+# private-submodule token as a boolean here for the force-checkout step below.
+env:
+  HAS_GUIDANCE_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,13 +30,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # TR_GuidancePN is a private submodule. Recurse only when the
-          # TR_GUIDANCEPN_TOKEN repo secret is present. Without it, the
-          # submodule is skipped and flight_computer's CMakeLists picks
-          # up the TR_GuidancePN_Stub component instead (no-op API).
-          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
-          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
+
+      # TR_GuidancePN is a private submodule marked `update = none` in
+      # .gitmodules so recursive clones (Xcode Cloud, casual
+      # `--recurse-submodules`) skip the private repo instead of failing on it
+      # (#255). On trusted branches the TR_GUIDANCEPN_TOKEN secret is present
+      # and we DO want real guidance coverage, so force the checkout here,
+      # overriding the `none` update mode. Forks / PRs without the token skip
+      # this step and flight_computer's CMakeLists picks up the
+      # TR_GuidancePN_Stub component instead (no-op API).
+      - name: Check out private TR_GuidancePN (trusted branches only)
+        if: ${{ env.HAS_GUIDANCE_TOKEN == 'true' }}
+        env:
+          TR_GUIDANCEPN_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN }}
+        run: |
+          # actions/checkout marks the workspace safe for its own git calls;
+          # this manual submodule call needs the same exception because the
+          # espressif container runs git as a different uid than the workspace
+          # owner ("detected dubious ownership" otherwise).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${TR_GUIDANCEPN_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
+            submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
 
       - name: Build ${{ matrix.project }}
         working-directory: tinkerrocket-idf/projects/${{ matrix.project }}

--- a/.github/workflows/sim-tests.yml
+++ b/.github/workflows/sim-tests.yml
@@ -16,20 +16,37 @@ on:
       - 'tinkerrocket-idf/components/**'
       - 'tests_cpp/host_shim/**'
 
+# The `secrets` context isn't available in step-level `if:`, so surface the
+# private-submodule token as a boolean here for the force-checkout step below.
+env:
+  HAS_GUIDANCE_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # TR_GuidancePN is a private submodule. Recurse only when the
-          # TR_GUIDANCEPN_TOKEN repo secret is present (trusted branches).
-          # Forks / PRs without the secret skip the submodule; the
-          # _guidance pybind11 extension is skipped in setup.py and the
-          # test file uses pytest.importorskip to skip at test time.
-          submodules: ${{ secrets.TR_GUIDANCEPN_TOKEN != '' && 'recursive' || 'false' }}
-          token: ${{ secrets.TR_GUIDANCEPN_TOKEN || github.token }}
+
+      # TR_GuidancePN is a private submodule marked `update = none` in
+      # .gitmodules so recursive clones (Xcode Cloud, casual
+      # `--recurse-submodules`) skip the private repo instead of failing on it
+      # (#255). On trusted branches the TR_GUIDANCEPN_TOKEN secret is present
+      # and we want real guidance coverage, so force the checkout here,
+      # overriding the `none` update mode. Forks / PRs without the token skip
+      # this step; the _guidance pybind11 extension is skipped in setup.py and
+      # the test file uses pytest.importorskip to skip at test time.
+      - name: Check out private TR_GuidancePN (trusted branches only)
+        if: ${{ env.HAS_GUIDANCE_TOKEN == 'true' }}
+        env:
+          TR_GUIDANCEPN_TOKEN: ${{ secrets.TR_GUIDANCEPN_TOKEN }}
+        run: |
+          # Match actions/checkout's safe.directory exception for this manual
+          # submodule call (harmless on the non-container runner).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${TR_GUIDANCEPN_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
+            submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
 
       - uses: actions/setup-python@v5
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,11 @@
 [submodule "tinkerrocket-idf/components/TR_GuidancePN"]
 	path = tinkerrocket-idf/components/TR_GuidancePN
 	url = https://github.com/Tinkerbug-Robotics/TR_GuidancePN.git
+	# Private firmware submodule — not used by the iOS app and not needed by a
+	# recursive clone of the monorepo. `update = none` makes recursive clones
+	# (Xcode Cloud's "Archive - iOS", `git clone --recurse-submodules`, and
+	# `git submodule update --init --recursive`) SKIP it, instead of failing on
+	# the private-repo access (#255). GitHub Actions is unaffected — it sets
+	# `submodules:` explicitly per-workflow (gated on TR_GUIDANCEPN_TOKEN).
+	# Firmware devs who need it: `git submodule update --init tinkerrocket-idf/components/TR_GuidancePN`.
+	update = none


### PR DESCRIPTION
Closes #255.

## Problem
Xcode Cloud's **Archive - iOS** recurse-clones every submodule of the monorepo, including the private firmware submodule `TR_GuidancePN`, which it can't reach → every push fails with *"unable to connect to the repository."* The iOS app never references `TR_GuidancePN` (it's firmware, never compiled into the app), so the clone is pure access-cost with no benefit.

Chosen approach: **B** (make the submodule git-level optional), keeping the proprietary repo out of Apple's Xcode Cloud — consistent with how it's already gated everywhere in CI.

## Change
**1. `.gitmodules`:** add `update = none` to the `TR_GuidancePN` stanza. Recursive clones (`git clone --recurse-submodules`, `git submodule update --init --recursive`, Xcode Cloud) now **skip** it instead of failing on the private fetch.
> Verified locally: a `--recurse-submodules` clone prints `Skipping submodule 'tinkerrocket-idf/components/TR_GuidancePN'`, exits 0, leaves the path uninitialized.

**2. CI safeguard (firmware-build, cpp-tests ×2 jobs, sim-tests):** `update = none` is global, so it *also* neuters `actions/checkout`'s `submodules: recursive` — which these workflows use (gated on `TR_GUIDANCEPN_TOKEN`) to pull **real** guidance coverage on trusted branches. Left bare, trusted-branch CI would silently fall back to the stub. So each affected checkout now force-checks-out the submodule when the token is present, overriding the `none` mode:
```sh
git config --global url."https://x-access-token:$TOKEN@github.com/".insteadOf "https://github.com/"
git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
  submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
```
> Verified locally that this override clones + checks out the real submodule despite `update = none`. Forks / PRs without the secret skip the step and fall back to the stub exactly as before.

**This PR's own CI is the live validation** — the firmware/cpp/sim jobs run on a trusted in-repo branch (secret available), so they exercise the force-checkout and must stay green building against real guidance.

## Trade-offs (vs. option A — granting Apple read access)
- Firmware devs who need the submodule run `git submodule update --init tinkerrocket-idf/components/TR_GuidancePN` once.
- Xcode Cloud may still list `TR_GuidancePN` under Manage Repositories; if the archive still trips there, "disconnect" it in that UI as a one-time follow-up. The git-level skip is the durable in-repo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
