### PR TITLE
fix(app): control-mode summary shows "Guidance" when guided, not the roll sub-mode

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -197,6 +197,19 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var magCal: MagCalData? = nil
     var sensorCal: SensorCalData? = nil
 
+    // MARK: Summary helpers
+
+    /// Human label for the active control mode, shown in the dashboard header
+    /// and the settings summary.  Guidance is the *top-level* mode (it
+    /// rate-nulls roll and ignores the roll profile, so the Null Roll /
+    /// Track Profile sub-mode is moot); otherwise it's Roll Control, whose
+    /// sub-mode is angle-track vs null-rate.  Mirrors `controlModeBinding` /
+    /// the Control Mode picker in SettingsView so summaries can't drift from it.
+    var controlModeLabel: String {
+        if guidanceEnabled { return "Guidance" }
+        return useAngleControl ? "Track Profile" : "Null Roll"
+    }
+
     /// A profile with all firmware factory defaults and the given name.
     static func makeDefault(name: String) -> RocketProfile {
         RocketProfile(name: name)

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -67,7 +67,7 @@ struct ActiveRocketHeader: View {
     }
 
     private func keyline(_ p: RocketProfile) -> String {
-        let mode = p.useAngleControl ? "Track Profile" : "Null Roll"
+        let mode = p.controlModeLabel
         let cam: String = {
             switch p.cameraType { case 1: return "GoPro"; case 2: return "RunCam"; default: return "No cam" }
         }()

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -245,7 +245,7 @@ struct SettingsView: View {
 
         if let p = store.activeProfile {
             Section(header: Text("Summary")) {
-                summaryRow("Control mode", p.useAngleControl ? "Track Profile" : "Null Roll")
+                summaryRow("Control mode", p.controlModeLabel)
                 summaryRow("Camera", cameraLabel(p.cameraType))
                 summaryRow("IMU mounting", p.imuOrientSetting == 0xFF
                     ? "Auto" : "Nose \(FlightSettingsData.b2rName(code: p.imuOrientSetting))")


### PR DESCRIPTION
## Problem
The dashboard header tile and the base-station settings **Summary** both rendered the control mode as `useAngleControl ? "Track Profile" : "Null Roll"` — the *Roll Control* sub-mode — without checking `guidanceEnabled`. So a rocket in **Guidance** mode (the top-level mode, which rate-nulls roll and ignores the roll profile) was mislabeled **"Null Roll"** in the summary tile, contradicting the Control Mode picker that correctly showed Guidance.

Reported from the field: a Guidance-configured rocket whose header tile read "Null Roll • RunCam • Pyro off • Cal saved".

## Fix
- Add `RocketProfile.controlModeLabel`, mirroring the Control Mode picker / `controlModeBinding`: **Guidance** when `guidanceEnabled`, else the Roll Control sub-mode (Track Profile / Null Roll).
- Use it in both summaries — `ActiveRocketHeader.keyline` and `SettingsView`'s Summary row — so they can't drift from the picker again.

No behavior change beyond the label; the firmware/config plumbing is untouched.

## Test
- Verified no other summary computes the label from `useAngleControl` alone (remaining hits are the legitimate Roll-Control sub-mode picker options).
- iOS build + full test suite green (iPhone 17 / OS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
