### PR TITLE
feat(oc): IRadioLink seam — direct LLCC68 vs UART-modem radio backends (#410)

### DIFF
--- a/tinkerrocket-idf/components/TR_RadioLink/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_RadioLink/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(SRCS "UartModemBackend.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES TR_LoRa_Comms TR_UART_Link TR_Compat
+                                esp_driver_gpio driver)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error)

--- a/tinkerrocket-idf/components/TR_RadioLink/IRadioLink.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/IRadioLink.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <TR_LoRa_Comms.h>  // Stats struct is the shared stats currency
+
+// Radio-backend seam for the out computer / base station (#410, tracking
+// #408): the same application code drives either the direct SPI LLCC68
+// (V7 boards, LoRaDirectBackend) or the UART radio daughterboard (V8,
+// UartModemBackend). Selected by the board header's USE_UART_RADIO_MODEM.
+//
+// The surface below is EXACTLY the set of TR_LoRa_Comms methods the OC
+// application calls (derived from a call-site audit of main.cpp) — no
+// speculative additions. Contracts the backends must preserve:
+//
+// - send() returns true when the transmission STARTS; canSend() flips true
+//   when airtime is finished. The hop machine uses canSend() as its
+//   "TX done, safe to retune" signal, so a backend must never report
+//   canSend()==true while its radio is still radiating (the UART modem
+//   backend therefore allows only ONE in-flight frame even though the
+//   link protocol supports a deeper credit window).
+// - reconfigure(wait_for_tx=false) must be non-blocking: return false when
+//   busy, the caller retries next loop iteration (#405 rendezvous paths).
+//   wait_for_tx=true may block bounded (~2 s) and its result is a
+//   synchronous decision (NVS persistence in uplink cmd 10/16).
+// - hopToFrequencyMHz() is the lightweight per-packet retune: must return
+//   false mid-TX (caller keeps channel state and retries at the next
+//   packet boundary), never block.
+// - readPacket()/canSend()/isInRxMode()/currentSpreadingFactor()/getStats()
+//   answer locally (no blocking I/O in the query path).
+class IRadioLink
+{
+public:
+    virtual ~IRadioLink() = default;
+
+    // Main-loop service step (completes TX, drains link I/O). Non-blocking.
+    virtual void service() = 0;
+
+    virtual bool send(const uint8_t* payload, size_t len) = 0;
+    virtual bool canSend() const = 0;
+
+    virtual bool startReceive() = 0;
+    virtual bool readPacket(uint8_t* buf, size_t maxLen, size_t& len) = 0;
+
+    virtual bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz,
+                             uint8_t cr, int8_t tx_power,
+                             bool wait_for_tx = true) = 0;
+    virtual bool hopToFrequencyMHz(float freq_mhz) = 0;
+
+    virtual float currentFrequencyMHz() const = 0;
+    virtual uint8_t currentSpreadingFactor() const = 0;
+    virtual bool isInRxMode() const = 0;
+
+    // Direct-backend housekeeping (missed-IRQ poll, stuck-TX watchdog).
+    // The modem backend maps these to its own liveness checks / no-ops.
+    virtual void pollDio1() = 0;
+    virtual void serviceTxWatchdog() = 0;
+
+    virtual void getStats(TR_LoRa_Comms::Stats& out) const = 0;
+};

