### PR TITLE
Baro apogee voter: 1s settle window after burnout (bay-pressure transient hardening)

### DIFF
--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -229,6 +229,46 @@ TEST_F(KinematicChecksTest, Apogee_N2Quorum_TwoOfFourFires) {
     EXPECT_TRUE(kc.apogee_flag) << "2 of 4 concurring must fire under N-2 (would need 3 under N-1)";
 }
 
+// Baro settle window after burnout (7/05 V2 F1 flight). At thrust tail-off the
+// bay pressure snaps back from its boost-suction offset: indicated altitude
+// fell 15 m in 0.25 s while the rocket climbed at 46 m/s — which satisfies the
+// baro apogee test (alt < ratcheted max − 5) the instant its burnout gate
+// opens.  The baro voter must stay silent through BARO_BURNOUT_SETTLE_MS, then
+// work normally on the real descent.
+TEST_F(KinematicChecksTest, Apogee_BurnoutBaroTransient_NoVoteInSettleWindow) {
+    for (int i = 0; i < 80; i++) {           // launch, climbing to ~40 m indicated
+        setMockMillis(i * 2);
+        callFlight(0.5f * i, 25.0f, 45.0f);
+    }
+    ASSERT_TRUE(kc.launch_flag);
+
+    // Burnout at t=160 ms: indicated altitude dives 40 → 22 m over 250 ms
+    // while EKF velocity says +45 m/s (still climbing hard).  Nose-up, no GPS.
+    for (int i = 0; i < 25; i++) {
+        setMockMillis(160 + i * 10);
+        callFlight(40.0f - 0.72f * i, 2.0f, 45.0f, 0.0f, 0.0f, false,
+                   /*pitch*/1.0f, /*burnout*/true);
+        EXPECT_FALSE(kc.alt_apogee_flag)
+            << "baro must not vote during the post-burnout settle window (i=" << i << ")";
+    }
+    EXPECT_FALSE(kc.apogee_flag);
+
+    // Recovery + continued climb through the rest of the settle window.
+    for (int i = 0; i < 80; i++) {
+        setMockMillis(410 + i * 10);
+        callFlight(25.0f + 1.0f * i, 2.0f, 30.0f, 0.0f, 0.0f, false, 1.0f, true);
+    }
+    EXPECT_FALSE(kc.alt_apogee_flag);
+
+    // Well past the window (t≈1.2 s+ after burnout): genuine descent from the
+    // peak — the baro voter must work normally again.
+    for (int i = 0; i < 60; i++) {
+        setMockMillis(1210 + i * 10);
+        callFlight(105.0f - 2.0f * i, 2.0f, -10.0f, 0.0f, 0.0f, false, 1.0f, true);
+    }
+    EXPECT_TRUE(kc.alt_apogee_flag) << "baro voter must recover after the settle window";
+}
+
 // #262 CORE: during mach-lockout (baro excluded) a single EKF-voter fault would
 // sink the old 2-of-2 {vel,pitch}.  With GPS restored as a non-EKF voter the
 // vote becomes 2-of-3 {vel,gps,pitch}, so pitch+GPS carry it.  Here EKF velocity

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -51,6 +51,17 @@ constexpr uint32_t GPS_APOGEE_FRESH_MS     = 500;
 constexpr float    LAUNCH_ACCEL_FALLBACK_MS2   = 30.0f;  // ~3 g
 constexpr uint16_t LAUNCH_ACCEL_FALLBACK_COUNT = 500;    // sustained samples
 
+// Baro settle window after burnout. Thrust tail-off can snap the bay pressure
+// back from its boost-suction offset (7/05 V2 F1: indicated altitude fell 15 m
+// in 0.25 s at burnout while climbing at 46 m/s), which satisfies the baro
+// apogee test the instant its burnout gate opens — the boost over-read has
+// already ratcheted max_altitude high.  Apogee physically cannot be at
+// burnout, so the baro voter is ignored for this long after burnout is first
+// seen.  The Layer-2 backstop below is NOT gated by this (its 30 m drop
+// threshold is far beyond the transient, and it must stay available in the
+// degraded case).
+constexpr uint32_t BARO_BURNOUT_SETTLE_MS  = 1000;
+
 // Layer-2 apogee backstop (#257). When the primary vote can't reach quorum
 // (e.g. an unhealthy EKF leaves < 2 healthy voters), a healthy + mach-unlocked
 // baro that has dropped this far below the running peak while still descending
