### PR TITLE
Roll profile v4: pure (time,angle) waypoints with ramped target + flown-mode verification in flight reports

### DIFF
--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -98,17 +98,35 @@ def _parse_profile(rc: dict) -> list[tuple[float, float, bool]]:
     return out
 
 
-def _profile_target(wps: list[tuple[float, float, bool]], t: float) -> tuple[float, bool]:
-    """Replicate firmware `roll_profile_query` (main.cpp:1008) EXACTLY: returns
+def _profile_target(wps: list[tuple[float, float, bool]], t: float,
+                    semantics: str = "step") -> tuple[float, bool]:
+    """Replicate firmware `roll_profile_query` EXACTLY: returns
     (target_angle_deg, is_angle_mode) at flight time `t` (seconds since launch).
-    Inside the profile the controller commands the segment's DESTINATION — the
+
+    semantics="step" (firmware pre-v4, sidecars without `profile_semantics`):
+    inside the profile the controller commands the segment's DESTINATION — the
     NEXT waypoint's absolute angle, as a STEP (no interpolation) — using the
-    CURRENT waypoint's mode, and lets controlAngle take the shortest path to it.
-    Holds the first / last waypoint outside the profile span.
-    (Was previously interpolating a0→a1, which mislabels the target during
-    multi-waypoint angle segments — the firmware does not ramp.)"""
+    CURRENT waypoint's per-waypoint mode; holds the first / last waypoint
+    outside the profile span.
+
+    semantics="ramp" (firmware v4+): pure (time, angle) waypoints — per-wp
+    modes ignored; NULL_RATE before the first waypoint; target linearly
+    interpolated along the shortest wrapped arc between waypoints; last angle
+    held after the profile."""
     if not wps:
         return 0.0, False
+    if semantics == "ramp":
+        if t < wps[0][0]:
+            return 0.0, False  # null-rate before the profile
+        if t >= wps[-1][0]:
+            return wps[-1][1], True
+        for i in range(len(wps) - 1):
+            (t0, a0, _), (t1, a1, _) = wps[i], wps[i + 1]
+            if t < t1:
+                frac = (t - t0) / (t1 - t0) if t1 - t0 > 1e-3 else 1.0
+                tgt = float(_wrap180(a0 + float(_wrap180(a1 - a0)) * frac))
+                return tgt, True
+        return wps[-1][1], True
     if t <= wps[0][0]:
         return wps[0][1], not wps[0][2]
     if t >= wps[-1][0]:
@@ -225,11 +243,14 @@ def _fine_time_axis(ax):
     ax.grid(True, which="minor", alpha=0.15)
 
 
-def _phase_label(wps, i):
-    """Short label for the control phase that STARTS at waypoint i. Matches the
-    firmware's step semantics: an angle segment commands the NEXT waypoint's
-    angle immediately (no ramp)."""
+def _phase_label(wps, i, semantics="step"):
+    """Short label for the control phase that STARTS at waypoint i."""
     wt, wa, wnull = wps[i]
+    if semantics == "ramp":
+        if i < len(wps) - 1:
+            a1 = wps[i + 1][1]
+            return f"hold {wa:g}°" if a1 == wa else f"ramp {wa:g}→{a1:g}°"
+        return f"hold {wa:g}°"
     if wnull:
         return "null-rate"
     if i < len(wps) - 1:
@@ -237,16 +258,26 @@ def _phase_label(wps, i):
     return f"hold {wa:g}°"
 
 
-def _effective_plan(wps):
-    """Human-readable EFFECTIVE command timeline under the firmware's step
-    semantics (`roll_profile_query`): inside segment [i, i+1) the controller
-    commands waypoint i+1's angle as a step, using waypoint i's mode. This is
-    what actually drives the fins — the raw waypoint list reads misleadingly
-    as \"reach angle X at time T\"."""
+def _effective_plan(wps, semantics="step"):
+    """Human-readable EFFECTIVE command timeline as the firmware flies it.
+    step (pre-v4): inside segment [i, i+1) the controller commands waypoint
+    i+1's angle as a STEP, using waypoint i's mode — the raw waypoint list
+    reads misleadingly as \"reach angle X at time T\".
+    ramp (v4+): null-rate before the first waypoint, target lerps between
+    waypoints, last angle held."""
     if not wps:
         return "—"
     parts = []
     t_first, a_first, n_first = wps[0]
+    if semantics == "ramp":
+        if t_first > 0:
+            parts.append(f"<{t_first:g}s null-rate")
+        for i in range(len(wps) - 1):
+            (ta, a0, _), (tb, a1, _) = wps[i], wps[i + 1]
+            seg = f"hold {a0:g}°" if a1 == a0 else f"ramp {a0:g}→{a1:g}°"
+            parts.append(f"{ta:g}–{tb:g}s {seg}")
+        parts.append(f"≥{wps[-1][0]:g}s hold {wps[-1][1]:g}°")
+        return "; ".join(parts)
     if t_first > 0:
         parts.append(f"<{t_first:g}s {'null-rate' if n_first else f'cmd {a_first:g}°'}")
     for i in range(len(wps) - 1):
@@ -432,6 +463,10 @@ def analyze(flight: Flight) -> AnalysisResult:
     rc_cfg = _roll_cfg(flight.sidecar)
     wps = _parse_profile(rc_cfg)
     claimed_mode = str(rc_cfg.get("mode", "")).lower()
+    # Profile semantics the FIRMWARE flew: "ramp" (v4+: lerp between waypoints,
+    # per-wp modes ignored) vs "step" (pre-v4: step to NEXT waypoint's angle,
+    # per-wp null_rate honored). Exports without the marker are pre-v4.
+    semantics = str(rc_cfg.get("profile_semantics", "step")).lower()
     has_wp_angles = any(not null for (_, _, null) in wps)
 
     # Ejection ≈ apogee (end of roll authority), launch-relative.
@@ -471,7 +506,8 @@ def analyze(flight: Flight) -> AnalysisResult:
     for i in range(len(wps) - 1):
         (t0w, a0w, n0), (t1w, a1w, _) = wps[i], wps[i + 1]
         if not n0 and t1w > t0w:
-            profile_ramp = max(profile_ramp, abs(a1w - a0w) / (t1w - t0w))
+            d_ang = abs(float(_wrap180(a1w - a0w)))  # shortest-path arc
+            profile_ramp = max(profile_ramp, d_ang / (t1w - t0w))
 
     track_tw = track_tgt = track_act = track_err = track_is_ang = track_ratecmd = None
     track_cmd = None
@@ -482,7 +518,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         track_tw = t_ns[wmask]
         track_cmd = cmd[wmask]
         act_w = roll_act[wmask]
-        tq = [_profile_target(wps, float(tt)) for tt in track_tw]
+        tq = [_profile_target(wps, float(tt), semantics) for tt in track_tw]
         target_ang = np.array([x[0] for x in tq], dtype=float)
         track_is_ang = np.array([x[1] for x in tq], dtype=bool)
         # Wrapped shortest-path error, exactly like servo_control.controlAngle().
