### PR TITLE
fix(i2s/dedup): stop stale-descriptor replays and harden reboot detection (#468)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -390,3 +390,18 @@ target_include_directories(test_baro_gate_policy PRIVATE
 )
 target_link_libraries(test_baro_gate_policy GTest::gtest_main)
 gtest_discover_tests(test_baro_gate_policy)
+
+# ---------- test_dedup_reboot_policy ----------
+# Host-side test for the OC's FC-reboot-vs-replay discriminator (#468): a
+# reboot verdict requires the timestamp backstep to persist for the confirm
+# window; replayed stale I2S TX descriptors (once per DMA ring revolution,
+# interleaved with fresh frames) must be dropped without resetting the dedup
+# baselines. dedup_reboot_policy.h is pure, so the test just adds the
+# out_computer/main dir.
+add_executable(test_dedup_reboot_policy test_dedup_reboot_policy.cpp)
+target_include_directories(test_dedup_reboot_policy PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/out_computer/main
+)
+target_link_libraries(test_dedup_reboot_policy GTest::gtest_main)
+gtest_discover_tests(test_dedup_reboot_policy)

--- a/tests_cpp/test_dedup_reboot_policy.cpp
+++ b/tests_cpp/test_dedup_reboot_policy.cpp
@@ -1,0 +1,125 @@
+// #468: DedupRebootPolicy — a reboot verdict requires the timestamp
+// backstep to persist; replayed stale TX descriptors interleaved with
+// fresh traffic must be dropped without resetting the dedup baselines.
+
+#include <gtest/gtest.h>
+
+#include "dedup_reboot_policy.h"
+
+using Action = DedupRebootPolicy::Action;
+
+TEST(DedupRebootPolicy, FreshTrafficAlwaysProceeds)
+{
+    DedupRebootPolicy p;
+    for (uint32_t t = 0; t < 1000; t += 1)
+    {
+        EXPECT_EQ(p.onFrame(false, t), Action::PROCEED);
+    }
+    EXPECT_FALSE(p.suspectActive());
+}
+
+TEST(DedupRebootPolicy, LoneReplayDroppedWithoutReset)
+{
+    DedupRebootPolicy p;
+    EXPECT_EQ(p.onFrame(false, 10), Action::PROCEED);
+    EXPECT_EQ(p.onFrame(true, 11), Action::DROP_REPLAY);
+    EXPECT_TRUE(p.suspectActive());
+    // Fresh frame right after: the backstep was a replay, suspicion clears.
+    EXPECT_EQ(p.onFrame(false, 12), Action::PROCEED);
+    EXPECT_FALSE(p.suspectActive());
+}
+
+// The bench signature that motivated #468: one stale descriptor re-arrives
+// every TX DMA ring revolution (~46 ms), ~15 frames per burst, with fresh
+// traffic flowing in between. The old heuristic reset baselines 21.5x/s;
+// the policy must never confirm a reboot.
+TEST(DedupRebootPolicy, PerRevolutionReplayBurstsNeverConfirm)
+{
+    DedupRebootPolicy p;
+    uint32_t resets = 0;
+    for (uint32_t rev = 0; rev < 220; rev++)  // ~10 s of revolutions
+    {
+        const uint32_t t0 = rev * 46;
+        for (int i = 0; i < 15; i++)  // stale burst (all within ~3 ms)
+        {
+            if (p.onFrame(true, t0 + (i * 3) / 15) == Action::RESET_BASELINE)
+            {
+                resets++;
+            }
+        }
+        for (int i = 0; i < 40; i++)  // fresh traffic for the rest of the rev
+        {
+            EXPECT_EQ(p.onFrame(false, t0 + 3 + i), Action::PROCEED);
+        }
+    }
+    EXPECT_EQ(resets, 0u);
+}
+
+TEST(DedupRebootPolicy, SustainedBackstepConfirmsOnceAfterWindow)
+{
+    DedupRebootPolicy p(100);
+    uint32_t confirms = 0;
+    uint32_t confirm_time = 0;
+    // Genuine reboot: every frame from t=500 on is backstepped (2 ms cadence).
+    for (uint32_t t = 500; t < 700; t += 2)
+    {
+        const Action a = p.onFrame(true, t);
+        if (a == Action::RESET_BASELINE)
+        {
+            confirms++;
+            if (confirms == 1) confirm_time = t;
+            break;  // caller resets max_time_us, so later frames aren't backstepped
+        }
+        EXPECT_EQ(a, Action::DROP_REPLAY);
+    }
+    EXPECT_EQ(confirms, 1u);
+    EXPECT_EQ(confirm_time, 600u);  // first frame at >= suspect_since + 100
+}
+
+TEST(DedupRebootPolicy, FreshFrameRestartsConfirmWindow)
+{
+    DedupRebootPolicy p(100);
+    // 60 ms of backstep...
+    for (uint32_t t = 0; t <= 60; t += 2)
+    {
+        EXPECT_EQ(p.onFrame(true, t), Action::DROP_REPLAY);
+    }
+    // ...interrupted by one fresh frame: window must restart.
+    EXPECT_EQ(p.onFrame(false, 61), Action::PROCEED);
+    for (uint32_t t = 62; t < 161; t += 2)
+    {
+        EXPECT_EQ(p.onFrame(true, t), Action::DROP_REPLAY);
+    }
+    // 62 + 100 = 162: first frame at/after that confirms.
+    EXPECT_EQ(p.onFrame(true, 162), Action::RESET_BASELINE);
+}
+
+TEST(DedupRebootPolicy, ExactBoundaryConfirms)
+{
+    DedupRebootPolicy p(100);
+    EXPECT_EQ(p.onFrame(true, 1000), Action::DROP_REPLAY);
+    EXPECT_EQ(p.onFrame(true, 1099), Action::DROP_REPLAY);
+    EXPECT_EQ(p.onFrame(true, 1100), Action::RESET_BASELINE);
+}
+
+TEST(DedupRebootPolicy, MillisWrapDuringWindow)
+{
+    DedupRebootPolicy p(100);
+    const uint32_t near_wrap = 0xFFFFFFF0u;
+    EXPECT_EQ(p.onFrame(true, near_wrap), Action::DROP_REPLAY);
+    // 16 ms later millis() has wrapped to 0; 84 ms into the window.
+    EXPECT_EQ(p.onFrame(true, 0x00000044u), Action::DROP_REPLAY);  // +84 ms
+    EXPECT_EQ(p.onFrame(true, 0x00000054u), Action::RESET_BASELINE);  // +100 ms
+}
+
+TEST(DedupRebootPolicy, ReusableAfterConfirm)
+{
+    DedupRebootPolicy p(100);
+    EXPECT_EQ(p.onFrame(true, 0), Action::DROP_REPLAY);
+    EXPECT_EQ(p.onFrame(true, 100), Action::RESET_BASELINE);
+    // New session runs fresh...
+    EXPECT_EQ(p.onFrame(false, 200), Action::PROCEED);
+    // ...and a later genuine reboot confirms again.
+    EXPECT_EQ(p.onFrame(true, 300), Action::DROP_REPLAY);
+    EXPECT_EQ(p.onFrame(true, 400), Action::RESET_BASELINE);
+}

