### PR TITLE
fix(oc): close both cross-core races at the logging-activation edge (#365, #370)

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -325,17 +325,22 @@ void TR_LogToFlash::service()
         return;
     }
 
-    // Single-threaded fallback (flush task not started yet — startup/recovery)
-    if (start_logging_requested && !logging_active)
+    // Single-threaded fallback (flush task not started yet — startup/recovery).
+    // #365: same consume-on-observe shape as flushTaskLoop — the launch edge
+    // is raised from another task, so even this path must not blind-clear.
+    if (start_logging_requested)
     {
-        if (!file_open)
+        if (!logging_active)
         {
-            openLogSession();
-            markDirty();
+            if (!file_open)
+            {
+                openLogSession();
+                markDirty();
+            }
+            activateLogging();
         }
-        activateLogging();
+        start_logging_requested = false;
     }
-    start_logging_requested = false;
     flushRingToNand();
 }
 
@@ -2194,16 +2199,21 @@ void TR_LogToFlash::flushTaskLoop()
     {
         const int64_t iter_t0 = esp_timer_get_time();
 
-        // Handle deferred pre-create request (from PRELAUNCH state)
-        if (prepare_file_requested_ && !file_open && !logging_active)
+        // Handle deferred pre-create request (from PRELAUNCH state).
+        // #365: consume the request ONLY after observing it set.  The old
+        // unconditional else-clear could destroy a request that landed
+        // between the condition load and the store — the pre-create would
+        // silently vanish and openLogSession would instead run at launch
+        // detect, right in the busiest window.
+        if (prepare_file_requested_)
         {
-            openLogSession();   // Creates file on NAND (slow, but we're not in a hurry yet)
-            markDirty();
-            prepare_file_requested_ = false;
-            if (cfg.debug) ESP_LOGI(TAG, "Log file pre-created for launch");
-        }
-        else
-        {
+            if (!file_open && !logging_active)
+            {
+                openLogSession();   // Creates file on NAND (slow, but we're not in a hurry yet)
+                markDirty();
+                if (cfg.debug) ESP_LOGI(TAG, "Log file pre-created for launch");
+            }
+            // else: file already open / logging — request is moot; consume it.
             prepare_file_requested_ = false;
         }
 
@@ -2217,20 +2227,27 @@ void TR_LogToFlash::flushTaskLoop()
             cfg.flush_task_hook(cfg.flush_task_hook_ctx);
         }
 
-        // Handle deferred start-logging request (launch detected)
-        if (start_logging_requested && !logging_active)
+        // Handle deferred start-logging request (launch detected).
+        // #365: consume ONLY after observing the request.  The old blind
+        // else-clear raced the Core-1 setter: a launch edge landing between
+        // the condition load and the else-store was destroyed with no retry
+        // — logging_active never set, and the whole flight was reduced to
+        // the last ~63 KB MRAM remnant.  A duplicate request set while we
+        // service this one is absorbed harmlessly (logging_active is already
+        // true by the time we clear).
+        if (start_logging_requested)
         {
-            if (!file_open)
+            if (!logging_active)
             {
-                // File not pre-created — create now (legacy path)
-                openLogSession();
-                markDirty();
+                if (!file_open)
+                {
+                    // File not pre-created — create now (legacy path)
+                    openLogSession();
+                    markDirty();
+                }
+                activateLogging();  // Fast — just flips flags, no NAND I/O
             }
-            activateLogging();  // Fast — just flips flags, no NAND I/O
-            start_logging_requested = false;
-        }
-        else
-        {
+            // else: already logging — duplicate request; consume it.
             start_logging_requested = false;
         }
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -919,6 +919,21 @@ bool TR_LogToFlash::ringPush(const uint8_t* data, uint32_t len)
 
 uint32_t TR_LogToFlash::ringPop(uint8_t* out, uint32_t len)
 {
+    // #370: serialize against ringPush's prelaunch drop-oldest path, which
+    // advances rb_tail and stores rb_count ABSOLUTELY under push_mutex_.
+    // At the logging-activation edge a Core-1 push that sampled
+    // logging_active==false microseconds before the flush task flipped it
+    // can still be inside that loop while this pop (Core 0) advances the
+    // same rb_tail — rewinding the tail into consumed data and clobbering
+    // the count, which garbles the prelaunch + early-boost drain into the
+    // bad-SOF -> clearRing path.  #74 covered push-vs-push and
+    // push-vs-clearRing; this closes push-vs-pop.  Lock order matches the
+    // push side (push_mutex_ -> spi_mutex_ inside the MRAM access), so no
+    // inversion.  Cost: a push can block for one pop's MRAM read (<= one
+    // page) — the two already serialize on spi_mutex_ per transaction, so
+    // the added wait is the same order of magnitude.
+    if (push_mutex_) xSemaphoreTake(push_mutex_, portMAX_DELAY);
+
     // Read count under spinlock
     portENTER_CRITICAL(&ring_mux_);
     const uint32_t count_now = rb_count;
@@ -926,6 +941,7 @@ uint32_t TR_LogToFlash::ringPop(uint8_t* out, uint32_t len)
 
     if (len == 0 || len > count_now)
     {
+        if (push_mutex_) xSemaphoreGive(push_mutex_);
         return 0;
     }
 
@@ -963,6 +979,7 @@ uint32_t TR_LogToFlash::ringPop(uint8_t* out, uint32_t len)
 
     ringpop_bytes_ += len;
 
+    if (push_mutex_) xSemaphoreGive(push_mutex_);
     return len;
 }
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -290,9 +290,17 @@ private:
     uint32_t nand_erase_ops = 0;
     uint16_t file_index = 0;
     char filename[64] = {};
