### PR TITLE
fix(app): per-device syncer/announcer attach + power-state-unknown gate (#375, #377)

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -24,6 +24,35 @@ jobs:
         # ships 26.3 with the iOS 26.2 simulator runtime.
         run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
 
+      - name: Boot simulator
+        id: sim
+        # Pick the newest available iPhone simulator at runtime and pre-boot
+        # it, waiting for bootstatus. Two flakes this kills: (a) xcodebuild
+        # querying destinations before CoreSimulator has the device set ready
+        # ("Unable to find a device matching the provided destination
+        # specifier" while the echo shows the device exists — hit on the
+        # first #434 run), and (b) hard-pinned OS versions drifting across
+        # runner-image rollouts.
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)['devices']
+          phones = []
+          for runtime, devs in data.items():
+              if 'iOS' not in runtime:
+                  continue
+              ver = runtime.rsplit('iOS-', 1)[-1].replace('-', '.')
+              for d in devs:
+                  if d.get('isAvailable') and d['name'].startswith('iPhone'):
+                      phones.append((tuple(int(x) for x in ver.split('.')), d['name'], d['udid']))
+          phones.sort()
+          print(phones[-1][2])
+          ")
+          echo "Using simulator $UDID"
+          xcrun simctl boot "$UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$UDID" -b
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
       - name: Build and test
         working-directory: TinkerRocketApp
         # pipefail so xcodebuild's exit code survives the xcpretty pipe. The
@@ -38,7 +67,7 @@ jobs:
           xcodebuild test \
             -project TinkerRocketApp.xcodeproj \
             -scheme TinkerRocketApp \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.2' \
+            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}' \
             -parallel-testing-enabled NO \
             -resultBundlePath TestResults \
             | xcpretty

