### PR TITLE
SAM-M10Q high-perf-clock OTP: burst write, module-memory tri-state, and layered never-rewrite guards

### DIFF
--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "TR_GNSSReceiverUBlox_Serial.cpp" "u-blox_GNSS.cpp" "sfe_bus.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_uart TR_Compat TR_RocketComputerTypes driver)
+idf_component_register(SRCS "TR_GNSSReceiverUBlox_Serial.cpp" "u-blox_GNSS.cpp" "sfe_bus.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_uart TR_Compat TR_RocketComputerTypes driver PRIV_REQUIRES TR_NVS)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -599,13 +599,13 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 // already programmed this boot and re-verified).  Returns false when the OTP
 // string was just written — the caller must hardware-reset the receiver and
 // reconnect, since the OTP config only applies at startup.
-// Auto-programming master switch.  Currently READ-ONLY: the boot check reads
-// and logs the module's OTP state (all four §2.1.5 keys individually) but
-// never writes.  The OTP config budget is 69 bytes TOTAL (§2.3) and the
-// high-perf config takes 18, so writes are a once-or-twice-per-module-
-// lifetime resource — flip this only after the read-only diagnostics of the
-// target module have been reviewed.
-static constexpr bool kOtpAutoProgram = false;
+// Auto-programming master switch.  When false the boot check is READ-ONLY:
+// it reads and logs the module's OTP state (all four §2.1.5 keys
+// individually) but never writes.  The OTP config budget is 69 bytes TOTAL
+// (§2.3) and the high-perf config takes 18, so writes are a once-or-twice-
+// per-module-lifetime resource; when enabled, writes only ever target a
+// module whose OTP reads fully BLANK, at most once per module (NVS guard).
+static constexpr bool kOtpAutoProgram = true;
 
 bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
 {

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -2,6 +2,7 @@
 #include <esp_log.h>
 #include <driver/uart.h>
 #include <cstring>
+#include <TR_NVS.h>  // Preferences — once-ever OTP write guard
 
 static const char* TAG = "GNSS";
 
@@ -645,14 +646,57 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
 
     if (otp_program_attempted_)
     {
-        return false;  // already wrote this boot; caller logs the failure
+        // Wrote earlier THIS boot and the post-reset verify still fails.
+        // Do not write again — the NVS record below also blocks future boots.
+        ESP_LOGE(TAG, "High-perf clock verify fails after this boot's OTP "
+                      "write — NOT retrying (finite OTP)");
+        return true;
     }
+
+    // ── Once-EVER-per-module write guard ─────────────────────────────────
+    // OTP capacity is a finite physical resource and u-blox does not
+    // document whether repeated CFG-OTP writes consume additional space.
+    // Policy: at most ONE programming attempt per physical module, tracked
+    // in FC NVS against the receiver's unique chip ID (UBX-SEC-UNIQID).
+    // No readable unique ID → no write, ever.
+    const char *uniq = gnss.getUniqueChipIdStr(nullptr, 1100);
+    if (uniq == nullptr || uniq[0] == '\0')
+    {
+        ESP_LOGE(TAG, "Cannot read module unique ID — refusing to write OTP "
+                      "(no way to enforce the once-ever guard)");
+        return true;
+    }
+    // NVS keys max 15 chars: "o" + up to 14 hex chars of the unique ID.
+    char nvs_key[16] = {'o'};
+    strncpy(nvs_key + 1, uniq, sizeof(nvs_key) - 2);
+    nvs_key[sizeof(nvs_key) - 1] = '\0';
+
+    Preferences prefs;
+    if (!prefs.begin("gnssotp", false))
+    {
+        ESP_LOGE(TAG, "NVS unavailable — refusing to write OTP without the "
+                      "once-ever guard");
+        return true;
+    }
+    if (prefs.getUChar(nvs_key, 0) != 0)
+    {
+        prefs.end();
+        ESP_LOGE(TAG, "OTP write was ALREADY attempted on module %s (NVS "
+                      "guard) but verify fails — NOT rewriting. Investigate "
+                      "manually (u-center) before clearing NVS key gnssotp/%s",
+                 uniq, nvs_key);
+        return true;
+    }
+    // Record the attempt BEFORE sending anything, so a crash/brownout
+    // mid-write can never lead to a second automatic attempt.
+    prefs.putUChar(nvs_key, 1);
+    prefs.end();
     otp_program_attempted_ = true;
 
     // §2.1.5 Table 3 configuration string, byte-exact (two UBX-CFG 0x06/0x41
     // frames; sendCommand recomputes the checksums).  PERMANENT.
-    ESP_LOGW(TAG, "Programming high-performance clock into OTP "
-                  "(one-time, permanent, ~18 B of OTP)");
+    ESP_LOGW(TAG, "Programming high-performance clock into OTP of module %s "
+                  "(single attempt, one-time, permanent)", uniq);
 
     static uint8_t otp1[16] = {0x03, 0x00, 0x04, 0x1F, 0x54, 0x5E, 0x79, 0xBF,
                                0x28, 0xEF, 0x12, 0x05, 0xFD, 0xFF, 0xFF, 0xFF};
@@ -661,29 +705,57 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
                                0x00, 0xB0, 0x71, 0x0B, 0x0A, 0x00, 0xA4, 0x40,
                                0x00, 0xD8, 0xB8, 0x05};
 
-    ubxPacket pkt = {0x06, 0x41, 0, 0, 0, nullptr, 0, 0,
-                     SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED,
-                     SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
-
-    pkt.len = sizeof(otp1);
-    pkt.payload = otp1;
-    const sfe_ublox_status_e s1 = gnss.sendCommand(&pkt, 1100);
-    pkt.len = sizeof(otp2);
-    pkt.payload = otp2;
-    const sfe_ublox_status_e s2 = gnss.sendCommand(&pkt, 1100);
-
-    const bool acked =
-        (s1 == SFE_UBLOX_STATUS_DATA_SENT || s1 == SFE_UBLOX_STATUS_DATA_RECEIVED) &&
-        (s2 == SFE_UBLOX_STATUS_DATA_SENT || s2 == SFE_UBLOX_STATUS_DATA_RECEIVED);
-    if (acked)
+    // Retry policy inside the single attempt (bench 7/07: frame 1 DATA_SENT,
+    // back-to-back frame 2 COMMAND_NACK — the module is briefly busy
+    // programming the previous frame's bits):
+    //   * COMMAND_NACK → the frame was REJECTED, nothing committed: safe to
+    //     retry after a settle delay.
+    //   * TIMEOUT (or anything else) → ambiguous: the frame may have been
+    //     committed with the ACK lost.  ABORT the attempt — never risk a
+    //     duplicate commit against finite OTP.
+    auto sendOtpFrame = [&](uint8_t *payload, uint16_t len, const char *which) -> bool
     {
-        ESP_LOGW(TAG, "OTP high-clock config written and ACKed");
-    }
-    else
+        for (uint8_t i = 0; i < 3; i++)
+        {
+            ubxPacket pkt = {0x06, 0x41, len, 0, 0, payload, 0, 0,
+                             SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED,
+                             SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+            const sfe_ublox_status_e s = gnss.sendCommand(&pkt, 1100);
+            if (s == SFE_UBLOX_STATUS_DATA_SENT || s == SFE_UBLOX_STATUS_DATA_RECEIVED)
+            {
+                ESP_LOGI(TAG, "CFG-OTP %s ACKed (attempt %u)", which, i + 1);
+                return true;
+            }
+            if (s != SFE_UBLOX_STATUS_COMMAND_NACK)
+            {
+                ESP_LOGE(TAG, "CFG-OTP %s attempt %u: status %d (not a NACK) "
+                              "— aborting, frame state ambiguous", which, i + 1, (int)s);
+                return false;
+            }
+            ESP_LOGW(TAG, "CFG-OTP %s attempt %u: NACK (module busy) — "
+                          "retrying after settle", which, i + 1);
+            delay(300);
+        }
+        return false;
+    };
+
+    const bool f1 = sendOtpFrame(otp1, sizeof(otp1), "frame 1");
+    bool f2 = false;
+    if (f1)
     {
-        ESP_LOGE(TAG, "OTP write not ACKed (s1=%d s2=%d)", (int)s1, (int)s2);
+        delay(300);  // let frame-1 OTP programming settle before frame 2
+        f2 = sendOtpFrame(otp2, sizeof(otp2), "frame 2");
     }
-    return false;  // reset + re-verify either way
+
+    if (f1 && f2)
+    {
+        ESP_LOGW(TAG, "OTP high-clock config written — both frames ACKed");
+        return false;  // caller resets the receiver and re-verifies once
+    }
+    ESP_LOGE(TAG, "OTP write incomplete (frame1 %s, frame2 %s) — locked out "
+                  "by the NVS guard; complete manually via u-center",
+             f1 ? "ACKed" : "FAILED", f2 ? "ACKed" : "FAILED");
+    return true;  // no reset loop; continue at current clock
 }
 
 bool TR_GNSSReceiverUBloxSerial::pollNewPVT(GNSSData &gnss_data)

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -605,7 +605,7 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 // (§2.3) and the high-perf config takes 18, so writes are a once-or-twice-
 // per-module-lifetime resource; when enabled, writes only ever target a
 // module whose OTP reads fully BLANK, at most once per module (NVS guard).
-static constexpr bool kOtpAutoProgram = true;
+static constexpr bool kOtpAutoProgram = false;
 
 bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
 {
@@ -708,27 +708,15 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
                       "once-ever guard");
         return true;
     }
