### PR TITLE
fix(bs): make BLE log download cooperative — one chunk per loop pass (#380)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -320,6 +320,18 @@ target_include_directories(test_bs_uplink_policy PRIVATE
 target_link_libraries(test_bs_uplink_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_policy)
 
+# ---------- test_bs_download_policy ----------
+# Host-side test for the base-station cooperative BLE download (#380): chunk
+# planning bounded by open-time file size + the 15 ms notify-drain pacing gate.
+# bs_download_policy.h is pure, so the test just adds the base_station/main dir.
+add_executable(test_bs_download_policy test_bs_download_policy.cpp)
+target_include_directories(test_bs_download_policy PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_download_policy GTest::gtest_main)
+gtest_discover_tests(test_bs_download_policy)
+
 # ---------- test_burnout_detector (#197/#256) ----------
 # Detector logic is shared with the firmware via
 # components/TR_KinematicChecks/BurnoutDetector.h — the test exercises the

--- a/tests_cpp/test_bs_download_policy.cpp
+++ b/tests_cpp/test_bs_download_policy.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include "bs_download_policy.h"
+
+using bs_download_policy::mayEmitChunk;
+using bs_download_policy::nextChunk;
+
+// #380: the BLE download is a per-loop-iteration state machine; these helpers
+// carry its chunk arithmetic (bounded by the size measured at open) and the
+// 15 ms wall-time pacing the BLE notify path needs to drain its mbufs.
+
+namespace {
+constexpr uint32_t CHUNK = 170;   // config::BLE_FILE_CHUNK_SIZE
+constexpr uint32_t DELAY = 15;    // config::BLE_CHUNK_DELAY_MS
+}
+
+// ---- nextChunk ----
+
+TEST(BsDownloadPolicy, EmptyFileIsSingleEmptyEofChunk) {
+    const auto p = nextChunk(/*file_size=*/0, /*offset=*/0, CHUNK);
+    EXPECT_EQ(p.read_len, 0u);
+    EXPECT_TRUE(p.eof);
+}
+
+TEST(BsDownloadPolicy, FileSmallerThanChunkIsSingleEofChunk) {
+    const auto p = nextChunk(100, 0, CHUNK);
+    EXPECT_EQ(p.read_len, 100u);
+    EXPECT_TRUE(p.eof);
+}
+
+TEST(BsDownloadPolicy, MidFileChunkIsFullSizeNotEof) {
+    const auto p = nextChunk(10 * CHUNK, 3 * CHUNK, CHUNK);
+    EXPECT_EQ(p.read_len, CHUNK);
+    EXPECT_FALSE(p.eof);
+}
+
+TEST(BsDownloadPolicy, ExactMultipleFlagsEofOnFinalFullChunk) {
+    // size == 4 chunks: the 4th chunk is full AND terminal — eof must ride on
+    // it, not require a 5th empty chunk.
+    const auto p = nextChunk(4 * CHUNK, 3 * CHUNK, CHUNK);
+    EXPECT_EQ(p.read_len, CHUNK);
+    EXPECT_TRUE(p.eof);
+}
+
+TEST(BsDownloadPolicy, RemainderTailChunkFlagsEof) {
+    const auto p = nextChunk(4 * CHUNK + 37, 4 * CHUNK, CHUNK);
+    EXPECT_EQ(p.read_len, 37u);
+    EXPECT_TRUE(p.eof);
+}
+
+TEST(BsDownloadPolicy, OffsetAtOrPastSizeIsEmptyEof) {
+    // Defensive: never a negative/underflowed read, always terminal.
+    for (uint32_t off : {4 * CHUNK, 4 * CHUNK + 1, 100 * CHUNK}) {
+        const auto p = nextChunk(4 * CHUNK, off, CHUNK);
+        EXPECT_EQ(p.read_len, 0u) << "offset " << off;
+        EXPECT_TRUE(p.eof) << "offset " << off;
+    }
+}
+
+TEST(BsDownloadPolicy, WalkedTransferDeliversExactlyFileSizeAndTerminates) {
+    // The no-hang property: iterating plan->advance covers the whole file,
+    // flags eof exactly once (on the last chunk), and never overshoots.
+    const uint32_t size = 3 * CHUNK + 121;  // 3 full chunks + a tail
+    uint32_t offset = 0;
+    uint32_t chunks = 0;
+    bool done = false;
+    while (!done) {
+        ASSERT_LT(chunks, 100u) << "transfer did not terminate";
+        const auto p = nextChunk(size, offset, CHUNK);
+        offset += p.read_len;
+        done = p.eof;
+        ++chunks;
+    }
+    EXPECT_EQ(offset, size);
+    EXPECT_EQ(chunks, 4u);
+}
+
+// ---- mayEmitChunk (pacing) ----
+
+TEST(BsDownloadPolicy, FirstChunkEmitsImmediately) {
+    EXPECT_TRUE(mayEmitChunk(/*now=*/12345, /*last=*/0, DELAY));
+}
+
+TEST(BsDownloadPolicy, WithinDrainIntervalHolds) {
+    EXPECT_FALSE(mayEmitChunk(1000, 990, DELAY));   // 10 ms < 15 ms
+    EXPECT_FALSE(mayEmitChunk(1014, 1000, DELAY));  // 14 ms
+}
+
+TEST(BsDownloadPolicy, AtOrPastDrainIntervalEmits) {
+    EXPECT_TRUE(mayEmitChunk(1015, 1000, DELAY));
+    EXPECT_TRUE(mayEmitChunk(2000, 1000, DELAY));
+}
+
+TEST(BsDownloadPolicy, MillisWraparoundStillPaces) {
+    // last stamped just before uint32 wrap; now just after. Unsigned
+    // subtraction must see the true elapsed time, not a huge negative.
+    const uint32_t last = 0xFFFFFFF8u;              // 8 ticks before wrap
+    EXPECT_FALSE(mayEmitChunk(/*now=*/2, last, DELAY));   // elapsed 10 ms
+    EXPECT_TRUE(mayEmitChunk(/*now=*/7, last, DELAY));    // elapsed 15 ms
+}

--- a/tinkerrocket-idf/projects/base_station/main/bs_download_policy.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_download_policy.h
@@ -1,0 +1,53 @@
+#pragma once
+
+// Base-station BLE file-download chunking policy (#380).
+//
+// Pure helpers extracted from main.cpp's cooperative download state machine so
+// the host-side gtest can drive them without SD/FILE* or the BLE stack.  Must
+// stay free of ESP-IDF / FreeRTOS / hardware dependencies.
+//
+// Background: the download used to run as a synchronous while-loop on the
+// single bs_loop task (fread + sendFileChunk + delay(15 ms) per 170 B chunk),
+// blocking telemetry RX, uplink retries, heartbeats, and CSV flushes for the
+// whole transfer (~11 s per 120 KB; minutes for a multi-MB log). It is now a
+// per-loop-iteration state machine; these predicates carry the arithmetic.
+
+#include <cstdint>
+
+namespace bs_download_policy {
+
+struct ChunkPlan {
+    uint32_t read_len;  // bytes to read/send this chunk (0 => empty-EOF chunk)
+    bool     eof;       // set the EOF flag on this chunk (terminal)
+};
+
+// Plan the next chunk of a transfer bounded by the file size measured at open.
+// Bounding by the open-time size keeps a download of the ACTIVE (still-growing)
+// log finite; growth past `file_size` is simply not part of this transfer.
+//
+// The empty-file case (file_size == 0) falls out naturally: read_len 0 +
+// eof true == the single empty EOF chunk the old code special-cased.
+static inline ChunkPlan nextChunk(uint32_t file_size, uint32_t offset,
+                                  uint32_t chunk_size)
+{
+    ChunkPlan p{};
+    const uint32_t remaining = (offset < file_size) ? (file_size - offset) : 0;
+    p.read_len = (remaining < chunk_size) ? remaining : chunk_size;
+    p.eof      = (offset + p.read_len >= file_size);
+    return p;
+}
+
+// Inter-chunk pacing gate. The 15 ms spacing is NOT arbitrary — it mirrors
+// notify_data()'s mbuf drain budget (TR_BLE_To_APP), giving the controller
+// time to flush notifications so the pool doesn't exhaust. The bs_loop
+// iterates every ~1 ms, so the state machine must gate on wall time, not on
+// loop cadence. last_chunk_ms == 0 means "no chunk sent yet" -> send now.
+// Unsigned subtraction keeps the comparison millis()-wraparound-safe.
+static inline bool mayEmitChunk(uint32_t now_ms, uint32_t last_chunk_ms,
+                                uint32_t min_interval_ms)
+{
+    if (last_chunk_ms == 0) return true;
+    return (now_ms - last_chunk_ms) >= min_interval_ms;
+}
+
+}  // namespace bs_download_policy

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "bs_log_policy.h"        // parseSequentialFilename() (#137)
 #include "bs_uplink_policy.h"     // mayTransmitUplink() scan gate (#379)
+#include "bs_download_policy.h"   // nextChunk()/mayEmitChunk() pacing (#380)
 
 #include <TR_LoRa_Comms.h>
 #include <TR_Sensor_Data_Converter.h>
@@ -1033,10 +1034,54 @@ static void handleDeleteCommand()
     handleFileListCommand();
 }
 
