### PR TITLE
feat(logging): IMU logging at 1920 Hz — queue handoff, drain-all consume, 2x I2S link

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -94,7 +94,6 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     uint8_t i = 0;
 
     // Data ready flag init
-    ism6hg256_data_ready = false;
     bmp585_data_ready = false;
     mmc5983ma_data_ready = false;
     iis2mdc_data_ready = false;
@@ -162,13 +161,16 @@ void SensorCollector::begin(uint8_t imu_execution_core)
     mmc_stall_threshold_us  = 5U  * (1000000UL / (uint32_t)MMC5983MA_UPDATE_RATE);
     mmc_recover_cooldown_us = 15U * (1000000UL / (uint32_t)MMC5983MA_UPDATE_RATE);
 
-    ism6hg256DataSemaphore = xSemaphoreCreateBinary();
-    if (ism6hg256DataSemaphore == NULL)
+    // IMU handoff queue (see header): the poll task pushes every sample; the
+    // flight loop drains all of them per iteration so the LOGGED rate follows
+    // the chip ODR instead of being capped at the loop rate.
+    ism6Queue = xQueueCreate(ISM6_QUEUE_DEPTH, sizeof(ISM6HG256Data));
+    if (ism6Queue == NULL)
     {
-        ESP_LOGE(SC_TAG, "Failed to create ISM6HG256 data semaphore!");
+        ESP_LOGE(SC_TAG, "Failed to create ISM6HG256 sample queue!");
         while (1) delay_ms(1000);
     }
-    xSemaphoreGive(ism6hg256DataSemaphore);
+    ism6_queue_drops = 0;
 
     bmp585DataSemaphore = xSemaphoreCreateBinary();
     if (bmp585DataSemaphore == NULL)
@@ -579,7 +581,6 @@ void SensorCollector::pollIMUdata(void* parameter)
             // Bulk read: gyro + lg accel + hg accel in one 24-byte SPI transaction
             (void)self->ism6hg256.Get_AllAxesRaw(&g_raw, &lg_raw, &hg_raw);
 
-            if (xSemaphoreTake(self->ism6hg256DataSemaphore, 0) == pdTRUE)
             {
                 self->start_time = time_us();
                 self->ism6hg256_data.time_us = self->start_time;
@@ -613,8 +614,17 @@ void SensorCollector::pollIMUdata(void* parameter)
                 }
                 self->pt_last_ism6_time_us = this_time;
 
-                self->ism6hg256_data_ready = true;
-                xSemaphoreGive(self->ism6hg256DataSemaphore);
+                // Enqueue the sample; on a full queue drop the OLDEST so the
+                // freshest data always lands (control reads the tail).  A
+                // nonzero drop counter means the consumer stalled for longer
+                // than ISM6_QUEUE_DEPTH samples — visible in [SENSOR] diag.
+                if (xQueueSend(self->ism6Queue, &self->ism6hg256_data, 0) != pdTRUE)
+                {
+                    ISM6HG256Data discard;
+                    (void)xQueueReceive(self->ism6Queue, &discard, 0);
+                    self->ism6_queue_drops++;
+                    (void)xQueueSend(self->ism6Queue, &self->ism6hg256_data, 0);
+                }
             }
 
             const uint32_t ism6_elapsed = time_us() - ism6_t0;
@@ -845,14 +855,12 @@ void SensorCollector::pollGNSSdata(void* parameter)
 // Returns the latest sensor data if available, and marks the data as read so that new data can be collected
 bool SensorCollector::getISM6HG256Data(ISM6HG256Data& ism6hg256_out)
 {
-    if (ism6hg256_data_ready && xSemaphoreTake(ism6hg256DataSemaphore, 0) == pdTRUE) 
-    {
-        ism6hg256_out = ism6hg256_data;
-        xSemaphoreGive(ism6hg256DataSemaphore);
-        ism6hg256_data_ready = false;
-        return true;
-    }
-    return false;
+    // Pops ONE sample; callers drain with a while() loop.  Returns false when
+    // no sample is pending — same contract as before, but samples queue up
+    // instead of overwriting, so a consumer slower than the ODR sees every
+    // sample (up to ISM6_QUEUE_DEPTH of backlog) rather than only the latest.
+    return ism6Queue != nullptr &&
+           xQueueReceive(ism6Queue, &ism6hg256_out, 0) == pdTRUE;
 }
 
 bool SensorCollector::getBMP585Data(BMP585Data& bmp585_out)
