### PR TITLE
fix(bs): netid-gated proof of life + atomic BLE command latches (#384)

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -366,47 +366,59 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
 
     uint8_t cmd = data[0];
 
+    // #384: parse into locals; nothing shared is touched until the single
+    // atomic commit at the end. The old per-branch writes let bs_loop observe
+    // a command with the WRONG payload/filename (a second BLE write between
+    // getCommand() and getCommandPayload() swapped the latch), and the String
+    // filename members did heap ops from two tasks with no lock.
+    char    name_local[64];
+    bool    have_delete = false, have_download = false;
+    int     page_local  = -1;
+    uint8_t payload_local[sizeof(pending_payload_)];
+    size_t  payload_len_local = 0;
+    bool    have_payload = false;
+
+    auto copyName = [&](const uint8_t* src, size_t n) {
+        if (n >= sizeof(name_local)) n = sizeof(name_local) - 1;
+        memcpy(name_local, src, n);
+        name_local[n] = '\0';
+    };
+
     if (cmd == 2 && length > 1)
     {
         // Command 2: File list request (optional page number follows)
-        pending_file_list_page_ = data[1];
-        ESP_LOGI(BLE_TAG, "File list request, page: %u", pending_file_list_page_);
+        page_local = data[1];
+        ESP_LOGI(BLE_TAG, "File list request, page: %u", (unsigned)page_local);
     }
     else if (cmd == 2)
     {
         // Command 2 without page number defaults to page 0
-        pending_file_list_page_ = 0;
+        page_local = 0;
     }
     else if (cmd == 3 && length > 1)
     {
         // Command 3: Delete file (filename follows command byte)
-        pending_delete_filename_ = "";
-        for (size_t i = 1; i < length; ++i)
-        {
-            pending_delete_filename_ += (char)data[i];
-        }
-        ESP_LOGI(BLE_TAG, "Delete file request: %s", pending_delete_filename_.c_str());
+        copyName(data + 1, length - 1);
+        have_delete = true;
+        ESP_LOGI(BLE_TAG, "Delete file request: %s", name_local);
     }
     else if (cmd == 4 && length > 1)
     {
         // Command 4: Download file (filename follows command byte)
-        pending_download_filename_ = "";
-        for (size_t i = 1; i < length; ++i)
-        {
-            pending_download_filename_ += (char)data[i];
-        }
-        ESP_LOGI(BLE_TAG, "Download file request: %s", pending_download_filename_.c_str());
+        copyName(data + 1, length - 1);
+        have_download = true;
+        ESP_LOGI(BLE_TAG, "Download file request: %s", name_local);
     }
     else if (cmd == 5 && length >= 13)
     {
         // Command 5: Sim config [cmd][mass_g:4][thrust_n:4][burn_s:4]
-        size_t payload_len = length - 1;
-        if (payload_len > sizeof(pending_payload_))
+        payload_len_local = length - 1;
+        if (payload_len_local > sizeof(payload_local))
         {
-            payload_len = sizeof(pending_payload_);
+            payload_len_local = sizeof(payload_local);
         }
-        memcpy(pending_payload_, data + 1, payload_len);
-        pending_payload_len_ = payload_len;
+        memcpy(payload_local, data + 1, payload_len_local);
+        have_payload = true;
         ESP_LOGI(BLE_TAG, "Sim config received");
     }
     else if (cmd == 6)
@@ -427,13 +439,13 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
     else if (cmd == 9 && length >= 8)
     {
         // Command 9: Time sync [cmd][year_lo][year_hi][month][day][hour][minute][second]
-        size_t payload_len = length - 1;
-        if (payload_len > sizeof(pending_payload_))
+        payload_len_local = length - 1;
+        if (payload_len_local > sizeof(payload_local))
         {
-            payload_len = sizeof(pending_payload_);
+            payload_len_local = sizeof(payload_local);
         }
-        memcpy(pending_payload_, data + 1, payload_len);
-        pending_payload_len_ = payload_len;
+        memcpy(payload_local, data + 1, payload_len_local);
+        have_payload = true;
         ESP_LOGI(BLE_TAG, "Time sync received");
     }
     else if (cmd == 70)
@@ -459,26 +471,38 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
     else if (length > 1)
     {
         // Generic payload handler for any other command carrying data
-        size_t payload_len = length - 1;
-        if (payload_len > sizeof(pending_payload_))
+        payload_len_local = length - 1;
+        if (payload_len_local > sizeof(payload_local))
         {
-            payload_len = sizeof(pending_payload_);
+            payload_len_local = sizeof(payload_local);
         }
-        memcpy(pending_payload_, data + 1, payload_len);
-        pending_payload_len_ = payload_len;
+        memcpy(payload_local, data + 1, payload_len_local);
+        have_payload = true;
     }
 
+    // #384: commit the command AND everything that travels with it in one
+    // critical section, so bs_loop can never pair a command with a different
+    // write's payload/filename/page.
+    uint8_t overwritten = 0;
     portENTER_CRITICAL(&s_cmd_mux);
-    if (pending_command_ != 0)
+    overwritten = pending_command_;
+    if (have_payload)
     {
-        // Previous command not yet consumed — log and overwrite
-        portEXIT_CRITICAL(&s_cmd_mux);
-        ESP_LOGW(BLE_TAG, "Overwriting unconsumed cmd %u with %u",
-                 pending_command_, cmd);
-        portENTER_CRITICAL(&s_cmd_mux);
+        memcpy(pending_payload_, payload_local, payload_len_local);
+        pending_payload_len_ = payload_len_local;
     }
+    if (page_local >= 0)   pending_file_list_page_ = (uint8_t)page_local;
+    if (have_delete)       strlcpy(pending_delete_filename_,   name_local, sizeof(pending_delete_filename_));
+    if (have_download)     strlcpy(pending_download_filename_, name_local, sizeof(pending_download_filename_));
     pending_command_ = cmd;
     portEXIT_CRITICAL(&s_cmd_mux);
+    if (overwritten != 0)
+    {
+        // Previous command not yet consumed — it was overwritten wholesale
+        // (command + latches together, so at least never mismatched).
+        ESP_LOGW(BLE_TAG, "Overwriting unconsumed cmd %u with %u",
+                 overwritten, cmd);
+    }
 
     ESP_LOGI(BLE_TAG, "Received command: %u", cmd);
 }
