### PR TITLE
fix(bs): gate uplink transmit on frequency-scan state (#379)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -308,6 +308,18 @@ target_include_directories(test_bs_log_policy PRIVATE
 target_link_libraries(test_bs_log_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_log_policy)
 
+# ---------- test_bs_uplink_policy ----------
+# Host-side test for the base-station uplink transmit gate (#379): an uplink TX
+# during a LoRa frequency scan must be deferred, not sent on the scan channel.
+# bs_uplink_policy.h is pure, so the test just adds the base_station/main dir.
+add_executable(test_bs_uplink_policy test_bs_uplink_policy.cpp)
+target_include_directories(test_bs_uplink_policy PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_uplink_policy GTest::gtest_main)
+gtest_discover_tests(test_bs_uplink_policy)
+
 # ---------- test_burnout_detector (#197/#256) ----------
 # Detector logic is shared with the firmware via
 # components/TR_KinematicChecks/BurnoutDetector.h — the test exercises the

--- a/tests_cpp/test_bs_uplink_policy.cpp
+++ b/tests_cpp/test_bs_uplink_policy.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include "bs_uplink_policy.h"
+
+using bs_uplink_policy::mayTransmitUplink;
+
+// The #379 fix: an uplink command must NOT be transmitted while a LoRa
+// frequency scan is running (scan_passes_remaining != 0), because the TX would
+// go out on the scan's dwell channel — silently missing the rocket and
+// corrupting the pass's RSSI. Gating here (before the send that consumes a
+// retry) also defers the command until the scan finishes rather than dropping
+// it.
+
+namespace {
+constexpr uint8_t RETRIES = 8;  // config::UPLINK_RETRIES
+}
+
+// ---- No command pending ----
+
+TEST(BsUplinkPolicy, NoTransmitWhenNothingPending) {
+    EXPECT_FALSE(mayTransmitUplink(/*pending=*/false, RETRIES, /*scan=*/0,
+                                   /*can_send=*/true));
+}
+
+TEST(BsUplinkPolicy, NoTransmitWhenRetriesExhausted) {
+    EXPECT_FALSE(mayTransmitUplink(/*pending=*/true, /*retries=*/0, /*scan=*/0,
+                                   /*can_send=*/true));
+}
+
+// ---- The scan gate (#379) ----
+
+TEST(BsUplinkPolicy, NoTransmitDuringScanEvenWhenRadioReady) {
+    // The regression: a pending command with retries and a ready radio must
+    // still be held while any scan pass remains.
+    EXPECT_FALSE(mayTransmitUplink(/*pending=*/true, RETRIES,
+                                   /*scan_passes_remaining=*/1,
+                                   /*can_send=*/true));
+    EXPECT_FALSE(mayTransmitUplink(/*pending=*/true, RETRIES,
+                                   /*scan_passes_remaining=*/5,
+                                   /*can_send=*/true));
+}
+
+TEST(BsUplinkPolicy, RetriesPreservedImpliesDeferNotDrop) {
+    // While scanning we refuse; the caller returns before decrementing retries,
+    // so the SAME slot (still pending, retries intact) transmits once the scan
+    // completes (scan_passes_remaining hits 0). Model that transition here.
+    const uint8_t retries = 4;  // some retries already used, some left
+    EXPECT_FALSE(mayTransmitUplink(true, retries, /*scan=*/2, /*can_send=*/true));
+    EXPECT_TRUE(mayTransmitUplink(true, retries, /*scan=*/0, /*can_send=*/true));
+}
+
+// ---- Normal (no scan) behavior unchanged ----
+
+TEST(BsUplinkPolicy, TransmitsWhenPendingReadyAndNotScanning) {
+    EXPECT_TRUE(mayTransmitUplink(/*pending=*/true, RETRIES, /*scan=*/0,
+                                  /*can_send=*/true));
+}
+
+TEST(BsUplinkPolicy, NoTransmitWhenRadioBusy) {
+    // canSend() false (previous TX in progress) still blocks, scan or not.
+    EXPECT_FALSE(mayTransmitUplink(/*pending=*/true, RETRIES, /*scan=*/0,
+                                   /*can_send=*/false));
+}

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -171,6 +171,15 @@ bool TR_LoRa_Comms::send(const uint8_t* payload, size_t len)
     {
         return false;
     }
+    // A scan owns the radio's tuning; transmitting now would go out on whatever
+    // channel it is dwelling on and corrupt the pass. Refuse, mirroring
+    // hopToFrequencyMHz's can't-retune-mid-scan guard (#379). Callers should
+    // gate on their own scan tracking too (see serviceUplink) — this is the
+    // driver-level backstop.
+    if (isScanActive())
+    {
+        return false;
+    }
 
     // Switch out of RX mode if active
     rx_mode_ = false;
@@ -198,7 +207,7 @@ bool TR_LoRa_Comms::send(const uint8_t* payload, size_t len)
 
 bool TR_LoRa_Comms::canSend() const
 {
-    return enabled_ && !tx_ongoing_;
+    return enabled_ && !tx_ongoing_ && !isScanActive();  // #379: not mid-scan
 }
 
 void TR_LoRa_Comms::getStats(Stats& out) const

--- a/tinkerrocket-idf/projects/base_station/main/bs_uplink_policy.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_uplink_policy.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Base-station uplink transmit-gate policy (#379).
+//
+// Pure predicate extracted from main.cpp's serviceUplink so the host-side gtest
+// can drive it without the LoRa radio / BLE stack.  Must stay free of ESP-IDF /
+// FreeRTOS / hardware dependencies.
+
+#include <cstdint>
+
+namespace bs_uplink_policy {
+
+// Whether serviceUplink may START an uplink transmit this pass.
+//
+// The scan gate (scan_passes_remaining == 0) is the #379 fix. A frequency scan
+// owns the radio's tuning for its whole 5-pass run; an uplink TX started during
+// it goes out on whatever channel the scan is currently dwelling on — so the
+// command silently never reaches the rocket (there is no ACK to catch it) and
+// the transmission corrupts that pass's RSSI samples. serviceHeartbeat already
+// gates on the same counter (main.cpp: `if (scan_passes_remaining_ != 0)
+// return;`); user uplink commands must too.
+//
+// scan_passes_remaining_ is used rather than the LoRa driver's per-pass
+// scan_state_ because it stays non-zero across the ENTIRE scan, including the
+// brief inter-pass gaps where the next pass is re-armed — exactly the windows a
+// per-pass guard would miss.
+//
+// Because serviceUplink returns before the send() that consumes a retry, gating
+// here defers the command (retries intact) until the scan finishes, rather than
+// dropping it.
+static inline bool mayTransmitUplink(bool uplink_pending,
+                                     uint8_t retries_left,
+                                     uint8_t scan_passes_remaining,
+                                     bool radio_can_send)
+{
+    if (!uplink_pending || retries_left == 0) return false;
+    if (scan_passes_remaining != 0)           return false;  // #379: defer through the scan
+    return radio_can_send;
+}
+
+}  // namespace bs_uplink_policy

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include "bs_log_policy.h"        // parseSequentialFilename() (#137)
+#include "bs_uplink_policy.h"     // mayTransmitUplink() scan gate (#379)
 
 #include <TR_LoRa_Comms.h>
 #include <TR_Sensor_Data_Converter.h>
@@ -1463,9 +1464,17 @@ static void serviceUplink()
         return;  // Wait between retries
     }
 
-    if (!lora_comms.canSend())
+    // #379: gate the transmit on radio-ready AND not-scanning. A TX during a
+    // frequency scan goes out on the scan's dwell channel (silently missing the
+    // rocket, no ACK to catch it) and corrupts that pass's RSSI — so defer.
+    // Returning here before send() preserves uplink_retries_left, so the command
+    // fires once the scan completes instead of being lost. Mirrors
+    // serviceHeartbeat's scan_passes_remaining_ gate.
+    if (!bs_uplink_policy::mayTransmitUplink(uplink_pending, uplink_retries_left,
+                                             scan_passes_remaining_,
+                                             lora_comms.canSend()))
     {
-        return;  // Previous TX still in progress
+        return;  // radio busy, or a scan owns the channel — retry next pass
     }
 
     if (lora_comms.send(uplink_buf, uplink_len))


### PR DESCRIPTION
## Summary
Fixes #379. `serviceUplink` called `canSend()`/`send()` with **no scan guard**, and the LoRa driver's `canSend()`/`send()` only checked `tx_ongoing_`. So an uplink command (camera / logging / relay) sent during a frequency scan transmitted on **whatever channel the scan was dwelling on** — the command silently never reached the rocket (blind uplink, no ACK to catch it) **and** the TX corrupted that pass's RSSI samples. `serviceScan`'s next `setFrequency` over the live TX could also wedge the radio until the 3 s watchdog. `serviceHeartbeat` already gates on `scan_passes_remaining_` (#136); user commands didn't.

## Fix
Gate `serviceUplink` on `scan_passes_remaining_`, via a new pure predicate `bs_uplink_policy::mayTransmitUplink(...)`, mirroring the heartbeat gate. That counter is the right one (not the driver's per-pass `scan_state_`): it stays non-zero across the **whole 5-pass scan including the inter-pass gaps** a per-pass guard would miss, and it's set for **both** the standalone noise scan and the coordinated scan (which delegates its RSSI phase to `startNoiseScan`).

- **Defer, not drop:** the gate returns *before* the `send()` that decrements `uplink_retries_left`, so the command sits pending with retries intact and fires once the scan completes. No queue needed.
- **Driver backstop:** added `isScanActive()` to `TR_LoRa_Comms::send()`/`canSend()` (mirrors `hopToFrequencyMHz`) so the radio refuses to transmit mid-scan regardless of caller — the issue's literal suggestion, as defense-in-depth.
- Does **not** block the coordinated scan's own channel-set push (that runs after `scan_passes_remaining_` reaches 0).

## Test
New host `test_bs_uplink_policy` (6 cases), mirroring the `bs_log_policy.h` host-seam pattern: refuses while any scan pass remains even with a ready radio (the #379 regression), transmits when idle, defers-not-drops across the scan→idle transition, and respects pending/retries/`canSend`. **Host suite 403/403.**

## Notes
- The `TR_LoRa_Comms` driver changes compile only in the ESP-IDF base-station build (validated by CI's `build (base_station)`); the gate *logic* is covered by the host test.
- Bench check: run the iOS Frequency Scan, then tap camera/logging mid-scan — the command should fire cleanly **after** the scan finishes (not vanish), and the scan's RSSI plot should be free of the self-inflicted TX spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
