### PR TITLE
fix(app): disable Drift-Cast Send to Unit — cmd 28 has no firmware handler (#376)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -919,6 +919,11 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendCommand(23)
     }
 
+    /// #376/#435: cmd 28 is NOT handled by any firmware — the OC dispatch
+    /// doesn't include it and the BS doesn't relay it, so this vanishes
+    /// silently. The Drift-Cast "Send to Unit" button that called this is
+    /// disabled until #435 implements the handler end-to-end. Do not wire
+    /// this to UI again without gating success on a firmware readback echo.
     func sendGuidancePoint(lat: Double, lon: Double, altitudeM: Float) {
         var payload = Data()
         var latVal = lat

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -1100,54 +1100,39 @@ struct DriftCastView: View {
 // MARK: - Send-to-Unit Button
 
 /// Send-to-unit control for the drift cast result.  Split out so it can hold an
-/// `@ObservedObject` device — re-disabling itself the moment the BLE link drops
-/// — while the parent DriftCastView runs device-free (#42).  Only rendered when
-/// a device is present, so the standalone tool never shows a dead "Send" button.
+/// `@ObservedObject` device — while the parent DriftCastView runs device-free
+/// (#42).  Only rendered when a device is present.
+///
+/// #376: DISABLED pending firmware support (#435). The button used to send
+/// BLE cmd 28 — which no firmware handles (the OC dispatch doesn't include it
+/// and the BS doesn't relay it) — and then unconditionally reported
+/// "Guidance point sent". An operator would wind-compensate the aim point,
+/// see success, and fly believing the target moved, while the rocket guided
+/// to the profile's overhead target. Until cmd 28 exists end-to-end, show the
+/// computed point with an honest "not supported yet" note instead of a
+/// dangerous no-op button.
 private struct DriftCastSendButton: View {
     @ObservedObject var device: BLEDevice
     let result: GuidanceResult
     let unitSystem: UnitSystem
 
-    @State private var showSendConfirm = false
-    @State private var showSentAlert = false
-
-    private var canSend: Bool {
-        device.isConnected && result.feasible
-    }
-
     var body: some View {
-        Button(action: { showSendConfirm = true }) {
+        VStack(spacing: 6) {
             Label("Send to Unit", systemImage: "antenna.radiowaves.left.and.right")
                 .fontWeight(.bold)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(canSend ? Color.blue : Color.gray)
-                .foregroundColor(.white)
+                .background(Color.gray)
+                .foregroundColor(.white.opacity(0.7))
                 .cornerRadius(10)
+            Label("Not supported by the rocket firmware yet (#435) — the unit always guides to the profile's target. Use the computed point manually.",
+                  systemImage: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundColor(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .disabled(!canSend)
         .padding(.horizontal)
         .padding(.bottom, 20)
-        .alert("Send to Unit?", isPresented: $showSendConfirm) {
-            Button("Send", role: .none) { sendToUnit() }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            Text(String(format: "Send guidance point (%.6f, %.6f) at ", result.guidanceLat, result.guidanceLon)
-                 + UnitFormatter.altitude(ftToM(result.apogeeFt), system: unitSystem)
-                 + String(format: " AGL to %@?", device.connectedDeviceName))
-        }
-        .alert("Guidance Sent", isPresented: $showSentAlert) {
-            Button("OK") { }
-        } message: {
-            Text(String(format: "Guidance point sent to unit:\n%.6f, %.6f\nAltitude: ", result.guidanceLat, result.guidanceLon)
-                 + UnitFormatter.altitude(ftToM(result.apogeeFt), system: unitSystem) + " AGL")
-        }
-    }
-
-    private func sendToUnit() {
-        let altM = Float(ftToM(result.apogeeFt))
-        device.sendGuidancePoint(lat: result.guidanceLat, lon: result.guidanceLon, altitudeM: altM)
-        showSentAlert = true
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #376. Drift-Cast's **Send to Unit** sent BLE cmd 28, which **no firmware handles** (OC dispatch covers {1-3,5-16,20-27,29-36,40-42,50-58,61-66}; BS doesn't relay it), then unconditionally reported *'Guidance point sent to unit'* — an operator could wind-compensate the aim point, see success, and fly believing the target moved while the rocket guided to the profile's overhead target.

## Fix (per design discussion: disable + file feature issue)
- Button replaced with a visibly disabled control + amber note: *'Not supported by the rocket firmware yet (#435) — the unit always guides to the profile's target. Use the computed point manually.'*
- Confirm + false-success alerts removed entirely.
- `sendGuidancePoint` documented against re-wiring without firmware support and readback-gated success.
- Real capability tracked in #435 (OC cmd-28 handler + BS relay + FC guidance-target update + SIL validation).

## Verification
Local full suite **156/156** (UI-only change; no new unit-testable surface — the honest state is visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)