@@ -962,6 +970,7 @@ void SensorCollector::getPollTimingSnapshot(PollTimingSnapshot &snapshot_out) co
     snapshot_out.gnss_over_1ms   = pt_gnss_over_1ms;
     snapshot_out.gnss_over_5ms   = pt_gnss_over_5ms;
     snapshot_out.gnss_over_10ms  = pt_gnss_over_10ms;
+    snapshot_out.ism6_queue_drops = ism6_queue_drops;
 }
 
 void SensorCollector::resetPollTimingSnapshot()

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -39,6 +39,7 @@ typedef struct
     uint32_t gnss_over_1ms;         // GNSS parses > 1 ms
     uint32_t gnss_over_5ms;         // GNSS parses > 5 ms
     uint32_t gnss_over_10ms;        // GNSS parses > 10 ms
+    uint32_t ism6_queue_drops;      // IMU samples evicted from a full handoff queue
 } PollTimingSnapshot;
 
 typedef struct
@@ -111,7 +112,6 @@ public:
     const uint16_t ism6_high_g_fs_g_;
     const uint16_t ism6_gyro_fs_dps_;
 
-    volatile bool ism6hg256_data_ready;
     volatile bool bmp585_data_ready;
     volatile bool mmc5983ma_data_ready;
     volatile bool iis2mdc_data_ready;
@@ -190,13 +190,24 @@ private:
     TR_MMC5983MA mmc5983ma;
     TR_IIS2MDC iis2mdc;
     TR_GNSSReceiverUBloxSerial gnss_receiver;
-    ISM6HG256Data ism6hg256_data;
+    ISM6HG256Data ism6hg256_data;   // scratch for the poll task (queue is the handoff)
     BMP585Data bmp585_data;
     MMC5983MAData mmc5983ma_data;
     IIS2MDCData iis2mdc_data;
     GNSSData gnss_data;
 
-    SemaphoreHandle_t ism6hg256DataSemaphore;
+    // IMU handoff queue (poll task -> consumer).  The previous single-slot
+    // latest-sample handoff silently dropped any sample the consumer didn't
+    // collect before the next DRDY — capping the LOGGED rate at the flight
+    // loop rate (~980/s) no matter the chip ODR.  A short queue lets the loop
+    // drain every sample (it logs each one; control uses the freshest), so
+    // the logged rate follows ISM6HG256_UPDATE_RATE.  Depth 8 ≈ 4 ms at
+    // 1920 Hz — far beyond any loop-iteration jitter observed ([GAP DIAG]
+    // iter_max ≈ 1.4 ms); overflow drops the OLDEST sample and counts it.
+    QueueHandle_t ism6Queue = nullptr;
+    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 8;
+    volatile uint32_t ism6_queue_drops = 0;
+
     SemaphoreHandle_t bmp585DataSemaphore;
     SemaphoreHandle_t mmc5983maDataSemaphore;
     SemaphoreHandle_t iis2mdcDataSemaphore;

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -38,13 +38,22 @@ struct config : board_pins
     // MMC5983MA hardware supports 1/10/20/50/100/200/1000 Hz only.
     // 200 Hz is the highest step that fits within I2C budget.
     static constexpr uint16_t MMC5983MA_UPDATE_RATE = 200;
