### PR TITLE
fix(fc): emit the settings snapshot periodically pre-flight so bench recordings get provenance (#452)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -376,8 +376,10 @@ nonisolated class CSVGenerator {
         }()
 
         // Decode the flight settings snapshot (#165), if present. The FC emits
-        // it a few times right after launch for redundancy; all copies are
-        // identical, so take the first one that decodes.
+        // it a few times right after launch for redundancy, and (since #452)
+        // every 5 s outside of flight so command-started bench recordings get
+        // provenance too. Copies within one flight are identical; take the
+        // first one that decodes.
         let flightSettings: FlightSettings? = frames
             .first(where: { $0.type == MessageType.flightSettings.rawValue })
             .flatMap { try? FlightSettingsData(from: $0.payload) }

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5459,6 +5459,26 @@ static void loop_fc()
         max_alt_m = kinematics.max_altitude;
         max_speed_mps = kinematics.max_speed;
 
+        // #452: periodic pre-flight settings snapshot.  Command-started bench
+        // recordings never enter INFLIGHT, where the per-flight emissions
+        // (#165/#418) live, so their logs contained no FlightSettingsData and
+        // the exported .json had no fw sha / settings provenance.  The FC has
+        // no signal for when the OC starts a logging session, so emit a copy
+        // every 5 s outside INFLIGHT instead: any session picks one up within
+        // seconds, idle copies churn out of the pre-launch ring harmlessly
+        // (208 B per 5 s against an 86 KB/s link), and the in-flight schedule
+        // is untouched.  Runs at loop level (not in the state machine) so
+        // recordings made during ground/servo test modes get provenance too.
+        {
+            static uint32_t last_preflight_settings_ms = 0;
+            if (rocket_state != INFLIGHT &&
+                now_ms - last_preflight_settings_ms >= 5000U)
+            {
+                last_preflight_settings_ms = now_ms;
+                sendFlightSettings();
+            }
+        }
+
         // #363 SAFETY: the state machine (and servicePyroChannels) live in the
         // `else` of the test-mode chain below, so a ground/servo/replay test
         // left active at launch would suppress PRELAUNCH->INFLIGHT and pyro


### PR DESCRIPTION
## Summary

Fixes #452 — command-started bench recordings never enter INFLIGHT, where the only `sendFlightSettings()` calls lived, so their logs had no `FlightSettingsData` and exports had no fw sha / settings provenance.

- FC now emits one settings snapshot every 5 s whenever **not** INFLIGHT (loop-level, so ground/servo-test-mode recordings are covered too). In-flight schedule (#165/#418) unchanged.
- Cost: 208 B / 5 s on the 86 KB/s I2S link; idle copies churn out of the pre-launch ring by design.

## End-to-end compatibility (verified, no changes needed)

- OC whitelists `FLIGHT_SETTINGS_MSG` and deliberately excludes it from the time_us dedup (payload doesn't start with a timestamp) — periodic copies pass through.
- App exporter takes the first decodable settings frame anywhere in the file (position-independent); stale comment updated.

## Testing

- CI firmware builds; behavior is timing-only.
- Bench verification on next recording: .json settings block (incl. `fw_git_sha`) should populate within ~5 s of session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)