### PR TITLE
fix(fc): throttle EKF baro fusion to 50 Hz to recover loop headroom

### DIFF
--- a/tests_cpp/test_baro_gate_policy.cpp
+++ b/tests_cpp/test_baro_gate_policy.cpp
@@ -20,11 +20,17 @@ namespace
 {
 constexpr float kSpikeThreshM  = 5.0f;
 constexpr float kSpikeRateMps  = 500.0f;
+constexpr uint32_t kFuseIntervalUs = 20000u;  // config::BARO_FUSE_MIN_INTERVAL_US
 
+// Pre-throttle tests evaluate with the throttle DISABLED (0) so they keep
+// exercising freshness/spike behavior on every sample; throttle tests pass
+// kFuseIntervalUs explicitly.
 BaroGatePolicy::Decision eval(BaroGatePolicy& p, uint32_t t_us, float alt_m,
-                              bool locked = false)
+                              bool locked = false,
+                              uint32_t fuse_interval_us = 0u)
 {
-    return p.evaluate(t_us, alt_m, locked, kSpikeThreshM, kSpikeRateMps);
+    return p.evaluate(t_us, alt_m, locked, kSpikeThreshM, kSpikeRateMps,
+                      fuse_interval_us);
 }
 }  // namespace
 
@@ -227,4 +233,91 @@ TEST(BaroGatePolicy, TimestampWrapIsHandled)
     EXPECT_FALSE(d.spike);
     EXPECT_TRUE(d.accept);
     EXPECT_NEAR(d.apparent_rate_mps, 0.2f / 2053e-6f, 5.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Fusion throttle (post-#450 CPU fix): fusing baro at the full 487 Hz ODR
+// tripled per-tick EKF cost (554 -> ~1650 us, loop 959 -> ~715/s) because each
+// fusion pays the 15x15 covariance update.  The throttle rate-limits ACCEPTED
+// samples to the configured interval while spike/freshness tracking still
+// inspects every sample.
+// ---------------------------------------------------------------------------
+TEST(BaroGatePolicy, ThrottleLimitsFusionRateOnFullOdrStream)
+{
+    BaroGatePolicy gate;
+    constexpr double kBmpPeriodUs = 1e6 / 487.0;
+    constexpr double kDurationS   = 10.0;
+
+    uint32_t fresh = 0, accepted = 0, spikes = 0;
+    const long n = (long)(kDurationS * 1e6 / kBmpPeriodUs);
+    for (long i = 0; i < n; ++i)
+    {
+        const uint32_t t = (uint32_t)(i * kBmpPeriodUs);
+        const float alt = 100.0f * (float)(t * 1e-6);  // 100 m/s climb
+        const auto d = eval(gate, t, alt, false, kFuseIntervalUs);
+        if (d.fresh) fresh++;
+        if (d.accept) accepted++;
+        if (d.spike) spikes++;
+    }
+
+    EXPECT_EQ(fresh, (uint32_t)n);          // every sample still inspected
+    EXPECT_EQ(spikes, 0u);
+    // 20 ms interval -> 50 Hz.  Sample grid quantizes to the next sample at
+    // or beyond each interval boundary, so allow a small band.
+    EXPECT_GE(accepted, 480u);
+    EXPECT_LE(accepted, 510u);
+}
+
+// Spike tracking must remain a consecutive-sample test while throttled: a
+// glitch landing between fusions is still measured against its immediate
+// predecessor (not the last fused sample), and a glitch on a fusion tick is
+// still rejected.
+TEST(BaroGatePolicy, ThrottleDoesNotBreakSpikeTracking)
+{
+    BaroGatePolicy gate;
+    // Establish stream at 2 ms cadence; fuse interval 20 ms.
+    uint32_t t = 0;
+    for (int i = 0; i < 11; ++i)
+    {
+        eval(gate, t, 100.0f + 0.2f * i, false, kFuseIntervalUs);
+        t += 2000u;
+    }
+    // Next sample is a +8 m glitch mid-throttle-window: apparent rate vs the
+    // IMMEDIATE predecessor is ~4000 m/s -> flagged spike even though it
+    // would not have been fused anyway.
+    const auto g = eval(gate, t, 110.2f, false, kFuseIntervalUs);
+    EXPECT_TRUE(g.fresh);
+    EXPECT_TRUE(g.spike);
+    EXPECT_FALSE(g.accept);
+}
+
+// Throttle interval 0 disables the throttle entirely (every clean fresh
+// sample fuses) — guards the config escape hatch.
+TEST(BaroGatePolicy, ZeroIntervalDisablesThrottle)
+{
+    BaroGatePolicy gate;
+    uint32_t accepted = 0;
+    for (int i = 0; i < 100; ++i)
+    {
+        const auto d = eval(gate, (uint32_t)(i * 2053u), 0.05f * i, false, 0u);
+        if (d.accept) accepted++;
+    }
+    EXPECT_EQ(accepted, 100u);
+}
+
+// The throttle clock restarts from the last FUSED sample, so a spike-rejected
+// or locked sample does not push the next fusion further out.
+TEST(BaroGatePolicy, RejectedSamplesDoNotResetThrottleClock)
+{
+    BaroGatePolicy gate;
+    eval(gate, 0u, 0.0f, false, kFuseIntervalUs);             // fused @ t=0
+
+    // Locked sample at t=10ms: fresh, tracked, not fused.
+    const auto locked = eval(gate, 10000u, 1.0f, true, kFuseIntervalUs);
+    EXPECT_TRUE(locked.fresh);
+    EXPECT_FALSE(locked.accept);
+
+    // Clean sample at t=20ms: 20 ms since last FUSION -> fuses.
+    const auto d = eval(gate, 20000u, 2.0f, false, kFuseIntervalUs);
+    EXPECT_TRUE(d.accept);
 }

--- a/tinkerrocket-idf/projects/flight_computer/main/baro_gate_policy.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/baro_gate_policy.h
@@ -45,11 +45,22 @@ public:
     // makes the repeats !fresh no-ops.  `locked` is the transonic lockout: the
     // sample still updates the internal reference (so unlock does not produce a
     // false delta) but is not accepted for the measurement update.
+    //
+    // `min_fuse_interval_us` throttles how often a sample is ACCEPTED for the
+    // EKF measurement update (0 disables).  Fusing baro at the full ~487 Hz ODR
+    // buys nothing — altitude dynamics are slow against the sample rate — but
+    // each fusion pays the EKF's covariance update, which tripled the per-tick
+    // EKF cost (554 us -> ~1650 us) and cut the flight loop from ~960/s to
+    // ~715/s when the #450 fix restored every-sample fusion.  Spike/freshness
+    // tracking still sees EVERY sample (references advance per sample, so the
+    // spike compare stays a consecutive-sample test); only the accept output
+    // is rate-limited, and the interval restarts from the last FUSED sample.
     Decision evaluate(uint32_t sample_time_us,
                       float    altitude_m,
                       bool     locked,
                       float    spike_thresh_m,
-                      float    spike_rate_mps)
+                      float    spike_rate_mps,
+                      uint32_t min_fuse_interval_us)
     {
         Decision d;
         d.fresh = !have_consumed_ || (sample_time_us != last_time_us_);
@@ -74,20 +85,34 @@ public:
                       (d.apparent_rate_mps > spike_rate_mps);
         }
 
-        // Always advance the reference — even on spike or lockout — so one bad
-        // sample (or a lockout window) cannot poison every following compare.
+        // Always advance the reference — even on spike, lockout or throttle —
+        // so one bad sample (or a lockout window) cannot poison every
+        // following compare.
         last_time_us_  = sample_time_us;
         prev_alt_m_    = altitude_m;
         have_consumed_ = true;
 
-        d.accept = !d.spike && !locked;
+        // Fusion throttle: wrap-safe elapsed-time check against the last
+        // ACCEPTED sample.  The first-ever sample always passes.
+        const bool throttled =
+            (min_fuse_interval_us > 0u) && have_fused_ &&
+            (sample_time_us - last_fused_time_us_) < min_fuse_interval_us;
+
+        d.accept = !d.spike && !locked && !throttled;
+        if (d.accept)
+        {
+            last_fused_time_us_ = sample_time_us;
+            have_fused_ = true;
+        }
         return d;
     }
 
 private:
     static constexpr uint32_t kMinPairDtUs = 100u;
 
