### PR TITLE
fix(oc): non-blocking rendezvous retunes + SPI-mutex contention instrumentation (#398)

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -394,7 +394,8 @@ void TR_LoRa_Comms::serviceTxWatchdog()
 // Runtime reconfiguration
 // ============================================================================
 
-bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power)
+bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power,
+                                bool wait_for_tx)
 {
     if (!enabled_ || radio_ == nullptr)
     {
@@ -405,9 +406,21 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     // logs even before any per-step warning fires.
     const int64_t _reconf_t0 = esp_timer_get_time();
 
-    // Wait for any in-progress TX to complete (up to 2 s).
-    // Without this, reconfigure silently fails ~18% of the time when
-    // the radio happens to be mid-transmit, and NVS never gets updated.
+    // A retune mid-TX corrupts the in-flight packet, so an ongoing TX must
+    // finish first.  Two modes (#398):
+    //   wait_for_tx=true  — block up to 2 s.  For user-initiated config paths
+    //                       that won't retry (without this, reconfigure
+    //                       silently failed ~18% of the time mid-transmit and
+    //                       NVS never got updated).
+    //   wait_for_tx=false — return busy immediately.  For main-loop service
+    //                       paths (rendezvous): a packet's airtime is
+    //                       100-200 ms at SF8/BW250 and the spin-wait stalled
+    //                       loop_oc for all of it; the caller retries next
+    //                       iteration instead.
+    if (tx_ongoing_ && !wait_for_tx)
+    {
+        return false;  // busy — caller retries
+    }
     if (tx_ongoing_)
     {
         const int64_t _wait_t0 = esp_timer_get_time();
@@ -421,9 +434,8 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
         const int64_t _wait_dt = esp_timer_get_time() - _wait_t0;
         if (_wait_dt > LORA_STALL_THRESHOLD_US) {
             ESP_LOGW(TAG, "STALL: reconfigure wait-for-TX took %lld us "
-                          "(tx_ongoing=%d, hit_deadline=%d)",
-                     (long long)_wait_dt, tx_ongoing_ ? 1 : 0,
-                     tx_ongoing_ ? 1 : 0);
+                          "(hit_deadline=%d)",
+                     (long long)_wait_dt, tx_ongoing_ ? 1 : 0);
         }
         if (tx_ongoing_) { return false; }  // TX stuck -- give up
     }

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -77,8 +77,17 @@ public:
     // pollDio1).  Cheap when not stuck (one millis() compare).
     void serviceTxWatchdog();
 
-    // Runtime reconfiguration (LLCC68: must set BW before SF)
-    bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power);
+    // Runtime reconfiguration (LLCC68: must set BW before SF).
+    // wait_for_tx (#398): when true (default), blocks up to 2 s for an
+    // in-flight TX to finish before retuning — needed on user-initiated
+    // config paths where the caller won't retry.  Pass FALSE from main-loop
+    // service paths (rendezvous enter/exit): a packet's airtime at SF8/BW250
+    // is 100-200 ms and the spin-wait stalled loop_oc for all of it (bench:
+    // "wait-for-TX took 115-215 ms"); a busy return lets the caller simply
+    // retry next iteration, mirroring hopToFrequencyMHz's can't-retune-mid-TX
+    // contract.
+    bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power,
+                     bool wait_for_tx = true);
 
     // Lightweight frequency-only retune for per-packet hopping (#40 / #41).
     // Unlike reconfigure(), this does not touch BW/SF/CR/power — those

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -367,6 +367,8 @@ void TR_LogToFlash::getStats(TR_LogToFlashStats& out) const
     out.activate_max_us = activate_max_us_;
     out.clear_ring_max_us = clear_ring_max_us_;
     out.flush_iter_max_us = flush_iter_max_us_;
+    out.spi_wait_max_us = spi_wait_max_us_;   // #398
+    out.spi_hold_max_us = spi_hold_max_us_;   // #398
     out.syncs_performed = syncs_performed_;
 
     out.known_bad_blocks = countBadBlocks();
@@ -383,6 +385,8 @@ void TR_LogToFlash::resetIntervalTimings()
     activate_max_us_ = 0;
     clear_ring_max_us_ = 0;
     flush_iter_max_us_ = 0;