-static void handleDownloadCommand()
+// ---------------------------------------------------------------------------
+// Cooperative BLE file download (#380).
+//
+// The download used to run to completion inside the command dispatch — a
+// synchronous fread/sendFileChunk/delay(15 ms) loop on the single bs_loop
+// task. A 120 KB CSV blocked the loop ~11 s (a multi-MB log for minutes),
+// starving telemetry RX, uplink retries, heartbeats, the LoRa transaction /
+// recovery state machines, and CSV flushes; a >5 min download silence-closed
+// the active log. It is now a state machine serviced once per loop iteration
+// (mirroring coord_scan_state_): startDownload() opens the file and captures
+// state, serviceDownload() emits at most one chunk per pass, gated on the
+// same 15 ms wall-time spacing the BLE notify path needs to drain its mbufs
+// (bs_download_policy::mayEmitChunk — the loop runs ~1 ms, so pacing must be
+// wall-time, not loop cadence). Throughput is unchanged (~11 KB/s); the loop
+// keeps servicing everything else between chunks.
+static FILE*    dl_file_          = nullptr;
+static uint32_t dl_file_size_     = 0;
+static uint32_t dl_offset_        = 0;
+static uint32_t dl_last_chunk_ms_ = 0;
+static char     dl_name_[40]      = {0};  // for logging only
+
+static void finishDownload(const char* outcome)
 {
+    ESP_LOGI(TAG, "[BLE] Download %s: %s (%lu of %lu bytes sent)",
+             outcome, dl_name_, (unsigned long)dl_offset_,
+             (unsigned long)dl_file_size_);
+    if (dl_file_ != nullptr) fclose(dl_file_);
+    dl_file_          = nullptr;
+    dl_file_size_     = 0;
+    dl_offset_        = 0;
+    dl_last_chunk_ms_ = 0;
+    dl_name_[0]       = '\0';
+}
+
+static void startDownload()
+{
+    // getDownloadFilename() clears on read — capture everything now; the
+    // per-iteration service below must not touch the BLE pending slot.
     String filename = ble_app.getDownloadFilename();
     if (filename.length() == 0) return;
+
+    if (dl_file_ != nullptr)
+    {
+        // A new request supersedes an in-flight transfer (same "latest wins"
+        // semantics as the uplink slot). The app only runs one download UI.
+        ESP_LOGW(TAG, "[BLE] New download request supersedes active transfer");
+        finishDownload("superseded");
+    }
 
     char path[64];
     snprintf(path, sizeof(path), "%s/%s", SD_MOUNT_POINT, filename.c_str());
@@ -1048,41 +1093,68 @@ static void handleDownloadCommand()
         return;
     }
 
