### PR TITLE
fix(bs): per-rocket CSV log transitions + rocket_id column (#381)

### DIFF
--- a/Data_Analysis/flight_report/modules/lora.py
+++ b/Data_Analysis/flight_report/modules/lora.py
@@ -281,6 +281,28 @@ def analyze(flight: Flight) -> AnalysisResult:
         result.warnings.append("LoRa CSV(s) found but contain no telemetry rows.")
         return result
 
+    # Multi-rocket demux (#381): post-#381 BS CSVs carry a rocket_id column
+    # because one file can interleave several rockets' telemetry (e.g. a
+    # landed rocket still transmitting while the next one preps). Analyze the
+    # dominant rocket and say so, rather than silently blending trajectories.
+    # Older CSVs without the column (or single-rocket files) are unaffected.
+    if "rocket_id" in df.columns:
+        rid = pd.to_numeric(df.rocket_id, errors="coerce")
+        ids = rid.dropna().unique()
+        if len(ids) > 1:
+            dominant = int(rid.value_counts().idxmax())
+            n_before = len(df)
+            df = df[rid == dominant].reset_index(drop=True)
+            others = sorted(int(i) for i in ids if int(i) != dominant)
+            result.warnings.append(
+                f"LoRa CSV contains {len(ids)} rockets; analyzing rocket_id="
+                f"{dominant} ({len(df)}/{n_before} rows) — other rocket(s) "
+                f"{others} excluded."
+            )
+        if df.empty:
+            result.warnings.append("No telemetry rows left after rocket_id demux.")
+            return result
+
     t_ms = df.time_ms.to_numpy()
     t = (t_ms - t_ms[0]) / 1000.0
 

--- a/Data_Analysis/landing_predictor.py
+++ b/Data_Analysis/landing_predictor.py
@@ -252,6 +252,17 @@ def actual_landing_enu(result: ReplayResult,
     if lora_csv is not None and lora_csv.exists():
         with open(lora_csv) as f:
             rows = list(csv.DictReader(f))
+        # Multi-rocket demux (#381): post-#381 BS CSVs can interleave several
+        # rockets (rocket_id column). Keep only the dominant rocket's rows so
+        # "the last landed row" is this flight's landing, not whichever other
+        # rocket happened to transmit last. No-op for pre-#381 CSVs.
+        rids = [r["rocket_id"] for r in rows
+                if r.get("rocket_id") not in (None, "") ]
+        if len(set(rids)) > 1:
+            from collections import Counter
+            dominant = Counter(rids).most_common(1)[0][0]
+            rows = [r for r in rows
+                    if r.get("rocket_id") in (None, "", dominant)]
         # Last row with landed flag set and a usable fix
         landed = [r for r in rows
                   if r.get("landed", "0") == "1"

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -304,6 +304,9 @@ add_executable(test_bs_log_policy test_bs_log_policy.cpp)
 target_include_directories(test_bs_log_policy PRIVATE
     ${SHIM_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+    # bs_log_policy.h pulls the rocket-state enum + computeFreqLockForFlight
+    # from the shared types header (#381 multi-rocket transitions)
+    ${LIB_DIR}/TR_RocketComputerTypes
 )
 target_link_libraries(test_bs_log_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_log_policy)

--- a/tests_cpp/test_bs_log_policy.cpp
+++ b/tests_cpp/test_bs_log_policy.cpp
@@ -101,3 +101,214 @@ TEST(BSLogPolicyParseFilename, RejectsOversized)
     // Boundary: 65535 is the highest uint16 (5 digits) — accepted.
     EXPECT_TRUE(bs_log_policy::parseSequentialFilename("lora_65535.csv", n));
 }
+
+// ---------------------------------------------------------------------------
+// #381 — multi-rocket log transitions
+//
+// The regression scenario: rocket A has landed and keeps transmitting LANDED
+// at ~2 Hz while rocket B powers up READY on the pad. With the old single
+// global last_rocket_state, every interleaved A-then-B pair looked like a
+// LANDED transition (close!) followed by a non-LANDED packet (reopen!) —
+// one CSV file per interleave cycle. These tests drive the per-rocket
+// transition state + aggregate close/lock policy through that exact traffic.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using bs_log_policy::RocketLogState;
+using bs_log_policy::RocketView;
+using bs_log_policy::updateRocketLogState;
+using bs_log_policy::noFreshRocketFlying;
+using bs_log_policy::anySafetyExpired;
+using bs_log_policy::aggregateFreqLock;
+
+constexpr uint32_t FRESH_MS  = 5 * 60 * 1000;   // config::LOG_SILENCE_TIMEOUT_MS
+constexpr uint32_t SAFETY_MS = 20 * 60 * 1000;  // config::LOG_INFLIGHT_SAFETY_MS
+constexpr int      NSLOTS    = 4;
+
+// Minimal stand-in for the main.cpp wiring: per-slot state, the same
+// open/close decisions serviceUplink's RX block makes, and open/close
+// counters so a test can assert "exactly one file".
+struct SimBS {
+    RocketLogState slots[NSLOTS] = {};
+    uint32_t       last_seen[NSLOTS] = {};
+    bool           slot_active[NSLOTS] = {};
+    bool           logging = false;
+    int            opens = 0;
+    int            closes = 0;
+
+    void views(RocketView out[NSLOTS]) const {
+        for (int i = 0; i < NSLOTS; ++i) {
+            out[i].active            = slot_active[i];
+            out[i].last_seen_ms      = last_seen[i];
+            out[i].state             = slots[i].last_state;
+            out[i].inflight_entry_ms = slots[i].inflight_entry_ms;
+            out[i].freq_lock         = slots[i].freq_lock;
+        }
+    }
+
+    // One received packet from rocket in `slot` reporting `state` at `now`.
+    // Mirrors main.cpp: auto-open gate, per-rocket fold, aggregate close.
+    void packet(int slot, uint8_t state, uint32_t now) {
+        if (!logging && state != LANDED) { logging = true; ++opens; }
+
+        slot_active[slot] = true;
+        const auto edges = updateRocketLogState(slots[slot], state, now);
+        last_seen[slot] = now;
+
+        RocketView v[NSLOTS];
+        views(v);
+        if (edges.landed_edge && logging &&
+            noFreshRocketFlying(v, NSLOTS, now, FRESH_MS, SAFETY_MS)) {
+            logging = false;
+            ++closes;
+            // stopLogging() disarms all safety timers with the file.
+            for (auto& s : slots) s.inflight_entry_ms = 0;
+        }
+    }
+
+    bool freqLock(uint32_t now) {
+        RocketView v[NSLOTS];
+        views(v);
+        return aggregateFreqLock(v, NSLOTS, now, FRESH_MS);
+    }
+};
+
+}  // namespace
+
+TEST(BSLogPolicyMultiRocket, InterleavedLandedReadyDoesNotChurnFiles)
+{
+    // A flies and lands; B powers up READY. 60 s of interleaved 2 Hz traffic
+    // must produce exactly ONE open and ZERO closes (B is still active) —
+    // pre-#381 this produced a close+reopen pair roughly once per second.
+    SimBS bs;
+    uint32_t t = 1000;
+    bs.packet(0, READY, t);          t += 500;   // A pad
+    bs.packet(0, INFLIGHT, t);       t += 500;   // A flies
+    bs.packet(0, LANDED, t);         t += 500;   // A lands — only rocket so far
+    EXPECT_EQ(bs.closes, 1);                     // single-rocket close intact
+    bs.packet(1, READY, t);          t += 500;   // B powers up -> reopen
+    EXPECT_EQ(bs.opens, 2);
+
+    for (int i = 0; i < 120; ++i) {              // 60 s interleave
+        bs.packet(0, LANDED, t);     t += 250;
+        bs.packet(1, READY, t);      t += 250;
+    }
+    EXPECT_EQ(bs.opens, 2) << "interleave must not reopen";
+    EXPECT_EQ(bs.closes, 1) << "A's repeat LANDED must not close while B is fresh";
+    EXPECT_TRUE(bs.logging);
+}
+
+TEST(BSLogPolicyMultiRocket, LastFreshRocketLandingCloses)
+{
+    SimBS bs;
+    uint32_t t = 1000;
+    bs.packet(0, LANDED, t);   t += 500;  // A: first packet LANDED (boot edge — no open)
+    bs.packet(1, READY, t);    t += 500;
+    bs.packet(1, INFLIGHT, t); t += 500;
+    bs.packet(0, LANDED, t);   t += 500;  // A repeats — no edge
+    EXPECT_EQ(bs.closes, 0);
+    bs.packet(1, LANDED, t);              // B, the last fresh flyer, lands
+    EXPECT_EQ(bs.closes, 1);
+    EXPECT_FALSE(bs.logging);
+}
+
+TEST(BSLogPolicyMultiRocket, StaleRocketDoesNotVetoClose)
+{
+    // B was READY once but has been silent past the freshness window — a
+    // powered-off rocket must not hold the log open forever.
+    SimBS bs;
+    uint32_t t = 1000;
+    bs.packet(1, READY, t);
+    bs.packet(0, READY, t + 500);
+    // A flies and lands; B never transmits again.
+    bs.packet(0, INFLIGHT, t + 1000);
+    const uint32_t t_land = t + 1000 + FRESH_MS + 1000;  // B now stale
+    bs.packet(0, LANDED, t_land);
+    EXPECT_EQ(bs.closes, 1);
+    EXPECT_FALSE(bs.logging);
+}
+
+TEST(BSLogPolicyMultiRocket, SafetyExpiredRocketCountsAsDown)
+{
+    // A went INFLIGHT and vanished (timer armed, now expired). When B lands,
+    // A must not veto the close — it is presumed down, not "still flying".
+    SimBS bs;
+    uint32_t t = 1000;
+    bs.packet(0, READY, t);          t += 500;
+    bs.packet(0, INFLIGHT, t);                   // A armed at t
+    const uint32_t t_a_armed = t;    t += 500;
+    bs.packet(1, READY, t);          t += 500;
+    bs.packet(1, INFLIGHT, t);       t += 500;
+
+    // B lands within A's freshness window but after A's safety expiry.
+    // Keep A "fresh" (recently seen) so only the expiry logic can clear it.
+    uint32_t t_b_lands = t_a_armed + SAFETY_MS + 1000;
+    bs.packet(0, INFLIGHT, t_b_lands - 1000);    // A still transmitting INFLIGHT (stuck)
+    bs.packet(1, LANDED, t_b_lands);
+    EXPECT_EQ(bs.closes, 1) << "expired-INFLIGHT rocket must not veto the close";
+}
+
+TEST(BSLogPolicyMultiRocket, PeriodicSafetyCloseHonorsOtherFlyer)
+{
+    // The periodic path: A armed+expired fires anySafetyExpired, but B fresh
+    // and INFLIGHT (not expired) keeps the log open; once B is gone stale,
+    // the close condition holds.
+    RocketLogState a{}, b{};
+    uint32_t t = 1000;
+    updateRocketLogState(a, READY, t);
+    updateRocketLogState(a, INFLIGHT, t + 500);       // A armed at t+500
+    updateRocketLogState(b, READY, t + 1000);
+    updateRocketLogState(b, INFLIGHT, t + 90000);     // B armed later
+
+    const uint32_t now = t + 500 + SAFETY_MS + 1;     // A expired; B not
+    RocketView v[2] = {
+        {true, now - 1000, a.last_state, a.inflight_entry_ms, a.freq_lock},
+        {true, now - 1000, b.last_state, b.inflight_entry_ms, b.freq_lock},
+    };
+    EXPECT_TRUE(anySafetyExpired(v, 2, now, SAFETY_MS));
+    EXPECT_FALSE(noFreshRocketFlying(v, 2, now, FRESH_MS, SAFETY_MS))
+        << "B is fresh, armed, and not expired — must hold the log open";
+
+    // B goes silent past the freshness window: nothing fresh is flying.
+    v[1].last_seen_ms = now - FRESH_MS - 1000;
+    EXPECT_TRUE(noFreshRocketFlying(v, 2, now, FRESH_MS, SAFETY_MS));
+}
+
+TEST(BSLogPolicyMultiRocket, FreqLockStableAcrossInterleave)
+{
+    // A INFLIGHT latches the aggregate lock; B's READY stream must not clear
+    // it (the old global flapped once per interleaved packet). A landing
+    // clears A's lock, and with B READY (lock false) the aggregate drops.
+    SimBS bs;
+    uint32_t t = 1000;
+    bs.packet(0, INFLIGHT, t);       t += 500;
+    EXPECT_TRUE(bs.freqLock(t));
+    for (int i = 0; i < 20; ++i) {
+        bs.packet(1, READY, t);      t += 250;
+        EXPECT_TRUE(bs.freqLock(t)) << "B's READY cleared A's in-flight lock";
+        bs.packet(0, INFLIGHT, t);   t += 250;
+    }
+    bs.packet(0, LANDED, t);
+    EXPECT_FALSE(bs.freqLock(t));
+}
+
+TEST(BSLogPolicyMultiRocket, BootEdgeAndSafetyArmSemantics)
+{
+    // First packet never edges (post-flight BS reboot seeing LANDED first
+    // must not close/open anything)...
+    RocketLogState s{};
+    auto e = updateRocketLogState(s, LANDED, 1000);
+    EXPECT_FALSE(e.landed_edge);
+    EXPECT_FALSE(e.state_changed);
+
+    // ...but a first packet already INFLIGHT arms the safety timer (BS
+    // booted mid-flight; the log must still be bounded).
+    RocketLogState s2{};
+    updateRocketLogState(s2, INFLIGHT, 2000);
+    EXPECT_EQ(s2.inflight_entry_ms, 2000u);
+
+    // Leaving INFLIGHT disarms.
+    updateRocketLogState(s2, LANDED, 3000);
+    EXPECT_EQ(s2.inflight_entry_ms, 0u);
+}

--- a/tinkerrocket-idf/projects/base_station/main/bs_log_policy.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_log_policy.h
@@ -1,16 +1,143 @@
 #pragma once
 
-// Base-station LoRa CSV logging policy helpers (#137).
+// Base-station LoRa CSV logging policy helpers (#137, #381).
 //
 // Pure functions extracted from main.cpp so the host-side gtest can drive
 // them without dragging in the LoRa radio, SD card, or BLE stack.  Anything
 // in here must remain free of ESP-IDF / FreeRTOS / hardware dependencies.
+// (RocketComputerTypes.h is pure types/helpers and host-compiles — the
+// rocket-state enum and computeFreqLockForFlight come from there so the
+// transition rules can't drift from the rocket side.)
 
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 
+#include <RocketComputerTypes.h>  // RocketState, computeFreqLockForFlight()
+
 namespace bs_log_policy {
+
+// ---------------------------------------------------------------------------
+// Per-rocket log-transition state (#381).
+//
+// The CSV open/close/freq-lock state machine used to key off ONE global
+// last_rocket_state while tracked_rockets[] accepts up to 4 rockets. With two
+// powered rockets in range (A landed + still transmitting, B powering up
+// READY), every interleaved A-then-B packet pair read as a LANDED transition
+// followed by a fresh non-LANDED packet: close, reopen, close, reopen — one
+// CSV per interleave cycle, rows scattered, and freq_locked_for_flight
+// flapping per packet. Each tracked slot now carries its own transition
+// state; the log open/close decision aggregates over the fresh slots.
+// ---------------------------------------------------------------------------
+struct RocketLogState {
+    uint8_t  last_state        = 0;      // last seen RocketState (wire value)
+    bool     have_seen_first   = false;  // boot-edge guard (per rocket)
+    uint32_t inflight_entry_ms = 0;      // INFLIGHT safety arm time; 0 = off
+    bool     freq_lock         = false;  // per-rocket computeFreqLockForFlight
+};
+
+// Edges detected while folding one received packet into a rocket's state.
+struct PacketEdges {
+    bool state_changed = false;  // any state transition (post boot-edge)
+    bool landed_edge   = false;  // non-LANDED -> LANDED transition
+};
+
+// Fold one packet's rocket_state into the per-rocket state: detect edges,
+// arm/disarm the INFLIGHT safety timer, latch the per-rocket freq lock.
+// Mirrors the old global logic exactly, including the boot-edge special
+// cases (first packet never edges; first packet already INFLIGHT arms the
+// safety timer so a BS that boots mid-flight still bounds the log).
+static inline PacketEdges updateRocketLogState(RocketLogState& s,
+                                               uint8_t in_state,
+                                               uint32_t now_ms)
+{
+    PacketEdges e{};
+    if (s.have_seen_first) {
+        e.state_changed = (in_state != s.last_state);
+        e.landed_edge   = (in_state == LANDED && s.last_state != LANDED);
+        if (in_state == INFLIGHT && s.last_state != INFLIGHT) {
+            s.inflight_entry_ms = now_ms;
+        } else if (s.last_state == INFLIGHT && in_state != INFLIGHT) {
+            s.inflight_entry_ms = 0;
+        }
+    } else if (in_state == INFLIGHT) {
+        s.inflight_entry_ms = now_ms;
+    }
+    s.have_seen_first = true;
+    s.last_state      = in_state;
+    s.freq_lock       = computeFreqLockForFlight(s.freq_lock, in_state);
+    return e;
+}
+
+// Snapshot of one tracked slot for the aggregate decisions below.
+struct RocketView {
+    bool     active            = false;
+    uint32_t last_seen_ms      = 0;
+    uint8_t  state             = 0;
+    uint32_t inflight_entry_ms = 0;
+    bool     freq_lock         = false;
+};
+
+// A rocket silent longer than fresh_window_ms no longer vetoes a log close
+// and no longer holds the freq lock — it powered off or left range. The
+// caller passes LOG_SILENCE_TIMEOUT_MS: coherent with the file-level rule
+// ("that silent" would have closed the log anyway). Unsigned subtraction is
+// millis()-wraparound-safe.
+static inline bool rocketFresh(const RocketView& r, uint32_t now_ms,
+                               uint32_t fresh_window_ms)
+{
+    return r.active && (now_ms - r.last_seen_ms) <= fresh_window_ms;
+}
+
+// True when NO fresh rocket is still "in play" — i.e. every fresh rocket is
+// either LANDED or presumed down (INFLIGHT safety timer expired: armed and
+// past safety_ms with no state change — telemetry lost mid-flight). This is
+// the multi-rocket close condition: rocket A's LANDED closes the log only
+// when it is the last fresh rocket flying.
+static inline bool noFreshRocketFlying(const RocketView* rockets, int n,
+                                       uint32_t now_ms,
+                                       uint32_t fresh_window_ms,
+                                       uint32_t safety_ms)
+{
+    for (int i = 0; i < n; ++i) {
+        const RocketView& r = rockets[i];
+        if (!rocketFresh(r, now_ms, fresh_window_ms)) continue;
+        if (r.state == LANDED) continue;
+        if (r.inflight_entry_ms != 0 &&
+            (now_ms - r.inflight_entry_ms) >= safety_ms) continue;  // presumed down
+        return false;
+    }
+    return true;
+}
+
+// True when any active rocket's INFLIGHT safety timer has expired — the
+// periodic close trigger (paired with noFreshRocketFlying so a second
+// still-flying rocket keeps the log open). Deliberately ignores freshness:
+// an expired timer means telemetry stopped, which is exactly the case the
+// safety net exists for.
+static inline bool anySafetyExpired(const RocketView* rockets, int n,
+                                    uint32_t now_ms, uint32_t safety_ms)
+{
+    for (int i = 0; i < n; ++i) {
+        const RocketView& r = rockets[i];
+        if (r.active && r.inflight_entry_ms != 0 &&
+            (now_ms - r.inflight_entry_ms) >= safety_ms) return true;
+    }
+    return false;
+}
+
+// Aggregate frequency lock: locked while ANY fresh rocket's per-rocket lock
+// is latched. Replaces the old single global that the last-arrived packet
+// overwrote (rocket B's READY unlocked mid-flight-of-A every other packet).
+static inline bool aggregateFreqLock(const RocketView* rockets, int n,
+                                     uint32_t now_ms, uint32_t fresh_window_ms)
+{
+    for (int i = 0; i < n; ++i) {
+        if (rocketFresh(rockets[i], now_ms, fresh_window_ms) &&
+            rockets[i].freq_lock) return true;
+    }
+    return false;
+}
 
 // Strict parser for the sequential lora_NNN.csv filenames used when the BS
 // has no phone time-sync yet.  Returns true and sets `out_num` only when

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -218,14 +218,11 @@ static uint32_t log_last_flush_ms = 0;
 // Reset to 0 by stopLogging() so the next flight can retry immediately
 // rather than waiting out the residual window.
 static uint32_t log_last_open_attempt_ms = 0;
-// INFLIGHT safety net (#107): tracks the moment the rocket first enters
-// INFLIGHT.  If we never see a LANDED transition (lost LoRa during descent,
-// rocket-side IMU stuck mid-flight, etc.) we close the log
-// LOG_INFLIGHT_SAFETY_MS after the entry so the file isn't unbounded.
-// Reset on any state change away from INFLIGHT and on safety fire.
-static uint32_t inflight_entry_ms = 0;
-static uint8_t  last_rocket_state = 0;  // Track state transitions
-static bool     have_seen_first_state = false;  // Detect very first packet so we don't false-trigger LANDED-close on boot
+// State-transition tracking (INFLIGHT safety arm time, last state, boot-edge
+// guard, per-rocket freq lock) lives per tracked rocket in
+// TrackedRocket::log_state (#381) — one global here made two interleaved
+// rockets read as a state transition on every packet, closing and reopening
+// the CSV once per interleave cycle. See bs_log_policy.h.
 // Sticky inhibit set by a manual cmd 23 stop so auto-start doesn't immediately
 // re-open on the next packet (#107).  Cleared on any rocket state change or
 // by a manual cmd 23 start, so a real next flight is still captured.
@@ -244,12 +241,13 @@ static bool     last_known_rocket_logging = false;    // Actual rocket logging s
 //     we refuse on the base station side too as belt-and-braces.
 // The transition logic is shared with the rocket side via
 // computeFreqLockForFlight() in RocketComputerTypes.h.
+//
+// #381: this is now the AGGREGATE across tracked rockets — locked while any
+// fresh rocket's per-rocket lock is latched (bs_log_policy::aggregateFreqLock,
+// recomputed after each packet). The old single global was overwritten by
+// whichever rocket's packet arrived last, so a second rocket's READY cleared
+// the lock mid-flight of the first, once per interleaved packet.
 static bool freq_locked_for_flight = false;
-
-static inline void updateFreqLockFromRocketState(uint8_t s)
-{
-    freq_locked_for_flight = computeFreqLockForFlight(freq_locked_for_flight, s);
-}
 
 // ----------------------------------------------------------------------------
 // Per-packet channel-hop state (issues #40 / #41, phase 2a — BS side)
@@ -378,6 +376,9 @@ struct TrackedRocket {
     // lora_tx_seq restarted at 0.  int32_t to hold the full uint16
     // range plus the -1 sentinel.
     int32_t    last_seq = -1;
+    // Per-rocket CSV/freq-lock transition state (#381) — replaces the old
+    // globals last_rocket_state / have_seen_first_state / inflight_entry_ms.
+    bs_log_policy::RocketLogState log_state = {};
 };
 static TrackedRocket tracked_rockets[MAX_TRACKED_ROCKETS];
 static uint8_t active_rocket_idx = 0;  // Which rocket the BLE telemetry currently shows
@@ -412,7 +413,40 @@ static int findOrAllocRocket(uint8_t rid) {
     tracked_rockets[oldest_idx].rocket_id = rid;
     tracked_rockets[oldest_idx].unit_name[0] = '\0';
     tracked_rockets[oldest_idx].last_seen_ms = millis();
+    tracked_rockets[oldest_idx].log_state = {};  // evicted slot: fresh transitions
     return oldest_idx;
+}
+
+// Snapshot the tracked slots for the aggregate log-close / freq-lock
+// decisions (#381). Pure data out; bs_log_policy does the reasoning.
+static void buildRocketViews(bs_log_policy::RocketView out[MAX_TRACKED_ROCKETS])
+{
+    for (int i = 0; i < MAX_TRACKED_ROCKETS; i++) {
+        out[i].active            = tracked_rockets[i].active;
+        out[i].last_seen_ms      = tracked_rockets[i].last_seen_ms;
+        out[i].state             = tracked_rockets[i].log_state.last_state;
+        out[i].inflight_entry_ms = tracked_rockets[i].log_state.inflight_entry_ms;
+        out[i].freq_lock         = tracked_rockets[i].log_state.freq_lock;
+    }
+}
+
+// State of the most recently heard tracked rocket (0 = INITIALIZATION when
+// none). The single-rocket predecessor was the last_rocket_state global —
+// "state of whichever packet arrived last" — which matches the hop-follow
+// code's one-rocket-drives-the-hop semantics (#40/#41 caveat).
+static uint8_t lastSeenRocketState()
+{
+    uint32_t newest_ms = 0;
+    uint8_t  state     = 0;
+    for (int i = 0; i < MAX_TRACKED_ROCKETS; i++) {
+        if (tracked_rockets[i].active &&
+            tracked_rockets[i].log_state.have_seen_first &&
+            tracked_rockets[i].last_seen_ms >= newest_ms) {
+            newest_ms = tracked_rockets[i].last_seen_ms;
+            state     = tracked_rockets[i].log_state.last_state;
+        }
+    }
+    return state;
 }
 static char log_filename[64] = "";
 
@@ -683,12 +717,16 @@ static void startLogging()
     // BS was actually tuned to, the rocket's free-running seq and the
     // BS-derived gap to the last RX, plus an `event` column populated
     // for non-telemetry rows (hop_active / hop_inactive / hop_silence).
+    // rocket_id (#381) attributes each telemetry row to its source rocket
+    // now that one file can interleave several; empty on EVENT rows (those
+    // are station-level, not per-rocket). All downstream consumers key
+    // columns by header name, so the trailing add is non-breaking.
     fprintf(log_file, "time_ms,state,num_sats,pdop,lat,lon,alt_m,h_acc,"
                       "acc_x,acc_y,acc_z,gyro_x,gyro_y,gyro_z,"
                       "pressure_alt,alt_rate,max_alt,max_speed,"
                       "voltage,current,soc,roll,pitch,yaw,speed,"
                       "launch,vel_apo,alt_apo,landed,rssi,snr,"
-                      "next_ch,rx_freq_mhz,seq,gap,event\n");
+                      "next_ch,rx_freq_mhz,seq,gap,event,rocket_id\n");
 
     logging_active = true;
     log_start_ms = millis();
@@ -705,6 +743,13 @@ static void stopLogging()
     if (log_file) { fclose(log_file); log_file = nullptr; }
     logging_active = false;
     log_last_open_attempt_ms = 0;  // allow the next packet to retry immediately (#107)
+
+    // Disarm every rocket's INFLIGHT safety timer with the file it bounds
+    // (#381) — a timer that expired while another rocket kept the log open
+    // must not instantly close the NEXT session's file.
+    for (int i = 0; i < MAX_TRACKED_ROCKETS; i++) {
+        tracked_rockets[i].log_state.inflight_entry_ms = 0;
+    }
 
     ESP_LOGI(TAG, "[LOG] Closed log: %s", log_filename);
 }
@@ -839,7 +884,7 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                     "%.1f,%.1f,%.1f,%.1f,"
                     "%.2f,%.0f,%.1f,%.1f,%.1f,%.1f,%.1f,"
                     "%d,%d,%d,%d,%.0f,%.1f,"
-                    "%u,%.3f,%u,%d,\n",   // trailing comma keeps `event` empty
+                    "%u,%.3f,%u,%d,,%u\n",  // empty `event`, then rocket_id (#381)
                     (unsigned long)time_ms,
                     rocketStateToString(data.rocket_state),
                     (unsigned)data.num_sats,
@@ -859,7 +904,8 @@ static void logLoRaPacket(const LoRaDataSI& data, float rssi, float snr,
                     data.alt_landed_flag ? 1 : 0,
                     (double)rssi, (double)snr,
                     (unsigned)data.next_channel_idx, (double)rx_freq_mhz,
-                    (unsigned)data.seq, (int)observed_gap);
+                    (unsigned)data.seq, (int)observed_gap,
+                    (unsigned)data.rocket_id);
 
     if (written <= 0)
     {
@@ -897,7 +943,7 @@ static void logHopEvent(const char* event_str, float rx_freq_mhz)
                     ",,,,,,,"                 // voltage..speed (7)
                     ",,,,,,"                  // launch, vel_apo, alt_apo, landed, rssi, snr
                     "%u,%.3f,,,"              // next_ch=255 sentinel, rx_freq_mhz, seq=, gap=
-                    "%s\n",
+                    "%s,\n",                  // event, rocket_id empty (station-level row, #381)
                     (unsigned long)time_ms,
                     (unsigned)LORA_NEXT_CH_NO_HOP,
                     (double)rx_freq_mhz,
@@ -3365,7 +3411,8 @@ static void loop_bs()
 
                 printTelemetry(decoded, ls.last_rssi, ls.last_snr, lat_deg, lon_deg, alt_m);
 
-                // Base station CSV logging policy (#107, refined in #168):
+                // Base station CSV logging policy (#107, refined in #168,
+                // multi-rocket in #381):
                 //   • Start a log whenever a non-LANDED packet arrives and
                 //     we aren't already logging.  Every flight state counts
                 //     — even READY pre-flight setup is worth keeping.
@@ -3377,9 +3424,12 @@ static void loop_bs()
                 //     the LANDED-only files in the 5/17/26 flight folders.
                 //     Operators can still capture LANDED telemetry via the
                 //     manual BLE cmd 23 start, which bypasses this gate.
-                //   • Close on LANDED transition so the flight's data is
-                //     committed to disk immediately; the next non-LANDED
-                //     packet (e.g., a re-flight) auto-opens a fresh file.
+                //   • Close on a rocket's LANDED transition ONLY when it is
+                //     the last fresh rocket flying (#381): state edges are
+                //     tracked per tracked_rockets slot, so a landed rocket's
+                //     repeat LANDED packets interleaved with another rocket's
+                //     READY no longer read as close/reopen transitions once
+                //     per packet pair (the one-file-per-second shred).
                 //   • Throttled by LOG_OPEN_RETRY_MS so a persistent
                 //     fopen() failure (wedged SD) doesn't log-spam.
                 if (!logging_active && !log_manual_inhibit &&
@@ -3400,54 +3450,70 @@ static void loop_bs()
                                   currentRxFreqMHz(), observed_gap);
                 }
 
