### PR TITLE
fix(fc,app): pad-trim live preview, full fin-cal servo-test range, boot-settle at trimmed neutral + servo diagnostics

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -237,7 +237,11 @@ struct DashboardView: View {
                 case .settings:
                     if let device = fleet.activeDevice { SettingsView(device: device) }
                 case .servoTest:
-                    if let device = fleet.activeDevice { ServoTestView(device: device) }
+                    if let device = fleet.activeDevice {
+                        ServoTestView(device: device,
+                                      finMinDeg: Double(profileStore.activeProfile?.finMinDeg ?? -20),
+                                      finMaxDeg: Double(profileStore.activeProfile?.finMaxDeg ?? 20))
+                    }
                 }
             }
             // SwiftUI sheets get a fresh environment by default — re-inject

--- a/TinkerRocketApp/TinkerRocketApp/Views/ServoTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ServoTestView.swift
@@ -2,8 +2,11 @@
 //  ServoTestView.swift
 //  TinkerRocketApp
 //
-//  Manual servo test mode. Presents sliders for each servo (-20° to +20°).
-//  Angles are sent to the rocket in real time. On dismiss, servos return
+//  Manual servo test mode. Presents a slider per servo spanning the active
+//  profile's fin calibration (servo_min_us<->finMinDeg, servo_max_us<->
+//  finMaxDeg), so the test can command the full mechanical travel — different
+//  models use different servos/cals, so the range is per-profile, not a fixed
+//  ±20. Angles are sent to the rocket in real time. On dismiss, servos return
 //  to their midpoints.
 //
 