-    uint32_t last_time_us_  = 0;
-    float    prev_alt_m_    = 0.0f;
-    bool     have_consumed_ = false;
+    uint32_t last_time_us_       = 0;
+    float    prev_alt_m_         = 0.0f;
+    bool     have_consumed_      = false;
+    uint32_t last_fused_time_us_ = 0;
+    bool     have_fused_         = false;
 };

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -234,6 +234,17 @@ struct config : board_pins
     static constexpr float BARO_SPIKE_THRESH_M  = 5.0f;
     static constexpr float BARO_SPIKE_RATE_MPS  = 500.0f;
 
+    // Barometer fusion throttle: minimum spacing between baro samples ACCEPTED
+    // into the EKF measurement update (0 disables).  Fusing at the full
+    // ~487 Hz ODR buys nothing — altitude dynamics are slow against the sample
+    // rate — but each fusion pays the EKF's 15x15 covariance update.  When
+    // #450 restored every-sample fusion, per-tick EKF cost tripled
+    // (554 -> ~1650 us) and the flight loop fell ~960 -> ~715/s.  20 ms
+    // (50 Hz) keeps altitude aiding far above its information rate while
+    // making the covariance cost negligible.  Spike/freshness tracking in
+    // BaroGatePolicy still inspects every sample; only fusion is rate-limited.
+    static constexpr uint32_t BARO_FUSE_MIN_INTERVAL_US = 20000u;
+
     // Transonic barometer lockout: shock waves near Mach 1 cause large static
     // pressure errors (the "transonic jump").  Lock out baro updates when EKF
     // speed estimate exceeds LOCK_ON and keep them locked until speed drops

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3836,7 +3836,8 @@ static void loop_fc()
                                            pressure_altitude_m,
                                            baro_locked,
                                            config::BARO_SPIKE_THRESH_M,
