### PR TITLE
Settings-snapshot re-emit at launch+5s + truthful log-buffer report stats

### DIFF
--- a/Data_Analysis/flight_report/modules/gaps.py
+++ b/Data_Analysis/flight_report/modules/gaps.py
@@ -191,7 +191,14 @@ def analyze(flight: Flight) -> AnalysisResult:
     result = AnalysisResult(name="gaps", title="Frame Gaps & Sample Rates")
     records = flight.records
 
-    all_ts = extract_all_timestamps(records)
+    # Exclude OC-clock frame types from the MERGED stream: LogBufferStats is
+    # stamped with the OutComputer's micros(), offset minutes from the FC
+    # clock, which would manufacture one giant fake gap. Its per-sensor
+    # cadence (against its own clock) is still analyzed below.
+    from .timestamps import OC_CLOCK_TYPES
+    merged_records = {k: v for k, v in records.items() if k not in OC_CLOCK_TYPES}
+
+    all_ts = extract_all_timestamps(merged_records)
     per_sensor = extract_per_sensor_timestamps(records)
     if len(all_ts) < 2:
         result.warnings.append("Not enough records to analyze.")

--- a/Data_Analysis/flight_report/modules/log_buffer.py
+++ b/Data_Analysis/flight_report/modules/log_buffer.py
@@ -118,15 +118,23 @@ def analyze(flight: Flight) -> AnalysisResult:
     # ring_highwater is monotonic since boot, so the *max* over samples is the
     # session peak.  ring_overruns / ring_drop_oldest_bytes likewise.
     peak_fill = max(s["ring_highwater"] for s in samples)
-    final_overruns = samples[-1]["ring_overruns"]
-    final_drop_oldest = samples[-1]["ring_drop_oldest_bytes"]
     final_bad_sof = samples[-1]["ring_bad_sof_clears"]
-    initial_overruns = samples[0]["ring_overruns"]
-    initial_drop_oldest = samples[0]["ring_drop_oldest_bytes"]
-    # In-flight deltas tell you whether overrun/drop happened *during this
-    # session* vs. carried over from a prior session on the same boot.
-    overruns_this_session = max(0, final_overruns - initial_overruns)
-    drop_oldest_this_session = max(0, final_drop_oldest - initial_drop_oldest)
+
+    # Counter deltas, split at the FIRST inter-sample interval.  The stats
+    # emitter starts with the log session, so samples[0]→samples[1] straddles
+    # logging activation: its delta is dominated by normal PRE-activation pad
+    # turnover (the rolling prelaunch window drop-oldests on every push while
+    # the ring sits at the pad cap — by design, not data loss).  Only deltas
+    # AFTER samples[1] are unambiguous in-flight events: the push path rejects
+    # the incoming frame when logging is active, so a post-activation overrun
+    # means live flight frames were actually discarded.
+    first = samples[0]
+    pivot = samples[1] if len(samples) > 1 else samples[-1]
+    last = samples[-1]
+    overruns_activation = max(0, pivot["ring_overruns"] - first["ring_overruns"])
+    drop_activation = max(0, pivot["ring_drop_oldest_bytes"] - first["ring_drop_oldest_bytes"])
+    overruns_inflight = max(0, last["ring_overruns"] - pivot["ring_overruns"])
+    drop_inflight = max(0, last["ring_drop_oldest_bytes"] - pivot["ring_drop_oldest_bytes"])
 
     pct = _peak_fill_pct(peak_fill, capacity) or 0.0
 
@@ -137,20 +145,26 @@ def analyze(flight: Flight) -> AnalysisResult:
         "peak_fill_bytes":               peak_fill,
         "peak_fill_kb":                  round(peak_fill / 1024.0, 1),
         "peak_fill_pct":                 round(pct, 1),
-        "ring_overruns_in_session":      overruns_this_session,
-        "ring_drop_oldest_bytes_session":drop_oldest_this_session,
+        # Pad cap is ring_size/2; activateLogging() raises the cap to the full
+        # ring so the reserved half absorbs the launch drain.
+        "overruns_activation_interval":  overruns_activation,
+        "drop_oldest_B_activation_interval": drop_activation,
+        "overruns_in_flight":            overruns_inflight,
+        "drop_oldest_B_in_flight":       drop_inflight,
         "ring_bad_sof_clears_final":     final_bad_sof,
     }
 
-    if overruns_this_session > 0:
+    if overruns_inflight > 0:
         result.warnings.append(
-            f"{overruns_this_session} ring overrun(s) during this session — "
-            "writer outpaced flush; some frames were dropped."
+            f"{overruns_inflight} ring overrun(s) AFTER activation — the push "
+            "path rejects incoming frames while logging, so live flight frames "
+            "were discarded (flush stalled or sustained inflow burst)."
         )
