### PR TITLE
fix(fc): controlAngle no longer persists its rate command into pid_setpoint (#372)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -38,6 +38,22 @@ target_include_directories(test_pid PRIVATE
 target_link_libraries(test_pid GTest::gtest_main)
 gtest_discover_tests(test_pid)
 
+# ---------- test_servo_control ----------
+# TR_ServoControl's LEDC calls resolve to the host_shim no-ops; the
+# controller math (controlAngle cascade, gain schedule, #372 setpoint
+# semantics) runs as on target.
+add_executable(test_servo_control test_servo_control.cpp
+    ${LIB_DIR}/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+    ${LIB_DIR}/TR_PID/TR_PID.cpp
+)
+target_include_directories(test_servo_control PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_ServoControl_ledc_mult
+    ${LIB_DIR}/TR_PID
+)
+target_link_libraries(test_servo_control GTest::gtest_main)
+gtest_discover_tests(test_servo_control)
+
 # ---------- test_rocket_computer_types ----------
 add_executable(test_rocket_computer_types test_rocket_computer_types.cpp)
 target_include_directories(test_rocket_computer_types PRIVATE

--- a/tests_cpp/test_servo_control.cpp
+++ b/tests_cpp/test_servo_control.cpp
@@ -1,0 +1,129 @@
+// Tests for TR_ServoControl (ledc_mult) — the roll-rate / roll-angle
+// controller that drives the fin servos.
+//
+// The core regression here is #372: controlAngle() used to persist its
+// outer-loop rate command into pid_setpoint, so after an ANGLE tick the
+// rate-null paths (control / controlWithGainSchedule) held the residual
+// rate command instead of nulling to the configured setpoint.  Post-v4
+// roll profiles are always ANGLE once past the first waypoint, so the
+// transition back to rate-null happens exactly on the #265 EKF-health
+// fallback — the safety path — which made the stale setpoint worse.
+//
+// The LEDC calls are no-ops on the host (host_shim/driver/ledc.h); the
+// controller math runs exactly as on the rocket.  micros() is the shim's
+// mock clock, advanced explicitly per tick.
+
+#include <gtest/gtest.h>
+#include <Arduino.h>  // host shim: setMockMicros()
+#include "TR_ServoControl_ledc_mult.h"
+
+namespace {
+
+constexpr float KP      = 1.0f;   // P-only inner loop: output == rate error
+constexpr float KI      = 0.0f;
+constexpr float KD      = 0.0f;
+constexpr float MIN_CMD = -60.0f;
+constexpr float MAX_CMD = 60.0f;
+
+constexpr uint32_t TICK_US = 2000;  // 500 Hz control loop
+
+class ServoControlTest : public ::testing::Test {
+protected:
+    TR_ServoControl servo{1, 2, 3, 4,      // pins
+                          0, 0, 0, 0,      // bias us
+                          50, 1000, 2000,  // hz, min/max us
+                          KP, KI, KD,
+                          MIN_CMD, MAX_CMD};
+
+    uint32_t now_us_ = 0;
+
+    void SetUp() override {
+        setMockMicros(0);
+        servo.begin();
+        // TR_PID returns 0 on its first call (dt bootstrap) — burn it so
+        // every test asserts on steady-state ticks.
+        tick();
+        servo.control(0.0f);
+    }
+
+    // Advance the mock clock one control period.
+    void tick() {
+        now_us_ += TICK_US;
+        setMockMicros(now_us_);
+    }
+};
+
+// ---------- controlAngle cascade behavior (unchanged by #372 fix) ----------
+
+TEST_F(ServoControlTest, ControlAngleTracksProportionalRateCommand) {
+    // Outer loop: rate_cmd = kp_angle * (target - actual) = 2 * 10 = 20 dps.
+    // Inner loop (P-only, measured rate 0): output = -rate_cmd - 0 = -20.
+    tick();
+    servo.controlAngle(10.0f, 0.0f, 0.0f, 50.0f,
+                       /*kp_angle=*/2.0f, /*rate_cap_dps=*/60.0f);
+    EXPECT_NEAR(servo.getRollCmdDeg(), -20.0f, 1e-4f);
+}
+
+TEST_F(ServoControlTest, ControlAngleCapsOuterLoopRateCommand) {
+    // 180 deg error at kp_angle=4 would demand 720 dps; the cap holds it
+    // at 60, so the inner loop sees setpoint -60.
+    tick();
+    servo.controlAngle(180.0f, 0.0f, 0.0f, 50.0f, 4.0f, 60.0f);
+    EXPECT_NEAR(servo.getRollCmdDeg(), -60.0f, 1e-4f);
+}
+
+TEST_F(ServoControlTest, ControlAngleWrapsAngleError) {
+    // target -170, actual +170: raw error -340 wraps to +20 -> rate_cmd
+    // +40 at kp_angle=2 -> inner-loop output -40.
+    tick();
+    servo.controlAngle(-170.0f, 170.0f, 0.0f, 50.0f, 2.0f, 60.0f);
+    EXPECT_NEAR(servo.getRollCmdDeg(), -40.0f, 1e-4f);
+}
+
+// ---------- #372 regression: no stale setpoint after an ANGLE tick ----------
+
+TEST_F(ServoControlTest, RateNullAfterAngleTickNullsToConfiguredSetpoint) {
+    servo.setSetpoint(0.0f);
+
+    // Saturating ANGLE tick: outer loop commands the full ±60 dps cap.
+    tick();
+    servo.controlAngle(180.0f, 0.0f, 0.0f, 50.0f, 4.0f, 60.0f);
+    ASSERT_NEAR(servo.getRollCmdDeg(), -60.0f, 1e-4f);
+
+    // Next tick drops to rate-null (profile segment change / #265 EKF-health
+    // fallback).  Measured rate is already 0, so a correct null commands 0.
+    // Pre-#372-fix this held the stale -60 dps setpoint -> -60 output.
+    tick();
+    servo.control(0.0f);
+    EXPECT_NEAR(servo.getRollCmdDeg(), 0.0f, 1e-4f);
+}
+
+TEST_F(ServoControlTest, GainScheduledRateNullAfterAngleTickAlsoNulls) {
+    servo.setSetpoint(0.0f);
+
+    tick();
+    servo.controlAngle(180.0f, 0.0f, 0.0f, 50.0f, 4.0f, 60.0f);
+    ASSERT_NEAR(servo.getRollCmdDeg(), -60.0f, 1e-4f);
+
+    // The FC's gain-scheduled rate-null path (controlWithGainSchedule) must
+    // null to the configured setpoint too — schedule disabled, gains as-is.
+    tick();
+    servo.controlWithGainSchedule(0.0f, 40.0f);
+    EXPECT_NEAR(servo.getRollCmdDeg(), 0.0f, 1e-4f);
+}
+
+TEST_F(ServoControlTest, SetSetpointStillGovernsRateNull) {
+    // The one legitimate way to bias the rate loop: setSetpoint().  An
+    // intervening ANGLE tick must not clobber it.
+    servo.setSetpoint(5.0f);
+
+    tick();
+    servo.controlAngle(10.0f, 0.0f, 0.0f, 50.0f, 2.0f, 60.0f);
+
+    tick();
+    servo.control(0.0f);
+    // P-only: output = setpoint - measured = 5.
+    EXPECT_NEAR(servo.getRollCmdDeg(), 5.0f, 1e-4f);
+}
+
+}  // namespace

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -91,8 +91,12 @@ void TR_ServoControl::setSetpoint(float setpoint) {
 }
 
 void TR_ServoControl::control(float roll_rate) {
+    controlToSetpoint(pid_setpoint, roll_rate);
+}
+
+void TR_ServoControl::controlToSetpoint(float setpoint, float roll_rate) {
     // PID output (deg) within [min_cmd..max_cmd]
-    roll_cmd_deg = pid.computePID(pid_setpoint, roll_rate);
+    roll_cmd_deg = pid.computePID(setpoint, roll_rate);
     roll_cmd_deg = constrain(roll_cmd_deg, min_cmd, max_cmd);
 
     // Map the commanded fin angle (deg) to a servo pulse via the physical
@@ -301,25 +305,30 @@ void TR_ServoControl::disableGainSchedule() {
     pid.setKd(kd_base);
 }
 
-void TR_ServoControl::controlWithGainSchedule(float roll_rate, float velocity_ms) {
-    if (gain_schedule_enabled) {
-        float v = std::max(std::fabs(velocity_ms), gain_schedule_v_min);
-        float v_ratio = gain_schedule_v_ref / v;
-        float scale = v_ratio * v_ratio;
-        // Cap the scale factor so servo saturates at ~50 deg/s error, not gyro noise
-        scale = std::min(scale, GAIN_SCHEDULE_SCALE_CAP);
-
-        // Reset I-term when gain scale changes significantly to prevent
-        // accumulated integral from spiking the output after a step change in Ki.
-        if (fabs(scale - prev_gain_scale_) > 0.1f) {
-            pid.resetIntegral();
-        }
-        prev_gain_scale_ = scale;
-
-        pid.setKp(kp_base * scale);
-        pid.setKi(ki_base * scale);
-        pid.setKd(kd_base * scale);
+void TR_ServoControl::applyGainSchedule(float velocity_ms) {
+    if (!gain_schedule_enabled) {
+        return;
     }
+    float v = std::max(std::fabs(velocity_ms), gain_schedule_v_min);
+    float v_ratio = gain_schedule_v_ref / v;
+    float scale = v_ratio * v_ratio;
+    // Cap the scale factor so servo saturates at ~50 deg/s error, not gyro noise
+    scale = std::min(scale, GAIN_SCHEDULE_SCALE_CAP);
+
+    // Reset I-term when gain scale changes significantly to prevent
+    // accumulated integral from spiking the output after a step change in Ki.
+    if (fabs(scale - prev_gain_scale_) > 0.1f) {
+        pid.resetIntegral();
+    }
+    prev_gain_scale_ = scale;
+
+    pid.setKp(kp_base * scale);
+    pid.setKi(ki_base * scale);
+    pid.setKd(kd_base * scale);
+}
+
+void TR_ServoControl::controlWithGainSchedule(float roll_rate, float velocity_ms) {
+    applyGainSchedule(velocity_ms);
     control(roll_rate);
 }
 
@@ -347,6 +356,10 @@ void TR_ServoControl::controlAngle(float target_roll_deg,
     // ── Inner loop: PID on rate error with gain scheduling ──
     // roll_rate_dps is passed in negated (–gyro_x) to match servo sign
     // convention, so negate rate_cmd to keep setpoint in the same frame.
-    pid_setpoint = -rate_cmd;
-    controlWithGainSchedule(roll_rate_dps, velocity_ms);
+    // The angle-loop rate command applies to THIS tick only — pid_setpoint is
+    // never mutated here (#372), so a later rate-null tick (profile segment
+    // change or the #265 EKF-health fallback) nulls to the configured
+    // setpoint instead of holding the last angle-loop rate command.
+    applyGainSchedule(velocity_ms);
+    controlToSetpoint(-rate_cmd, roll_rate_dps);
 }

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -125,6 +125,14 @@ public:
     float getAngleControlKpAngle() const { return kp_angle_; }
 
 private:
+    // Inner rate loop against an explicit setpoint: PID -> clamp -> fin-cal
+    // pulse -> drive.  Shared by control() (persistent pid_setpoint) and
+    // controlAngle() (per-tick rate command); does NOT touch pid_setpoint.
+    void controlToSetpoint(float setpoint, float roll_rate);
+    // Scale the PID gains by (V_ref/V)² (capped) when the gain schedule is
+    // enabled; no-op otherwise.  Split out so controlAngle() can schedule
+    // gains without routing through the persistent-setpoint control() path.
+    void applyGainSchedule(float velocity_ms);
     // update all four servos to a single nominal pulse
     void setPulse(int base_pulse_us);
     // drive ONE servo channel to a nominal pulse (bias applied); used by
@@ -147,7 +155,9 @@ private:
     int   servo_min_us;
     int   servo_max_us;
 
-    // PID for roll‑rate control
+    // PID for roll‑rate control.  pid_setpoint is mutated ONLY by
+    // setSetpoint() — controlAngle()'s rate command is passed per-tick via
+    // controlToSetpoint() so it can never leak into a rate-null path (#372).
     float pid_setpoint;
     TR_PID pid;
     float roll_cmd_deg;

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -262,6 +262,12 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         servo.set_pid_derivative_filter_cutoff_hz(config.d_lpf_hz)
     if config.integral_sep_threshold > 0.0:
         servo.set_pid_integral_separation_threshold(config.integral_sep_threshold)
+    # Seed the persistent rate setpoint ONCE, mirroring the firmware boot /
+    # SERVO_CTRL_ENABLE path (main.cpp:2768,4078 -> setSetpoint(ROLL_RATE_SET_POINT)).
+    # After this, the rate-null path never re-writes the setpoint — exactly like
+    # firmware — so a stale setpoint left by controlAngle (#372) would manifest
+    # here instead of being masked by a per-tick reset.
+    servo.set_setpoint(config.roll_setpoint_dps)
     servo_clock_us = 0
 
     # Initialize EKF
@@ -913,7 +919,13 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                             servo_clock_us += int(round(imu_dt * 1e6))
                             _servo_set_micros(servo_clock_us)
                             if seg_mode == "null_rate":
-                                servo.set_setpoint(config.roll_setpoint_dps)
+                                # Firmware-faithful: the rate-null path is a bare
+                                # controlWithGainSchedule (main.cpp:5849). It does
+                                # NOT reset the setpoint — it relies on the
+                                # persistent ROLL_RATE_SET_POINT seeded at init.
+                                # Pre-#372-fix, controlAngle would have left a
+                                # residual rate command here, holding it instead
+                                # of nulling.
                                 servo.control_with_gain_schedule(
                                     -roll_rate_dps, speed)
                             else:

--- a/tinkerrocket-sim/tests/test_roll_stale_setpoint.py
+++ b/tinkerrocket-sim/tests/test_roll_stale_setpoint.py
@@ -1,0 +1,133 @@
+"""SIL regression for #372: controlAngle() must not leave a stale rate setpoint.
+
+Post-v4 roll profiles are ANGLE-mode for the whole profile (incl. hold-last-
+angle), so the ANGLE -> rate-null transition happens exactly on the #265
+EKF-health gate: when the EKF goes unhealthy, `angle_mode_active` drops and the
+firmware falls from controlAngle() to the bare rate-null path
+(controlWithGainSchedule / control) — main.cpp:5816-5857. Pre-#372, controlAngle
+persisted its outer-loop rate command into pid_setpoint, so that rate-null path
+HELD the residual rate (up to ±rate_cap) instead of nulling — corrupting the
+safety fallback itself.
+
+These tests drive the *real firmware controller* (the SIL _servo binding, the
+exact object closed_loop_sim.py flies) through that sequence, mirroring the
+firmware call convention: advance the servo's mock clock each tick, pass the
+rate arg negated (-roll_rate_dps), seed the persistent setpoint ONCE at init
+(as the hardened sim now does, matching the firmware boot / SERVO_CTRL_ENABLE
+path). On pre-#372 firmware the null command sticks at ≈ -rate_cap; with the
+fix it nulls to the configured setpoint.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from tinkerrocket_sim._servo import ServoControl, set_mock_micros
+
+# Mirror the sim's firmware-controller wiring.
+IMU_DT = 1.0 / 1200.0            # closed_loop_sim imu_rate
+KP, KI, KD = 1.0, 0.0, 0.0      # P-only inner loop: fin cmd == rate error
+MIN_CMD, MAX_CMD = -60.0, 60.0
+GAIN_V_REF, GAIN_V_MIN = 50.0, 25.0
+KP_ANGLE = 4.0
+RATE_CAP_DPS = 60.0
+SPEED_MS = 40.0                 # < V_ref, so the V^2 schedule is active (>1x)
+
+
+class _Servo:
+    """A firmware-controller instance clocked exactly like closed_loop_sim."""
+
+    def __init__(self, setpoint_dps=0.0, gain_schedule=True):
+        self.s = ServoControl(kp=KP, ki=KI, kd=KD,
+                              min_cmd=MIN_CMD, max_cmd=MAX_CMD)
+        if gain_schedule:
+            self.s.enable_gain_schedule(GAIN_V_REF, GAIN_V_MIN)
+        # One-time setpoint seed — mirrors firmware boot (main.cpp:2768) and the
+        # hardened sim init. The rate-null path relies on this persistent value.
+        self.s.set_setpoint(setpoint_dps)
+        self._t_us = 0
+        self._tick()  # TR_PID returns 0 on its first call; burn the dt bootstrap
+        self.s.control(0.0)
+
+    def _tick(self):
+        self._t_us += int(round(IMU_DT * 1e6))
+        set_mock_micros(self._t_us)
+
+    def angle_tick(self, target_deg, actual_deg, roll_rate_dps):
+        self._tick()
+        self.s.control_angle(target_deg, actual_deg, -roll_rate_dps,
+                             SPEED_MS, KP_ANGLE, RATE_CAP_DPS)
+        return self.s.roll_cmd_deg
+
+    def gain_sched_null_tick(self, roll_rate_dps):
+        # Firmware ROLL_SEG_NULL_RATE / EKF-healthy fallback (main.cpp:5849).
+        self._tick()
+        self.s.control_with_gain_schedule(-roll_rate_dps, SPEED_MS)
+        return self.s.roll_cmd_deg
+
+    def gyro_null_tick(self, roll_rate_dps):
+        # Firmware pure-gyro fallback when the gain schedule is off / EKF
+        # unhealthy (main.cpp:5856).
+        self._tick()
+        self.s.control(-roll_rate_dps)
+        return self.s.roll_cmd_deg
+
+
+def _drive_unconverged_angle_segment(servo):
+    """An ANGLE segment that ends unconverged: a 180° error the vehicle can't
+    close, so every tick's outer loop saturates the rate command at ±rate_cap.
+    Returns the last angle-tick fin command (should be the saturated cmd)."""
+    cmd = 0.0
+    for _ in range(20):
+        cmd = servo.angle_tick(target_deg=180.0, actual_deg=0.0,
+                               roll_rate_dps=0.0)
+    return cmd
+
+
+def test_ekf_health_drop_after_angle_nulls_cleanly():
+    # Angle segment saturates the outer loop at the +rate_cap; the inner-loop
+    # setpoint for that tick is -rate_cap.
+    servo = _Servo(setpoint_dps=0.0, gain_schedule=True)
+    ang_cmd = _drive_unconverged_angle_segment(servo)
+    assert abs(ang_cmd) > 30.0, f"angle segment should saturate, got {ang_cmd}"
+
+    # #265 EKF-health drop: fall to the rate-null path with the measured rate
+    # already at the setpoint (0). A correct null commands ~0; the pre-#372 bug
+    # would hold ≈ -rate_cap here.
+    null_cmd = servo.gain_sched_null_tick(roll_rate_dps=0.0)
+    assert abs(null_cmd) < 1e-3, (
+        f"rate-null after ANGLE held a residual command ({null_cmd:.3f} deg) — "
+        f"stale pid_setpoint (#372)")
+
+
+def test_pure_gyro_fallback_after_angle_nulls_cleanly():
+    # Same transition but into the pure-gyro fallback (gain schedule off) — the
+    # deepest safety path (EKF unhealthy AND schedule off).
+    servo = _Servo(setpoint_dps=0.0, gain_schedule=False)
+    _drive_unconverged_angle_segment(servo)
+    null_cmd = servo.gyro_null_tick(roll_rate_dps=0.0)
+    assert abs(null_cmd) < 1e-3, (
+        f"pure-gyro rate-null after ANGLE held a residual command "
+        f"({null_cmd:.3f} deg) — stale pid_setpoint (#372)")
+
+
+def test_configured_setpoint_survives_angle_segment():
+    # A non-zero constant-rate setpoint must still govern the rate-null path
+    # after an ANGLE segment — the angle tick must neither clobber it (bug) nor
+    # zero it. P-only: fin cmd == setpoint - measured.
+    servo = _Servo(setpoint_dps=5.0, gain_schedule=False)
+    _drive_unconverged_angle_segment(servo)
+    null_cmd = servo.gyro_null_tick(roll_rate_dps=0.0)
+    assert abs(null_cmd - 5.0) < 1e-3, (
+        f"configured setpoint not honored after ANGLE segment: {null_cmd:.3f}")
+
+
+def test_angle_segment_still_tracks():
+    # Guard the fix didn't perturb angle-mode behavior: a converging angle tick
+    # commands the proportional rate. target-actual = 10°, kp_angle=4 -> 40 dps
+    # cap-clear; inner P-only, measured 0 -> fin cmd -40.
+    servo = _Servo(setpoint_dps=0.0, gain_schedule=False)
+    servo._tick()
+    cmd = servo.s.roll_cmd_deg  # unused; just keep clock aligned
+    cmd = servo.angle_tick(target_deg=10.0, actual_deg=0.0, roll_rate_dps=0.0)
+    assert abs(cmd - (-40.0)) < 1e-4, f"angle tracking changed: {cmd}"


### PR DESCRIPTION
## Summary
Fixes #372. `controlAngle()` wrote its outer-loop rate command (up to ±`rate_cap`, e.g. 60 dps) into the persistent `pid_setpoint`, and nothing restored it — `setSetpoint()` runs only at boot and on `SERVO_CTRL_ENABLE`. After any ANGLE tick, every subsequent rate-null tick (`control` / `controlWithGainSchedule`) held that residual rate instead of nulling.

Post-v4, roll profiles are ANGLE-mode for the whole profile (including hold-last-angle), so the ANGLE→rate-null transition now happens **exactly on the #265 EKF-health gate**: if the EKF goes unhealthy mid-profile, `angle_mode_active` drops and the controller falls to the rate-null path — which then held the stale rate. The bug corrupted the safety fallback itself.

## Fix
Component-level so the FC and the SIL binding both inherit it:
- `controlAngle()` passes its rate command per-tick through a new private `controlToSetpoint(setpoint, rate)`; `pid_setpoint` is now mutated **only** by `setSetpoint()`.
- Gain scheduling split into `applyGainSchedule()` so the angle path schedules gains identically.
- Behavior within angle mode is numerically unchanged.

## Tests
**Host gtest** — new `tests_cpp/test_servo_control.cpp` (6 tests): controlAngle cascade (proportional command, rate cap, angle wrap) + the #372 regression (gain-scheduled null, pure-gyro null, setpoint-honored). The three setpoint tests **fail on the pre-fix component and pass with the fix**.

**SIL regression** — new `tinkerrocket-sim/tests/test_roll_stale_setpoint.py` drives the real firmware controller (the `_servo` binding `closed_loop_sim` flies) through the #265-gate ANGLE→rate-null transition, mirroring the sim's call convention. Also hardens `closed_loop_sim.py` to match flight code: the null-rate branch is now a bare `controlWithGainSchedule` relying on a persistent setpoint seeded once at init (mirroring the firmware boot `setSetpoint`), instead of a per-tick `set_setpoint()` that was masking this exact class of bug. Verified against a clean pre-#372 rebuild: the stale-setpoint tests report a held −60 dps residual and fail; the fix nulls cleanly.

- `ctest` host suite: **393/393 pass**
- Sim suite (worktree build): **46 passed, 1 skipped**

## Note — not bench-reproducible by design
`controlAngle()` is only wired into the in-flight roll-control block; no `GROUND_TEST` / `SERVO_REPLAY` / `SERVO_TEST` command routes through it (ground test uses a separate standalone PID; replay only calls `controlWithGainSchedule`). So this is verified at the unit + SIL level rather than on the pad — the host gtest is its proper bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