-    // Targeted override for the 7/07 bench module: its first guarded attempt
-    // used per-frame sends (frame 1 ACKed, frame 2 NACKed — see burst comment
-    // below), so exactly ONE more attempt with the corrected burst method is
-    // allowed for this specific module.  Remove after the bench session.
-    static constexpr char kOtpGuardOverrideModule[] = "B9A8090FB454";
     const uint8_t prior_attempts = prefs.getUChar(nvs_key, 0);
     if (prior_attempts != 0)
     {
-        const bool override_ok =
-            (strcmp(uniq, kOtpGuardOverrideModule) == 0) && (prior_attempts < 2);
-        if (!override_ok)
-        {
-            prefs.end();
-            ESP_LOGE(TAG, "OTP write was ALREADY attempted on module %s (NVS "
-                          "guard) but verify fails — NOT rewriting. Investigate "
-                          "manually before clearing NVS key gnssotp/%s",
-                     uniq, nvs_key);
-            return true;
-        }
-        ESP_LOGW(TAG, "Guard override for bench module %s — one burst-method "
-                      "attempt allowed", uniq);
+        prefs.end();
+        ESP_LOGE(TAG, "OTP write was ALREADY attempted on module %s (NVS "
+                      "guard) but verify fails — NOT rewriting. Investigate "
+                      "manually before clearing NVS key gnssotp/%s",
+                 uniq, nvs_key);
+        return true;
     }
     // Record the attempt BEFORE sending anything, so a crash/brownout
     // mid-write can never lead to a second automatic attempt.

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -604,8 +604,24 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 // individually) but never writes.  The OTP config budget is 69 bytes TOTAL
 // (§2.3) and the high-perf config takes 18, so writes are a once-or-twice-
 // per-module-lifetime resource; when enabled, writes only ever target a