@@ -854,32 +878,47 @@ void TR_BLE_To_APP::sendTelemetry(const TelemetryData& data)
 
 uint8_t TR_BLE_To_APP::getCommand()
 {
+    // #384: consume the command and snapshot its payload in the SAME critical
+    // section — a later BLE write can then only replace the pending latch,
+    // never the copy this command's handler reads via getCommandPayload().
     portENTER_CRITICAL(&s_cmd_mux);
     uint8_t cmd = pending_command_;
     pending_command_ = 0;
+    consumed_payload_len_ = pending_payload_len_;
+    memcpy(consumed_payload_, pending_payload_, sizeof(consumed_payload_));
     portEXIT_CRITICAL(&s_cmd_mux);
     return cmd;
 }
 
 uint8_t TR_BLE_To_APP::getFileListPage()
 {
+    portENTER_CRITICAL(&s_cmd_mux);
     uint8_t page = pending_file_list_page_;
     pending_file_list_page_ = 0;
+    portEXIT_CRITICAL(&s_cmd_mux);
     return page;
 }
 
 String TR_BLE_To_APP::getDeleteFilename()
 {
-    String filename = pending_delete_filename_;
-    pending_delete_filename_ = "";
-    return filename;
+    // Copy out under the mux; build the String (heap) only after exiting the
+    // critical section.
+    char buf[sizeof(pending_delete_filename_)];
+    portENTER_CRITICAL(&s_cmd_mux);
+    strlcpy(buf, pending_delete_filename_, sizeof(buf));
+    pending_delete_filename_[0] = '\0';
+    portEXIT_CRITICAL(&s_cmd_mux);
+    return String(buf);
 }
 
 String TR_BLE_To_APP::getDownloadFilename()
 {
-    String filename = pending_download_filename_;
-    pending_download_filename_ = "";
-    return filename;
+    char buf[sizeof(pending_download_filename_)];
+    portENTER_CRITICAL(&s_cmd_mux);
+    strlcpy(buf, pending_download_filename_, sizeof(buf));
+    pending_download_filename_[0] = '\0';
+    portEXIT_CRITICAL(&s_cmd_mux);
+    return String(buf);
 }
 
 void TR_BLE_To_APP::sendConfigJSON(const String& json)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -143,8 +143,11 @@ public:
     uint8_t getFileListPage();
 
     // Get raw command payload (for commands that carry data, e.g. sim config)
-    const uint8_t* getCommandPayload() const { return pending_payload_; }
-    size_t getCommandPayloadLength() const { return pending_payload_len_; }
+    // #384: return the loop-task snapshot taken atomically by getCommand(),
+    // not the live latch — a second BLE write between getCommand() and this
+    // call could otherwise swap (or tear) the payload under the command.
+    const uint8_t* getCommandPayload() const { return consumed_payload_; }
+    size_t getCommandPayloadLength() const { return consumed_payload_len_; }
 
     // Get pending delete filename (empty if none)
     // Clears the filename after reading
@@ -234,12 +237,23 @@ private:
     volatile uint16_t negotiated_mtu_;
     volatile bool telem_notify_subscribed_;  // central enabled notifications on telemetry/config char
     volatile uint16_t conn_handle_;          // NimBLE connection handle