--- a/tinkerrocket-idf/components/TR_RadioLink/LoRaDirectBackend.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/LoRaDirectBackend.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "IRadioLink.h"
+
+// Direct SPI LLCC68 backend (V7 boards): pure 1:1 delegation to
+// TR_LoRa_Comms. Deliberately contains zero logic — the V7 flight path
+// must be behavior-identical to the pre-seam code (#410).
+class LoRaDirectBackend final : public IRadioLink
+{
+public:
+    bool begin(const TR_LoRa_Comms::Config& cfg, bool debug)
+    {
+        return lora_.begin(cfg, debug);
+    }
+
+    void service() override { lora_.service(); }
+
+    bool send(const uint8_t* payload, size_t len) override
+    {
+        return lora_.send(payload, len);
+    }
+    bool canSend() const override { return lora_.canSend(); }
+
+    bool startReceive() override { return lora_.startReceive(); }
+    bool readPacket(uint8_t* buf, size_t maxLen, size_t& len) override
+    {
+        return lora_.readPacket(buf, maxLen, len);
+    }
+
+    bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr,
+                     int8_t tx_power, bool wait_for_tx = true) override
+    {
+        return lora_.reconfigure(freq_mhz, sf, bw_khz, cr, tx_power, wait_for_tx);
+    }
+    bool hopToFrequencyMHz(float freq_mhz) override
+    {
+        return lora_.hopToFrequencyMHz(freq_mhz);
+    }
+
+    float currentFrequencyMHz() const override { return lora_.currentFrequencyMHz(); }
+    uint8_t currentSpreadingFactor() const override { return lora_.currentSpreadingFactor(); }
+    bool isInRxMode() const override { return lora_.isInRxMode(); }
+
+    void pollDio1() override { lora_.pollDio1(); }
+    void serviceTxWatchdog() override { lora_.serviceTxWatchdog(); }
+
+    void getStats(TR_LoRa_Comms::Stats& out) const override { lora_.getStats(out); }
+
+private:
+    TR_LoRa_Comms lora_;
+};

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
@@ -1,0 +1,416 @@
+#include "UartModemBackend.h"
+
+#include <cstring>
+
+#include <compat.h>
+#include <driver/gpio.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+static const char* TAG = "RADIO_MODEM";
+
+using namespace radio_modem;
+
+// ---------------------------------------------------------------------------
+// begin / config push
+// ---------------------------------------------------------------------------
+
+bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
+                             float bw_khz, uint8_t cr, int8_t tx_power,
+                             bool debug)
+{
+    cfg_ = cfg;
+    debug_ = debug;
+
+    if (cfg.act_pin >= 0)
+    {
+        gpio_set_direction((gpio_num_t)cfg.act_pin, GPIO_MODE_OUTPUT);
+        gpio_set_level((gpio_num_t)cfg.act_pin, 1);  // power the daughterboard
+    }
+
+    if (link_.begin(cfg.uart) != ESP_OK)
+    {
+        ESP_LOGE(TAG, "UART link init failed");
+        return false;
+    }
+    began_ = true;
+
+    // The modem sends BOOT (identity payload) once its firmware is up —
+    // S3 boot is ~1 s from the ACT edge; wait generously. If we attached to
+    // an already-running modem (warm OC reboot), there is no BOOT coming, so
+    // also poke GET_IDENTITY and accept either reply.
+    const uint32_t deadline = millis() + 4000;
+    (void)link_.sendFrame(MSG_GET_IDENTITY, nullptr, 0);
+    while (millis() < deadline && !modem_alive_)
+    {
+        link_.poll(&UartModemBackend::onFrameTrampoline, this);
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (!modem_alive_)
+    {
+        ESP_LOGE(TAG, "no modem answer on the UART link — radio disabled");
+        return false;
+    }
+    if (identity_.protocol_version != PROTOCOL_VERSION)
+    {
+        // Loud and fatal-for-the-radio: a mismatched matched-pair must not
+        // limp along mis-parsing frames.
+        ESP_LOGE(TAG, "modem protocol v%u != host v%u — radio disabled "
+                      "(mismatched daughterboard pair?)",
+                 identity_.protocol_version, PROTOCOL_VERSION);
+        modem_alive_ = false;
+        return false;
+    }
+    ESP_LOGI(TAG, "modem up: chip=%u fw=%.32s max_tx=%ddBm band=%.0f-%.0fMHz",
+             identity_.chip, identity_.fw_version,
+             (int)identity_.max_tx_power_dbm,
+             (double)identity_.freq_min_mhz, (double)identity_.freq_max_mhz);
+
+    if (!pushConfig(freq_mhz, sf, bw_khz, cr, tx_power, /*start_rx=*/true,
+                    /*ack_timeout_ms=*/500))
+    {
+        ESP_LOGE(TAG, "initial SET_CONFIG not acknowledged — radio disabled");
+        modem_alive_ = false;
+        return false;
+    }
+
+    stats_.enabled = true;
+    ESP_LOGI(TAG, "radio configured via modem: %.1f MHz SF%u BW%.0f CR%u %ddBm",
+             (double)freq_mhz, sf, (double)bw_khz, cr, (int)tx_power);
+    return true;
+}
+
+bool UartModemBackend::pushConfig(float freq_mhz, uint8_t sf, float bw_khz,
+                                  uint8_t cr, int8_t tx_power, bool start_rx,
+                                  uint32_t ack_timeout_ms)
+{
+    RadioConfigData d = {};
+    d.freq_mhz = freq_mhz;
+    d.bandwidth_khz = bw_khz;
+    d.spreading_factor = sf;
+    d.coding_rate = cr;
+    // Clamp host-side too (modem clamps as well — belt & braces for a
+    // higher-power pair on one end only).
+    d.tx_power_dbm = (identity_.max_tx_power_dbm != 0 &&
+                      tx_power > identity_.max_tx_power_dbm)
+                         ? identity_.max_tx_power_dbm
+                         : tx_power;
+    d.preamble_len = cfg_.preamble_len;
+    d.flags = (cfg_.crc_on ? CFG_FLAG_CRC_ON : 0) |
+              (cfg_.rx_boosted_gain ? CFG_FLAG_RX_BOOSTED_GAIN : 0) |
+              (cfg_.syncword_private ? CFG_FLAG_SYNCWORD_PRIVATE : 0);
+    d.start_rx = start_rx ? 1 : 0;
+
+    const uint32_t status_before = status_rx_count_;
+    if (!link_.sendFrame(MSG_SET_CONFIG, reinterpret_cast<uint8_t*>(&d),
+                         sizeof(d)))
+    {
+        return false;
+    }
+
+    // The modem acks every SET_CONFIG with a STATUS frame.
+    const uint32_t deadline = millis() + ack_timeout_ms;
+    while (millis() < deadline)
+    {
+        link_.poll(&UartModemBackend::onFrameTrampoline, this);
+        if (status_rx_count_ != status_before)
+        {
+            cfg_freq_mhz_ = freq_mhz;
+            cfg_sf_ = sf;
+            cfg_bw_khz_ = bw_khz;
+            cfg_cr_ = cr;
+            cfg_tx_power_ = d.tx_power_dbm;
+            return true;
+        }
+        vTaskDelay(1);
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Frame dispatch
+// ---------------------------------------------------------------------------
+
+void UartModemBackend::onFrameTrampoline(void* ctx, uint8_t type,
+                                         const uint8_t* payload, size_t len)
+{
+    static_cast<UartModemBackend*>(ctx)->onFrame(type, payload, len);
+}
+
+void UartModemBackend::onFrame(uint8_t type, const uint8_t* payload, size_t len)
+{
+    switch (type)
+    {
+        case MSG_RX_FRAME:
+        {
+            if (len <= sizeof(RxFrameHeader))
+            {
+                break;
+            }
+            RxFrameHeader hdr;
+            memcpy(&hdr, payload, sizeof(hdr));
+            const uint8_t* air = payload + sizeof(hdr);
+            const size_t air_len = len - sizeof(hdr);
+            if (air_len > MAX_AIR_FRAME)
+            {
+                break;
+            }
+            if (rxq_used_ >= RX_QUEUE_LEN)
+            {
+                // Oldest-drop: the OC polls every loop tick, so a full queue
+                // means the loop stalled — keep the newest frames.
+                rxq_head_ = (rxq_head_ + 1) % RX_QUEUE_LEN;
+                rxq_used_--;
+                stats_.rx_len_drop++;  // repurposed: queue-overflow drops
+            }
+            RxEntry& e = rx_queue_[(rxq_head_ + rxq_used_) % RX_QUEUE_LEN];
+            e.len = static_cast<uint8_t>(air_len);
+            e.rssi = hdr.rssi_dbm;
+            e.snr = hdr.snr_db;
+            memcpy(e.data, air, air_len);
+            rxq_used_++;
+            stats_.rx_count++;
+            break;
+        }
+
+        case MSG_TX_RESULT:
+        {
+            if (len != sizeof(TxResultData))
+            {
+                break;
+            }
+            TxResultData r;
+            memcpy(&r, payload, sizeof(r));
+            if (tx_in_flight_ && r.seq == tx_seq_)
+            {
+                tx_in_flight_ = false;
+                stats_.transmitting = false;
+                if (r.ok)
+                {
+                    stats_.tx_ok++;
+                }
+                else
+                {
+                    stats_.tx_fail++;
+                }
+            }
+            break;
+        }
+
+        case MSG_STATUS:
+        {
+            if (len != sizeof(ModemStatusData))
+            {
+                break;
+            }
+            memcpy(&last_status_, payload, sizeof(last_status_));
+            status_rx_count_++;
+            // Adopt link-health counters the host can't see locally
+            stats_.rx_crc_fail = last_status_.rx_crc_fail;
+            stats_.tx_watchdog_fires = last_status_.tx_watchdog_fires;
+            break;
+        }
+
+        case MSG_IDENTITY:
+        case MSG_BOOT:
+        {
+            if (len != sizeof(ModemIdentityData))
+            {
+                break;
+            }
+            memcpy(&identity_, payload, sizeof(identity_));
+            const bool was_alive = modem_alive_;
+            modem_alive_ = true;
+            if (type == MSG_BOOT && was_alive)
+            {
+                // Daughterboard rebooted underneath us (brownout / watchdog):
+                // its queue is empty and its radio is on boot defaults.
+                // Clear the in-flight slot and re-push our config.
+                ESP_LOGW(TAG, "modem REBOOTED — re-pushing radio config");
+                if (tx_in_flight_)
+                {
+                    tx_in_flight_ = false;
+                    stats_.tx_fail++;
+                }
+                (void)pushConfig(cfg_freq_mhz_, cfg_sf_, cfg_bw_khz_, cfg_cr_,
+                                 cfg_tx_power_, /*start_rx=*/true,
+                                 /*ack_timeout_ms=*/300);
+            }
+            break;
+        }
+
+        default:
+            if (debug_)
+            {
+                ESP_LOGW(TAG, "unknown modem msg 0x%02X (%u B)", type,
+                         (unsigned)len);
+            }
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IRadioLink surface
+// ---------------------------------------------------------------------------
+
+void UartModemBackend::service()
+{
+    if (!began_)
+    {
+        return;
+    }
+    link_.poll(&UartModemBackend::onFrameTrampoline, this);
+}
+
+bool UartModemBackend::send(const uint8_t* payload, size_t len)
+{
+    if (!modem_alive_ || payload == nullptr || len == 0 ||
+        len > MAX_AIR_FRAME || tx_in_flight_)
+    {
+        return false;
+    }
+
+    uint8_t buf[sizeof(TxFrameHeader) + MAX_AIR_FRAME];
+    tx_seq_++;
+    buf[0] = tx_seq_;
+    memcpy(buf + sizeof(TxFrameHeader), payload, len);
+    if (!link_.sendFrame(MSG_TX_FRAME, buf, sizeof(TxFrameHeader) + len))
+    {
+        stats_.tx_fail++;
+        return false;
+    }
+    tx_in_flight_ = true;
+    tx_started_ms_ = millis();
+    stats_.tx_started++;
+    stats_.transmitting = true;
+    return true;
+}
+
+bool UartModemBackend::canSend() const
+{
+    return modem_alive_ && !tx_in_flight_;
+}
+
+bool UartModemBackend::startReceive()
+{
+    if (!modem_alive_)
+    {
+        return false;
+    }
+    // The modem auto-listens whenever it isn't transmitting; this is a
+    // belt-and-braces nudge, always considered successful.
+    (void)link_.sendFrame(MSG_START_RX, nullptr, 0);
+    return true;
+}
+
+bool UartModemBackend::readPacket(uint8_t* buf, size_t maxLen, size_t& len)
+{
+    len = 0;
+    if (rxq_used_ == 0)
+    {
+        return false;
+    }
+    RxEntry& e = rx_queue_[rxq_head_];
+    rxq_head_ = (rxq_head_ + 1) % RX_QUEUE_LEN;
+    rxq_used_--;
+    if (e.len > maxLen)
+    {
+        stats_.rx_len_drop++;
+        return false;
+    }
+    memcpy(buf, e.data, e.len);
+    len = e.len;
+    stats_.last_rssi = e.rssi;
+    stats_.last_snr = e.snr;
+    return true;
+}
+
+bool UartModemBackend::waitTxIdle(uint32_t timeout_ms)
+{
+    const uint32_t deadline = millis() + timeout_ms;
+    while (tx_in_flight_)
+    {
+        if (millis() >= deadline)
+        {
+            return false;
+        }
+        link_.poll(&UartModemBackend::onFrameTrampoline, this);
+        serviceTxWatchdog();
+        vTaskDelay(1);
+    }
+    return true;
+}
+
+bool UartModemBackend::reconfigure(float freq_mhz, uint8_t sf, float bw_khz,
+                                   uint8_t cr, int8_t tx_power,
+                                   bool wait_for_tx)
+{
+    if (!modem_alive_)
+    {
+        return false;
+    }
+    if (tx_in_flight_)
+    {
+        if (!wait_for_tx)
+        {
+            // Non-blocking contract (#405 rendezvous paths): busy → caller
+            // retries next loop iteration.
+            return false;
+        }
+        if (!waitTxIdle(2000))  // matches the direct driver's 2 s deadline
+        {
+            return false;
+        }
+    }
+    return pushConfig(freq_mhz, sf, bw_khz, cr, tx_power, /*start_rx=*/true,
+                      /*ack_timeout_ms=*/500);
+}
+
+bool UartModemBackend::hopToFrequencyMHz(float freq_mhz)
+{
+    if (!modem_alive_ || tx_in_flight_)
+    {
+        // Mirrors the direct driver: no retune mid-TX; caller keeps its
+        // channel state and retries at the next packet boundary.
+        return false;
+    }
+    HopFreqData d = {freq_mhz};
+    if (!link_.sendFrame(MSG_HOP_FREQ, reinterpret_cast<uint8_t*>(&d),
+                         sizeof(d)))
+    {
+        return false;
+    }
+    cfg_freq_mhz_ = freq_mhz;
+    return true;
+}
+
+bool UartModemBackend::isInRxMode() const
+{
+    // Modem policy: always listening except while transmitting.
+    return modem_alive_ && !tx_in_flight_;
+}
+
+void UartModemBackend::serviceTxWatchdog()
+{
+    if (tx_in_flight_ &&
+        (millis() - tx_started_ms_) > TX_WATCHDOG_MS)
+    {
+        // TX_RESULT never came back (modem died mid-frame / UART glitch):
+        // free the slot so canSend() can't wedge false forever (#105
+        // philosophy). The modem's own watchdog guards its side.
+        ESP_LOGW(TAG, "TX_RESULT watchdog fired (seq=%u)", tx_seq_);
+        tx_in_flight_ = false;
+        stats_.transmitting = false;
+        stats_.tx_fail++;
+        stats_.tx_watchdog_fires++;
+    }
+}
+
+void UartModemBackend::getStats(TR_LoRa_Comms::Stats& out) const
+{
+    out = stats_;
+    out.enabled = modem_alive_;
+    out.rx_mode = isInRxMode();
+    out.transmitting = tx_in_flight_;
+}

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <RadioModemProtocol.h>
+#include <TR_UART_Link.h>
+
+#include "IRadioLink.h"
+
+// UART radio-daughterboard backend (V8 boards, #410): implements the
+// IRadioLink contract over the transparent-modem protocol (#409,
+// RadioModemProtocol.h). The daughterboard owns the LLCC68; this backend
+// tunnels opaque air frames and mirrors radio state locally so every
+// query-path call answers without link I/O.
+//
+// Contract-preserving choices (see IRadioLink.h):
+// - ONE in-flight TX at a time: canSend() == no outstanding TX_RESULT.
+//   The protocol's 8-credit window is deliberately not used — the hop
+//   machine relies on canSend() meaning "airtime finished".
+// - reconfigure(): SET_CONFIG → bounded wait for the STATUS ack (the
+//   modem always echoes STATUS after SET_CONFIG). wait_for_tx=true first
+//   waits (bounded) for an outstanding TX; =false returns false when busy,
+//   matching the direct driver's non-blocking rendezvous contract (#405).
+// - hopToFrequencyMHz(): refuses mid-TX locally (mirrors the driver's
+//   can't-retune-mid-TX rule), otherwise fire-and-forget HOP_FREQ.
+// - A modem BOOT message (daughterboard rebooted/power-cycled) clears the
+//   in-flight slot and triggers an automatic config re-push.
+class UartModemBackend final : public IRadioLink
+{
+public:
+    struct Config
+    {
+        TR_UART_Link::Config uart;
+        int act_pin = -1;  // daughterboard power gate (LORA_ACT); -1 = none
+        // Boot-fixed radio fields forwarded in every SET_CONFIG
+        uint16_t preamble_len = 12;
+        bool crc_on = true;
+        bool rx_boosted_gain = true;
+        bool syncword_private = true;
+    };
+
+    // Powers the daughterboard (act_pin high), opens the UART, waits
+    // (bounded) for the modem's BOOT identity, verifies the protocol
+    // version, then pushes the initial radio config. Returns false on
+    // no/incompatible modem — the OC then runs radio-less, mirroring a
+    // failed TR_LoRa_Comms::begin().
+    bool begin(const Config& cfg, float freq_mhz, uint8_t sf, float bw_khz,
+               uint8_t cr, int8_t tx_power, bool debug);
+
+    void service() override;
+
+    bool send(const uint8_t* payload, size_t len) override;
+    bool canSend() const override;
+
+    bool startReceive() override;
+    bool readPacket(uint8_t* buf, size_t maxLen, size_t& len) override;
+
+    bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr,
+                     int8_t tx_power, bool wait_for_tx = true) override;
+    bool hopToFrequencyMHz(float freq_mhz) override;
+
+    float currentFrequencyMHz() const override { return cfg_freq_mhz_; }
+    uint8_t currentSpreadingFactor() const override { return cfg_sf_; }
+    bool isInRxMode() const override;
+
+    // No DIO1 on this side of the link; the watchdog slot instead clears a
+    // TX_RESULT that never arrived (modem died mid-frame) so canSend()
+    // can't wedge false forever — same failure philosophy as #105.
+    void pollDio1() override {}
+    void serviceTxWatchdog() override;
+
+    void getStats(TR_LoRa_Comms::Stats& out) const override;
+
+    // Modem-side identity captured from BOOT/IDENTITY (fw version, chip,
+    // capabilities) — surfaced for status/logging.
+    const radio_modem::ModemIdentityData& identity() const { return identity_; }
+    bool modemAlive() const { return modem_alive_; }
+
+private:
+    static void onFrameTrampoline(void* ctx, uint8_t type,
+                                  const uint8_t* payload, size_t len);
+    void onFrame(uint8_t type, const uint8_t* payload, size_t len);
+    bool pushConfig(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr,
+                    int8_t tx_power, bool start_rx, uint32_t ack_timeout_ms);
+    bool waitTxIdle(uint32_t timeout_ms);
+
+    TR_UART_Link link_;
+    Config cfg_{};
+    bool began_ = false;
+    bool debug_ = false;
+    bool modem_alive_ = false;
+
+    // In-flight TX slot (single — see header comment)
+    bool tx_in_flight_ = false;
+    uint8_t tx_seq_ = 0;
+    uint32_t tx_started_ms_ = 0;
+    static constexpr uint32_t TX_WATCHDOG_MS = 3000;  // matches TR_LoRa_Comms
+
+    // Cached radio params (last accepted by begin/reconfigure/hop)
+    float cfg_freq_mhz_ = 915.0f;
+    uint8_t cfg_sf_ = 10;
+    float cfg_bw_khz_ = 125.0f;
+    uint8_t cfg_cr_ = 7;
+    int8_t cfg_tx_power_ = 20;
+
+    // RX queue: LoRa airtime paces arrivals (~10 Hz), the OC polls every
+    // loop iteration — 4 slots is generous.
+    static constexpr size_t RX_QUEUE_LEN = 4;
+    struct RxEntry
+    {
+        uint8_t len;
+        float rssi;
+        float snr;
+        uint8_t data[radio_modem::MAX_AIR_FRAME];
+    };
+    RxEntry rx_queue_[RX_QUEUE_LEN] = {};
+    uint8_t rxq_head_ = 0;
+    uint8_t rxq_used_ = 0;
+
+    // STATUS ack tracking for reconfigure()
+    uint32_t status_rx_count_ = 0;
+
+    // Stats mirror in TR_LoRa_Comms currency (fed by TX_RESULT / RX_FRAME /
+    // STATUS)
+    TR_LoRa_Comms::Stats stats_ = {};
+    radio_modem::ModemIdentityData identity_ = {};
+    radio_modem::ModemStatusData last_status_ = {};
+};

--- a/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
         TR_LogToFlash
         TR_FlightLog
         TR_LoRa_Comms
+        TR_RadioLink
         TR_Sensor_Data_Converter
         TR_Orientation
         TR_Coordinates

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v7.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v7.h
@@ -43,6 +43,7 @@ struct board_pins
     // --- Radio topology: direct LLCC68 on SPI ---
     // (V8 replaces this with the UART radio daughterboard, #410/#414.)
     static constexpr bool USE_LORA_RADIO = true;
+    static constexpr bool USE_UART_RADIO_MODEM = false;
     static constexpr int LORA_SPI_SCK = 14;
     static constexpr int LORA_SPI_MISO = 11;
     static constexpr int LORA_SPI_MOSI = 12;

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
@@ -44,7 +44,10 @@ struct board_pins
     static constexpr int I2S_FSYNC_PIN = 4;  // ESP_SDI
 
     // --- Radio topology: UART daughterboard (#409/#410) — no direct LLCC68.
-    static constexpr bool USE_LORA_RADIO = false;
+    // USE_LORA_RADIO=true: the radio paths run, through the UART-modem
+    // backend rather than the direct SPI driver.
+    static constexpr bool USE_LORA_RADIO = true;
+    static constexpr bool USE_UART_RADIO_MODEM = true;
     static constexpr int LORA_SPI_SCK = -1;
     static constexpr int LORA_SPI_MISO = -1;
     static constexpr int LORA_SPI_MOSI = -1;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -51,6 +51,9 @@ static inline std::string itos(int v)
 #include <TR_I2S_Stream.h>
 #include <TR_LogToFlash.h>
 #include <TR_LoRa_Comms.h>
+#include <IRadioLink.h>
+#include <LoRaDirectBackend.h>
+#include <UartModemBackend.h>
 #include <TR_Sensor_Data_Converter.h>
 #include <TR_Orientation.h>
 #include <TR_Coordinates.h>
@@ -367,7 +370,16 @@ static void flightlogEndFlight()
     // operation (re-backed on TR_FlightLog in Stage 3).
 }
 static TR_BLE_To_APP ble_app("TinkerRocket");
-static TR_LoRa_Comms lora_comms;
+// Radio backend seam (#410): direct SPI LLCC68 (V7 boards) or the UART
+// radio-daughterboard modem (V8), selected by the board header. The
+// reference keeps the historical `lora_comms` name so every call site
+// below is untouched; the unused backend is never begun.
+static LoRaDirectBackend lora_direct_backend;
+static UartModemBackend lora_modem_backend;
+static IRadioLink& lora_comms =
+    config::USE_UART_RADIO_MODEM
+        ? static_cast<IRadioLink&>(lora_modem_backend)
+        : static_cast<IRadioLink&>(lora_direct_backend);
 static SensorConverter sensor_converter;
 static TR_Coordinates coord;
 
@@ -4555,26 +4567,48 @@ void initPeripherals()
 
     if (config::USE_LORA_RADIO)
     {
-        TR_LoRa_Comms::Config lora_cfg = {};
-        lora_cfg.enabled = config::USE_LORA_RADIO;
-        lora_cfg.cs_pin = config::LORA_CS_PIN;
-        lora_cfg.dio1_pin = config::LORA_DIO1_PIN;
-        lora_cfg.rst_pin = config::LORA_RST_PIN;
-        lora_cfg.busy_pin = config::LORA_BUSY_PIN;
-        lora_cfg.spi_sck = config::LORA_SPI_SCK;
-        lora_cfg.spi_miso = config::LORA_SPI_MISO;
-        lora_cfg.spi_mosi = config::LORA_SPI_MOSI;
-        lora_cfg.spi_host = SPI3_HOST;  // SPI2 used by NAND/MRAM
-        lora_cfg.freq_mhz = lora_freq_mhz;
-        lora_cfg.spreading_factor = lora_sf;
-        lora_cfg.bandwidth_khz = lora_bw_khz;
-        lora_cfg.coding_rate = lora_cr;
-        lora_cfg.preamble_len = config::LORA_PREAMBLE_LEN;
-        lora_cfg.tx_power_dbm = lora_tx_power;
-        lora_cfg.crc_on = config::LORA_CRC_ON;
-        lora_cfg.rx_boosted_gain = config::LORA_RX_BOOSTED_GAIN;
-        lora_cfg.syncword_private = config::LORA_SYNCWORD_PRIVATE;
-        if (!lora_comms.begin(lora_cfg, config::DEBUG))
+        bool radio_ok = false;
+        if (config::USE_UART_RADIO_MODEM)
+        {
+            // V8: LoRa daughterboard over UART (#409/#410). NVS-restored
+            // modulation params are pushed to the modem; pins/baud from the
+            // board header (baud must match projects/radio_board).
+            UartModemBackend::Config mcfg = {};
+            mcfg.uart.tx_pin = config::LORA_UART_TX_PIN;
+            mcfg.uart.rx_pin = config::LORA_UART_RX_PIN;
+            mcfg.act_pin = config::LORA_ACT_PIN;
+            mcfg.preamble_len = config::LORA_PREAMBLE_LEN;
+            mcfg.crc_on = config::LORA_CRC_ON;
+            mcfg.rx_boosted_gain = config::LORA_RX_BOOSTED_GAIN;
+            mcfg.syncword_private = config::LORA_SYNCWORD_PRIVATE;
+            radio_ok = lora_modem_backend.begin(mcfg, lora_freq_mhz, lora_sf,
+                                                lora_bw_khz, lora_cr,
+                                                lora_tx_power, config::DEBUG);
+        }
+        else
+        {
+            TR_LoRa_Comms::Config lora_cfg = {};
+            lora_cfg.enabled = config::USE_LORA_RADIO;
+            lora_cfg.cs_pin = config::LORA_CS_PIN;
+            lora_cfg.dio1_pin = config::LORA_DIO1_PIN;
+            lora_cfg.rst_pin = config::LORA_RST_PIN;
+            lora_cfg.busy_pin = config::LORA_BUSY_PIN;
+            lora_cfg.spi_sck = config::LORA_SPI_SCK;
+            lora_cfg.spi_miso = config::LORA_SPI_MISO;
+            lora_cfg.spi_mosi = config::LORA_SPI_MOSI;
+            lora_cfg.spi_host = SPI3_HOST;  // SPI2 used by NAND/MRAM
+            lora_cfg.freq_mhz = lora_freq_mhz;
+            lora_cfg.spreading_factor = lora_sf;
+            lora_cfg.bandwidth_khz = lora_bw_khz;
+            lora_cfg.coding_rate = lora_cr;
+            lora_cfg.preamble_len = config::LORA_PREAMBLE_LEN;
+            lora_cfg.tx_power_dbm = lora_tx_power;
+            lora_cfg.crc_on = config::LORA_CRC_ON;
+            lora_cfg.rx_boosted_gain = config::LORA_RX_BOOSTED_GAIN;
+            lora_cfg.syncword_private = config::LORA_SYNCWORD_PRIVATE;
+            radio_ok = lora_direct_backend.begin(lora_cfg, config::DEBUG);
+        }
+        if (!radio_ok)
         {
             ESP_LOGE("PWR", "LoRa init failed");
         }


### PR DESCRIPTION
Part of #410 (tracking #408). No closing keyword on purpose — #410 stays open for the daughterboard/devkit bench pass (deferred until the radio-board PCB respin; landing now to stop branch divergence — the V8 modem path is dormant on the default V7 build).

## What

The OC now drives its radio through an `IRadioLink` seam (`components/TR_RadioLink`), selected by the board header:

- **`LoRaDirectBackend`** (V7, default): pure 1:1 delegation to `TR_LoRa_Comms` — zero logic, zero behavior change on the flight path.
- **`UartModemBackend`** (V8): speaks the #409 transparent-modem protocol to the radio daughterboard over `TR_UART_Link`.

The `lora_comms` reference keeps its name, so all ~25 radio call sites in `main.cpp` are untouched; only the object declaration and the `begin()` block changed.

## UartModemBackend contract fidelity (from a call-site audit)

- **Single in-flight TX**: `canSend()` keeps meaning "airtime finished" — the hop machine gates retunes on it. The protocol's 8-credit window is deliberately unused at this seam.
- `reconfigure(wait_for_tx=false)` stays non-blocking (busy → false → caller retries next loop, the #405 rendezvous contract); `=true` bounded-waits like the direct driver's 2 s deadline, then SET_CONFIG → STATUS ack.
- `hopToFrequencyMHz()` refuses mid-TX locally, else fire-and-forget.
- 3 s TX_RESULT watchdog (mirrors #105) so a dead modem can't wedge `canSend()`; modem BOOT mid-run → credit reset + automatic config re-push + warning; protocol-version mismatch at `begin()` disables the radio loudly.
- Modem TX power clamped host-side to the daughterboard's reported capability (matched-pair safety).

V8 board header: `USE_LORA_RADIO` now true (radio paths run, via the modem); new `USE_UART_RADIO_MODEM` selects the backend (false on V7).

## Validation

- OC V7 + V8 build-verified (IDF v6.0). V7 is a mechanical refactor (delegation-only backend).
- Bench (tracked on #410, blocked on hardware): V8 OC ↔ S3 devkit running `projects/radio_board` over jumpers ↔ existing base station; V7 regression pass on current hardware before any flight use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