-// module whose OTP reads fully BLANK, at most once per module (NVS guard).
-static constexpr bool kOtpAutoProgram = false;
+// module whose OTP reads fully BLANK, at most once per module (NVS guard +
+// the blocklist below).
+static constexpr bool kOtpAutoProgram = true;
+
+// Modules that must NEVER be auto-programmed, by UBX-SEC-UNIQID unique chip
+// ID.  This travels with the FIRMWARE: the once-ever NVS guard lives on one
+// main board, but GNSS daughter boards migrate between main boards, and a
+// failed-attempt module READS BLANK — indistinguishable from factory-fresh
+// by its own memory.  Any module whose write attempt fails must be added
+// here so no other main board ever retries it.
+//   B9A8090FB454 — bench module, 7/07: frame 2 of the OTP config string is
+//   NAKed on content (per-frame AND contiguous-burst delivery, string
+//   byte-identical across three u-blox manuals); most likely the interrupted
+//   first attempt left its config region failing read-back.  Works normally
+//   at the default clock.
+static constexpr const char *kOtpNeverProgram[] = {
+    "B9A8090FB454",
+};
 
 bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
 {
@@ -695,6 +711,17 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
         ESP_LOGE(TAG, "Cannot read module unique ID — refusing to write OTP "
                       "(no way to enforce the once-ever guard)");
         return true;
+    }
+    // Firmware-resident blocklist first: protects known failed/wedged modules
+    // on ANY main board (a failed module reads BLANK, like factory-fresh).
+    for (const char *blocked : kOtpNeverProgram)
+    {
+        if (strcmp(uniq, blocked) == 0)
+        {
+            ESP_LOGW(TAG, "Module %s is on the OTP never-program list — "
+                          "running at default clock", uniq);
+            return true;
+        }
     }
     // NVS keys max 15 chars: "o" + up to 14 hex chars of the unique ID.
     char nvs_key[16] = {'o'};