+    spi_wait_max_us_ = 0;   // #398
+    spi_hold_max_us_ = 0;   // #398
 }
 
 void TR_LogToFlash::getRecoveryInfo(TR_LogToFlashRecoveryInfo& out) const
@@ -620,12 +624,24 @@ bool TR_LogToFlash::isLoggingActive() const
 
 void TR_LogToFlash::spiAcquire()
 {
-    if (spi_mutex_) xSemaphoreTake(spi_mutex_, portMAX_DELAY);
+    if (!spi_mutex_) return;
+    // #398: measure time blocked acquiring + hold duration, so the stats
+    // window shows exactly which flush-side work starves the parser's MRAM
+    // pushes (the multi-second parser_max mystery).
+    const int64_t t0 = esp_timer_get_time();
+    xSemaphoreTake(spi_mutex_, portMAX_DELAY);
+    const int64_t now = esp_timer_get_time();
+    const uint32_t waited = (uint32_t)(now - t0);
+    if (waited > spi_wait_max_us_) spi_wait_max_us_ = waited;
+    spi_hold_start_us_ = now;
 }
 
 void TR_LogToFlash::spiRelease()
 {
-    if (spi_mutex_) xSemaphoreGive(spi_mutex_);
+    if (!spi_mutex_) return;
+    const uint32_t held = (uint32_t)(esp_timer_get_time() - spi_hold_start_us_);
+    if (held > spi_hold_max_us_) spi_hold_max_us_ = held;
+    xSemaphoreGive(spi_mutex_);
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -97,6 +97,13 @@ struct TR_LogToFlashStats
     uint32_t activate_max_us = 0;      // max activateLogging() wall time
     uint32_t clear_ring_max_us = 0;    // max clearRing() wall time
     uint32_t flush_iter_max_us = 0;    // max single flushTaskLoop iteration
+    // #398: shared NAND/MRAM SPI-bus mutex contention.  spi_wait is the max
+    // time any task spent BLOCKED acquiring the mutex (the I2S parser's MRAM
+    // pushes starving behind flush-side work shows up here); spi_hold is the
+    // max single hold.  Together they pinpoint which window causes the
+    // multi-second parser_max stalls.
+    uint32_t spi_wait_max_us = 0;      // max time blocked acquiring spi_mutex_
+    uint32_t spi_hold_max_us = 0;      // max single spi_mutex_ hold
     uint32_t syncs_performed = 0;      // cumulative lfs_file_sync calls since begin()
 
     // Persistent bad-block avoidance (#47): once a NAND block is known bad,
@@ -322,6 +329,13 @@ private:
     uint32_t activate_max_us_ = 0;
     uint32_t clear_ring_max_us_ = 0;
     uint32_t flush_iter_max_us_ = 0;
+    // #398: spi_mutex_ contention peaks.  Written from multiple tasks; the
+    // read-modify-write max update is unsynchronized (a lost update is
+    // acceptable for diagnostics).  hold_start is only touched by the
+    // current mutex holder, so it needs no extra guard.
+    volatile uint32_t spi_wait_max_us_ = 0;
+    volatile uint32_t spi_hold_max_us_ = 0;
+    int64_t  spi_hold_start_us_ = 0;
     uint32_t syncs_performed_ = 0;
 
     // Cumulative LFS-callback op counters (#47 follow-up).  Used to break

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -3399,7 +3399,13 @@ static constexpr uint32_t RENDEZVOUS_SAVED_MS           = 20000;  // back on sav
 // BW125).  Both sides need to agree on every modulation parameter to
 // decode each other; the rendezvous mode is the shared known-good
 // fallback.
-static void rendezvousHopToRendezvousMode()
+// #398: returns success so the state machine only advances when the radio
+// actually retuned.  Passes wait_for_tx=false — a mid-TX hop returns busy
+// immediately instead of spin-waiting out the packet's 100-200 ms airtime
+// inside loop_oc; the rendezvous service simply retries next iteration.
+// (Previously the state advanced even on failure, leaving the state machine
+// and the radio on different modes until the next window boundary.)
+static bool rendezvousHopToRendezvousMode()
 {
     // All five values are compile-time constants in RocketComputerTypes.h
     // so the BS and OC are guaranteed to agree on the meeting place even
@@ -3408,38 +3414,43 @@ static void rendezvousHopToRendezvousMode()
                                 LORA_FACTORY_RENDEZVOUS_SF,
                                 LORA_FACTORY_RENDEZVOUS_BW_KHZ,
                                 LORA_FACTORY_RENDEZVOUS_CR,
-                                LORA_FACTORY_RENDEZVOUS_TX_DBM))
+                                LORA_FACTORY_RENDEZVOUS_TX_DBM,
+                                /*wait_for_tx=*/false))
     {
         lora_comms.startReceive();
         lora_in_rx_mode = true;
+        return true;
     }
