### PR TITLE
feat: user-configurable IMU logging rate (960/1920/3840 Hz), app to chip

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -198,6 +198,7 @@ final class ActiveRocketSyncer: ObservableObject {
                              rollReverse: profile.finRollReverse)
         device.sendCameraConfig(cameraType: profile.cameraType)
         device.sendImuOrientationConfig(profile.imuOrientSetting)
+        device.sendImuRateConfig(profile.imuRateHz)
         device.sendSoundConfig(enabled: profile.soundsEnabled)
         device.sendPyroConfig(channels: [
             (profile.pyro1Enabled, profile.pyro1TriggerMode, profile.pyro1TriggerValue),

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -846,6 +846,19 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
+    /// IMU logging rate in Hz — whitelisted ISM6HG256 ODR (960/1920/3840).
+    /// The FC applies it live on the pad and persists it in FC NVS.
+    func sendImuRateConfig(_ rateHz: UInt16) {
+        var payload = Data()
+        payload.append(UInt8(rateHz & 0xFF))
+        payload.append(UInt8(rateHz >> 8))
+        sendRawCommand(67, payload: payload)
+        if var cfg = rocketConfig {
+            cfg.imuRateHz = rateHz
+            rocketConfig = cfg
+        }
+    }
+
     /// 4-channel pyro config. Each tuple is (enabled, trigger_mode, trigger_value).
     /// Wire layout (24 bytes): 4 × {u8 enabled, u8 mode, f32 value}.
     func sendPyroConfig(channels: [(enabled: Bool, mode: UInt8, value: Float)]) {
@@ -1439,6 +1452,9 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             if let iw = parseFloat(dict["iwind"]), iw >= 0 { cfg.integralSepThreshold = iw }
             cfg.guidanceEnabled = dict["ge"] as? Bool ?? cfg.guidanceEnabled
             cfg.cameraType = UInt8(dict["camt"] as? Int ?? Int(cfg.cameraType))
+            if let irate = dict["irate"] as? Int, let hz = UInt16(exactly: irate) {
+                cfg.imuRateHz = hz
+            }
             cfg.loraFreqMHz = parseFloat(dict["lf"])
             cfg.loraSF = (dict["lsf"] as? Int).map { UInt8($0) }
             cfg.loraBwKHz = parseFloat(dict["lbw"])

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -104,6 +104,7 @@ struct RocketConfig {
     var guidanceEnabled: Bool = false
     var cameraType: UInt8 = 2
     var imuOrientSetting: UInt8? = nil   // 0xFF auto / 0..23 manual (nil = not reported)
+    var imuRateHz: UInt16? = nil         // ISM6 logging rate readback (nil = not reported)
     var loraFreqMHz: Float? = nil
     var loraSF: UInt8? = nil
     var loraBwKHz: Float? = nil

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -711,6 +711,7 @@ nonisolated struct FlightSettings: Codable, Sendable {
             gyro_fs_dps: Int(raw.ism6_gyro_fs_dps),
             low_g_fs_g: Int(raw.ism6_low_g_fs_g),
             high_g_fs_g: Int(raw.ism6_high_g_fs_g),
+            update_rate_hz: raw.ism6_update_rate_hz.map(Int.init),
             mounting: MountingSettings(from: raw)
         )
     }
@@ -863,6 +864,9 @@ nonisolated struct IMUSettings: Codable, Sendable {
     let gyro_fs_dps: Int
     let low_g_fs_g: Int
     let high_g_fs_g: Int
+    /// Logged IMU sample rate in Hz (v5 settings frames). nil on older
+    /// logs, which ran the then-fixed build default.
+    let update_rate_hz: Int?
     /// Board→rocket mounting orientation (v2 settings frames). nil on
     /// pre-orientation logs, which always meant the +X-nose mounting.
     let mounting: MountingSettings?

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -119,6 +119,11 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     /// off-axis board; optional for non-controlled flights.
     var imuOrientSetting: UInt8 = 0   // default: manual identity (+X nose/up); 0xFF = pad auto-detect
 
+    /// IMU logging rate in Hz (ISM6HG256 ODR): 960, 1920, or 3840. Logged
+    /// samples follow this rate; the control loop always consumes the
+    /// freshest sample regardless.
+    var imuRateHz: UInt16 = 1920
+
     // MARK: Servo
     var servoBias1: Int16 = 85
     var servoBias2: Int16 = 0
@@ -271,6 +276,7 @@ extension RocketProfile {
         pnTargetN = try c.decodeIfPresent(Float.self, forKey: .pnTargetN) ?? defaults.pnTargetN
         cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
         imuOrientSetting = try c.decodeIfPresent(UInt8.self, forKey: .imuOrientSetting) ?? defaults.imuOrientSetting
+        imuRateHz = try c.decodeIfPresent(UInt16.self, forKey: .imuRateHz) ?? defaults.imuRateHz
 
         servoBias1 = try c.decodeIfPresent(Int16.self, forKey: .servoBias1) ?? defaults.servoBias1
         servoBias2 = try c.decodeIfPresent(Int16.self, forKey: .servoBias2) ?? defaults.servoBias2

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -168,6 +168,8 @@ nonisolated struct FlightSettingsData {
     // pre-v3 frames.
     let fin_min_deg: Float?
     let fin_max_deg: Float?
+    /// v5+: IMU logging rate (ISM6HG256 ODR, Hz) that actually flew.
+    let ism6_update_rate_hz: UInt16?
 
     let b2r_code: UInt8?
     let b2r_mode: UInt8?            // 0 default, 1 manual, 2 auto-snap, 3 auto-exact
@@ -293,6 +295,14 @@ nonisolated struct FlightSettingsData {
         } else {
             fin_min_deg = nil
             fin_max_deg = nil
+        }
+
+        // v5 IMU logging rate tail at fixed offset 208.
+        if version >= 5 && data.count >= 210 {
+            var o = 208
+            ism6_update_rate_hz = data.readUInt16LE(at: &o)
+        } else {
+            ism6_update_rate_hz = nil
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -609,6 +609,17 @@ struct SettingsView: View {
             }
         }
 
+        Section("IMU Logging Rate") {
+            Picker("Rate", selection: imuRateBinding) {
+                Text("1k").tag(UInt16(960))
+                Text("2k").tag(UInt16(1920))
+                Text("4k").tag(UInt16(3840))
+            }
+            .pickerStyle(.segmented)
+            Text("Samples logged per second from the IMU (actual: 960 / 1920 / 3840 Hz). Higher rates capture faster shock and vibration detail; the control loop is unaffected. Applies on the pad \u{2014} never mid-flight.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+
         // Device-level firmware update lives on the General tab only (#314).
         firmwareSection
     }
@@ -649,6 +660,16 @@ struct SettingsView: View {
         let v = UInt8(clamping: axis * 4 + clock)
         updateProfile { $0.imuOrientSetting = v }
         if device.isConnected { device.sendImuOrientationConfig(v) }
+    }
+
+    // IMU logging rate: whitelisted ISM6HG256 ODR steps.
+    private var imuRateBinding: Binding<UInt16> {
+        Binding(
+            get: { profile.imuRateHz },
+            set: { hz in
+                updateProfile { $0.imuRateHz = hz }
+                if device.isConnected { device.sendImuRateConfig(hz) }
+            })
     }
 
     @ViewBuilder

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -859,7 +859,7 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
 // by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
 // here so a struct edit can't silently desync the cross-language decode.
 TEST(RocketComputerTypes, FlightSettingsData_Layout) {
-    EXPECT_EQ(sizeof(FlightSettingsData), 208u);  // v2: +12 b2r orientation; v3: +8 fin cal
+    EXPECT_EQ(sizeof(FlightSettingsData), 210u);  // v2: +12 b2r orientation; v3: +8 fin cal; v5: +2 imu rate
     EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
 
     EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
@@ -905,6 +905,7 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
     // so v1/v2 parsers decode their prefix unchanged.
     EXPECT_EQ(offsetof(FlightSettingsData, fin_min_deg),       200u);
     EXPECT_EQ(offsetof(FlightSettingsData, fin_max_deg),       204u);
+    EXPECT_EQ(offsetof(FlightSettingsData, ism6_update_rate_hz), 208u);
 }
 
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
@@ -998,6 +999,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         // passed the guard silently).
         MT(GUIDANCE_CONFIG_PENDING),  MT(GUIDANCE_CONFIG_MSG),
         MT(FIN_CONFIG_PENDING),       MT(FIN_CONFIG_MSG),
+        // IMU logging rate config (BLE cmd 67).
+        MT(IMU_RATE_CONFIG_PENDING),  MT(IMU_RATE_CONFIG_MSG),
         // #402: FC->OC slave TX-ring desync recovery trigger.
         MT(I2C_TX_RESYNC),
     };
@@ -1019,9 +1022,9 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // Tripwire: keep the registry above exhaustive.  If you add or remove a
     // message type in RocketComputerTypes.h, update this list AND this count
     // -- the uniqueness check is only as strong as the list it walks.
-    // 85 = 80 prior + guidance/fin config pair codes (were missing, #386 gap)
-    //    + I2C_TX_RESYNC (#402).
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 85u)
+    // 87 = 80 prior + guidance/fin config pair codes (were missing, #386 gap)
+    //    + I2C_TX_RESYNC (#402) + IMU rate config pair (BLE cmd 67).
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 87u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1636,6 +1636,12 @@ static constexpr uint8_t GUIDANCE_CONFIG_PENDING = 0xEF;  // OC→FC: payload fo
 static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceConfigData
 static constexpr uint8_t FIN_CONFIG_PENDING      = 0xF2;  // OC→FC: payload follows as FIN_CONFIG_MSG
 static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 18-byte FinConfigData
+// IMU logging rate (user setting, BLE cmd 67): the ISM6HG256 ODR the FC
+// programs for all three channels (low-g XL / high-g XL / gyro) and logs
+// at. Whitelisted to 960/1920/3840 Hz — the chip's ODR ladder steps that
+// the 44100 Hz I2S link can carry (3840 ≈ 156 of 176 KB/s framed).
+static constexpr uint8_t IMU_RATE_CONFIG_PENDING = 0xF5;  // OC→FC: payload follows as IMU_RATE_CONFIG_MSG
+static constexpr uint8_t IMU_RATE_CONFIG_MSG     = 0xF6;  // 2-byte ImuRateConfigData
 
 // #402: FC→OC over I2C, sent as a master WRITE (writes still work while the
 // slave TX ring is desynced by an aborted read).  On receipt the OC resets its
@@ -1699,6 +1705,23 @@ typedef struct __attribute__((packed))
     uint8_t setting;  // IMU_ORIENT_AUTO or orientation code 0..23
 } ImuOrientConfigData;
 static_assert(sizeof(ImuOrientConfigData) == 1, "ImuOrientConfigData must be 1 byte");
+
+// IMU logging rate setting (IMU_RATE_CONFIG_MSG payload).
+static constexpr uint16_t IMU_RATE_OPTIONS_HZ[] = {960, 1920, 3840};
+typedef struct __attribute__((packed))
+{
+    uint16_t rate_hz;  // one of IMU_RATE_OPTIONS_HZ
+} ImuRateConfigData;
+static_assert(sizeof(ImuRateConfigData) == 2, "ImuRateConfigData must be 2 bytes");
+
+inline bool imuRateValid(uint16_t hz)
+{
+    for (uint16_t opt : IMU_RATE_OPTIONS_HZ)
+    {
+        if (hz == opt) return true;
+    }
+    return false;
+}
 
 // Pyro trigger modes
 enum PyroTriggerMode : uint8_t {
@@ -1878,7 +1901,8 @@ struct __attribute__((packed)) FlightSettingsData
     //     waypoint, hold after the last; per-waypoint mode bytes are ignored.
     //     (Pre-v4 firmware stepped to the NEXT waypoint's angle and honored
     //     per-waypoint null_rate modes — analysis must branch on this.)
-    static constexpr uint8_t VERSION = 4;
+    // v5: appended ism6_update_rate_hz (user-configurable IMU logging rate).
+    static constexpr uint8_t VERSION = 5;
 
     // flags bit positions
     static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only
@@ -1950,8 +1974,11 @@ struct __attribute__((packed)) FlightSettingsData
     // deflection (deg) at servo_min_us / servo_max_us.
     float    fin_min_deg;
     float    fin_max_deg;
+
+    // IMU logging rate that actually flew (v5+): the ISM6HG256 ODR in Hz.
+    uint16_t ism6_update_rate_hz;
 };
-static_assert(sizeof(FlightSettingsData) == 208, "FlightSettingsData layout check");
+static_assert(sizeof(FlightSettingsData) == 210, "FlightSettingsData layout check");
 
 // --- Log Buffer Stats Data (OC self-emitted, ~1 Hz while logging) -----------
 // Snapshot of the OC's ring-buffer health written into the flight log so the

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -453,6 +453,7 @@ void SensorCollector::begin(uint8_t imu_execution_core)
         status = (TR_ISM6HG256Status)(status | ism6hg256.Set_X_OutputDataRate((float)ISM6HG256_UPDATE_RATE));
         status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_OutputDataRate((float)ISM6HG256_UPDATE_RATE));
         status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_OutputDataRate((float)ISM6HG256_UPDATE_RATE));
+        ism6_rate_applied_ = (status == TR_ISM6HG256_OK);
 
         // Full-scale settings — from the ctor (config::ISM6_*_FS on the FC),
         // the same constants the converter scale + snapshots read (#386).
@@ -1204,4 +1205,31 @@ void IRAM_ATTR SensorCollector::onMMC5983MAInt()
     {
         portYIELD_FROM_ISR();
     }
+}
+
+
+bool SensorCollector::setIsm6Rate(uint16_t rate_hz)
+{
+    if (rate_hz == 0)
+    {
+        return false;
+    }
+    ISM6HG256_UPDATE_RATE = rate_hz;
+    ism6hg256_update_period = (uint32_t)(1000000 / ISM6HG256_UPDATE_RATE);
+    if (!ism6_rate_applied_)
+    {
+        // Pre-Begin(): just stage the value; Begin() programs the chip.
+        return true;
+    }
+    TR_ISM6HG256Status status = TR_ISM6HG256_OK;
+    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_X_OutputDataRate((float)rate_hz));
+    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_OutputDataRate((float)rate_hz));
+    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_OutputDataRate((float)rate_hz));
+    if (status != TR_ISM6HG256_OK)
+    {
+        ESP_LOGE(SC_TAG, "setIsm6Rate(%u): ODR reprogram failed (0x%x)", rate_hz, status);
+        return false;
+    }
+    ESP_LOGI(SC_TAG, "ISM6HG256 logging rate -> %u Hz (live)", rate_hz);
+    return true;
 }

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -158,6 +158,7 @@ private:
     uint8_t ISM6HG256_CS;
     uint8_t ISM6HG256_INT;
     uint16_t ISM6HG256_UPDATE_RATE;