@@ -625,11 +661,13 @@ def analyze(flight: Flight) -> AnalysisResult:
     if eject_baro is not None:
         metrics["baro_eject_s"] = round(eject_baro, 2)
     metrics["plot_window_s"] = f"[0, {win_end:.2f}]"
+    if wps:
+        metrics["profile_semantics"] = semantics
     if has_wp_angles and not has_angle_profile:
         # Profile stored on the FC but not followed (rate mode flew).
-        metrics["profile_stored_NOT_followed"] = _effective_plan(wps)
+        metrics["profile_stored_NOT_followed"] = _effective_plan(wps, semantics)
     if has_angle_profile:
-        metrics["profile_commanded"] = _effective_plan(wps)
+        metrics["profile_commanded"] = _effective_plan(wps, semantics)
         metrics["profile_waypoints"] = "; ".join(
             f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
         if profile_ramp > 0:
@@ -649,7 +687,14 @@ def analyze(flight: Flight) -> AnalysisResult:
             if b - a < 0.05:
                 continue
             mid = 0.5 * (a + b)
-            tgt_mid, is_ang_mid = _profile_target(wps, mid)
+            eps = min(0.02, 0.25 * (b - a))
+            tgt_a, is_ang_a = _profile_target(wps, a + eps, semantics)
+            tgt_b, _ = _profile_target(wps, b - eps, semantics)
+            _, is_ang_mid = _profile_target(wps, mid, semantics)
+            if abs(float(_wrap180(tgt_b - tgt_a))) < 0.5:
+                cmd_desc = f"cmd {tgt_a:g}°"
+            else:
+                cmd_desc = f"ramp {tgt_a:.0f}→{tgt_b:.0f}°"
             mi = (t_imu >= a) & (t_imu <= b)
             mc = (t_ns >= a) & (t_ns <= b)
             rate_rms_seg = float(np.sqrt(np.mean(g[mi] ** 2))) if mi.any() else float("nan")
@@ -659,10 +704,10 @@ def analyze(flight: Flight) -> AnalysisResult:
                 e_seg = track_err[ms] if ms.any() else np.array([])
                 e_seg = e_seg[np.isfinite(e_seg)]
                 if e_seg.size:
-                    desc = (f"cmd {tgt_mid:g}°: err {e_seg[0]:+.0f}→{e_seg[-1]:+.0f}° "
+                    desc = (f"{cmd_desc}: err {e_seg[0]:+.0f}→{e_seg[-1]:+.0f}° "
                             f"(RMS {np.sqrt(np.mean(e_seg**2)):.0f}°), ")
                 else:
-                    desc = f"cmd {tgt_mid:g}°: "
+                    desc = f"{cmd_desc}: "
             else:
                 desc = "null-rate: "
             desc += f"rate RMS {rate_rms_seg:.0f}°/s, |fin cmd| max {cmd_max_seg:.1f}°"
@@ -713,7 +758,8 @@ def analyze(flight: Flight) -> AnalysisResult:
             if -0.2 <= wt <= win_end + 0.2:
                 # null-rate segments are already shown by the gray shading; only
                 # label the meaningful mode-change transitions (angle / hold).
-                evs.append((wt, None if wnull else _phase_label(wps, i), "gray", ":"))
+                lbl = _phase_label(wps, i, semantics)
+                evs.append((wt, None if (semantics != "ramp" and wnull) else lbl, "gray", ":"))
         return evs
 
     def _mark_events(ax, annotate=False):
@@ -772,21 +818,30 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].set_yticks([-180, -90, 0, 90, 180])
         axes[0].set_title("Roll angle tracking vs profile plan (launch → ejection)")
         axes[0].grid(True, alpha=0.3)
-        # Label each ANGLE segment with its effective command (the NEXT
-        # waypoint's angle, per the firmware's step semantics), centred on the
-        # visible part of the segment — not the waypoint angle at the waypoint
-        # time, which reads as "hold this from here" and is wrong.
-        seg_spans = [(wps[i][0], wps[i + 1][0], wps[i + 1][1], wps[i][2])
-                     for i in range(len(wps) - 1)]
-        if not wps[-1][2]:  # trailing hold segment if the last waypoint is angle-mode
-            seg_spans.append((wps[-1][0], win_end, wps[-1][1], False))
-        for (sa, sb, s_ang, s_null) in seg_spans:
-            sa, sb = max(sa, 0.0), min(sb, win_end)
-            if s_null or sb - sa < 0.05:
-                continue
-            axes[0].annotate(f"cmd {s_ang:g}°", xy=(0.5 * (sa + sb), _wrap180(s_ang)),
-                             fontsize=8, color="tab:orange", ha="center", va="bottom",
-                             xytext=(0, 3), textcoords="offset points")
+        if semantics == "ramp":
+            # Ramp semantics: the target passes through each waypoint's
+            # (time, angle) exactly — annotate the waypoints themselves.
+            for (wt, wa, _) in wps:
+                if 0 <= wt <= win_end:
+                    axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
+                                     color="tab:orange", ha="left", va="bottom",
+                                     xytext=(2, 2), textcoords="offset points")
+        else:
+            # Step semantics: label each ANGLE segment with its effective
+            # command (the NEXT waypoint's angle), centred on the visible part
+            # of the segment — not the waypoint angle at the waypoint time,
+            # which reads as "hold this from here" and is wrong.
+            seg_spans = [(wps[i][0], wps[i + 1][0], wps[i + 1][1], wps[i][2])
+                         for i in range(len(wps) - 1)]
+            if not wps[-1][2]:  # trailing hold segment if the last waypoint is angle-mode
+                seg_spans.append((wps[-1][0], win_end, wps[-1][1], False))
+            for (sa, sb, s_ang, s_null) in seg_spans:
+                sa, sb = max(sa, 0.0), min(sb, win_end)
+                if s_null or sb - sa < 0.05:
+                    continue
+                axes[0].annotate(f"cmd {s_ang:g}°", xy=(0.5 * (sa + sb), _wrap180(s_ang)),
+                                 fontsize=8, color="tab:orange", ha="center", va="bottom",
+                                 xytext=(0, 3), textcoords="offset points")
         _mark_events(axes[0], annotate=True)
         axes[0].legend(loc="upper left", fontsize=8)
 

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -226,13 +226,67 @@ def _fine_time_axis(ax):
 
 
 def _phase_label(wps, i):
-    """Short label for the control phase that STARTS at waypoint i."""
+    """Short label for the control phase that STARTS at waypoint i. Matches the
+    firmware's step semantics: an angle segment commands the NEXT waypoint's
+    angle immediately (no ramp)."""
     wt, wa, wnull = wps[i]
     if wnull:
         return "null-rate"
     if i < len(wps) - 1:
-        return f"angle ramp →{wps[i + 1][1]:g}°"
+        return f"cmd {wps[i + 1][1]:g}° (step)"
     return f"hold {wa:g}°"