-    if drop_oldest_this_session > 0:
+    if drop_inflight > 0:
         result.warnings.append(
-            f"{drop_oldest_this_session:,} bytes dropped from ring tail "
-            "(drop-oldest path) — ring undersized for this load."
+            f"{drop_inflight:,} bytes drop-oldested AFTER activation — "
+            "unexpected: drop-oldest should only run pre-activation. Suspect "
+            "the log session (re)started mid-flight."
         )
     if pct >= 90.0:
         result.warnings.append(

--- a/Data_Analysis/flight_report/modules/timestamps.py
+++ b/Data_Analysis/flight_report/modules/timestamps.py
@@ -11,12 +11,22 @@ from ..flight import Flight
 from ..registry import AnalysisResult
 
 
+# Frame types stamped with the OutComputer's own micros() rather than the
+# FC clock the sensor stream uses.  The clocks are offset by however long one
+# board booted before the other (minutes), so mixing them into the merged
+# stream manufactures one giant fake "jump" per flight.  Their internal
+# cadence is still valid — they are only excluded from the MERGED analysis.
+OC_CLOCK_TYPES = {"LogBufferStats"}
+
+
 def analyze(flight: Flight) -> AnalysisResult:
     result = AnalysisResult(name="timestamps", title="Timestamp Anomalies")
     recs = flight.records
 
     all_ts = []
     for sname, rlist in recs.items():
+        if sname in OC_CLOCK_TYPES:
+            continue
         for r in rlist:
             if "time_us" in r:
                 all_ts.append((r["time_us"], sname))
@@ -43,12 +53,14 @@ def analyze(flight: Flight) -> AnalysisResult:
     big = int(np.sum(deltas > 1_000_000))   # >1 s in merged stream
     huge = int(np.sum(deltas > 10_000_000))  # >10 s — likely reboot/log split
 
+    excluded = sorted(s for s in OC_CLOCK_TYPES if recs.get(s))
     result.metrics = {
         "merged_records": len(all_ts),
         "merged_span_s": round((times[-1] - times[0]) / 1e6, 2),
         "merged_jumps_gt_1s": big,
         "merged_jumps_gt_10s": huge,
         "nonmono_sensors": ", ".join(f"{k}={v}" for k, v in nonmono_per_sensor.items()) or "none",
+        "excluded_oc_clock_types": ", ".join(excluded) or "none",
     }
 
     if huge:

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -463,7 +463,9 @@ static bool     reboot_recovery_telem = false; // true for rest of flight (telem
 static uint32_t servo_settle_end_ms = 0;      // hold servos neutral until this time
 static uint32_t last_snapshot_ms = 0;         // rate-limit NVS writes to 10 Hz
 // Resend the flight settings snapshot (#165) on the first few INFLIGHT ticks
-// so a single dropped I2S frame at launch doesn't lose the record.
+// so a single dropped I2S frame at launch doesn't lose the record, plus one
+// late copy at launch+5 s, clear of the logging-activation edge (7/05 V2 F2
+// lost all three early copies to the pre-#418 races).
 static uint8_t  settings_emit_count = 0;
 
 static uint32_t computeSnapshotCRC(const FlightSnapshotData& snap)
@@ -5570,6 +5572,18 @@ static void loop_fc()
                     // dropped frame; values are stable in flight so all copies
                     // are identical and the app reads the first one.
                     if (settings_emit_count < 3) {
+                        sendFlightSettings();
+                        settings_emit_count++;
+                    }
+                    // One more copy well clear of the logging-activation edge:
+                    // the first three ride launch+0/100/200 ms, exactly the
+                    // window where the OC's ring drain is busiest and where the
+                    // pre-#418 races ate all three on the 7/05 V2 flight (its
+                    // .json has no settings block).  By launch+5 s the ring is
+                    // long drained, so this copy survives anything short of a
+                    // dead link.
+                    else if (settings_emit_count == 3 &&
+                             now_ms - launch_time_millis >= 5000U) {
                         sendFlightSettings();
                         settings_emit_count++;
                     }


### PR DESCRIPTION
Follow-ups from the 2026-07-05 CENJARS log-ring investigation.

## fc: re-emit the flight-settings snapshot at launch+5 s

All three 0xE1 copies ride launch+0/100/200 ms — exactly the logging-activation edge, where the pre-#418 races ate all three on the V2 F2 flight (its flight .json has no settings block). One extra copy at launch+5 s is cheap insurance clear of that window. The app takes the first 0xE1 that decodes (CSVGenerator.swift), so duplicate copies are handled today with no app change; values are stable in flight so all copies are identical.

## analysis: stop reporting pad ring turnover as data loss

- log_buffer: counter deltas split into activation-interval (straddles activation; dominated by normal pre-activation pad drop-oldest turnover — the rolling prelaunch window, by design) vs in-flight. Warnings only fire on post-activation events, which are real frame rejections. "Ring undersized" wording removed — the cap raises to the full 130 KB ring at activation and observed highwater was 65 KB.
- timestamps/gaps: LogBufferStats is stamped with the OC clock (minutes offset from FC-stamped frames); it is now excluded from merged-stream jump/gap analysis (per-sensor cadence still checked). This removes the fake "jump > 10 s" + dozens of fake gaps every flight.

Regenerated on the four 7/05 flights: the two clean flights now report zero warnings across log_buffer/timestamps/gaps; the remaining warnings are the real anomalies (V2 F1 mid-flight sensor self-gaps; V2 F2 single all-stream gap = the pre-#418 race hole). In-flight overruns read 0 on all four, confirming capacity was never the loss mechanism.

## Verification

- flight_computer builds clean (IDF v6.0)
- 17/17 pytest (report smoke test + profile-semantics units)
- All four CENJARS reports regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)