+    bool ism6_rate_applied_ = false;  // Begin() programmed the chip ODR
     uint8_t BMP585_CS;
     uint8_t BMP585_INT;
     uint16_t BMP585_UPDATE_RATE;
@@ -210,13 +211,26 @@ private:
     // consumer when it starts draining — the ~4 s of pre-loop boot produce
     // thousands of meaningless pre-consumer drops otherwise).
     QueueHandle_t ism6Queue = nullptr;
-    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 32;
+    // 64 samples = ~16.7 ms of buffer at 3840 Hz (33 ms at 1920) — sized so the
+    // user-selectable top rate keeps the same stall tolerance the depth-32
+    // queue gave 1920 Hz (a measured 47.7 ms I2C-recovery stall overflowed
+    // even 32 at 1920; the [GAP DIAG] imu_q_drops gauge stays the witness).
+    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 64;
     volatile uint32_t ism6_queue_drops = 0;
 
 public:
     // Zero the drop counter (and nothing else).  Called once by the consumer
     // when it begins draining, so the gauge counts only consumer-era drops.
     void resetIsm6QueueDrops() { ism6_queue_drops = 0; }
+
+    // Runtime IMU logging-rate change (user setting, BLE cmd 67): reprograms
+    // the ISM6HG256 ODR on all three channels and the derived period. Safe
+    // while the DRDY-driven poll task runs — the task services whatever
+    // cadence the chip produces; one inter-sample gap changes length at the
+    // switch and downstream consumers use per-sample timestamps. Call before
+    // Begin() to only stage the rate for init.
+    bool setIsm6Rate(uint16_t rate_hz);
+    uint16_t ism6Rate() const { return ISM6HG256_UPDATE_RATE; }
 
 private:
 

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -38,14 +38,19 @@ struct config : board_pins
     // MMC5983MA hardware supports 1/10/20/50/100/200/1000 Hz only.
     // 200 Hz is the highest step that fits within I2C budget.
     static constexpr uint16_t MMC5983MA_UPDATE_RATE = 200;