+
+
+def _effective_plan(wps):
+    """Human-readable EFFECTIVE command timeline under the firmware's step
+    semantics (`roll_profile_query`): inside segment [i, i+1) the controller
+    commands waypoint i+1's angle as a step, using waypoint i's mode. This is
+    what actually drives the fins — the raw waypoint list reads misleadingly
+    as \"reach angle X at time T\"."""
+    if not wps:
+        return "—"
+    parts = []
+    t_first, a_first, n_first = wps[0]
+    if t_first > 0:
+        parts.append(f"<{t_first:g}s {'null-rate' if n_first else f'cmd {a_first:g}°'}")
+    for i in range(len(wps) - 1):
+        (ta, _, n0), (tb, a1, _) = wps[i], wps[i + 1]
+        parts.append(f"{ta:g}–{tb:g}s {'null-rate' if n0 else f'cmd {a1:g}°'}")
+    t_last, a_last, n_last = wps[-1]
+    parts.append(f"≥{t_last:g}s {'null-rate' if n_last else f'hold {a_last:g}°'}")
+    return "; ".join(parts)
+
+
+def _fit_r2(x, y):
+    """R² of the least-squares line y ≈ kx + b (slope sign free), or NaN if x
+    is ~constant. Can go negative for fits worse than the mean."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    ok = np.isfinite(x) & np.isfinite(y)
+    x, y = x[ok], y[ok]
+    if x.size < 10 or np.std(x) < 1e-9 or np.std(y) < 1e-9:
+        return float("nan")
+    k, b = np.polyfit(x, y, 1)
+    ss_res = float(np.sum((y - (k * x + b)) ** 2))
+    ss_tot = float(np.sum((y - y.mean()) ** 2))
+    return 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+
+def _gain_schedule_scale(rc_cfg, speed):
+    """Firmware gain-schedule multiplier per sample (TR_ServoControl::
+    controlWithGainSchedule): min((v_ref / max(|v|, v_min))², scale_cap).
+    Returns 1.0s when the schedule is disabled or unconfigured."""
+    gs = rc_cfg.get("gain_schedule") or {}
+    speed = np.asarray(speed, dtype=float)
+    if not gs.get("enabled"):
+        return np.ones_like(speed)
+    v_ref = _as_float(gs.get("v_ref"))
+    v_min = _as_float(gs.get("v_min"))
+    cap = _as_float(gs.get("scale_cap"))
+    if not v_ref or not v_min or not cap:
+        return np.ones_like(speed)
+    v = np.maximum(np.abs(speed), v_min)
+    return np.minimum((v_ref / v) ** 2, cap)
 
 
 def _baro_eject_time(flight, t0, launch_t, burnout_t, apogee_t):
@@ -377,7 +431,8 @@ def analyze(flight: Flight) -> AnalysisResult:
     # regulated, both exactly as the firmware computes them.
     rc_cfg = _roll_cfg(flight.sidecar)
     wps = _parse_profile(rc_cfg)
-    has_angle_profile = any(not null for (_, _, null) in wps)
+    claimed_mode = str(rc_cfg.get("mode", "")).lower()
+    has_wp_angles = any(not null for (_, _, null) in wps)
 
     # Ejection ≈ apogee (end of roll authority), launch-relative.
     eject_t = None
@@ -419,11 +474,13 @@ def analyze(flight: Flight) -> AnalysisResult:
             profile_ramp = max(profile_ramp, abs(a1w - a0w) / (t1w - t0w))
 
     track_tw = track_tgt = track_act = track_err = track_is_ang = track_ratecmd = None
+    track_cmd = None
     angle_rms = angle_peak = float("nan")
-    if has_angle_profile:
+    if has_wp_angles:
         roll_act = _quat_roll_deg(*(get_array(ns, k) for k in ("q0", "q1", "q2", "q3")))
         wmask = (t_ns >= 0.0) & (t_ns <= win_end + 0.05) & np.isfinite(roll_act)
         track_tw = t_ns[wmask]
+        track_cmd = cmd[wmask]
         act_w = roll_act[wmask]
         tq = [_profile_target(wps, float(tt)) for tt in track_tw]
         target_ang = np.array([x[0] for x in tq], dtype=float)
@@ -447,6 +504,58 @@ def analyze(flight: Flight) -> AnalysisResult:
         if kp_angle_cfg is not None and rate_cap_cfg is not None:
             rc_angle = np.clip(kp_angle_cfg * err, -rate_cap_cfg, rate_cap_cfg)
             track_ratecmd = np.where(track_is_ang, rc_angle, rate_setpt)
+
+    # ── Which roll mode actually FLEW? ──
+    # The sidecar `mode` can't be trusted on its own: app exports before
+    # 2026-07-05 labeled any flight with a *stored* waypoint profile
+    # "angle_profile" even when use_angle_control was off (Null Roll) — and the
+    # firmware ignores a stored profile in that case and flies pure rate-null.
+    # Cross-check against the log: the inner rate loop's error is
+    # (gyro − rate_cmd) if the angle cascade ran, vs (gyro − setpoint) if
+    # rate-null flew; the logged servo command is ~proportional to whichever
+    # error was real, so correlation over the angle segments separates them.
+    flown_mode_note = None
+    has_angle_profile = has_wp_angles and claimed_mode != "rate"
+    if has_wp_angles and claimed_mode != "rate" and track_ratecmd is not None:
+        gyro_w = np.interp(track_tw, t_imu, g)
+        # Only samples where the hypotheses actually differ are informative.
+        sel = track_is_ang & (np.abs(track_ratecmd - rate_setpt) > 10.0)
+        # The fin command is Kp_eff·error (+ small I/D); divide out the
+        # velocity gain schedule so the fit slope is ~constant over the window.
+        cmd_norm = track_cmd / _gain_schedule_scale(rc_cfg, speed[wmask])
+        if sel.sum() < 20:
+            flown_mode_note = ("undecidable from servo data (too few angle-segment "
+                               "samples) — trusting sidecar mode")
+        elif float(np.std(track_ratecmd[sel])) < 15.0:
+            # Outer-loop cmd railed ~constant: the two error series differ only
+            # by a constant, which the fit intercept absorbs — undecidable.
+            flown_mode_note = ("undecidable from servo data (outer-loop cmd "
+                               "~constant over angle segments) — trusting sidecar mode")
+        else:
+            r2_angle = _fit_r2(gyro_w[sel] - track_ratecmd[sel], cmd_norm[sel])
+            r2_null = _fit_r2(gyro_w[sel] - rate_setpt, cmd_norm[sel])
+            if not (np.isfinite(r2_null) and np.isfinite(r2_angle)):
+                # Typically the fin command pinned at the ± limit throughout.
+                flown_mode_note = ("undecidable from servo data (fin command "
+                                   "~constant/saturated over angle segments) — "
+                                   "trusting sidecar mode")
+            elif r2_null - r2_angle > 0.25 and r2_null > 0.3:
+                has_angle_profile = False
+                result.warnings.append(
+                    f"Sidecar claims roll mode '{claimed_mode}' but the servo "
+                    f"command fits pure rate-null (R²={r2_null:.2f}) far better "
+                    f"than the angle cascade (R²={r2_angle:.2f}) — the stored "
+                    f"profile was NOT followed (use_angle_control off; app exports "
+                    f"before 2026-07-05 mislabel this). Analyzing as rate-null."
+                )
+                flown_mode_note = (f"rate-null flew (servo fit R² {r2_null:.2f} "
+                                   f"vs angle-cascade {r2_angle:.2f})")
+            elif r2_angle - r2_null > 0.25 and r2_angle > 0.3:
+                flown_mode_note = (f"angle cascade confirmed (servo fit R² "
+                                   f"{r2_angle:.2f} vs rate-null {r2_null:.2f})")
+            else:
+                flown_mode_note = (f"inconclusive (servo fit R²: angle {r2_angle:.2f}, "
+                                   f"rate-null {r2_null:.2f}) — trusting sidecar mode")
 
     # ── Current gains (from sidecar if available) ──
     kp_flight, ki_flight, kd_flight = _gain_from_sidecar(flight.sidecar)
@@ -503,6 +612,8 @@ def analyze(flight: Flight) -> AnalysisResult:
     # Flown roll-control setup parameters (from the #165 settings snapshot).
     if rc_cfg:
         metrics["roll_mode"]      = rc_cfg.get("mode", "—")
+        if flown_mode_note:
+            metrics["flown_mode_check"] = flown_mode_note
         metrics["roll_delay_ms"]  = rc_cfg.get("delay_ms", "—")
         metrics["rate_cap_dps"]   = rc_cfg.get("rate_cap_dps", "—")
         metrics["cmd_limit_deg"]  = (f"[{rc_cfg.get('cmd_limit_min_deg', '?')}, "
@@ -514,8 +625,12 @@ def analyze(flight: Flight) -> AnalysisResult:
     if eject_baro is not None:
         metrics["baro_eject_s"] = round(eject_baro, 2)
     metrics["plot_window_s"] = f"[0, {win_end:.2f}]"
+    if has_wp_angles and not has_angle_profile:
+        # Profile stored on the FC but not followed (rate mode flew).
+        metrics["profile_stored_NOT_followed"] = _effective_plan(wps)
     if has_angle_profile:
-        metrics["profile_plan"] = "; ".join(
+        metrics["profile_commanded"] = _effective_plan(wps)
+        metrics["profile_waypoints"] = "; ".join(
             f"{wt:g}s→{'null-rate' if wn else f'{wa:g}°'}" for (wt, wa, wn) in wps)
         if profile_ramp > 0:
             feasible = (rate_cap_cfg is None) or (profile_ramp <= rate_cap_cfg + 1e-6)
@@ -525,6 +640,33 @@ def analyze(flight: Flight) -> AnalysisResult:
         # setpoint, not control performance — read alongside profile_ramp_dps.
         metrics["angle_track_rms_deg"]  = round(angle_rms, 1)  if np.isfinite(angle_rms)  else "—"
         metrics["angle_track_peak_deg"] = round(angle_peak, 1) if np.isfinite(angle_peak) else "—"
+
+        # Per-segment breakdown over the analysis window: what was commanded,
+        # how the angle error evolved, and the residual rate / fin activity.
+        bounds = [0.0] + [wt for (wt, _, _) in wps if 0.0 < wt < win_end] + [win_end]
+        for si in range(len(bounds) - 1):
+            a, b = bounds[si], bounds[si + 1]
+            if b - a < 0.05:
+                continue
+            mid = 0.5 * (a + b)
+            tgt_mid, is_ang_mid = _profile_target(wps, mid)
+            mi = (t_imu >= a) & (t_imu <= b)
+            mc = (t_ns >= a) & (t_ns <= b)
+            rate_rms_seg = float(np.sqrt(np.mean(g[mi] ** 2))) if mi.any() else float("nan")
+            cmd_max_seg = float(np.max(np.abs(cmd[mc]))) if mc.any() else float("nan")
+            if is_ang_mid and track_tw is not None:
+                ms = (track_tw >= a) & (track_tw <= b) & track_is_ang
+                e_seg = track_err[ms] if ms.any() else np.array([])
+                e_seg = e_seg[np.isfinite(e_seg)]
+                if e_seg.size:
+                    desc = (f"cmd {tgt_mid:g}°: err {e_seg[0]:+.0f}→{e_seg[-1]:+.0f}° "
+                            f"(RMS {np.sqrt(np.mean(e_seg**2)):.0f}°), ")
+                else:
+                    desc = f"cmd {tgt_mid:g}°: "
+            else:
+                desc = "null-rate: "
+            desc += f"rate RMS {rate_rms_seg:.0f}°/s, |fin cmd| max {cmd_max_seg:.1f}°"
+            metrics[f"segment {a:.2g}–{b:.2g}s"] = desc
     result.metrics = metrics
 
     # ── Figures ──
@@ -630,11 +772,21 @@ def analyze(flight: Flight) -> AnalysisResult:
         axes[0].set_yticks([-180, -90, 0, 90, 180])
         axes[0].set_title("Roll angle tracking vs profile plan (launch → ejection)")
         axes[0].grid(True, alpha=0.3)
-        for (wt, wa, wn) in wps:
-            if not wn and 0 <= wt <= win_end:
-                axes[0].annotate(f"{wa:g}°", xy=(wt, _wrap180(wa)), fontsize=8,
-                                 color="tab:orange", ha="left", va="bottom",
-                                 xytext=(2, 2), textcoords="offset points")
+        # Label each ANGLE segment with its effective command (the NEXT
+        # waypoint's angle, per the firmware's step semantics), centred on the
+        # visible part of the segment — not the waypoint angle at the waypoint
+        # time, which reads as "hold this from here" and is wrong.
+        seg_spans = [(wps[i][0], wps[i + 1][0], wps[i + 1][1], wps[i][2])
+                     for i in range(len(wps) - 1)]
+        if not wps[-1][2]:  # trailing hold segment if the last waypoint is angle-mode
+            seg_spans.append((wps[-1][0], win_end, wps[-1][1], False))
+        for (sa, sb, s_ang, s_null) in seg_spans:
+            sa, sb = max(sa, 0.0), min(sb, win_end)
+            if s_null or sb - sa < 0.05:
+                continue
+            axes[0].annotate(f"cmd {s_ang:g}°", xy=(0.5 * (sa + sb), _wrap180(s_ang)),
+                             fontsize=8, color="tab:orange", ha="center", va="bottom",
+                             xytext=(0, 3), textcoords="offset points")
         _mark_events(axes[0], annotate=True)
         axes[0].legend(loc="upper left", fontsize=8)
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -159,8 +159,9 @@ final class ActiveRocketSyncer: ObservableObject {
                                      rateCapDps: profile.rateCapDps,
                                      kpAngle: profile.kpAngle,
                                      integralSepThreshold: profile.integralSepThreshold)
+        // mode byte is a legacy wire field (pre-v4 firmware); always send .angle
         device.sendRollProfile(waypoints: profile.rollWaypoints.map {
-            (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
+            (time: $0.timeSeconds, angle: $0.angleDeg, mode: RollSegmentMode.angle.rawValue)
         })
         device.sendGuidanceConfig(enabled: profile.guidanceEnabled,
                                   navGain: profile.pnNavGain, maxAccel: profile.pnMaxAccel,

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -730,6 +730,7 @@ nonisolated struct RollControlSettings: Codable, Sendable {
     let roll_rate_set_point: Double
     let guidance_enabled: Bool
     let gain_schedule: GainScheduleSettings
+    let profile_semantics: String  // "ramp" (fw v4+: lerp between waypoints) or "step" (pre-v4)
     let profile: [RollWaypointJSON]
 
     init(from raw: FlightSettingsData) {
@@ -760,11 +761,17 @@ nonisolated struct RollControlSettings: Codable, Sendable {
             v_min: sigFig(raw.gs_v_min),
             scale_cap: sigFig(raw.gs_scale_cap)
         )
+        // v4+ firmware ramps the target linearly between waypoints and ignores
+        // the legacy per-waypoint mode bytes; pre-v4 stepped to the NEXT
+        // waypoint's angle honoring per-waypoint null_rate modes. Post-flight
+        // analysis branches on this marker, so it must reflect the FIRMWARE
+        // version that flew, not what this app version would send.
+        profile_semantics = raw.version >= 4 ? "ramp" : "step"
         profile = raw.waypoints.map {
             RollWaypointJSON(
                 time_s: sigFig($0.time_s),
                 angle_deg: sigFig($0.angle_deg),
-                mode: $0.mode == 1 ? "null_rate" : "angle"
+                mode: raw.version >= 4 ? nil : ($0.mode == 1 ? "null_rate" : "angle")
             )
         }
     }
@@ -780,7 +787,7 @@ nonisolated struct GainScheduleSettings: Codable, Sendable {
 nonisolated struct RollWaypointJSON: Codable, Sendable {
     let time_s: Double
     let angle_deg: Double
-    let mode: String   // "angle" or "null_rate"
+    let mode: String?  // pre-v4 only: "angle" or "null_rate"; omitted on ramp-semantics exports
 }
 
 nonisolated struct ServoSettings: Codable, Sendable {

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -733,12 +733,15 @@ nonisolated struct RollControlSettings: Codable, Sendable {
     let profile: [RollWaypointJSON]
 
     init(from raw: FlightSettingsData) {
-        if raw.num_waypoints > 0 {
-            mode = "angle_profile"
-        } else if raw.useAngleControl {
-            mode = "angle"
-        } else {
+        // The firmware only runs the angle cascade when use_angle_control is
+        // set (Null Roll / Track Profile toggle) — a stored waypoint profile
+        // alone is inert, so it must not decide the exported mode.
+        if !raw.useAngleControl {
             mode = "rate"
+        } else if raw.num_waypoints > 0 {
+            mode = "angle_profile"
+        } else {
+            mode = "angle"
         }
         kp = sigFig(raw.kp)
         ki = sigFig(raw.ki)

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -25,16 +25,20 @@
 
 import Foundation
 
-/// Segment mode for a roll-profile waypoint.  Matches the firmware enum
-/// (ROLL_SEG_* in RocketComputerTypes.h): the mode applies to the segment
-/// *starting* at this waypoint.
+/// LEGACY segment mode (pre-v4 firmware; ROLL_SEG_* in RocketComputerTypes.h).
+/// Since firmware v4 the profile is pure (time, angle) waypoints — the target
+/// ramps linearly between them, null-rate flies before the first waypoint, and
+/// the last angle holds after it. The enum survives only for the wire byte
+/// (always sent as .angle) and for decoding old saved profiles.
 enum RollSegmentMode: UInt8, Codable, CaseIterable {
-    case angle    = 0   // interpolate target roll angle to the next waypoint
-    case nullRate = 1   // hold zero roll rate; the angle field is ignored
+    case angle    = 0
+    case nullRate = 1
 }
 
 /// One roll-profile waypoint.  `id` gives SwiftUI stable identity in the
 /// editor; it is persisted but otherwise carries no wire meaning.
+/// `mode` is legacy (see RollSegmentMode) — ignored by v4+ firmware and no
+/// longer editable; kept so old saved profiles still decode.
 struct RollWaypoint: Codable, Equatable, Identifiable {
     var id: UUID = UUID()
     var timeSeconds: Float

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -57,7 +57,7 @@ struct SettingsView: View {
     @State private var sPnMinSpeed = ""
 
     // Roll waypoints edited as strings; committed to the profile on change.
-    @State private var rollWaypoints: [(time: String, angle: String, mode: UInt8)] = []
+    @State private var rollWaypoints: [(time: String, angle: String)] = []
 
     // Pyro trigger values edited as strings (seconds or meters by mode).
     @State private var sPyroValue: [String] = ["", "", "", ""]
@@ -830,46 +830,34 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var rollWaypointEditor: some View {
-        Text("Each waypoint defines the START of a segment. Angle interpolates the target roll angle to the next waypoint; Null Rate holds zero roll rate (angle ignored) for the segment.")
+        Text("The target roll angle ramps linearly between waypoints. Before the first waypoint the controller nulls roll rate (fins keep zero roll through boost); after the last waypoint the final angle is held. To hold an angle, give two consecutive waypoints the same angle.")
             .font(.caption).foregroundColor(.secondary)
 
         ForEach(rollWaypoints.indices, id: \.self) { i in
-            VStack(spacing: 4) {
-                HStack(spacing: 8) {
-                    Text("WP \(i + 1)")
-                        .font(.caption).foregroundColor(.secondary).frame(width: 40)
-                    TextField("Time", text: Binding(
-                        get: { rollWaypoints[i].time },
-                        set: { rollWaypoints[i].time = $0 }))
-                        .keyboardType(.decimalPad)
-                        .multilineTextAlignment(.trailing).frame(width: 60)
-                        .focused($focusedField, equals: .wpTime(i))
-                    Text("s").foregroundColor(.secondary).frame(width: 15)
-                    TextField("Angle", text: Binding(
-                        get: { rollWaypoints[i].angle },
-                        set: { rollWaypoints[i].angle = $0 }))
-                        .keyboardType(.numbersAndPunctuation)
-                        .multilineTextAlignment(.trailing).frame(width: 60)
-                        .focused($focusedField, equals: .wpAngle(i))
-                        .disabled(rollWaypoints[i].mode == 1)
-                        .foregroundColor(rollWaypoints[i].mode == 1 ? .secondary : .primary)
-                    Text("\u{00B0}").foregroundColor(.secondary).frame(width: 15)
-                    Button(role: .destructive) {
-                        rollWaypoints.remove(at: i)
-                        applyRollProfile()
-                    } label: {
-                        Image(systemName: "minus.circle.fill").foregroundColor(.red)
-                    }
-                    .buttonStyle(.borderless)
+            HStack(spacing: 8) {
+                Text("WP \(i + 1)")
+                    .font(.caption).foregroundColor(.secondary).frame(width: 40)
+                TextField("Time", text: Binding(
+                    get: { rollWaypoints[i].time },
+                    set: { rollWaypoints[i].time = $0 }))
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing).frame(width: 60)
+                    .focused($focusedField, equals: .wpTime(i))
+                Text("s").foregroundColor(.secondary).frame(width: 15)
+                TextField("Angle", text: Binding(
+                    get: { rollWaypoints[i].angle },
+                    set: { rollWaypoints[i].angle = $0 }))
+                    .keyboardType(.numbersAndPunctuation)
+                    .multilineTextAlignment(.trailing).frame(width: 60)
+                    .focused($focusedField, equals: .wpAngle(i))
+                Text("\u{00B0}").foregroundColor(.secondary).frame(width: 15)
+                Button(role: .destructive) {
+                    rollWaypoints.remove(at: i)
+                    applyRollProfile()
+                } label: {
+                    Image(systemName: "minus.circle.fill").foregroundColor(.red)
                 }
-                Picker("Mode", selection: Binding(
-                    get: { rollWaypoints[i].mode },
-                    set: { rollWaypoints[i].mode = $0; applyRollProfile() })) {
-                    Text("Angle").tag(UInt8(0))
-                    Text("Null Rate").tag(UInt8(1))
-                }
-                .pickerStyle(.segmented)
-                .padding(.leading, 40)
+                .buttonStyle(.borderless)
             }
         }
 
@@ -877,7 +865,7 @@ struct SettingsView: View {
             Button {
                 let defaultTime = rollWaypoints.isEmpty ? "0.0" :
                     String(format: "%.1f", (Double(rollWaypoints.last?.time ?? "0") ?? 0) + 1.0)
-                rollWaypoints.append((time: defaultTime, angle: "0", mode: 0))
+                rollWaypoints.append((time: defaultTime, angle: "0"))
                 applyRollProfile()
             } label: {
                 HStack { Image(systemName: "plus.circle.fill"); Text("Add Waypoint") }
@@ -1018,7 +1006,7 @@ struct SettingsView: View {
         sPnMaxFin = formatDecimal(Double(p.pnMaxFinDeg))
         sPnMinSpeed = formatDecimal(Double(p.pnMinSpeed))
         rollWaypoints = p.rollWaypoints.map {
-            (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg), mode: $0.mode.rawValue)
+            (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg))
         }
         reloadPyroValueStrings()
     }
@@ -1245,14 +1233,14 @@ struct SettingsView: View {
     private func applyRollProfile() {
         let waypoints: [RollWaypoint] = rollWaypoints.map {
             RollWaypoint(timeSeconds: Float($0.time) ?? 0,
-                         angleDeg: Float($0.angle) ?? 0,
-                         mode: RollSegmentMode(rawValue: $0.mode) ?? .angle)
+                         angleDeg: Float($0.angle) ?? 0)
         }.sorted { $0.timeSeconds < $1.timeSeconds }
 
         updateProfile { $0.rollWaypoints = waypoints }
         if device.isConnected {
+            // mode byte is a legacy wire field (pre-v4); always send .angle
             device.sendRollProfile(waypoints: waypoints.map {
-                (time: $0.timeSeconds, angle: $0.angleDeg, mode: $0.mode.rawValue)
+                (time: $0.timeSeconds, angle: $0.angleDeg, mode: RollSegmentMode.angle.rawValue)
             })
         }
         showApplied($rollControlApplied)

--- a/tests/test_roll_profile_semantics.py
+++ b/tests/test_roll_profile_semantics.py
@@ -1,0 +1,97 @@
+"""Unit tests for the roll-profile target reconstruction in the flight-report
+roll_pid module — both firmware semantics generations:
+
+* "step" (pre-v4): inside segment [i, i+1) the controller commands waypoint
+  i+1's angle as a STEP, using waypoint i's per-waypoint mode.
+* "ramp" (v4+): pure (time, angle) waypoints — null-rate before the first
+  waypoint, target lerped along the shortest wrapped arc between waypoints,
+  last angle held after the profile.
+
+These must mirror firmware `roll_profile_query()` (flight_computer main.cpp)
+exactly; the analysis reconstructs the commanded target from them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "Data_Analysis"))
+
+from flight_report.modules.roll_pid import (  # noqa: E402
+    _effective_plan,
+    _profile_target,
+)
+
+# (time_s, angle_deg, is_null_rate) — as _parse_profile produces
+RAMP_WPS = [(1.5, 0.0, False), (3.0, 90.0, False), (5.0, 180.0, False)]
+STEP_WPS = [(1.5, 0.0, True), (3.0, 90.0, False), (5.0, 180.0, True)]
+
+
+class TestRampSemantics:
+    def test_null_rate_before_first_waypoint(self):
+        tgt, is_ang = _profile_target(RAMP_WPS, 0.5, "ramp")
+        assert not is_ang
+
+    def test_lerp_between_waypoints(self):
+        assert _profile_target(RAMP_WPS, 2.25, "ramp") == (45.0, True)
+        assert _profile_target(RAMP_WPS, 4.0, "ramp") == (135.0, True)
+
+    def test_waypoints_hit_exactly(self):
+        assert _profile_target(RAMP_WPS, 1.5, "ramp") == (0.0, True)
+        assert _profile_target(RAMP_WPS, 3.0, "ramp") == (90.0, True)
+
+    def test_hold_after_last_waypoint(self):
+        assert _profile_target(RAMP_WPS, 7.0, "ramp") == (180.0, True)
+
+    def test_equal_waypoints_hold(self):
+        wps = [(1.0, 45.0, False), (3.0, 45.0, False)]
+        assert _profile_target(wps, 2.0, "ramp") == (45.0, True)
+
+    def test_wrap_shortest_path(self):
+        # 170° → -170° must cross the ±180 seam (Δ=+20°), not sweep through 0.
+        wps = [(0.0, 170.0, False), (2.0, -170.0, False)]
+        tgt, _ = _profile_target(wps, 0.5, "ramp")
+        assert tgt == pytest.approx(175.0)
+        tgt, _ = _profile_target(wps, 1.5, "ramp")
+        assert tgt == pytest.approx(-175.0)
+
+    def test_zero_duration_segment(self):
+        wps = [(1.0, 0.0, False), (1.0, 90.0, False)]
+        tgt, is_ang = _profile_target(wps, 1.0, "ramp")
+        assert is_ang
+
+    def test_per_waypoint_null_flags_ignored(self):
+        # Legacy null_rate flags must not matter under ramp semantics.
+        assert _profile_target(STEP_WPS, 2.25, "ramp") == (45.0, True)
+
+    def test_effective_plan(self):
+        plan = _effective_plan(RAMP_WPS, "ramp")
+        assert plan == "<1.5s null-rate; 1.5–3s ramp 0→90°; 3–5s ramp 90→180°; ≥5s hold 180°"
+
+
+class TestStepSemantics:
+    """Pre-v4 firmware: unchanged behavior — regression-guard the old parser."""
+
+    def test_holds_first_waypoint_before_profile(self):
+        tgt, is_ang = _profile_target(STEP_WPS, 0.5, "step")
+        assert (tgt, is_ang) == (0.0, False)  # null-rate first waypoint
+
+    def test_steps_to_next_angle_with_current_mode(self):
+        # [1.5, 3): current wp null_rate → null, regardless of next angle
+        assert _profile_target(STEP_WPS, 2.0, "step")[1] is False
+        # [3, 5): current wp angle-mode → command NEXT waypoint's angle (180)
+        assert _profile_target(STEP_WPS, 4.0, "step") == (180.0, True)
+
+    def test_holds_last_waypoint_after_profile(self):
+        tgt, is_ang = _profile_target(STEP_WPS, 6.0, "step")
+        assert (tgt, is_ang) == (180.0, False)  # null-rate last waypoint
+
+    def test_default_semantics_is_step(self):
+        assert _profile_target(STEP_WPS, 4.0) == (180.0, True)
+
+    def test_effective_plan(self):
+        plan = _effective_plan(STEP_WPS, "step")
+        assert plan == "<1.5s null-rate; 1.5–3s null-rate; 3–5s cmd 180°; ≥5s null-rate"

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1815,20 +1815,24 @@ static_assert(sizeof(ServoReplayData) == 4, "ServoReplayData must be 4 bytes");
 // Max 8 waypoints: fits in single BLE MTU with header
 static constexpr uint8_t MAX_ROLL_WAYPOINTS = 8;
 
