### PR TITLE
feat(app): one PRELAUNCH pad label + EKF Ready badge; un-invert state colors (#382)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -691,10 +691,30 @@ struct DeviceChipBar: View {
 struct RocketStateView: View {
     let state: String
 
+    // #382 (display-only): the wire states READY and PRELAUNCH both mean "on
+    // the pad" — READY is still waiting on the OC/GNSS gates, PRELAUNCH means
+    // the gates are met (GNSS lock, OC link, EKF running: the fully-armed
+    // guided path). The raw names read backwards (READY sounds MORE ready
+    // than PRELAUNCH), and the old colors — READY green, PRELAUNCH orange —
+    // reinforced the inversion. Render ONE "PRELAUNCH" label for both pad
+    // states and carry the real distinction in a readiness badge. Wire
+    // strings, CSV columns, and the announcer's raw-state logic are untouched.
+    static func displayLabel(for state: String) -> String {
+        state == "READY" ? "PRELAUNCH" : state
+    }
+    /// Badge (text, isReady) for the pad states; nil elsewhere.
+    static func padBadge(for state: String) -> (String, Bool)? {
+        switch state {
+        case "PRELAUNCH": return ("EKF Ready", true)
+        case "READY":     return ("Acquiring — waiting for GNSS + OC link", false)
+        default:          return nil
+        }
+    }
+
     var stateColor: Color {
         switch state {
-        case "READY": return .green
-        case "PRELAUNCH": return .orange
+        case "READY": return .orange     // acquiring (was green — inverted)
+        case "PRELAUNCH": return .green  // fully ready (was orange)
         case "INFLIGHT": return .red
         case "COMPLETE": return .blue
         case "MAG_CAL": return .blue   // ground-only excursion (issue #96)
@@ -703,10 +723,15 @@ struct RocketStateView: View {
     }
 
     var body: some View {
-        VStack {
-            Text(state)
+        VStack(spacing: 4) {
+            Text(Self.displayLabel(for: state))
                 .font(.system(size: 36, weight: .bold))
                 .foregroundColor(stateColor)
+            if let (text, ready) = Self.padBadge(for: state) {
+                Label(text, systemImage: ready ? "checkmark.seal.fill" : "hourglass")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(ready ? .green : .orange)
+            }
             Text("Rocket State")
                 .font(.caption)
                 .foregroundColor(.secondary)

--- a/TinkerRocketApp/TinkerRocketAppTests/PadStateDisplayTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/PadStateDisplayTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// #382 display mapping: READY and PRELAUNCH are both "on the pad"; the app
+/// shows one PRELAUNCH label with a readiness badge instead of two states
+/// whose names read backwards. Wire strings are untouched — only display.
+final class PadStateDisplayTests: XCTestCase {
+
+    func testBothPadStatesDisplayAsPrelaunch() {
+        XCTAssertEqual(RocketStateView.displayLabel(for: "READY"), "PRELAUNCH")
+        XCTAssertEqual(RocketStateView.displayLabel(for: "PRELAUNCH"), "PRELAUNCH")
+    }
+
+    func testNonPadStatesUnchanged() {
+        for s in ["INIT", "INFLIGHT", "COMPLETE", "MAG_CAL", "LANDED", "UNKNOWN"] {
+            XCTAssertEqual(RocketStateView.displayLabel(for: s), s)
+        }
+    }
+
+    func testBadgeSemantics() {
+        let ready = RocketStateView.padBadge(for: "PRELAUNCH")
+        XCTAssertEqual(ready?.0, "EKF Ready")
+        XCTAssertEqual(ready?.1, true)
+
+        let acquiring = RocketStateView.padBadge(for: "READY")
+        XCTAssertEqual(acquiring?.1, false)
+
+        XCTAssertNil(RocketStateView.padBadge(for: "INFLIGHT"))
+        XCTAssertNil(RocketStateView.padBadge(for: "COMPLETE"))
+    }
+}


### PR DESCRIPTION
## Summary
Companion to #445, per the design discussion (display-only option). The wire states READY/PRELAUNCH both mean *on the pad*, their names read backwards (READY sounds more ready than the fully-gated PRELAUNCH), and the dashboard's colors — READY **green**, PRELAUNCH **orange** — reinforced the inversion.

## Change (display-only)
- Both pad states render as one **PRELAUNCH** label.
- A badge carries the real distinction: green **EKF Ready** (wire state PRELAUNCH = GNSS+OC+EKF gates met) vs amber **Acquiring — waiting for GNSS + OC link** (wire READY).
- State colors un-inverted: ready = green, acquiring = orange.
- Wire strings, BS CSV columns, the announcer's raw-state logic, and the analysis scripts' filters are all untouched — zero data-compatibility impact.

## Tests
`PadStateDisplayTests` (3) on the static label/badge mapping. Suite **184/184**.

Refs #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)