### PR TITLE
chore(app): shorten pre-EKF pad badge to 'Acquiring GNSS'

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -706,7 +706,7 @@ struct RocketStateView: View {
     static func padBadge(for state: String) -> (String, Bool)? {
         switch state {
         case "PRELAUNCH": return ("EKF Ready", true)
-        case "READY":     return ("Acquiring — waiting for GNSS + OC link", false)
+        case "READY":     return ("Acquiring GNSS", false)
         default:          return nil
         }
     }


### PR DESCRIPTION
One-string change: the READY-state (pre-EKF-init) pad badge now reads **Acquiring GNSS** instead of 'Acquiring — waiting for GNSS + OC link' — the OC link is necessarily already up for the badge to be showing telemetry at all; the actual gate is GNSS quality for EKF init. No logic changes; single occurrence, no test references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)