@@ -789,8 +816,9 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
         return false;  // caller resets the receiver and re-verifies once
     }
     ESP_LOGE(TAG, "OTP burst result: %u ACK, %u NAK (need 2 ACK / 0 NAK) — "
-                  "locked out by the NVS guard; investigate before any retry",
-             acks, naks);
+                  "locked out on this board by the NVS guard. ADD module %s "
+                  "to kOtpNeverProgram so no other main board retries it.",
+             acks, naks, uniq);
     return true;  // no reset loop; continue at current clock
 }
 

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -708,83 +708,101 @@ bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
                       "once-ever guard");
         return true;
     }
-    if (prefs.getUChar(nvs_key, 0) != 0)
+    // Targeted override for the 7/07 bench module: its first guarded attempt
+    // used per-frame sends (frame 1 ACKed, frame 2 NACKed — see burst comment
+    // below), so exactly ONE more attempt with the corrected burst method is
+    // allowed for this specific module.  Remove after the bench session.
+    static constexpr char kOtpGuardOverrideModule[] = "B9A8090FB454";
+    const uint8_t prior_attempts = prefs.getUChar(nvs_key, 0);
+    if (prior_attempts != 0)
     {
-        prefs.end();
-        ESP_LOGE(TAG, "OTP write was ALREADY attempted on module %s (NVS "
-                      "guard) but verify fails — NOT rewriting. Investigate "
-                      "manually (u-center) before clearing NVS key gnssotp/%s",
-                 uniq, nvs_key);
-        return true;
+        const bool override_ok =
+            (strcmp(uniq, kOtpGuardOverrideModule) == 0) && (prior_attempts < 2);
+        if (!override_ok)
+        {
+            prefs.end();
+            ESP_LOGE(TAG, "OTP write was ALREADY attempted on module %s (NVS "
+                          "guard) but verify fails — NOT rewriting. Investigate "
+                          "manually before clearing NVS key gnssotp/%s",
+                     uniq, nvs_key);
+            return true;
+        }
+        ESP_LOGW(TAG, "Guard override for bench module %s — one burst-method "
+                      "attempt allowed", uniq);
     }
     // Record the attempt BEFORE sending anything, so a crash/brownout
     // mid-write can never lead to a second automatic attempt.
