### PR TITLE
fix(oc): relay the IMU-rate config frame — isConfigCommand() missed 0xF5

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1312,6 +1312,7 @@ static bool isConfigCommand(uint8_t cmd)
            cmd == PYRO_CONFIG_PENDING ||
            cmd == CAMERA_CONFIG_PENDING ||     // FC needs the CameraConfigData frame appended
            cmd == ORIENT_CONFIG_PENDING ||
+           cmd == IMU_RATE_CONFIG_PENDING ||   // ISM6 logging-rate payload (2 bytes)
            cmd == PYRO_CONT_TEST ||
            cmd == PYRO_FIRE_TEST ||
            cmd == MAG_CAL_APPLY_PENDING ||     // #132: app-pushed mag cal payload
@@ -1439,6 +1440,15 @@ static void queueOutStatusResponse(bool ready)
     {
         ESP_LOGW("OC", "I2C TX config cmd=0x%02X but data_len=0",
                       (unsigned)cmd);
+    }
+    else if (cmd != 0U && serving_cfg_len > 0)
+    {
+        // Staged payload exists but the command is not in isConfigCommand():
+        // the whitelist is out of sync with a stageXxxConfig() helper and the
+        // FC will never receive the frame (how IMU_RATE_CONFIG_PENDING failed).
+        ESP_LOGE("OC", "I2C TX cmd=0x%02X has %u staged config bytes but is not "
+                       "in isConfigCommand() — frame dropped",
+                      (unsigned)cmd, (unsigned)serving_cfg_len);
     }
 
     // Non-blocking (timeout=0): if the TX ringbuffer is full, drop this


### PR DESCRIPTION
## Problem

The #472 IMU logging-rate feature never actually delivered the rate to the FlightComputer. Bench serial (OC 514228c, fw both boards current) shows the full chain working up to the last hop:

- `BLE: Received command: 67` → `BLE: IMU logging rate: 3840 Hz -> FlightComputer` ✅
- `I2C TX StatusResponse: ready=1 cmd=0xF5 attempt=1..3/3` ✅ delivered three times, both connects
- **No `I2C TX Config frame type=0xF6` line — ever.** Every other config-bearing command in the same connect burst shows its paired frame (0xAE→0xB0, 0xAF→0xB1, 0xED→0xEE orient, 0xCD→0xCE pyro, …).

The FC heard "command 0xF5 pending" but the 2-byte `ImuRateConfigData` payload never crossed the wire, so nothing applied and the FC kept its NVS default (1920). The subsequent recording confirmed it: `rxk=99.2` KB/s and `update_rate_hz: 1920` in the flight json.

## Root cause

`queueOutStatusResponse()` appends the staged config frame only when `isConfigCommand(cmd)` passes — a second whitelist, separate from the `stageImuRateConfig()` helper and the per-entry queue snapshot (which both worked; `serving_cfg_len` was 2). `IMU_RATE_CONFIG_PENDING` (0xF5) was never added to that list.

The failure was **completely silent**: the existing `data_len=0` warning branch also requires `isConfigCommand()` to pass, so the staged-but-not-whitelisted case fell through with no log at all.

## Fix

- Add `IMU_RATE_CONFIG_PENDING` to `isConfigCommand()`.
- Add an `ESP_LOGE` for the "staged config bytes present but command not whitelisted" case, so the next stage-helper/whitelist desync shows up on the first bench connect instead of dropping payloads silently.

Audited all 18 `pending_config_msg_type` staging sites against the whitelist — IMU rate was the only omission. The FC-side handler (readConfigFrame of 0xF6) was already correct and is unchanged: **only the OC needs a reflash**.

## Testing

- Host suite: 448/448 pass.
- Bench verification after merge: reflash OC, reconnect app (profile already stores 3840 → connect push resends cmd 67), expect `I2C TX Config frame type=0xF6 len=10` after the 0xF5 status response, FC logs `ISM6HG256 logging rate -> 3840 Hz (live)` + `[CFG] IMU logging rate: 3840 Hz (persisted)`, and a recording at ~156 KB/s with `update_rate_hz: 3840`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
