### PR TITLE
fix: low-risk firmware roundup batch (#382/#383/#384/#386 items)

### DIFF
--- a/tests_cpp/test_lora_roundtrip.cpp
+++ b/tests_cpp/test_lora_roundtrip.cpp
@@ -194,8 +194,11 @@ TEST_F(LoRaRoundtripTest, i24_SignExtension) {
 }
 
 TEST_F(LoRaRoundtripTest, RocketState_AllValues) {
-    // All 5 RocketState enum values must survive the 3-bit encoding
-    for (uint8_t state = 0; state <= 4; state++) {
+    // All RocketState enum values incl. MAG_CALIBRATION (5) must survive the
+    // 3-bit encoding — #386: the old pack clamp mangled 5 into LANDED (4), so
+    // a bench mag-cal with the BS listening displayed a fake LANDED and
+    // closed the BS log. The field holds 0..7.
+    for (uint8_t state = 0; state <= 5; state++) {
         LoRaDataSI in{};
         in.rocket_state = state;
 

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -276,11 +276,15 @@ private:
     float vEst_NED_mps_[3];
     float aEst_B_mps2_[3];
     float wEst_B_rps_[3];
-    uint32_t tPrev_us_;
-    float dt_s_;
-    uint32_t timeWeekPrev_;
+    // #386: default-initialized — the FC path always runs init()/
+    // setQuaternion() first, but the sim/ECEF path could reach measUpdate()'s
+    // cos^4(pitch) gate with garbage euler_BL_rad_ (and dt math with garbage
+    // tPrev_us_/timeWeekPrev_) on its very first update.
+    uint32_t tPrev_us_ = 0;
+    float dt_s_ = 0.0f;
+    uint32_t timeWeekPrev_ = 0;
     uint32_t baroTimePrev_ = 0;
-    float euler_BL_rad_[3];
+    float euler_BL_rad_[3] = {0.0f, 0.0f, 0.0f};
 
     // GNSS-acceleration estimate for accelMatchHeadingUpdate: previous GNSS
     // velocity + sample time to difference, and a low-pass on the result

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -555,7 +555,8 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
             // samples, so a transient can't fire it.  Being non-EKF, it restores
             // voter diversity exactly when the EKF voters and/or baro are at
             // risk — baro mach-locked-out (the #262 common-mode case) or a
-            // degraded EKF.  Same 5 s freshness gate as the landing vote.
+            // degraded EKF.  Gated on GPS_APOGEE_FRESH_MS freshness (500 ms
+            // since #262 — this comment used to claim 5 s).
             const bool gps_fresh = gps_available_ &&
                                    (millis() - last_gps_time_ms_) < GPS_APOGEE_FRESH_MS;
             if (gps_fresh)

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1430,7 +1430,7 @@ typedef struct
             launch_flag,            // bit          : bool
             camera_recording,       // bit 7        : bool
             logging_active;         // MSB of num_sats byte
-    uint8_t rocket_state;           // 3 bits       : states 0 through 4
+    uint8_t rocket_state;           // 3 bits       : states 0 through 5 (incl. MAG_CALIBRATION; field holds 0-7)
     float   acc_x;                  // 0.1 m/s2     : -400 to 400
     float   acc_y;                  // 0.1 m/s2     : -400 to 400
     float   acc_z;                  // 0.1 m/s2     : -400 to 400
@@ -2089,6 +2089,123 @@ static constexpr size_t SIZE_OF_MMC5983MA_DATA  = sizeof(MMC5983MAData);
 static constexpr size_t SIZE_OF_IIS2MDC_DATA    = sizeof(IIS2MDCData);
 static constexpr size_t SIZE_OF_POWER_DATA      = sizeof(POWERData);
 static constexpr size_t SIZE_OF_NON_SENSOR_DATA = sizeof(NonSensorData);
+// --- #386: wire-layout offset pins ------------------------------------
+// The cross-device structs are size-pinned, but a same-size field reorder
+// or type swap passes a size assert silently and scrambles every consumer
+// of the wire format. Pin every field offset so any layout change is a
+// loud compile error on firmware and host builds alike. Values were
+// derived from the declared layouts; the compiler proves each line.
+static_assert(sizeof(LoRaData) == 66, "LoRaData wire size");
+static_assert(offsetof(LoRaData, network_id) == 0, "LoRaData.network_id moved");
+static_assert(offsetof(LoRaData, rocket_id) == 1, "LoRaData.rocket_id moved");
+static_assert(offsetof(LoRaData, next_channel_idx) == 2, "LoRaData.next_channel_idx moved");
+static_assert(offsetof(LoRaData, seq) == 3, "LoRaData.seq moved");
+static_assert(offsetof(LoRaData, num_sats) == 5, "LoRaData.num_sats moved");
+static_assert(offsetof(LoRaData, pdop_u8) == 6, "LoRaData.pdop_u8 moved");
+static_assert(offsetof(LoRaData, ecef_x_m) == 7, "LoRaData.ecef_x_m moved");
+static_assert(offsetof(LoRaData, ecef_y_m) == 10, "LoRaData.ecef_y_m moved");
+static_assert(offsetof(LoRaData, ecef_z_m) == 13, "LoRaData.ecef_z_m moved");
+static_assert(offsetof(LoRaData, hacc_u8) == 16, "LoRaData.hacc_u8 moved");
+static_assert(offsetof(LoRaData, flags_state) == 17, "LoRaData.flags_state moved");
+static_assert(offsetof(LoRaData, acc_x_x10) == 18, "LoRaData.acc_x_x10 moved");
+static_assert(offsetof(LoRaData, acc_y_x10) == 20, "LoRaData.acc_y_x10 moved");
+static_assert(offsetof(LoRaData, acc_z_x10) == 22, "LoRaData.acc_z_x10 moved");
+static_assert(offsetof(LoRaData, gyro_x_x10) == 24, "LoRaData.gyro_x_x10 moved");
+static_assert(offsetof(LoRaData, gyro_y_x10) == 26, "LoRaData.gyro_y_x10 moved");
+static_assert(offsetof(LoRaData, gyro_z_x10) == 28, "LoRaData.gyro_z_x10 moved");
+static_assert(offsetof(LoRaData, temp_x10) == 30, "LoRaData.temp_x10 moved");
+static_assert(offsetof(LoRaData, voltage_u8) == 32, "LoRaData.voltage_u8 moved");
+static_assert(offsetof(LoRaData, current_ma) == 33, "LoRaData.current_ma moved");
+static_assert(offsetof(LoRaData, soc_i8) == 35, "LoRaData.soc_i8 moved");
+static_assert(offsetof(LoRaData, pressure_alt_m) == 36, "LoRaData.pressure_alt_m moved");
+static_assert(offsetof(LoRaData, altitude_rate) == 39, "LoRaData.altitude_rate moved");
+static_assert(offsetof(LoRaData, max_alt_m) == 41, "LoRaData.max_alt_m moved");
+static_assert(offsetof(LoRaData, max_speed) == 44, "LoRaData.max_speed moved");
+static_assert(offsetof(LoRaData, roll_cd) == 46, "LoRaData.roll_cd moved");
+static_assert(offsetof(LoRaData, pitch_cd) == 48, "LoRaData.pitch_cd moved");
+static_assert(offsetof(LoRaData, yaw_cd) == 50, "LoRaData.yaw_cd moved");
+static_assert(offsetof(LoRaData, q0) == 52, "LoRaData.q0 moved");
+static_assert(offsetof(LoRaData, q1) == 54, "LoRaData.q1 moved");
+static_assert(offsetof(LoRaData, q2) == 56, "LoRaData.q2 moved");
+static_assert(offsetof(LoRaData, q3) == 58, "LoRaData.q3 moved");
+static_assert(offsetof(LoRaData, speed) == 60, "LoRaData.speed moved");
+static_assert(offsetof(LoRaData, sensor_health) == 62, "LoRaData.sensor_health moved");
+
+static_assert(sizeof(GNSSData) == 42, "GNSSData wire size");
+static_assert(offsetof(GNSSData, time_us) == 0, "GNSSData.time_us moved");
+static_assert(offsetof(GNSSData, year) == 4, "GNSSData.year moved");
+static_assert(offsetof(GNSSData, month) == 6, "GNSSData.month moved");
+static_assert(offsetof(GNSSData, day) == 7, "GNSSData.day moved");
+static_assert(offsetof(GNSSData, hour) == 8, "GNSSData.hour moved");
+static_assert(offsetof(GNSSData, minute) == 9, "GNSSData.minute moved");
+static_assert(offsetof(GNSSData, second) == 10, "GNSSData.second moved");
+static_assert(offsetof(GNSSData, milli_second) == 11, "GNSSData.milli_second moved");
+static_assert(offsetof(GNSSData, fix_mode) == 13, "GNSSData.fix_mode moved");
+static_assert(offsetof(GNSSData, num_sats) == 14, "GNSSData.num_sats moved");
+static_assert(offsetof(GNSSData, pdop_x10) == 15, "GNSSData.pdop_x10 moved");
+static_assert(offsetof(GNSSData, lat_e7) == 16, "GNSSData.lat_e7 moved");
+static_assert(offsetof(GNSSData, lon_e7) == 20, "GNSSData.lon_e7 moved");
+static_assert(offsetof(GNSSData, alt_mm) == 24, "GNSSData.alt_mm moved");
+static_assert(offsetof(GNSSData, vel_e_mmps) == 28, "GNSSData.vel_e_mmps moved");
+static_assert(offsetof(GNSSData, vel_n_mmps) == 32, "GNSSData.vel_n_mmps moved");
+static_assert(offsetof(GNSSData, vel_u_mmps) == 36, "GNSSData.vel_u_mmps moved");
+static_assert(offsetof(GNSSData, h_acc_m) == 40, "GNSSData.h_acc_m moved");
+static_assert(offsetof(GNSSData, v_acc_m) == 41, "GNSSData.v_acc_m moved");
+
+static_assert(sizeof(NonSensorData) == 48, "NonSensorData wire size");
+static_assert(offsetof(NonSensorData, time_us) == 0, "NonSensorData.time_us moved");
+static_assert(offsetof(NonSensorData, q0) == 4, "NonSensorData.q0 moved");
+static_assert(offsetof(NonSensorData, q1) == 6, "NonSensorData.q1 moved");
+static_assert(offsetof(NonSensorData, q2) == 8, "NonSensorData.q2 moved");
+static_assert(offsetof(NonSensorData, q3) == 10, "NonSensorData.q3 moved");
+static_assert(offsetof(NonSensorData, roll_cmd) == 12, "NonSensorData.roll_cmd moved");
+static_assert(offsetof(NonSensorData, e_pos) == 14, "NonSensorData.e_pos moved");
+static_assert(offsetof(NonSensorData, n_pos) == 18, "NonSensorData.n_pos moved");
+static_assert(offsetof(NonSensorData, u_pos) == 22, "NonSensorData.u_pos moved");
+static_assert(offsetof(NonSensorData, e_vel) == 26, "NonSensorData.e_vel moved");
+static_assert(offsetof(NonSensorData, n_vel) == 30, "NonSensorData.n_vel moved");
+static_assert(offsetof(NonSensorData, u_vel) == 34, "NonSensorData.u_vel moved");
+static_assert(offsetof(NonSensorData, flags) == 38, "NonSensorData.flags moved");
+static_assert(offsetof(NonSensorData, rocket_state) == 39, "NonSensorData.rocket_state moved");
+static_assert(offsetof(NonSensorData, baro_alt_rate_dmps) == 40, "NonSensorData.baro_alt_rate_dmps moved");
+static_assert(offsetof(NonSensorData, pyro_status) == 42, "NonSensorData.pyro_status moved");
+static_assert(offsetof(NonSensorData, apogee_flags) == 43, "NonSensorData.apogee_flags moved");
+static_assert(offsetof(NonSensorData, sensor_health) == 44, "NonSensorData.sensor_health moved");
+
+static_assert(sizeof(OutStatusQueryData) == 28, "OutStatusQueryData wire size");
+static_assert(offsetof(OutStatusQueryData, ism6_low_g_fs_g) == 0, "OutStatusQueryData.ism6_low_g_fs_g moved");
+static_assert(offsetof(OutStatusQueryData, ism6_high_g_fs_g) == 1, "OutStatusQueryData.ism6_high_g_fs_g moved");
+static_assert(offsetof(OutStatusQueryData, ism6_gyro_fs_dps) == 3, "OutStatusQueryData.ism6_gyro_fs_dps moved");
+static_assert(offsetof(OutStatusQueryData, ism6_rot_z_cdeg) == 5, "OutStatusQueryData.ism6_rot_z_cdeg moved");
+static_assert(offsetof(OutStatusQueryData, mmc_rot_z_cdeg) == 7, "OutStatusQueryData.mmc_rot_z_cdeg moved");
+static_assert(offsetof(OutStatusQueryData, format_version) == 9, "OutStatusQueryData.format_version moved");
+static_assert(offsetof(OutStatusQueryData, hg_bias_x_cmss) == 10, "OutStatusQueryData.hg_bias_x_cmss moved");
+static_assert(offsetof(OutStatusQueryData, hg_bias_y_cmss) == 12, "OutStatusQueryData.hg_bias_y_cmss moved");
+static_assert(offsetof(OutStatusQueryData, hg_bias_z_cmss) == 14, "OutStatusQueryData.hg_bias_z_cmss moved");
+static_assert(offsetof(OutStatusQueryData, b2r_code) == 16, "OutStatusQueryData.b2r_code moved");
+static_assert(offsetof(OutStatusQueryData, b2r_mode) == 17, "OutStatusQueryData.b2r_mode moved");
+static_assert(offsetof(OutStatusQueryData, b2r_q) == 18, "OutStatusQueryData.b2r_q moved");
+static_assert(offsetof(OutStatusQueryData, iis2mdc_rot_z_cdeg) == 26, "OutStatusQueryData.iis2mdc_rot_z_cdeg moved");
+
+static_assert(sizeof(ServoConfigData) == 22, "ServoConfigData wire size");
+static_assert(offsetof(ServoConfigData, bias_us) == 0, "ServoConfigData.bias_us moved");
+static_assert(offsetof(ServoConfigData, hz) == 8, "ServoConfigData.hz moved");
+static_assert(offsetof(ServoConfigData, min_us) == 10, "ServoConfigData.min_us moved");
+static_assert(offsetof(ServoConfigData, max_us) == 12, "ServoConfigData.max_us moved");
+static_assert(offsetof(ServoConfigData, fin_min_deg) == 14, "ServoConfigData.fin_min_deg moved");
+static_assert(offsetof(ServoConfigData, fin_max_deg) == 18, "ServoConfigData.fin_max_deg moved");
+
+static_assert(sizeof(RollProfileData) == 76, "RollProfileData wire size");
+static_assert(offsetof(RollProfileData, num_waypoints) == 0, "RollProfileData.num_waypoints moved");
+static_assert(offsetof(RollProfileData, _pad) == 1, "RollProfileData._pad moved");
+static_assert(offsetof(RollProfileData, waypoints) == 4, "RollProfileData.waypoints moved");
+
+// LoRaChannelSetSelection is all-uint8_t (alignment 1, padding impossible),
+// so a size pin fully constrains the layout without adding packed (which
+// could have changed the in-memory layout for existing consumers).
+static_assert(sizeof(LoRaChannelSetSelection) == 1 + LORA_SKIP_MASK_MAX_BYTES,
+              "LoRaChannelSetSelection wire size");
+
 static constexpr size_t SIZE_OF_LORA_DATA       = sizeof(LoRaData);
 static constexpr size_t SIZE_OF_LORA_DATA_SI = sizeof(LoRaDataSI);
 
@@ -2101,7 +2218,7 @@ static constexpr size_t P5 = SIZE_OF_POWER_DATA;
 static constexpr size_t P6 = SIZE_OF_NON_SENSOR_DATA;
 static constexpr size_t P7 = SIZE_OF_LORA_DATA;
 static constexpr size_t P8 = sizeof(RollProfileData);
-static constexpr size_t P9 = sizeof(FlightSnapshotData);  // largest payload (216 B)
+static constexpr size_t P9 = sizeof(FlightSnapshotData);  // largest payload (224 B as of snapshot v3)
 
 static constexpr size_t M12   = (P1 > P2 ? P1 : P2);
 static constexpr size_t M34   = (P3 > P4 ? P3 : P4);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -51,8 +51,14 @@ SensorCollector::SensorCollector(
                            bool use_iis2mdc,
                            bool use_gnss,
                            bool use_ism6hg256,
-                           uint32_t spi_speed)
-    : ISM6HG256_CS(ISM6HG256_CS),
+                           uint32_t spi_speed,
+                           uint8_t  ism6_low_g_fs_g,
+                           uint16_t ism6_high_g_fs_g,
+                           uint16_t ism6_gyro_fs_dps)
+    : ism6_low_g_fs_g_(ism6_low_g_fs_g),
+      ism6_high_g_fs_g_(ism6_high_g_fs_g),
+      ism6_gyro_fs_dps_(ism6_gyro_fs_dps),
+      ISM6HG256_CS(ISM6HG256_CS),
       ISM6HG256_INT(ISM6HG256_INT),
       ISM6HG256_UPDATE_RATE(ISM6HG256_UPDATE_RATE),
       BMP585_CS(BMP585_CS),
@@ -443,10 +449,11 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_OutputDataRate((float)ISM6HG256_UPDATE_RATE));
         status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_OutputDataRate((float)ISM6HG256_UPDATE_RATE));
 
-        // Full-scale settings: low-g=16g, high-g=256g, gyro=4000 dps.
-        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_X_FullScale(16));
-        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_FullScale(256));
-        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_FullScale(4000));
+        // Full-scale settings — from the ctor (config::ISM6_*_FS on the FC),
+        // the same constants the converter scale + snapshots read (#386).
+        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_X_FullScale(ism6_low_g_fs_g_));
+        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_FullScale(ism6_high_g_fs_g_));
+        status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_FullScale(ism6_gyro_fs_dps_));
 
         if (status != TR_ISM6HG256_OK)
         {

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -92,9 +92,24 @@ public:
                     bool use_iis2mdc,
                     bool use_gnss,
                     bool use_ism6hg256,
-                    uint32_t spi_speed);
+                    uint32_t spi_speed,
+                    // #386: ISM6 full-scale settings. Were hardcoded 16/256/4000
+                    // literals in begin() while the converter scale + snapshots
+                    // read config::ISM6_*_FS — editing config.h silently
+                    // desynced chip FS from conversion scale (2x-8x data
+                    // error). Defaults preserve the flown values; the FC
+                    // passes its config constants so there is one source of
+                    // truth.
+                    uint8_t  ism6_low_g_fs_g   = 16,
+                    uint16_t ism6_high_g_fs_g  = 256,
+                    uint16_t ism6_gyro_fs_dps  = 4000);
 
     void begin(uint8_t imu_execution_core);