-    // 1920 Hz: first step of the logging-rate maximization.  The chip supports
-    // 1920/3840/7680; the poll task's handoff queue + the loop's drain-all
-    // consumption log EVERY sample regardless of loop rate (~980/s).  The
-    // control/EKF/guidance path still consumes the freshest sample at loop
-    // rate.  I2S share at 1920: 1920 x 30 B = 58 KB/s of the 176 KB/s link
-    // (I2S_SAMPLE_RATE below).  Going to 3840 needs a further link bump and
-    // bench proof of OC ingest headroom first ([GAP DIAG] imu_q_drops and the
-    // OC LogBufferStats ring fill are the gauges).
+    // DEFAULT IMU logging rate — the user can select 960/1920/3840 Hz from
+    // the app (BLE cmd 67); the FC persists the choice in NVS ("imu"/"rate")
+    // and stages it into the collector before begin().  The poll task's
+    // handoff queue + the loop's drain-all consumption log EVERY sample
+    // regardless of loop rate (~980/s); control/EKF/guidance still consume
+    // the freshest sample at loop rate.  Link budget on the 44100 Hz I2S
+    // (176.4 KB/s): ISM6 framed = rate x 30 B, so 1920 -> ~58 KB/s and
+    // 3840 -> ~115 KB/s; with all other streams total inflow is ~99 KB/s
+    // at 1920 and ~156 KB/s (88%) at 3840 — no link bump needed, verified
+    // against the post-#467/#469 OC budgets (parser ~10x headroom, MRAM
+    // staging ~8% duty, NAND flush ~50% duty at 3840).  Bench gauges for
+    // any new rate: [GAP DIAG] imu_q_drops, FC I2S enqueue drops, OC
+    // rx_ovf/ring_peak, and the .bin per-type rates.
     static constexpr uint16_t ISM6HG256_UPDATE_RATE = 1920;
     static constexpr uint16_t NON_SENSOR_UPDATE_RATE = 500;
     // Guidance telemetry (GUIDANCE_TELEM_MSG) log rate while guidance is active.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1592,6 +1592,7 @@ static void buildFlightSettings(FlightSettingsData& s)
     s.ism6_low_g_fs_g  = config::ISM6_LOW_G_FS_G;
     s.ism6_high_g_fs_g = config::ISM6_HIGH_G_FS_G;
     s.ism6_gyro_fs_dps = config::ISM6_GYRO_FS_DPS;
