### PR TITLE
fix(app): low-risk roundup batch — pyro-test logging, idle timer, scan spinner (#385)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -69,6 +69,9 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     // Frequency scan state (base-station pre-launch collision avoidance)
     @Published var scanSamples: [FrequencyScanSample] = []
     @Published var isScanning: Bool = false
+    // #385: monotonically identifies the latest scan request so the wedge
+    // timeout can't clear a newer scan's spinner.
+    private var scanGeneration = 0
 
     // Magnetometer hard-iron calibration status (issue #96).  Latest frame
     // received from the FC over BLE on the file_ops characteristic with a
@@ -240,7 +243,16 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // state-restoration path that reuses one.
         hasReceivedTelemetry = false
         flightAnnouncer?.reset()
-        UIApplication.shared.isIdleTimerDisabled = false
+        // #385: only re-arm screen auto-lock when this was the last connected
+        // device — with BS + rocket both up, either one dropping used to
+        // re-enable sleep while telemetry still streamed on the other.
+        // (BLEFleet calls onDisconnect() before removing us from devices,
+        // so exclude self and check live connections.)
+        let anotherStillConnected =
+            fleet?.devices.contains { $0 !== self && $0.isConnected } ?? false
+        if !anotherStillConnected {
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
     }
 
     // MARK: - BLE RSSI Polling
@@ -475,6 +487,18 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         payload.append(Data(bytes: &dwell, count: 2))
         scanSamples = []
         isScanning = true
+        // #385: only a parsed 0xAA result cleared isScanning, so a lost result
+        // notification wedged the scan UI until reconnect. The BS runs 5
+        // passes (~10-45 s); if nothing arrived well past that, declare the
+        // result lost. The generation guard keeps a stale timeout from
+        // clearing a newer scan.
+        scanGeneration += 1
+        let gen = scanGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + 75) { [weak self] in
+            guard let self, self.isScanning, self.scanGeneration == gen else { return }
+            print("[SCAN] result timeout — clearing stuck scan state")
+            self.isScanning = false
+        }
         sendRawCommand(60, payload: payload)
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
@@ -54,6 +54,7 @@ struct PyroTestView: View {
     @State private var secondsRemaining: Int = 10
     @State private var recordSecondsRemaining: Int = 10
     @State private var cameraRecording = false
+    @State private var startedLoggingForTest = false  // #385: only stop what we started
     @State private var videoSaved = false
     @State private var errorMessage: String?
 
@@ -96,7 +97,15 @@ struct PyroTestView: View {
                 // Start recording + logging at T-5
                 if secondsRemaining == 5 {
                     cameraRecording = true
-                    device.sendToggleLogging()
+                    // #385: cmd 23 is a TOGGLE — the blind send used to STOP
+                    // logging right before the fire when a session was already
+                    // running (fire event not recorded), then restart it after.
+                    // Only start if the rocket isn't logging, and only stop
+                    // afterwards if we were the ones who started it.
+                    if !device.telemetry.rocketLoggingActive {
+                        device.sendToggleLogging()
+                        startedLoggingForTest = true
+                    }
                     camera.startRecording { url, error in
                         if let url = url {
                             saveToPhotoLibrary(url: url)
@@ -130,7 +139,10 @@ struct PyroTestView: View {
                 recordSecondsRemaining -= 1
                 if recordSecondsRemaining <= 0 {
                     ticker.stop()
-                    device.sendToggleLogging()
+                    if startedLoggingForTest {
+                        device.sendToggleLogging()
+                        startedLoggingForTest = false
+                    }
                     camera.stopRecording()
                 }
             default:

--- a/TinkerRocketApp/TinkerRocketAppTests/IdleTimerPolicyTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/IdleTimerPolicyTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// #385: `onDisconnect` used to re-enable screen auto-lock unconditionally —
+/// with a base station AND a rocket connected, either one dropping re-armed
+/// sleep while telemetry still streamed on the other. The idle timer must only
+/// re-arm when the LAST connected device goes away.
+final class IdleTimerPolicyTests: XCTestCase {
+
+    @MainActor
+    func testDisconnect_WithAnotherDeviceStillConnected_KeepsScreenAwake() {
+        let fleet = BLEFleet()
+        let bs = BLEDevice(peripheral: nil, name: "TR-B-Test")
+        let rocket = BLEDevice(peripheral: nil, name: "TR-R-Test")
+        bs.fleet = fleet
+        rocket.fleet = fleet
+        bs.isConnected = true
+        rocket.isConnected = true
+        fleet.devices = [bs, rocket]
+
+        UIApplication.shared.isIdleTimerDisabled = true
+        rocket.onDisconnect()
+        XCTAssertTrue(UIApplication.shared.isIdleTimerDisabled,
+                      "BS is still connected and streaming — screen must stay awake")
+    }
+
+    @MainActor
+    func testDisconnect_LastDevice_ReenablesAutoLock() {
+        let fleet = BLEFleet()
+        let rocket = BLEDevice(peripheral: nil, name: "TR-R-Test")
+        rocket.fleet = fleet
+        rocket.isConnected = true
+        fleet.devices = [rocket]
+
+        UIApplication.shared.isIdleTimerDisabled = true
+        rocket.onDisconnect()
+        XCTAssertFalse(UIApplication.shared.isIdleTimerDisabled,
+                       "last device out — auto-lock must re-arm")
+    }
+
+    @MainActor
+    func testDisconnect_NoFleet_ReenablesAutoLock() {
+        // A device without a fleet reference (defensive path) behaves as before.
+        let rocket = BLEDevice(peripheral: nil, name: "TR-R-Test")
+        rocket.isConnected = true
+
+        UIApplication.shared.isIdleTimerDisabled = true
+        rocket.onDisconnect()
+        XCTAssertFalse(UIApplication.shared.isIdleTimerDisabled)
+    }
+}


### PR DESCRIPTION
## Summary
All three findings from the #385 app roundup, per the triage discussion.

1. **Pyro test-fire no longer toggles logging blindly** — cmd 23 is a toggle, so the T-5 send used to *stop* an already-running logging session right before the fire (the one event the test exists to record), then restart it afterwards. Now gated on `telemetry.rocketLoggingActive`, and the post-test stop only fires if the test started logging itself.
2. **Screen stays awake while any device is connected** — `onDisconnect` re-enabled auto-lock unconditionally; with BS + rocket both up, either dropping re-armed sleep mid-telemetry. Only the last device out re-arms it.
3. **Frequency-scan spinner can't wedge forever** — a lost 0xAA result notification used to stick `isScanning` until reconnect; 75 s timeout (5-pass scan runs ~10–45 s) with a generation guard so a stale timeout never clears a newer scan.

## Tests
`IdleTimerPolicyTests` (3, headless via the fleet/device seam). Full suite **180/180** locally.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)