+
+    // #386: chip full-scale settings (see ctor comment).
+    const uint8_t  ism6_low_g_fs_g_;
+    const uint16_t ism6_high_g_fs_g_;
+    const uint16_t ism6_gyro_fs_dps_;
 
     volatile bool ism6hg256_data_ready;
     volatile bool bmp585_data_ready;

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -388,7 +388,11 @@ void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
     if (in.alt_apogee_flag)   packed |= LORA_ALT_APOGEE;
     if (in.alt_landed_flag)   packed |= LORA_ALT_LANDED;
     if (in.camera_recording)  packed |= LORA_CAMERA_REC;
-    uint8_t state = (uint8_t)(in.rocket_state > 4 ? 4 : in.rocket_state);
+    // #386: clamp to the 3-bit field's full 0..7 range, not 0..4 — the old
+    // clamp wire-mangled MAG_CALIBRATION (5) into LANDED (4), so a bench
+    // mag-cal with the BS listening showed a fake LANDED (and closed the BS
+    // log). The BS decoder already prints state 5 as MAG_CAL.
+    uint8_t state = (uint8_t)(in.rocket_state > 7 ? 7 : in.rocket_state);
     packed |= (state & 0x07u) << LORA_STATE_SHIFT; // b4..b6
     out.flags_state = packed;
 

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -218,6 +218,12 @@ static uint32_t log_last_flush_ms = 0;
 // Reset to 0 by stopLogging() so the next flight can retry immediately
 // rather than waiting out the residual window.
 static uint32_t log_last_open_attempt_ms = 0;
