### PR TITLE
feat(fc,oc): in-band RESYNC recovery for I2C slave TX-ring desync (#402)

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -993,6 +993,13 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         // Board->rocket mounting orientation setting (app->OC->FC).
         MT(ORIENT_CONFIG_PENDING),    MT(ORIENT_CONFIG_MSG),
         MT(LORA_MSG),
+        // Guidance + fin-layout config (were missing from this registry —
+        // the pre-flight review's #386 gap; a colliding new code would have
+        // passed the guard silently).
+        MT(GUIDANCE_CONFIG_PENDING),  MT(GUIDANCE_CONFIG_MSG),
+        MT(FIN_CONFIG_PENDING),       MT(FIN_CONFIG_MSG),
+        // #402: FC->OC slave TX-ring desync recovery trigger.
+        MT(I2C_TX_RESYNC),
     };
 #undef MT
 
@@ -1012,7 +1019,9 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 80u)
+    // 85 = 80 prior + guidance/fin config pair codes (were missing, #386 gap)
+    //    + I2C_TX_RESYNC (#402).
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 85u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.cpp
@@ -97,44 +97,41 @@ esp_err_t TR_I2C_Interface::beginSlave(int sda_pin,
 {
     (void)clock_hz;  // slave clock is driven by master
 
+    // #402: save the init parameters so resetSlaveTx() can recreate the device.
+    _slave_sda        = sda_pin;
+    _slave_scl        = scl_pin;
+    _slave_rx_len     = rx_buffer_len;
+    _slave_tx_len_cfg = tx_buffer_len;
+    _slave_pullups    = enable_internal_pullups;
+
     // ISR -> task signals: _rx_queue carries each received frame's byte count;
     // _tx_req_queue carries one token per master-read request. _tx_mux guards
     // the staged TX response shared between writeToSlave() and slaveTxTask().
+    // _dev_mux (#402) serializes slaveTxTask's i2c_slave_write against the
+    // del/re-create in resetSlaveTx().
     _rx_queue     = xQueueCreate(4, sizeof(size_t));
     _tx_req_queue = xQueueCreate(4, sizeof(uint8_t));
     _tx_mux       = xSemaphoreCreateMutex();
-    if (_rx_queue == nullptr || _tx_req_queue == nullptr || _tx_mux == nullptr)
+    _dev_mux      = xSemaphoreCreateMutex();
+    if (_rx_queue == nullptr || _tx_req_queue == nullptr ||
+        _tx_mux == nullptr || _dev_mux == nullptr)
     {
         ESP_LOGE(TAG, "Failed to create slave queues/mutex");
         return ESP_ERR_NO_MEM;
     }
     _tx_len = 0;
 
-    i2c_slave_config_t slave_cfg = {};
-    slave_cfg.i2c_port = I2C_NUM_0;
-    slave_cfg.sda_io_num = static_cast<gpio_num_t>(sda_pin);
-    slave_cfg.scl_io_num = static_cast<gpio_num_t>(scl_pin);
-    slave_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
-    slave_cfg.send_buf_depth = tx_buffer_len;     // TX ringbuffer depth
-    slave_cfg.receive_buf_depth = rx_buffer_len;  // driver-owned RX ring
-    slave_cfg.slave_addr = device_address;
-    slave_cfg.addr_bit_len = I2C_ADDR_BIT_LEN_7;
-    slave_cfg.intr_priority = 0;
-    slave_cfg.flags.enable_internal_pullup = enable_internal_pullups;
-
-    esp_err_t err = i2c_new_slave_device(&slave_cfg, &_slave_dev);
+    esp_err_t err = createSlaveDevice();
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "i2c_new_slave_device failed: %s", esp_err_to_name(err));
         return err;
     }
 
     memset(_slave_rx_buf, 0, SLAVE_RX_BUF_SIZE);
 