-// Per-waypoint segment mode: how the controller should behave during the
-// segment that STARTS at this waypoint (and ends at the next waypoint, or
-// holds indefinitely if this is the last waypoint).
+// Controller behavior for a stretch of the profile (roll_profile_query result).
+// Since FlightSettingsData v4 this is NOT a per-waypoint choice anymore: the
+// profile is pure (time, angle) waypoints — the target ramps linearly
+// (shortest path) between them, null-rate flies before the first waypoint,
+// and the last angle holds after it. To hold an angle mid-profile, give two
+// consecutive waypoints the same angle.
 enum RollSegmentMode : uint8_t
 {
-    ROLL_SEG_ANGLE     = 0,  // hold next waypoint's absolute angle, shortest path (cascaded angle PID)
+    ROLL_SEG_ANGLE     = 0,  // track the profile's interpolated target angle (cascaded angle PID)
     ROLL_SEG_NULL_RATE = 1,  // hold roll rate = 0 (rate-only inner PID); angle field ignored
 };
 
 typedef struct __attribute__((packed))
 {
     float   time_s;     // seconds after launch
-    float   angle_deg;  // target roll angle (deg) -- ignored when mode==ROLL_SEG_NULL_RATE
-    uint8_t mode;       // RollSegmentMode for the segment starting at this waypoint
+    float   angle_deg;  // target roll angle (deg) at this time
+    uint8_t mode;       // LEGACY (pre-v4 per-waypoint RollSegmentMode); kept for wire
+                        // layout, ignored by firmware — always write ROLL_SEG_ANGLE
 } RollWaypoint;
 static_assert(sizeof(RollWaypoint) == 9, "RollWaypoint must be 9 bytes");
 
