### PR TITLE
fix(oc): serialize TR_FlightLog index/bitmap across cores with a mutex (#388)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -16,6 +16,10 @@ FetchContent_MakeAvailable(googletest)
 include(GoogleTest)
 enable_testing()
 
+# TR_FlightLog's cross-core lock (#388) is a std::mutex on the host build, which
+# needs pthread on Linux. Targets that compile TR_FlightLog.cpp link this.
+find_package(Threads REQUIRED)
+
 # ---------- Path shortcuts ----------
 # Component sources now live under the ESP-IDF tree. The libraries/
 # mirror is being removed in a follow-up; all paths below point at
@@ -265,7 +269,7 @@ target_include_directories(test_tr_flightlog_core PRIVATE
     ${LIB_DIR}/CRC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-target_link_libraries(test_tr_flightlog_core GTest::gtest_main)
+target_link_libraries(test_tr_flightlog_core GTest::gtest_main Threads::Threads)
 gtest_discover_tests(test_tr_flightlog_core)
 
 # ---------- test_tr_ota (#8 phase 2) ----------

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -8,8 +8,12 @@
 #include "fakes/fake_nand_backend.h"
 #include "fakes/memory_bitmap_store.h"
 
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 using tr_flightlog::BLOCK_ALLOCATED;
@@ -1856,4 +1860,178 @@ TEST(TRFlightLogRead, CapsReadAtFileEnd) {
     ASSERT_EQ(fl.readFlightPage("f.bin", 0, out, sizeof(out), out_len), Status::Ok);
     EXPECT_EQ(out_len, 100u);  // capped at final_bytes
     for (size_t i = 0; i < 100; ++i) EXPECT_EQ(out[i], 0x5A);
+}
+
+// ================================================================
+// #388 — cross-core locking. The single flightlog instance is mutated from
+// two pinned tasks: Core-0 flush (prepareFlight / writeFrame / finalizeFlight)
+// and Core-1 oc_loop BLE handler (deleteFlight, listFlights, readFlightPage).
+// Without a lock, a BLE delete concurrent with a flush-side finalize/prepare
+// interleaves two erase+program sequences on the dual index snapshot and can
+// tear BOTH copies -> next boot both CRC-fail and all flight metadata is lost.
+// The fix guards every flight-log entry point with one mutex, so at most one
+// operation touches the NAND / index / bitmap at a time.
+// ================================================================
+
+namespace {
+
+// Wraps a FakeNandBackend and measures how many threads are ever inside a NAND
+// op at once. TR_FlightLog only reaches the backend from inside a guarded
+// flight-log operation, so post-#388 the mutex serializes every caller and the
+// observed concurrency is 1. Pre-fix, the two cores reach the backend at the
+// same time and it climbs to 2.
+//
+// An internal io_mutex_ serializes the inner (non-thread-safe) fake so a
+// pre-fix data race can't segfault it before the assertion runs; concurrency
+// is sampled by an atomic counter taken BEFORE that mutex, with a short window
+// (only while `armed`) so the sample reflects true flight-log-level overlap.
+class SerializationProbeBackend : public tr_flightlog::TR_NandBackend {
+public:
+    explicit SerializationProbeBackend(FakeNandBackend& inner) : inner_(inner) {}
+
+    void arm()  { armed_.store(true); }
+    int  maxConcurrency() const { return max_concurrency_.load(); }
+
+    bool readPage(uint32_t b, uint32_t p, uint8_t* out) override {
+        ScopedProbe probe(*this);
+        std::lock_guard<std::mutex> lk(io_mutex_);
+        return inner_.readPage(b, p, out);
+    }
+    bool programPage(uint32_t b, uint32_t p, const uint8_t* d) override {
+        ScopedProbe probe(*this);
+        std::lock_guard<std::mutex> lk(io_mutex_);
+        return inner_.programPage(b, p, d);
+    }
+    bool eraseBlock(uint32_t b) override {
+        ScopedProbe probe(*this);
+        std::lock_guard<std::mutex> lk(io_mutex_);
+        return inner_.eraseBlock(b);
+    }
+    bool isBlockBad(uint32_t b) override {
+        ScopedProbe probe(*this);
+        std::lock_guard<std::mutex> lk(io_mutex_);
+        return inner_.isBlockBad(b);
+    }
+    bool markBlockBad(uint32_t b) override {
+        ScopedProbe probe(*this);
+        std::lock_guard<std::mutex> lk(io_mutex_);
+        return inner_.markBlockBad(b);
+    }
+
+private:
+    struct ScopedProbe {
+        SerializationProbeBackend& s;
+        explicit ScopedProbe(SerializationProbeBackend& self) : s(self) {
+            int now = s.active_.fetch_add(1) + 1;
+            int prev = s.max_concurrency_.load();
+            while (now > prev &&
+                   !s.max_concurrency_.compare_exchange_weak(prev, now)) {}
+            if (s.armed_.load())  // widen the overlap window during the race phase
+                std::this_thread::sleep_for(std::chrono::microseconds(40));
+        }
+        ~ScopedProbe() { s.active_.fetch_sub(1); }
+        ScopedProbe(const ScopedProbe&) = delete;
+        ScopedProbe& operator=(const ScopedProbe&) = delete;
+    };
+
+    FakeNandBackend& inner_;
+    std::mutex       io_mutex_;
+    std::atomic<int> active_{0};
+    std::atomic<int> max_concurrency_{0};
+    std::atomic<bool> armed_{false};
+};
+
+}  // namespace
+
+TEST(TRFlightLogConcurrency, FlushAndBleOpsAreSerialized) {
+    FakeNandBackend inner;
+    SerializationProbeBackend nand(inner);
+
+    // prealloc_blocks=1 lets us cycle many short flights without exhausting the
+    // region; bitmap_store=nullptr keeps the probe focused on the index path.
+    TR_FlightLog::Config cfg;
+    cfg.prealloc_blocks = 1;
+
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, cfg, nullptr), Status::Ok);
+
+    // Seed a pool of flights for the BLE thread to read and delete.
+    constexpr int kSeeds = 8;
+    for (int i = 0; i < kSeeds; ++i) {
+        uint32_t id = 0;
+        ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+        std::vector<uint8_t> payload(64, static_cast<uint8_t>(i));
+        ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+        char name[32];
+        std::snprintf(name, sizeof(name), "seed_%02d.bin", i);
+        ASSERT_EQ(fl.finalizeFlight(name, 64), Status::Ok);
+    }
+
+    constexpr int kRuns = 60;
+    std::atomic<bool> go{false};
+    std::atomic<int>  created{0};
+
+    // Core-0 role: create + finalize new flights (prepare erase, page write,
+    // index append + dual-copy save).
+    std::thread creator([&] {
+        while (!go.load()) { std::this_thread::yield(); }
+        for (int i = 0; i < kRuns; ++i) {
+            uint32_t id = 0;
+            if (fl.prepareFlight(id) != Status::Ok) continue;
+            std::vector<uint8_t> payload(64, 0xA5);
+            fl.writeFrame(payload.data(), payload.size());
+            char name[32];
+            std::snprintf(name, sizeof(name), "run_%03d.bin", i);
+            if (fl.finalizeFlight(name, 64) == Status::Ok) created.fetch_add(1);
+        }
+    });
+
+    // Core-1 role: read + delete seeded flights, then churn list/read against
+    // the creator's freshly finalized flights.
+    std::thread ble([&] {
+        while (!go.load()) { std::this_thread::yield(); }
+        for (int i = 0; i < kSeeds; ++i) {
+            char name[32];
+            std::snprintf(name, sizeof(name), "seed_%02d.bin", i);
+            uint8_t buf[64];
+            size_t got = 0;
+            fl.readFlightPage(name, 0, buf, sizeof(buf), got);
+            fl.deleteFlight(name);
+        }
+        for (int i = 0; i < kRuns; ++i) {
+            FlightIndexEntry out[4] = {};
+            fl.listFlights(out, 4, 0, 4);
+            char name[32];
+            std::snprintf(name, sizeof(name), "run_%03d.bin", i);
+            uint8_t buf[64];
+            size_t got = 0;
+            fl.readFlightPage(name, 0, buf, sizeof(buf), got);
+        }
+    });
+
+    nand.arm();
+    go.store(true);
+    creator.join();
+    ble.join();
+
+    // (1) The lock held: no two flight-log operations were ever in flight at
+    //     once on the NAND backend. Pre-#388 this reaches 2.
+    EXPECT_EQ(nand.maxConcurrency(), 1)
+        << "flight-log operations overlapped on the NAND backend — index/bitmap "
+           "mutation is not mutually exclusive (#388)";
+
+    // (2) The on-flash index survived intact: reload it and confirm no tear
+    //     (never the empty-both-copies catastrophe) and every surviving entry
+    //     is well-formed.
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, cfg, nullptr), Status::Ok);
+    const size_t n = fl2.index().size();
+    EXPECT_GT(n, 0u) << "index reloaded empty — both snapshot copies torn (#388)";
+    for (size_t i = 0; i < n; ++i) {
+        const FlightIndexEntry& e = fl2.index().at(i);
+        EXPECT_EQ(e.magic, FLGT_MAGIC) << "torn/garbled index entry " << i;
+        EXPECT_GT(std::strlen(e.filename), 0u) << "empty filename at entry " << i;
+        EXPECT_LT(std::strlen(e.filename), sizeof(e.filename))
+            << "unterminated filename at entry " << i;
+    }
 }

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -284,6 +284,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
 }
 
 Status TR_FlightLog::markBlockBad(uint32_t block) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_) return Status::NotInitialized;
     if (block >= NAND_BLOCK_COUNT) return Status::OutOfRange;
     bitmap_.set(block, BLOCK_BAD);