-    // Start the TX service task before registering callbacks so the consumer
-    // is ready the instant on_request can fire. Pin it to the core this runs
-    // on — the slave ISR is allocated on the same core, so on_request -> task
-    // wakeups stay on-core and clear the SCL stretch with minimal latency.
+    // Start the TX service task. Pin it to the core this runs on — the slave
+    // ISR is allocated on the same core, so on_request -> task wakeups stay
+    // on-core and clear the SCL stretch with minimal latency.
     BaseType_t task_ok = xTaskCreatePinnedToCore(slaveTxTask, "i2c_slv_tx",
                                                  SLAVE_TX_TASK_STACK, this,
                                                  SLAVE_TX_TASK_PRIO, &_tx_task,
@@ -145,10 +142,37 @@ esp_err_t TR_I2C_Interface::beginSlave(int sda_pin,
         return ESP_ERR_NO_MEM;
     }
 
-    // Register both halves of the V2 slave protocol: on_receive (master writes
-    // land in our RX ring) and on_request (master reads -> wake the TX task).
-    // The V2 driver auto-receives, so there is no i2c_slave_receive() arming
-    // call as in V1.
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+//  #402: create (or re-create) the V2 slave device from the saved parameters
+//  and register both ISR callbacks.  on_receive: master writes land in our RX
+//  ring.  on_request: master reads -> wake the TX task (the V2 driver
+//  auto-receives, so there is no i2c_slave_receive() arming call as in V1).
+// ---------------------------------------------------------------------------
+esp_err_t TR_I2C_Interface::createSlaveDevice()
+{
+    i2c_slave_config_t slave_cfg = {};
+    slave_cfg.i2c_port = I2C_NUM_0;
+    slave_cfg.sda_io_num = static_cast<gpio_num_t>(_slave_sda);
+    slave_cfg.scl_io_num = static_cast<gpio_num_t>(_slave_scl);
+    slave_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
+    slave_cfg.send_buf_depth = _slave_tx_len_cfg;   // TX ringbuffer depth
+    slave_cfg.receive_buf_depth = _slave_rx_len;    // driver-owned RX ring
+    slave_cfg.slave_addr = device_address;
+    slave_cfg.addr_bit_len = I2C_ADDR_BIT_LEN_7;
+    slave_cfg.intr_priority = 0;
+    slave_cfg.flags.enable_internal_pullup = _slave_pullups;
+
+    esp_err_t err = i2c_new_slave_device(&slave_cfg, &_slave_dev);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "i2c_new_slave_device failed: %s", esp_err_to_name(err));
+        _slave_dev = nullptr;
+        return err;
+    }
+
     i2c_slave_event_callbacks_t cbs = {};
     cbs.on_receive = slaveReceiveISR;
     cbs.on_request = slaveRequestISR;
@@ -156,12 +180,50 @@ esp_err_t TR_I2C_Interface::beginSlave(int sda_pin,
     if (err != ESP_OK)
     {
         ESP_LOGE(TAG, "i2c_slave_register_event_callbacks failed: %s", esp_err_to_name(err));
-        vTaskDelete(_tx_task);
-        _tx_task = nullptr;
+        i2c_del_slave_device(_slave_dev);
+        _slave_dev = nullptr;
         return err;
     }
 
     return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+//  #402: flush the slave TX path after an aborted-read desync by deleting and
+//  re-creating the slave device (the V2 driver exposes no TX-ring flush).
+//  The ISR->task queues, TX task, and staged response survive; stale serve
+//  tokens are drained so the fresh device doesn't answer a request that died
+//  with the old one.  Caller guarantees bus idle — the FC suspends ALL
+//  polling for its RESYNC grace window before we run (#279: a reset racing an
+//  in-flight read destroys that read).
+// ---------------------------------------------------------------------------
+esp_err_t TR_I2C_Interface::resetSlaveTx()
+{
+    if (_slave_dev == nullptr || _dev_mux == nullptr)
+    {
+        return ESP_ERR_INVALID_STATE;
+    }
+    xSemaphoreTake(_dev_mux, portMAX_DELAY);
+
+    uint8_t tok;
+    while (xQueueReceive(_tx_req_queue, &tok, 0) == pdTRUE) {}
+
+    esp_err_t err = i2c_del_slave_device(_slave_dev);
+    _slave_dev = nullptr;
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "resetSlaveTx: del failed: %s", esp_err_to_name(err));
+        xSemaphoreGive(_dev_mux);
+        return err;
+    }
+
+    err = createSlaveDevice();
+    xSemaphoreGive(_dev_mux);
+    if (err == ESP_OK)
+    {
+        ESP_LOGW(TAG, "slave TX path reset (desync recovery, #402)");
+    }
+    return err;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,12 +338,24 @@ void TR_I2C_Interface::slaveTxTask(void *arg)
         // nothing and the FC logs "[I2C] read FAIL dur~2400us", query ok/fail=0/N.
         // #279 added a per-serve reset to flush short-read residue and it broke
         // 100% of FC<-OC reads on the bench (regression of the bench-validated