@@ -1869,7 +1873,12 @@ struct __attribute__((packed)) FlightSettingsData
 {
     // v2: appended board→rocket mounting orientation (b2r_* fields).
     // v3: appended fin-angle calibration (fin_min_deg/fin_max_deg, #267).
-    static constexpr uint8_t VERSION = 3;
+    // v4: NO layout change — marks the roll-profile semantics switch: the
+    //     target ramps linearly between waypoints, null-rate before the first
+    //     waypoint, hold after the last; per-waypoint mode bytes are ignored.
+    //     (Pre-v4 firmware stepped to the NEXT waypoint's angle and honored
+    //     per-waypoint null_rate modes — analysis must branch on this.)
+    static constexpr uint8_t VERSION = 4;
 
     // flags bit positions
     static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1030,21 +1030,30 @@ static void servicePyroChannels(uint32_t now_ms)
 
 // ── Roll profile lookup ─────────────────────────────────────────────────────
 // Returns the desired (angle, mode) for the current flight time.
-// Mode is the segment mode of the waypoint that STARTS the current segment.
-// Within a ROLL_SEG_ANGLE segment the controller is commanded straight to the
-// segment's DESTINATION (next waypoint's) absolute angle and takes the shortest
-// path there — no ramp. (Previously the setpoint was linearly interpolated
-// between waypoints, but sweeping it through intermediate angles flipped the
-// command direction at the ±180° error wrap mid-maneuver; see the roll-control
-// flight analysis.) ROLL_SEG_NULL_RATE segments null roll rate to 0 in the
-// inner loop and ignore the angle field. Before WP1 or after WPn we hold that
-// waypoint's mode and angle.
+// FlightSettingsData v4 semantics: the profile is pure (time, angle) waypoints —
+// per-waypoint mode bytes are IGNORED (legacy wire field, pre-v4).
+//   * before WP1:        NULL_RATE (fins hold zero roll rate through boost)
+//   * WPi..WPi+1:        ANGLE, target linearly interpolated WPi→WPi+1 along
+//                        the shortest wrapped arc
+//   * after WPn:         ANGLE, hold WPn's angle
+// To hold an angle (or "null roll") mid-profile, give two consecutive
+// waypoints the same angle. An earlier interpolation attempt was reverted
+// because it lerped the RAW angles, sweeping the long way round and flipping
+// the command at the ±180° error wrap; interpolating the WRAPPED delta keeps
+// the target on the shortest arc, so the target never jumps.
 // If no waypoints are loaded, defaults to NULL_RATE / 0 deg.
 struct RollProfileQuery
 {
     float   angle_deg;
     uint8_t mode;
 };
+
+static inline float wrap180f(float a)
+{
+    while (a > 180.0f)  a -= 360.0f;
+    while (a < -180.0f) a += 360.0f;
+    return a;
+}
 
 static RollProfileQuery roll_profile_query(float t_flight_s)
 {
@@ -1058,34 +1067,38 @@ static RollProfileQuery roll_profile_query(float t_flight_s)
     }
     const uint8_t n = roll_profile.num_waypoints;
 
-    // Before first waypoint: hold first angle & mode
-    if (t_flight_s <= roll_profile.waypoints[0].time_s)
+    // Before first waypoint: null roll rate (safe boost behavior)
+    if (t_flight_s < roll_profile.waypoints[0].time_s)
     {
-        out.angle_deg = roll_profile.waypoints[0].angle_deg;
-        out.mode      = roll_profile.waypoints[0].mode;
         return out;
     }
-    // After last waypoint: hold last angle & mode
+    // After last waypoint: hold last angle
     if (t_flight_s >= roll_profile.waypoints[n - 1].time_s)
     {
         out.angle_deg = roll_profile.waypoints[n - 1].angle_deg;
-        out.mode      = roll_profile.waypoints[n - 1].mode;
+        out.mode      = ROLL_SEG_ANGLE;
         return out;
     }
-    // Inside profile -- find the active segment [i, i+1). No ramp: command the
-    // segment's DESTINATION (next waypoint's) absolute angle directly and let
-    // controlAngle take the shortest path to it.
+    // Inside profile -- find the active segment [i, i+1) and interpolate the
+    // target along the shortest wrapped arc from WPi to WPi+1.
     for (uint8_t i = 0; i < n - 1; ++i)
     {
-        if (t_flight_s < roll_profile.waypoints[i + 1].time_s)
+        const RollWaypoint &w0 = roll_profile.waypoints[i];
+        const RollWaypoint &w1 = roll_profile.waypoints[i + 1];
+        if (t_flight_s < w1.time_s)
         {
-            out.angle_deg = roll_profile.waypoints[i + 1].angle_deg;
-            out.mode      = roll_profile.waypoints[i].mode;
+            const float span = w1.time_s - w0.time_s;
+            const float frac = (span > 1e-3f)
+                                   ? (t_flight_s - w0.time_s) / span
+                                   : 1.0f;
+            out.angle_deg = wrap180f(w0.angle_deg +
+                                     wrap180f(w1.angle_deg - w0.angle_deg) * frac);
+            out.mode      = ROLL_SEG_ANGLE;
             return out;
         }
     }
     out.angle_deg = roll_profile.waypoints[n - 1].angle_deg;
-    out.mode      = roll_profile.waypoints[n - 1].mode;
+    out.mode      = ROLL_SEG_ANGLE;
     return out;
 }
 