-    static constexpr uint16_t ISM6HG256_UPDATE_RATE = 960;
+    // 1920 Hz: first step of the logging-rate maximization.  The chip supports
+    // 1920/3840/7680; the poll task's handoff queue + the loop's drain-all
+    // consumption log EVERY sample regardless of loop rate (~980/s).  The
+    // control/EKF/guidance path still consumes the freshest sample at loop
+    // rate.  I2S share at 1920: 1920 x 30 B = 58 KB/s of the 176 KB/s link
+    // (I2S_SAMPLE_RATE below).  Going to 3840 needs a further link bump and
+    // bench proof of OC ingest headroom first ([GAP DIAG] imu_q_drops and the
+    // OC LogBufferStats ring fill are the gauges).
+    static constexpr uint16_t ISM6HG256_UPDATE_RATE = 1920;
     static constexpr uint16_t NON_SENSOR_UPDATE_RATE = 500;
     // Guidance telemetry (GUIDANCE_TELEM_MSG) log rate while guidance is active.
     // Emitted from inside the NonSensor TX block, so it must divide
     // NON_SENSOR_UPDATE_RATE; 500 = lockstep with NonSensor/roll_cmd (frames
-    // time-aligned 1:1). The guidance law recomputes at ISM6HG256_UPDATE_RATE
-    // (960 Hz), so values are fresh at any rate up to NON_SENSOR_UPDATE_RATE.
+    // time-aligned 1:1). The guidance law recomputes once per flight-loop
+    // iteration (~980 Hz, on the freshest IMU sample), so values are fresh at
+    // any rate up to NON_SENSOR_UPDATE_RATE.
     static constexpr uint16_t GUIDANCE_TELEM_RATE_HZ = 500;
     static_assert(GUIDANCE_TELEM_RATE_HZ >= 1 &&
                   GUIDANCE_TELEM_RATE_HZ <= NON_SENSOR_UPDATE_RATE,
@@ -387,9 +396,12 @@ struct config : board_pins
     //     header) ###
     // I2S bandwidth = sample_rate * 4 bytes (16-bit stereo).
     // Higher rate = faster DMA buffer turnover = less stale data.
-    // 22050 Hz = 88 KB/s.  Lower rates cause more gaps from DMA replay.
-    // IMPORTANT: If sensor rates increase, raise this proportionally.
-    static constexpr uint32_t I2S_SAMPLE_RATE = 22050;  // Must match OC
+    // 44100 Hz = 176 KB/s.  Raised from 22050 with the IMU 960 -> 1920 Hz
+    // step: at 22050 the link was already ~76% full (~67 KB/s) and doubling
+    // the IMU frames would not fit.  New steady-state budget ~97 KB/s (55%):
+    // IMU 58 K + NonSensor 24 K + baro 10 K + mag/GNSS/power/misc ~5 K.
+    // IMPORTANT: must match the OC's I2S_SAMPLE_RATE — flash both together.
+    static constexpr uint32_t I2S_SAMPLE_RATE = 44100;  // Must match OC
  
     // ### Execution Cores ###
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3198,27 +3198,42 @@ static void loop_fc()
     // loop-period gating.
     static uint32_t dbg_ism6_reads = 0, dbg_bmp_reads = 0, dbg_bmp_bad_reads = 0, dbg_mmc_reads = 0, dbg_iis2mdc_reads = 0, dbg_gnss_reads = 0;
 
-    if (sensor_collector.getISM6HG256Data(ism6hg256_data))
+    // Drain ALL pending IMU samples each iteration.  The chip runs at
+    // ISM6HG256_UPDATE_RATE (1920 Hz) — about two samples per ~1 ms loop pass —
+    // and every one is logged to I2S so the recorded IMU rate follows the chip
+    // ODR, not the loop rate (single-slot handoff used to cap it at ~980/s).
+    // The control/EKF path converts only the FRESHEST drained sample: guidance,
+    // kinematics and the EKF all keep running at loop rate exactly as before.
     {
-        dbg_ism6_reads++;
-        sensor_converter.convertISM6HG256Data(ism6hg256_data, ism6_latest_si);
-        have_ism6_si = true;
+        bool ism6_new_this_iter = false;
+        while (sensor_collector.getISM6HG256Data(ism6hg256_data))
+        {
+            dbg_ism6_reads++;
+            ism6_new_this_iter = true;
 
-        // Feed the live low-g accel to the mag calibrator so each
-        // incoming mag sample can be bucketed by physical orientation
-        // (issue #96 follow-up).  Raw int16 LSB units share the same
-        // sign convention as the mag direction-wedge encoding.
-        mag_calibrator.setLiveAccel(ism6hg256_data.acc_low_raw.x,
-                                    ism6hg256_data.acc_low_raw.y,
-                                    ism6hg256_data.acc_low_raw.z);
+            memcpy(ism6hg256_data_buffer,
+                   &ism6hg256_data,
+                   SIZE_OF_ISM6HG256_DATA);
 
-        memcpy(ism6hg256_data_buffer,
-               &ism6hg256_data,
-               SIZE_OF_ISM6HG256_DATA);
+            (void)enqueueI2STx(ISM6HG256_MSG,
+                               ism6hg256_data_buffer,
+                               SIZE_OF_ISM6HG256_DATA);
+        }
 
-        (void)enqueueI2STx(ISM6HG256_MSG,
-                           ism6hg256_data_buffer,
-                           SIZE_OF_ISM6HG256_DATA);
+        if (ism6_new_this_iter)
+        {
+            sensor_converter.convertISM6HG256Data(ism6hg256_data, ism6_latest_si);
+            have_ism6_si = true;
+
+            // Feed the live low-g accel to the mag calibrator so each
+            // incoming mag sample can be bucketed by physical orientation
+            // (issue #96 follow-up).  Raw int16 LSB units share the same
+            // sign convention as the mag direction-wedge encoding.  The
+            // freshest sample is sufficient — the mag runs at 100 Hz.
+            mag_calibrator.setLiveAccel(ism6hg256_data.acc_low_raw.x,
+                                        ism6hg256_data.acc_low_raw.y,
+                                        ism6hg256_data.acc_low_raw.z);
+        }
     }
 
     if (sensor_collector.getBMP585Data(bmp585_data))
@@ -6350,13 +6365,14 @@ static void loop_fc()
                           (unsigned long)pt.bmp_max_us,
                           (unsigned long)pt.mmc_max_us,
                           (unsigned long)pt.ism6_read_max_us);
