### PR TITLE
fix: I2C slave TX-ring desync + sim Stop mid-flight (bench-validated) (#399, #393)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -102,6 +102,10 @@ struct TelemetryData: Codable {
     var camera_recording: Bool  { (flight_status_bits & 0x20) != 0 }
     var logging_active: Bool    { (flight_status_bits & 0x40) != 0 }
     var bs_logging_active: Bool { (flight_status_bits & 0x80) != 0 }
+    // #393: simulated flight in progress, reported by the rocket (NSF_SIM_ACTIVE
+    // -> fs bit 8).  Drives the sim banner / Stop-sim control so it survives BLE
+    // reconnects, unlike the client-side simLaunched latch.
+    var sim_active: Bool        { (flight_status_bits & 0x100) != 0 }
 
     // Source rocket identity (base station relay only, nil for direct BLE)
     var source_rocket_id: Int?        // rocket_id from LoRa header

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -377,7 +377,11 @@ struct ConnectedDashboardView: View {
                     .opacity(staleOpacity)
             }
 
-            if device.simLaunched {
+            // #393: gate on the rocket's REPORTED sim state (fs bit 8) OR the
+            // local launch latch.  The latch alone dies on BLE reconnect
+            // (BLEDevice is recreated), which made the Stop-sim control vanish
+            // mid-sim; telemetry keeps the banner up as long as the sim runs.
+            if device.simLaunched || device.telemetry.sim_active {
                 SimModeBannerView {
                     device.sendCommand(7)
                     device.clearSimBanner()

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1216,20 +1216,23 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     }
 
     // Packed flight-status bits (saves ~90 B vs 8 separate JSON booleans).
-    // The pyro flags use the same trick via "ps" — same pattern.
+    // The pyro flags use the same trick via "ps" — same pattern.  "fs" is a
+    // JSON int, so bits past 7 are fine (older app builds just mask them off).
     //   b0  launch_flag           b4  pwr_pin_on
     //   b1  vel_u_apogee_flag     b5  camera_recording
     //   b2  alt_apogee_flag       b6  logging_active
     //   b3  alt_landed_flag       b7  bs_logging_active
+    //   b8  sim_active (#393)
     {
-        uint8_t fs = (data.launch_flag        ? 0x01 : 0)
-                   | (data.vel_u_apogee_flag  ? 0x02 : 0)
-                   | (data.alt_apogee_flag    ? 0x04 : 0)
-                   | (data.alt_landed_flag    ? 0x08 : 0)
-                   | (data.pwr_pin_on         ? 0x10 : 0)
-                   | (data.camera_recording   ? 0x20 : 0)
-                   | (data.logging_active     ? 0x40 : 0)
-                   | (data.bs_logging_active  ? 0x80 : 0);
+        uint16_t fs = (data.launch_flag        ? 0x001 : 0)
+                    | (data.vel_u_apogee_flag  ? 0x002 : 0)
+                    | (data.alt_apogee_flag    ? 0x004 : 0)
+                    | (data.alt_landed_flag    ? 0x008 : 0)
+                    | (data.pwr_pin_on         ? 0x010 : 0)
+                    | (data.camera_recording   ? 0x020 : 0)
+                    | (data.logging_active     ? 0x040 : 0)
+                    | (data.bs_logging_active  ? 0x080 : 0)
+                    | (data.sim_active         ? 0x100 : 0);
         addInt("fs", fs);
     }
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -79,6 +79,7 @@ public:
         bool vel_u_apogee_flag; // Velocity apogee (vertical vel crossed zero)
         bool alt_apogee_flag;   // Altitude apogee (alt started decreasing)
         bool alt_landed_flag;   // Landing detected
+        bool sim_active;        // #393: simulated flight in progress (NSF_SIM_ACTIVE)
 
         // Power rail state
         bool pwr_pin_on;        // true = FlightComputer + sensors powered on

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -220,11 +220,18 @@ bool IRAM_ATTR TR_I2C_Interface::slaveRequestISR(
 //  read still completes and the bus is released promptly instead of hanging
 //  until the hardware stretch-protect timer.
 //
-//  Wire-alignment note: i2c_slave_write() pushes exactly _tx_len bytes; the FC
-//  reads a fixed size and resyncs on the SOF marker, so a small size mismatch
-//  is tolerated. Watch for cumulative drift on the bench — if the staged size
-//  and the master read size differ, leftover TX bytes can accumulate in the
-//  ringbuffer across polls.
+//  Wire-alignment INVARIANT (#399): i2c_slave_write() pushes exactly _tx_len
+//  bytes per master read.  Every master read MUST clock exactly that many
+//  bytes — a read of FEWER bytes leaves the remainder in the V2 driver's TX
+//  ringbuffer, which is clocked out FIRST on the next read, permanently
+//  misaligning every subsequent transfer (bench 2026-07-03: one 44-byte
+//  readConfigFrame retry against a 96-byte stage -> 100% read failures for
+//  the rest of the flight; the master's SOF scan cannot recover a persistent
+//  off-cycle drift).  There is no safe in-band flush (see the #279 note
+//  below), so the invariant is enforced on the MASTER side: the FC reads
+//  COMBINED_READ_SIZE on the status/config path and the exact staged frame
+//  size on the snapshot path.  Any new slave exchange must keep the master
+//  read size equal to the staged size.
 // ---------------------------------------------------------------------------
 void TR_I2C_Interface::slaveTxTask(void *arg)
 {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1206,7 +1206,10 @@ static constexpr uint8_t NSF_GUIDANCE     = (1u << 5);
 // New-PCB pyro: single shared arming FET drives all four channels, so
 // only one global "armed" bit is reported. Live-mirrors the ARM pin.
 static constexpr uint8_t NSF_PYRO_ARMED   = (1u << 6);
-// bit 7 reserved
+// Simulated flight in progress (#393): reported so the app's sim banner /
+// Stop-sim control is driven by the rocket's actual state instead of a
+// client-side latch that dies on BLE reconnect (BLEDevice is recreated).
+static constexpr uint8_t NSF_SIM_ACTIVE   = (1u << 7);
 
 // NonSensorData.apogee_flags bit masks (appended in #142/#143).
 static constexpr uint8_t NSF2_GPS_APOGEE       = (1u << 0);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5950,6 +5950,9 @@ static void loop_fc()
         }
         portEXIT_CRITICAL(&pyro_spinlock);
         if (arm_now) non_sensor_data.flags |= NSF_PYRO_ARMED;
+        // #393: report sim-active so the app's Stop-sim control survives BLE
+        // reconnects (its local latch dies with the recreated BLEDevice).
+        if (sensor_collector.isSimActive()) non_sensor_data.flags |= NSF_SIM_ACTIVE;
         non_sensor_data.rocket_state = (uint8_t)rocket_state;
         // 4-channel pyro status byte: bit pairs (cont, fired) per channel.
         // CONT bits reflect the last known reading (set during a CONT test

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2940,6 +2940,48 @@ static void setup_fc()
 
 }
 
+// #393: reset the flight state machine for a sim run.  Used on the sim START
+// edge (fresh run — the sim's equivalent of a reboot) and on an explicit sim
+// STOP (SIM_STOP_CMD → abort back to READY).  Deliberately NOT called on the
+// sim's natural completion (SIM_LANDED → SIM_IDLE auto-stop), so a flown-out sim
+// still holds LANDED to validate the post-flight lockout.  `edge` labels the log.
+static void resetFlightStateForSim(const char* edge)
+{
+    // Also resets GNSS state: the sim injects synthetic GNSS (fix=3, sats=12);
+    // a stale copy would otherwise immediately re-trip READY -> PRELAUNCH.
+    pyroSafeAll();
+    rocket_state = READY;
+    post_flight_lockout = false;  // #317: a deliberate sim start/stop re-arms
+    ground_pressure_found = false;
+    out_ready = false;
+    end_flight_sent = false;
+    landed_actions_done = false;
+    landed_candidate_active = false;   // #297
+    kinematics.reset();
+    ekf_initialized = false;
+    have_ref_pos = false;
+    ref_pos_frozen = false;
+    ref_lat_sum = ref_lon_sum = ref_alt_sum = 0.0;
+    ref_pos_count = 0;
+    ref_pos_first_time_ms = 0;
+    last_gnss_time_us_for_ekf = 0;
+    last_gnss_fix_second = 0xFF;
+    last_gnss_fix_ms     = 0xFFFF;
+    gnss_started = false;
+    have_gnss_si = false;
+    guidance.reset();
+    control_mixer.reset();
+    roll_rate_pid_standalone.reset();
+    burnout_detected = false;
+    burnout_time_ms = 0;
+    burnout_neg_count = 0;
+    guidance_active = false;
+    reboot_recovery = false;
+    reboot_recovery_telem = false;
+    clearFlightSnapshot();
+    ESP_LOGI(TAG, "[STATE] Sim %s -> READY", edge);
+}
+
 // Loop is responsible for reading sensor data
 static void loop_fc()
 {
@@ -3671,12 +3713,19 @@ static void loop_fc()
         // processed mid-flight.  I2C is now command-only (telemetry uses I2S)
         // Mutex protects the I2C bus from the sender task.
         //
+        // #393 exception: keep polling during a SIM flight so SIM_STOP can be
+        // delivered mid-flight (a sim is a test, never a real flight — the
+        // isSimActive() guard means real INFLIGHT still skips the poll).
+        // Without this the sim runs the whole trajectory before the stop is
+        // even seen.
+        //
         // Pipelined protocol: READ first (response from previous query),
         // then SEND the next query.  This gives the OutComputer a full
         // 250 ms poll interval to process each query and pre-load its
         // response into the slave TX FIFO, avoiding the race where the
         // OC hasn't called i2c_slave_transmit() yet.
-        if (rocket_state != INFLIGHT && (now_ms - out_ready_request_time_ms) > 250U)
+        if ((rocket_state != INFLIGHT || sensor_collector.isSimActive())
+            && (now_ms - out_ready_request_time_ms) > 250U)
         {
             out_ready_request_time_ms = now_ms;
 
@@ -3991,8 +4040,14 @@ static void loop_fc()
             }
             else if (out_pending_command == SIM_STOP_CMD)
             {
+                // #393: an explicit Stop aborts the sim flight back to READY.
+                // Reset here (not on the isSimActive falling edge) so it fires
+                // only for a real user Stop, never a naturally-completed sim.
+                // Works whether the sim is still airborne (delivered mid-flight
+                // via the #393 INFLIGHT-poll exception) or already LANDED.
                 sensor_collector.stopSim();
-                ESP_LOGI(TAG, "[SIM] Stop cmd received");
+                resetFlightStateForSim("stop");
+                ESP_LOGI(TAG, "[SIM] Stop cmd received — flight state reset (#393)");
             }
             else if (out_pending_command == GROUND_TEST_START)
             {
@@ -5797,49 +5852,17 @@ static void loop_fc()
         // A sim flight that reaches LANDED must STAY landed — terminal, exactly
         // like real hardware — so the sim faithfully reproduces and can validate
         // the post-flight lockout. Re-arm on the RISING edge of sim-active (the
-        // deliberate start of a new run, the sim's equivalent of a reboot), never
-        // on the falling edge. When a sim ends we do nothing: the FC holds the
-        // state it reached (LANDED if it flew) and the lockout stays in force.
+        // deliberate start of a new run, the sim's equivalent of a reboot).  We
+        // do NOT reset on the falling edge: the sim drops to SIM_IDLE on its
+        // NATURAL completion too (SIM_LANDED auto-stop), and there we want the FC
+        // to hold LANDED so the lockout stays validated.  An explicit Stop is
+        // handled in the SIM_STOP_CMD handler instead (#393), which is the only
+        // way to distinguish a user abort from a flown-out sim.
         {
             const bool curr_sim_active = sensor_collector.isSimActive();
             if (!prev_sim_active && curr_sim_active)
             {
-                // New sim run — reset state machine for a fresh flight. Also
-                // resets GNSS state: the sim injects synthetic GNSS (fix=3,
-                // sats=12); a stale copy would otherwise immediately re-trip
-                // READY -> PRELAUNCH on the new run.
-                pyroSafeAll();
-                rocket_state = READY;
-                post_flight_lockout = false;  // #317: a deliberate new sim run re-arms
-                ground_pressure_found = false;
-                out_ready = false;
-                end_flight_sent = false;
-                landed_actions_done = false;
-                landed_candidate_active = false;   // #297
-                kinematics.reset();
-                ekf_initialized = false;
-                have_ref_pos = false;
-                ref_pos_frozen = false;
-                ref_lat_sum = ref_lon_sum = ref_alt_sum = 0.0;
-                ref_pos_count = 0;
-                ref_pos_first_time_ms = 0;
-                last_gnss_time_us_for_ekf = 0;
-                last_gnss_fix_second = 0xFF;
-                last_gnss_fix_ms     = 0xFFFF;
-                gnss_started = false;
-                have_gnss_si = false;
-                // Reset guidance state for next sim run
-                guidance.reset();
-                control_mixer.reset();
-                roll_rate_pid_standalone.reset();
-                burnout_detected = false;
-                burnout_time_ms = 0;
-                burnout_neg_count = 0;
-                guidance_active = false;
-                reboot_recovery = false;
-                reboot_recovery_telem = false;
-                clearFlightSnapshot();
-                ESP_LOGI(TAG, "[STATE] Sim start -> READY (re-armed for new run)");
+                resetFlightStateForSim("start");
             }
             prev_sim_active = curr_sim_active;
         }

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -643,8 +643,16 @@ static bool readConfigFrame(uint8_t expected_type,
     // The "inner" part of the frame: [type:1][len:1][payload:N][CRC:2]
     const size_t inner_size = 1 + 1 + expected_payload_len + 2;
     const size_t frame_size = 4 + inner_size;  // with SOF
-    // Read extra bytes to account for up to 20 bytes of misalignment
-    const size_t read_size  = frame_size + 20;
+    // #399: retry reads MUST clock exactly COMBINED_READ_SIZE — the size the
+    // OC's slave stages (and pushes per on_request) on the status/config path.
+    // The old "frame_size + 20" (e.g. 44 B for a 16 B config) read FEWER bytes
+    // than the 96 pushed, leaving residue in the V2 slave's TX ringbuffer; one
+    // mismatched read permanently misaligned every subsequent 96-byte poll
+    // read (bench 2026-07-03: 100% read failures for the rest of the flight).
+    // Reading the full staged size keeps the ring drained; the SOF scan below
+    // finds the config frame anywhere within it (every config frame fits —
+    // the OC's fit-check guarantees status+config <= COMBINED_READ_SIZE).
+    const size_t read_size  = COMBINED_READ_SIZE;
 
     for (int attempt = 0; attempt < 3; attempt++)
     {
@@ -3720,10 +3728,25 @@ static void loop_fc()
                 if (gor_us > i2c_gor_max_us) { i2c_gor_max_us = gor_us; }
                 if (query_ok) { i2c_query_ok++; } else { i2c_query_fail++; }
 
-                if (!query_ok) {
+                // #399: a run of consecutive unpack failures with the transfer
+                // completing (bytes clocked, framing garbage) is the signature
+                // of OC slave TX-ring desync — every read misaligned until
+                // reboot.  Shout once at the threshold so the bench log shows
+                // one loud diagnosis instead of a wall of identical FAILs.
+                static uint32_t consec_read_fails = 0;
+                if (query_ok) {
+                    consec_read_fails = 0;
+                } else {
+                    consec_read_fails++;
                     ESP_LOGW(TAG, "[I2C] read FAIL cmd=0x%02X dur=%lu us",
                                   (unsigned)out_pending_command,
                                   (unsigned long)gor_us);
+                    if (consec_read_fails == 8) {
+                        ESP_LOGE(TAG, "[I2C] 8 consecutive read failures — likely OC "
+                                      "slave TX-ring desync (#399: a size-mismatched "
+                                      "read left residue). Command channel is dead "
+                                      "until the OC reboots.");
+                    }
                 }
             }
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4058,6 +4058,7 @@ static void printStats()
     ble_telem.vel_u_apogee_flag = nsFlagSet(latest_non_sensor.flags, NSF_VEL_APOGEE);
     ble_telem.alt_apogee_flag   = nsFlagSet(latest_non_sensor.flags, NSF_ALT_APOGEE);
     ble_telem.alt_landed_flag   = nsFlagSet(latest_non_sensor.flags, NSF_ALT_LANDED);
+    ble_telem.sim_active        = nsFlagSet(latest_non_sensor.flags, NSF_SIM_ACTIVE);  // #393
     ble_telem.pwr_pin_on        = pwr_pin_on;
     // Pyro channel status from NonSensorData (single shared armed bit
     // mirrors the live ARM pin; 4 per-channel cont/fired bits).


### PR DESCRIPTION
Three commits fixing the I2C command-channel desync and the sim-stop path it was blocking — all **bench-validated on hardware** (2026-07-03/04).

**Closes #399. Closes #393.**

## 1. `fix(fc)`: read exactly the staged size — prevent I2C slave TX-ring desync (#399)
The OC's V2 slave pushes exactly the staged `_tx_len` per master read, so a read of FEWER bytes leaves residue in the driver's TX ringbuffer — clocked out FIRST on the next read, permanently misaligning every subsequent transfer (no safe in-band flush; #279 proved a per-serve FIFO reset destroys the in-flight read). Trigger found on the bench: `readConfigFrame` retries read `frame_size + 20` (44 B for a 16 B config) against the 96-byte stage → 100% read failures for the rest of the flight. Fix: retries read exactly `COMBINED_READ_SIZE`; all four FC read sites now match their staged sizes; a loud one-shot `ESP_LOGE` names the desync signature after 8 consecutive failures; interface comment upgraded to a hard invariant.

**Bench:** `[CFG READ] attempt 1/2 (read=96)`; `query ok/fail` climbed 52/0 → 311/0 through an entire sim flight + landing (previously froze at 24 with 100% failures at sim start).

## 2. `fix(fc)`: honor sim Stop mid-flight and reset state on abort (#393)
Re-applied from the earlier revert (b6b02e8), now that #399 makes the command channel survive a flight: keep polling during INFLIGHT when a sim is active (real flights unchanged — `isSimActive()` gate), and reset the flight state in the `SIM_STOP_CMD` handler (extracted `resetFlightStateForSim()`, shared with the sim-start edge). Reset deliberately NOT on the sim-active falling edge — natural completion also drops to `SIM_IDLE` and must keep holding LANDED to validate the post-flight lockout.

**Bench:** Stop pressed mid-climb at 176 m → `pending_command=0xB7` → `[PYRO] All channels safed` → `[STATE] Sim stop -> READY` → clean abort, channel healthy throughout; a separate fly-out run confirmed natural completion still holds LANDED.

## 3. `feat`: report sim-active in telemetry so Stop-sim survives reconnects (#393)
The sim banner (hosting the Stop button) was gated on a client-side latch that dies whenever the BLEDevice is recreated on BLE reconnect — on the bench the Stop control simply wasn't in the GUI mid-sim. Now sim-active is a reported fact: `NSF_SIM_ACTIVE` (bit 7 of the existing NonSensorData flags byte — no layout change) → FC sets while sim runs → OC relays → `"fs"` bit 8 (JSON int, backward-compatible) → app shows the banner on `simLaunched || telemetry.sim_active`.

**Bench:** banner present mid-flight; Stop delivered and clean.

## Verification
- esp32p4 FC + esp32s3 OC clean builds (IDF v6.0); iOS app BUILD SUCCEEDED.
- Full sim flight to LANDED (channel alive throughout) + mid-flight Stop abort, both on hardware.

Related: #398 (loop stalls — the desync's compounding factor, still open), #366 (both bench runs also reproduced the SIM_CONFIG single-slot overwrite — sim flew default motor params; separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