-    prefs.putUChar(nvs_key, 1);
+    prefs.putUChar(nvs_key, (uint8_t)(prior_attempts + 1));
     prefs.end();
     otp_program_attempted_ = true;
 
-    // §2.1.5 Table 3 configuration string, byte-exact (two UBX-CFG 0x06/0x41
-    // frames; sendCommand recomputes the checksums).  PERMANENT.
+    // §2.1.5 Table 3 configuration string as ONE CONTIGUOUS BURST, byte-exact
+    // including sync chars and checksums (validated against the manual's own
+    // published checksum bytes).  Bench 7/07 established that the two frames
+    // sent as separate ACK-interleaved messages always fail: frame 1 ACKs but
+    // a standalone frame 2 is NACKed at ANY spacing (15 ms and 300–900 ms
+    // both tried) — CFG-OTP evidently treats the full string as one
+    // transaction, matching the manual's flow ("send the configuration
+    // string" ... "the device returns two UBX-ACK-ACK"): u-center transmits
+    // the whole string first, then both ACKs come back.  The library can only
+    // send one message per ACK round-trip, so this transaction bypasses it:
+    // write the burst raw on the UART and scan the RX stream for the two
+    // ACK-ACK sequences directly (NMEA chatter may interleave; the pattern
+    // matcher tolerates it).
     ESP_LOGW(TAG, "Programming high-performance clock into OTP of module %s "
-                  "(single attempt, one-time, permanent)", uniq);
+                  "(single burst attempt, one-time, permanent)", uniq);
 