+    s.ism6_update_rate_hz = sensor_collector_hw.ism6Rate();  // live (v5+)
 
     // Servo trim + timing (live values from servo_control).
     for (int i = 0; i < 4; ++i) {
@@ -2533,6 +2534,27 @@ static void setup_fc()
     ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X rollrev=0x%X",
                   (double)fin_az[0], (double)fin_az[1], (double)fin_az[2], (double)fin_az[3],
                   (unsigned)fin_rev, (unsigned)fin_rrev);
+
+    // Restore the user-selected IMU logging rate (BLE cmd 67, namespace
+    // "imu").  Staged into the collector BEFORE sensor_collector.begin()
+    // below, which programs the chip ODR from it.  Whitelist on read so a
+    // corrupted NVS value can't run the IMU at an unplanned rate.
+    prefs.begin("imu", false);
+    if (prefs.isKey("rate"))
+    {
+        const uint16_t nvs_rate = prefs.getUShort("rate", config::ISM6HG256_UPDATE_RATE);
+        if (imuRateValid(nvs_rate))
+        {
+            sensor_collector_hw.setIsm6Rate(nvs_rate);
+            ESP_LOGI(TAG, "NVS IMU logging rate: %u Hz", (unsigned)nvs_rate);
+        }
+        else
+        {
+            ESP_LOGW(TAG, "NVS IMU logging rate %u invalid — using default %u",
+                     (unsigned)nvs_rate, (unsigned)config::ISM6HG256_UPDATE_RATE);
+        }
+    }
+    prefs.end();
 
     // Restore high-g accelerometer bias from NVS (namespace "cal")
     prefs.begin("cal", false);  // read-write (creates namespace on first boot)