-                // Arm / disarm the INFLIGHT safety timer on state edges.
-                // Skip the very first packet so a BS that boots while the
-                // rocket is already INFLIGHT doesn't immediately disarm
-                // (last_rocket_state defaults to 0 = INITIALIZATION).
-                if (have_seen_first_state)
+                if (slot >= 0)
                 {
-                    if (decoded.rocket_state == INFLIGHT && last_rocket_state != INFLIGHT)
+                    const uint32_t now_ms = millis();
+                    auto& rls = tracked_rockets[slot].log_state;
+                    const bool was_inflight_armed = (rls.inflight_entry_ms != 0);
+
+                    // Fold this packet into the rocket's own transition state:
+                    // detects edges, arms/disarms its INFLIGHT safety timer,
+                    // latches its freq lock (bs_log_policy #381).
+                    const auto edges =
+                        bs_log_policy::updateRocketLogState(rls,
+                                                            decoded.rocket_state,
+                                                            now_ms);
+                    if (!was_inflight_armed && rls.inflight_entry_ms != 0)
                     {
-                        inflight_entry_ms = millis();
-                        ESP_LOGI(TAG, "[LOG] INFLIGHT entry — safety timer armed (%u min)",
+                        ESP_LOGI(TAG, "[LOG] Rocket %u INFLIGHT entry — safety timer armed (%u min)",
+                                 (unsigned)decoded.rocket_id,
                                  (unsigned)(config::LOG_INFLIGHT_SAFETY_MS / 60000));
                     }
-                    else if (last_rocket_state == INFLIGHT && decoded.rocket_state != INFLIGHT)
+
+                    // Freshness for the aggregate decisions below uses
+                    // last_seen_ms; stamp it now (the tracker mirror further
+                    // down stamps it again — idempotent).
+                    tracked_rockets[slot].last_seen_ms = now_ms;
+
+                    bs_log_policy::RocketView views[MAX_TRACKED_ROCKETS];
+                    buildRocketViews(views);
+                    freq_locked_for_flight = bs_log_policy::aggregateFreqLock(
+                        views, MAX_TRACKED_ROCKETS, now_ms,
+                        config::LOG_SILENCE_TIMEOUT_MS);
+
+                    // Close on LANDED transition — but only when no other
+                    // fresh rocket is still flying (#381). Boot edge is
+                    // handled inside updateRocketLogState (no edge on a
+                    // rocket's first packet), so a post-flight BS reboot
+                    // seeing LANDED first doesn't produce a zero-byte file.
+                    if (edges.landed_edge && logging_active)
                     {
-                        inflight_entry_ms = 0;
+                        if (bs_log_policy::noFreshRocketFlying(
+                                views, MAX_TRACKED_ROCKETS, now_ms,
+                                config::LOG_SILENCE_TIMEOUT_MS,
+                                config::LOG_INFLIGHT_SAFETY_MS))
+                        {
+                            ESP_LOGI(TAG, "[LOG] Rocket %u LANDED (last fresh rocket) — closing flight log",
+                                     (unsigned)decoded.rocket_id);
+                            stopLogging();
+                        }
+                        else
+                        {
+                            ESP_LOGI(TAG, "[LOG] Rocket %u LANDED — log stays open (another rocket still active)",
+                                     (unsigned)decoded.rocket_id);
+                        }
+                    }
+
+                    // This rocket changing state clears the manual stop
+                    // inhibit so the next flight gets logged automatically
+                    // (#107). Keyed per rocket: a second rocket's steady
+                    // stream no longer fabricates state changes.
+                    if (edges.state_changed && log_manual_inhibit)
+                    {
+                        log_manual_inhibit = false;
+                        ESP_LOGI(TAG, "[LOG] State change cleared manual stop inhibit");
                     }
                 }
-                else if (decoded.rocket_state == INFLIGHT)
-                {
-                    // First packet ever, and the rocket is already in flight.
-                    // Arm the safety timer so a stuck-INFLIGHT scenario still
-                    // bounds the log size, even though we missed the entry edge.
-                    inflight_entry_ms = millis();
-                }
-
-                // Close on LANDED transition so each flight is its own file
-                // and the data is on disk immediately.  Skip the boot edge
-                // so seeing LANDED as the first packet (post-flight reboot)
-                // doesn't generate a zero-byte file.
-                if (logging_active && have_seen_first_state &&
-                    decoded.rocket_state == LANDED && last_rocket_state != LANDED)
-                {
-                    ESP_LOGI(TAG, "[LOG] LANDED transition — closing flight log");
-                    stopLogging();
-                }
-
-                // Any rocket-state change clears the manual stop inhibit so
-                // the next flight gets logged automatically (#107).
-                if (have_seen_first_state && decoded.rocket_state != last_rocket_state &&
-                    log_manual_inhibit)
-                {
-                    log_manual_inhibit = false;
-                    ESP_LOGI(TAG, "[LOG] State change cleared manual stop inhibit");
-                }
-
-                have_seen_first_state = true;
-                last_rocket_state = decoded.rocket_state;
-                updateFreqLockFromRocketState(decoded.rocket_state);
 
                 // Hop state follow (#40 / #41 phase 2a, seq-anchored in
                 // #105 follow-up).  The rocket and the BS both compute
@@ -3593,21 +3659,30 @@ static void loop_bs()
         }
     }
 