+// #329: CSV writes/flushes that failed.  fprintf() usually buffers a row and
+// returns OK even on a full card, so a full disk surfaces only at fflush/fsync
+// (ENOSPC) — counting both makes otherwise-silent row loss visible instead of
+// vanishing with no warning. (Declared here so startLogging/stopLogging can
+// count header-write and close failures too — the #384 gaps.)
+static uint32_t log_write_fail_count = 0;
 // State-transition tracking (INFLIGHT safety arm time, last state, boot-edge
 // guard, per-rocket freq lock) lives per tracked rocket in
 // TrackedRocket::log_state (#381) — one global here made two interleaved
@@ -721,12 +727,21 @@ static void startLogging()
     // now that one file can interleave several; empty on EVENT rows (those
     // are station-level, not per-rocket). All downstream consumers key
     // columns by header name, so the trailing add is non-breaking.
-    fprintf(log_file, "time_ms,state,num_sats,pdop,lat,lon,alt_m,h_acc,"
+    int hdr_written = fprintf(log_file, "time_ms,state,num_sats,pdop,lat,lon,alt_m,h_acc,"
                       "acc_x,acc_y,acc_z,gyro_x,gyro_y,gyro_z,"
                       "pressure_alt,alt_rate,max_alt,max_speed,"
                       "voltage,current,soc,roll,pitch,yaw,speed,"
                       "launch,vel_apo,alt_apo,landed,rssi,snr,"
                       "next_ch,rx_freq_mhz,seq,gap,event,rocket_id\n");
+    if (hdr_written <= 0)
+    {
+        // #384 (#329 residual): a full/wedged card at open used to fail the
+        // header silently; every later name-keyed consumer then sees a
+        // headerless CSV.
+        log_write_fail_count++;
+        ESP_LOGW(TAG, "[LOG] header fprintf() failed (ret=%d, errno=%d %s)",
+                 hdr_written, errno, strerror(errno));
+    }
 
     logging_active = true;
     log_start_ms = millis();
@@ -740,7 +755,18 @@ static void stopLogging()
 {
     if (!logging_active) return;
 
-    if (log_file) { fclose(log_file); log_file = nullptr; }
+    if (log_file)
+    {
+        // #384 (#329 residual): fclose flushes the final buffered rows — the
+        // LANDED-close tail of a flight. A card-full here was fully silent.
+        if (fclose(log_file) != 0)
+        {
+            log_write_fail_count++;
+            ESP_LOGW(TAG, "[LOG] fclose() failed — final buffered rows may be lost (errno=%d %s)",
+                     errno, strerror(errno));
+        }
+        log_file = nullptr;
+    }
     logging_active = false;
     log_last_open_attempt_ms = 0;  // allow the next packet to retry immediately (#107)
 
@@ -827,11 +853,6 @@ static void renameOpenLogIfSequential()
 
 static uint32_t log_write_count = 0;  // Tracks calls for periodic flash check
 
-// #329: CSV writes/flushes that failed.  fprintf() usually buffers a row and
-// returns OK even on a full card, so a full disk surfaces only at fflush/fsync
-// (ENOSPC) — counting both makes otherwise-silent row loss visible instead of
-// vanishing with no warning.
-static uint32_t log_write_fail_count = 0;
 
 // Query the active log filesystem (SPIFFS or FAT) for total/used bytes.
 // Returns true if a backend is mounted and the query succeeded.
@@ -949,6 +970,7 @@ static void logHopEvent(const char* event_str, float rx_freq_mhz)
                     (double)rx_freq_mhz,
                     event_str);
     if (written <= 0) {
+        log_write_fail_count++;  // #384: event rows now count toward #329 stats
         ESP_LOGW(TAG, "[LOG] fprintf(event) failed");
     }
     log_last_write_ms = millis();
@@ -3323,7 +3345,12 @@ static void loop_bs()
         last_packet_ms = millis();
 
         // --- Name beacon: [0xBE][network_id][rocket_id][unit_name...] ---
-        if (rx_len >= 3 && rx_buf[0] == LORA_BEACON_SYNC)
+        // #384: a telemetry frame whose first byte (network_id) happens to
+        // equal LORA_BEACON_SYNC (0xBE = nid 190) would otherwise parse as a
+        // beacon and shadow 100% of telemetry. Inert today (boot forces
+        // nid 0), so require the length to disambiguate: beacons are short,
+        // telemetry is exactly SIZE_OF_LORA_DATA.
+        if (rx_len >= 3 && rx_len != SIZE_OF_LORA_DATA && rx_buf[0] == LORA_BEACON_SYNC)
         {
             uint8_t bcn_nid = rx_buf[1];
             uint8_t bcn_rid = rx_buf[2];
@@ -3343,7 +3370,7 @@ static void loop_bs()
                 }
             }
         }
