### PR TITLE
fix(fc): stop dropping ~50% of baro samples from the EKF path (#450)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -377,3 +377,16 @@ target_include_directories(test_mag_calibrator PRIVATE
 )
 target_link_libraries(test_mag_calibrator GTest::gtest_main)
 gtest_discover_tests(test_mag_calibrator)
+
+# ---------- test_baro_gate_policy ----------
+# Host-side test for the FC EKF barometer admission gate (#450): consume-on-use
+# freshness (the old bmp_new_for_kf flag dropped ~50% of samples under the
+# 487 Hz BMP / 479.5 Hz decimated-EKF beat) and the rate-aware spike test.
+# baro_gate_policy.h is pure, so the test just adds the flight_computer/main dir.
+add_executable(test_baro_gate_policy test_baro_gate_policy.cpp)
+target_include_directories(test_baro_gate_policy PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/flight_computer/main
+)
+target_link_libraries(test_baro_gate_policy GTest::gtest_main)
+gtest_discover_tests(test_baro_gate_policy)

--- a/tests_cpp/test_baro_gate_policy.cpp
+++ b/tests_cpp/test_baro_gate_policy.cpp
@@ -1,0 +1,230 @@
+// Host tests for BaroGatePolicy (#450) — the EKF-side barometer admission gate.
+//
+// The centerpiece is a replay of the exact cadence mismatch from the
+// 2026-07-09 bench sim flight: BMP samples at 487 Hz beating against a 959 Hz
+// flight loop with EKF_DECIMATION=2 (EKF ticks at 479.5 Hz).  The old
+// bmp_new_for_kf gate dropped every sample that arrived on an EKF-off loop
+// iteration — ~50% of all samples, in alternating ~66 ms dead/live windows —
+// and its rate-blind 5 m spike test then rejected the first sample after each
+// dead window once climb rate exceeded ~75 m/s.  The policy must accept
+// virtually every sample and flag zero spikes on that same replay.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "baro_gate_policy.h"
+
+namespace
+{
+constexpr float kSpikeThreshM  = 5.0f;
+constexpr float kSpikeRateMps  = 500.0f;
+
+BaroGatePolicy::Decision eval(BaroGatePolicy& p, uint32_t t_us, float alt_m,
+                              bool locked = false)
+{
+    return p.evaluate(t_us, alt_m, locked, kSpikeThreshM, kSpikeRateMps);
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Flight replay: 487 Hz BMP vs 959 Hz loop, EKF_DECIMATION=2, 100 m/s climb.
+// Models the real consumption pattern: the loop reads samples into a
+// "latest" slot every iteration; only every 2nd iteration presents that slot
+// to the gate.  Samples overwritten in the slot between two EKF ticks are
+// invisible to the gate by construction (~1.5% at these rates); everything
+// else must be consumed exactly once, with no spikes.
+// ---------------------------------------------------------------------------
+TEST(BaroGatePolicy, BeatReplayConsumesEverySampleWithoutSpikes)
+{
+    constexpr double kLoopPeriodUs = 1e6 / 959.0;   // 1042.75 us
+    constexpr double kBmpPeriodUs  = 1e6 / 487.0;   // 2053.39 us
+    constexpr float  kClimbRateMps = 100.0f;        // fast boost, worst case
+    constexpr int    kEkfDecimation = 2;
+    constexpr double kDurationS   = 10.0;
+
+    BaroGatePolicy gate;
+
+    double   next_bmp_us   = 1000.0;
+    uint32_t slot_time_us  = 0;      // "bmp_latest_si" equivalent
+    float    slot_alt_m    = 0.0f;
+    bool     slot_valid    = false;
+    uint32_t slot_writes   = 0;      // samples produced into the slot
+    uint32_t overwritten   = 0;      // produced but replaced before an EKF tick
+    bool     slot_seen_by_ekf = true;
+
+    uint32_t consumed = 0;
+    uint32_t spikes   = 0;
+    int      decim    = 0;
+
+    const long total_iters = (long)(kDurationS * 1e6 / kLoopPeriodUs);
+    for (long i = 0; i < total_iters; ++i)
+    {
+        const double now_us = i * kLoopPeriodUs;
+
+        // Sensor read phase (every iteration, like main.cpp)
+        if (now_us >= next_bmp_us)
+        {
+            if (!slot_seen_by_ekf) overwritten++;
+            slot_time_us = (uint32_t)next_bmp_us;
+            slot_alt_m   = kClimbRateMps * (float)(next_bmp_us * 1e-6);
+            slot_valid   = true;
+            slot_seen_by_ekf = false;
+            slot_writes++;
+            next_bmp_us += kBmpPeriodUs;
+        }
+
+        // EKF phase (every EKF_DECIMATION-th iteration)
+        if (++decim >= kEkfDecimation)
+        {
+            decim = 0;
+            if (slot_valid)
+            {
+                const auto d = eval(gate, slot_time_us, slot_alt_m);
+                if (d.fresh)
+                {
+                    consumed++;
+                    slot_seen_by_ekf = true;
+                    if (d.spike) spikes++;
+                }
+            }
+        }
+    }
+
+    // Every produced sample is either consumed or was overwritten in the slot;
+    // nothing silently vanishes, and overwrites stay a rounding error.
+    EXPECT_EQ(consumed + overwritten, slot_writes);
+    EXPECT_LT((double)overwritten / slot_writes, 0.03);
+    EXPECT_GT(consumed, (uint32_t)(0.97 * slot_writes));
+
+    // The whole point of #450: a clean 100 m/s climb produces ZERO spikes.
+    EXPECT_EQ(spikes, 0u);
+}
+
+// Consume-on-use: the EKF sees the same "latest sample" slot on every tick;
+// a sample must be consumed exactly once, and re-presentations are no-ops
+// rather than duplicate measurement updates.
+TEST(BaroGatePolicy, RepeatedPresentationIsConsumedExactlyOnce)
+{
+    BaroGatePolicy gate;
+
+    auto d1 = eval(gate, 1000u, 0.10f);
+    EXPECT_TRUE(d1.fresh);
+    EXPECT_TRUE(d1.accept);
+
+    // Same sample presented on the next EKF ticks (no new BMP data yet):
+    // consume-on-use makes the repeats no-ops instead of duplicate updates.
+    auto d2 = eval(gate, 1000u, 0.10f);
+    EXPECT_FALSE(d2.fresh);
+    EXPECT_FALSE(d2.accept);
+    auto d3 = eval(gate, 1000u, 0.10f);
+    EXPECT_FALSE(d3.fresh);
+
+    // Next real sample is fresh again.
+    auto d4 = eval(gate, 3053u, 0.31f);
+    EXPECT_TRUE(d4.fresh);
+    EXPECT_TRUE(d4.accept);
+}
+
+// A legitimate ~66 ms sampling gap at 100 m/s (the exact #450 false-positive:
+// delta ~6.6 m > 5 m threshold) must be ACCEPTED — the apparent rate is just
+// the true climb rate, nowhere near the glitch regime.
+TEST(BaroGatePolicy, LegitimateGapAtSpeedIsNotASpike)
+{
+    BaroGatePolicy gate;
+    eval(gate, 0u, 0.0f);
+
+    const auto d = eval(gate, 66000u, 6.6f);  // 66 ms later, +6.6 m
+    EXPECT_TRUE(d.fresh);
+    EXPECT_FALSE(d.spike);
+    EXPECT_TRUE(d.accept);
+    EXPECT_NEAR(d.apparent_rate_mps, 100.0f, 1.0f);
+}
+
+// An in-band glitch at the normal ~2 ms ODR (e.g. SPI-corrupted low bytes,
+// ejection-charge transient) shows a km/s-scale apparent rate and is rejected;
+// the reference still advances so the stream recovers immediately after.
+TEST(BaroGatePolicy, GlitchAtOdrIsRejectedAndRecovers)
+{
+    BaroGatePolicy gate;
+    eval(gate, 0u, 100.0f);
+    eval(gate, 2053u, 100.2f);
+
+    // Glitch: +8 m in one 2 ms sample -> ~3900 m/s apparent.
+    const auto g = eval(gate, 4106u, 108.2f);
+    EXPECT_TRUE(g.spike);
+    EXPECT_FALSE(g.accept);
+
+    // Return to trend: also ~8 m/2 ms relative to the (advanced) reference,
+    // so this recovery sample is rejected too — matching the pre-#450
+    // "always update reference" behavior that bounds rejection to two samples.
+    const auto r1 = eval(gate, 6159u, 100.6f);
+    EXPECT_TRUE(r1.spike);
+
+    // Fully recovered on the next sample.
+    const auto r2 = eval(gate, 8212u, 100.8f);
+    EXPECT_FALSE(r2.spike);
+    EXPECT_TRUE(r2.accept);
+}
+
+// Small deltas never spike regardless of timestamp pathology (duplicate/near-
+// duplicate timestamps hit the dt floor, not a divide-by-zero).
+TEST(BaroGatePolicy, DeadbandAndDtFloor)
+{
+    BaroGatePolicy gate;
+    eval(gate, 1000u, 50.0f);
+
+    // 4.9 m in 1 us: below the 5 m deadband -> not a spike even at an
+    // absurd apparent rate.
+    const auto d = eval(gate, 1001u, 54.9f);
+    EXPECT_FALSE(d.spike);
+    EXPECT_TRUE(d.accept);
+    // dt floored at 100 us -> finite rate.
+    EXPECT_LT(d.apparent_rate_mps, 4.9f / 100e-6f + 1.0f);
+}
+
+// Transonic lockout: fresh clean samples are not accepted while locked, but
+// they DO advance the reference, so the first sample after unlock does not
+// read as a spike (pre-#450 behavior, preserved).
+TEST(BaroGatePolicy, LockoutBlocksAcceptButTracksReference)
+{
+    BaroGatePolicy gate;
+    eval(gate, 0u, 0.0f);
+
+    // 100 m/s climb, locked for 50 samples (~103 ms of flight).
+    uint32_t t = 2053u;
+    float    alt = 0.2053f;
+    for (int i = 0; i < 50; ++i)
+    {
+        const auto d = eval(gate, t, alt, /*locked=*/true);
+        EXPECT_TRUE(d.fresh);
+        EXPECT_FALSE(d.spike);
+        EXPECT_FALSE(d.accept);
+        t += 2053u;
+        alt += 0.2053f;
+    }
+
+    // First sample after unlock: normal delta vs the tracked reference.
+    const auto d = eval(gate, t, alt);
+    EXPECT_TRUE(d.fresh);
+    EXPECT_FALSE(d.spike);
+    EXPECT_TRUE(d.accept);
+}
+
+// Timestamp wrap (micros() rolls over at ~71.6 min): unsigned subtraction
+// keeps the pair spacing correct across the wrap.
+TEST(BaroGatePolicy, TimestampWrapIsHandled)
+{
+    BaroGatePolicy gate;
+    const uint32_t near_wrap = 0xFFFFFC00u;  // 1024 us before rollover
+    eval(gate, near_wrap, 10.0f);
+
+    const uint32_t after_wrap = near_wrap + 2053u;  // wraps past 0
+    ASSERT_LT(after_wrap, near_wrap);
+    const auto d = eval(gate, after_wrap, 10.2f);
+    EXPECT_TRUE(d.fresh);
+    EXPECT_FALSE(d.spike);
+    EXPECT_TRUE(d.accept);
+    EXPECT_NEAR(d.apparent_rate_mps, 0.2f / 2053e-6f, 5.0f);
+}

--- a/tinkerrocket-idf/projects/flight_computer/main/baro_gate_policy.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/baro_gate_policy.h
@@ -1,0 +1,93 @@
+// Pure decision logic for admitting barometer samples to the EKF measurement
+// update (issue #450).  No ESP-IDF dependencies so it is host-testable.
+//
+// Solves two problems with the previous inline gate in main.cpp:
+//
+// 1. Sample drop (#450): the old gate keyed on the loop-lifetime flag
+//    bmp_new_for_kf, which is cleared at the end of EVERY loop iteration while
+//    the EKF only runs every EKF_DECIMATION-th iteration.  A sample read on an
+//    EKF-off iteration was wiped before any EKF tick saw it.  With the BMP ODR
+//    (487 Hz) beating against the decimated EKF rate (959/2 = 479.5 Hz) the
+//    arrival parity drifts continuously, so the EKF baro path alternated
+//    ~66 ms dead / ~66 ms live for the whole flight — the EKF silently lost
+//    ~50% of baro measurements.  This policy instead tracks the last CONSUMED
+//    sample timestamp, so freshness survives EKF-off iterations and every
+//    accepted BMP sample reaches exactly one EKF tick (only samples overwritten
+//    in bmp_latest_si between two EKF ticks are lost: ~1.5% at these rates).
+//
+// 2. Rate-blind spike test: the old test rejected any |delta| > 5 m between
+//    consecutive compared samples regardless of how far apart in time they
+//    were, so a legitimate gap (the very dead windows above, or a future
+//    lockout/outage) at >75 m/s read as a "spike" and the recovery sample was
+//    discarded too.  A spike now additionally requires the APPARENT RATE
+//    (delta / actual pair spacing) to exceed a limit far above any subsonic
+//    flight profile.  Glitches remain caught: an in-band corrupted sample or
+//    ejection-charge transient at ~2 ms spacing shows km/s-scale apparent rate.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+class BaroGatePolicy
+{
+public:
+    struct Decision
+    {
+        bool  fresh  = false;  // sample not yet seen by the EKF path
+        bool  spike  = false;  // fresh but rejected as a spike
+        bool  accept = false;  // fresh && !spike && !locked -> run baroMeasUpdate
+        float delta_m = 0.0f;             // |alt - prev alt| (fresh only)
+        float apparent_rate_mps = 0.0f;   // delta / actual pair spacing
+    };
+
+    // Evaluate the latest available sample on an EKF tick.  Call with the same
+    // sample repeatedly (EKF ticks between BMP arrivals) is fine: consume-on-use
+    // makes the repeats !fresh no-ops.  `locked` is the transonic lockout: the
+    // sample still updates the internal reference (so unlock does not produce a
+    // false delta) but is not accepted for the measurement update.
+    Decision evaluate(uint32_t sample_time_us,
+                      float    altitude_m,
+                      bool     locked,
+                      float    spike_thresh_m,
+                      float    spike_rate_mps)
+    {
+        Decision d;
+        d.fresh = !have_consumed_ || (sample_time_us != last_time_us_);
+        if (!d.fresh)
+        {
+            return d;
+        }
+
+        if (have_consumed_)
+        {
+            d.delta_m = fabsf(altitude_m - prev_alt_m_);
+            // Pair spacing from the sample's own timestamps; unsigned
+            // subtraction is wrap-safe.  Floor keeps the rate finite on a
+            // duplicate/garbage timestamp.
+            uint32_t dt_us = sample_time_us - last_time_us_;
+            if (dt_us < kMinPairDtUs)
+            {
+                dt_us = kMinPairDtUs;
+            }
+            d.apparent_rate_mps = d.delta_m / ((float)dt_us * 1e-6f);
+            d.spike = (d.delta_m > spike_thresh_m) &&
+                      (d.apparent_rate_mps > spike_rate_mps);
+        }
+
+        // Always advance the reference — even on spike or lockout — so one bad
+        // sample (or a lockout window) cannot poison every following compare.
+        last_time_us_  = sample_time_us;
+        prev_alt_m_    = altitude_m;
+        have_consumed_ = true;
+
+        d.accept = !d.spike && !locked;
+        return d;
+    }
+
+private:
+    static constexpr uint32_t kMinPairDtUs = 100u;
+
+    uint32_t last_time_us_  = 0;
+    float    prev_alt_m_    = 0.0f;
+    bool     have_consumed_ = false;
+};

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -222,11 +222,17 @@ struct config : board_pins
     static constexpr float    EKF_ATT_VAR_OK        = 0.1f;   // rad²,  worst attitude axis (~18° 1σ)
     static constexpr float    EKF_VEL_VAR_OK        = 4.0f;   // (m/s)², worst velocity axis (~2 m/s 1σ)
 
-    // Barometer spike rejection: max altitude change (m) between consecutive
-    // BMP585 samples before the reading is rejected.  At 500 Hz a 5 m jump
-    // implies >2500 m/s — far beyond any model rocket — so real flight data
-    // passes easily while ejection-charge pressure transients are rejected.
-    static constexpr float BARO_SPIKE_THRESH_M = 5.0f;
+    // Barometer spike rejection (#450: rate-aware).  A sample is rejected only
+    // if BOTH hold between it and the previous sample the EKF gate consumed:
+    //   |delta|        > BARO_SPIKE_THRESH_M   (absolute deadband), AND
+    //   |delta| / dt   > BARO_SPIKE_RATE_MPS   (apparent rate over the ACTUAL
+    //                                           pair spacing from timestamps)
+    // Real subsonic flight through any legitimate sampling gap stays far below
+    // the rate limit (a 66 ms gap at 100 m/s is 6.6 m but only 100 m/s), while
+    // glitches — an in-band SPI-corrupted sample or an ejection-charge pressure
+    // transient at the ~2 ms ODR — show km/s-scale apparent rates.
+    static constexpr float BARO_SPIKE_THRESH_M  = 5.0f;
+    static constexpr float BARO_SPIKE_RATE_MPS  = 500.0f;
 
     // Transonic barometer lockout: shock waves near Mach 1 cause large static
     // pressure errors (the "transonic jump").  Lock out baro updates when EKF

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2,6 +2,7 @@
 
 // Configuration Parameters
 #include "config.h"
+#include "baro_gate_policy.h"
 
 // Libraries
 #include <TR_Sensor_Collector.h>
@@ -240,7 +241,11 @@ static bool have_ism6_si = false;
 static bool have_bmp_si = false;
 static bool have_mmc_si = false;
 static bool have_gnss_si = false;
-static bool bmp_new_for_kf = false; // Set when new BMP sample arrives, cleared after KF update
+static bool bmp_new_for_kf = false; // Set when new BMP sample arrives, cleared at loop end.
+                                    // Consumed by kinematicChecks (runs every iteration).
+                                    // The EKF baro gate deliberately does NOT use it: it
+                                    // would miss samples read on EKF-off decimation ticks
+                                    // (#450) — see BaroGatePolicy.
 
 // --- Flight logic state ---
 static RocketState rocket_state = INITIALIZATION;
@@ -3797,12 +3802,17 @@ static void loop_fc()
                 const bool use_ahrs_acc = (rocket_state != INFLIGHT) || post_apogee;
                 ekf.update(use_ahrs_acc, ekf_imu, ekf_gnss, ekf_mag);
 
-                // Barometer measurement update (when new BMP sample available)
-                if (bmp_new_for_kf && have_bmp_si)
+                // Barometer measurement update.  Freshness is tracked by
+                // BaroGatePolicy against the sample's own timestamp, NOT the
+                // loop-lifetime bmp_new_for_kf flag: that flag is cleared at
+                // the end of every loop iteration, so a sample read on an
+                // EKF-off iteration (EKF_DECIMATION) was wiped before any EKF
+                // tick saw it — the 487 Hz BMP ODR beating against the
+                // 479.5 Hz EKF rate starved the EKF of baro in ~66 ms bursts
+                // for ~half of every flight (#450).
+                if (have_bmp_si)
                 {
-                    static float prev_baro_alt_m = 0.0f;
-                    static bool  prev_baro_valid = false;
-                    // mach_locked_out is now file-scope (used by apogee voting)
+                    // mach_locked_out is file-scope (used by apogee voting)
 
                     // --- Transonic lockout (hysteresis) ---
                     bool baro_locked = false;
@@ -3820,12 +3830,15 @@ static void loop_fc()
                         baro_locked = mach_locked_out;
                     }
 
-                    // --- Spike rejection ---
-                    const float delta = fabsf(pressure_altitude_m - prev_baro_alt_m);
-                    const bool  spike = prev_baro_valid &&
-                                        (delta > config::BARO_SPIKE_THRESH_M);
+                    static BaroGatePolicy baro_gate;
+                    const BaroGatePolicy::Decision gate =
+                        baro_gate.evaluate(bmp_latest_si.time_us,
+                                           pressure_altitude_m,
+                                           baro_locked,
+                                           config::BARO_SPIKE_THRESH_M,
+                                           config::BARO_SPIKE_RATE_MPS);
 
-                    if (!spike && !baro_locked)
+                    if (gate.accept)
                     {
                         EkfBaroData ekf_baro = {};
                         ekf_baro.time_us = bmp_latest_si.time_us;
@@ -3843,16 +3856,14 @@ static void loop_fc()
                         ekf_baro.altitude_m = (double)pressure_altitude_m + ref_alt_m;
                         ekf.baroMeasUpdate(ekf_baro);
                     }
-                    else if (spike)
+                    else if (gate.spike)
                     {
-                        ESP_LOGW(TAG, "[BARO] Spike rejected: delta=%.1f m (thresh=%.1f)",
-                                 (double)delta, (double)config::BARO_SPIKE_THRESH_M);
+                        ESP_LOGW(TAG, "[BARO] Spike rejected: delta=%.1f m rate=%.0f m/s "
+                                 "(thresh=%.1f m @ >%.0f m/s)",
+                                 (double)gate.delta_m, (double)gate.apparent_rate_mps,
+                                 (double)config::BARO_SPIKE_THRESH_M,
+                                 (double)config::BARO_SPIKE_RATE_MPS);
                     }
-                    // Always update reference so the next sample compares against
-                    // the latest reading — prevents prolonged rejection after a
-                    // single transient spike or mach lockout exit.
-                    prev_baro_alt_m = pressure_altitude_m;
-                    prev_baro_valid = true;
                 }
 
                 const uint32_t ekf_us = time_us() - ekf_t0;


### PR DESCRIPTION
## Summary

Fixes #450 — the EKF barometer path was silently dropping ~50% of BMP585 samples, and the rate-blind spike test then rejected legitimate recovery samples during fast flight (the six false `[BARO] Spike rejected` warnings in the 2026-07-09 bench sim flight).

**Root cause** (full evidence chain in #450): `bmp_new_for_kf` is cleared at the end of every loop iteration, but the EKF consumer runs only every `EKF_DECIMATION`-th (=2nd) iteration. The 487 Hz BMP ODR beats against the 479.5 Hz EKF tick rate, so sample arrival parity drifts continuously → the EKF baro path alternated ~66 ms dead / ~66 ms live all flight. Each dead→live transition compared against a stale reference; above ~75 m/s that exceeded the fixed 5 m threshold (predicted staleness ceiling 66.7 ms vs 52.6–67.2 ms measured from the flight data — exact match).

## Changes

- **`baro_gate_policy.h` (new, pure header)**: consume-on-use freshness keyed on the sample's own `time_us` (survives EKF-off iterations; every sample reaches exactly one EKF tick, ~1.5% slot overwrites vs ~50% dropped) + rate-aware spike test (reject only if `|delta| > 5 m` **and** apparent rate over the actual pair spacing `> 500 m/s`). Reference always advances (spike or lockout), preserving the pre-existing bounded-rejection and clean-lockout-exit behavior.
- **`main.cpp`**: EKF baro block now uses the policy; `bmp_new_for_kf` remains for `kinematicChecks` (runs every iteration; was never affected — baro apogee voting confirmed healthy in the same flight). Transonic lockout hysteresis now evaluates on every EKF tick instead of only in live beat windows.
- **`config.h`**: adds `BARO_SPIKE_RATE_MPS = 500` and documents the two-condition spike test.
- **`tests_cpp/test_baro_gate_policy.cpp` (new)**: replays the exact 487 Hz vs 959 Hz / DECIMATION=2 beat at 100 m/s — every sample consumed or accounted (<3% overwrites), zero spikes; plus consume-once, the #450 legit-gap false positive, glitch reject/recover, dt floor, lockout tracking, micros() wrap.

## Testing

- Host suite: **431/431** (424 existing + 7 new).
- The beat-replay test fails against the old flag semantics (consumes only ~half the samples) and the legit-gap test fails against the old rate-blind threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