-    // Get file size
+    // Size measured at open bounds the whole transfer — a still-growing active
+    // log downloads the bytes that existed at request time and terminates.
     fseek(f, 0, SEEK_END);
-    uint32_t file_size = (uint32_t)ftell(f);
+    dl_file_size_ = (uint32_t)ftell(f);
     fseek(f, 0, SEEK_SET);
 
-    uint32_t offset = 0;
-    uint8_t chunk_buf[config::BLE_FILE_CHUNK_SIZE];
+    dl_file_          = f;
+    dl_offset_        = 0;
+    dl_last_chunk_ms_ = 0;
+    snprintf(dl_name_, sizeof(dl_name_), "%s", filename.c_str());
 
     ESP_LOGI(TAG, "[BLE] Starting download: %s (%lu bytes)",
-             filename.c_str(), (unsigned long)file_size);
+             dl_name_, (unsigned long)dl_file_size_);
+}
 
-    while (!feof(f))
+static void serviceDownload()
+{
+    if (dl_file_ == nullptr) return;
+
+    if (!ble_app.isConnected())
     {
-        if (!ble_app.isConnected())
+        // Abort without an EOF chunk, matching the old behavior — the peer is
+        // gone, and a reconnecting app re-requests from scratch.
+        ESP_LOGW(TAG, "[BLE] Disconnected during download, aborting");
+        finishDownload("aborted");
+        return;
+    }
+
+    const uint32_t now = millis();
+    if (!bs_download_policy::mayEmitChunk(now, dl_last_chunk_ms_,
+                                          config::BLE_CHUNK_DELAY_MS))
+    {
+        return;  // BLE notify path still draining — try next iteration
+    }
+
+    const auto plan = bs_download_policy::nextChunk(
+        dl_file_size_, dl_offset_, config::BLE_FILE_CHUNK_SIZE);
+
+    uint8_t chunk_buf[config::BLE_FILE_CHUNK_SIZE];
+    size_t got = 0;
+    if (plan.read_len > 0)
+    {
+        got = fread(chunk_buf, 1, plan.read_len, dl_file_);
+        if (got == 0)
         {
-            ESP_LOGW(TAG, "[BLE] Disconnected during download, aborting");
-            break;
+            // Unexpected short read (SD error / file truncated underneath us).
+            // Terminate with an empty EOF chunk so the app doesn't hang — the
+            // old loop just stopped here without ever flagging EOF.
+            ESP_LOGE(TAG, "[BLE] Download read failed at offset %lu of %s",
+                     (unsigned long)dl_offset_, dl_name_);
+            ble_app.sendFileChunk(dl_offset_, nullptr, 0, true);
+            finishDownload("failed");
+            return;
         }
-        size_t got = fread(chunk_buf, 1, config::BLE_FILE_CHUNK_SIZE, f);
-        if (got == 0) break;
-        bool eof = feof(f);
-        ble_app.sendFileChunk(offset, chunk_buf, got, eof);
-        offset += got;
-        delay(config::BLE_CHUNK_DELAY_MS);
     }
 
-    // Handle empty file
-    if (file_size == 0)
-    {
-        ble_app.sendFileChunk(0, nullptr, 0, true);
-    }
+    const bool eof = plan.eof && (got == plan.read_len);
+    ble_app.sendFileChunk(dl_offset_, got ? chunk_buf : nullptr, got, eof);
+    dl_offset_ += got;
+    dl_last_chunk_ms_ = now;
 
-    fclose(f);
-    ESP_LOGI(TAG, "[BLE] Download complete: %s (%lu bytes sent)",
-             filename.c_str(), (unsigned long)offset);
+    if (eof) finishDownload("complete");
 }
 
 // ============================================================================
