### PR TITLE
fix(fc): raise I2C poll-read timeout 10→50 ms — aborted reads desync the channel (#402)

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2639,8 +2639,15 @@ static void setup_fc()
     delay_ms(10); // let OutComputer process query and queue 96-byte response
     {
         uint8_t init_buf[COMBINED_READ_SIZE] = {};
+        // 50 ms timeout (was 10): an ABORTED read leaves residue in the OC's
+        // V2 slave TX ring and permanently desyncs the channel (#399's
+        // residual hazard — seen on the bench at the LANDED transition, where
+        // the OC's finalize churn delayed the serve past 10 ms: one
+        // "i2c.master: I2C software timeout" then 100% read failures until
+        // reboot).  Waiting longer and completing the transfer is strictly
+        // safer than aborting; normal serves finish in ~2.5 ms.
         esp_err_t read_err = i2c_interface.masterRead(
-            init_buf, COMBINED_READ_SIZE, 10);
+            init_buf, COMBINED_READ_SIZE, 50);
         if (read_err == ESP_OK)
         {
             uint8_t resp_type = 0;
@@ -3740,8 +3747,14 @@ static void loop_fc()
             {
                 const uint32_t gor_start = time_us();
                 uint8_t combined_buf[COMBINED_READ_SIZE] = {};
+                // 50 ms timeout (was 10) — an aborted read permanently desyncs
+                // the OC's slave TX ring (#399 residual hazard; hit on the
+                // bench at LANDED when the OC's finalize churn delayed the
+                // serve past 10 ms).  Completing late beats aborting; normal
+                // serves take ~2.5 ms, and real-flight INFLIGHT never polls,
+                // so the worst case is a rare bounded stall in ground states.
                 esp_err_t read_err = i2c_interface.masterRead(
-                    combined_buf, COMBINED_READ_SIZE, 10);
+                    combined_buf, COMBINED_READ_SIZE, 50);
 
                 if (read_err == ESP_OK)
                 {


### PR DESCRIPTION
Mitigation for the aborted-read desync observed on the bench (2026-07-04). **References #402** (the in-band RESYNC recovery, which stays open) — this PR shrinks the trigger window but is prevention only.

## What happened
A full sim flight ran with a perfect command channel (`query ok/fail = 327/0`), then ~150 ms after `INFLIGHT -> LANDED` a single poll read hit its **10 ms** master timeout (`i2c.master: I2C software timeout`, dur=9905 µs) and aborted mid-transaction — the OC's landed-transition churn (finalizeFlight + LoRa reconfig, the #398 stall family) delayed the slave TX serve past 10 ms. The abort left residue in the OC's V2 slave TX ring: every subsequent read clocked misaligned bytes and failed to unpack (`327/0 → 327/24+`, permanent until OC reboot). This is exactly the "aborted read" residual hazard documented in #399 — and the 8-consecutive-failure alarm added there identified it on the bench by name.

## Fix
Raise the boot-handshake and main-poll `masterRead` timeouts **10 → 50 ms** so a delayed serve *completes* instead of aborting:
- Normal serves finish in ~2.5 ms — the timeout only matters when the OC is stalled.
- Real-flight INFLIGHT never polls, so there is zero flight-path cost; worst case is a rare bounded stall in ground states.
- The config-retry and snapshot reads already used 100 ms.

## Verification
- Clean esp32p4 build (IDF v6.0).
- Mechanism fully characterized from the bench log (quoted in #402); next sim-to-landed run will confirm the LANDED transition no longer kills the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
