### PR TITLE
fix(oc): relocate salvaged pages on mid-block NAND program failure (#371)

### DIFF
--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -1016,15 +1016,18 @@ TEST(TRFlightLogWrite, ProgramFailMarksBlockBadAndSkipsToNextBlock) {
     const uint32_t bad_page  = next_rel % NAND_PAGES_PER_BLK;
     nand.injectProgramFailOnce(bad_block, bad_page);
 
-    // Subsequent writePage should skip the now-bad block entirely and land at
-    // the start of the next block.
+    // Subsequent writePage retires the now-bad block. The page already written
+    // in it (page 0) is RELOCATED to the next block rather than orphaned (#371),
+    // and the current write lands right after the relocated page.
     ASSERT_EQ(fl.writePage(buf.data()), Status::Ok);
     EXPECT_EQ(fl.bitmap().get(bad_block), BLOCK_BAD);
     EXPECT_TRUE(nand.isBlockBad(bad_block));
+    EXPECT_EQ(fl.salvagedBlockCount(), 1u);  // one page relocated, not lost
 
-    // Next write position: next-block-page 1 (we just wrote page 0 of the new block).
+    // Next write position: next-block page 2 — page 0 holds the salvaged page,
+    // page 1 holds the write that hit the bad page, so the cursor is at page 2.
     const uint32_t next_written_rel = fl.activePagesWritten();
-    EXPECT_EQ(next_written_rel, (next_rel / NAND_PAGES_PER_BLK + 1) * NAND_PAGES_PER_BLK + 1);
+    EXPECT_EQ(next_written_rel, (next_rel / NAND_PAGES_PER_BLK + 1) * NAND_PAGES_PER_BLK + 2);
 }
 
 TEST(TRFlightLogWrite, OverflowExtendSucceedsWhenAdjacentFree) {
@@ -1756,6 +1759,140 @@ TEST(TRFlightLogFinalize, BadBlockMidFlightKeepsAllDataAndBlocks) {
                   Status::Ok) << "page " << p;
         ASSERT_EQ(out_len, PAYLOAD_PER_PAGE) << "page " << p;
         for (uint8_t b : out) ASSERT_EQ(b, 0x5Au) << "garbage at page " << p;
+    }
+}
+
+// Helper for the #371 relocation tests: fill a page with a byte equal to its
+// logical index so a *shift* (not just a loss) is detectable on read-back.
+// Frame count is kept < 256 so the byte uniquely identifies the frame.
+namespace {
+void writeIndexedFrame(TR_FlightLog& fl, uint32_t idx) {
+    std::vector<uint8_t> payload(PAYLOAD_PER_PAGE, static_cast<uint8_t>(idx));
+    ASSERT_EQ(fl.writeFrame(payload.data(), payload.size()), Status::Ok);
+}
+void expectIndexedReadback(TR_FlightLog& fl, const char* name, uint32_t total) {
+    for (uint32_t p = 0; p < total; ++p) {
+        std::vector<uint8_t> out(PAYLOAD_PER_PAGE, 0xEE);
+        size_t out_len = 0;
+        ASSERT_EQ(fl.readFlightPage(name, p * PAYLOAD_PER_PAGE, out.data(),
+                                    out.size(), out_len), Status::Ok)
+            << "page " << p;
+        ASSERT_EQ(out_len, PAYLOAD_PER_PAGE) << "early EOF at page " << p;
+        for (uint8_t b : out)
+            ASSERT_EQ(b, static_cast<uint8_t>(p))
+                << "misaligned/lost data at logical page " << p;
+    }
+}
+}  // namespace
+
+TEST(TRFlightLogFinalize, MidBlockFailureRelocatesSalvagedPagesInOrder) {
+    // #371: a program failure at page p>0 must relocate the p pages already
+    // written in the block (not orphan them + shift everything after). The
+    // pre-fix code marked the whole block BAD and skipped it, losing those p
+    // pages and misaligning the rest — undetectable with same-byte payloads,
+    // so this fills each page with its logical index.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    const uint32_t start_block = fl.activeStartBlock();
+
+    constexpr uint32_t BLOCK0 = NAND_PAGES_PER_BLK;  // 64 -> fills block 0
+    constexpr uint32_t P      = 10;                  // fail at page 10 of block 1
+    constexpr uint32_t TAIL   = 40;
+    constexpr uint32_t TOTAL  = BLOCK0 + P + TAIL;   // 114 frames (< 256)
+
+    // Frame (BLOCK0+P) is the write that hits the injected failure; the P
+    // frames before it (block 1 pages 0..P-1) are the salvaged ones.
+    nand.injectProgramFailOnce(start_block + 1, P);
+    for (uint32_t i = 0; i < TOTAL; ++i) writeIndexedFrame(fl, i);
+
+    EXPECT_EQ(fl.salvagedBlockCount(), 1u);       // block 1 relocated (p>0)
+    EXPECT_EQ(fl.unrecoverablePageCount(), 0u);   // every page re-read fine
+
+    ASSERT_EQ(fl.finalizeFlight("f.bin", TOTAL * PAYLOAD_PER_PAGE), Status::Ok);
+    const FlightIndexEntry* e = fl.index().findByFilename("f.bin");
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->final_bytes, TOTAL * PAYLOAD_PER_PAGE);
+    EXPECT_EQ(fl.bitmap().get(start_block + 1), BLOCK_BAD);  // retired
+
+    expectIndexedReadback(fl, "f.bin", TOTAL);
+
+    // Survives a reboot (index + data reload) with the same alignment.
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    expectIndexedReadback(fl2, "f.bin", TOTAL);
+}
+
+TEST(TRFlightLogFinalize, MidBlockFailureCascadesToSecondBadBlock) {
+    // Salvage destination ALSO fails mid-relocation: the relocation restarts
+    // into the next block, re-reading the (still-readable) source, so no
+    // salvaged page is dropped even across two bad blocks.
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    const uint32_t start_block = fl.activeStartBlock();
+
+    constexpr uint32_t BLOCK0 = NAND_PAGES_PER_BLK;
+    constexpr uint32_t P      = 10;
+    constexpr uint32_t TAIL   = 40;
+    constexpr uint32_t TOTAL  = BLOCK0 + P + TAIL;
+
+    nand.injectProgramFailOnce(start_block + 1, P);       // block 1 page 10
+    nand.injectProgramFailOnce(start_block + 2, 5);       // block 2 page 5 (salvage dst)
+    for (uint32_t i = 0; i < TOTAL; ++i) writeIndexedFrame(fl, i);
+
+    EXPECT_EQ(fl.salvagedBlockCount(), 1u);       // one source block salvaged
+    EXPECT_EQ(fl.unrecoverablePageCount(), 0u);
+    EXPECT_EQ(fl.bitmap().get(start_block + 1), BLOCK_BAD);
+    EXPECT_EQ(fl.bitmap().get(start_block + 2), BLOCK_BAD);  // failed destination
+
+    ASSERT_EQ(fl.finalizeFlight("f.bin", TOTAL * PAYLOAD_PER_PAGE), Status::Ok);
+    expectIndexedReadback(fl, "f.bin", TOTAL);
+}
+
+TEST(TRFlightLogFinalize, MidBlockFailureUnreadableSalvagePageKeepsAlignment) {
+    // If a salvaged page cannot be re-read (a committed page that won't read
+    // back — genuinely unrecoverable), a zeroed placeholder is written so the
+    // stream stays ALIGNED (one lost page, not a shift of everything after).
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    uint32_t id = 0;
+    ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+    const uint32_t start_block = fl.activeStartBlock();
+
+    constexpr uint32_t BLOCK0 = NAND_PAGES_PER_BLK;
+    constexpr uint32_t P      = 10;
+    constexpr uint32_t TAIL   = 20;
+    constexpr uint32_t TOTAL  = BLOCK0 + P + TAIL;
+    constexpr uint32_t LOST   = BLOCK0 + 3;  // salvage page 3 of block 1 won't read
+
+    nand.injectProgramFailOnce(start_block + 1, P);
+    nand.injectReadErrorPersistent(start_block + 1, 3);  // salvage re-read fails
+    for (uint32_t i = 0; i < TOTAL; ++i) writeIndexedFrame(fl, i);
+
+    EXPECT_EQ(fl.salvagedBlockCount(), 1u);
+    EXPECT_EQ(fl.unrecoverablePageCount(), 1u);  // exactly the one page
+
+    ASSERT_EQ(fl.finalizeFlight("f.bin", TOTAL * PAYLOAD_PER_PAGE), Status::Ok);
+
+    // Every page except the unrecoverable one reads its own index; the lost
+    // page reads as the zeroed placeholder — alignment preserved either way.
+    for (uint32_t p = 0; p < TOTAL; ++p) {
+        std::vector<uint8_t> out(PAYLOAD_PER_PAGE, 0xEE);
+        size_t out_len = 0;
+        ASSERT_EQ(fl.readFlightPage("f.bin", p * PAYLOAD_PER_PAGE, out.data(),
+                                    out.size(), out_len), Status::Ok) << "page " << p;
+        ASSERT_EQ(out_len, PAYLOAD_PER_PAGE) << "page " << p;
+        const uint8_t expect = (p == LOST) ? 0x00 : static_cast<uint8_t>(p);
+        for (uint8_t b : out) ASSERT_EQ(b, expect) << "page " << p;
     }
 }
 

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -449,15 +449,81 @@ Status TR_FlightLog::writePageLocked(const uint8_t* page) {
             return Status::Ok;
         }
 
