### PR TITLE
feat(app): consolidate pyro controls into the Pyro settings tab; trim dashboard tile

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1576,7 +1576,6 @@ struct PyroChannelsView: View {
     @State private var showPyroSheet = false
     @State private var editingChannel: Int = 1
     @State private var contTestChannel: Int = 0   // 0 = none, 1 = CH1, 2 = CH2
-    @State private var pyroTestChannel: Int?       // nil = hidden, 1 or 2 = show test view
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -1602,12 +1601,6 @@ struct PyroChannelsView: View {
         .cornerRadius(10)
         .sheet(isPresented: $showPyroSheet) {
             PyroConfigSheet(device: device, channel: editingChannel)
-        }
-        .fullScreenCover(item: Binding<IdentifiableInt?>(
-            get: { pyroTestChannel.map { IdentifiableInt(value: $0) } },
-            set: { pyroTestChannel = $0?.value }
-        )) { item in
-            PyroTestView(device: device, channel: item.value)
         }
     }
 
@@ -1695,15 +1688,8 @@ struct PyroChannelsView: View {
                         .foregroundColor(.blue)
                 }
                 .buttonStyle(.plain)
-
-                Button {
-                    pyroTestChannel = channel
-                } label: {
-                    Text("Test Pyro Channel")
-                        .font(.caption2)
-                        .foregroundColor(.orange)
-                }
-                .buttonStyle(.plain)
+                // Test Pyro Channel (test-fire) lives on the detailed Pyro
+                // settings screen only — kept off the main dashboard tile.
             }
         }
         .padding(10)

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -62,6 +62,13 @@ struct SettingsView: View {
     // Pyro trigger values edited as strings (seconds or meters by mode).
     @State private var sPyroValue: [String] = ["", "", "", ""]
 
+    // Pyro continuity / test-fire, brought into the Pyro tab so all pyro
+    // controls live with the rocket's settings.  contTestChannel latches which
+    // channel's continuity readout to show after a Test Continuity press (0 =
+    // none); pyroTestChannel drives the full-screen test-fire flow.
+    @State private var pyroContTestChannel: Int = 0
+    @State private var pyroTestChannel: Int?
+
     // "Sent" feedback in section headers.
     @State private var servoApplied = false
     @State private var pidApplied = false
@@ -202,6 +209,14 @@ struct SettingsView: View {
                 }
             }
             .onAppear { loadFromProfile() }
+            // Test Pyro Channel (from the Pyro tab) presents the same full-screen
+            // test-fire flow the dashboard uses.
+            .fullScreenCover(item: Binding<IdentifiableInt?>(
+                get: { pyroTestChannel.map { IdentifiableInt(value: $0) } },
+                set: { pyroTestChannel = $0?.value }
+            )) { item in
+                PyroTestView(device: device, channel: item.value)
+            }
             .onChange(of: store.activeId) { _ in loadFromProfile() }
             // Leaving a tab commits its pending text edit; reloading then snaps
             // any unparseable input back to the last saved (valid) value.
@@ -451,6 +466,51 @@ struct SettingsView: View {
                     ? "Fires this many seconds after apogee is detected."
                     : "Fires when the rocket descends through this altitude (AGL).")
                     .font(.caption).foregroundColor(.secondary)
+            }
+            pyroTestControls(ch)
+        }
+    }
+
+    /// Continuity readout + Test Continuity / Test Pyro Channel controls,
+    /// brought in from the dashboard pyro tile so the Pyro settings tab is the
+    /// single place for all pyro controls, obviously tied to the active rocket.
+    /// Only meaningful on a live rocket link; the actuating buttons hide once
+    /// armed / fired / in flight.
+    @ViewBuilder
+    private func pyroTestControls(_ ch: Int) -> some View {
+        if device.isConnected && !device.isBaseStation {
+            // Continuity is only valid while the shared ARM FET is engaged —
+            // i.e. right after a Test Continuity pulse, or when armed.  Gate to
+            // a LIVE frame so a held-over stale frame fails safe to NO CONT
+            // (#297), matching the dashboard tile.
+            if device.telemetry.pyro_armed || pyroContTestChannel == ch {
+                let cont = device.telemetry.pyroCont(channel: ch)
+                    && device.telemetry.data_status == .live
+                HStack {
+                    Text("Continuity")
+                    Spacer()
+                    Circle().fill(cont ? Color.green : Color.red)
+                        .frame(width: 8, height: 8)
+                    Text(cont ? "CONT" : "NO CONT")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(cont ? .green : .red)
+                }
+            }
+
+            let blocked = device.telemetry.pyro_armed
+                || device.telemetry.pyroFired(channel: ch)
+                || device.telemetry.state == "INFLIGHT"
+            if !blocked {
+                Button("Test Continuity") {
+                    device.sendPyroContTest(channel: UInt8(ch))
+                    pyroContTestChannel = ch
+                    // Auto-hide the readout after 5s, matching the dashboard.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        if pyroContTestChannel == ch { pyroContTestChannel = 0 }
+                    }
+                }
+                Button("Test Pyro Channel") { pyroTestChannel = ch }
+                    .foregroundColor(.orange)
             }
         }
     }


### PR DESCRIPTION
Consolidates all pyro controls into the Pyro settings tab, and trims the dashboard tile to at-a-glance controls.

## Motivation
Pyro controls were split: the settings Pyro tab had only enable + trigger config, while the dashboard pyro tiles carried continuity, Test Continuity, and Test Pyro Channel (test-fire). This made the settings tab feel less like part of the rocket's settings. Pyro config was already per-`RocketProfile` and synced to the rocket on connect / profile-switch (`ActiveRocketSyncer`) — this is purely a UI consolidation, no change to persistence or the wire path.

## Changes
**Pyro settings tab (`SettingsView`)** — now the single home for all pyro controls, obviously tied to the active rocket:
- Continuity readout, **Test Continuity**, and **Test Pyro Channel** (test-fire) added to each channel section (enable + trigger config were already there).
- Mirrors the dashboard tile exactly: continuity shown only while the shared ARM FET is engaged (after a Test Continuity pulse, or when armed) and gated to a LIVE frame so a stale frame fails safe to NO CONT (#297); Test Continuity auto-hides after 5s; test-fire uses the same full-screen `PyroTestView`; actuating buttons hide once armed / fired / in flight.

**Dashboard pyro tiles (`PyroChannelsView`)** — kept for at-a-glance pad status:
- Enable/Disable (tap → config sheet) and Test Continuity remain.
- **Test Pyro Channel removed** — the more deliberate test-fire flow is reached only from settings now.
- Dropped the now-unused `pyroTestChannel` state + `PyroTestView` cover.

## Test
iOS build + full test suite green (iPhone 17 / OS 26.5). Pyro test controls are gated on a live rocket link, so they come alive with a connected rocket at the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
