### PR TITLE
fix(oc): relay BMP585 temperature in LoRa telemetry instead of hardwired 0 (#386)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -2585,7 +2585,16 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
         lora.gyro_x = (float)ism_si.gyro_x;
         lora.gyro_y = (float)ism_si.gyro_y;
         lora.gyro_z = (float)ism_si.gyro_z;
-        lora.temp = 0.0f;
+    }
+
+    // #386: temp_x10 was transmitted as a hardwired 0.0 degC.  The BMP585
+    // measures die temperature alongside pressure and the OC already latches
+    // those frames — relay it as the board temperature.
+    if (latest_bmp_valid)
+    {
+        BMP585DataSI bmp_si = {};
+        sensor_converter.convertBMP585Data(latest_bmp_raw, bmp_si);
+        lora.temp = bmp_si.temperature;
     }
 
     if (latest_power_valid)


### PR DESCRIPTION
## Summary

The #386 `temp_x10` item: LoRa telemetry carried a hardwired 0.0 °C. The OC already latches BMP585 frames (which include die temperature) for its derived-altitude path, so this relays that as the board temperature — no new plumbing, no wire-format change (encode already clamps −40..200 °C ×10 i16).

The "needs a temp source decision" note resolves naturally: the BMP585 is the only temperature-instrumented sensor already flowing to the OC, and die-temp-at-the-baro is the standard interpretation for a telemetry board-temp field.

## Verification

- CI firmware builds (assembly-path change only).
- Bench: app/BS temperature should read ~room temp instead of 0.0 on the next connected session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)