@@ -5031,6 +5053,42 @@ static void loop_fc()
                         if (changed && ekf_initialized) ekf_initialized = false;
                         ESP_LOGI(TAG, "[CFG] IMU orientation: MANUAL %s",
                                  orientCodeName(setting));
+                    }
+                }
+            }
+            else if (out_pending_command == IMU_RATE_CONFIG_PENDING)
+            {
+                delay_ms(1);
+                uint8_t cfg_payload[sizeof(ImuRateConfigData)];
+                size_t  cfg_len = 0;
+                if (readConfigFrame(IMU_RATE_CONFIG_MSG, sizeof(ImuRateConfigData),
+                                    cfg_payload, sizeof(cfg_payload), cfg_len)
+                    && cfg_len >= sizeof(ImuRateConfigData))
+                {
+                    uint16_t rate_hz;
+                    memcpy(&rate_hz, cfg_payload, sizeof(rate_hz));
+                    if (rocket_state == INFLIGHT)
+                    {
+                        // Never mid-flight: the ODR switch produces one
+                        // odd-length inter-sample gap and changes the log
+                        // cadence — fine on the pad, not during boost.
+                        ESP_LOGW(TAG, "[CFG] IMU rate change ignored INFLIGHT");
+                    }
+                    else if (imuRateValid(rate_hz))
+                    {
+                        if (sensor_collector_hw.setIsm6Rate(rate_hz))
+                        {
+                            prefs.begin("imu", false);
+                            prefs.putUShort("rate", rate_hz);
+                            prefs.end();
+                            ESP_LOGI(TAG, "[CFG] IMU logging rate: %u Hz (persisted)",
+                                     (unsigned)rate_hz);
+                        }
+                    }
+                    else
+                    {
+                        ESP_LOGW(TAG, "[CFG] IMU rate %u Hz rejected (not 960/1920/3840)",
+                                 (unsigned)rate_hz);
                     }
                 }
             }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -727,6 +727,21 @@ static void stageImuOrientConfig()
     pending_config_msg_type = ORIENT_CONFIG_MSG;
     setPendingCommand(ORIENT_CONFIG_PENDING);
 }