-    // INFLIGHT safety timeout (#107): close the log if we've been in
-    // INFLIGHT for too long without seeing LANDED.  Catches lost-LoRa-
-    // during-descent and stuck-rocket-state-machine scenarios so the
-    // file isn't unbounded.  Disarmed (= 0) after firing; the next
-    // INFLIGHT entry re-arms.  Does NOT inhibit the auto-restart that
-    // fires on the next packet — if the rocket is genuinely stuck in
-    // INFLIGHT past the cap, we'll start a fresh file uncapped, and
-    // the operator will see two files instead of one.
-    if (logging_active && inflight_entry_ms > 0 &&
-        (millis() - inflight_entry_ms) >= config::LOG_INFLIGHT_SAFETY_MS)
+    // INFLIGHT safety timeout (#107, per-rocket in #381): close the log if a
+    // rocket has been in INFLIGHT too long without a LANDED — lost-LoRa-
+    // during-descent / stuck-rocket-state-machine — UNLESS another fresh
+    // rocket is still flying (its own flight keeps the file open; the expired
+    // rocket already counts as "presumed down" in that aggregate, so the log
+    // closes when the last fresh rocket lands). Timers disarm in
+    // stopLogging(). Does NOT inhibit the auto-restart on the next packet —
+    // a rocket genuinely stuck INFLIGHT past the cap starts a fresh file and
+    // the operator sees two files instead of one.
+    if (logging_active)
     {
-        ESP_LOGW(TAG, "[LOG] INFLIGHT safety timeout (%u min), closing log",
-                 (unsigned)(config::LOG_INFLIGHT_SAFETY_MS / 60000));
-        inflight_entry_ms = 0;
-        stopLogging();
+        const uint32_t now_ms = millis();
+        bs_log_policy::RocketView views[MAX_TRACKED_ROCKETS];
+        buildRocketViews(views);
+        if (bs_log_policy::anySafetyExpired(views, MAX_TRACKED_ROCKETS, now_ms,
+                                            config::LOG_INFLIGHT_SAFETY_MS) &&
+            bs_log_policy::noFreshRocketFlying(views, MAX_TRACKED_ROCKETS, now_ms,
+                                               config::LOG_SILENCE_TIMEOUT_MS,
+                                               config::LOG_INFLIGHT_SAFETY_MS))
+        {
+            ESP_LOGW(TAG, "[LOG] INFLIGHT safety timeout (%u min), closing log",
+                     (unsigned)(config::LOG_INFLIGHT_SAFETY_MS / 60000));
+            stopLogging();
+        }
     }
 
     // Silence timeout: close log if no packets for LOG_SILENCE_TIMEOUT_MS