-            ESP_LOGI(TAG, "[GAP DIAG] gaps>10ms=%lu worst=%lu us | gnss calls=%lu >1ms=%lu >5ms=%lu >10ms=%lu",
+            ESP_LOGI(TAG, "[GAP DIAG] gaps>10ms=%lu worst=%lu us | gnss calls=%lu >1ms=%lu >5ms=%lu >10ms=%lu | imu_q_drops=%lu",
                           (unsigned long)pt.gap_count,
                           (unsigned long)pt.gap_worst_us,
                           (unsigned long)pt.gnss_calls,
                           (unsigned long)pt.gnss_over_1ms,
                           (unsigned long)pt.gnss_over_5ms,
-                          (unsigned long)pt.gnss_over_10ms);
+                          (unsigned long)pt.gnss_over_10ms,
+                          (unsigned long)pt.ism6_queue_drops);
             ESP_LOGI(TAG, "[GAP DIAG] i2s enqueue ok/drop=%lu/%lu tx ok/fail=%lu/%lu last_err=%d q_free=%u",
                           (unsigned long)i2s_tx_enqueue_ok,
                           (unsigned long)i2s_tx_enqueue_drop,

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -68,9 +68,11 @@ struct config : board_pins
     //     board header) ---
     // I2S bandwidth = sample_rate * 4 bytes (16-bit stereo).
     // Higher rate = faster DMA buffer turnover = less stale data.
-    // 22050 Hz = 88 KB/s.  Lower rates cause more gaps from DMA replay.
-    // IMPORTANT: If sensor rates increase, raise this proportionally.
-    static constexpr uint32_t I2S_SAMPLE_RATE = 22050;  // Must match FC
+    // 44100 Hz = 176 KB/s.  Raised from 22050 with the FC's IMU 960 -> 1920 Hz
+    // logging step (the link was ~76% full at 22050).  RX DMA descriptors are
+    // sized in setup (dma_frame_num) to keep the callback cadence ~3 ms at
+    // this rate.  IMPORTANT: must match the FC — flash both together.
+    static constexpr uint32_t I2S_SAMPLE_RATE = 44100;  // Must match FC
 
     // --- LoRa RF parameters (radio presence + pins in board header) ---
     static constexpr float LORA_FREQ_MHZ = 915.0f;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4699,16 +4699,19 @@ void initPeripherals()
         oc_ota_tx_queue = xQueueCreate(16, sizeof(OcOtaTxFrame));
 
     // I2S telemetry stream from FlightComputer (DMA-based slave RX)
-    // Small DMA buffers (4 × 256 bytes = 1 KB) minimize latency.
+    // Small DMA buffers (4 × 512 bytes = 2 KB) minimize latency.
     // FRAME_SYNC interrupt gating prevents stale replay regardless of
     // buffer count, but smaller buffers reduce read-to-parse latency.
+    // dma_frame_num doubled 64 -> 128 alongside the 22050 -> 44100 link rate
+    // so each descriptor still spans ~2.9 ms (512 B at 176 KB/s) — the same
+    // callback cadence the parser was tuned against at the old rate.
     if (i2s_stream.beginSlaveRx(config::I2S_BCLK_PIN,
                                  config::I2S_WS_PIN,
                                  config::I2S_DIN_PIN,
                                  config::I2S_FSYNC_PIN,
                                  config::I2S_SAMPLE_RATE,
-                                 4,     // dma_desc_num
-                                 64) != ESP_OK)  // dma_frame_num → 256 bytes each
+                                 4,      // dma_desc_num
+                                 128) != ESP_OK)  // dma_frame_num → 512 bytes each
     {
         ESP_LOGE("PWR", "I2S slave RX init failed");
     }