@@ -315,6 +316,7 @@ void TR_FlightLog::requestPrepareFlight() {
 }
 
 bool TR_FlightLog::servicePendingPrepareFlight(uint32_t& id_out, Status& status_out) {
+    FlightLogLockGuard guard(mutex_);
     if (!prepare_request_pending_) return false;
     // Always clear the flag — even when we won't run prepareFlight — so a
     // stale request can't fire on a later iteration after the flight has
@@ -322,11 +324,16 @@ bool TR_FlightLog::servicePendingPrepareFlight(uint32_t& id_out, Status& status_
     prepare_request_pending_ = false;
     if (flight_active_) return false;
 
-    status_out = prepareFlight(id_out);
+    status_out = prepareFlightLocked(id_out);
     return true;
 }
 
 Status TR_FlightLog::prepareFlight(uint32_t& flight_id_out) {
+    FlightLogLockGuard guard(mutex_);
+    return prepareFlightLocked(flight_id_out);
+}
+
+Status TR_FlightLog::prepareFlightLocked(uint32_t& flight_id_out) {
     if (!initialized_) return Status::NotInitialized;
     if (flight_active_)  return Status::Error;  // already flying
 
@@ -390,6 +397,7 @@ bool TR_FlightLog::extendActiveRange() {
 }
 
 Status TR_FlightLog::writeFrame(const uint8_t* payload, size_t payload_len) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_)   return Status::NotInitialized;
     if (!flight_active_) return Status::Error;
     if (payload == nullptr && payload_len != 0) return Status::OutOfRange;
@@ -409,10 +417,17 @@ Status TR_FlightLog::writeFrame(const uint8_t* payload, size_t payload_len) {
     const uint32_t crc = page_crc(page);
     std::memcpy(page, &crc, sizeof(crc));
 
-    return writePage(page);
+    // Lock already held; go straight to the locked impl (writePage would
+    // re-take the non-recursive mutex and deadlock).
+    return writePageLocked(page);
 }
 
 Status TR_FlightLog::writePage(const uint8_t* page) {
+    FlightLogLockGuard guard(mutex_);
+    return writePageLocked(page);
+}
+
+Status TR_FlightLog::writePageLocked(const uint8_t* page) {
     if (!initialized_)  return Status::NotInitialized;
     if (!flight_active_) return Status::Error;
     if (page == nullptr) return Status::OutOfRange;
@@ -446,6 +461,7 @@ Status TR_FlightLog::writePage(const uint8_t* page) {
 }
 
 Status TR_FlightLog::finalizeFlight(const char* filename, uint32_t final_bytes) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_)    return Status::NotInitialized;
     if (!flight_active_)  return Status::Error;
     if (filename == nullptr) return Status::OutOfRange;
@@ -512,6 +528,7 @@ Status TR_FlightLog::finalizeFlight(const char* filename, uint32_t final_bytes) 
 
 size_t TR_FlightLog::listFlights(FlightIndexEntry* out, size_t max,
                                  size_t page, size_t per_page) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_ || out == nullptr || max == 0 || per_page == 0) return 0;
     const size_t total = index_.size();
     const size_t start = page * per_page;