-        // on_request model). If TX residue ever resurfaces, flush ONCE at a
-        // between-transaction point (begin()/post-recovery), never per serve.
+        // on_request model). Residue DID resurface (#402: aborted master read);
+        // the sanctioned flush lives in resetSlaveTx(), which runs only at a
+        // master-guaranteed bus-idle point — never per serve.
+        //
+        // _dev_mux (#402): serializes this write against del/re-create in
+        // resetSlaveTx(); skip the serve if the device is mid-reset.
         uint32_t written = 0;
-        esp_err_t werr = i2c_slave_write(self->_slave_dev, local,
-                                         static_cast<uint32_t>(len), &written,
-                                         SLAVE_TX_WRITE_TIMEOUT_MS);
+        esp_err_t werr = ESP_ERR_INVALID_STATE;
+        if (xSemaphoreTake(self->_dev_mux, portMAX_DELAY) == pdTRUE)
+        {
+            if (self->_slave_dev != nullptr)
+            {
+                werr = i2c_slave_write(self->_slave_dev, local,
+                                       static_cast<uint32_t>(len), &written,
+                                       SLAVE_TX_WRITE_TIMEOUT_MS);
+            }
+            xSemaphoreGive(self->_dev_mux);
+        }
         // #280: surface a chronically failing serve. The status was discarded,
         // so a TX that timed out every poll looked identical to a healthy one.
         self->_tx_writes++;

--- a/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
+++ b/tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h
@@ -26,6 +26,15 @@ public:
                          size_t tx_buffer_len = 256,
                          bool enable_internal_pullups = false);
 
+    // #402: flush the slave TX path after a desync (an aborted master read
+    // leaves residue in the V2 driver's TX ring that misaligns every later
+    // read).  Deletes and re-creates the slave device with the parameters
+    // saved by beginSlave() and re-registers the callbacks; the ISR->task
+    // queues, TX task, and staged response survive.  MUST only be called at a
+    // guaranteed bus-idle point (the master suspends polling around it) —
+    // resetting mid-transaction destroys the in-flight read (#279).
+    esp_err_t resetSlaveTx();
+
     esp_err_t sendMessage(uint8_t type,
                           const uint8_t *payload,
                           size_t len,
@@ -89,6 +98,10 @@ private:
     // TX service task: blocks on _tx_req_queue, writes the staged response.
     static void slaveTxTask(void *arg);
 
+    // #402: build the slave device from the saved init parameters and register
+    // the ISR callbacks.  Shared by beginSlave() and resetSlaveTx().
+    esp_err_t createSlaveDevice();
+
     uint8_t device_address;
 
     // Master mode handles
@@ -120,6 +133,16 @@ private:
     // one. Counted in slaveTxTask, surfaced via a rate-limited ESP_LOGW.
     uint32_t _tx_writes      = 0;  // total i2c_slave_write calls
     uint32_t _tx_write_fails = 0;  // non-OK or short writes
+
+    // #402: slave device lifetime guard + saved init parameters so
+    // resetSlaveTx() can recreate the device.  _dev_mux serializes
+    // slaveTxTask's i2c_slave_write against del/re-create in resetSlaveTx.
+    SemaphoreHandle_t _dev_mux = nullptr;
+    int    _slave_sda = -1;
+    int    _slave_scl = -1;
+    size_t _slave_rx_len = 0;
+    size_t _slave_tx_len_cfg = 0;
+    bool   _slave_pullups = false;
 };
 
 #endif

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1637,6 +1637,13 @@ static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceCon
 static constexpr uint8_t FIN_CONFIG_PENDING      = 0xF2;  // OC→FC: payload follows as FIN_CONFIG_MSG
 static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 18-byte FinConfigData
 
