### PR TITLE
chore(fc): silence [MMC DIAG] when the IIS2MDC is the active magnetometer

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -300,6 +300,9 @@ void SensorCollector::begin(uint8_t imu_execution_core)
 
             iis2mdc_active = true;
             ESP_LOGI(SC_TAG, "IIS2MDC found and initialized (100 Hz continuous, BDU on)");
+            ESP_LOGI(SC_TAG, "MMC5983MA path skipped — IIS2MDC is the magnetometer on this "
+                             "board (shared pin %d owned by I2C SDA)",
+                     (int)IIS2MDC_SDA);
 
             // Dump OFFSET_X/Y/Z hard-iron correction registers — should be all
             // zero after softReset(); non-zero values would be subtracted from

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -6396,6 +6396,10 @@ static void loop_fc()
             //   lost     = stall-recovery tripped (sensor went silent)
             //   rec ok/a = recovery-reinit attempts / successes
             //   int_pin  = live state of MMC5983MA INT line
+            // Skipped when the IIS2MDC won the boot-time probe: the MMC path
+            // was never started, so every counter is a meaningless zero (and
+            // reads as a dead sensor to anyone reviewing the log).
+            if (!sensor_collector.isIIS2MDCActive())
             {
                 static MMC5983MADebugSnapshot prev_mmc_snap = {};
                 MMC5983MADebugSnapshot now_mmc_snap;


### PR DESCRIPTION
## Summary

When the IIS2MDC wins the boot-time magnetometer probe, the MMC5983MA path never starts — but `[MMC DIAG]` still printed all-zero counters every 10 s, reading as a dead sensor during log review (caused a false regression hunt on the 2026-07-09 bench data).

- `[MMC DIAG]` now prints only when the MMC path is actually active (`!isIIS2MDCActive()`).
- New boot line after IIS2MDC init: `MMC5983MA path skipped — IIS2MDC is the magnetometer on this board (shared pin N owned by I2C SDA)`.

Log-only change; no behavior differences. Verified by CI firmware builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)