-        // Program failure: runtime bad-block discovery. Mark bad, skip to
-        // the next block, retry the same data.
-        bitmap_.set(abs_block, BLOCK_BAD);
-        nand_->markBlockBad(abs_block);
-        persistBitmap();
-        // Round up to the next block boundary.
-        active_next_page_ = (rel_block + 1) * NAND_PAGES_PER_BLK;
+        // Program failure: runtime bad-block discovery. Retire the block and
+        // relocate the `page_in_blk` pages already written in it (#371) so the
+        // reader's dense-page model stays correct and no logged data is
+        // orphaned. active_next_page_ is left just past the relocated pages, in
+        // a good block, so the loop retries `page` there.
+        if (!retireBlockAndSalvage(abs_block, rel_block, page_in_blk)) {
+            return Status::NoSpace;
+        }
     }
     return Status::BackendFailed;
+}
+
+bool TR_FlightLog::retireBlockAndSalvage(uint32_t bad_block, uint32_t rel_block,
+                                         uint32_t valid_pages) {
+    bitmap_.set(bad_block, BLOCK_BAD);
+    nand_->markBlockBad(bad_block);
+    persistBitmap();
+    active_next_page_ = (rel_block + 1) * NAND_PAGES_PER_BLK;
+
+    // page-0 failure: nothing was written in the block, so it's a clean
+    // skip-ahead with nothing to relocate (the pre-#371 behavior).
+    if (valid_pages == 0) return true;
+    ++salvaged_block_count_;
+    FL_LOGW("bad block %lu mid-flight: relocating %lu already-written pages (#371)",
+            (unsigned long)bad_block, (unsigned long)valid_pages);
+
+    // Relocate pages [0, valid_pages) of the retired block to the write cursor.
+    // The retired block stays readable for its committed pages (the failure was
+    // on a *later* page), so each is re-read and reprogrammed densely into the
+    // next good block(s). If a destination block ALSO fails mid-relocation, it
+    // is retired and the relocation restarts from page 0 into the next block —
+    // the source is still readable, so no salvaged page is dropped. Restarts
+    // are bounded by the number of blocks available.
+    uint8_t buf[NAND_PAGE_SIZE];
+    const uint32_t max_restarts = active_n_blocks_ + cfg_.extend_blocks + 1;
+    uint32_t restarts = 0;
+    uint32_t i = 0;
+    while (i < valid_pages) {
+        const uint32_t rel = active_next_page_ / NAND_PAGES_PER_BLK;
+        if (rel >= active_n_blocks_) {
+            if (!extendActiveRange()) return false;
+            continue;
+        }
+        const uint32_t dst_block = active_start_block_ + rel;
+        const uint32_t dst_page  = active_next_page_ % NAND_PAGES_PER_BLK;
+
+        if (!nand_->readPage(bad_block, i, buf)) {
+            // A committed page that will not read back — genuinely
+            // unrecoverable. Write a zeroed placeholder so the stream stays
+            // aligned (one lost page beats orphaning + shifting everything
+            // after it) and flag it.
+            std::memset(buf, 0x00, sizeof(buf));
+            ++unrecoverable_page_count_;
+            FL_LOGW("salvage: page %lu of retired block %lu unreadable — wrote "
+                    "zeroed placeholder to keep the stream aligned (#371)",
+                    (unsigned long)i, (unsigned long)bad_block);
+        }
+
+        if (nand_->programPage(dst_block, dst_page, buf)) {
+            ++active_next_page_;
+            ++i;
+            continue;
+        }
+
+        // Destination is bad too. Retire it and restart the relocation from
+        // page 0 into the next block (partial copies in dst_block are abandoned
+        // — the reader skips the BAD block; the source is re-read intact).
+        bitmap_.set(dst_block, BLOCK_BAD);
+        nand_->markBlockBad(dst_block);
+        persistBitmap();
+        active_next_page_ = (rel + 1) * NAND_PAGES_PER_BLK;
+        i = 0;
+        if (++restarts > max_restarts) return false;
+    }
+    return true;
 }
 
 Status TR_FlightLog::finalizeFlight(const char* filename, uint32_t final_bytes) {

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -65,6 +65,16 @@ public:
     // Useful for post-flight log analysis to spot overflow events.
     uint32_t  overflowExtensionCount() const { return extension_count_; }
 
+    // #371 diagnostics. salvagedBlockCount(): runtime bad blocks that had
+    // already-written pages relocated to a good block (distinguishes a
+    // mid-block program failure — where data was preserved — from a clean
+    // page-0 skip-ahead, which relocates nothing). unrecoverablePageCount():
+    // salvaged pages that could not be re-read from the retired block and were
+    // replaced with a zeroed placeholder to keep the stream aligned (expected
+    // to stay 0; a non-zero value flags genuine, unavoidable loss).
+    uint32_t  salvagedBlockCount()    const { return salvaged_block_count_; }
+    uint32_t  unrecoverablePageCount() const { return unrecoverable_page_count_; }
+
     // Pre-launch: pick + erase a free contiguous range. May stall ~770 ms.
     // Writes the assigned flight_id to `flight_id_out` on success.
     //
@@ -136,6 +146,8 @@ private:
     uint32_t active_n_blocks_     = 0;
     uint32_t active_next_page_    = 0;  // absolute page index within the flight range
     uint32_t extension_count_     = 0;
+    uint32_t salvaged_block_count_    = 0;  // #371: bad blocks whose pages were relocated
+    uint32_t unrecoverable_page_count_ = 0; // #371: salvage pages that would not re-read
     bool     flight_active_       = false;
 
     // Single-producer (any task) / single-consumer (flush task) request flag
@@ -157,6 +169,17 @@ private:
     // twice on one thread.
     Status prepareFlightLocked(uint32_t& flight_id_out);
     Status writePageLocked(const uint8_t* page);
+
+    // On a mid-block program failure, retire `bad_block` (relative index
+    // `rel_block`) and relocate the `valid_pages` pages already written at its
+    // start to the next good block(s), advancing active_next_page_ to just past
+    // them so the caller can retry the failed write there. The retired block
+    // stays readable for its committed pages (the failure was on a later page),
+    // so each is re-read and reprogrammed; a destination that also fails is
+    // retired and the whole relocation restarts into the next block, so no
+    // salvaged page is dropped. Returns false only on NoSpace. (#371)
+    bool retireBlockAndSalvage(uint32_t bad_block, uint32_t rel_block,
+                               uint32_t valid_pages);
 
     void persistBitmap();
     void seedBitmapFromBackend();  // initial bad-block scan into the fresh bitmap

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -267,9 +267,12 @@ static void flightlogServicePendingFinalize()
     if (st == tr_flightlog::Status::Ok)
     {
         ESP_LOGI("FLIGHTLOG",
-                 "finalizeFlight OK (deferred): %s (%u bytes, %u extensions)",
+                 "finalizeFlight OK (deferred): %s (%u bytes, %u extensions, "
+                 "%u salvaged bad blocks, %u unrecoverable pages)",
                  name_local, (unsigned)bytes,
-                 (unsigned)flightlog.overflowExtensionCount());
+                 (unsigned)flightlog.overflowExtensionCount(),
+                 (unsigned)flightlog.salvagedBlockCount(),
+                 (unsigned)flightlog.unrecoverablePageCount());
     }
     else
     {


### PR DESCRIPTION
## Summary
Fixes #371. When `programPage` failed at page **p>0** of a block, `writePage` marked the **whole block BAD** and skipped to the next block — but pages 0..p−1 were already programmed and counted by the caller (`lastClosedSessionBytes` → `final_bytes`), while `readFlightPage` **skips BAD blocks entirely**. So up to ~126 KB of already-flushed flight data was silently orphaned **and** every page after that block boundary shifted by p, so the download read short and misaligned mid-stream. The existing gtest only injected at page 0 (the one benign case where nothing was written yet), so it never caught this.

## Fix — relocate (not truncate)
Chosen because flight data is irreplaceable; relocation is also the standard NAND bad-block-management pattern. On a mid-block program failure:
1. Retire the block (mark BAD + `markBlockBad` + persist).
2. Re-read its p committed pages (a block that failed a *later* program still reads its earlier pages) and reprogram them densely into the next good block.
3. Retry the failed write right after them.

The reader's "dense pages across non-BAD blocks" model is preserved — **no reader or index-schema change**. Robustness:
- A **destination block that also fails** mid-relocation is retired and the relocation **restarts** into the next block (source re-read intact) → no salvaged page dropped; restarts bounded by block count.
- A committed page that **won't re-read** (genuinely unrecoverable) is replaced with a **zeroed placeholder** so the stream stays *aligned* rather than shifting everything after it.

Adds `salvagedBlockCount()` / `unrecoverablePageCount()` (the issue's "distinguish this from a clean skip-ahead"), an `FL_LOGW` at each salvage/loss event, and surfaces the counts in the OC `finalizeFlight` log line.

## Tests
Three new `test_tr_flightlog_core` cases, each with **index-encoded payloads** (each page filled with its logical index, so a *shift* is caught — the old test's same-byte fill couldn't):
- `MidBlockFailureRelocatesSalvagedPagesInOrder` — in-order relocation + reboot reload
- `MidBlockFailureCascadesToSecondBadBlock` — salvage destination also fails
- `MidBlockFailureUnreadableSalvagePageKeepsAlignment` — placeholder preserves alignment

All three **fail on the pre-fix component, pass with the fix** (verified via a clean revert). Also updated `ProgramFailMarksBlockBadAndSkipsToNextBlock`, which had encoded the old orphan behavior (p=1), to assert relocation. **Host suite: 397/397.**

## Bench-validation note
Salvage re-reads a block's committed pages *after* `markBlockBad`. Standard SPI NAND puts the bad-block marker in the page-0 **spare/OOB** area, leaving main data readable — but this is the one behavior best confirmed on real hardware (inject/observe a mid-block bad block, download, verify the file is complete and aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