-    else
-    {
-        ESP_LOGE("OC", "[RENDEZVOUS] reconfigure to rendezvous mode failed");
-    }
+    // Busy (mid-TX) or failed — caller retries next loop iteration.
+    return false;
 }
 
 // Hop the radio back to whatever NVS says — i.e. the working config the
 // user picked (or factory defaults if NVS empty).  Called when exiting
 // rendezvous and at the end of each ON_RENDEZVOUS window.
-static void rendezvousHopToSavedMode()
+static bool rendezvousHopToSavedMode()
 {
     if (lora_comms.reconfigure(lora_freq_mhz, lora_sf, lora_bw_khz,
-                                lora_cr, lora_tx_power))
+                                lora_cr, lora_tx_power,
+                                /*wait_for_tx=*/false))
     {
         lora_comms.startReceive();
         lora_in_rx_mode = true;
+        return true;
     }
-    else
-    {
-        ESP_LOGE("OC", "[RENDEZVOUS] reconfigure to saved mode failed");
-    }
+    return false;
 }
 
 static void rendezvousExit(const char* why)
 {
     if (rendezvous_state == RocketRendezvousState::IDLE) return;
-    rendezvousHopToSavedMode();
+    if (!rendezvousHopToSavedMode())
+    {
+        // Radio busy/failed — stay in the current state; the silence-broke
+        // check at the top of serviceRocketRendezvous re-runs this exit on
+        // the next loop iteration.
+        return;
+    }
     rendezvous_state = RocketRendezvousState::IDLE;
     ESP_LOGI("OC", "[RENDEZVOUS] Exit (%s); back on saved mode %.2f MHz SF%u",
              why, (double)lora_freq_mhz, (unsigned)lora_sf);
@@ -3491,32 +3502,41 @@ static void serviceRocketRendezvous()
         case RocketRendezvousState::IDLE:
             if (silent_for >= trigger_ms)
             {
-                rendezvousHopToRendezvousMode();
-                rendezvous_phase_start_ms = now;
-                rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
-                ESP_LOGW("OC", "[RENDEZVOUS] Silent %u s; hop to rendezvous mode %.2f MHz SF%u BW%.0f",
-                         (unsigned)(silent_for / 1000),
-                         (double)LORA_FACTORY_RENDEZVOUS_MHZ,
-                         (unsigned)LORA_FACTORY_RENDEZVOUS_SF,
-                         (double)LORA_FACTORY_RENDEZVOUS_BW_KHZ);
+                // #398: advance only when the retune actually happened; a
+                // busy radio (mid-TX) retries next loop iteration instead of
+                // stalling loop_oc for the packet's airtime.
+                if (rendezvousHopToRendezvousMode())
+                {
+                    rendezvous_phase_start_ms = now;
+                    rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
+                    ESP_LOGW("OC", "[RENDEZVOUS] Silent %u s; hop to rendezvous mode %.2f MHz SF%u BW%.0f",
+                             (unsigned)(silent_for / 1000),
+                             (double)LORA_FACTORY_RENDEZVOUS_MHZ,
+                             (unsigned)LORA_FACTORY_RENDEZVOUS_SF,
+                             (double)LORA_FACTORY_RENDEZVOUS_BW_KHZ);
+                }
             }
             break;
 
         case RocketRendezvousState::ON_RENDEZVOUS:
             if ((now - rendezvous_phase_start_ms) >= RENDEZVOUS_WINDOW_MS)
             {
-                rendezvousHopToSavedMode();
-                rendezvous_phase_start_ms = now;
-                rendezvous_state = RocketRendezvousState::ON_SAVED;
+                if (rendezvousHopToSavedMode())
+                {
+                    rendezvous_phase_start_ms = now;
+                    rendezvous_state = RocketRendezvousState::ON_SAVED;
+                }
             }
             break;
 
         case RocketRendezvousState::ON_SAVED:
             if ((now - rendezvous_phase_start_ms) >= RENDEZVOUS_SAVED_MS)
             {
-                rendezvousHopToRendezvousMode();
-                rendezvous_phase_start_ms = now;
-                rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
+                if (rendezvousHopToRendezvousMode())
+                {
+                    rendezvous_phase_start_ms = now;
+                    rendezvous_state = RocketRendezvousState::ON_RENDEZVOUS;
+                }
             }
             break;
     }