+// #402: FC→OC over I2C, sent as a master WRITE (writes still work while the
+// slave TX ring is desynced by an aborted read).  On receipt the OC resets its
+// V2 slave device to flush the residue; the FC guarantees a bus-idle window by
+// suspending ALL polling for I2C_RESYNC_GRACE_MS after sending, so the reset
+// can never race an in-flight read (the #279 constraint).  No payload.
+static constexpr uint8_t I2C_TX_RESYNC           = 0xF4;
+
 // I2S sample rate for the Layer 3 image pump.  BCLK = rate * 32 (16-bit stereo).
 // Counter-intuitively this wants to be SLOW, not fast.  BLE (~6-16 KB/s) is the
 // real bottleneck, and the FC writes each received frame to flash (~2-3 ms/frame)

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -414,6 +414,12 @@ struct config
     static constexpr uint8_t ESP_SCL_PIN = 42;
     static constexpr uint32_t ESP_I2C_FREQ_HZ = 400'000; // Reduced — only commands now
     static constexpr uint16_t I2S_TX_QUEUE_LEN = 512;    // Must handle ~2160 frames/sec burst rate
+    // #402: after sending I2C_TX_RESYNC the FC suspends ALL I2C polling for
+    // this window so the OC can reset its slave device at guaranteed bus-idle
+    // (a reset racing an in-flight read destroys it — #279).  Sized to cover
+    // the OC's observed loop-stall worst cases (#398, ~1.2 s) with margin; the
+    // detector re-sends every 8 further failures if the OC lagged past it.
+    static constexpr uint32_t I2C_RESYNC_GRACE_MS = 2000;
 
     // ### I2S Parameters (high-frequency telemetry FC→OC) ###
     static constexpr int I2S_BCLK_PIN  = 27;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3731,8 +3731,14 @@ static void loop_fc()
         // 250 ms poll interval to process each query and pre-load its
         // response into the slave TX FIFO, avoiding the race where the
         // OC hasn't called i2c_slave_transmit() yet.
+        // #402: after sending I2C_TX_RESYNC we suspend ALL bus traffic for a
+        // grace window so the OC can reset its slave device with zero risk of
+        // racing an in-flight transaction (the #279 constraint).
+        static uint32_t i2c_resync_grace_until_ms = 0;
+        static bool     i2c_resync_active = false;
         if ((rocket_state != INFLIGHT || sensor_collector.isSimActive())
-            && (now_ms - out_ready_request_time_ms) > 250U)
+            && (now_ms - out_ready_request_time_ms) > 250U
+            && (int32_t)(now_ms - i2c_resync_grace_until_ms) >= 0)
         {
             out_ready_request_time_ms = now_ms;
 
@@ -3792,11 +3798,18 @@ static void loop_fc()
 
                 // #399: a run of consecutive unpack failures with the transfer
                 // completing (bytes clocked, framing garbage) is the signature
-                // of OC slave TX-ring desync — every read misaligned until
-                // reboot.  Shout once at the threshold so the bench log shows
-                // one loud diagnosis instead of a wall of identical FAILs.
+                // of OC slave TX-ring desync — every read misaligned.
+                // #402: recover in-band.  Master WRITES still work during a
+                // desync, so send I2C_TX_RESYNC (the OC resets its slave
+                // device) and suspend ALL polling for a grace window so the
+                // reset can't race a transaction.  Re-attempt every 8 further
+                // failures until the channel recovers.
                 static uint32_t consec_read_fails = 0;
                 if (query_ok) {
+                    if (i2c_resync_active) {
+                        i2c_resync_active = false;
+                        ESP_LOGW(TAG, "[I2C] channel RECOVERED after RESYNC (#402)");
+                    }
                     consec_read_fails = 0;
                 } else {
                     consec_read_fails++;
@@ -3804,10 +3817,17 @@ static void loop_fc()
                                   (unsigned)out_pending_command,
                                   (unsigned long)gor_us);
                     if (consec_read_fails == 8) {
-                        ESP_LOGE(TAG, "[I2C] 8 consecutive read failures — likely OC "
-                                      "slave TX-ring desync (#399: a size-mismatched "
-                                      "read left residue). Command channel is dead "
-                                      "until the OC reboots.");
+                        ESP_LOGE(TAG, "[I2C] 8 consecutive read failures — OC slave "
+                                      "TX-ring desync (aborted read left residue, "
+                                      "#402). Sending RESYNC + suspending polls.");
+                    }
+                    if (consec_read_fails >= 8 && (consec_read_fails % 8) == 0) {
+                        (void)i2c_interface.sendMessage(I2C_TX_RESYNC, nullptr, 0, 10);
+                        i2c_resync_grace_until_ms = now_ms + config::I2C_RESYNC_GRACE_MS;
+                        i2c_resync_active = true;
+                        query_pending = false;  // pipeline state is stale after the quiet window
+                        ESP_LOGW(TAG, "[I2C] RESYNC sent — bus quiet for %u ms",
+                                      (unsigned)config::I2C_RESYNC_GRACE_MS);
                     }
                 }
             }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1742,6 +1742,7 @@ static bool isKnownMessageType(uint8_t type)
         case OTA_STATUS_MSG:         // FC→OC over I2S — OTA relay status (#8 Phase 4)
         case FLIGHT_SETTINGS_MSG:    // FC→OC over I2S at flight-start — issue #165
         case FC_IDENTITY:            // FC→OC over I2C — FC firmware version (#8 Phase 4)