@@ -13,9 +16,18 @@ struct ServoTestView: View {
     @ObservedObject var device: BLEDevice
     @Environment(\.dismiss) var dismiss
 
+    // Fin-angle endpoints the test may command, from the active profile's fin
+    // calibration. Falls back to ±20° when no calibration is available.
+    var finMinDeg: Double = -20
+    var finMaxDeg: Double = 20
+
     @State private var angles: [Double] = [0, 0, 0, 0]
 
-    private let range: ClosedRange<Double> = -20...20
+    private var range: ClosedRange<Double> {
+        let lo = Swift.min(finMinDeg, finMaxDeg)
+        let hi = Swift.max(finMinDeg, finMaxDeg)
+        return lo < hi ? lo...hi : -20...20
+    }
     private let step: Double = 0.5
 
     var body: some View {

--- a/tests_cpp/host_shim/compat.h
+++ b/tests_cpp/host_shim/compat.h
@@ -14,6 +14,10 @@
 #pragma once
 
 #include "Arduino.h"
+// The device compat.h includes <esp_log.h>, so components reach ESP_LOG*
+// through <compat.h> alone (e.g. TR_ServoControl's begin() error check).
+// Mirror that with the host no-op stub.
+#include "esp_log.h"
 
 // Mirror the real TR_Compat compat.h on the device, which defines
 // `constrain` as a macro but does NOT poison `min`/`max`/`abs`.

--- a/tests_cpp/host_shim/driver/ledc.h
+++ b/tests_cpp/host_shim/driver/ledc.h
@@ -60,10 +60,20 @@ typedef struct {
     int              hpoint;
 } ledc_channel_config_t;
 
-// No-op stubs (host has no PWM peripheral). Return 0 == ESP_OK; callers ignore it.
-static inline int ledc_timer_config(const ledc_timer_config_t*)        { return 0; }
-static inline int ledc_channel_config(const ledc_channel_config_t*)    { return 0; }
-static inline int ledc_set_duty(ledc_mode_t, ledc_channel_t, uint32_t) { return 0; }
-static inline int ledc_update_duty(ledc_mode_t, ledc_channel_t)        { return 0; }
+// Minimal esp_err surface — TR_ServoControl::begin() checks the LEDC config
+// results (esp_err_t / ESP_OK / esp_err_to_name).  Guarded: other shim headers
+// (or a future esp_err.h shim) may define these too.
+#ifndef ESP_OK
+typedef int esp_err_t;
+#define ESP_OK 0
+static inline const char* esp_err_to_name(esp_err_t) { return "ESP_OK"; }
+#endif
+
+// No-op stubs (host has no PWM peripheral). Return ESP_OK; the servo
+// controller checks these in begin() and logs (no-op on host) on failure.
+static inline esp_err_t ledc_timer_config(const ledc_timer_config_t*)        { return ESP_OK; }
+static inline esp_err_t ledc_channel_config(const ledc_channel_config_t*)    { return ESP_OK; }
+static inline esp_err_t ledc_set_duty(ledc_mode_t, ledc_channel_t, uint32_t) { return ESP_OK; }
+static inline esp_err_t ledc_update_duty(ledc_mode_t, ledc_channel_t)        { return ESP_OK; }
 
 #endif  // HOST_SHIM_DRIVER_LEDC_H

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -152,10 +152,18 @@ void TR_ServoControl::idle() {
 void TR_ServoControl::setServoAngles(const float angles[4]) {
     is_idle_ = false;  // commanding a pulse resumes PWM after idle()
     for (int i = 0; i < LEDC_CHANNEL_COUNT; ++i) {
-        // Clamp to the command limit (max deflection), then map via the physical
-        // fin calibration (#267) so the fin reaches the commanded *physical* angle
-        // — no longer truncated to / scaled by the roll-PID clamp.
-        float angle = constrain(angles[i], min_cmd, max_cmd);
+        // Clamp the commanded fin angle to the physical fin-calibration range
+        // (fin_min_deg_..fin_max_deg_), then map via that calibration (#267) so
+        // the fin reaches the commanded *physical* angle.  Clamp to the fin
+        // range — NOT the roll/guidance command authority (min_cmd/max_cmd):
+        // this path drives both the flight mixer (already pre-clamped to its own
+        // authority upstream) and the manual servo test, and the test must be
+        // able to sweep to the calibrated endpoints so servo_min_us<->fin_min_deg
+        // and servo_max_us<->fin_max_deg are honoured per model instead of being
+        // capped at the (narrower, model-varying) flight authority.  Fin cal
+        // defaults to [min_cmd,max_cmd] until configured, so behaviour is
+        // unchanged until a real fin calibration is set.
+        float angle = constrain(angles[i], fin_min_deg_, fin_max_deg_);
         int pulse_us = usFromFinDeg(angle) + servo_bias_us_[i];
         pulse_us = saturateCommand(pulse_us);
 

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -62,7 +62,7 @@ void TR_ServoControl::begin() {
         timer_conf.timer_num       = LEDC_TIMERS[i];
         timer_conf.freq_hz         = static_cast<uint32_t>(servo_hz);
         timer_conf.clk_cfg         = LEDC_AUTO_CLK;
-        ledc_timer_config(&timer_conf);
+        esp_err_t terr = ledc_timer_config(&timer_conf);
 
         ledc_channel_config_t channel_conf = {};
         channel_conf.gpio_num   = servo_pin_[i];
@@ -72,7 +72,15 @@ void TR_ServoControl::begin() {
         channel_conf.timer_sel  = LEDC_TIMERS[i];
         channel_conf.duty       = 0;
         channel_conf.hpoint     = 0;
-        ledc_channel_config(&channel_conf);
+        esp_err_t cerr = ledc_channel_config(&channel_conf);
+
+        // A silent failure here leaves one servo dead with everything else
+        // healthy (command path fine, no pulse on the pad) — make it loud.
+        if (terr != ESP_OK || cerr != ESP_OK) {
+            ESP_LOGE("SERVO", "begin: servo %d (pin %d) LEDC config FAILED timer=%s channel=%s",
+                     i + 1, (int)servo_pin_[i],
+                     esp_err_to_name(terr), esp_err_to_name(cerr));
+        }
     }
     // centre all servos
     setPulse(0);
@@ -166,6 +174,7 @@ void TR_ServoControl::setServoAngles(const float angles[4]) {
         float angle = constrain(angles[i], fin_min_deg_, fin_max_deg_);
         int pulse_us = usFromFinDeg(angle) + servo_bias_us_[i];
         pulse_us = saturateCommand(pulse_us);
+        last_pulse_us_[i] = pulse_us;
 
         uint32_t max_duty = (1u << LEDC_RESOLUTION) - 1;
         uint32_t duty = (static_cast<uint32_t>(pulse_us)
@@ -192,6 +201,7 @@ void TR_ServoControl::setPulseChannel(int channel, int base_pulse_us) {
     int pulse_us = (base_pulse_us == 0) ? servo_mid_us_[channel]
                                         : base_pulse_us + servo_bias_us_[channel];
     pulse_us = saturateCommand(pulse_us);
+    last_pulse_us_[channel] = pulse_us;
 
     uint32_t max_duty = (1u << LEDC_RESOLUTION) - 1;
     uint32_t duty     = (static_cast<uint32_t>(pulse_us)

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -99,6 +99,12 @@ public:
     int getServoHz() const { return servo_hz; }
     int getServoMinUs() const { return servo_min_us; }
     int getServoMaxUs() const { return servo_max_us; }
+    // Last pulse (µs) actually written to a channel's LEDC duty — diagnostic
+    // ground truth for "did the command reach the pin", per servo (the legacy
+    // getRollCmdUs only reports servo 0).  0 until first driven.
+    int getServoPulseUs(int servoIndex) const {
+        return (servoIndex >= 0 && servoIndex < 4) ? last_pulse_us_[servoIndex] : 0;
+    }
     // update PWM outputs with velocity-based gain scaling
     void controlWithGainSchedule(float roll_rate, float velocity_ms);
 
@@ -133,6 +139,8 @@ private:
     uint8_t servo_pin_[4];
     int     servo_bias_us_[4];
     int     servo_mid_us_[4];
+    // last pulse written per channel (diagnostics; see getServoPulseUs)
+    int     last_pulse_us_[4] = {0, 0, 0, 0};
 
     // shared config
     int   servo_hz;

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -243,6 +243,16 @@ struct config
     // servo-power MOSFET is the guaranteed fix; this is the interim lever.
     static constexpr bool SERVO_RELAX_ON_PAD = true;
 
+    // #345 follow-up: pad-trim wake window (ms).  With SERVO_RELAX_ON_PAD the
+    // servos are relaxed every tick on the pad, so a live trim/servo-config
+    // change would be invisible — setBias only updates offsets, and the next
+    // idle() strips the pulse train.  When a servo-config command lands on the
+    // pad we drive the servos to the freshly-trimmed centre and hold them
+    // energised for this long so the fin visibly moves to the new trim; each
+    // further change re-arms the window, and it relaxes again once the operator
+    // stops adjusting.  Only spent while actively trimming on the bench.
+    static constexpr uint32_t SERVO_PAD_TRIM_WAKE_MS = 6000;
+
     // EKF pad heading: compass heading of board Z+ (deg, 0=North, 90=East)
     static constexpr float PAD_HEADING_DEG = 0.0f;
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -395,6 +395,9 @@ static float last_external_roll_cmd_deg = 0.0f;
 static bool servo_test_active = false;
 static float servo_test_angles[4] = {0, 0, 0, 0};
 static bool servo_replay_active = false;
+// #345 follow-up: while now_ms < this, READY/PRELAUNCH skip the per-tick
+// servo idle() so a just-applied trim stays driven and visible on the pad.
+static uint32_t servo_pad_wake_until_ms = 0;
 static bool prev_sim_active = false;
 // Roll profile: (time, angle) waypoints for cascaded angle controller
 static RollProfileData roll_profile = {};  // zeroed → num_waypoints = 0 (rate-only)
@@ -3946,6 +3949,21 @@ static void loop_fc()
                         ESP_LOGW(TAG, "[SERVO CFG] Hz/min/max/fin deferred (INFLIGHT)");
                     }
 
+                    // #345 follow-up: make trim live on the pad.  Drive the
+                    // servos to the freshly-trimmed centre and arm the wake
+                    // window so READY/PRELAUNCH stop relaxing them for a few
+                    // seconds — otherwise setBias just updates offsets and the
+                    // next idle() strips the pulse train, so the operator never
+                    // sees the fin move.  Skipped while a test/replay owns the
+                    // servos (they suppress idle already and drive their own
+                    // angles) and while INFLIGHT (never relax in flight).
+                    if (servo_enabled && rocket_state != INFLIGHT &&
+                        !servo_test_active && !ground_test_active && !servo_replay_active)
+                    {
+                        servo_control.stowControl();  // centre = (min+max)/2 + new bias
+                        servo_pad_wake_until_ms = now_ms + config::SERVO_PAD_TRIM_WAKE_MS;
+                    }
+
                     prefs.begin("servo", false);
                     prefs.putShort("b1", cfg.bias_us[0]);
                     prefs.putShort("b2", cfg.bias_us[1]);
@@ -5392,7 +5410,10 @@ static void loop_fc()
                 // digital servos stop drawing ~150 mA of holding current while
                 // we wait for GNSS/launch.  Re-asserted each tick (idempotent);
                 // PWM resumes automatically when INFLIGHT first commands a pulse.
-                if (servo_enabled && config::SERVO_RELAX_ON_PAD)
+                // Held off during the pad-trim wake window (#345 follow-up) so a
+                // just-applied trim stays driven long enough to see.
+                if (servo_enabled && config::SERVO_RELAX_ON_PAD &&
+                    (int32_t)(now_ms - servo_pad_wake_until_ms) >= 0)
                     servo_control.idle();
 
                 const bool gnss_ready = gnss_started &&
@@ -5415,8 +5436,10 @@ static void loop_fc()
             {
                 // Stay relaxed through the pad wait; the INFLIGHT control path
                 // re-drives (and so re-energises) the servos the instant
-                // launch_flag flips below.
-                if (servo_enabled && config::SERVO_RELAX_ON_PAD)
+                // launch_flag flips below.  Held off during the pad-trim wake
+                // window (#345 follow-up) so a just-applied trim stays visible.
+                if (servo_enabled && config::SERVO_RELAX_ON_PAD &&
+                    (int32_t)(now_ms - servo_pad_wake_until_ms) >= 0)
                     servo_control.idle();
 
                 if (kinematics.launch_flag)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2741,6 +2741,23 @@ static void setup_fc()
         {
             servo_control.wiggle();
         }
+        if (servo_enabled)
+        {
+            // #345 follow-up: settle at the *commanded* neutral (0deg -> the
+            // physical fin-neutral incl. trim, via the fin calibration), NOT the
+            // raw pulse-midpoint the wiggle returns to.  Those two only coincide
+            // for a symmetric fin cal; with a per-model/asymmetric cal the wiggle
+            // leaves the tabs off the trimmed straight position.  Drive through
+            // the same setServoAngles() path the flight/servo-test neutral uses
+            // so the boot rest position matches exactly what was trimmed.
+            const float neutral[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+            servo_control.setServoAngles(neutral);
+            // Hold that trimmed neutral briefly before the pad relax kicks in, so
+            // the operator can see/verify the tabs sit straight on boot instead
+            // of going limp the instant READY starts.
+            if (config::SERVO_RELAX_ON_PAD)
+                servo_pad_wake_until_ms = time_ms() + config::SERVO_PAD_TRIM_WAKE_MS;
+        }
         ESP_LOGI(TAG, "Servo control %s, gain schedule %s (hardware ready)",
                       servo_enabled ? "enabled" : "disabled",
                       gain_sched_enabled ? "ON" : "OFF");
@@ -3960,7 +3977,13 @@ static void loop_fc()
                     if (servo_enabled && rocket_state != INFLIGHT &&
                         !servo_test_active && !ground_test_active && !servo_replay_active)
                     {
-                        servo_control.stowControl();  // centre = (min+max)/2 + new bias
+                        // Drive to the commanded neutral (0deg incl. the new trim,
+                        // via the fin calibration) — the same path the boot-settle
+                        // and flight neutral use — so the preview shows the tab
+                        // exactly where a 0-command holds it, not the raw pulse
+                        // midpoint (which differs under an asymmetric fin cal).
+                        const float neutral[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+                        servo_control.setServoAngles(neutral);
                         servo_pad_wake_until_ms = now_ms + config::SERVO_PAD_TRIM_WAKE_MS;
                     }
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4985,9 +4985,13 @@ static void loop_fc()
                         }
                         servo_test_active = true;
                         servo_control.setServoAngles(servo_test_angles);
-                        ESP_LOGI(TAG, "[SERVO TEST] Angles: [%.1f, %.1f, %.1f, %.1f] deg",
+                        // Pulses = LEDC ground truth (angle -> fin cal -> +bias
+                        // -> clamp): shows whether each command reached its pin.
+                        ESP_LOGI(TAG, "[SERVO TEST] Angles: [%.1f, %.1f, %.1f, %.1f] deg -> pulses [%d, %d, %d, %d] us",
                                       (double)servo_test_angles[0], (double)servo_test_angles[1],
-                                      (double)servo_test_angles[2], (double)servo_test_angles[3]);
+                                      (double)servo_test_angles[2], (double)servo_test_angles[3],
+                                      servo_control.getServoPulseUs(0), servo_control.getServoPulseUs(1),
+                                      servo_control.getServoPulseUs(2), servo_control.getServoPulseUs(3));
                     }
                     else
                     {


### PR DESCRIPTION
Bench-found servo bugs ahead of the weekend test flights: trim was dead on the pad, the servo test under-travelled and read one-sided, and the boot rest position didn't match the trimmed neutral. Four commits, all bench-driven:

## 1. Trim live on the pad (`f158228`)
The #345 pad relax idles the servos every tick in READY/PRELAUNCH, and `setBias()` only updates offsets — so a trim change was invisible exactly where you trim. Fix: a 6 s **pad-trim wake window** — a servo-config on the pad drives the servos to the freshly-trimmed neutral and suppresses `idle()` until the window elapses (re-armed per adjustment). The #345 idle-current saving is preserved; INFLIGHT/LANDED behaviour unchanged.

## 2. Servo test honours the full fin-cal range (`00c9c17`, FC + app)
`setServoAngles()` clamped to the *flight* authority (`min_cmd`/`max_cmd`, ±20°) — so the manual test could never reach the calibrated endpoints (with fin cal ±60° over 1250–1750 µs, ±20° ≈ 1/3 travel, and a big trim then pushes the compressed window one-sided). Now clamps to the **fin-calibration range**, so min/max pulse maps to min/max fin angle per model — the invariant that must hold across different servos. Flight is unchanged (those callers pre-clamp to `PN_MAX_FIN_DEG`; fin cal defaults to the command clamp until configured). App: the ServoTestView slider now spans the active profile's `[finMinDeg, finMaxDeg]` instead of hardcoded ±20°.

## 3. Boot settles at the commanded fin-neutral (`bbd2630`)
The wiggle's "return to centre" is the raw pulse midpoint + bias, which equals the true fin-neutral (`usFromFinDeg(0)+bias`) only for a symmetric cal. After the wiggle the FC now drives `setServoAngles({0,0,0,0})` — the same neutral the flight/test paths use — and holds it for the wake window so the operator can verify the tabs sit straight on boot instead of going limp instantly. Trim preview switched to the same neutral drive for consistency.

## 4. Servo diagnostics (`ed0b006`)
`begin()` ignored the LEDC config return codes (a dead channel was silent) — now ESP_LOGE with servo/pin/error names. Per-channel `last_pulse_us_` tracking + `getServoPulseUs()`, and the `[SERVO TEST]` log now appends the actual pulses written (`... -> pulses [1500, 1500, 1500, 1500] us`) — LEDC ground truth per channel for hardware-vs-software triage. This instrumentation is what isolated the bench "servo 3 off by ~10°" to mechanical hysteresis (identical commanded pulse, different landing position depending on approach direction) rather than firmware.

Bench-validated: trim now previews live on the pad and holds ~6 s; test sweeps full travel symmetric about the trimmed centre; boot settles at trimmed neutral. Follow-up items (anti-backlash neutral approach, FinLayoutView jog range, app servo-default mismatch) tracked in a separate issue.

Clean builds: esp32p4 FC (IDF v6.0) + TinkerRocketApp (iphonesimulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