@@ -3679,7 +3751,10 @@ static void loop_bs()
     }
     else if (ble_cmd == BLE_BS_CMD_FILE_DOWNLOAD)
     {
-        handleDownloadCommand();
+        // #380: only STARTS the transfer (opens the file, captures state).
+        // Chunks go out one per loop pass via serviceDownload() below, so the
+        // RX/uplink/heartbeat/flush services keep running during the download.
+        startDownload();
     }
     else if (ble_cmd == BLE_BS_CMD_CAMERA_TOGGLE)
     {
@@ -4042,6 +4117,10 @@ static void loop_bs()
     // slow-rendezvous timer doesn't expire during normal idle operation.
     // Gates itself on recovery/transaction state internally.
     serviceHeartbeat();
+
+    // BLE file download — at most one 170 B chunk per pass, paced to the BLE
+    // notify drain interval. No-op unless a transfer is active (#380).
+    serviceDownload();
 
     printStats();
 


### PR DESCRIPTION
## Summary
Fixes #380. `handleDownloadCommand` ran the entire BLE file transfer synchronously inside the command dispatch on the single `bs_loop` task (fread + `sendFileChunk` + `delay(15 ms)` per 170 B chunk ≈ 11 KB/s). A 120 KB flight CSV blocked the loop ~11 s; a multi-MB log for minutes. During the block: no `lora_comms.service()`/`readPacket` (telemetry lost and unlogged), no uplink retries, no heartbeats (rocket falls into slow-rendezvous after 15 s), no CSV flush — and a >5 min download silence-closed the active log.

## Fix — cooperative state machine (one chunk per loop pass)
Mirrors the existing `coord_scan_state_` pattern:
- The dispatch now only calls **`startDownload()`** — opens the file and captures filename/size/offset into file-scope statics. (`getDownloadFilename()` clears on read, so state must be captured at start.)
- A new **`serviceDownload()`**, slotted with the other `service*` calls, emits **at most one chunk per loop iteration**.
- **Pacing is wall-time, not loop cadence:** the 15 ms inter-chunk spacing is the BLE notify path's mbuf **drain budget** (`notify_data`'s 3×5 ms retry), and `bs_loop` iterates ~1 ms — so chunk emission is gated on `millis()` via `bs_download_policy::mayEmitChunk`. Throughput is unchanged (~11 KB/s); everything else now runs between chunks.
- Chunk arithmetic is a pure header (`bs_download_policy.h`, same seam as `bs_log_policy`/`bs_uplink_policy`), **bounded by the size measured at open** — downloading the still-growing active log now transfers a finite snapshot.

**Preserved behaviors:** missing file → single empty EOF; empty file → single empty EOF (falls out of `nextChunk`); disconnect mid-transfer → abort without EOF.

**Two improvements found in passing:**
1. An unexpected short read (SD error) now terminates with an empty EOF chunk — the old loop just stopped without ever flagging EOF, leaving the app hanging.
2. A new download request supersedes an in-flight transfer (latest-wins, like the uplink slot) — previously impossible only because the loop was blocked.

## Tests
New host `test_bs_download_policy` (11 cases): empty/short/mid/exact-multiple/remainder chunk plans, offset-past-size safety, a walked-transfer termination property (delivers exactly `file_size`, flags EOF exactly once), and the pacing gate including millis wraparound. **Host suite 414/414.**

## Bench check
Start a large log download in the app while a rocket is streaming on the pad: telemetry should keep flowing in the dashboard and the CSV should stay gapless for the whole transfer; download completes at the same ~11 KB/s as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