-        // --- Telemetry packet: SIZE_OF_LORA_DATA (61) bytes ---
+        // --- Telemetry packet: SIZE_OF_LORA_DATA (66) bytes ---
         else if (rx_len == SIZE_OF_LORA_DATA)
         {
             // Decode the telemetry packet

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -95,7 +95,10 @@ SensorCollector sensor_collector_hw(config::ISM6HG256_CS,
                                     config::USE_IIS2MDC,
                                     config::USE_GNSS,
                                     config::USE_ISM6HG256,
-                                    config::SPI_SPEED);
+                                    config::SPI_SPEED,
+                                    config::ISM6_LOW_G_FS_G,
+                                    config::ISM6_HIGH_G_FS_G,
+                                    config::ISM6_GYRO_FS_DPS);
 
 // Sim wrapper: passthrough when sim inactive, replaces data when sim active
 SensorCollectorSim sensor_collector(sensor_collector_hw);
@@ -899,12 +902,34 @@ static void pyroSetArmLocked(bool want_high)
     pyro_arm_pin_state = want_high;
 }
 
+// #386: high-g bias -> cm/s² wire encode with an explicit int16 clamp. The
+// raw lroundf cast wrapped sign for |bias| > ~327 m/s², so the OC applied a
+// grossly wrong bias to its displayed/logged high-g stream (the FC control
+// path uses the float directly and was unaffected). Clamped, a huge bias
+// saturates instead of flipping sign.
+static inline int16_t encodeHgBiasCmss(float bias_mss)
+{
+    float v = bias_mss * 100.0f;
+    if (v >  32767.0f) v =  32767.0f;
+    if (v < -32768.0f) v = -32768.0f;
+    return (int16_t)lroundf(v);
+}
+
 static void pyroSafeAll()
 {
     portENTER_CRITICAL(&pyro_spinlock);
     for (int i = 0; i < 4; ++i) {
         gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 0);
-        pyro_ch[i].state          = PyroChState::Idle;
+        // #382: keep the Done latch — safing (incl. the LANDED transition)
+        // must not erase the record of a channel having fired, or post-flight
+        // pyro_status reads all-zeros and the app/logs misreport what
+        // deployed. No safety change: pins still drop, ARM still drops, Done
+        // never re-fires (auto-fire only starts from Idle), and the
+        // PRELAUNCH->INFLIGHT edge already resets channels for a new flight.
+        // Reboot recovery restores Done from the snapshot for the same reason.
+        if (pyro_ch[i].state != PyroChState::Done) {
+            pyro_ch[i].state = PyroChState::Idle;
+        }
         pyro_ch[i].phase_start_ms = 0;
     }
     pyroSetArmLocked(false);
