### PR TITLE
fix(fc): apply live ISM6 rate change from the poll task (SPI polling-transmit race killed the channel)

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -552,6 +552,29 @@ void SensorCollector::pollIMUdata(void* parameter)
             self->ism6_notify_timeouts++;
         }
 
+        // Apply a staged live rate change here, between transactions — this
+        // task is the sole owner of the ISM6 SPI device once running (#475).
+        if (self->ism6_rate_pending_ != 0)
+        {
+            const uint16_t new_rate = self->ism6_rate_pending_;
+            self->ism6_rate_pending_ = 0;
+            TR_ISM6HG256Status st = TR_ISM6HG256_OK;
+            st = (TR_ISM6HG256Status)(st | self->ism6hg256.Set_X_OutputDataRate((float)new_rate));
+            st = (TR_ISM6HG256Status)(st | self->ism6hg256.Set_HG_X_OutputDataRate((float)new_rate));
+            st = (TR_ISM6HG256Status)(st | self->ism6hg256.Set_G_OutputDataRate((float)new_rate));
+            if (st == TR_ISM6HG256_OK)
+            {
+                self->ISM6HG256_UPDATE_RATE = new_rate;
+                self->ism6hg256_update_period = (uint32_t)(1000000 / new_rate);
+                ESP_LOGI(SC_TAG, "ISM6HG256 logging rate -> %u Hz (live)", new_rate);
+            }
+            else
+            {
+                ESP_LOGE(SC_TAG, "ISM6HG256 live rate %u Hz FAILED (0x%x); keeping %u Hz",
+                         new_rate, st, self->ISM6HG256_UPDATE_RATE);
+            }
+        }
+
         // === ISM6HG256 FIRST — highest rate sensor, latency-critical ===
         // Use the ISR flag instead of an SPI DRDY register read.  The ISR
         // fires when ANY routed DRDY goes high.  We read all three channels
@@ -1214,22 +1237,19 @@ bool SensorCollector::setIsm6Rate(uint16_t rate_hz)
     {
         return false;
     }
-    ISM6HG256_UPDATE_RATE = rate_hz;
-    ism6hg256_update_period = (uint32_t)(1000000 / ISM6HG256_UPDATE_RATE);
     if (!ism6_rate_applied_)
     {
         // Pre-Begin(): just stage the value; Begin() programs the chip.
+        ISM6HG256_UPDATE_RATE = rate_hz;
+        ism6hg256_update_period = (uint32_t)(1000000 / ISM6HG256_UPDATE_RATE);
         return true;
     }
-    TR_ISM6HG256Status status = TR_ISM6HG256_OK;
-    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_X_OutputDataRate((float)rate_hz));
-    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_HG_X_OutputDataRate((float)rate_hz));
-    status = (TR_ISM6HG256Status)(status | ism6hg256.Set_G_OutputDataRate((float)rate_hz));
-    if (status != TR_ISM6HG256_OK)
-    {
-        ESP_LOGE(SC_TAG, "setIsm6Rate(%u): ODR reprogram failed (0x%x)", rate_hz, status);
-        return false;
-    }
-    ESP_LOGI(SC_TAG, "ISM6HG256 logging rate -> %u Hz (live)", rate_hz);
+    // Live: the ISM6 uses spi_device_polling_transmit, and concurrent polling
+    // transactions from two tasks corrupt the register RMW (#475 — reprogram
+    // from the relay handler while pollIMUdata reads killed the channel).
+    // Stage the change; pollIMUdata applies it between transactions and
+    // updates the rate members on success.
+    ism6_rate_pending_ = rate_hz;
+    ESP_LOGI(SC_TAG, "ISM6HG256 logging rate %u Hz staged for poll-task apply", rate_hz);
     return true;
 }

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -159,6 +159,10 @@ private:
     uint8_t ISM6HG256_INT;
     uint16_t ISM6HG256_UPDATE_RATE;
     bool ism6_rate_applied_ = false;  // Begin() programmed the chip ODR
+    // Live rate change staged by setIsm6Rate(); pollIMUdata applies it
+    // between transactions. The ISM6 uses spi_device_polling_transmit, so
+    // only the poll task may touch the chip once it is running (#475).
+    volatile uint16_t ism6_rate_pending_ = 0;
     uint8_t BMP585_CS;
     uint8_t BMP585_INT;
     uint16_t BMP585_UPDATE_RATE;


### PR DESCRIPTION
## Problem

`setIsm6Rate()`'s live path ran three CTRL-register read-modify-writes from the config-relay context while `pollIMUdata` was doing back-to-back reads on the **same SPI device** at up to 3840 Hz. The driver uses `spi_device_polling_transmit`, and concurrent polling transactions on one device from two tasks are the documented-unsafe case.

**Confirmed on bench** (FC serial, 2026-07-10 run 2): the live apply produced
```
E spi_master: spi_device_polling_start(1386): Cannot send polling transaction while the previous polling transaction is not terminated
```
interleaved with the apply logs. In that instance the collision's victim was a single poll-task read (`ism6_max=790 µs` blip) and the stream survived; a torn CTRL RMW is the same race with a worse victim. Boot-time programming never hits this (poll task not yet running); `calibrateSensors()` already guards the same hazard by suspending the poll task.

## Fix

`setIsm6Rate()` live path stages the rate in `ism6_rate_pending_`; `pollIMUdata` applies it at the top of its loop, between transactions — sole-owner context, no locking. Rate members update only on successful reprogram, so `ism6Rate()` and the flight-settings snapshot always report the rate actually running. Pre-`Begin()` staging path unchanged. The `ISM6HG256 logging rate -> N Hz (live)` acceptance line is unchanged.

Note: this hardens the race but does NOT resolve #475's observed data collapse — bench run 2 shows the FC side fully healthy at 3840 (`ism6=3790-3823/s`, zero queue/enqueue drops), so the ~614-frames/s OC-side reception is a link/receive issue tracked separately in #475.

## Testing

- Host suite 448/448 (firmware-side change, not host-coverable).
- Bench: live 1k/2k/4k flips while streaming — expect the spi_master error line to never appear, `[SENSOR] ism6=` tracking each flip, no blips beyond the single ~1 ms apply window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