-    bool logging_active = false;
-    bool start_logging_requested = false;
-    bool end_flight_requested = false;
+    // Cross-core flags (#365): logging_active is written by the Core-0 flush
+    // task and read per-frame on Core 1; the request flags are set on Core 1
+    // (launch/land edges, BLE) and consumed on Core 0.  volatile so neither
+    // side caches a stale value.  Requests are CONSUME-ON-OBSERVE: the
+    // servicing side may clear one only after reading it true — a blind
+    // else-clear destroys a request that lands between the load and the
+    // store (ns window per ~1 ms flush iteration), which for the start
+    // request means the entire flight never logs.
+    volatile bool logging_active = false;
+    volatile bool start_logging_requested = false;
+    volatile bool end_flight_requested = false;
     uint32_t log_start_block = 1;
     uint32_t log_curr_block = 1;
     bool log_block_erased = false;


### PR DESCRIPTION
The two cross-core races at the logging-activation edge from the pre-flight review — the highest-stakes items in the backlog (each loses flight data). Both bench-validated with a full sim flight on this branch.

## #365 — start/pre-create requests are consume-on-observe (`0afcdd8`)
The flush task (Core 0) serviced the launch-start and pre-create requests with an unconditional else-clear every ~1 ms iteration. `startLogging()` fires exactly once, from Core 1, on the NSF_LAUNCH rising edge — if its store landed between Core 0's condition load and the else-store, the request was destroyed with no retry: no `logging_active`, frames drop-oldest-cycling forever, no drain, finalize never services — **the entire flight reduced to the last ~63 KB MRAM remnant**.

Requests are now cleared only after being observed `true` (duplicates raised mid-service are absorbed — `logging_active`/`file_open` flip before the clear). Same restructure for `prepare_file_requested_` (a destroyed pre-create silently pushed the slow `openLogSession` into the launch-detect window) and the single-threaded `service()` fallback. `logging_active` / `start_logging_requested` / `end_flight_requested` are now `volatile` like their sibling cross-core flags.

## #370 — ringPop takes push_mutex_ (`b78a077`)
`ringPush`'s prelaunch drop-oldest advances `rb_tail` and stores `rb_count` **absolutely** under `push_mutex_`; `ringPop` (flush task) advanced the same `rb_tail` with no lock. At the activation edge, a Core-1 push that sampled `logging_active == false` microseconds before the flip is still inside the drop-oldest loop while the first pops run — tail rewound into consumed data → garbage drain → bad-SOF → `clearRing` → **loss of the prelaunch buffer and first moments of boost**, with every-launch exposure (the prelaunch ring rides its 50% cap continuously). #74 covered push-vs-push and push-vs-clearRing; this closes push-vs-pop.

All other `rb_tail` writers already hold the mutex; `ringPop`'s only caller never holds it (no self-deadlock) and lock order matches the push side (`push_mutex_` → `spi_mutex_`), so no inversion.

## Bench validation (full sim flight to LANDED, OC serial + flight binary)
- Pre-create, launch start, drain (`drain=1ms close=7ms`), and `finalizeFlight OK` (4,121,454 B) — happy path unchanged.
- `FL00 peek=AA55AA55...` clean frame boundary at first drain; **zero** bad-SOF clears; `rx_ovf=0`, `skips=0` throughout.
- Pop-lock cost: `spiw` unchanged vs the pre-change baseline (~1 ms steady, 2.2 ms activation peak).
- Flight binary frame-walk: **122,458 frames, 0 SOF breaks** across all 4.1 MB; first 64 KiB (the prelaunch/early-boost region #370 garbled) = 1,934 frames, 0 breaks.

Clean build: esp32s3 OC, IDF v6.0.

Closes #365
Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