@@ -999,8 +1024,10 @@ static void servicePyroChannels(uint32_t now_ms)
     }
 
     // While ARM is HIGH (only during a channel's fire window in flight),
-    // refresh its CONT bit. ARM=LOW leaves CONT floating, so the cached
-    // value from the last test stands.
+    // refresh its CONT bit. Outside a fire window the cached value from the
+    // last pad test stands. (#382 comment fix: on the current PCB the CONT
+    // divider is VPP-fed and always readable (#264) — ARM=LOW does NOT float
+    // CONT; we just don't bother re-sampling outside fire windows.)
     if (pyro_arm_pin_state) {
         for (int i = 0; i < 4; ++i) {
             if (pyro_ch[i].state == PyroChState::ArmSettle ||
@@ -2496,9 +2523,9 @@ static void setup_fc()
         float by = prefs.getFloat("hgby", 0.0f);
         float bz = prefs.getFloat("hgbz", 0.0f);
         sensor_converter.setHighGBias(bx, by, bz);
-        out_status_query_data.hg_bias_x_cmss = (int16_t)lroundf(bx * 100.0f);
-        out_status_query_data.hg_bias_y_cmss = (int16_t)lroundf(by * 100.0f);
-        out_status_query_data.hg_bias_z_cmss = (int16_t)lroundf(bz * 100.0f);
+        out_status_query_data.hg_bias_x_cmss = encodeHgBiasCmss(bx);
+        out_status_query_data.hg_bias_y_cmss = encodeHgBiasCmss(by);
+        out_status_query_data.hg_bias_z_cmss = encodeHgBiasCmss(bz);
         ESP_LOGI(TAG, "NVS HG bias: %.3f, %.3f, %.3f m/s²",
                       (double)bx, (double)by, (double)bz);
     }
@@ -4195,9 +4222,9 @@ static void loop_fc()
                                               sensor_collector.hg_bias_y,
                                               sensor_collector.hg_bias_z);
                 // Propagate bias to OutComputer via status query payload
-                out_status_query_data.hg_bias_x_cmss = (int16_t)lroundf(sensor_collector.hg_bias_x * 100.0f);
-                out_status_query_data.hg_bias_y_cmss = (int16_t)lroundf(sensor_collector.hg_bias_y * 100.0f);
-                out_status_query_data.hg_bias_z_cmss = (int16_t)lroundf(sensor_collector.hg_bias_z * 100.0f);
+                out_status_query_data.hg_bias_x_cmss = encodeHgBiasCmss(sensor_collector.hg_bias_x);
+                out_status_query_data.hg_bias_y_cmss = encodeHgBiasCmss(sensor_collector.hg_bias_y);
+                out_status_query_data.hg_bias_z_cmss = encodeHgBiasCmss(sensor_collector.hg_bias_z);
                 // Persist to NVS — high-g bias + gyro zero-rate bias (#132).
                 prefs.begin("cal", false);
                 prefs.putFloat("hgbx", sensor_collector.hg_bias_x);
@@ -4604,9 +4631,9 @@ static void loop_fc()
                         sensor_collector_hw.gyro_cal_y = ap.gyro_y;
                         sensor_collector_hw.gyro_cal_z = ap.gyro_z;
                         sensor_converter.setHighGBias(ap.hg_x, ap.hg_y, ap.hg_z);
-                        out_status_query_data.hg_bias_x_cmss = (int16_t)lroundf(ap.hg_x * 100.0f);
-                        out_status_query_data.hg_bias_y_cmss = (int16_t)lroundf(ap.hg_y * 100.0f);
-                        out_status_query_data.hg_bias_z_cmss = (int16_t)lroundf(ap.hg_z * 100.0f);
+                        out_status_query_data.hg_bias_x_cmss = encodeHgBiasCmss(ap.hg_x);
+                        out_status_query_data.hg_bias_y_cmss = encodeHgBiasCmss(ap.hg_y);
+                        out_status_query_data.hg_bias_z_cmss = encodeHgBiasCmss(ap.hg_z);
 
                         prefs.begin("cal", false);
                         prefs.putFloat("hgbx", ap.hg_x);
@@ -5405,8 +5432,11 @@ static void loop_fc()
                 // would stay zero otherwise.
                 last_external_roll_cmd_deg = roll_fin_cmd;
 
-                // 4-fin mix via the configured fin layout (servo→azimuth + reverse)
-                float max_fin = config::PN_MAX_FIN_DEG;
+                // 4-fin mix via the configured fin layout (servo→azimuth + reverse).
+                // #382: use the runtime clamp (app-tunable via guidance config,
+                // same as the in-flight path) — the compile-time constant made
+                // a bench ground test not match an app-tuned flight clamp.
+                float max_fin = pn_max_fin_deg;
                 float deflections[4];
                 control_mixer.mixToFins(roll_fin_cmd, pitch_fin, yaw_fin, max_fin, deflections);
                 servo_control.setServoAngles(deflections);
@@ -5488,8 +5518,9 @@ static void loop_fc()
                     rocket_state = PRELAUNCH;
                     prelaunch_time_millis = now_ms;
                     // Camera is manually controlled via app — no auto-start on prelaunch
-                    // Verify pyro continuity on the pad via momentary arm-disarm.
-                    // Non-blocking — runs over the next ~60 ms of main loop ticks.
+                    // Verify pyro continuity on the pad. (#382 comment fix:
+                    // this is a synchronous single read of the VPP-fed CONT
+                    // dividers (#264) — no arm pulse, no multi-tick sequence.)
                     pyroPrelaunchContTest(now_ms);
                     ESP_LOGI(TAG, "[STATE] READY -> PRELAUNCH");
                 }