### PR DESCRIPTION
## Investigation (full pipeline audit)

| Stage | Current | Ceiling | Verdict |
|---|---|---|---|
| ISM6HG256 | 960 Hz ODR, ~940/s logged | chip: 1920/3840/7680 Hz | **raised to 1920** |
| IMU handoff | single latest-sample slot | logging welded to loop rate | **replaced with queue** |
| BMP585 | ~487/s | continuous-mode OSR max | already maxed |
| IIS2MDC | 100 Hz | chip max | already maxed |
| GNSS SAM-M10Q | 18 Hz | 4-constellation max (25 Hz costs constellations) | keep |
| I2S link | 88 KB/s, **~76% used** | config both sides | **→ 176 KB/s (55% used)** |
| OC ingest | ~2 kframes/s, parser prio 6 > loop prio 5 | CPU — measure on bench | gauges below |
| NAND flush | 67 KB/s, ring ~idle | MB/s-class | non-issue |
| LoRa downlink | 2 Hz | airtime, tiny CPU | non-issue |

## Changes

- **Collector**: 8-deep queue replaces the single-slot handoff (which silently overwrote any sample the loop hadn't collected — the reason logged rate ≈ loop rate). Poll task pushes every sample, drop-oldest on overflow with a counter; `getISM6HG256Data()` keeps its signature (pops one).
- **FC loop**: drains all pending samples per iteration, logs each to I2S; control/EKF/guidance still consume only the freshest at loop rate (unchanged cadence).
- **Config**: IMU 960→1920 Hz; I2S 22050→44100 both sides (**flash FC + OC together**); OC RX `dma_frame_num` 64→128 to hold ~2.9 ms descriptor cadence.
- New `[GAP DIAG] imu_q_drops=` gauge (must stay 0).

## Bench acceptance (next tabletop/sim run)

- `[SENSOR] ism6≈1900/s`, `imu_q_drops=0`, `gaps>10ms=0`, `i2s enqueue drop=0`
- OC LogBufferStats: fill/highwater comfortably under the prelaunch cap, zero in-session overruns
- Downlink (BS 2 Hz CSV) + BLE live telemetry unaffected
- .bin from a session: ISM6 cadence median ~0.52 ms

Known tradeoff: pre-launch ring history halves (~0.75 s → ~0.4 s) since the ring is byte-sized — revisit ring size before any 3840 step. 3840 Hz is the next rung if the gauges show headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)