### PR TITLE
feat(radio,bs): LoRa daughterboard firmware — transparent UART modem + TR_UART_Link (#409)

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -27,6 +27,7 @@ jobs:
           - out_computer
           - base_station
           - flight_computer
+          - radio_board
 
     steps:
       - uses: actions/checkout@v4

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -69,6 +69,29 @@ target_include_directories(test_crc16_compat PRIVATE
 target_link_libraries(test_crc16_compat GTest::gtest_main)
 gtest_discover_tests(test_crc16_compat)
 
+# ---------- test_uart_link_codec ----------
+# UART radio-modem link (#409): tr_msg codec + deframer + protocol layouts.
+# TR_MsgCodec.cpp is deliberately IDF-free so it compiles on the host; the
+# CRC sources come along for calcCRC16 (same shim note as test_crc16_compat).
+add_executable(test_uart_link_codec test_uart_link_codec.cpp
+    ${LIB_DIR}/TR_UART_Link/TR_MsgCodec.cpp
+    ${LIB_DIR}/CRC/CRC16.cpp
+    ${LIB_DIR}/CRC/CRC.cpp
+    ${LIB_DIR}/CRC/CrcFastReverse.cpp
+    ${LIB_DIR}/CRC/CRC8.cpp
+    ${LIB_DIR}/CRC/CRC12.cpp
+    ${LIB_DIR}/CRC/CRC32.cpp
+    ${LIB_DIR}/CRC/CRC64.cpp
+    ${LIB_DIR}/CRC/FastCRC32.cpp
+)
+target_include_directories(test_uart_link_codec PRIVATE
+    ${SHIM_DIR}   # Must come first so Arduino.h resolves to our shim
+    ${LIB_DIR}/TR_UART_Link
+    ${LIB_DIR}/CRC
+)
+target_link_libraries(test_uart_link_codec GTest::gtest_main)
+gtest_discover_tests(test_uart_link_codec)
+
 # ============================================================
 # Phase 2: Safety-Critical Tests
 # ============================================================

--- a/tests_cpp/test_uart_link_codec.cpp
+++ b/tests_cpp/test_uart_link_codec.cpp
@@ -1,0 +1,246 @@
+// Tests for the UART radio-modem link codec (#409):
+//  - tr_msg::pack produces the exact TR_I2C_Interface::packMessage wire
+//    format (golden-byte check so the two codecs can't silently drift)
+//  - MsgDeframer round-trips frames from a byte stream, resynchronizes
+//    through garbage/corruption, and counts drops
+//  - RadioModemProtocol struct layouts stay wire-stable
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include <CRC.h>
+
+#include "../tinkerrocket-idf/components/TR_UART_Link/TR_MsgCodec.h"
+#include "../tinkerrocket-idf/components/TR_UART_Link/RadioModemProtocol.h"
+
+using tr_msg::MsgDeframer;
+
+namespace
+{
+
+std::vector<uint8_t> packVec(uint8_t type, const std::vector<uint8_t>& payload)
+{
+    std::vector<uint8_t> out(tr_msg::MAX_FRAME);
+    size_t frame_len = 0;
+    EXPECT_TRUE(tr_msg::pack(type, payload.empty() ? nullptr : payload.data(),
+                             payload.size(), out.data(), out.size(), frame_len));
+    out.resize(frame_len);
+    return out;
+}
+
+// Feed a byte vector through a deframer, collecting completed frames.
+struct Collected
+{
+    uint8_t type;
+    std::vector<uint8_t> payload;
+};
+
+std::vector<Collected> run(MsgDeframer& d, const std::vector<uint8_t>& bytes)
+{
+    std::vector<Collected> got;
+    for (uint8_t b : bytes)
+    {
+        if (d.feed(b))
+        {
+            got.push_back({d.type(),
+                           {d.payload(), d.payload() + d.payloadLen()}});
+        }
+    }
+    return got;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// pack: wire format
+// ---------------------------------------------------------------------------
+
+TEST(UartLinkCodec, PackGoldenFrame)
+{
+    // Golden layout: SOF(4) + type + len + payload + CRC16be(type+len+payload).
+    // CRC computed with the same library call TR_I2C_Interface::packMessage
+    // uses — if either side changes polynomial/params, this fails.
+    const std::vector<uint8_t> payload = {0x01, 0x02, 0x03};
+    const auto frame = packVec(0x42, payload);
+
+    ASSERT_EQ(frame.size(), 4u + 1 + 1 + 3 + 2);
+    EXPECT_EQ(frame[0], 0xAA);
+    EXPECT_EQ(frame[1], 0x55);
+    EXPECT_EQ(frame[2], 0xAA);
+    EXPECT_EQ(frame[3], 0x55);
+    EXPECT_EQ(frame[4], 0x42);
+    EXPECT_EQ(frame[5], 0x03);
+    EXPECT_EQ(frame[6], 0x01);
+    EXPECT_EQ(frame[7], 0x02);
+    EXPECT_EQ(frame[8], 0x03);
+
+    const uint8_t crc_input[] = {0x42, 0x03, 0x01, 0x02, 0x03};
+    const uint16_t crc = calcCRC16(crc_input, sizeof(crc_input));
+    EXPECT_EQ(frame[9], static_cast<uint8_t>(crc >> 8));
+    EXPECT_EQ(frame[10], static_cast<uint8_t>(crc & 0xFF));
+}
+
+TEST(UartLinkCodec, PackRejectsBadArgs)
+{
+    uint8_t out[tr_msg::MAX_FRAME];
+    size_t frame_len = 0;
+
+    // Null output
+    EXPECT_FALSE(tr_msg::pack(1, nullptr, 0, nullptr, sizeof(out), frame_len));
+    // Payload bytes promised but null pointer
+    EXPECT_FALSE(tr_msg::pack(1, nullptr, 3, out, sizeof(out), frame_len));
+    // Capacity too small
+    EXPECT_FALSE(tr_msg::pack(1, nullptr, 0, out, 7, frame_len));
+    // Zero-length payload is legal
+    EXPECT_TRUE(tr_msg::pack(1, nullptr, 0, out, sizeof(out), frame_len));
+    EXPECT_EQ(frame_len, tr_msg::FRAME_OVERHEAD);
+}
+
+// ---------------------------------------------------------------------------
+// Deframer: round trips
+// ---------------------------------------------------------------------------
+
+TEST(UartLinkCodec, RoundTripSingleFrame)
+{
+    MsgDeframer d;
+    const std::vector<uint8_t> payload = {9, 8, 7, 6, 5};
+    const auto got = run(d, packVec(0x11, payload));
+
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_EQ(got[0].type, 0x11);
+    EXPECT_EQ(got[0].payload, payload);
+    EXPECT_EQ(d.stats().frames, 1u);
+    EXPECT_EQ(d.stats().crc_fails, 0u);
+    EXPECT_EQ(d.stats().resync_bytes, 0u);
+}
+
+TEST(UartLinkCodec, RoundTripZeroAndMaxPayload)
+{
+    MsgDeframer d;
+    std::vector<uint8_t> maxp(tr_msg::MAX_PAYLOAD);
+    for (size_t i = 0; i < maxp.size(); i++)
+    {
+        maxp[i] = static_cast<uint8_t>(i);
+    }
+
+    std::vector<uint8_t> stream = packVec(0x01, {});
+    const auto f2 = packVec(0x02, maxp);
+    stream.insert(stream.end(), f2.begin(), f2.end());
+
+    const auto got = run(d, stream);
+    ASSERT_EQ(got.size(), 2u);
+    EXPECT_EQ(got[0].type, 0x01);
+    EXPECT_TRUE(got[0].payload.empty());
+    EXPECT_EQ(got[1].type, 0x02);
+    EXPECT_EQ(got[1].payload, maxp);
+}
+
+TEST(UartLinkCodec, ResyncThroughLeadingGarbage)
+{
+    MsgDeframer d;
+    std::vector<uint8_t> stream = {0x00, 0xFF, 0xAA, 0xAA, 0x13, 0x55};
+    const auto frame = packVec(0x33, {1, 2});
+    stream.insert(stream.end(), frame.begin(), frame.end());
+
+    const auto got = run(d, stream);
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_EQ(got[0].type, 0x33);
+    EXPECT_GT(d.stats().resync_bytes, 0u);
+}
+
+TEST(UartLinkCodec, CorruptedFrameDroppedNextFrameSurvives)
+{
+    MsgDeframer d;
+    auto bad = packVec(0x44, {10, 20, 30});
+    bad[7] ^= 0xFF;  // corrupt a payload byte -> CRC fail
+    const auto good = packVec(0x55, {42});
+
+    std::vector<uint8_t> stream = bad;
+    stream.insert(stream.end(), good.begin(), good.end());
+
+    const auto got = run(d, stream);
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_EQ(got[0].type, 0x55);
+    ASSERT_EQ(got[0].payload.size(), 1u);
+    EXPECT_EQ(got[0].payload[0], 42);
+    EXPECT_EQ(d.stats().crc_fails, 1u);
+}
+
+TEST(UartLinkCodec, TruncatedFrameThenNewSofRecovers)
+{
+    MsgDeframer d;
+    auto truncated = packVec(0x66, {1, 2, 3, 4, 5, 6, 7, 8});
+    truncated.resize(truncated.size() - 6);  // cut mid-payload
+    const auto good = packVec(0x77, {0xEE});
+
+    std::vector<uint8_t> stream = truncated;
+    stream.insert(stream.end(), good.begin(), good.end());
+
+    // The truncated frame's tail is consumed as payload bytes of the partial
+    // frame; the CRC check then fails on whatever lands in the CRC slots, and
+    // the good frame that follows must still be recovered — worst case after
+    // one more frame's worth of resync. Send the good frame twice to prove
+    // the parser can't wedge permanently.
+    stream.insert(stream.end(), good.begin(), good.end());
+
+    const auto got = run(d, stream);
+    ASSERT_GE(got.size(), 1u);
+    EXPECT_EQ(got.back().type, 0x77);
+    ASSERT_EQ(got.back().payload.size(), 1u);
+    EXPECT_EQ(got.back().payload[0], 0xEE);
+}
+
+TEST(UartLinkCodec, BackToBackFramesNoLoss)
+{
+    MsgDeframer d;
+    std::vector<uint8_t> stream;
+    for (int i = 0; i < 50; i++)
+    {
+        const auto f = packVec(static_cast<uint8_t>(i),
+                               {static_cast<uint8_t>(i), static_cast<uint8_t>(i + 1)});
+        stream.insert(stream.end(), f.begin(), f.end());
+    }
+    const auto got = run(d, stream);
+    ASSERT_EQ(got.size(), 50u);
+    for (int i = 0; i < 50; i++)
+    {
+        EXPECT_EQ(got[i].type, static_cast<uint8_t>(i));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RadioModemProtocol: wire-stable layouts
+// ---------------------------------------------------------------------------
+
+TEST(RadioModemProtocol, StructSizesAreWireStable)
+{
+    using namespace radio_modem;
+    EXPECT_EQ(sizeof(TxFrameHeader), 1u);
+    EXPECT_EQ(sizeof(RadioConfigData), 16u);
+    EXPECT_EQ(sizeof(HopFreqData), 4u);
+    EXPECT_EQ(sizeof(RxFrameHeader), 8u);
+    EXPECT_EQ(sizeof(TxResultData), 2u);
+    EXPECT_EQ(sizeof(ModemIdentityData), 44u);
+    EXPECT_EQ(sizeof(ModemStatusData), 52u);
+    EXPECT_EQ(sizeof(ScanRequestData), 12u);
+    EXPECT_EQ(sizeof(ScanResultHeader), 12u);
+}
+
+TEST(RadioModemProtocol, ScanResultFitsOneFrame)
+{
+    // SCAN_MAX_SAMPLES int8 samples + header must fit a single tr_msg frame
+    // (the protocol relies on this to avoid chunking).
+    EXPECT_LE(sizeof(radio_modem::ScanResultHeader) + 128, tr_msg::MAX_PAYLOAD);
+}
+
+TEST(RadioModemProtocol, MaxAirFrameFitsWithHeaders)
+{
+    // MAX_AIR_FRAME must fit alongside BOTH per-frame headers so anything a
+    // host may transmit is also deliverable on the receive side.
+    EXPECT_LE(radio_modem::MAX_AIR_FRAME + sizeof(radio_modem::TxFrameHeader),
+              tr_msg::MAX_PAYLOAD);
+    EXPECT_LE(radio_modem::MAX_AIR_FRAME + sizeof(radio_modem::RxFrameHeader),
+              tr_msg::MAX_PAYLOAD);
+}

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -62,6 +62,13 @@ bool TR_LoRa_Comms::begin(const Config& cfg, bool debug)
     hal_->delay(50);
 
     (void)radio_->setDio2AsRfSwitch(true);
+    if (cfg.rxen_pin >= 0)
+    {
+        // MCU-driven RX-enable half of the RF switch (TX half is DIO2,
+        // radio-driven). RadioLib toggles it on every mode transition.
+        module_->setRfSwitchPins(static_cast<uint32_t>(cfg.rxen_pin),
+                                 RADIOLIB_NC);
+    }
 
     int16_t st = radio_->begin();
     stats_.last_error = st;

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -14,6 +14,11 @@ public:
         int dio1_pin = -1;
         int rst_pin = -1;
         int busy_pin = -1;
+        // RF-switch RX enable for modules with a discrete antenna switch
+        // (TX side is DIO2, see setDio2AsRfSwitch in begin()). RadioLib
+        // drives it HIGH in RX / LOW in TX+idle via setRfSwitchPins.
+        // -1 = not wired (existing V7 OC / original-BS boards).
+        int rxen_pin = -1;
         int spi_sck = -1;
         int spi_miso = -1;
         int spi_mosi = -1;

--- a/tinkerrocket-idf/components/TR_UART_Link/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_UART_Link/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "TR_UART_Link.cpp" "TR_MsgCodec.cpp"
                        INCLUDE_DIRS "."
-                       REQUIRES driver CRC TR_Compat)
+                       REQUIRES esp_driver_uart driver CRC TR_Compat)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error)

--- a/tinkerrocket-idf/components/TR_UART_Link/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_UART_Link/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "TR_UART_Link.cpp" "TR_MsgCodec.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES driver CRC TR_Compat)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error)

--- a/tinkerrocket-idf/components/TR_UART_Link/RadioModemProtocol.h
+++ b/tinkerrocket-idf/components/TR_UART_Link/RadioModemProtocol.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <stdint.h>
+
+// UART radio-modem link protocol (#409): host (OC on the rocket, BS on the
+// ground, #414) <-> LoRa daughterboard.
+//
+// The daughterboard is a TRANSPARENT MODEM: TX_FRAME / RX_FRAME payloads are
+// the exact bytes the host would have handed to / read from TR_LoRa_Comms on
+// a direct-SPI board. The modem never parses them, so the on-air format
+// (LORA_PROTO_VERSION, network id, hopping schedule contents...) is owned
+// entirely by the hosts and stays byte-identical to direct-radio boards.
+// The same daughterboard hardware + firmware binary serves both ends of the
+// link — nothing here may assume which end it is plugged into.
+//
+// Transport: tr_msg framing (TR_MsgCodec.h) over UART. The message types
+// below live in a fresh, link-local namespace — they do NOT collide with
+// I2C message-type codes or ble_cmd numbers. Keep every code for this link
+// in this one enum pair so duplicates stay impossible to miss (see the
+// wire-code collision history, #132/#148).
+//
+// Flow control (in-band credits): each TX_FRAME carries a one-byte seq; the
+// modem returns it in a TX_RESULT when the airtime is spent (or the frame is
+// rejected). The host may have at most TX_QUEUE_CAPACITY unacknowledged
+// seqs outstanding. A MODEM BOOT message resets the credit window (modem
+// rebooted; its queue is empty). A TX frame is therefore never silently
+// dropped: every accepted seq is answered.
+//
+// Versioning: PROTOCOL_VERSION is carried in IDENTITY/BOOT. Hosts must
+// check it and refuse (loudly — log + status surface) to run a mismatched
+// pair rather than mis-parse.
+
+namespace radio_modem
+{
+
+static constexpr uint8_t PROTOCOL_VERSION = 1;
+
+// Modem-side TX queue depth == the host's credit window.
+static constexpr uint8_t TX_QUEUE_CAPACITY = 8;
+
+// Largest air frame the tunnel carries in either direction: one tr_msg
+// payload (255) minus the larger per-frame header (RxFrameHeader, 8 bytes).
+// Applies symmetrically so anything a host may transmit is also deliverable
+// on the receive side. Generous vs. the ~62-byte frames the LoRa protocol
+// actually uses; oversize TX_FRAMEs are rejected with TX_RESULT ok=0, and
+// oversize air receptions (foreign traffic) are dropped and counted.
+static constexpr size_t MAX_AIR_FRAME = 247;
+
+// ---- Message types: host -> modem -----------------------------------------
+enum HostToModem : uint8_t
+{
+    MSG_TX_FRAME     = 0x01,  // TxFrameHeader + opaque air bytes
+    MSG_SET_CONFIG   = 0x02,  // RadioConfigData
+    MSG_HOP_FREQ     = 0x03,  // HopFreqData (per-packet hopping; no reply)
+    MSG_START_RX     = 0x04,  // (empty) enter RX mode
+    MSG_GET_STATUS   = 0x05,  // (empty) -> MSG_STATUS
+    MSG_GET_IDENTITY = 0x06,  // (empty) -> MSG_IDENTITY
+    MSG_START_SCAN   = 0x07,  // ScanRequestData -> MSG_SCAN_RESULT when done
+};
+
+// ---- Message types: modem -> host ------------------------------------------
+enum ModemToHost : uint8_t
+{
+    MSG_RX_FRAME    = 0x81,  // RxFrameHeader + opaque air bytes
+    MSG_TX_RESULT   = 0x82,  // TxResultData (returns the seq = credit)
+    MSG_STATUS      = 0x83,  // ModemStatusData
+    MSG_IDENTITY    = 0x84,  // ModemIdentityData
+    MSG_SCAN_RESULT = 0x85,  // ScanResultHeader + int8 RSSI samples
+    MSG_BOOT        = 0x86,  // ModemIdentityData; sent once at modem boot —
+                             // host must reset its credit window on receipt
+};
+
+// ---- Radio chip identifiers (IDENTITY.chip) ---------------------------------
+enum RadioChip : uint8_t
+{
+    CHIP_UNKNOWN = 0,
+    CHIP_LLCC68  = 1,
+    // Future higher-power / alternate modules get new ids; hosts clamp
+    // config to the reported capability fields, not the chip id.
+};
+
+// ---- Payload structs --------------------------------------------------------
+
+struct __attribute__((packed)) TxFrameHeader
+{
+    uint8_t seq;  // echoed in TX_RESULT; host-chosen (wrapping counter)
+};
+static_assert(sizeof(TxFrameHeader) == 1, "TxFrameHeader must be 1 byte");
+
+// Mirrors the radio-parameter fields of TR_LoRa_Comms::Config. The five
+// reconfigure() parameters (freq/sf/bw/cr/power) apply at any time; the
+// boot-fixed fields (preamble/flags) only take effect if the radio has not
+// begun yet (e.g. first SET_CONFIG after a failed-at-boot radio) — matching
+// the direct-SPI driver, which also fixes them at begin().
+struct __attribute__((packed)) RadioConfigData
+{
+    float freq_mhz;
+    float bandwidth_khz;
+    uint8_t spreading_factor;
+    uint8_t coding_rate;
+    int8_t tx_power_dbm;
+    uint8_t flags;  // bit0 crc_on, bit1 rx_boosted_gain, bit2 syncword_private
+    uint16_t preamble_len;
+    uint8_t start_rx;  // nonzero: enter RX mode after applying
+    uint8_t reserved;
+};
+static_assert(sizeof(RadioConfigData) == 16, "RadioConfigData must be 16 bytes");
+
+static constexpr uint8_t CFG_FLAG_CRC_ON            = 1 << 0;
+static constexpr uint8_t CFG_FLAG_RX_BOOSTED_GAIN   = 1 << 1;
+static constexpr uint8_t CFG_FLAG_SYNCWORD_PRIVATE  = 1 << 2;
+
+struct __attribute__((packed)) HopFreqData
+{
+    float freq_mhz;
+};
+static_assert(sizeof(HopFreqData) == 4, "HopFreqData must be 4 bytes");
+
+struct __attribute__((packed)) RxFrameHeader
+{
+    float rssi_dbm;
+    float snr_db;
+};
+static_assert(sizeof(RxFrameHeader) == 8, "RxFrameHeader must be 8 bytes");
+
+struct __attribute__((packed)) TxResultData
+{
+    uint8_t seq;
+    uint8_t ok;  // 1 = radiated, 0 = failed/rejected (queue full, radio down,
+                 //     TX watchdog fired)
+};
+static_assert(sizeof(TxResultData) == 2, "TxResultData must be 2 bytes");
+
+struct __attribute__((packed)) ModemIdentityData
+{
+    uint8_t protocol_version;  // PROTOCOL_VERSION
+    uint8_t chip;              // RadioChip
+    int8_t max_tx_power_dbm;   // capability ceiling — hosts clamp to this
+    uint8_t reserved;
+    float freq_min_mhz;        // capability band edges
+    float freq_max_mhz;
+    char fw_version[32];       // esp_app_desc version (git sha + build stamp),
+                               // NUL-terminated / NUL-padded
+};
+static_assert(sizeof(ModemIdentityData) == 44, "ModemIdentityData must be 44 bytes");
+
+struct __attribute__((packed)) ModemStatusData
+{
+    uint32_t uptime_ms;
+    uint8_t radio_enabled;    // 0: radio failed to init — modem alive, RF dead
+    uint8_t rx_mode;
+    uint8_t tx_queue_used;
+    uint8_t tx_queue_capacity;  // == TX_QUEUE_CAPACITY (belt & braces)
+    uint32_t tx_ok;
+    uint32_t tx_fail;
+    uint32_t rx_count;
+    uint32_t rx_crc_fail;
+    uint32_t tx_watchdog_fires;
+    uint32_t uart_rx_crc_fails;    // host->modem link health
+    uint32_t uart_rx_resync_bytes;
+    float last_rssi_dbm;
+    float last_snr_db;
+    float current_freq_mhz;
+    uint8_t current_sf;
+    uint8_t reserved[3];
+};
+static_assert(sizeof(ModemStatusData) == 52, "ModemStatusData must be 52 bytes");
+
+struct __attribute__((packed)) ScanRequestData
+{
+    float start_mhz;
+    float stop_mhz;
+    uint16_t step_khz;
+    uint16_t dwell_ms;
+};
+static_assert(sizeof(ScanRequestData) == 12, "ScanRequestData must be 12 bytes");
+
+// SCAN_RESULT payload: this header followed by `count` int8 RSSI samples
+// (dBm, clamped); sample i is at freq start_mhz + i * step_khz/1000.
+// TR_LoRa_Comms::SCAN_MAX_SAMPLES = 128, so header + samples always fits a
+// single tr_msg frame (12 + 128 <= 255) — no chunking needed.
+struct __attribute__((packed)) ScanResultHeader
+{
+    uint8_t count;
+    uint8_t reserved[3];
+    float start_mhz;
+    float step_khz;
+};
+static_assert(sizeof(ScanResultHeader) == 12, "ScanResultHeader must be 12 bytes");
+
+}  // namespace radio_modem

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_MsgCodec.cpp
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_MsgCodec.cpp
@@ -1,0 +1,164 @@
+#include "TR_MsgCodec.h"
+
+#include <CRC.h>
+
+namespace tr_msg
+{
+
+bool pack(uint8_t type,
+          const uint8_t* payload,
+          size_t len,
+          uint8_t* frame_out,
+          size_t frame_out_capacity,
+          size_t& frame_len_out)
+{
+    frame_len_out = 0;
+
+    if (frame_out == nullptr)
+    {
+        return false;
+    }
+    if ((len > 0) && (payload == nullptr))
+    {
+        return false;
+    }
+    if (len > MAX_PAYLOAD)
+    {
+        return false;
+    }
+
+    const size_t frame_len = FRAME_OVERHEAD + len;
+    if (frame_out_capacity < frame_len)
+    {
+        return false;
+    }
+
+    size_t idx = 0;
+    frame_out[idx++] = SOF0;
+    frame_out[idx++] = SOF1;
+    frame_out[idx++] = SOF2;
+    frame_out[idx++] = SOF3;
+
+    frame_out[idx++] = type;
+    frame_out[idx++] = static_cast<uint8_t>(len);
+
+    for (size_t i = 0; i < len; i++)
+    {
+        frame_out[idx++] = payload[i];
+    }
+
+    // Same call as TR_I2C_Interface: CRC16 (library defaults) over
+    // type + len + payload, stored big-endian.
+    const uint16_t crc = calcCRC16(frame_out + 4, static_cast<int>(1 + 1 + len));
+    frame_out[idx++] = static_cast<uint8_t>(crc >> 8);
+    frame_out[idx++] = static_cast<uint8_t>(crc & 0xFF);
+
+    frame_len_out = frame_len;
+    return true;
+}
+
+void MsgDeframer::rehunt(uint8_t b)
+{
+    stats_.resync_bytes++;
+    // SOF0 == SOF2 == 0xAA, so any stray 0xAA restarts the hunt one byte in.
+    state_ = (b == SOF0) ? St::Hunt1 : St::Hunt0;
+}
+
+bool MsgDeframer::feed(uint8_t b)
+{
+    switch (state_)
+    {
+        case St::Hunt0:
+            if (b == SOF0)
+            {
+                state_ = St::Hunt1;
+            }
+            else
+            {
+                stats_.resync_bytes++;
+            }
+            break;
+
+        case St::Hunt1:
+            if (b == SOF1)
+            {
+                state_ = St::Hunt2;
+            }
+            else if (b == SOF0)
+            {
+                // AA AA 55 ... — the second AA may start the real SOF.
+                stats_.resync_bytes++;
+            }
+            else
+            {
+                rehunt(b);
+            }
+            break;
+
+        case St::Hunt2:
+            if (b == SOF2)
+            {
+                state_ = St::Hunt3;
+            }
+            else
+            {
+                rehunt(b);
+            }
+            break;
+
+        case St::Hunt3:
+            if (b == SOF3)
+            {
+                state_ = St::Type;
+            }
+            else
+            {
+                rehunt(b);
+            }
+            break;
+
+        case St::Type:
+            buf_[0] = b;
+            state_ = St::Len;
+            break;
+
+        case St::Len:
+            buf_[1] = b;
+            payload_len_ = b;
+            payload_got_ = 0;
+            state_ = (payload_len_ > 0) ? St::Payload : St::Crc0;
+            break;
+
+        case St::Payload:
+            buf_[2 + payload_got_++] = b;
+            if (payload_got_ >= payload_len_)
+            {
+                state_ = St::Crc0;
+            }
+            break;
+
+        case St::Crc0:
+            crc_hi_ = b;
+            state_ = St::Crc1;
+            break;
+
+        case St::Crc1:
+        {
+            const uint16_t crc_expected =
+                static_cast<uint16_t>((crc_hi_ << 8) | b);
+            const uint16_t crc_actual =
+                calcCRC16(buf_, static_cast<int>(2 + payload_len_));
+            state_ = St::Hunt0;
+            if (crc_actual == crc_expected)
+            {
+                stats_.frames++;
+                return true;
+            }
+            stats_.crc_fails++;
+            break;
+        }
+    }
+    return false;
+}
+
+}  // namespace tr_msg

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_MsgCodec.h
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_MsgCodec.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Shared SOF + type + len + CRC16 message codec for framed UART links
+// (radio daughterboard <-> host, #409).
+//
+// Wire format — byte-identical to TR_I2C_Interface::packMessage / the
+// TR_I2S_Stream framing, so all three transports speak one codec family:
+//
+//   [0..3]  SOF        AA 55 AA 55
+//   [4]     type       message type (link-local namespace)
+//   [5]     len        payload byte count (0..MAX_PAYLOAD)
+//   [6..]   payload
+//   [+0,+1] CRC16      big-endian, over type + len + payload
+//                      (Rob Tillaart CRC16 with library defaults —
+//                       identical call to TR_I2C_Interface)
+//
+// Unlike I2C/I2S — where the driver hands us whole transactions — UART is
+// a raw byte stream, so this header also provides MsgDeframer: a per-byte
+// state machine that hunts for SOF, validates length + CRC, and
+// resynchronizes on garbage. A corrupted frame is dropped (counted in
+// stats) and the parser recovers at the next SOF; at LoRa frame rates a
+// rare drop is recovered by the next telemetry/command frame.
+//
+// This header is intentionally free of ESP-IDF includes: tests_cpp
+// compiles TR_MsgCodec.cpp directly on the host
+// (tests_cpp/test_uart_link_codec.cpp).
+
+namespace tr_msg
+{
+
+static constexpr uint8_t SOF0 = 0xAA;
+static constexpr uint8_t SOF1 = 0x55;
+static constexpr uint8_t SOF2 = 0xAA;
+static constexpr uint8_t SOF3 = 0x55;
+
+// The len field is one byte, so the codec's capacity is a superset of the
+// I2C link's MAX_PAYLOAD (RocketComputerTypes.h) — same format, no shared
+// upper bound needed.
+static constexpr size_t MAX_PAYLOAD = 255;
+static constexpr size_t FRAME_OVERHEAD = 4 + 1 + 1 + 2;  // SOF + type + len + CRC
+static constexpr size_t MAX_FRAME = FRAME_OVERHEAD + MAX_PAYLOAD;
+
+// Pack one message into frame_out. Returns false on bad args / capacity.
+// Mirrors TR_I2C_Interface::packMessage byte-for-byte.
+bool pack(uint8_t type,
+          const uint8_t* payload,
+          size_t len,
+          uint8_t* frame_out,
+          size_t frame_out_capacity,
+          size_t& frame_len_out);
+
+// Streaming deframer: feed() one byte at a time; when it returns true a
+// complete CRC-valid frame is available via type()/payload()/payloadLen()
+// until the next feed() call.
+class MsgDeframer
+{
+public:
+    struct Stats
+    {
+        uint32_t frames = 0;        // complete valid frames delivered
+        uint32_t crc_fails = 0;     // frames dropped for CRC mismatch
+        uint32_t resync_bytes = 0;  // bytes discarded hunting for SOF
+    };
+
+    bool feed(uint8_t b);
+
+    uint8_t type() const { return buf_[0]; }
+    const uint8_t* payload() const { return &buf_[2]; }
+    size_t payloadLen() const { return payload_len_; }
+    const Stats& stats() const { return stats_; }
+
+    // Abandon any partial frame and return to SOF hunting (stats survive).
+    void reset() { state_ = St::Hunt0; }
+
+private:
+    enum class St : uint8_t
+    {
+        Hunt0,    // waiting for SOF0
+        Hunt1,    // got SOF0, waiting for SOF1
+        Hunt2,
+        Hunt3,
+        Type,
+        Len,
+        Payload,
+        Crc0,
+        Crc1,
+    };
+
+    // A mismatched hunt byte may itself begin a new SOF sequence — route it
+    // back into the hunt instead of blindly restarting at Hunt0.
+    void rehunt(uint8_t b);
+
+    St state_ = St::Hunt0;
+    // type + len + payload, contiguous so the CRC check runs straight over it
+    // (CRC covers exactly these bytes).
+    uint8_t buf_[2 + MAX_PAYLOAD] = {};
+    size_t payload_len_ = 0;
+    size_t payload_got_ = 0;
+    uint8_t crc_hi_ = 0;
+    Stats stats_;
+};
+
+}  // namespace tr_msg

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
@@ -1,0 +1,136 @@
+#include "TR_UART_Link.h"
+
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+static const char* TAG = "TR_UART_Link";
+
+esp_err_t TR_UART_Link::begin(const Config& cfg)
+{
+    cfg_ = cfg;
+
+    const uart_config_t uart_cfg = {
+        .baud_rate = cfg.baud,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        // Frame-level flow control is in-band (TX_RESULT credits,
+        // RadioModemProtocol.h) — no RTS/CTS wires on the daughterboard
+        // connector.
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .rx_flow_ctrl_thresh = 0,
+        .source_clk = UART_SCLK_DEFAULT,
+    };
+
+    esp_err_t err = uart_driver_install(cfg.port,
+                                        static_cast<int>(cfg.rx_ring),
+                                        static_cast<int>(cfg.tx_ring),
+                                        0, nullptr, 0);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = uart_param_config(cfg.port, &uart_cfg);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = uart_set_pin(cfg.port, cfg.tx_pin, cfg.rx_pin,
+                       UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    began_ = true;
+    return ESP_OK;
+}
+
+bool TR_UART_Link::sendFrame(uint8_t type, const uint8_t* payload, size_t len,
+                             uint32_t timeout_ms)
+{
+    if (!began_)
+    {
+        return false;
+    }
+
+    size_t frame_len = 0;
+    if (!tr_msg::pack(type, payload, len, tx_frame_, sizeof(tx_frame_), frame_len))
+    {
+        stats_.tx_fails++;
+        return false;
+    }
+
+    // uart_write_bytes copies into the driver TX ring; it only blocks when
+    // the ring is full. Guard with a bounded wait for free space so a wedged
+    // link degrades to counted drops instead of stalling the caller's loop.
+    size_t free_space = 0;
+    if (uart_get_tx_buffer_free_size(cfg_.port, &free_space) == ESP_OK &&
+        free_space < frame_len)
+    {
+        const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(timeout_ms);
+        while (free_space < frame_len)
+        {
+            if (xTaskGetTickCount() >= deadline)
+            {
+                stats_.tx_fails++;
+                return false;
+            }
+            vTaskDelay(1);
+            if (uart_get_tx_buffer_free_size(cfg_.port, &free_space) != ESP_OK)
+            {
+                break;
+            }
+        }
+    }
+
+    const int written = uart_write_bytes(cfg_.port, tx_frame_, frame_len);
+    if (written != static_cast<int>(frame_len))
+    {
+        stats_.tx_fails++;
+        return false;
+    }
+    stats_.tx_frames++;
+    return true;
+}
+
+void TR_UART_Link::poll(FrameHandler handler, void* ctx)
+{
+    if (!began_)
+    {
+        return;
+    }
+
+    for (;;)
+    {
+        const int n = uart_read_bytes(cfg_.port, rx_chunk_, sizeof(rx_chunk_), 0);
+        if (n <= 0)
+        {
+            break;
+        }
+        for (int i = 0; i < n; i++)
+        {
+            if (deframer_.feed(rx_chunk_[i]))
+            {
+                handler(ctx, deframer_.type(), deframer_.payload(),
+                        deframer_.payloadLen());
+            }
+        }
+    }
+
+    // Mirror deframer counters into link stats so one getStats() call tells
+    // the whole RX health story.
+    const tr_msg::MsgDeframer::Stats& ds = deframer_.stats();
+    stats_.rx_frames = ds.frames;
+    stats_.rx_crc_fails = ds.crc_fails;
+    stats_.rx_resync_bytes = ds.resync_bytes;
+}
+
+void TR_UART_Link::getStats(Stats& out) const
+{
+    out = stats_;
+}

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.h
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <compat.h>
+#include <driver/uart.h>
+
+#include "TR_MsgCodec.h"
+
+// Framed UART transport for the radio-modem link (#409): tr_msg codec over
+// an ESP-IDF UART port. Used on both ends — the daughterboard's host port
+// and the OC/BS side of the link — so the two directions can never drift.
+//
+// Threading: begin() once, then sendFrame()/poll() from a single task (the
+// main loop on both current hosts and the modem). No internal locking.
+class TR_UART_Link
+{
+public:
+    struct Config
+    {
+        uart_port_t port = UART_NUM_1;
+        int tx_pin = -1;
+        int rx_pin = -1;
+        int baud = 921'600;
+        // Driver ring buffers. RX sized for a burst of full frames arriving
+        // while the loop is busy elsewhere; TX sized so sendFrame never
+        // blocks in practice at link rates (LoRa airtime dominates).
+        size_t rx_ring = 4096;
+        size_t tx_ring = 4096;
+    };
+
+    struct Stats
+    {
+        uint32_t tx_frames = 0;
+        uint32_t tx_fails = 0;      // pack error or ring-buffer write short
+        uint32_t rx_frames = 0;
+        uint32_t rx_crc_fails = 0;
+        uint32_t rx_resync_bytes = 0;
+    };
+
+    esp_err_t begin(const Config& cfg);
+
+    // Pack and queue one frame. Returns false on pack failure or if the
+    // driver TX ring cannot take the whole frame within timeout_ms.
+    bool sendFrame(uint8_t type, const uint8_t* payload, size_t len,
+                   uint32_t timeout_ms = 20);
+
+    // Drain all pending RX bytes through the deframer, invoking handler for
+    // each complete valid frame. Non-blocking; call every loop iteration.
+    using FrameHandler = void (*)(void* ctx, uint8_t type,
+                                  const uint8_t* payload, size_t len);
+    void poll(FrameHandler handler, void* ctx);
+
+    void getStats(Stats& out) const;
+
+private:
+    Config cfg_{};
+    bool began_ = false;
+    tr_msg::MsgDeframer deframer_;
+    Stats stats_{};
+    uint8_t tx_frame_[tr_msg::MAX_FRAME] = {};
+    uint8_t rx_chunk_[256] = {};
+};

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3038,6 +3038,9 @@ static void setup_bs()
     lora_cfg.dio1_pin          = config::LORA_DIO1_PIN;
     lora_cfg.rst_pin           = config::LORA_RST_PIN;
     lora_cfg.busy_pin          = config::LORA_BUSY_PIN;
+    // V2 PCB: MCU-driven RX half of the RF switch (was defined but never
+    // driven — RXEN floated in RX). -1 on the original PCB (no switch).
+    lora_cfg.rxen_pin          = config::LORA_RXEN_PIN;
     lora_cfg.spi_sck           = config::LORA_SPI_SCK;
     lora_cfg.spi_miso          = config::LORA_SPI_MISO;
     lora_cfg.spi_mosi          = config::LORA_SPI_MOSI;

--- a/tinkerrocket-idf/projects/radio_board/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/radio_board/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.16)
+set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
+# The modem is protocol-blind by design: no guidance, no BLE, no sensor stack.
+set(EXCLUDE_COMPONENTS "TR_GuidancePN TR_GuidancePN_Stub TR_BLE_To_APP")
+
+# Embed git short-sha + build timestamp into the firmware image header
+# (esp_app_desc.version), same pattern as flight_computer / out_computer.
+# Reported to the host in IDENTITY/BOOT (RadioModemProtocol.h).
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TR_GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT TR_GIT_SHA)
+    set(TR_GIT_SHA "unknown")
+endif()
+execute_process(
+    COMMAND git diff-index --quiet HEAD --
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE TR_GIT_DIRTY_CODE
+    OUTPUT_QUIET ERROR_QUIET
+)
+if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
+    set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
+endif()
+string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
+set(PROJECT_VER "${TR_GIT_SHA}+${TR_BUILD_DATE}")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(radio_board)

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -20,8 +20,10 @@ idf.py build
 idf.py -p <port> flash monitor
 ```
 
-Pins in [main/config.h](main/config.h) are **devkit bench wiring** until the
-V8 daughterboard schematic lands.
+LoRa, RXEN, and indicator-LED pins in [main/config.h](main/config.h) are the
+V8 daughterboard schematic values; the **host-link UART pins are still
+placeholders** (TODO in config.h). The TX LED lights for the duration of each
+transmission; the RX LED pulses per received air packet.
 
 ## UART link
 

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -1,0 +1,94 @@
+# radio_board — LoRa daughterboard firmware (transparent UART modem)
+
+Firmware for the V8 radio daughterboard (#409): an ESP32-S3 that owns the
+LoRa radio (LLCC68) and exposes it to a host over UART as a **transparent
+modem**. The same hardware + firmware binary serves both ends of the link —
+plugged into the rocket (out computer, #410) or the base station (#414) —
+and matched pairs are swapped as a unit (e.g. a future higher-power module).
+
+**Transparent** means: `TX_FRAME`/`RX_FRAME` payloads are the exact bytes the
+host would have handed to / read from `TR_LoRa_Comms` on a direct-SPI board.
+The modem never parses them. The on-air format (`LORA_PROTO_VERSION`,
+network ids, hop schedules) is owned entirely by the hosts, so deployed
+direct-radio base stations interoperate with a V8 rocket unchanged.
+
+## Build & flash
+
+```sh
+. ~/esp/esp-idf-v6.0/export.sh      # IDF v6.0, same as FC/OC
+idf.py build
+idf.py -p <port> flash monitor
+```
+
+Pins in [main/config.h](main/config.h) are **devkit bench wiring** until the
+V8 daughterboard schematic lands.
+
+## UART link
+
+- Framing: `tr_msg` codec ([TR_MsgCodec.h](../../components/TR_UART_Link/TR_MsgCodec.h)) —
+  `AA 55 AA 55 | type | len | payload | CRC16be(type+len+payload)`, byte-identical
+  to the FC↔OC I2C/I2S framing. UART is a byte stream, so a per-byte deframer
+  hunts SOF and resynchronizes through garbage (drops are counted, never silent).
+- 921600 baud 8N1, no RTS/CTS — flow control is in-band (below).
+- Message set: [RadioModemProtocol.h](../../components/TR_UART_Link/RadioModemProtocol.h)
+  (`PROTOCOL_VERSION` = 1). All codes for this link live in that one file.
+
+### Messages
+
+| Dir | Type | Code | Payload |
+|-----|------|------|---------|
+| H→M | `TX_FRAME` | 0x01 | `TxFrameHeader{seq}` + air bytes (≤ `MAX_AIR_FRAME` = 247) |
+| H→M | `SET_CONFIG` | 0x02 | `RadioConfigData` (freq/SF/BW/CR/power/preamble/flags, `start_rx`) |
+| H→M | `HOP_FREQ` | 0x03 | `HopFreqData` — per-packet hop; fire-and-forget, mid-TX refusal keeps channel |
+| H→M | `START_RX` | 0x04 | — |
+| H→M | `GET_STATUS` | 0x05 | — → `STATUS` |
+| H→M | `GET_IDENTITY` | 0x06 | — → `IDENTITY` |
+| H→M | `START_SCAN` | 0x07 | `ScanRequestData` → `SCAN_RESULT` when the sweep completes |
+| M→H | `RX_FRAME` | 0x81 | `RxFrameHeader{rssi,snr}` + air bytes |
+| M→H | `TX_RESULT` | 0x82 | `TxResultData{seq, ok}` — the credit return |
+| M→H | `STATUS` | 0x83 | `ModemStatusData` (also sent as the ack to every `SET_CONFIG`) |
+| M→H | `IDENTITY` | 0x84 | `ModemIdentityData` |
+| M→H | `SCAN_RESULT` | 0x85 | `ScanResultHeader` + int8 RSSI samples |
+| M→H | `BOOT` | 0x86 | `ModemIdentityData` — host must reset its credit window |
+
+### Flow control (in-band credits)
+
+The radio is orders of magnitude slower than the UART. The modem queues up to
+`TX_QUEUE_CAPACITY` (8) frames; each accepted `TX_FRAME` seq is **always**
+answered with a `TX_RESULT` — after airtime is spent, on failure, on
+oversize/queue-full rejection, or when the TX watchdog clears a wedge. The
+host keeps ≤ 8 unacknowledged seqs outstanding. `BOOT` resets the window
+(modem rebooted, queue empty). No frame is ever silently dropped.
+
+### Identity / capabilities (swappable modules)
+
+`IDENTITY`/`BOOT` report protocol version, radio chip, band edges, max TX
+power, and the firmware version (git sha, embedded via `esp_app_desc`).
+Hosts clamp their radio config to the reported capabilities and must refuse
+loudly on a protocol-version mismatch. The modem additionally clamps TX power
+itself — a mismatched pair degrades, it never transmits out of spec.
+
+### Modem behavior
+
+- Boots listening on defaults (915 MHz / SF10 / BW125) so a bench modem is
+  immediately visible; the host's `SET_CONFIG` replaces this. The host owns
+  config — the modem has **no NVS**.
+- Half-duplex policy matches `TR_LoRa_Comms`: auto-return to RX after every
+  TX and read; TX is deferred while a spectrum scan is active.
+- If the radio fails to init, the modem stays alive UART-side
+  (`STATUS.radio_enabled = 0`, all TX_FRAMEs fail-fast) and the next
+  `SET_CONFIG` retries a full `begin()`.
+
+## Bench validation
+
+1. **UART loopback** (no radio): drive with a USB-UART, check `BOOT`,
+   `IDENTITY`, `STATUS`, and TX_RESULT fail-fasts.
+2. **Over-the-air**: devkit + LLCC68 breakout driven over UART, exchanging
+   frames with an **unmodified existing base station** — proves the
+   transparent tunnel end-to-end (acceptance criterion of #409).
+
+## Tests
+
+Host-side codec/protocol tests: `tests_cpp/test_uart_link_codec.cpp`
+(golden wire-format bytes, deframer resync/corruption behavior, wire-stable
+struct layouts).

--- a/tinkerrocket-idf/projects/radio_board/dependencies.lock
+++ b/tinkerrocket-idf/projects/radio_board/dependencies.lock
@@ -1,0 +1,18 @@
+dependencies:
+  espressif/dhara:
+    component_hash: 88968cff2e88853a29366ad556e9c27596d18e15028b6e9f3cd627665f914440
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.0.0
+  idf:
+    source:
+      type: idf
+    version: 6.0.1
+direct_dependencies:
+- espressif/dhara
+- idf
+manifest_hash: 6f4972c0cd856d2015cba9831063a6a730deae8bd16edbea178fa4c6411182a3
+target: esp32s3
+version: 3.0.0

--- a/tinkerrocket-idf/projects/radio_board/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/radio_board/main/CMakeLists.txt
@@ -1,0 +1,12 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS "."
+    REQUIRES
+        TR_Compat
+        driver
+        esp_timer
+        esp_app_format
+        TR_UART_Link
+        TR_LoRa_Comms
+)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)

--- a/tinkerrocket-idf/projects/radio_board/main/config.h
+++ b/tinkerrocket-idf/projects/radio_board/main/config.h
@@ -4,30 +4,39 @@
 
 // Radio daughterboard (ESP32-S3) pin/board configuration (#409).
 //
-// CURRENT VALUES ARE DEVKIT BENCH WIRING (ESP32-S3-DevKitC + LLCC68 breakout).
-// The final V8 daughterboard pin map replaces these when the schematic lands
-// (per-board headers arrive with #411's pattern if the daughterboard itself
-// ever needs variants).
+// LoRa + LED pins are from the V8 daughterboard schematic (L_* / LED nets).
+// TODO: host-link UART pins are still placeholders — set from the schematic's
+// host-connector nets before flashing real hardware.
 struct config
 {
     // ---- UART link to the host (OC on the rocket, BS on the ground) --------
     // The modem must never care which host it is plugged into (#409:
     // host-agnostic, swappable matched pairs).
     static constexpr uart_port_t HOST_UART_PORT = UART_NUM_1;
-    static constexpr int HOST_UART_TX = 17;
-    static constexpr int HOST_UART_RX = 18;
+    static constexpr int HOST_UART_TX = 5;   // TODO: TBD from V8 schematic
+    static constexpr int HOST_UART_RX = 6;   // TODO: TBD from V8 schematic
     // Sized for tunnel traffic (LoRa airtime dominates), not raw UART
     // capability; must match the host side (#410).
     static constexpr int HOST_UART_BAUD = 921'600;
 
-    // ---- LoRa radio (LLCC68 over SPI) --------------------------------------
-    static constexpr int LORA_SPI_SCK = 12;
-    static constexpr int LORA_SPI_MISO = 13;
-    static constexpr int LORA_SPI_MOSI = 11;
-    static constexpr int LORA_CS_PIN = 10;
-    static constexpr int LORA_DIO1_PIN = 4;
-    static constexpr int LORA_RST_PIN = 5;
-    static constexpr int LORA_BUSY_PIN = 6;
+    // ---- LoRa radio (LLCC68 over SPI) — V8 daughterboard nets ---------------
+    static constexpr int LORA_SPI_SCK = 17;   // L_SCK
+    static constexpr int LORA_SPI_MISO = 33;  // L_MISO
+    static constexpr int LORA_SPI_MOSI = 21;  // L_MOSI
+    static constexpr int LORA_CS_PIN = 18;    // L_CS
+    static constexpr int LORA_DIO1_PIN = 2;   // L_DIO1
+    static constexpr int LORA_RST_PIN = 38;   // L_RST
+    static constexpr int LORA_BUSY_PIN = 34;  // L_BUSY
+    static constexpr int LORA_RXEN_PIN = 35;  // L_RXEN (RF switch RX enable;
+                                              // TX side is DIO2-driven)
+
+    // ---- Indicator LEDs ------------------------------------------------------
+    // TX LED is lit for the duration of a transmission (airtime-length flash);
+    // RX LED pulses per received air packet.
+    static constexpr int LED_RX_PIN = 7;
+    static constexpr int LED_TX_PIN = 8;
+    static constexpr uint32_t LED_ACTIVE_LEVEL = 1;  // flip if wired to VCC
+    static constexpr uint32_t LED_RX_PULSE_MS = 40;
 
     // ---- Radio capability (reported in IDENTITY; hosts clamp to these) -----
     static constexpr int8_t RADIO_MAX_TX_POWER_DBM = 22;   // LLCC68 ceiling

--- a/tinkerrocket-idf/projects/radio_board/main/config.h
+++ b/tinkerrocket-idf/projects/radio_board/main/config.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <driver/uart.h>
+
+// Radio daughterboard (ESP32-S3) pin/board configuration (#409).
+//
+// CURRENT VALUES ARE DEVKIT BENCH WIRING (ESP32-S3-DevKitC + LLCC68 breakout).
+// The final V8 daughterboard pin map replaces these when the schematic lands
+// (per-board headers arrive with #411's pattern if the daughterboard itself
+// ever needs variants).
+struct config
+{
+    // ---- UART link to the host (OC on the rocket, BS on the ground) --------
+    // The modem must never care which host it is plugged into (#409:
+    // host-agnostic, swappable matched pairs).
+    static constexpr uart_port_t HOST_UART_PORT = UART_NUM_1;
+    static constexpr int HOST_UART_TX = 17;
+    static constexpr int HOST_UART_RX = 18;
+    // Sized for tunnel traffic (LoRa airtime dominates), not raw UART
+    // capability; must match the host side (#410).
+    static constexpr int HOST_UART_BAUD = 921'600;
+
+    // ---- LoRa radio (LLCC68 over SPI) --------------------------------------
+    static constexpr int LORA_SPI_SCK = 12;
+    static constexpr int LORA_SPI_MISO = 13;
+    static constexpr int LORA_SPI_MOSI = 11;
+    static constexpr int LORA_CS_PIN = 10;
+    static constexpr int LORA_DIO1_PIN = 4;
+    static constexpr int LORA_RST_PIN = 5;
+    static constexpr int LORA_BUSY_PIN = 6;
+
+    // ---- Radio capability (reported in IDENTITY; hosts clamp to these) -----
+    static constexpr int8_t RADIO_MAX_TX_POWER_DBM = 22;   // LLCC68 ceiling
+    static constexpr float RADIO_FREQ_MIN_MHZ = 150.0f;    // LLCC68 band edges
+    static constexpr float RADIO_FREQ_MAX_MHZ = 960.0f;
+
+    // ---- Boot radio defaults ------------------------------------------------
+    // The modem comes up listening on these until the host pushes SET_CONFIG,
+    // mirroring TR_LoRa_Comms defaults. The host owns the real config
+    // (transparent-modem principle: no NVS on the modem).
+    static constexpr float BOOT_FREQ_MHZ = 915.0f;
+    static constexpr uint8_t BOOT_SF = 10;
+    static constexpr float BOOT_BW_KHZ = 125.0f;
+    static constexpr uint8_t BOOT_CR = 7;
+    static constexpr int8_t BOOT_TX_POWER_DBM = 20;
+
+    static constexpr bool DEBUG = true;
+};

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -14,6 +14,7 @@
 
 #include <cstring>
 
+#include <driver/gpio.h>
 #include <esp_app_desc.h>
 #include <esp_log.h>
 #include <esp_timer.h>
@@ -54,6 +55,50 @@ struct InFlight
     uint32_t ok_before = 0;
 };
 static InFlight in_flight;
+
+// ---- Indicator LEDs ----------------------------------------------------------
+// TX LED tracks the transmission (airtime-length flash); RX LED pulses
+// LED_RX_PULSE_MS per received air packet.
+
+static uint32_t rx_led_off_at_ms = 0;
+
+static uint32_t uptimeMs()
+{
+    return static_cast<uint32_t>(esp_timer_get_time() / 1000);
+}
+
+static void ledWrite(int pin, bool lit)
+{
+    gpio_set_level(static_cast<gpio_num_t>(pin),
+                   lit ? config::LED_ACTIVE_LEVEL : !config::LED_ACTIVE_LEVEL);
+}
+
+static void initLeds()
+{
+    gpio_config_t io = {};
+    io.pin_bit_mask = (1ULL << config::LED_RX_PIN) |
+                      (1ULL << config::LED_TX_PIN);
+    io.mode = GPIO_MODE_OUTPUT;
+    gpio_config(&io);
+    ledWrite(config::LED_RX_PIN, false);
+    ledWrite(config::LED_TX_PIN, false);
+}
+
+static void pulseRxLed()
+{
+    ledWrite(config::LED_RX_PIN, true);
+    rx_led_off_at_ms = uptimeMs() + config::LED_RX_PULSE_MS;
+}
+
+static void serviceLeds()
+{
+    if (rx_led_off_at_ms != 0 &&
+        static_cast<int32_t>(uptimeMs() - rx_led_off_at_ms) >= 0)
+    {
+        ledWrite(config::LED_RX_PIN, false);
+        rx_led_off_at_ms = 0;
+    }
+}
 
 static void sendTxResult(uint8_t seq, bool ok)
 {
@@ -116,6 +161,7 @@ static TR_LoRa_Comms::Config radioConfigFromMsg(const RadioConfigData& d)
     cfg.dio1_pin = config::LORA_DIO1_PIN;
     cfg.rst_pin = config::LORA_RST_PIN;
     cfg.busy_pin = config::LORA_BUSY_PIN;
+    cfg.rxen_pin = config::LORA_RXEN_PIN;
     cfg.spi_sck = config::LORA_SPI_SCK;
     cfg.spi_miso = config::LORA_SPI_MISO;
     cfg.spi_mosi = config::LORA_SPI_MOSI;
@@ -269,6 +315,7 @@ static void serviceTx()
         radio.getStats(rs);
         sendTxResult(in_flight.seq, rs.tx_ok > in_flight.ok_before);
         in_flight.active = false;
+        ledWrite(config::LED_TX_PIN, false);
     }
 
     if (!in_flight.active && txq_used > 0 && radio.canSend() &&
@@ -282,6 +329,7 @@ static void serviceTx()
             in_flight.active = true;
             in_flight.seq = e.seq;
             in_flight.ok_before = rs.tx_ok;
+            ledWrite(config::LED_TX_PIN, true);
         }
         else
         {
@@ -310,6 +358,7 @@ static void serviceRx()
     RxFrameHeader hdr = {rs.last_rssi, rs.last_snr};
     memcpy(out, &hdr, sizeof(hdr));
     uart_link.sendFrame(MSG_RX_FRAME, out, sizeof(hdr) + air_len);
+    pulseRxLed();
 }
 
 static void serviceScanResult()
@@ -344,6 +393,8 @@ extern "C" void app_main(void)
     const esp_app_desc_t* app = esp_app_get_description();
     ESP_LOGI(TAG, "radio_board fw %s (protocol v%u)", app->version,
              PROTOCOL_VERSION);
+
+    initLeds();
 
     TR_UART_Link::Config ucfg = {};
     ucfg.port = config::HOST_UART_PORT;
@@ -399,6 +450,7 @@ extern "C" void app_main(void)
         serviceTx();
         serviceRx();
         serviceScanResult();
+        serviceLeds();
 
         vTaskDelay(1);  // 1 ms at CONFIG_FREERTOS_HZ=1000
     }

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -1,0 +1,405 @@
+// Radio daughterboard firmware (#409): a transparent UART<->LoRa modem.
+//
+// The host (OC on the rocket, BS on the ground — this firmware never knows
+// which) sends fully-formed air frames over the UART link; we radiate them
+// unmodified and tunnel received frames back with RSSI/SNR metadata. All
+// protocol knowledge (LORA_PROTO_VERSION, network ids, hop schedules) stays
+// on the hosts, so the on-air format is byte-identical to direct-SPI boards
+// and deployed base stations interoperate unchanged.
+//
+// Protocol: components/TR_UART_Link/RadioModemProtocol.h (v1).
+// Flow control: modem-side TX queue of TX_QUEUE_CAPACITY frames; every
+// accepted TX_FRAME seq is eventually answered with a TX_RESULT (the credit
+// return) — never silently dropped.
+
+#include <cstring>
+
+#include <esp_app_desc.h>
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <RadioModemProtocol.h>
+#include <TR_LoRa_Comms.h>
+#include <TR_UART_Link.h>
+
+#include "config.h"
+
+static const char* TAG = "radio_board";
+
+using namespace radio_modem;
+
+static TR_UART_Link uart_link;
+static TR_LoRa_Comms radio;
+static bool radio_up = false;
+
+// ---- TX queue + in-flight tracking -----------------------------------------
+
+struct TxEntry
+{
+    uint8_t seq;
+    uint8_t len;
+    uint8_t data[MAX_AIR_FRAME];
+};
+
+static TxEntry tx_queue[TX_QUEUE_CAPACITY];
+static uint8_t txq_head = 0;  // next to send
+static uint8_t txq_used = 0;
+
+struct InFlight
+{
+    bool active = false;
+    uint8_t seq = 0;
+    uint32_t ok_before = 0;
+};
+static InFlight in_flight;
+
+static void sendTxResult(uint8_t seq, bool ok)
+{
+    const TxResultData res = {seq, static_cast<uint8_t>(ok ? 1 : 0)};
+    uart_link.sendFrame(MSG_TX_RESULT,
+                        reinterpret_cast<const uint8_t*>(&res), sizeof(res));
+}
+
+// ---- Outbound status/identity ----------------------------------------------
+
+static void sendIdentity(uint8_t msg_type)
+{
+    ModemIdentityData id = {};
+    id.protocol_version = PROTOCOL_VERSION;
+    id.chip = CHIP_LLCC68;
+    id.max_tx_power_dbm = config::RADIO_MAX_TX_POWER_DBM;
+    id.freq_min_mhz = config::RADIO_FREQ_MIN_MHZ;
+    id.freq_max_mhz = config::RADIO_FREQ_MAX_MHZ;
+    const esp_app_desc_t* app = esp_app_get_description();
+    strncpy(id.fw_version, app->version, sizeof(id.fw_version) - 1);
+    uart_link.sendFrame(msg_type, reinterpret_cast<const uint8_t*>(&id),
+                        sizeof(id));
+}
+
+static void sendStatus()
+{
+    TR_LoRa_Comms::Stats rs = {};
+    radio.getStats(rs);
+    TR_UART_Link::Stats us = {};
+    uart_link.getStats(us);
+
+    ModemStatusData st = {};
+    st.uptime_ms = static_cast<uint32_t>(esp_timer_get_time() / 1000);
+    st.radio_enabled = radio_up ? 1 : 0;
+    st.rx_mode = rs.rx_mode ? 1 : 0;
+    st.tx_queue_used = txq_used + (in_flight.active ? 1 : 0);
+    st.tx_queue_capacity = TX_QUEUE_CAPACITY;
+    st.tx_ok = rs.tx_ok;
+    st.tx_fail = rs.tx_fail;
+    st.rx_count = rs.rx_count;
+    st.rx_crc_fail = rs.rx_crc_fail;
+    st.tx_watchdog_fires = rs.tx_watchdog_fires;
+    st.uart_rx_crc_fails = us.rx_crc_fails;
+    st.uart_rx_resync_bytes = us.rx_resync_bytes;
+    st.last_rssi_dbm = rs.last_rssi;
+    st.last_snr_db = rs.last_snr;
+    st.current_freq_mhz = radio.currentFrequencyMHz();
+    st.current_sf = radio.currentSpreadingFactor();
+    uart_link.sendFrame(MSG_STATUS, reinterpret_cast<const uint8_t*>(&st),
+                        sizeof(st));
+}
+
+// ---- Inbound message handling ------------------------------------------------
+
+static TR_LoRa_Comms::Config radioConfigFromMsg(const RadioConfigData& d)
+{
+    TR_LoRa_Comms::Config cfg = {};
+    cfg.enabled = true;
+    cfg.cs_pin = config::LORA_CS_PIN;
+    cfg.dio1_pin = config::LORA_DIO1_PIN;
+    cfg.rst_pin = config::LORA_RST_PIN;
+    cfg.busy_pin = config::LORA_BUSY_PIN;
+    cfg.spi_sck = config::LORA_SPI_SCK;
+    cfg.spi_miso = config::LORA_SPI_MISO;
+    cfg.spi_mosi = config::LORA_SPI_MOSI;
+    cfg.freq_mhz = d.freq_mhz;
+    cfg.spreading_factor = d.spreading_factor;
+    cfg.bandwidth_khz = d.bandwidth_khz;
+    cfg.coding_rate = d.coding_rate;
+    cfg.preamble_len = d.preamble_len;
+    cfg.tx_power_dbm = d.tx_power_dbm;
+    cfg.crc_on = (d.flags & CFG_FLAG_CRC_ON) != 0;
+    cfg.rx_boosted_gain = (d.flags & CFG_FLAG_RX_BOOSTED_GAIN) != 0;
+    cfg.syncword_private = (d.flags & CFG_FLAG_SYNCWORD_PRIVATE) != 0;
+    return cfg;
+}
+
+static void handleTxFrame(const uint8_t* payload, size_t len)
+{
+    if (len < sizeof(TxFrameHeader) + 1)
+    {
+        return;  // no seq to answer — malformed, drop
+    }
+    const uint8_t seq = payload[0];
+    const uint8_t* air = payload + sizeof(TxFrameHeader);
+    const size_t air_len = len - sizeof(TxFrameHeader);
+
+    if (air_len > MAX_AIR_FRAME || !radio_up)
+    {
+        sendTxResult(seq, false);
+        return;
+    }
+    if (txq_used >= TX_QUEUE_CAPACITY)
+    {
+        // Host exceeded its credit window (or credits desynced) — reject so
+        // the credit is returned rather than leaked.
+        sendTxResult(seq, false);
+        return;
+    }
+
+    TxEntry& e = tx_queue[(txq_head + txq_used) % TX_QUEUE_CAPACITY];
+    e.seq = seq;
+    e.len = static_cast<uint8_t>(air_len);
+    memcpy(e.data, air, air_len);
+    txq_used++;
+}
+
+static void handleSetConfig(const uint8_t* payload, size_t len)
+{
+    if (len != sizeof(RadioConfigData))
+    {
+        ESP_LOGW(TAG, "SET_CONFIG bad length %u", (unsigned)len);
+        return;
+    }
+    RadioConfigData d;
+    memcpy(&d, payload, sizeof(d));
+
+    // Clamp to module capability — hosts should already respect IDENTITY,
+    // but a matched-pair mismatch must degrade, not transmit out of spec.
+    if (d.tx_power_dbm > config::RADIO_MAX_TX_POWER_DBM)
+    {
+        d.tx_power_dbm = config::RADIO_MAX_TX_POWER_DBM;
+    }
+
+    if (!radio_up)
+    {
+        // Radio never came up (or wasn't wired at boot) — full begin() so the
+        // boot-fixed fields (preamble/flags) from the host apply too.
+        radio_up = radio.begin(radioConfigFromMsg(d), config::DEBUG);
+    }
+    else
+    {
+        radio.reconfigure(d.freq_mhz, d.spreading_factor, d.bandwidth_khz,
+                          d.coding_rate, d.tx_power_dbm);
+    }
+    if (radio_up && d.start_rx)
+    {
+        radio.startReceive();
+    }
+    sendStatus();  // config paths always get a status echo as the ack
+}
+
+static void onHostFrame(void* /*ctx*/, uint8_t type, const uint8_t* payload,
+                        size_t len)
+{
+    switch (type)
+    {
+        case MSG_TX_FRAME:
+            handleTxFrame(payload, len);
+            break;
+
+        case MSG_SET_CONFIG:
+            handleSetConfig(payload, len);
+            break;
+
+        case MSG_HOP_FREQ:
+            if (len == sizeof(HopFreqData) && radio_up)
+            {
+                HopFreqData d;
+                memcpy(&d, payload, sizeof(d));
+                // Fire-and-forget by design (per-packet hop latency path):
+                // a mid-TX refusal keeps the current channel, matching the
+                // direct driver's can't-retune-mid-TX contract.
+                (void)radio.hopToFrequencyMHz(d.freq_mhz);
+            }
+            break;
+
+        case MSG_START_RX:
+            if (radio_up)
+            {
+                radio.startReceive();
+            }
+            break;
+
+        case MSG_GET_STATUS:
+            sendStatus();
+            break;
+
+        case MSG_GET_IDENTITY:
+            sendIdentity(MSG_IDENTITY);
+            break;
+
+        case MSG_START_SCAN:
+            if (len == sizeof(ScanRequestData) && radio_up)
+            {
+                ScanRequestData d;
+                memcpy(&d, payload, sizeof(d));
+                radio.startScan(d.start_mhz, d.stop_mhz, d.step_khz, d.dwell_ms);
+            }
+            break;
+
+        default:
+            ESP_LOGW(TAG, "unknown host msg type 0x%02X (%u B)", type,
+                     (unsigned)len);
+            break;
+    }
+}
+
+// ---- Radio-side servicing ----------------------------------------------------
+
+static void serviceTx()
+{
+    if (!radio_up)
+    {
+        return;
+    }
+
+    // Close out a completed transmission: service() has run finishTransmit
+    // (or the TX watchdog force-cleared a wedge) once canSend() goes true.
+    if (in_flight.active && radio.canSend())
+    {
+        TR_LoRa_Comms::Stats rs = {};
+        radio.getStats(rs);
+        sendTxResult(in_flight.seq, rs.tx_ok > in_flight.ok_before);
+        in_flight.active = false;
+    }
+
+    if (!in_flight.active && txq_used > 0 && radio.canSend() &&
+        !radio.isScanActive())
+    {
+        TxEntry& e = tx_queue[txq_head];
+        TR_LoRa_Comms::Stats rs = {};
+        radio.getStats(rs);
+        if (radio.send(e.data, e.len))
+        {
+            in_flight.active = true;
+            in_flight.seq = e.seq;
+            in_flight.ok_before = rs.tx_ok;
+        }
+        else
+        {
+            sendTxResult(e.seq, false);
+        }
+        txq_head = (txq_head + 1) % TX_QUEUE_CAPACITY;
+        txq_used--;
+    }
+}
+
+static void serviceRx()
+{
+    if (!radio_up)
+    {
+        return;
+    }
+    // RX_FRAME payload = RxFrameHeader + air bytes, packed in one buffer.
+    static uint8_t out[sizeof(RxFrameHeader) + MAX_AIR_FRAME];
+    size_t air_len = 0;
+    if (!radio.readPacket(out + sizeof(RxFrameHeader), MAX_AIR_FRAME, air_len))
+    {
+        return;
+    }
+    TR_LoRa_Comms::Stats rs = {};
+    radio.getStats(rs);
+    RxFrameHeader hdr = {rs.last_rssi, rs.last_snr};
+    memcpy(out, &hdr, sizeof(hdr));
+    uart_link.sendFrame(MSG_RX_FRAME, out, sizeof(hdr) + air_len);
+}
+
+static void serviceScanResult()
+{
+    if (!radio_up || !radio.isScanDone())
+    {
+        return;
+    }
+
+    const size_t n = radio.getScanSampleCount();
+    const TR_LoRa_Comms::ScanSample* samples = radio.getScanSamples();
+
+    static uint8_t out[sizeof(ScanResultHeader) + TR_LoRa_Comms::SCAN_MAX_SAMPLES];
+    ScanResultHeader hdr = {};
+    hdr.count = static_cast<uint8_t>(n);
+    hdr.start_mhz = radio.getScanStartMHz();
+    hdr.step_khz = radio.getScanStepKHz();
+    memcpy(out, &hdr, sizeof(hdr));
+    for (size_t i = 0; i < n; i++)
+    {
+        out[sizeof(hdr) + i] = static_cast<uint8_t>(samples[i].rssi_dbm);
+    }
+    uart_link.sendFrame(MSG_SCAN_RESULT, out, sizeof(hdr) + n);
+    radio.consumeScanDone();
+    radio.startReceive();  // resume listening after the scan sweep
+}
+
+// ---- Entry -------------------------------------------------------------------
+
+extern "C" void app_main(void)
+{
+    const esp_app_desc_t* app = esp_app_get_description();
+    ESP_LOGI(TAG, "radio_board fw %s (protocol v%u)", app->version,
+             PROTOCOL_VERSION);
+
+    TR_UART_Link::Config ucfg = {};
+    ucfg.port = config::HOST_UART_PORT;
+    ucfg.tx_pin = config::HOST_UART_TX;
+    ucfg.rx_pin = config::HOST_UART_RX;
+    ucfg.baud = config::HOST_UART_BAUD;
+    ESP_ERROR_CHECK(uart_link.begin(ucfg));
+
+    // Bring the radio up on boot defaults so the modem listens immediately;
+    // the host's SET_CONFIG replaces these (and is also the recovery path if
+    // the radio fails here — see handleSetConfig).
+    RadioConfigData boot = {};
+    boot.freq_mhz = config::BOOT_FREQ_MHZ;
+    boot.bandwidth_khz = config::BOOT_BW_KHZ;
+    boot.spreading_factor = config::BOOT_SF;
+    boot.coding_rate = config::BOOT_CR;
+    boot.tx_power_dbm = config::BOOT_TX_POWER_DBM;
+    boot.preamble_len = 16;
+    boot.flags = CFG_FLAG_CRC_ON | CFG_FLAG_RX_BOOSTED_GAIN |
+                 CFG_FLAG_SYNCWORD_PRIVATE;
+    radio_up = radio.begin(radioConfigFromMsg(boot), config::DEBUG);
+    if (radio_up)
+    {
+        radio.startReceive();
+        ESP_LOGI(TAG, "radio up, listening at %.1f MHz SF%u",
+                 (double)config::BOOT_FREQ_MHZ, config::BOOT_SF);
+    }
+    else
+    {
+        ESP_LOGE(TAG, "radio init FAILED — modem alive, RF dead (host sees "
+                      "radio_enabled=0)");
+    }
+
+    // Announce boot: identity payload doubles as the host's signal to reset
+    // its credit window (our TX queue is empty now).
+    sendIdentity(MSG_BOOT);
+
+    for (;;)
+    {
+        uart_link.poll(onHostFrame, nullptr);
+
+        if (radio_up)
+        {
+            radio.pollDio1();
+            radio.service();
+            radio.serviceTxWatchdog();
+            if (radio.isScanActive())
+            {
+                radio.serviceScan();
+            }
+        }
+
+        serviceTx();
+        serviceRx();
+        serviceScanResult();
+
+        vTaskDelay(1);  // 1 ms at CONFIG_FREERTOS_HZ=1000
+    }
+}

--- a/tinkerrocket-idf/projects/radio_board/partitions.csv
+++ b/tinkerrocket-idf/projects/radio_board/partitions.csv
@@ -1,0 +1,8 @@
+# Name,   Type, SubType, Offset,  Size,    Flags
+# Compact enough for a 4 MB flash part (daughterboard module TBD); OTA pair
+# kept so #412 (UART-tunneled update) needs no repartition later.
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+ota_0,    app,  ota_0,   0x10000, 0x180000,
+ota_1,    app,  ota_1,   0x190000,0x180000,
+coredump, data, coredump,0x310000,0x10000,

--- a/tinkerrocket-idf/projects/radio_board/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/radio_board/sdkconfig.defaults
@@ -1,0 +1,24 @@
+CONFIG_IDF_TARGET="esp32s3"
+
+# Flash — devkit modules are >=8MB; partition table stays within 4MB in case
+# the final daughterboard uses a smaller part.
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+
+# FreeRTOS
+CONFIG_FREERTOS_HZ=1000
+
+# Interrupt WDT
+CONFIG_ESP_INT_WDT=y
+CONFIG_ESP_INT_WDT_TIMEOUT_MS=300
+
+# Core dump to flash — retrieve after crash with:
+#   espcoredump.py info_corefile -t raw -c 0x310000 build/radio_board.elf
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
+
+# Partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+
+# Serial console on USB (the UART link owns the host pins)
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y


### PR DESCRIPTION
Part of #409 (tracking #408). No closing keyword on purpose — #409 stays open for live-hardware bench validation once the daughterboard PCB respin (power redesign) exists. All software deliverables land here so #410 can build on them.

## What

- **`components/TR_UART_Link`** — framed UART link for the radio daughterboard:
  - `TR_MsgCodec`: `SOF + type + len + CRC16` codec, byte-identical to the I2C/I2S framing, plus a streaming deframer (UART is a byte stream) with SOF-hunt resync and drop counters. IDF-free, host-tested.
  - `RadioModemProtocol.h`: transparent-modem protocol v1 — opaque air-frame tunnel (on-air format stays byte-identical to direct-radio boards → deployed base stations unaffected), in-band seq/TX_RESULT credit flow control, radio config, identity/capabilities (chip, band, max TX power, fw version) for swappable matched daughterboard pairs, status, spectrum-scan passthrough.
- **`projects/radio_board`** — ESP32-S3 daughterboard firmware: reuses `TR_LoRa_Comms` unchanged, host-agnostic (same binary on the rocket or base-station end), every accepted TX seq answered (never silently dropped), modem-side TX-power clamp to module capability, TX/RX indicator LEDs, V8 schematic pin map (host-UART pins still TODO), OTA-ready partition table, full protocol spec in the README. Added to the firmware CI matrix.
- **`TR_LoRa_Comms.Config.rxen_pin`** (default −1) — RadioLib `setRfSwitchPins` drives the RF-switch RX half (DIO2 remains the TX half). Rider fix: the **V2 base station's L_RXEN (GPIO17) was defined but never driven** — now wired through; V1 unaffected. Bench follow-up: compare V2 RX RSSI before/after.

## Validation

- 11 host gtests green (`tests_cpp/test_uart_link_codec.cpp`): golden wire bytes, corruption/truncation resync, wire-stable protocol layouts
- Build-verified (IDF v6.0): `radio_board`, `out_computer`, `base_station` in **both** BS_BOARD_V2 variants
- Hardware validation pending the daughterboard respin (its SPI flash accepts writes but never programs — hardware fault, board shelved) — tracked on #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