@@ -5565,6 +5596,11 @@ static void loop_fc()
                     // channel's trigger fires (per-fire arming on new PCB).
                     pyro_apogee_detected = false;
                     pyro_apogee_time_ms  = 0;
+                    // #382: re-arm the per-flight settings snapshot (#165) —
+                    // without this only the first flight/sim per boot emitted
+                    // FlightSettingsData, so sim runs #2+ in one boot had no
+                    // settings block in their reports.
+                    settings_emit_count = 0;
                     portENTER_CRITICAL(&pyro_spinlock);
                     for (int i = 0; i < 4; ++i) {
                         pyro_ch[i].state          = PyroChState::Idle;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2187,10 +2187,31 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         // partial write.  ~700 us per write on the SPI bus.
         if (payload_len == sizeof(FlightSnapshotData))
         {
-            // Save the full ~224 B wire frame (SOF + type + len + payload + CRC)
-            // so the recovery path can hand the bytes straight back to FC.
-            (void)logger.mramRawWrite(config::SNAPSHOT_REGION_BASE,
-                                      frame, frame_len);
+            // #383: SNAPSHOT_MSG bypasses the sensor-frame dedup (its payload
+            // starts with the magic, not a timestamp — putting it in that
+            // switch would misread the constant magic as a ts and drop every
+            // snapshot after the first). Guard the MRAM slot here instead: an
+            // I2S DMA replay delivers a snapshot a few hundred ms OLDER than
+            // the one already stored, and overwriting would hand brownout
+            // recovery stale state. Reject slightly-older frames; a frame
+            // MUCH older (>10 s behind) can only be a new flight's near-zero
+            // clock — accept it and re-seed the baseline.
+            uint32_t elapsed_ms = 0;
+            memcpy(&elapsed_ms, payload + offsetof(FlightSnapshotData, flight_elapsed_ms),
+                   sizeof(elapsed_ms));
+            static uint32_t last_snap_elapsed_ms = 0;
+            constexpr uint32_t NEW_FLIGHT_BACKSTEP_MS = 10'000;
+            const bool stale_replay =
+                elapsed_ms < last_snap_elapsed_ms &&
+                (last_snap_elapsed_ms - elapsed_ms) <= NEW_FLIGHT_BACKSTEP_MS;
+            if (!stale_replay)
+            {
+                last_snap_elapsed_ms = elapsed_ms;
+                // Save the full ~224 B wire frame (SOF + type + len + payload + CRC)
+                // so the recovery path can hand the bytes straight back to FC.
+                (void)logger.mramRawWrite(config::SNAPSHOT_REGION_BASE,
+                                          frame, frame_len);
+            }
         }
     }
     else if (type == GET_FLIGHT_SNAPSHOT)