+        case I2C_TX_RESYNC:          // FC→OC over I2C — slave TX desync recovery (#402)
             return true;
         default:
             return false;
@@ -2192,6 +2193,20 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
             // Non-blocking write — if the TX ringbuffer is full, drop;
             // FC's masterRead retry path will handle it.
             i2c_interface.writeToSlave(snap_frame, sizeof(snap_frame), 0);
+        }
+    }
+    else if (type == I2C_TX_RESYNC)
+    {
+        // #402: the FC detected a slave TX-ring desync (aborted read left
+        // residue) and has suspended ALL polling for its grace window — the
+        // bus is guaranteed idle, so resetting the slave device here is safe
+        // (the #279 constraint).  The next poll after the grace window gets a
+        // freshly staged, aligned response.
+        ESP_LOGW("OC", "[I2C] RESYNC from FC — resetting slave TX path (#402)");
+        const esp_err_t rerr = i2c_interface.resetSlaveTx();
+        if (rerr != ESP_OK)
+        {
+            ESP_LOGE("OC", "[I2C] slave TX reset FAILED: %s", esp_err_to_name(rerr));
         }
     }
     else


### PR DESCRIPTION
Recovery for the aborted-read I2C TX-ring desync — the command channel now heals itself instead of staying dead until an OC reboot.

**Closes #402.**

## Background
An aborted master read leaves residue in the OC's V2 slave TX ring, misaligning every subsequent read (observed on the bench 2026-07-04: the OC's LANDED-transition churn delayed a serve past the FC's read timeout → one `i2c.master: I2C software timeout` → 100% read failures until reboot). #403 widened the timeout (prevention); this PR adds **recovery**.

## Protocol
Exploits the bench-verified fact that master **writes** keep working during a desync (the OC received every FC query while all reads failed):
- **FC**: on the existing 8-consecutive-failure detection, send the new `I2C_TX_RESYNC` (0xF4, master write) and suspend **all** polling for `I2C_RESYNC_GRACE_MS` (2 s) — a guaranteed bus-idle window. Re-sends every 8 further failures if the OC lagged past the window; logs `channel RECOVERED after RESYNC` on the first good read.
- **OC**: on RESYNC, `TR_I2C_Interface::resetSlaveTx()` deletes + re-creates the slave device (the V2 driver exposes no TX-ring flush) and re-registers callbacks; queues/task/staged response survive, stale serve tokens drained. Safe **by construction** — the bus is idle for the whole window, satisfying the #279 constraint (the per-serve reset that was reverted destroyed in-flight reads; this one cannot race a read). New `_dev_mux` serializes the TX task's `i2c_slave_write` against del/re-create.
- `TR_I2C_Interface`: device creation factored into `createSlaveDevice()` (shared by `beginSlave`/`resetSlaveTx`); `beginSlave` saves its init params.

## Registry hardening (the #386 gap, in passing)
The wire-code uniqueness gtest was missing `GUIDANCE_CONFIG_PENDING/MSG` and `FIN_CONFIG_PENDING/MSG` — a colliding new code would have passed silently. Registry made exhaustive again (+ the new 0xF4); the count tripwire (80 → 85) fired during development exactly as designed. No collisions found.

## Verification
- esp32p4 FC + esp32s3 OC clean builds (IDF v6.0); **384/384** cpp gtests.
- Bench (optional, post-merge): force the desync with an FC test build using a 1–2 ms poll-read timeout, run a sim to LANDED, and watch: FC `Sending RESYNC` → OC `resetting slave TX path` → FC `channel RECOVERED after RESYNC (#402)`. Post-#403 the condition is hard to hit naturally; this rides as loud defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