--- a/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.cpp
+++ b/tinkerrocket-idf/components/TR_I2S_Stream/TR_I2S_Stream.cpp
@@ -64,6 +64,13 @@ esp_err_t TR_I2S_Stream::beginMasterTx(int bclk_pin,
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
     chan_cfg.dma_desc_num  = dma_desc_num;
     chan_cfg.dma_frame_num = dma_frame_num;
+    // #468: zero each DMA descriptor after it transmits. Without this, a
+    // sender-task underrun makes the DMA re-transmit whatever stale frames
+    // are still in the ring — the receiver saw one descriptor's worth of
+    // 10+ s-old frames once per ring revolution (46.4 ms at 44100), which
+    // its dedup misread as an FC reboot. With auto_clear an underrun sends
+    // zeros, which every receiver in this system already skips as idle fill.
+    chan_cfg.auto_clear = true;
 
     esp_err_t err = i2s_new_channel(&chan_cfg, &chan_handle_, nullptr);
     if (err != ESP_OK)

--- a/tinkerrocket-idf/projects/out_computer/main/dedup_reboot_policy.h
+++ b/tinkerrocket-idf/projects/out_computer/main/dedup_reboot_policy.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+
+// #468: decide whether a far-backstepped frame timestamp means the FC
+// rebooted or a stale I2S TX descriptor got replayed.
+//
+// The old heuristic reset every dedup baseline the moment one frame's
+// time_us fell more than REBOOT_BACKSTEP_US behind the global high-water
+// mark. On the bench that fired at 21.5 Hz for seconds at a time: an FC
+// sender underrun leaves one descriptor of old frames in the TX DMA ring,
+// and the same 10+ s-old frame re-arrives once per ring revolution
+// (46.4 ms at 44100 Hz) interleaved with perfectly fresh traffic. Each
+// false "reboot" wiped the baselines — briefly disabling replay
+// protection for every frame type — and flooded the log.
+//
+// The physical discriminator: after a REAL reboot (or a uint32 time_us
+// wrap) every subsequent frame is backstepped, because the FC's clock
+// restarted; a replay burst is always followed within a couple of
+// milliseconds by fresh frames. So a reboot verdict requires the
+// backstep to PERSIST for confirm_ms with no fresh frame in between —
+// default 100 ms, a bit over two TX DMA ring revolutions, so a replayed
+// descriptor recurring every revolution still cannot confirm as long as
+// live frames keep flowing around it.
+//
+// Pure header (no ESP-IDF deps) so the host suite can exercise it; the
+// caller owns time (millis()) and the actual baseline reset.
+class DedupRebootPolicy
+{
+public:
+    enum class Action : uint8_t
+    {
+        PROCEED,         // not backstepped — frame flows to the normal dedup checks
+        DROP_REPLAY,     // backstepped but unconfirmed — drop it, keep all baselines
+        RESET_BASELINE,  // backstep persisted — genuine reboot, reset dedup state
+    };
+
+    explicit DedupRebootPolicy(uint32_t confirm_ms = 100)
+        : confirm_ms_(confirm_ms)
+    {
+    }
+
+    Action onFrame(bool far_backstepped, uint32_t now_ms)
+    {
+        if (!far_backstepped)
+        {
+            // Fresh traffic still flowing: any pending suspicion was a replay.
+            suspect_active_ = false;
+            return Action::PROCEED;
+        }
+        if (!suspect_active_)
+        {
+            suspect_active_ = true;
+            suspect_since_ms_ = now_ms;
+            return Action::DROP_REPLAY;
+        }
+        if ((uint32_t)(now_ms - suspect_since_ms_) >= confirm_ms_)
+        {
+            suspect_active_ = false;
+            return Action::RESET_BASELINE;
+        }
+        return Action::DROP_REPLAY;
+    }
+
+    bool suspectActive() const { return suspect_active_; }
+
+private:
+    uint32_t confirm_ms_;
+    uint32_t suspect_since_ms_ = 0;
+    bool suspect_active_ = false;
+};

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -46,6 +46,7 @@ static inline std::string itos(int v)
 }
 
 #include "config.h"
