### PR TITLE
fix: correct ISM6HG256 gyro sensitivity (ST fixed per-FS, not FS/32768) (#369)

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -118,7 +118,10 @@ def ism6_scales(low_g_fs, high_g_fs, gyro_fs):
     denom = 32768.0
     acc_low  = (low_g_fs  * 1000.0 / denom) * 1e-3 * G_MS2
     acc_high = (high_g_fs * 1000.0 / denom) * 1e-3 * G_MS2
-    gyro     = (gyro_fs   * 1000.0 / denom) * 1e-3
+    # #369: ST gyro uses a fixed per-FS sensitivity (8.75 mdps/LSB @ ±250,
+    # doubling each step -> 140 @ ±4000), i.e. FS*0.035 mdps/LSB, NOT FS/32768
+    # (which under-reads by ~12.8%). Accel really is FS/32768.
+    gyro     = (gyro_fs   * 0.035) * 1e-3
     return acc_low, acc_high, gyro
 
 def pressure_to_altitude(p_pa, p0=101325.0):

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -34,7 +34,8 @@ FIGURE_DPI = 150
 
 # ---------- Sensor conversion constants ----------
 # ISM6HG256: configurable full-scale.  Defaults match FlightComputer config.h
-# Sensitivity: value = raw * (full_scale / 32768)
+# Sensitivity: accel = raw * (full_scale / 32768).  Gyro is DIFFERENT — ST uses
+# a fixed per-FS sensitivity (140 mdps/LSB @ ±4000, = FS*0.035), NOT FS/32768 (#369).
 G_MS2 = 9.80665
 
 # Default full-scale settings (updated from OUT_STATUS_QUERY if present)
@@ -51,7 +52,7 @@ def ism6_scales(low_g_fs=ISM6_LOW_G_FS_G, high_g_fs=ISM6_HIGH_G_FS_G,
     denom = 32768.0
     acc_low  = (low_g_fs  * 1000.0 / denom) * 1e-3 * G_MS2
     acc_high = (high_g_fs * 1000.0 / denom) * 1e-3 * G_MS2
-    gyro     = (gyro_fs   * 1000.0 / denom) * 1e-3
+    gyro     = (gyro_fs   * 0.035) * 1e-3  # #369: FS*0.035 mdps/LSB, NOT FS/32768
     return acc_low, acc_high, gyro
 
 # MMC5983MA: 18-bit centered, Gauss = centered * (8 / 131072), uT = Gauss * 100

--- a/tests_cpp/test_sensor_data_converter.cpp
+++ b/tests_cpp/test_sensor_data_converter.cpp
@@ -217,7 +217,7 @@ TEST_F(SensorConverterB2RTest, ZNose_MovesBoardZToRocketX_AllChannels) {
     ISM6HG256Data raw{};
     raw.acc_low_raw.z  = 16384;  // +8g
     raw.acc_high_raw.z = 1024;   // +8g at 256g FS
-    raw.gyro_raw.z     = 8192;   // +1000 dps at 4000 FS
+    raw.gyro_raw.z     = 8192;   // 8192 LSB × 0.140 mdps/LSB = 1146.88 dps (±4000 FS, #369)
     ISM6HG256DataSI si{};
     conv.convertISM6HG256Data(raw, si);
 
@@ -226,7 +226,7 @@ TEST_F(SensorConverterB2RTest, ZNose_MovesBoardZToRocketX_AllChannels) {
     EXPECT_NEAR(si.low_g_acc_y, 0.0, 1e-6);
     EXPECT_NEAR(si.low_g_acc_z, 0.0, 1e-6);
     EXPECT_NEAR(si.high_g_acc_x, exp_lg, 0.2);
-    EXPECT_NEAR(si.gyro_x, 1000.0, 0.5);
+    EXPECT_NEAR(si.gyro_x, 1146.88, 0.5);  // #369: 8192 × 0.140 mdps/LSB
     EXPECT_NEAR(si.gyro_z, 0.0, 1e-6);
 }
 

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -17,13 +17,14 @@ void SensorConverter::configureISM6HG256FullScale(
                                 ISM6HighGFullScale high_g_fs,
                                 ISM6GyroFullScale gyro_fs)
 {
-    // Sensitivity mapping assumption:
-    // ISM6HG256X outputs 16-bit two's-complement samples:
-    //   value = raw * (full_scale / 32768)
-    // Therefore:
-    //   accel: mg/LSB   = FS[g] * 1000 / 32768
-    //   gyro : mdps/LSB = FS[dps] * 1000 / 32768
-    //
+    // Sensitivity mapping (per ISM6HG256X datasheet / ST ism6hg256x_reg.c):
+    //   accel: the full ±32768 LSB span maps to the full scale, so
+    //          mg/LSB = FS[g] * 1000 / 32768  (16g -> 0.488, 256g -> 7.81).
+    //   gyro : ST gyros use a FIXED per-FS sensitivity, NOT FS/32768.  It is
+    //          8.75 mdps/LSB at ±250 dps and DOUBLES each FS step (…70 @ ±2000,
+    //          140 @ ±4000 dps) — i.e. mdps/LSB = FS[dps] * (8.75/250) = FS*0.035.
+    //          Full scale is FS/sensitivity ≈ ±28571 LSB, not ±32768; the old
+    //          FS/32768 form under-reported every gyro reading by ~12.8% (#369).
 
     const float denom = 32768.0f;
 
@@ -33,7 +34,8 @@ void SensorConverter::configureISM6HG256FullScale(
 
     const float low_mg_per_lsb = (low_fs_g  * 1000.0f) / denom;
     const float high_mg_per_lsb = (high_fs_g * 1000.0f) / denom;
-    const float gyro_mdps_per_lsb = (gyro_fs_dps * 1000.0f) / denom;
+    // #369: fixed ST gyro sensitivity (0.035 mdps/LSB per dps of FS), NOT FS/32768.
+    const float gyro_mdps_per_lsb = gyro_fs_dps * 0.035f;
 
     // mg/LSB -> m/s^2 per LSB
     acc_low_ms2_per_lsb  = (low_mg_per_lsb  * 1e-3f) * g_ms2;


### PR DESCRIPTION
The ISM6HG256 gyro conversion used `mdps/LSB = FS/32768`, but ST gyros use a **fixed per-FS sensitivity** (datasheet + vendored `ism6hg256x_reg.c`): 8.75 mdps/LSB at ±250 dps, doubling each step → **140 mdps/LSB at ±4000 dps** (= `FS × 0.035`). Full scale is FS/sensitivity ≈ ±28571 LSB, not ±32768, so the old form **under-read every gyro sample by ~12.8%** (reported 0.872× truth — a real 100 dps logged as 87.2). The accelerometer genuinely spans ±32768, so accel is unaffected and stays on `FS/32768`.

**Closes #369.**

## Corrected everywhere the raw→dps scale is computed
- Firmware `TR_Sensor_Data_Converter` — feeds the roll PID, EKF, kinematic checks, LoRa telemetry, and the SI flight log.
- Its gtest (±4000 FS axis-mapping case now pins `8192 LSB → 1146.88 dps`).
- `Data_Analysis/analyze_launch_detection.py` + `plot_flight_data_mini.py` — both had the identical `FS/32768` bug. `plot_flight_data_legacy.py` uses the old-PCB ICM sensor (different part) and is correctly left alone.

## Verification
- **375/375** cpp gtests pass.
- Clean **esp32p4** FC build (IDF v6.0).
- Datasheet: [ISM6HG256X](https://www.st.com/resource/en/datasheet/ism6hg256x.pdf) — "1 LSB = 140 mdps at ±4000 dps".

## ⚠ Follow-up required before flying roll-controlled / guided
Correcting the scale multiplies the roll rate the controller sees by **1.147×**. The flown roll PID gains and rate caps were tuned against the old (0.872×) scale, so to preserve behavior the **rate-loop gains must be ×0.872 and the caps/`kp_angle` ×1.147** per airframe (config.h + app `RollControlConfigData` defaults + saved profiles). Being handled manually per rocket. The SIL Kt fit also needs a re-fit (same physical torque, different number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