+    // #384: every latch below is written on the NimBLE host task and read on
+    // bs_loop. They are all committed/consumed inside the same s_cmd_mux
+    // critical section as pending_command_, so a command and its payload/
+    // filename travel as one atomic unit. The filenames are fixed buffers —
+    // the old String members did heap operations from two tasks with no
+    // lock, which risks allocator corruption, not just a swapped name.
     volatile uint8_t pending_command_;
     volatile uint8_t pending_file_list_page_;
-    String pending_delete_filename_;
-    String pending_download_filename_;
+    char pending_delete_filename_[64] = {};
+    char pending_download_filename_[64] = {};
     uint8_t pending_payload_[80] = {};   // Raw payload for commands with data (max = RollProfileData 76 bytes)
     size_t  pending_payload_len_ = 0;
+    // Loop-task-only snapshot of the payload, filled by getCommand() under
+    // the mux; getCommandPayload() reads this so later BLE writes can't
+    // mutate it mid-use.
+    uint8_t consumed_payload_[80] = {};
+    size_t  consumed_payload_len_ = 0;
     String file_list_json_;              // Persistent storage for file list
     uint8_t* chunk_buffer_;              // Persistent storage for file chunks
     size_t chunk_buffer_size_;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -83,6 +83,9 @@ static int8_t  lora_tx_power   = config::LORA_TX_POWER_DBM;
 // Stats tracking
 static uint32_t last_stats_ms = 0;
 static uint32_t last_rx_count = 0;
+// Last time we heard OUR rocket: bumped only on a network-id-matched beacon
+// or telemetry decode (#384). Drives the cmd-10 VERIFYING predicate, silence
+// recovery, and hop-liveness — none of which should trust foreign traffic.
 static uint32_t last_packet_ms = 0;
 // CRC-passing decodes whose SNR was below loraMinValidSnrDb(current_sf)
 // — almost certainly noise-floor false positives.  Counted but otherwise
@@ -3342,7 +3345,15 @@ static void loop_bs()
 
     if (rx_packet_accepted)
     {
-        last_packet_ms = millis();
+        // #384: last_packet_ms deliberately NOT bumped here — this point is
+        // before the network-id filter, so foreign-network packets (or any
+        // SNR-passing decode of the right shape) counted as proof of life.
+        // That suppressed silence recovery and, worse, satisfied the cmd-10
+        // VERIFYING predicate ("any last_packet_ms increase = the rocket
+        // followed us"), committing a new frequency to NVS on the strength
+        // of somebody else's traffic and stranding the BS on a channel our
+        // rocket isn't on. The bump now lives in the two netid-matched
+        // branches below (beacon + telemetry).
 
         // --- Name beacon: [0xBE][network_id][rocket_id][unit_name...] ---
         // #384: a telemetry frame whose first byte (network_id) happens to
@@ -3356,6 +3367,7 @@ static void loop_bs()
             uint8_t bcn_rid = rx_buf[2];
             if (bcn_nid == network_id)
             {
+                last_packet_ms = millis();  // netid-matched proof of life (#384)
                 int slot = findOrAllocRocket(bcn_rid);
                 if (slot >= 0 && rx_len > 3)
                 {
@@ -3396,6 +3408,8 @@ static void loop_bs()
             }
             else
             {
+                last_packet_ms = millis();  // netid-matched proof of life (#384)
+
                 // Route to per-rocket tracker
                 int slot = findOrAllocRocket(decoded.rocket_id);
 


### PR DESCRIPTION
## Summary
Closes #384 — the two remaining items.

### 1. Proof of life requires a netid-matched decode
`last_packet_ms` was bumped **before** the network-id filter, so foreign-network packets counted as our rocket being alive. Consequences: silence recovery never tripped, and the **cmd-10 VERIFYING predicate** (any `last_packet_ms` increase = rocket followed the frequency change) could **commit a new frequency to NVS on somebody else's traffic** — stranding the BS on a channel our rocket isn't on. The bump now lives only in the two netid-matched branches (beacon + telemetry); every consumer — verify predicate, recovery baselines, hop-liveness, status display — is repointed at the truthful semantic in one move. Foreign traffic remains visible via the existing #329 drop counters.

### 2. BLE command latches become one atomic unit
`pending_command_` was mux-protected, but its payload/page/filename latches were written on the NimBLE host task and read+cleared on `bs_loop` with **no lock** — a second BLE write between `getCommand()` and `getCommandPayload()` swapped the payload under a latched command, and the `String` filename members did **heap operations from two tasks** (allocator-corruption risk). Now: `onCommandWrite` parses into locals and commits command+payload+page+filename in one critical section; `getCommand()` snapshots the payload under the same mux; filenames are fixed buffers copied out under the mux with the `String` built outside the critical section.

## Verification
Host suite **424/424** (regression). BS-only firmware; CI `build (base_station)` gates. Bench check: with a foreign-nid transmitter running, execute a cmd-10 frequency change — VERIFYING must hold until **our** rocket's packets arrive on the new channel.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)