### PR TITLE
fix(fc): clean the IMU-queue drop gauge — zero at consumer start, depth 8→32

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -201,12 +201,24 @@ private:
     // collect before the next DRDY — capping the LOGGED rate at the flight
     // loop rate (~980/s) no matter the chip ODR.  A short queue lets the loop
     // drain every sample (it logs each one; control uses the freshest), so
-    // the logged rate follows ISM6HG256_UPDATE_RATE.  Depth 8 ≈ 4 ms at
-    // 1920 Hz — far beyond any loop-iteration jitter observed ([GAP DIAG]
-    // iter_max ≈ 1.4 ms); overflow drops the OLDEST sample and counts it.
+    // the logged rate follows ISM6HG256_UPDATE_RATE.  Depth 32 ≈ 17 ms at
+    // 1920 Hz: loop jitter is ~1.4 ms, but blocking loop work (NVS commits on
+    // config saves) measured ~1-3 dropped samples per commit at depth 8 on
+    // the 2026-07-09 bench — 32 gives margin over the worst observed stall so
+    // in-session drops genuinely mean something is wrong.  Overflow drops the
+    // OLDEST sample and counts it (imu_q_drops in [GAP DIAG], zeroed by the
+    // consumer when it starts draining — the ~4 s of pre-loop boot produce
+    // thousands of meaningless pre-consumer drops otherwise).
     QueueHandle_t ism6Queue = nullptr;
-    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 8;
+    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 32;
     volatile uint32_t ism6_queue_drops = 0;
+
+public:
+    // Zero the drop counter (and nothing else).  Called once by the consumer
+    // when it begins draining, so the gauge counts only consumer-era drops.
+    void resetIsm6QueueDrops() { ism6_queue_drops = 0; }
+
+private:
 
     SemaphoreHandle_t bmp585DataSemaphore;
     SemaphoreHandle_t mmc5983maDataSemaphore;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -3174,6 +3174,19 @@ static void enterInflight(uint32_t now_ms, const char* from_state)
 
 static void loop_fc()
 {
+    // Zero the IMU-queue drop gauge on the first pass: the poll task starts
+    // ~4 s before this loop does (servo init holds setup), producing ~8k
+    // meaningless pre-consumer drops into an unconsumed queue.  From here on
+    // a nonzero [GAP DIAG] imu_q_drops means the consumer actually stalled.
+    {
+        static bool imu_drop_gauge_zeroed = false;
+        if (!imu_drop_gauge_zeroed)
+        {
+            imu_drop_gauge_zeroed = true;
+            sensor_collector_hw.resetIsm6QueueDrops();
+        }
+    }
+
     fcMaybeMarkOtaValid();   // Layer 4: confirm a freshly OTA'd image after a stable run
 
     // ── OTA image pump: yield the core to the OTA RX parser ──


### PR DESCRIPTION
## Summary

Follow-up from the first 1920 Hz bench run (which validated the rate itself: `ism6=1908/s` sustained, loop ~980/s unchanged, zero I2S drops, EKF untouched). Two gauge refinements so `imu_q_drops` is trustworthy for the 3840 decision:

- **Zero at consumer start**: the poll task begins ~4 s before `loop_fc` (servo init holds setup), so the queue churned ~8k meaningless pre-consumer drops — the gauge started at 8,051 instead of 0.
- **Depth 8 → 32** (~17 ms headroom, 704 B): NVS commits during config saves block the loop past 4 ms and cost ~1–3 samples each (+37 during the bench config burst, ~0.2/s idle). With 32, in-session drops genuinely mean a stall worth investigating.

## Bench acceptance
`imu_q_drops=0` from the first `[GAP DIAG]` line and staying 0 through app config saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)