+
+// IMU logging rate setting (BLE cmd 67).  Cached here for app readback and
+// re-push on connect; the FC persists it in its own NVS and re-applies at
+// boot, so no status-query self-heal is needed (unlike orientation).
+static uint16_t cfg_imu_rate = 1920;
+
+static void stageImuRateConfig()
+{
+    ImuRateConfigData cfg;
+    cfg.rate_hz = cfg_imu_rate;
+    memcpy(pending_config_data, &cfg, sizeof(cfg));
+    pending_config_data_len = sizeof(cfg);
+    pending_config_msg_type = IMU_RATE_CONFIG_MSG;
+    setPendingCommand(IMU_RATE_CONFIG_PENDING);
+}
 // Pyro config cache (4 channels on new PCB)
 static bool    cfg_pyro_enabled[4]      = { false, false, false, false };
 static uint8_t cfg_pyro_trigger_mode[4] = { 0, 0, 0, 0 };
@@ -1776,6 +1791,8 @@ static bool isKnownMessageType(uint8_t type)
         case CAMERA_CONFIG_MSG:
         case ORIENT_CONFIG_PENDING:
         case ORIENT_CONFIG_MSG:
+        case IMU_RATE_CONFIG_PENDING:
+        case IMU_RATE_CONFIG_MSG:
         case LORA_MSG:
         case SNAPSHOT_MSG:           // FC→OC over I2S during INFLIGHT
         case GET_FLIGHT_SNAPSHOT:    // FC→OC over I2C at boot recovery
@@ -2874,6 +2891,7 @@ static void sendCurrentConfig()
     j += ",\"iwind\":"; j += fmtf(cfg_iwind_dps, 1);
     j += ",\"ge\":";  j += cfg_guidance_en ? "true" : "false";
     j += ",\"camt\":"; j += itos(cfg_camera_type);
+    j += ",\"irate\":"; j += itos(cfg_imu_rate);
     // LoRa settings
     j += ",\"lf\":";  j += fmtf(lora_freq_mhz, 1);
     j += ",\"lsf\":"; j += itos(lora_sf);
@@ -4653,6 +4671,13 @@ void initPeripherals()
                  cfg_imu_orient == IMU_ORIENT_AUTO
                      ? "AUTO" : orientCodeName(cfg_imu_orient));
 