@@ -2535,10 +2548,9 @@ static void setup_fc()
             ESP_LOGI(TAG, "NVS roll profile: %d waypoints", roll_profile.num_waypoints);
             for (uint8_t i = 0; i < roll_profile.num_waypoints; ++i)
             {
-                ESP_LOGI(TAG, "  WP%d: t=%.1fs angle=%.1f° mode=%s", i,
+                ESP_LOGI(TAG, "  WP%d: t=%.1fs angle=%.1f°", i,
                               (double)roll_profile.waypoints[i].time_s,
-                              (double)roll_profile.waypoints[i].angle_deg,
-                              roll_profile.waypoints[i].mode == ROLL_SEG_NULL_RATE ? "NULL_RATE" : "ANGLE");
+                              (double)roll_profile.waypoints[i].angle_deg);
             }
         }
         else

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -78,9 +78,11 @@ class SimConfig:
     d_lpf_hz: float = 0.0                      # servo PID derivative LPF cutoff Hz (0=off)
     integral_sep_threshold: float = 0.0        # PID integral-separation anti-windup; freeze I when |err|>thr (0=off)
     # Roll-profile targeting: "hold" = flown 6/14 firmware (hold the most-recent
-    # waypoint); "endpoint" = updated firmware (803d23f) — command the segment's
+    # waypoint); "endpoint" = pre-v4 firmware (803d23f) — command the segment's
     # END waypoint angle by the shortest path (no ramp), so a maneuver engages at