-    static uint8_t otp1[16] = {0x03, 0x00, 0x04, 0x1F, 0x54, 0x5E, 0x79, 0xBF,
-                               0x28, 0xEF, 0x12, 0x05, 0xFD, 0xFF, 0xFF, 0xFF};
-    static uint8_t otp2[28] = {0x04, 0x01, 0xA4, 0x10, 0xBD, 0x34, 0xF9, 0x12,
-                               0x28, 0xEF, 0x12, 0x05, 0x05, 0x00, 0xA4, 0x40,
-                               0x00, 0xB0, 0x71, 0x0B, 0x0A, 0x00, 0xA4, 0x40,
-                               0x00, 0xD8, 0xB8, 0x05};
-
-    // Retry policy inside the single attempt (bench 7/07: frame 1 DATA_SENT,
-    // back-to-back frame 2 COMMAND_NACK — the module is briefly busy
-    // programming the previous frame's bits):
-    //   * COMMAND_NACK → the frame was REJECTED, nothing committed: safe to
-    //     retry after a settle delay.
-    //   * TIMEOUT (or anything else) → ambiguous: the frame may have been
-    //     committed with the ACK lost.  ABORT the attempt — never risk a
-    //     duplicate commit against finite OTP.
-    auto sendOtpFrame = [&](uint8_t *payload, uint16_t len, const char *which) -> bool
-    {
-        for (uint8_t i = 0; i < 3; i++)
-        {
-            ubxPacket pkt = {0x06, 0x41, len, 0, 0, payload, 0, 0,
-                             SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED,
-                             SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
-            const sfe_ublox_status_e s = gnss.sendCommand(&pkt, 1100);
-            if (s == SFE_UBLOX_STATUS_DATA_SENT || s == SFE_UBLOX_STATUS_DATA_RECEIVED)
-            {
-                ESP_LOGI(TAG, "CFG-OTP %s ACKed (attempt %u)", which, i + 1);
-                return true;
-            }
-            if (s != SFE_UBLOX_STATUS_COMMAND_NACK)
-            {
-                ESP_LOGE(TAG, "CFG-OTP %s attempt %u: status %d (not a NACK) "
-                              "— aborting, frame state ambiguous", which, i + 1, (int)s);
-                return false;
-            }
-            ESP_LOGW(TAG, "CFG-OTP %s attempt %u: NACK (module busy) — "
-                          "retrying after settle", which, i + 1);
-            delay(300);
-        }
-        return false;
+    static const uint8_t kOtpBurst[] = {
+        0xB5, 0x62, 0x06, 0x41, 0x10, 0x00,
+        0x03, 0x00, 0x04, 0x1F, 0x54, 0x5E, 0x79, 0xBF,
+        0x28, 0xEF, 0x12, 0x05, 0xFD, 0xFF, 0xFF, 0xFF,
+        0x8F, 0x0D,
+        0xB5, 0x62, 0x06, 0x41, 0x1C, 0x00,
+        0x04, 0x01, 0xA4, 0x10, 0xBD, 0x34, 0xF9, 0x12,
+        0x28, 0xEF, 0x12, 0x05, 0x05, 0x00, 0xA4, 0x40,
+        0x00, 0xB0, 0x71, 0x0B, 0x0A, 0x00, 0xA4, 0x40,
+        0x00, 0xD8, 0xB8, 0x05,
+        0xDE, 0xAE,
     };
+    // UBX-ACK-ACK / UBX-ACK-NAK for cls 0x06 id 0x41 (checksums recomputed
+    // and cross-checked against the manual's published ACK sequence).
+    static const uint8_t kAck[] = {0xB5, 0x62, 0x05, 0x01, 0x02, 0x00,
+                                   0x06, 0x41, 0x4F, 0x78};
+    static const uint8_t kNak[] = {0xB5, 0x62, 0x05, 0x00, 0x02, 0x00,
+                                   0x06, 0x41, 0x4E, 0x73};
 
-    const bool f1 = sendOtpFrame(otp1, sizeof(otp1), "frame 1");
-    bool f2 = false;
-    if (f1)
+    // Drain stale RX so the scan starts clean.
     {
-        delay(300);  // let frame-1 OTP programming settle before frame 2
-        f2 = sendOtpFrame(otp2, sizeof(otp2), "frame 2");
+        uint8_t tmp;
+        while (uart_read_bytes(_uartPort, &tmp, 1, 0) > 0) {}
     }
 
-    if (f1 && f2)
+    uart_write_bytes(_uartPort, kOtpBurst, sizeof(kOtpBurst));
+
+    uint8_t acks = 0, naks = 0;
+    size_t m_ack = 0, m_nak = 0;
+    const uint32_t scan_start = millis();
+    while ((millis() - scan_start) < 2500U && acks < 2)
     {
-        ESP_LOGW(TAG, "OTP high-clock config written — both frames ACKed");
+        uint8_t c;
+        if (uart_read_bytes(_uartPort, &c, 1, pdMS_TO_TICKS(20)) != 1)
+        {
+            continue;
+        }
+        m_ack = (c == kAck[m_ack]) ? m_ack + 1 : ((c == kAck[0]) ? 1 : 0);
+        if (m_ack == sizeof(kAck)) { acks++; m_ack = 0; }
+        m_nak = (c == kNak[m_nak]) ? m_nak + 1 : ((c == kNak[0]) ? 1 : 0);
+        if (m_nak == sizeof(kNak)) { naks++; m_nak = 0; }
+    }
+
+    if (acks == 2 && naks == 0)
+    {
+        ESP_LOGW(TAG, "OTP high-clock config written — both ACKs received");
         return false;  // caller resets the receiver and re-verifies once
     }
-    ESP_LOGE(TAG, "OTP write incomplete (frame1 %s, frame2 %s) — locked out "
-                  "by the NVS guard; complete manually via u-center",
-             f1 ? "ACKed" : "FAILED", f2 ? "ACKed" : "FAILED");
+    ESP_LOGE(TAG, "OTP burst result: %u ACK, %u NAK (need 2 ACK / 0 NAK) — "
+                  "locked out by the NVS guard; investigate before any retry",
+             acks, naks);
     return true;  // no reset loop; continue at current clock
 }
 

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -599,49 +599,79 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 // already programmed this boot and re-verified).  Returns false when the OTP
 // string was just written — the caller must hardware-reset the receiver and
 // reconnect, since the OTP config only applies at startup.
+// Auto-programming master switch.  Currently READ-ONLY: the boot check reads
+// and logs the module's OTP state (all four §2.1.5 keys individually) but
+// never writes.  The OTP config budget is 69 bytes TOTAL (§2.3) and the
+// high-perf config takes 18, so writes are a once-or-twice-per-module-
+// lifetime resource — flip this only after the read-only diagnostics of the
+// target module have been reviewed.
+static constexpr bool kOtpAutoProgram = false;
+
 bool TR_GNSSReceiverUBloxSerial::ensureHighPerformanceClock()
 {
-    // §2.1.5 step 5: VALGET (layer 0x04) of the OTP clock keys.  High CPU
-    // clock reads 0x0B71B000 at keys 0x40A40001/03/05 and 0x05B8D800 at
-    // 0x40A4000A; two keys (one of each expected value) are enough signal.
-    constexpr uint32_t KEY_CLK_A = 0x40A40003;
-    constexpr uint32_t KEY_CLK_B = 0x40A4000A;
-    constexpr uint32_t HI_CLK_A  = 0x0B71B000;
-    constexpr uint32_t HI_CLK_B  = 0x05B8D800;
-    constexpr uint8_t  OTP_LAYER = 0x04;  // layer byte from the manual's poll
+    // §2.1.5 step 5 verification keys.  The decision is made from the
+    // MODULE's own OTP contents (daughter boards move between main boards,
+    // so host-side records can't be the primary source of truth):
+    //   VERIFIED — all four keys read the high-clock values
+    //   PARTIAL  — some keys readable or values mismatch: something is in
+    //              the OTP already; NEVER auto-write over it (69-byte budget)
+    //   BLANK    — all keys NACK (the unprogrammed signature): the only
+    //              state eligible for programming
+    struct OtpKey { uint32_t key; uint32_t expect; };
+    static constexpr OtpKey kKeys[] = {
+        {0x40A40001, 0x0B71B000},
+        {0x40A40003, 0x0B71B000},
+        {0x40A40005, 0x0B71B000},
+        {0x40A4000A, 0x05B8D800},
+    };
+    constexpr uint8_t OTP_LAYER = 0x04;  // layer byte from the manual's poll
 
-    uint32_t a = 0, b = 0;
-    bool read_ok = false;
-    for (uint8_t i = 0; i < 4; i++)
+    uint8_t readable = 0, matching = 0;
+    for (const auto &k : kKeys)
     {
-        if (gnss.getVal32(KEY_CLK_A, &a, OTP_LAYER, 1100) &&
-            gnss.getVal32(KEY_CLK_B, &b, OTP_LAYER, 1100))
+        uint32_t v = 0;
+        bool ok = false;
+        for (uint8_t i = 0; i < 2 && !ok; i++)
         {
-            read_ok = true;
-            break;
+            ok = gnss.getVal32(k.key, &v, OTP_LAYER, 1100);
+            if (!ok) delay(100);
         }
-        delay(150);
+        if (ok)
+        {
+            readable++;
+            if (v == k.expect) matching++;
+            ESP_LOGI(TAG, "OTP key 0x%08lX = 0x%08lX (%s)",
+                     (unsigned long)k.key, (unsigned long)v,
+                     v == k.expect ? "expected" : "UNEXPECTED");
+        }
+        else
+        {
+            ESP_LOGI(TAG, "OTP key 0x%08lX: unreadable (NACK)", (unsigned long)k.key);
+        }
     }
 
-    if (read_ok && a == HI_CLK_A && b == HI_CLK_B)
+    if (matching == 4)
     {
-        ESP_LOGI(TAG, "High-performance clock OTP config verified "
-                      "(0x%08lX / 0x%08lX)",
-                 (unsigned long)a, (unsigned long)b);
+        ESP_LOGI(TAG, "High-performance clock OTP config VERIFIED (4/4 keys)");
         return true;
     }
-
-    if (read_ok)
+    if (readable > 0)
     {
-        ESP_LOGW(TAG, "OTP clock keys read 0x%08lX / 0x%08lX — NOT the "
-                      "high-performance configuration",
-                 (unsigned long)a, (unsigned long)b);
+        // Module memory says SOMETHING is programmed but not the expected
+        // full config (partial write, or different content).  Never gamble
+        // the remaining OTP budget on top of unknown content.
+        ESP_LOGE(TAG, "OTP state PARTIAL/MISMATCHED (%u/4 readable, %u/4 "
+                      "matching) — auto-programming refused; inspect with "
+                      "u-center", readable, matching);
+        return true;
     }
-    else
+    ESP_LOGW(TAG, "OTP state BLANK (all keys NACK) — module unprogrammed");
+
+    if (!kOtpAutoProgram)
     {
-        // An unprogrammed module NACKs the OTP-layer poll, so a persistent
-        // read failure is itself the "not programmed" signal.
-        ESP_LOGW(TAG, "OTP clock keys unreadable — treating as unprogrammed");
+        ESP_LOGW(TAG, "OTP auto-programming DISABLED in this build (read-only "
+                      "diagnostics) — running at default clock");
+        return true;
     }
 
     if (otp_program_attempted_)


### PR DESCRIPTION
Completes the OTP work started in #424 after two bench sessions on the real module. OTP config space is a finite lifetime resource (69 bytes total per integration manual sec 2.3; this config = 18 bytes), so the design treats writes as a 1-3-shot budget and layers every guard around that.

## What the bench taught us

- The fleet modules were NEVER OTP-programmed: an unprogrammed module NACKs the sec 2.1.5 verify poll, and the observed 18 Hz nav cadence is the default clock running past its 98%-fix-rate spec (per PCN UBX-23006557, high clock buys 4-constellation 5 -> 10 Hz guaranteed; 25 Hz is single-constellation).
- CFG-OTP frame 2 is NAKed on CONTENT on the bench module: per-frame at 15 ms, per-frame at 300-900 ms, and a contiguous 60-byte burst all give frame1-ACK/frame2-NAK. The configuration string is byte-identical across the SAM-M10Q, MAX-M10S and MIA-M10Q manuals (no typo; CFG-OTP internals are NDA-only). Most likely the interrupted first attempt wedged that OTP region (fails read-back forever). The module works normally at the default clock.
- A failed module READS BLANK - indistinguishable from factory-fresh by its own memory.

## Design

Every boot: read all four sec 2.1.5 OTP keys individually (logged per-key) and derive VERIFIED / PARTIAL / BLANK from the MODULE memory - daughter boards migrate between main boards, so host-side records are never the primary truth. A verified module is never written, on any board.

Write path (kOtpAutoProgram=true), gate chain in order:
1. OTP reads fully BLANK (verified/partial modules never touched)
2. Module unique ID (UBX-SEC-UNIQID) readable
3. Not on kOtpNeverProgram - a firmware-resident blocklist that travels to every main board (seeded with the wedged bench module B9A8090FB454); closes the daughter-board-migration hole since failed modules read BLANK
4. No prior attempt in this board's NVS (gnssotp namespace, recorded BEFORE the first byte is sent so a mid-write brownout cannot enable a retry)
5. Single contiguous-burst write of the manual's exact 60-byte string (checksums cross-validated against the published bytes), success only on 2 ACK / 0 NAK scanned from the raw RX stream, then hardware reset + 4/4-key re-verify

A failed attempt logs the exact instruction to add the module ID to the blocklist.

## Verification

- Bench: blocklist confirmed ("Module B9A8090FB454 is on the OTP never-program list"); per-key diagnostics confirmed on the real module; burst path exercised on hardware (1 ACK / 1 NAK on the wedged unit, correctly locked out)
- flight_computer builds clean (IDF v6.0)
- Fresh-module happy path (BLANK -> program -> VERIFIED) still pending a factory-fresh unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)