### PR TITLE
perf(log): prelaunch ring cap 50% → 75%, trim activation drain prints

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -76,7 +76,7 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
         if (cfg.debug) ESP_LOGI(TAG, "Allocated %lu byte RAM ring (free heap: %lu)",
                                       (unsigned long)ring_size_, (unsigned long)esp_get_free_heap_size());
     }
-    ring_prelaunch_cap_ = ring_size_ / 2;
+    ring_prelaunch_cap_ = prelaunchCap();
 
     // Mutex to serialize ringPush callers and to block clearRing from
     // running concurrently with an in-flight push (#74). Unconditionally
@@ -1678,8 +1678,12 @@ void TR_LogToFlash::activateLogging()
     logging_active = true;
     ring_prelaunch_cap_ = ring_size_;
     end_flight_requested = false;
-    // Arm per-drain diagnostic logs for the first 20 flushRingToNand drains.
-    flush_log_remaining_ = 20;
+    // Arm per-drain diagnostic logs for the first few flushRingToNand
+    // drains. Kept small on purpose: these are blocking UART writes (~9 ms
+    // each at 115200) inside the launch-critical prelaunch-drain window —
+    // 20 of them measured ~180 ms of the 438 ms activation drain on the
+    // 2026-07-09 bench. Four lines still show the handoff shape.
+    flush_log_remaining_ = 4;
 
     ESP_LOGW(TAG, "ACT2 exit      h=%lu t=%lu c=%lu (logging_active=1)",
              (unsigned long)rb_head, (unsigned long)rb_tail, (unsigned long)rb_count);
@@ -1712,7 +1716,7 @@ void TR_LogToFlash::closeLogSession()
         logging_active = false;
         clearDirty();
         persistBadBlocksIfDirty();
-        ring_prelaunch_cap_ = ring_size_ / 2;
+        ring_prelaunch_cap_ = prelaunchCap();
         if (cfg.debug)
         {
             ESP_LOGI(TAG, "closeLogSession (sink mode): %lu bytes handed off",
@@ -1756,7 +1760,7 @@ void TR_LogToFlash::closeLogSession()
 
     // Restore pre-launch ring cap so the buffer doesn't fill completely
     // before the next launch — leaves headroom for the initial flush.
-    ring_prelaunch_cap_ = ring_size_ / 2;
+    ring_prelaunch_cap_ = prelaunchCap();
 
     if (cfg.debug)
     {

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -275,10 +275,20 @@ private:
     // reset it to 0, clobbering the reset with a prelaunch value.
     // See #74 bench trace (CR1 h=0 → CR2 h=50771 despite zero-sweep).
     SemaphoreHandle_t push_mutex_ = nullptr;
-    // Before logging starts, cap the ring at 50% so the initial flush at
-    // launch detection doesn't stall the main loop.  Raised to full size
-    // once logging is active (see openLogSession / closeLogSession).
-    uint32_t ring_prelaunch_cap_ = 0;  // Set in begin() from ring_size_
+    // Before logging starts, cap the ring at 75% (was 50%) so drop-oldest
+    // keeps ~1 s of pre-ignition history at the 1920 Hz stream (~99 KB/s)
+    // while still leaving launch-transient headroom: at activation the
+    // flush task drains the prelaunch backlog to NAND at ~310 KB/s against
+    // ~99 KB/s inflow, so a 97 KB backlog clears in ~0.5 s and the free
+    // quarter (~33 KB = ~0.3 s of inflow) absorbs flush-task stalls during
+    // the drain. The historical 100-500 ms LFS stalls that motivated the
+    // 50% cap no longer occur in the boost window (sink mode skips LFS,
+    // the flight range is pre-erased at PRELAUNCH, the rename is deferred
+    // to end-of-flight); the worst bounded stall left is a ~7 ms page
+    // program plus NimBLE contention on core 0. Raised to full size once
+    // logging is active (see activateLogging / closeLogSession).
+    uint32_t prelaunchCap() const { return (ring_size_ / 4) * 3; }
+    uint32_t ring_prelaunch_cap_ = 0;  // Set in begin() from prelaunchCap()
 
     // MRAM write staging (2026-07-09 bench): a per-frame ringPush costs two
     // SPI transactions (WREN + WRITE) under the bus mutex — ~325 us/frame


### PR DESCRIPTION
Follow-up to the #469 discussion: the 50% prelaunch cap was sized for LFS stalls that have since been engineered out of the boost window, and at 99 KB/s it held only ~0.66 s of pre-ignition history.

- **Cap → 75%** (~97.5 KB ≈ **1.0 s of history** at 1920 Hz): the activation backlog drains at ~210 KB/s net so it empties in ~0.5 s, and the free quarter (~0.3 s of inflow) absorbs flush-task stalls during the drain — ~40× the worst bounded boost-window stall (7 ms page program). All three assignment sites share a `prelaunchCap()` helper.
- **Activation FL prints 20 → 4**: blocking UART writes (~9 ms each) inside the launch-critical drain; they measured ~180 ms of the 438 ms activation stall on last night's bench.

Bench acceptance: `ring_peak` plateaus ≈97.5 K during PRELAUNCH (was 65 K), activation stall ≈0.5 s, `rx_ovf=0` throughout, .bin carries ~1 s of pre-command history. Host suite 448/448.

At the upcoming 3840 Hz option (~156 KB/s) this cap gives ~0.63 s of history — the same effective window as today's 50% at 1920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)