@@ -526,6 +543,7 @@ size_t TR_FlightLog::listFlights(FlightIndexEntry* out, size_t max,
 Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
                                     uint8_t* buf, size_t buf_len,
                                     size_t& out_len) {
+    FlightLogLockGuard guard(mutex_);
     out_len = 0;
     if (!initialized_)       return Status::NotInitialized;
     if (filename == nullptr) return Status::OutOfRange;
@@ -581,6 +599,7 @@ Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
 }
 
 Status TR_FlightLog::deleteFlight(const char* filename) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_)       return Status::NotInitialized;
     if (filename == nullptr) return Status::OutOfRange;
 
@@ -603,6 +622,7 @@ Status TR_FlightLog::deleteFlight(const char* filename) {
 }
 
 Status TR_FlightLog::renameFlight(const char* old_name, const char* new_name) {
+    FlightLogLockGuard guard(mutex_);
     if (!initialized_)      return Status::NotInitialized;
     if (old_name == nullptr || new_name == nullptr) return Status::OutOfRange;
 

--- a/tinkerrocket-idf/components/TR_FlightLog/include/FlightLogLock.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/FlightLogLock.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// Cross-core mutual exclusion for TR_FlightLog's shared index_/bitmap_ state
+// (#388). The single flight-log instance is mutated from two pinned FreeRTOS
+// tasks: the Core-0 flush task (prepareFlight / writeFrame / finalizeFlight)
+// and the Core-1 oc_loop BLE handler (deleteFlight, plus the listFlights /
+// readFlightPage readers). With no lock, a BLE delete concurrent with a
+// flush-side prepare/finalize interleaves two erase+program sequences on the
+// index snapshot blocks (1020/1021) and can tear BOTH copies — next boot the
+// index CRC-fails both and all flight metadata is lost.
+//
+// TR_FlightLog is also compiled on the host for the gtest suite, which has no
+// FreeRTOS, so the primitive is a FreeRTOS mutex on target and a std::mutex on
+// host. The std::mutex is real (not a stub), so the host concurrency
+// regression test exercises genuine mutual exclusion.
+
+#ifdef ESP_PLATFORM
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#else
+#include <mutex>
+#endif
+
+namespace tr_flightlog {
+
+// Non-recursive mutex. TR_FlightLog never re-enters a guarded public method
+// from another guarded public method — the two internal call chains
+// (servicePendingPrepareFlight -> prepareFlight, writeFrame -> writePage) go
+// through private *Locked helpers that assume the lock is already held — so a
+// plain (cheaper) mutex is sufficient and matches the codebase idiom
+// (TR_LogToFlash's spi_mutex_).
+class FlightLogMutex {
+public:
+#ifdef ESP_PLATFORM
+    // Safe to create during C++ static init: xSemaphoreCreateMutex only
+    // allocates a queue structure and does not require the scheduler to be
+    // running. A null handle (allocation failure) degrades lock()/unlock() to
+    // no-ops — i.e. the pre-#388 unlocked behavior, never a crash.
+    FlightLogMutex() : handle_(xSemaphoreCreateMutex()) {}
+    ~FlightLogMutex() { if (handle_) vSemaphoreDelete(handle_); }
+    void lock()   { if (handle_) xSemaphoreTake(handle_, portMAX_DELAY); }
+    void unlock() { if (handle_) xSemaphoreGive(handle_); }
+#else
+    FlightLogMutex() = default;
+    void lock()   { m_.lock(); }
+    void unlock() { m_.unlock(); }
+#endif
+
+    FlightLogMutex(const FlightLogMutex&)            = delete;
+    FlightLogMutex& operator=(const FlightLogMutex&) = delete;
+
+private:
+#ifdef ESP_PLATFORM
+    SemaphoreHandle_t handle_;
+#else
+    std::mutex m_;
+#endif
+};
+
+// RAII scoped lock. Held for the full logical flight-log operation so a
+// multi-step index/bitmap mutation (e.g. FlightIndex::save's inspect -> erase
+// -> program N pages) is atomic with respect to every other flight-log entry
+// point on the other core.
+class FlightLogLockGuard {
+public:
+    explicit FlightLogLockGuard(FlightLogMutex& m) : m_(m) { m_.lock(); }
+    ~FlightLogLockGuard() { m_.unlock(); }
+
+    FlightLogLockGuard(const FlightLogLockGuard&)            = delete;
+    FlightLogLockGuard& operator=(const FlightLogLockGuard&) = delete;
+
+private:
+    FlightLogMutex& m_;
+};
+
+}  // namespace tr_flightlog

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -2,6 +2,7 @@
 
 #include "BlockStateBitmap.h"
 #include "FlightIndex.h"
+#include "FlightLogLock.h"
 #include "TR_BitmapStore.h"
 #include "TR_FlightLog_types.h"
 #include "TR_NandBackend.h"
@@ -142,6 +143,20 @@ private:
     // the consumer is idempotent: a missed clear at worst causes one extra
     // service call that no-ops via the flight_active_ check.
     volatile bool prepare_request_pending_ = false;
+
+    // Guards all mutation/read of index_ and bitmap_ across the two cores that
+    // touch this instance (#388). Held for the whole logical operation.
+    // requestPrepareFlight() deliberately does NOT take it — it only sets the
+    // volatile flag above, so the high-priority I2S task can never block on a
+    // ~770 ms prepareFlight erase that holds the lock.
+    FlightLogMutex mutex_;
+
+    // Lock-held implementations, called by the public wrappers and by the two
+    // internal call chains (servicePendingPrepareFlight -> prepareFlightLocked,
+    // writeFrame -> writePageLocked) so the non-recursive mutex is never taken
+    // twice on one thread.
+    Status prepareFlightLocked(uint32_t& flight_id_out);
+    Status writePageLocked(const uint8_t* page);
 
     void persistBitmap();
     void seedBitmapFromBackend();  // initial bad-block scan into the fresh bitmap


### PR DESCRIPTION
## Summary
Fixes #388. The single `flightlog` instance is mutated from two pinned FreeRTOS tasks with **no lock**:
- **Core 0** — the `log_flush` task: `prepareFlight` / `writeFrame` / `finalizeFlight`
- **Core 1** — `oc_loop` BLE handler: `deleteFlight`, plus the `listFlights` / `readFlightPage` readers

A BLE delete during a flush-side `finalizeFlight`/`prepareFlight` interleaves two erase+program sequences on the dual index snapshot (blocks 1020/1021) and can tear **both** copies → next boot both CRC-fail and **all flight metadata is lost**, after which the brownout scanner merges adjacent orphaned ranges into single `flight_recovered_*` blobs. The in-memory `FlightIndex` (`entries_`/`count_` shifts) and the packed `BlockStateBitmap` RMW race the same way. `beginPhoneIO` gates only Core-1 work, so it gave zero protection against the Core-0 flush task.

## Fix
Guard every flight-log entry point with **one mutex**, held for the whole logical operation, so a multi-step index/bitmap mutation is atomic with respect to any other entry point on the other core. Fully encapsulated in `TR_FlightLog` — **no `main.cpp` change** (the issue's preferred option).

- The two internal call chains (`servicePendingPrepareFlight → prepareFlight`, `writeFrame → writePage`) route through private `*Locked` helpers, so the non-recursive mutex is never taken twice on one thread.
- `requestPrepareFlight` stays **lock-free** — it only sets the volatile deferred-prepare flag, so the high-priority I2S task can never block on a ~770 ms `prepareFlight` erase that holds the lock.
- Lock order is always **flight-log → SPI** (the NAND backend's `spi_mutex_`), never the reverse → no deadlock.
- `TR_FlightLog` is also compiled host-side for gtest, so the primitive is a FreeRTOS mutex on target (matching `TR_LogToFlash`'s `spi_mutex_` idiom) and a `std::mutex` on host — the latter gives the regression test real mutual exclusion. New `FlightLogLock.h` holds the thin `FlightLogMutex` + scoped guard.

## Test
New `TRFlightLogConcurrency.FlushAndBleOpsAreSerialized` drives the **real component** from two threads (a creator finalizing flights vs. a BLE thread deleting/reading) through a probe backend that samples how many operations touch the NAND at once, then reloads the index and asserts no tear.

Verified against the pre-fix component (clean rebuild): **5/5 runs report overlap = 2 and fail**; with the fix everything is serialized (overlap = 1) and the reloaded index stays intact.

- Full host suite: **394/394 pass** (`ctest`)
- `tests_cpp` links `Threads::Threads` for the host `std::mutex`

## Note
The ESP-IDF firmware side (the FreeRTOS-mutex branch, and the static `flightlog` instance creating its mutex during C++ init) is validated by the CI firmware build — I can't build the IDF target locally. The host build exercises the `std::mutex` branch and the full logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