-    # the segment START, not its end.
+    # the segment START, not its end; "ramp" = v4 firmware — null-rate before the
+    # first waypoint, target lerped along the shortest wrapped arc between
+    # waypoints (per-waypoint modes ignored), last angle held after the profile.
     roll_targeting: str = "hold"
     # Impulsive roll-rate perturbation for the controller to null: add
     # roll_kick_dps to the body roll rate once at roll_kick_time_s (s after launch).
@@ -834,7 +836,33 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                         #    Waypoints are (time_s, angle_deg[, mode]), mode in
                         #    {"angle","null_rate"}.
                         _wps = config.roll_profile
-                        if config.roll_targeting == "endpoint" and len(_wps) > 1:
+                        if config.roll_targeting == "ramp":
+                            # v4 firmware (roll_profile_query): null-rate before
+                            # the first waypoint; lerp the target along the
+                            # shortest wrapped arc between waypoints (per-wp
+                            # modes ignored); hold the last angle afterwards.
+                            def _wrap180(a):
+                                while a > 180.0: a -= 360.0
+                                while a < -180.0: a += 360.0
+                                return a
+                            if t < _wps[0][0]:
+                                target_angle = 0.0
+                                seg_mode = "null_rate"
+                            elif t >= _wps[-1][0]:
+                                target_angle = _wps[-1][1]
+                                seg_mode = "angle"
+                            else:
+                                target_angle = _wps[-1][1]
+                                seg_mode = "angle"
+                                for i in range(len(_wps) - 1):
+                                    (t0w, a0w), (t1w, a1w) = _wps[i][:2], _wps[i + 1][:2]
+                                    if t < t1w:
+                                        frac = ((t - t0w) / (t1w - t0w)
+                                                if t1w - t0w > 1e-3 else 1.0)
+                                        target_angle = _wrap180(
+                                            a0w + _wrap180(a1w - a0w) * frac)
+                                        break
+                        elif config.roll_targeting == "endpoint" and len(_wps) > 1:
                             # Updated firmware (803d23f): command the END waypoint of
                             # the current segment; segment mode = the starting waypoint.
                             if t <= _wps[0][0]:


### PR DESCRIPTION
## Why

Post-flight analysis of the 7/05 CENJARS roll-control test day surfaced two layered problems:

1. **Export mislabel:** the flight-settings JSON labeled any flight with a *stored* waypoint profile as `angle_profile`, even with Null Roll selected (`use_angle_control` off) — where the firmware ignores the profile entirely. The 67mm Large Fin flight "failed" angle tracking that was never commanded (servo fit: rate-null R2 1.00 vs angle-cascade 0.31).
2. **Confusing profile semantics:** per-waypoint Angle/Null-Rate modes plus step-to-next-waypoint targeting meant the plan read one way and flew another — the 54mm flight commanded 180 deg during 3-5 s when the plan read "90 deg at 3 s".

## What

**Roll profile v4 (fc, sim):** profiles are now pure (time, angle) waypoints. Null-rate before the first waypoint (safe boost), target lerped along the shortest wrapped arc between waypoints, last angle held after. Hold an angle = two equal consecutive waypoints. Wire layout untouched (mode byte kept but ignored); FlightSettingsData VERSION 3->4 marks the semantics switch only. Sim gains matching roll_targeting="ramp".

**App:** waypoint editor rows are plain (time, angle) — the per-waypoint Angle/Null-Rate segmented control is gone, help text rewritten. Exported roll mode now derives from use_angle_control (not stored waypoints), and the JSON carries profile_semantics ("ramp"/"step") keyed off the firmware version that flew.

**Flight reports (Data_Analysis):** the roll_pid module now (a) verifies which mode *actually flew* from the servo data (gain-schedule-normalized fit; reclassifies with a warning when a stored profile provably was not followed, explicit "undecidable" verdicts otherwise), (b) reconstructs the commanded target under whichever semantics generation flew, and (c) shows the effective commanded timeline plus per-segment tracking metrics.

## Verification

- flight_computer + out_computer build clean (IDF v6.0)
- iOS app builds (xcodebuild, simulator)
- 384/384 C++ gtests; 17/17 pytest (new dual-semantics unit tests + report smoke test)
- All four 7/05 CENJARS reports regenerate with correct verdicts (67mm correctly reclassified rate-null; step-semantics reconstruction unchanged)

## Flight-day note

Existing saved profiles fly under the new reading — review rocket profiles in the app before the next flight (e.g. the 54mm profile now means ramp 0->90 over 1.5-3 s, then 90->180 by 5 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)