-                                           config::BARO_SPIKE_RATE_MPS);
+                                           config::BARO_SPIKE_RATE_MPS,
+                                           config::BARO_FUSE_MIN_INTERVAL_US);
 
                     if (gate.accept)
                     {


### PR DESCRIPTION
## Summary

Follow-up to #450: restoring every-sample baro fusion (~480/s) tripled per-tick EKF cost (`[TIMING] ekf avg` 554 → ~1650 µs) and cut the flight loop from ~960/s to ~715/s — confirmed by bench serial and `flight_20260709_113923` (ISM6 718/s, NonSensor cadence 2.65 ms). Each fusion pays the dense 15×15 Joseph-form covariance update; baro at full ODR carries no extra information for altitude aiding.

- `BaroGatePolicy` gains a fusion throttle: accept at most one sample per `BARO_FUSE_MIN_INTERVAL_US` (new config, 20 ms → 50 Hz; 0 disables). Spike/freshness tracking still inspects **every** sample; the interval restarts from the last *fused* sample so rejections/lockout don't delay fusion.
- 4 new host tests; suite 435/435.

## Verification

- Host: full-ODR replay fuses at 50 Hz with zero spikes; mid-throttle glitches still flagged against their immediate predecessor.
- Bench (next serial capture): `[TIMING] ekf avg` should return to ~600 µs and `loop` to ~950/s.

Follow-up PR (in progress): rank-1 O(n²) Joseph update in `baroMeasUpdate` so per-fusion cost stops mattering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)