+#include "dedup_reboot_policy.h"
 
 #include <TR_I2C_Interface.h>
 #include <TR_I2S_Stream.h>
@@ -1184,6 +1185,7 @@ static uint32_t frames_bad_crc = 0;
 static volatile uint32_t dma_cb_count = 0;      // DMA callback invocations
 static uint32_t dedup_drops_lt = 0;              // ts strictly less than prev (replay / reorder)
 static uint32_t dedup_drops_eq = 0;              // ts exactly equal to prev (byte-duplicate)
+static uint32_t dedup_replay_drops = 0;          // #468: >10 s backstep, unconfirmed (replayed TX descriptor)
 static uint32_t stale_drops = 0;                 // stale timestamp rejects
 static uint32_t raw_i2c_reads = 0;
 static uint64_t raw_i2c_bytes = 0;
@@ -1859,27 +1861,42 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
         }
         if (prev != nullptr)
         {
-            // FC-reboot detection (#16). The FC's time_us restarts near 0 on every
-            // reboot — including the one right after a successful OTA. All the
-            // prev_time_*/max_time_us state here is from the prior session, so every
-            // post-reboot frame looks non-monotonic (dropped below) AND stale (dropped
-            // by the 5 s filter) until ts climbs back past the old high-water mark —
-            // tens of seconds of lost telemetry, so the app shows stale FC data right
-            // after an update. A timestamp far behind the global high-water mark (well
-            // beyond any reorder/jitter, which is sub-second) can only mean a new
-            // session: reset the dedup baseline and adopt the new stream. Also covers a
-            // uint32 µs wrap (~71 min) gracefully.
+            // FC-reboot detection (#16, hardened in #468). The FC's time_us
+            // restarts near 0 on every reboot — including the one right after a
+            // successful OTA. All the prev_time_*/max_time_us state here is from
+            // the prior session, so every post-reboot frame looks non-monotonic
+            // (dropped below) AND stale (dropped by the 5 s filter) until ts
+            // climbs back past the old high-water mark — tens of seconds of lost
+            // telemetry, so the app shows stale FC data right after an update. A
+            // timestamp far behind the global high-water mark can only mean a
+            // new session... OR a replayed stale TX descriptor (#468): an FC
+            // sender underrun re-transmits 10+ s-old frames once per DMA ring
+            // revolution, interleaved with fresh traffic. DedupRebootPolicy
+            // tells them apart: only a backstep that PERSISTS (no fresh frame
+            // for 100 ms) is a reboot; a lone stale frame between fresh ones is
+            // dropped as a replay without touching the baselines. Also covers a
+            // uint32 µs wrap (~71 min) gracefully (wrap = sustained backstep).
             static constexpr uint32_t REBOOT_BACKSTEP_US = 10'000'000;  // 10 s
-            if (time_us != 0 && max_time_us > REBOOT_BACKSTEP_US &&
-                time_us < (max_time_us - REBOOT_BACKSTEP_US))
+            static DedupRebootPolicy reboot_policy;  // 100 ms > 2 TX ring revolutions
+            const bool far_backstep =
+                (time_us != 0 && max_time_us > REBOOT_BACKSTEP_US &&
+                 time_us < (max_time_us - REBOOT_BACKSTEP_US));
+            switch (reboot_policy.onFrame(far_backstep, millis()))
             {
-                ESP_LOGW("DEDUP", "FC reboot detected (ts=%lu << max=%lu); resetting baseline",
-                         (unsigned long)time_us, (unsigned long)max_time_us);
-                prev_time_ism6 = prev_time_bmp = prev_time_mmc = prev_time_iis2mdc =
-                    prev_time_gnss = prev_time_ns = prev_time_pwr = prev_time_guid = 0;
-                max_time_us = 0;
-                // *prev now reads 0, so this frame passes the checks below as the first
-                // of the new session and re-seeds the baseline.
+                case DedupRebootPolicy::Action::RESET_BASELINE:
+                    ESP_LOGW("DEDUP", "FC reboot confirmed (ts=%lu << max=%lu, sustained); resetting baseline",
+                             (unsigned long)time_us, (unsigned long)max_time_us);
+                    prev_time_ism6 = prev_time_bmp = prev_time_mmc = prev_time_iis2mdc =
+                        prev_time_gnss = prev_time_ns = prev_time_pwr = prev_time_guid = 0;
+                    max_time_us = 0;
+                    // *prev now reads 0, so this frame passes the checks below as the
+                    // first of the new session and re-seeds the baseline.
+                    break;
+                case DedupRebootPolicy::Action::DROP_REPLAY:
+                    dedup_replay_drops++;
+                    return;
+                case DedupRebootPolicy::Action::PROCEED:
+                    break;
             }
 
             // Non-monotonic or exact-duplicate frame for this type — drop.
@@ -4125,6 +4142,9 @@ static void printStats()
         uint32_t d_stale = stale_drops - prev_stale;
         uint32_t d_dedup_eq = dedup_drops_eq - prev_dedup_eq;
         uint32_t d_dedup_lt = dedup_drops_lt - prev_dedup_lt;
+        static uint32_t prev_replay = 0;
+        uint32_t d_replay = dedup_replay_drops - prev_replay;
+        prev_replay = dedup_replay_drops;
         uint32_t d_parsed = msg_count_ism6 + msg_count_bmp + msg_count_mmc + msg_count_non_sensor + msg_count_gnss;
         static uint32_t prev_total_parsed = 0;
         uint32_t d_p = d_parsed - prev_total_parsed;
@@ -4135,7 +4155,7 @@ static void printStats()
         uint32_t d_tot = dma_total_bytes - prev_tot;
         float nz_pct = (d_tot > 0) ? (d_nz * 100.0f / d_tot) : 0;
 
-        ESP_LOGI("I2S", "dma_cb=%lu KB=%.1f nz=%.1f%% ovf=%lu dedup_eq=%lu dedup_lt=%lu stale=%lu parsed=%lu frx=%lu fdr=%lu",
+        ESP_LOGI("I2S", "dma_cb=%lu KB=%.1f nz=%.1f%% ovf=%lu dedup_eq=%lu dedup_lt=%lu stale=%lu replay=%lu parsed=%lu frx=%lu fdr=%lu",
                  (unsigned long)d_cb,
                  (double)(d_bytes / 1024.0),
                  (double)nz_pct,
@@ -4143,6 +4163,7 @@ static void printStats()
                  (unsigned long)d_dedup_eq,
                  (unsigned long)d_dedup_lt,
                  (unsigned long)d_stale,
+                 (unsigned long)d_replay,
                  (unsigned long)d_p,
                  (unsigned long)s.frames_received,
                  (unsigned long)s.frames_dropped);


### PR DESCRIPTION
## The bug (#468)

Bench-idle floods of `DEDUP: FC reboot detected` at a rock-constant **46.4 ms cadence** — one FC TX DMA ring revolution — with a frozen backstepped ts while `max` advanced at wall-clock. A sender-task underrun leaves one descriptor of stale frames in the TX ring; the DMA re-transmits it every revolution, interleaved with fresh traffic. Each false reboot-detect **reset all dedup baselines**, briefly disabling replay protection for every frame type. Recurred 7+ episodes across three bench sessions.

## Fix 1 — FC/link: `auto_clear` on master TX

`TR_I2S_Stream::beginMasterTx` now sets `chan_cfg.auto_clear`: the driver zeroes each descriptor after it transmits, so an underrun sends **zeros** (the designed idle-fill every receiver already skips) instead of stale frames. Kills the replay at the source for all master-TX users (FC→OC link, OC OTA-mode flip, i2s_tx_test).

## Fix 2 — OC: reboot requires a *sustained* backstep

Physical discriminator: after a real reboot (or µs-counter wrap) **every** frame is backstepped — the FC clock restarted; a replay burst is followed within ~3 ms by fresh frames. New pure `dedup_reboot_policy.h`: confirm a reboot only when far-backstepped frames persist for **100 ms (>2 ring revolutions) with no fresh frame in between**; otherwise drop as replay, baselines untouched, counted in `dedup_replay_drops` (surfaced as `replay=` in the 1 Hz I2S stats line). Real-reboot detection latency: 0 → ~100 ms, invisible next to the FC's multi-second boot.

## Tests

`test_dedup_reboot_policy.cpp` (8 cases): the exact bench signature (per-revolution 15-frame bursts over 10 simulated seconds) never confirms; sustained backstep confirms exactly once at the boundary; fresh frame restarts the window; `millis()` wrap mid-window; reuse after confirm. **Suite: 448/448.**

## Bench acceptance

Flash **both** boards. Idle + recording session: zero `FC reboot` warnings; `replay=` stays 0 (auto_clear removes the bursts entirely) or counts quietly with no baseline resets; a deliberate FC reset mid-session still produces exactly one `FC reboot confirmed` line and telemetry resumes.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)