### PR TITLE
fix(ekf): setState() stored the inverse DCM in T_B2NED (#386)

### DIFF
--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -176,8 +176,16 @@ public:
         std::memcpy(P_,             s.P,           sizeof(P_));
         tPrev_us_ = s.t_prev_us;
         std::memcpy(euler_BL_rad_,  s.euler,       sizeof(euler_BL_rad_));
-        // Rebuild DCM from restored quaternion
-        Quat2DCM(T_B2NED, quat_BL_);
+        // Rebuild DCM from restored quaternion.  Quat2DCM produces T_NED2B;
+        // transpose into T_B2NED (#386: this used to store the inverse —
+        // latent because timeUpdate() recomputes the DCM every tick, but
+        // wrong for any consumer in the window between a reboot-recovery
+        // restore and the first EKF tick).  Same pattern as setQuaternion().
+        float T_NED2B[3][3];
+        Quat2DCM(T_NED2B, quat_BL_);
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                T_B2NED[j][i] = T_NED2B[i][j];
     }
 
     /// Add offset to covariance diagonal (inflate uncertainty after reboot)


### PR DESCRIPTION
## Summary

Last open item in #386: `setState()` (reboot-recovery restore) called `Quat2DCM(T_B2NED, quat_BL_)`, which produces **T_NED2B** — leaving the member holding its own inverse until the next `timeUpdate()` recomputed it. Fixed with the explicit transpose `setQuaternion()` already uses.

Latent in current code (private member, no getter, all internal consumers recompute first), which is also why there's no attached regression test — observing it would require adding public API solely for the test. The fix restores the invariant that `T_B2NED` holds body→NED at every exit point.

With this + #460 (PID accumulator clamp) + #461 (temp_x10), all #386 items are addressed.

## Testing
- Host suite 437/437 (compiles the header via test_ekf; goldens unchanged — the DCM member isn't read before recompute today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)