+        // Load cached IMU logging rate.  Readback/cache only — the FC owns
+        // application (its own NVS survives FC reboots independently).
+        prefs.begin("imurate", false);
+        cfg_imu_rate = prefs.getUShort("hz", cfg_imu_rate);
+        prefs.end();
+        ESP_LOGI("CFG", "NVS IMU logging rate: %u Hz", (unsigned)cfg_imu_rate);
+
         // Load cached pyro config from NVS (4 channels)
         prefs.begin("pyro", true);
         size_t pyro_sz = prefs.getBytesLength("cfg");
@@ -6049,6 +6074,35 @@ static void loop_oc()
                 ESP_LOGI("BLE", "IMU orientation setting: %s",
                          cfg_imu_orient == IMU_ORIENT_AUTO
                              ? "AUTO" : orientCodeName(cfg_imu_orient));
+            }
+        }
+        else if (ble_cmd == 67)
+        {
+            // IMU logging rate: [rate_hz:2 LE] — whitelisted ISM6HG256 ODR
+            // (960/1920/3840).  Relayed to the FC, which applies the ODR
+            // live (except INFLIGHT) and persists it in FC NVS.
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= 2)
+            {
+                uint16_t rate_hz;
+                memcpy(&rate_hz, payload, sizeof(rate_hz));
+                if (imuRateValid(rate_hz))
+                {
+                    cfg_imu_rate = rate_hz;
+                    stageImuRateConfig();
+                    Preferences p2;
+                    p2.begin("imurate", false);
+                    p2.putUShort("hz", cfg_imu_rate);
+                    p2.end();
+                    ESP_LOGI("BLE", "IMU logging rate: %u Hz -> FlightComputer",
+                             (unsigned)cfg_imu_rate);
+                }
+                else
+                {
+                    ESP_LOGW("BLE", "IMU logging rate %u Hz rejected (not 960/1920/3840)",
+                             (unsigned)rate_hz);
+                }
             }
         }
         else if (ble_cmd == 34)


### PR DESCRIPTION
## What

A new profile setting in the app — **IMU Logging Rate: 1k / 2k / 4k** (actual ISM6HG256 ODRs 960/1920/3840) — flowing the full stack:

```
SettingsView picker → RocketProfile (persisted) → BLE cmd 67 [rate_hz:2 LE]
  → OC: whitelist + NVS cache ("imurate"/"hz") + "irate" readback in config JSON
  → relay pair IMU_RATE_CONFIG_PENDING/MSG (0xF5/0xF6, ImuRateConfigData)
  → FC: whitelist + INFLIGHT guard + SensorCollector::setIsm6Rate() live ODR
        reprogram (all three channels) + FC NVS persist ("imu"/"rate")
```

FC NVS ownership means the rate survives FC reboots with no app/OC self-heal (unlike orientation). App re-pushes on connect as belt-and-braces.

## The 4k rung needs no link change

ISM6 framed = rate × 30 B → 3840 gives ~115 KB/s, **~156 KB/s total (88%) on the existing 44100 link** (176.4 KB/s). Post-#467/#469 OC budgets at that inflow: parser ~10× headroom, MRAM staging ~8%, NAND flush ~50%. The stale `config.h` claim that 3840 needs a link bump is rewritten with the measured budget. `ISM6_QUEUE_DEPTH` 32→64 keeps stall tolerance at ~16.7 ms at 3840.

## Recorded evidence trail

`FlightSettingsData` **v5** appends `ism6_update_rate_hz` (208→210 B, versioned tail like v2/v3); the FC reports the **live** collector rate; the app parses the tail and writes `imu.update_rate_hz` into the flight .json.

## Guards & tests

- `imuRateValid()` whitelist at every hop (OC BLE, FC relay, FC NVS boot read) — a corrupted value can never set an unplanned ODR.
- INFLIGHT changes refused (mirrors orientation).
- tests_cpp: v5 layout/offset asserts + message-type uniqueness registry & tripwire (85→87). **Suite 448/448**; `check_ble_command_ids.py` PASS (50 unique OC cmds).

## Bench acceptance (4k, FC-only flash after merge)

FC `[SENSOR] ism6≈3820/s`, `imu_q_drops=0`, zero I2S enqueue drops; OC `rx_ovf=0`, `parser_max` low-ms; .bin ism6 ~3820/s with med=mean ≈0.26 ms; app .json `update_rate_hz: 3840`. Then the same recording at 960 and 1920 to confirm the switch path both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)