@@ -3151,15 +3172,12 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         setPendingCommand(enabled ? GUIDANCE_ENABLE : GUIDANCE_DISABLE);
         ESP_LOGI("LORA", "UPLINK Guidance: %s", enabled ? "ENABLE" : "DISABLE");
     }
-    else if (cmd == 65 && payload_len >= sizeof(GuidanceConfigData))
-    {
-        // Full guidance config from BaseStation: relay to FC
-        memcpy(pending_config_data, payload, sizeof(GuidanceConfigData));
-        pending_config_data_len = sizeof(GuidanceConfigData);
-        pending_config_msg_type = GUIDANCE_CONFIG_MSG;
-        setPendingCommand(GUIDANCE_CONFIG_PENDING);
-        ESP_LOGI("LORA", "UPLINK Guidance config queued for RocketComputer");
-    }
+    // #383: no cmd-65 (GuidanceConfigData) uplink branch — deliberately.
+    // The LoRa uplink rx_buf is 32 bytes, so a 36-byte GuidanceConfigData
+    // payload can never arrive here (the old branch was dead code), and the
+    // BS stopped relaying config entirely in #285 — guidance config reaches
+    // the FC over BLE (cmd 65 handler in the BLE dispatch above). If uplink
+    // config relay ever returns, the buffer needs resizing first.
     else if (cmd == 66 && payload_len >= sizeof(FinConfigData))
     {
         // Full fin layout from BaseStation: relay to FC


### PR DESCRIPTION
## Summary
Batch of the low-risk findings from the #382/#383/#384/#386 roundups, per the triage discussion: zero-risk items (tests/comments/dead code/initializers) + small behavior fixes with no flight-control semantics. The EKF dt-floor item was deliberately promoted to #440 instead (needs SIL evidence).

## Zero-risk
- **99 compiler-proved wire-layout offset pins** for the six cross-device structs + a size pin for `LoRaChannelSetSelection` (no `packed` added — that could have changed existing in-memory layout). A same-size field reorder used to pass silently. (#386)
- EKF member default-init (sim-path garbage pitch gate). (#386)
- Dead OC cmd-65 uplink branch deleted with tombstone (36 B payload can't fit the 32 B uplink buffer; BS stopped relaying config in #285). (#383)
- Six rotted comments corrected (pyro cont test, CONT divider, 500 ms GPS gate, 224 B snapshot, 66 B LoRa frame, states 0-5). (#382/#386)

## Behavior fixes (small, none touch flight control)
- FC: `pyroSafeAll` keeps `Done` latches (truthful post-flight pyro_status); ground-test uses runtime `pn_max_fin_deg`; settings snapshot re-arms per launch; hg-bias encode clamps instead of sign-wrapping. (#382/#386)
- OC: MRAM snapshot slot rejects DMA-replayed older snapshots — **note:** the roundup's suggested fix (dedup switch) would have been wrong; the snapshot payload starts with the constant magic, which the dedup would misread as a timestamp and drop every snapshot after the first. Guarded at the store on `flight_elapsed_ms` instead. (#383)
- BS: #329-residual write-failure counting (header/fclose/event rows); beacon-vs-telemetry length disambiguation. (#384)
- Shared: `packLoRa` state clamp 0..7 (MAG_CALIBRATION no longer wire-mangled to LANDED — that fake LANDED closed the BS log during bench mag-cals); ISM6 full-scale single-sourced from config. (#386)

## Already-fixed items recorded
#384's exact-multiple EOF chunk (fixed by #380's rework, test exists) and #386's wire-code registry gap (landed in a prior merge) — checked off in the roundup issues at merge.

## Verification
Host suite **421/421** — including all 99 new static_asserts compiling (the compiler is the proof of each pin) and the extended state-5 roundtrip. Firmware builds via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)