### PR TITLE
fix(app): derive missing fin-angle cal from servo pulses on profile decode (#378)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -220,6 +220,16 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     }
 }
 
+extension RocketProfile {
+    /// Physical fin angle (deg) a servo pulse reaches on the 1:1 fin-to-servo-
+    /// arm line from #267: 1000 µs = −60°, 1500 µs = 0°, 2000 µs = +60°.
+    /// Used to migrate pre-#267 profiles whose JSON has pulse limits but no
+    /// fin-angle keys (#378) — static and pure so the migration is unit-tested.
+    static func finDegForPulse(_ us: Int16) -> Float {
+        (Float(us) - 1500.0) * (120.0 / 1000.0)
+    }
+}
+
 // MARK: - Backward-compatible decoding
 //
 // The synthesized Decodable conformance treats missing JSON keys as a hard
@@ -269,8 +279,20 @@ extension RocketProfile {
         servoHz = try c.decodeIfPresent(Int16.self, forKey: .servoHz) ?? defaults.servoHz
         servoMinUs = try c.decodeIfPresent(Int16.self, forKey: .servoMinUs) ?? defaults.servoMinUs
         servoMaxUs = try c.decodeIfPresent(Int16.self, forKey: .servoMaxUs) ?? defaults.servoMaxUs
-        finMinDeg = try c.decodeIfPresent(Float.self, forKey: .finMinDeg) ?? defaults.finMinDeg
-        finMaxDeg = try c.decodeIfPresent(Float.self, forKey: .finMaxDeg) ?? defaults.finMaxDeg
+        // #378: pre-#267 profiles carry pulse limits (e.g. the old 1250/1750
+        // defaults) but no fin-angle keys. Backfilling the angles with the new
+        // ±60° defaults paired old pulses with full-travel angles, so the FC's
+        // commanded-vs-physical fin mapping was off ~2× (~half roll/guidance
+        // authority, silently). Derive the missing angles from the pulses via
+        // the 1:1 servo-arm line instead (1000 µs = −60°, 2000 µs = +60°, per
+        // the #267 calibration above): the pair is then self-consistent and
+        // the hardware's actual travel is unchanged — 1250/1750 correctly
+        // becomes ±30°, and absent pulses still yield the ±60° defaults.
+        // Profiles that already carry angle keys are untouched.
+        finMinDeg = try c.decodeIfPresent(Float.self, forKey: .finMinDeg)
+            ?? RocketProfile.finDegForPulse(servoMinUs)
+        finMaxDeg = try c.decodeIfPresent(Float.self, forKey: .finMaxDeg)
+            ?? RocketProfile.finDegForPulse(servoMaxUs)
         finRingMode = try c.decodeIfPresent(UInt8.self, forKey: .finRingMode) ?? defaults.finRingMode
         let finSlots = try c.decodeIfPresent([Int].self, forKey: .finServoAtSlot) ?? defaults.finServoAtSlot
         finServoAtSlot = finSlots.count == 4 ? finSlots : defaults.finServoAtSlot

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketProfileMigrationTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketProfileMigrationTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Regression tests for #378: pre-#267 profile JSON carries servo pulse limits
+/// (old defaults 1250/1750 µs) but no finMinDeg/finMaxDeg keys. The decoder
+/// used to backfill the missing angles with the new ±60° defaults, pairing
+/// "1250–1750 µs ↔ ±60°" — a mapping whose commanded-vs-physical fin angle is
+/// off ~2×, so an untouched old profile silently flew with about half the
+/// roll/guidance authority the gains were retuned for. The migration now
+/// derives missing angles from the pulses via the 1:1 servo-arm line
+/// (1000 µs = −60°, 2000 µs = +60°), keeping the pair self-consistent without
+/// changing the hardware's actual travel.
+final class RocketProfileMigrationTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> RocketProfile {
+        try JSONDecoder().decode(RocketProfile.self, from: json.data(using: .utf8)!)
+    }
+
+    // MARK: - The pulse→angle line itself
+
+    func testFinDegForPulse_CanonicalLine() {
+        XCTAssertEqual(RocketProfile.finDegForPulse(1000), -60.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.finDegForPulse(1500), 0.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.finDegForPulse(2000), 60.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.finDegForPulse(1250), -30.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.finDegForPulse(1750), 30.0, accuracy: 0.001)
+    }
+
+    // MARK: - The #378 regression
+
+    func testPre267Profile_OldDefaultPulses_GetConsistentAngles() throws {
+        // The exact case from the issue: old defaults, no fin-angle keys.
+        let p = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750}"#)
+        XCTAssertEqual(p.servoMinUs, 1250)
+        XCTAssertEqual(p.servoMaxUs, 1750)
+        XCTAssertEqual(p.finMinDeg, -30.0, accuracy: 0.001,
+                       "1250 µs physically reaches −30°, not the ±60° default")
+        XCTAssertEqual(p.finMaxDeg, 30.0, accuracy: 0.001)
+    }
+
+    func testPre267Profile_CustomPulses_GetProportionalAngles() throws {
+        // A user-tuned old profile keeps its physical travel, correctly labeled.
+        let p = try decode(#"{"name":"Custom","servoMinUs":1100,"servoMaxUs":1900}"#)
+        XCTAssertEqual(p.finMinDeg, -48.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 48.0, accuracy: 0.001)
+    }
+
+    func testProfileWithoutAnyServoKeys_KeepsFullTravelDefaults() throws {
+        // No pulses AND no angles: defaults are 1000/2000 ↔ ±60 — the formula
+        // reproduces the defaults exactly, so nothing changes for new profiles.
+        let p = try decode(#"{"name":"Fresh"}"#)
+        XCTAssertEqual(p.servoMinUs, 1000)
+        XCTAssertEqual(p.servoMaxUs, 2000)
+        XCTAssertEqual(p.finMinDeg, -60.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 60.0, accuracy: 0.001)
+    }
+
+    func testPost267Profile_ExplicitAngles_Untouched() throws {
+        // A profile that already carries angle keys is never rewritten — even
+        // if the pair looks odd, explicit user data wins.
+        let p = try decode(
+            #"{"name":"Tuned","servoMinUs":1250,"servoMaxUs":1750,"finMinDeg":-25.5,"finMaxDeg":27.0}"#)
+        XCTAssertEqual(p.finMinDeg, -25.5, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 27.0, accuracy: 0.001)
+    }
+
+    func testMigratedProfile_RoundTripsStable() throws {
+        // Once migrated and re-saved, the angles are explicit — decoding the
+        // re-encoded JSON must not shift values again (idempotence).
+        let migrated = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750}"#)
+        let reencoded = try JSONEncoder().encode(migrated)
+        let again = try JSONDecoder().decode(RocketProfile.self, from: reencoded)
+        XCTAssertEqual(again.finMinDeg, migrated.finMinDeg, accuracy: 0.001)
+        XCTAssertEqual(again.finMaxDeg, migrated.finMaxDeg, accuracy: 0.001)
+        XCTAssertEqual(again.servoMinUs, 1250)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #378. Pre-#267 profiles (old 1250/1750 µs pulse defaults, no fin-angle keys) were decoded with the new ±60° angle defaults — an inconsistent pulse↔angle pair that made the FC's commanded-vs-physical fin deflection off ~2×: an untouched old profile silently flew with **half** the roll/guidance authority the gains were retuned for.

## Fix
Missing `finMinDeg/finMaxDeg` are now derived from the decoded pulses via the #267 physical line (1000 µs = −60°, 2000 µs = +60°, 1:1 fin-to-arm): 1250/1750 → ±30°, custom pulses → proportional angles, absent pulses → the ±60° defaults exactly. Key property: the migration **never changes the hardware's actual travel** — it makes the reported calibration truthful (rewriting pulses to 1000/2000 would have silently widened travel on airframes whose linkage may be why the pulses were narrower). Explicit angle keys are never rewritten; re-encoded profiles are stable (idempotent).

## Tests
`RocketProfileMigrationTests` (6): canonical line, the exact issue case, proportional custom pulses, fresh-profile defaults, explicit-keys-untouched, round-trip stability. Local suite **163/163**.

After this merges, the #378 field-discipline note ('audit any pre-June-22 profile's servo pulse↔angle pair') is resolved — old profiles self-heal on next load, and Settings shows the true physical pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)