@@ -4087,7 +4107,7 @@ static void printStats()
              "write=%lu sync=%lu erase=%lu open=%lu close=%lu "
              "activate=%lu clr_ring=%lu iter=%lu us  syncs=%lu erases=%lu ring_peak=%lu "
              "bad_blocks=%lu skips=%lu  "
-             "rx_ovf=%lu rx_peak=%lu parser_max=%lu us",
+             "rx_ovf=%lu rx_peak=%lu parser_max=%lu spiw=%lu spih=%lu us",
              (unsigned long)s.write_max_us,
              (unsigned long)s.sync_max_us,
              (unsigned long)s.erase_max_us,
@@ -4103,7 +4123,9 @@ static void printStats()
              (unsigned long)s.bad_block_skips,
              (unsigned long)d_rx_ovf,
              (unsigned long)cur_rx_peak,
-             (unsigned long)cur_parser);
+             (unsigned long)cur_parser,
+             (unsigned long)s.spi_wait_max_us,   // #398: parser starvation source
+             (unsigned long)s.spi_hold_max_us);  // #398
     logger.resetIntervalTimings();
 
     // Send telemetry to BLE app


### PR DESCRIPTION
First slice of #398 (references, does **not** close it). Bench-validated in two phases (idle rendezvous soak + full sim flight to LANDED with BS-initiated stop).

## 1. Non-blocking rendezvous retunes
`TR_LoRa_Comms::reconfigure()` spin-waited up to 2 s for an in-flight TX before retuning; at SF8/BW250 a packet's airtime is 100–200 ms and the rendezvous service calls it from `loop_oc` — bench logs showed `reconfigure wait-for-TX took 115–215 ms` stalling the whole loop (I2C staging, telemetry) for the airtime.

- `reconfigure()` gains `wait_for_tx` (default `true` — user-initiated config paths keep the blocking contract; without it reconfigure silently failed ~18% mid-TX).
- The rendezvous hop helpers pass `false` and now **return success**; the state machine advances only when the radio actually retuned, retrying next loop on busy. This also fixes a latent divergence bug: previously the state advanced even when reconfigure FAILED, leaving state machine and radio on different modes until the next window.
- Also fixes the stall log's `hit_deadline` field (printed `tx_ongoing` twice).

**Bench:** zero `wait-for-TX` stalls across both sessions (7+ hops, all succeeded first try, including a mid-telemetry `Silent 64 s` hop right after landing); both exit paths exercised (window cycle + BS-heartbeat `silence broke`).

## 2. SPI-mutex contention instrumentation
`spiAcquire`/`spiRelease` now record max blocked-wait and max hold per stats window, surfaced as `spiw=`/`spih=` in the `LOG TIMING` line (reset with the other interval timings).

**Bench payoff — mutex exonerated:** the multi-second parser stall reproduced (`parser_max=2129459` µs at launch) while `spiw` peaked at **2.4 ms** and `spih` at 2.2 ms. The parser starvation is NOT lock contention and not inside the MRAM push path. The whole disturbance is confined to the ~4 s launch-edge window (deferred 80-block erase + full prelaunch ring + activation drain) where INA/LoRa/loop all co-stalled 60–300 ms — pointing at core-1 CPU starvation by a >prio-6 task. `rx_ovf=0` throughout; flight log finalized complete (4,082,300 bytes); landing finalize clean (`close=6ms`, no recurrence of the old 7.7–11.9 s stalls). Follow-up scoped on #398.

Clean builds: esp32s3 OC + BS (shares TR_LoRa_Comms; call sites source-compatible via defaulted param), IDF v6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)