### PR TITLE
fix(app): don't auto-present the Add Device sheet on reconnect (#394)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -16,6 +16,12 @@ class BLEFleet: NSObject, ObservableObject {
     // MARK: - Published state
 
     @Published var isScanning = false
+    // #394: true only when the user explicitly asked to add a device (the "Add"
+    // button), false for automatic/background scans (reconnect fallback,
+    // auto-scan-on-disconnect, session restore). The dashboard's "Add Device"
+    // sheet gates on this so a returning unit re-pairing silently doesn't pop
+    // an unsolicited modal.
+    @Published var userInitiatedScan = false
     @Published var statusMessage = "Not connected"
     @Published var discoveredDevices: [DiscoveredDevice] = []
 
@@ -101,7 +107,7 @@ class BLEFleet: NSObject, ObservableObject {
 
     // MARK: - Scanning
 
-    func startScanning() {
+    func startScanning(userInitiated: Bool = false) {
         guard centralManager.state == .poweredOn else {
             statusMessage = "Bluetooth not ready"
             return
@@ -109,6 +115,7 @@ class BLEFleet: NSObject, ObservableObject {
         discoveredDevices = []
         statusMessage = "Scanning..."
         isScanning = true
+        userInitiatedScan = userInitiated  // #394: only the "Add" button drives the sheet
         centralManager.scanForPeripherals(withServices: [serviceUUID], options: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak self] in
@@ -128,6 +135,7 @@ class BLEFleet: NSObject, ObservableObject {
     func stopScanning() {
         centralManager.stopScan()
         isScanning = false
+        userInitiatedScan = false  // #394
     }
 
     // MARK: - Connection

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -251,7 +251,10 @@ struct DashboardView: View {
             }
         }
         .sheet(isPresented: Binding(
-            get: { fleet.isScanning && fleet.isConnected },
+            // #394: only present the "Add Device" sheet for an explicit user
+            // scan, not for a background reconnect/auto-scan that happens to
+            // land while connected (which popped the sheet unsolicited).
+            get: { fleet.userInitiatedScan && fleet.isConnected },
             set: { if !$0 { fleet.stopScanning() } }
         )) {
             NavigationView {
@@ -612,7 +615,7 @@ struct DeviceChipBar: View {
 
                 // Scan button in chip bar
                 Button {
-                    fleet.startScanning()
+                    fleet.startScanning(userInitiated: true)  // #394: explicit "Add" opens the sheet
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "plus")


### PR DESCRIPTION
Powering a connected rocket/base station down and back up popped the **"Add Device" / Searching** sheet unsolicited.

**Closes #394.**

## Root cause
The sheet was presented on `fleet.isScanning && fleet.isConnected` (`Views/DashboardView.swift`), but `isScanning` is reused for both the user's "Add Device" scan **and** the automatic background scans — the reconnect fallback (`BLEFleet.didDisconnect`), the auto-scan on disconnect (`DashboardView .onChange(of: isConnected)`), and session restore. So when a powered-down unit returned and reconnected while a background scan was still running, the modal appeared even though the user never asked to add a device.

## Fix
Add a `userInitiatedScan` intent flag, set only by the explicit "Add" button (`startScanning(userInitiated: true)`); all automatic scans default false. Gate the sheet on `userInitiatedScan && isConnected` instead of raw `isScanning`. `stopScanning()` clears the flag so the sheet still dismisses on Done / the 15 s scan timeout. The silent auto-reconnect (re-pairing a returning unit) is unchanged — only the unsolicited modal is gone.

Concrete symptom of the broader multi-device state confusion in #390.

## Verification
- `xcodebuild` (iphonesimulator, Debug): **BUILD SUCCEEDED**.
- On device: power a connected unit down/up → no sheet (silent re-pair); "+ Add" chip → sheet opens; Done / timeout → dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
