### PR TITLE
fix(ekf): skip the update on a frozen IMU timestamp instead of fabricating dt (#440)

### DIFF
--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -452,3 +452,94 @@ TEST_F(EKFTest, NoNaN_AfterManyUpdates) {
         EXPECT_FALSE(std::isnan(q[i])) << "q[" << i << "] is NaN";
     }
 }
+
+// ---------- #440: frozen IMU timestamp must hold, not drift ----------
+//
+// The dt floor used to rewrite a repeated timestamp's dt=0 to 2 ms, so a
+// stalled/wedged/replayed IMU stream re-integrated the same sample as if
+// time were passing — velocity and attitude drifted while isHealthy()
+// stayed true. The filter must HOLD its state through a stall and resume
+// cleanly when timestamps advance again.
+
+TEST_F(EKFTest, FrozenTimestamp_HoldsAttitudeAndVelocity) {
+    uint32_t t = 1000;
+    ekf.init(makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    for (int i = 0; i < 200; i++) {
+        t += 2000;
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+
+    float q_before[4], v_before[3];
+    ekf.getQuaternion(q_before);
+    ekf.getVelEst(v_before);
+
+    // IMU stalls at timestamp t while reporting a hard roll + a lateral
+    // specific-force error — the worst case for fabricated integration.
+    // 1000 frozen frames × the old fabricated 2 ms = 2 s of phantom time
+    // (≈ 200° of phantom roll pre-fix).
+    EkfIMUData frozen = makeStationaryIMU(t);
+    frozen.gyro_x = 100.0;   // dps
+    frozen.acc_y  = 3.0;     // m/s² lateral error
+    for (int i = 0; i < 1000; i++) {
+        ekf.update(true, frozen, makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+
+    float q_after[4], v_after[3];
+    ekf.getQuaternion(q_after);
+    ekf.getVelEst(v_after);
+
+    EXPECT_EQ(ekf.frozenDtSkips(), 1000u);
+    // Exact equality: a skipped tick touches NOTHING, so the state must be
+    // bit-identical. (A geodesic comparison is unusable here — the stored
+    // quaternion's norm sits one float-ulp under 1.0, so acos() reports
+    // ~0.04° even between identical values.)
+    for (int i = 0; i < 4; i++) {
+        EXPECT_EQ(q_after[i], q_before[i])
+            << "attitude must hold bit-exact through a stall (q[" << i << "])";
+    }
+    for (int i = 0; i < 3; i++) {
+        EXPECT_EQ(v_after[i], v_before[i])
+            << "velocity must hold bit-exact through a stall (axis " << i << ")";
+    }
+}
+
+TEST_F(EKFTest, FrozenTimestamp_ResumesCleanly) {
+    uint32_t t = 1000;
+    ekf.init(makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    for (int i = 0; i < 100; i++) {
+        t += 2000;
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+
+    // Brief stall, then the stream resumes with advancing timestamps.
+    for (int i = 0; i < 50; i++) {
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+    float q_stall[4]; ekf.getQuaternion(q_stall);
+
+    for (int i = 0; i < 200; i++) {
+        t += 2000;
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+    float q_resumed[4]; ekf.getQuaternion(q_resumed);
+
+    // Stationary data before, during, and after: the resumed filter should
+    // stay converged at the stationary attitude, not jump (a resume glitch
+    // would show as a large geodesic step).
+    EXPECT_LT(tqGeodesicDeg(q_stall, q_resumed), 1.0f)
+        << "filter must resume smoothly after a stall";
+    EXPECT_EQ(ekf.frozenDtSkips(), 50u);
+}
+
+TEST_F(EKFTest, AdvancingTimestamps_NeverTripTheSkip) {
+    // A healthy stream (the normal 500 Hz cadence every other test uses)
+    // must never hit the frozen-timestamp path — the fix is provably inert
+    // outside the anomaly it targets.
+    uint32_t t = 1000;
+    ekf.init(makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    for (int i = 0; i < 500; i++) {
+        t += 2000;
+        ekf.update(true, makeStationaryIMU(t), makeStationaryGNSS(t), makeStationaryMag(t));
+    }
+    EXPECT_EQ(ekf.frozenDtSkips(), 0u);
+}

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -150,6 +150,18 @@ void GpsInsEKF::updateCore(bool use_ahrs_acc,
                            uint32_t gnss_time_us) {
     // 1. Compute dt
     uint32_t t_us = imu_data.time_us;
+    // #440: a repeated/frozen IMU timestamp means no new time has provably
+    // elapsed — a stalled sensor, a wedged I2C read, or a replayed frame.
+    // The floor below used to rewrite dt=0 to 2 ms, re-integrating the SAME
+    // sample as if time had passed: velocity/attitude drifted while
+    // isHealthy() stayed true, feeding control a confidently wrong state.
+    // Skip the tick entirely — the filter HOLDS its state through a stall
+    // (the caller's raw-gyro fallbacks own control when the IMU is stale,
+    // #262/#270). The floor below still handles small-but-real dts.
+    if (t_us == tPrev_us_) {
+        ++frozen_dt_skips_;
+        return;
+    }
     dt_s_ = ((float)(t_us - tPrev_us_)) / 1e6f;
     tPrev_us_ = t_us;
     if (dt_s_ > 0.1f) dt_s_ = 0.1f;

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -130,6 +130,9 @@ public:
     void getAccelBias(float (&r)[3]) const { r[0]=aBias_mps2_[0]; r[1]=aBias_mps2_[1]; r[2]=aBias_mps2_[2]; }
     void getRotRateEst(float (&r)[3]) const { r[0]=wEst_B_rps_[0]; r[1]=wEst_B_rps_[1]; r[2]=wEst_B_rps_[2]; }
     void getRotRateBias(float (&r)[3]) const { r[0]=wBias_rps_[0]; r[1]=wBias_rps_[1]; r[2]=wBias_rps_[2]; }
+    // #440 diagnostics: updates skipped on a frozen IMU timestamp.
+    uint32_t frozenDtSkips() const { return frozen_dt_skips_; }
+
     void getOrientEst(float (&r)[3]) const { r[0]=euler_BL_rad_[0]; r[1]=euler_BL_rad_[1]; r[2]=euler_BL_rad_[2]; }
     void getPosEst(double (&r)[3]) const { r[0]=pEst_D_rrm_[0]; r[1]=pEst_D_rrm_[1]; r[2]=pEst_D_rrm_[2]; }
     void getVelEst(float (&r)[3]) const { r[0]=vEst_NED_mps_[0]; r[1]=vEst_NED_mps_[1]; r[2]=vEst_NED_mps_[2]; }
@@ -280,6 +283,9 @@ private:
     // setQuaternion() first, but the sim/ECEF path could reach measUpdate()'s
     // cos^4(pitch) gate with garbage euler_BL_rad_ (and dt math with garbage
     // tPrev_us_/timeWeekPrev_) on its very first update.
+    // #440: updates skipped because the IMU timestamp didn't advance.
+    // A nonzero value in flight means the IMU stream stalled or replayed.
+    uint32_t frozen_dt_skips_ = 0;
     uint32_t tPrev_us_ = 0;
     float dt_s_ = 0.0f;
     uint32_t timeWeekPrev_ = 0;


### PR DESCRIPTION
## Summary
Fixes #440 (promoted from the #386 roundup as its highest-value item; also the one item from #389's original pre-weekend list that never actually landed). The dt floor rewrote a frozen/repeated IMU timestamp's `dt=0` to 2 ms — the filter re-integrated the **same sample** as if time were passing, drifting velocity/attitude while `isHealthy()` stayed true. The FC's EKF call is gated on the *latched* `have_ism6_si`, not freshness, so nothing upstream stopped it: a stalled IMU fed guidance and roll-angle control a confidently wrong state.

## Fix
`t_us == tPrev_us_` → skip the tick. The filter **holds** through a stall (control's raw-gyro fallbacks own actuation when the IMU is stale — the #262/#270 pattern) and resumes with a real, 0.1 s-clamped dt when timestamps advance. The 0.5 ms floor still handles small-but-real dts. New `frozenDtSkips()` diagnostics counter — nonzero in flight = the IMU stream stalled or replayed.

## SIL evidence (as #440 required)
| Scenario | Pre-fix | Post-fix |
|---|---|---|
| 60 s deterministic synthetic flight, advancing timestamps (sim `_ekf` binding, 2999 sampled states) | hash `136fcc99…` | **identical hash** — provably inert on healthy data |
| 2 s frozen timestamp, gyro reporting 120 dps | **108.2° / 20.1 m/s** phantom drift | **12.0° / 0.99 m/s** = exactly the bounded resume tick (0.1 s clamp × 120 dps), zero stall drift |

## Tests
3 new host gtests: bit-exact state hold through 1000 frozen frames with hostile gyro/accel data, clean resume after a stall, and healthy-cadence-never-trips (skip counter stays 0). The two behavioral tests **fail on the pre-fix EKF** and pass with the fix. Host suite **424/424**; sim suite 46 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)