### PR TITLE
fix(app): show Firmware section on the General tab only for rocket profiles (#314)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -171,16 +171,20 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
+                // Firmware update is device-level (not profile-level). BS and
+                // no-profile devices have no tab bar, so they each carry a
+                // single firmwareSection here. For rocket profiles it lives
+                // inside generalSections so it shows on the General tab only,
+                // not duplicated across every rocket tab (#314).
                 if device.isBaseStation {
                     baseStationSections
+                    firmwareSection
                 } else if store.activeProfile == nil {
                     noProfileSection
+                    firmwareSection
                 } else {
                     rocketSettingsSections
                 }
-                // Firmware update is device-level (not profile-level), so it
-                // sits outside the branch above and shows for BS + OC alike.
-                firmwareSection
             }
             .navigationTitle(navTitle)
             .overlay { if isInitializing { initializingOverlay } }
@@ -585,6 +589,9 @@ struct SettingsView: View {
                 }
             }
         }
+
+        // Device-level firmware update lives on the General tab only (#314).
+        firmwareSection
     }
 
     // Board→rocket orientation: 0xFF = pad auto-detect, else code = axis*4 + clock.


### PR DESCRIPTION
Closes #314.

## Problem
`SettingsView` rendered `firmwareSection` unconditionally below the tab switch, so the **Firmware** section (Version + "Update firmware…") appeared on **every** rocket settings tab — Control, Camera, and Pyro as well as General. It was hoisted out of the per-tab branch because firmware update is device-level (not profile-level), but that left it duplicated across all four tabs.

## Fix
- **Rocket profiles:** moved `firmwareSection` into `generalSections`, so it shows on the **General tab only**.
- **Base-station / no-profile devices:** they have no tab bar (`baseStationSections` / `noProfileSection`), so each branch keeps its own single `firmwareSection` — preserving the original Phase-2 base-station firmware-update use case (the issue's open question).
- `firmwareSection` / `FirmwareUpdateView` plumbing unchanged.

## Acceptance
- Firmware shows on the rocket **General** tab only; gone from Control / Camera / Pyro. ✅
- Base station and no-profile devices still show a single Firmware section. ✅

## Test
iOS build + full test suite green (iPhone 17 / OS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