@@ -114,6 +125,8 @@ TR_KinematicChecks::TR_KinematicChecks()
     gps_apogee_count_ = 0;
     gps_available_ = false;
     last_gps_time_ms_ = 0;
+    burnout_seen_ = false;
+    burnout_seen_ms_ = 0;
     baro_gate_init_ = false;
     palt_accepted_ = 0.0f;
     last_baro_gate_ms_ = 0;
@@ -176,6 +189,8 @@ void TR_KinematicChecks::reset()
     palt_accepted_ = 0.0f;
     last_baro_gate_ms_ = 0;
     consec_baro_rejects_ = 0;
+    burnout_seen_ = false;
+    burnout_seen_ms_ = 0;
     kf_init_ = false;
     alt_est = 0.0f;
     d_alt_est_ = 0.0f;
@@ -435,6 +450,13 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
     // ================================================================
     if (launch_flag && burnout_detected)
     {
+        // Stamp the first time burnout is seen — starts the baro settle window.
+        if (!burnout_seen_)
+        {
+            burnout_seen_ = true;
+            burnout_seen_ms_ = millis();
+        }
+
         // --- Test 1: Velocity (EKF vertical velocity negative) ---
         const bool vel_pass = (position[2] > 15.0f && velocity[2] < 0.0f);
         if (vel_pass) {
@@ -449,7 +471,13 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
         // Uses KF-smoothed alt_est rather than raw pressure_altitude — boost
         // noise on the raw signal was previously tripping this test during
         // ascent (#142). Velocity gate (d_alt_est_ < 20 m/s) is preserved.
-        const bool baro_pass = (alt_est > 15.0f &&
+        // Ignored during the post-burnout settle window (see
+        // BARO_BURNOUT_SETTLE_MS): the bay-pressure snap-back at thrust
+        // tail-off reads as a >10 m altitude drop and otherwise casts a false
+        // vote the moment this gate opens.
+        const bool baro_settled = (millis() - burnout_seen_ms_ >= BARO_BURNOUT_SETTLE_MS);
+        const bool baro_pass = (baro_settled &&
+                                alt_est > 15.0f &&
                                 alt_est < max_altitude - 5.0f &&
                                 d_alt_est_ < 20.0f);
         if (baro_pass) {

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.h
@@ -71,6 +71,15 @@ private:
     bool gps_available_;
     uint32_t last_gps_time_ms_;
 
+    // Baro settle window after burnout (7/05 V2 F1): thrust tail-off can snap
+    // the bay pressure back from its boost-suction offset, dropping indicated
+    // altitude >10 m in ~0.25 s while still climbing — which satisfies the
+    // baro apogee test the instant its burnout gate opens.  The baro voter is
+    // ignored until BARO_BURNOUT_SETTLE_MS after burnout is first seen
+    // (apogee physically cannot be at burnout).
+    bool     burnout_seen_;
+    uint32_t burnout_seen_ms_;
+
     // Baro rate-gate state (rejects ejection / sensor spikes before they
     // reach the KF or the landing fast path).
     bool     baro_gate_init_;


### PR DESCRIPTION
Hardening from the 7/05 V2 F1 investigation: at thrust tail-off the bay pressure can snap back from its boost-suction offset — indicated altitude fell 15 m in 0.25 s at burnout while the rocket climbed at 46 m/s, satisfying the baro apogee test (alt < ratcheted max − 5) the instant its burnout gate opened and casting a false alt_apogee vote 12 ms after burnout.

The vote architecture already contained it (leaky counter un-voted 0.41 s later; 2-concurring floor kept the master safe), so this is belt-and-braces before pyro-deploy flights: apogee physically cannot be at burnout, so the baro voter is now ignored for BARO_BURNOUT_SETTLE_MS (1 s) after burnout is first seen. The Layer-2 backstop is deliberately NOT gated — its 30 m drop threshold is far beyond any observed transient and it must stay available in the degraded case.

## Verification

- New gtest replays the V2 F1 profile: the burnout dip casts no vote inside the window; the voter works normally on the real descent after it
- 387/387 host tests pass
- flight_computer builds clean (IDF v6.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)