@@ -3620,7 +3695,7 @@ static void loop_bs()
         (millis() - log_last_write_ms) >= config::LOG_SILENCE_TIMEOUT_MS)
     {
         ESP_LOGW(TAG, "[LOG] Silence timeout (state=%s), closing log file",
-                 rocketStateToString(last_rocket_state));
+                 rocketStateToString(lastSeenRocketState()));
         stopLogging();
     }
 
@@ -4024,7 +4099,7 @@ static void loop_bs()
 
             const bool need_coord = rocketLikelyHopping(
                 hop_active_, last_packet_ms, millis(),
-                last_rocket_state, COORD_HOP_RECENT_MS);
+                lastSeenRocketState(), COORD_HOP_RECENT_MS);
 
             if (!need_coord)
             {


### PR DESCRIPTION
## Summary
Fixes #381. The CSV logging state machine keyed off **one global** `last_rocket_state` while `tracked_rockets[4]` accepts multiple rockets. With a landed rocket still transmitting LANDED interleaved with a second rocket's READY, every packet pair read as a LANDED transition (close!) then a non-LANDED packet (reopen!) — **one CSV per interleave cycle at 2 Hz**, rows scattered across fragments with no attribution, and `freq_locked_for_flight` flapping per packet (B's READY cleared the lock mid-flight of A).

## Fix
**Per-rocket transitions, aggregate decisions, one shared file** (per design discussion):

- Transition state (`last_state`, boot-edge guard, INFLIGHT safety arm, per-rocket freq lock) moves into `TrackedRocket` via pure, host-tested `bs_log_policy` helpers (`updateRocketLogState` shares `computeFreqLockForFlight` with the rocket side so the rules can't drift).
- **LANDED close** fires only when the landing rocket is the **last fresh rocket flying** (`noFreshRocketFlying`; fresh = seen within `LOG_SILENCE_TIMEOUT_MS`, coherent with the file-level silence close). A safety-expired INFLIGHT rocket counts as presumed-down, not flying.
- **INFLIGHT safety timeout** arms per rocket; the periodic close holds while another fresh rocket keeps the file open. `stopLogging()` disarms all timers so an expired timer can't instantly close the next session's file.
- **freq lock** becomes the aggregate "any fresh rocket latched" — no more flap.
- Single-rocket behavior is bit-for-bit preserved (#107/#168 semantics incl. boot edge and first-packet-INFLIGHT).

**CSV schema:** new trailing `rocket_id` column on telemetry rows (the writer already had `data.rocket_id` in scope — it just never printed it); EVENT rows leave it empty (station-level). Every consumer — all four `Data_Analysis` readers and the iOS `CSVParser.swift` — keys columns by header name, so the trailing add is non-breaking (verified by reading each parser).

**Analysis demux (minimal):** `flight_report/modules/lora.py` analyzes the dominant `rocket_id` and warns which rockets were excluded; `landing_predictor.py` filters to the dominant rocket before taking the last landed row (so the landing point can't be another rocket's). Both are exact no-ops for pre-#381 CSVs.

## Tests
- **7 new host cases** in `test_bs_log_policy` incl. the exact regression: 60 s of 2 Hz interleaved A-LANDED/B-READY traffic produces **one open, zero spurious closes** (pre-fix: ~one close+reopen per second). Plus last-fresh-rocket close, stale-rocket-can't-veto, safety-expired-counts-as-down, periodic-close-honors-second-flyer, freq-lock stability, boot-edge semantics.
- Host suite **421/421**; flight-report suite **3/3**; synthetic mixed two-rocket CSV driven through both Python paths (dominant demux + correct landing row) and a pre-#381 CSV through the no-op path.

## Bench note
Two-rocket bench check when convenient: power rocket A through a simulated flight to LANDED, leave it on, power rocket B to READY — expect **one** CSV containing both rockets' rows with correct `rocket_id`s, no file churn in the log, and the freq-lock log lines stable. Single-rocket regression: a normal flight should behave exactly as before (one file per flight, close on LANDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