--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -38,6 +38,7 @@ final class ActiveRocketSyncer: ObservableObject {
 
     enum SyncState: Equatable {
         case idle              // not connected, or base station
+        case awaitingSync      // attached to a rocket; config readback not in yet (#375)
         case noProfile         // connected to a rocket but no active profile
         case syncing
         case synced
@@ -69,6 +70,13 @@ final class ActiveRocketSyncer: ObservableObject {
     // MARK: - Lifecycle
 
     func attach(device: BLEDevice, store: RocketProfileStore) {
+        // Idempotent for the same device+store pair (#375): the dashboard now
+        // re-attaches on every device-list / active-device change, and a
+        // redundant call must not tear down subscriptions or reset a .synced
+        // state back through the pipeline. A NEW device object (reconnects
+        // create one) intentionally falls through to a full re-attach.
+        if device === self.device && store === self.store { return }
+
         detach()
         self.device = device
         self.store = store
@@ -79,6 +87,11 @@ final class ActiveRocketSyncer: ObservableObject {
             syncState = .idle
             return
         }
+
+        // Visible from the first moment we're responsible for this rocket:
+        // "connected but not yet pushed" must not render as silent .idle
+        // (#375 — that silence is how an unsynced rocket reached the pad).
+        syncState = .awaitingSync
 
         // Sync once, when the first config readback AND the hardware id are
         // both in hand.  unitID arrives in a later readback message than the

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -42,6 +42,12 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
 
     @Published var isConnected = false
     @Published var telemetry = TelemetryData()
+    // #377: `telemetry` starts as TelemetryData() (all zeros), which reads as
+    // pwr_pin_on == false — indistinguishable from a genuinely-off rocket. In
+    // the (re)connect→first-frame window the power state is UNKNOWN, and UI
+    // must not offer the blind cmd-8 power toggle (one tap would power OFF an
+    // already-on rocket). False until the first decoded telemetry frame.
+    @Published private(set) var hasReceivedTelemetry = false
     @Published var connectedDeviceName: String = ""
     @Published var files: [FileInfo] = []
     @Published var currentPage: UInt8 = 0
@@ -229,6 +235,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // republishes IDLE on reconnect anyway.
         magCalStatus = nil
         sensorCalStatus = nil
+        // Power state is unknown again until the next session's first frame
+        // (#377). Reconnects build a new BLEDevice anyway; this covers the
+        // state-restoration path that reuses one.
+        hasReceivedTelemetry = false
         flightAnnouncer?.reset()
         UIApplication.shared.isIdleTimerDisabled = false
     }
@@ -1464,6 +1474,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // Regular telemetry
         do {
             let newTelemetry = try jsonDecoder.decode(TelemetryData.self, from: data)
+
+            // #377: power state (and the rest of the flags) are now confirmed —
+            // the UI may trust telemetry.pwr_pin_on from here on. Guarded so we
+            // don't republish on every frame.
+            if !self.hasReceivedTelemetry {
+                self.hasReceivedTelemetry = true
+            }
 
             // If telemetry has a source_rocket_id, it's relayed via base station
             // → route to RemoteRocket instead of updating our own telemetry

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -203,26 +203,30 @@ struct DashboardView: View {
         }
         .navigationViewStyle(.stack)
         .onAppear {
-            fleet.activeDevice?.flightAnnouncer = flightAnnouncer
-            if fleet.isConnected, let dev = fleet.activeDevice {
-                syncer.attach(device: dev, store: profileStore)
-            }
+            attachActiveDevice()
         }
         .onChange(of: fleet.isConnected) { connected in
-            if connected {
-                fleet.activeDevice?.flightAnnouncer = flightAnnouncer
-                if let dev = fleet.activeDevice {
-                    syncer.attach(device: dev, store: profileStore)
-                }
-            } else {
-                syncer.detach()
-            }
+            attachActiveDevice()
             if !connected && !fleet.isScanning {
                 fleet.startScanning()
             }
             // Phone-location lifecycle is driven from ConnectedDashboardView,
             // which observes the device — fleet.isConnected flips before the
             // device's type resolves, so it's the wrong signal to gate on here.
+        }
+        // #375: the syncer/announcer used to attach only on the fleet's 0→1
+        // connection edge, but the real lifecycle is per-BLEDevice — every
+        // reconnect creates a NEW device object (BLEFleet.didConnect), and a
+        // rocket connecting while the base station is already up never flips
+        // isConnected. Re-attach whenever the device list changes (reconnect,
+        // second device, removal) or the operator switches the active chip.
+        // Redundant calls are safe: syncer.attach is idempotent for the same
+        // device object, and the announcer assignment is too.
+        .onChange(of: fleet.devices) { _ in
+            attachActiveDevice()
+        }
+        .onChange(of: fleet.activeDeviceID) { _ in
+            attachActiveDevice()
         }
         .sheet(item: $activeSheet) { sheet in
             Group {
@@ -285,6 +289,24 @@ struct DashboardView: View {
             showProvisioning = true
         }
     }
+
+    /// Point the profile syncer and the flight announcer at the current
+    /// active device (#375). Called from every lifecycle edge that can change
+    /// which BLEDevice object is active: appear, connect/disconnect, device
+    /// list changes (reconnects create a new object), and chip switches.
+    /// The announcer follows the active device only — it's cleared from the
+    /// others so a background rocket's telemetry can't interleave callouts.
+    private func attachActiveDevice() {
+        guard let dev = fleet.activeDevice else {
+            syncer.detach()
+            return
+        }
+        for other in fleet.devices where other !== dev {
+            other.flightAnnouncer = nil
+        }
+        dev.flightAnnouncer = flightAnnouncer
+        syncer.attach(device: dev, store: profileStore)
+    }
 }
 
 // MARK: - Connected device dashboard (observes the BLEDevice for live updates)
@@ -333,8 +355,30 @@ struct ConnectedDashboardView: View {
             //     Drive the screen off a *positive* role instead, with an
             //     explicit identifying state for the unresolved case.
             IdentifyingDeviceView(deviceName: device.displayName)
+        } else if device.deviceType == .rocket && !device.hasReceivedTelemetry {
+            // --- Power state unknown (#377): same fail-to-positive principle
+            //     as #330 above, applied to power. A fresh/reconnected
+            //     BLEDevice's zeroed TelemetryData reads pwr_pin_on == false,
+            //     so this screen used to show "Power On" for an already-on
+            //     rocket in the reconnect→first-frame window — and cmd 8 is a
+            //     blind toggle, so one tap killed the FC rail (and the 180 s
+            //     poweringOn spinner then masked it). Hold a neutral waiting
+            //     state until the first frame confirms the actual state; a
+            //     genuinely-off rocket still sends OC telemetry, so this
+            //     resolves within ~a second either way.
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Waiting for telemetry…")
+                    .font(.headline)
+                Text("Power state unknown until the first frame arrives.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
         } else if device.deviceType == .rocket && !device.telemetry.pwr_pin_on {
-            // --- Powered OFF (rocket only): show battery + power on button ---
+            // --- Powered OFF (rocket only, confirmed by telemetry): show
+            //     battery + power on button ---
             BatteryView(telemetry: device.telemetry, isBaseStation: false)
 
             Button {

--- a/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/RocketProfileView.swift
@@ -199,6 +199,12 @@ struct SyncStatusRow: View {
         switch state {
         case .idle:
             EmptyView()
+        case .awaitingSync:
+            // #375: a connected-but-not-yet-synced rocket used to render as
+            // silent .idle/EmptyView — invisible, so an unsynced rocket could
+            // reach the pad on stale NVS settings. Amber until the push runs.
+            Label("Settings not yet applied to this rocket", systemImage: "exclamationmark.triangle.fill")
+                .font(.caption).foregroundColor(.orange)
         case .noProfile:
             Label("No active rocket — pick one to apply settings", systemImage: "questionmark.circle")
                 .font(.caption).foregroundColor(.secondary)

--- a/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerLifecycleTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerLifecycleTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Regression tests for #375: the syncer used to attach only on the fleet's
+/// 0→1 connection edge, so a rocket connecting after the base station (or an
+/// auto-reconnect, which creates a NEW BLEDevice) silently got no profile
+/// push, and its state rendered as .idle → EmptyView (no warning at all).
+/// The dashboard now re-attaches on every device-list / active-device change,
+/// which requires attach() to be (a) idempotent for the same device object and
+/// (b) visibly non-idle (.awaitingSync) from the moment a rocket is attached.
+final class ActiveRocketSyncerLifecycleTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defaults = UserDefaults(suiteName: "syncer-lifecycle-tests-\(UUID().uuidString)")
+    }
+
+    private func makeStore() -> RocketProfileStore {
+        RocketProfileStore(directory: tempDir, defaults: defaults)
+    }
+
+    private func makeRocket() -> BLEDevice {
+        let d = BLEDevice(peripheral: nil, name: "TR-R-Test")
+        d.isConnected = true
+        return d
+    }
+
+    func testAttachRocket_IsVisiblyAwaitingSync_NotSilentIdle() {
+        let syncer = ActiveRocketSyncer()
+        syncer.attach(device: makeRocket(), store: makeStore())
+        XCTAssertEqual(syncer.syncState, .awaitingSync,
+                       "connected-but-unsynced must be visible (#375), not .idle/EmptyView")
+    }
+
+    func testAttachBaseStation_StaysIdle() {
+        let syncer = ActiveRocketSyncer()
+        let bs = BLEDevice(peripheral: nil, name: "TR-B-Test")
+        syncer.attach(device: bs, store: makeStore())
+        XCTAssertEqual(syncer.syncState, .idle,
+                       "base station never receives a profile push")
+    }
+
+    func testReattachSameDevice_IsIdempotent() {
+        // The dashboard re-attaches on every fleet.devices / activeDeviceID
+        // change; a redundant call for the SAME device object must not tear
+        // down subscriptions or bounce the state.
+        let syncer = ActiveRocketSyncer()
+        let rocket = makeRocket()
+        let store = makeStore()
+
+        syncer.attach(device: rocket, store: store)
+        let stateAfterFirst = syncer.syncState
+        syncer.attach(device: rocket, store: store)
+        XCTAssertEqual(syncer.syncState, stateAfterFirst,
+                       "same-pair re-attach must be a no-op")
+    }
+
+    func testAttachNewDeviceObject_ReattachesFresh() {
+        // A reconnect creates a NEW BLEDevice — the exact #375 gap. Attaching
+        // the new object must run a full re-attach (fresh .awaitingSync), not
+        // be swallowed by the idempotence guard.
+        let syncer = ActiveRocketSyncer()
+        let store = makeStore()
+
+        syncer.attach(device: makeRocket(), store: store)
+        XCTAssertEqual(syncer.syncState, .awaitingSync)
+
+        let reconnected = makeRocket()   // new object, same physical rocket
+        syncer.attach(device: reconnected, store: store)
+        XCTAssertEqual(syncer.syncState, .awaitingSync,
+                       "new device object must get its own attach cycle")
+    }
+
+    func testDetach_ResetsToIdle() {
+        let syncer = ActiveRocketSyncer()
+        syncer.attach(device: makeRocket(), store: makeStore())
+        syncer.detach()
+        XCTAssertEqual(syncer.syncState, .idle)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/PowerStateGateTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/PowerStateGateTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Regression tests for #377: a freshly-(re)connected BLEDevice starts with a
+/// zeroed TelemetryData, which reads as pwr_pin_on == false — indistinguishable
+/// from a genuinely powered-off rocket. In that window the dashboard used to
+/// show the "Power On" button, and cmd 8 is a blind toggle: one tap powered an
+/// already-on rocket OFF (then the 180 s poweringOn spinner masked it).
+/// `hasReceivedTelemetry` is the "power state is confirmed" gate the UI now
+/// holds on.
+final class PowerStateGateTests: XCTestCase {
+
+    private func makeRocket() -> BLEDevice {
+        BLEDevice(peripheral: nil, name: "TR-R-Test")
+    }
+
+    /// fs bit 0x10 is pwr_pin_on (see TelemetryData.pwr_pin_on).
+    private func frame(fs: Int) -> Data {
+        """
+        {"st":"READY","fs":\(fs)}
+        """.data(using: .utf8)!
+    }
+
+    func testFreshDevice_PowerStateUnknown() {
+        let rocket = makeRocket()
+        XCTAssertFalse(rocket.hasReceivedTelemetry,
+                       "no frame yet — power state must read as unknown, not off")
+        XCTAssertFalse(rocket.telemetry.pwr_pin_on,
+                       "zeroed default telemetry (the #377 trap this flag guards)")
+    }
+
+    func testFirstFrame_ConfirmsPowerOn() {
+        let rocket = makeRocket()
+        rocket.parseTelemetryData(frame(fs: 0x10))
+        XCTAssertTrue(rocket.hasReceivedTelemetry)
+        XCTAssertTrue(rocket.telemetry.pwr_pin_on,
+                      "an already-on rocket is confirmed on by its first frame")
+    }
+
+    func testFirstFrame_ConfirmsPowerOff() {
+        let rocket = makeRocket()
+        rocket.parseTelemetryData(frame(fs: 0))
+        XCTAssertTrue(rocket.hasReceivedTelemetry,
+                      "a genuinely-off rocket still sends OC frames — state becomes KNOWN off")
+        XCTAssertFalse(rocket.telemetry.pwr_pin_on)
+    }
+
+    func testRelayedFrame_AlsoConfirms() {
+        // The BS relay path decodes through the same entry point; the gate
+        // must flip there too.
+        let bs = BLEDevice(peripheral: nil, name: "TR-B-Test")
+        bs.parseTelemetryData("""
+        {"rid":7,"run":"Atlas","st":"READY","fs":16}
+        """.data(using: .utf8)!)
+        XCTAssertTrue(bs.hasReceivedTelemetry)
+    }
+
+    func testDisconnect_ResetsToUnknown() {
+        let rocket = makeRocket()
+        rocket.parseTelemetryData(frame(fs: 0x10))
+        XCTAssertTrue(rocket.hasReceivedTelemetry)
+        rocket.onDisconnect()
+        XCTAssertFalse(rocket.hasReceivedTelemetry,
+                       "next session's power state is unknown until its first frame")
+    }
+
+    func testGarbageFrame_DoesNotConfirm() {
+        let rocket = makeRocket()
+        rocket.parseTelemetryData("not json".data(using: .utf8)!)
+        XCTAssertFalse(rocket.hasReceivedTelemetry,
+                       "a frame that fails to decode confirms nothing")
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #375 and #377 — both rooted in the same lifecycle mismatch: the app treated "the fleet connected" (a one-time 0→1 edge) as the moment to wire per-device services, but the real lifecycle is per-`BLEDevice` **object**, and reconnects create a new object every time.

## #375 — profile sync + voice callouts attach only on the fleet 0→1 edge
A rocket connecting while the base station is already up, an auto-reconnect (new `BLEDevice`), or an active-chip switch got **no profile push** (flying stale NVS settings, silently defeating #132's app-is-source-of-truth) and **no voice callouts** — and the sync row rendered `.idle` → `EmptyView`, i.e. no warning at all.

Fix:
- One `attachActiveDevice()` helper driven from **every** lifecycle edge: `.onAppear`, `.onChange(fleet.isConnected)`, `.onChange(fleet.devices)` (reconnects/second device), `.onChange(fleet.activeDeviceID)` (chip switch).
- `syncer.attach` is now **idempotent for the same device+store pair**, so redundant re-attach calls can't tear down subscriptions or reset a `.synced` state; a new device object still gets a full re-attach.
- The announcer follows the active device and is **cleared from the others**, so a background rocket's telemetry can't interleave callouts.
- New visible **`.awaitingSync`** state — amber *"Settings not yet applied to this rocket"* — replaces the silent `.idle` gap from the moment a rocket is attached until the push runs.

## #377 — blind Power-On toggle in the reconnect→first-telemetry window
A fresh `BLEDevice` starts with zeroed `TelemetryData` (`pwr_pin_on == false`), indistinguishable from a genuinely-off rocket — so the dashboard showed **"Power On"** for an already-on rocket, and cmd 8 is a blind toggle: one tap cut the FC rail (and the 180 s spinner masked it).

Fix: new `hasReceivedTelemetry` on `BLEDevice`, set at the single telemetry decode point (covers direct and BS-relay paths), reset on disconnect. The power screen now **fails to a positive state** (same principle as the #330 role gate): neutral *"Waiting for telemetry…"* until the first frame confirms the real power state. A genuinely-off rocket still sends OC frames, so the unknown state resolves within ~1 s either way.

## Tests
11 new XCTests, the first to land under the now-honest iOS CI (#433):
- `PowerStateGateTests` (6): unknown-until-first-frame, confirmed-on, confirmed-off, relay path, reset-on-disconnect, garbage frames don't confirm.
- `ActiveRocketSyncerLifecycleTests` (5): `.awaitingSync` visible (not silent `.idle`), BS stays `.idle`, same-pair attach idempotent, new-object re-attach, detach resets.

## Manual verification script (simulator or bench)
1. Connect BS, then connect/reconnect a rocket → amber "Settings not yet applied" appears, then the profile pushes; voice callouts fire on the new device object.
2. Immediately after a rocket reconnect → "Waiting for telemetry…" (no Power On button) for the first ~second, then the correct screen.
3. Chip-switch between two devices → syncer/announcer follow the active chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
