### PR TITLE
fix(ekf): fuse each mag sample once — freshness gate on time_us (#459)

### DIFF
--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -717,3 +717,39 @@ TEST_F(EKFTest, BaroJosephGoldenTrajectory) {
         EXPECT_NEAR(cov[i], cov_gold[i], 0.02f * cov_gold[i] + 1e-9f)
             << "cov[" << i << "]";
 }
+
+// #459: each unique mag sample (time_us) is fused exactly once. Re-presenting
+// the held sample on subsequent EKF ticks — which is what the FC does between
+// real ~98 Hz IIS2MDC samples while updateCore runs at ~480 Hz — must be a
+// bitwise no-op, identical to running those ticks with no mag at all. Before
+// the freshness gate, the held sample was re-fused every tick, contracting
+// yaw covariance ~5x faster than the sensor's real information rate.
+TEST_F(EKFTest, MagSampleFusedOncePerUniqueTimestamp) {
+    GpsInsEKF a, b;
+    a.init(makeNoseUpIMU(0), makeStationaryGNSS(0), makeNoseUpMag(0));
+    b.init(makeNoseUpIMU(0), makeStationaryGNSS(0), makeNoseUpMag(0));
+
+    const EkfMagData no_mag = {};   // zero field → mag_valid=false, fusion skipped
+
+    uint32_t last_fresh_t = 0;
+    for (int k = 1; k <= 500; k++) {
+        const uint32_t t = 2000u * k;               // 500 Hz ticks
+        EkfMagData mag_a, mag_b;
+        if ((k - 1) % 5 == 0) {                     // fresh sample at ~100 Hz
+            last_fresh_t = t;
+            mag_a = makeNoseUpMag(t);
+            mag_b = makeNoseUpMag(t);
+        } else {
+            mag_a = makeNoseUpMag(last_fresh_t);    // held sample, stale time_us
+            mag_b = no_mag;                         // nothing new arrived
+        }
+        a.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), mag_a);
+        b.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), mag_b);
+    }
+
+    float qa[4], qb[4], ca[3], cb[3];
+    a.getQuaternion(qa); b.getQuaternion(qb);
+    a.getCovOrient(ca);  b.getCovOrient(cb);
+    for (int i = 0; i < 4; i++) EXPECT_EQ(qa[i], qb[i]) << "quat[" << i << "]";
+    for (int i = 0; i < 3; i++) EXPECT_EQ(ca[i], cb[i]) << "covOrient[" << i << "]";
+}

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -212,7 +212,14 @@ void GpsInsEKF::updateCore(bool use_ahrs_acc,
     // 9. Magnetometer heading update — scalar Kalman, yaw-only (needs valid
     //    accel for the gravity/level reference; accel owns roll/pitch, mag owns
     //    heading, so the two are complementary, not competing).
-    if (mag_valid && accel_valid) magMeasUpdate(aMeas, magMeas);
+    //    #459: fuse each mag sample exactly once (same time_us dedup as
+    //    baroMeasUpdate) — the mag delivers ~98 Hz while this runs every EKF
+    //    tick (~480 Hz), and re-fusing one sample N times contracts yaw
+    //    covariance N-fold faster than the sensor's real information rate.
+    if (mag_valid && accel_valid && mag_data.time_us != magTimePrev_) {
+        magTimePrev_ = mag_data.time_us;
+        magMeasUpdate(aMeas, magMeas);
+    }
 
     // 10. GNSS measurement update
     if ((gnss_time_us - timeWeekPrev_) > 0) {

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -298,6 +298,9 @@ private:
     float dt_s_ = 0.0f;
     uint32_t timeWeekPrev_ = 0;
     uint32_t baroTimePrev_ = 0;
+    // #459: last fused mag sample time — fuse each unique sample exactly once
+    // (the mag delivers ~98 Hz; updateCore ticks ~480 Hz).
+    uint32_t magTimePrev_ = 0;
     float euler_BL_rad_[3] = {0.0f, 0.0f, 0.0f};
 
     // GNSS-acceleration estimate for accelMatchHeadingUpdate: previous GNSS

--- a/tinkerrocket-sim/src/tinkerrocket_sim/sensors/baro_model.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/sensors/baro_model.py
@@ -17,12 +17,13 @@ class BaroModel:
                  pressure_noise_sigma: float = 1.0,    # Pa
                  temp_noise_sigma: float = 0.5,         # K
                  rate_hz: float = 500.0,
-                 ground_pressure_pa: float = 101325.0):
+                 ground_pressure_pa: float = 101325.0,
+                 seed: int = None):
         self.pressure_noise_sigma = pressure_noise_sigma
         self.temp_noise_sigma = temp_noise_sigma
         self.rate_hz = rate_hz
         self.ground_pressure_pa = ground_pressure_pa
-        self._rng = np.random.default_rng()
+        self._rng = np.random.default_rng(seed)
 
     def measure(self, altitude_m: float, mach: float = 0.0) -> dict:
         """Generate barometric measurement from true altitude.

--- a/tinkerrocket-sim/src/tinkerrocket_sim/sensors/gnss_model.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/sensors/gnss_model.py
@@ -38,7 +38,8 @@ class GNSSModel:
                  # Recovery quality
                  recovery_noise_scale_initial: float = 15.0,
                  recovery_settle_time_s: float = 2.0,
-                 enable_dropout: bool = True):
+                 enable_dropout: bool = True,
+                 seed: int = None):
         self.pos_noise_ne = pos_noise_ne_m
         self.pos_noise_d = pos_noise_d_m
         self.vel_noise_ne = vel_noise_ne_mps
@@ -73,7 +74,7 @@ class GNSSModel:
         self._recovery_start_time = None  # when fix was reacquired
         self._boost_lockout = False  # preemptive lockout during boost
 
-        self._rng = np.random.default_rng()
+        self._rng = np.random.default_rng(seed)
 
     def measure(self, pos_enu: np.ndarray, vel_enu: np.ndarray,
                 accel_magnitude: float = None,

--- a/tinkerrocket-sim/src/tinkerrocket_sim/sensors/imu_model.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/sensors/imu_model.py
@@ -23,7 +23,8 @@ class IMUModel:
                  gyro_bias_sigma: float = 0.00025,     # rad/s
                  accel_bias_tau: float = 100.0,        # s
                  gyro_bias_tau: float = 50.0,          # s
-                 rate_hz: float = 1200.0):
+                 rate_hz: float = 1200.0,
+                 seed: int = None):
         self.accel_noise_sigma = accel_noise_sigma
         self.gyro_noise_sigma = gyro_noise_sigma
         self.accel_bias_sigma = accel_bias_sigma
@@ -37,7 +38,7 @@ class IMUModel:
         self.accel_bias = np.zeros(3)
         self.gyro_bias = np.zeros(3)
 
-        self._rng = np.random.default_rng()
+        self._rng = np.random.default_rng(seed)
 
     def measure(self, true_accel_enu: np.ndarray,
                 true_omega_body: np.ndarray,

--- a/tinkerrocket-sim/src/tinkerrocket_sim/sensors/mag_model.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/sensors/mag_model.py
@@ -14,7 +14,8 @@ class MagModel:
     def __init__(self,
                  noise_sigma: float = 0.5,  # uT
                  rate_hz: float = 1000.0,
-                 field_ned: np.ndarray = None):
+                 field_ned: np.ndarray = None,
+                 seed: int = None):
         """
         Args:
             noise_sigma: Measurement noise std dev in uT.
@@ -29,7 +30,7 @@ class MagModel:
             self.field_ned = np.array([22.0, 5.0, 42.0])
         else:
             self.field_ned = np.array(field_ned)
-        self._rng = np.random.default_rng()
+        self._rng = np.random.default_rng(seed)
 
     def measure(self, quaternion: np.ndarray) -> dict:
         """Generate magnetometer measurement from true orientation.

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -41,6 +41,9 @@ class SimConfig:
     baro_rate: float = 500.0
     mag_rate: float = 1000.0
     gnss_rate: float = 25.0
+    # Seed for the sensor-noise RNGs (None = nondeterministic). Each model
+    # gets a distinct derived seed so streams are independent (#459 A/B).
+    sensor_seed: int = None
     duration: float = 30.0          # max sim time (after launch)
     pad_time: float = 0.0           # pre-launch pad warmup (s) for EKF convergence
 
@@ -222,19 +225,23 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         wind_enu = np.array([wind_east, wind_north, 0.0])
 
     # Initialize sensors
+    def _seed(i):
+        return None if config.sensor_seed is None else config.sensor_seed + i
     if config.perfect_imu:
         imu = IMUModel(rate_hz=config.imu_rate,
                        accel_noise_sigma=0.0, gyro_noise_sigma=0.0,
-                       accel_bias_sigma=0.0, gyro_bias_sigma=0.0)
+                       accel_bias_sigma=0.0, gyro_bias_sigma=0.0,
+                       seed=_seed(0))
     else:
-        imu = IMUModel(rate_hz=config.imu_rate)
-    baro = BaroModel(rate_hz=config.baro_rate)
-    mag = MagModel(rate_hz=config.mag_rate)
+        imu = IMUModel(rate_hz=config.imu_rate, seed=_seed(0))
+    baro = BaroModel(rate_hz=config.baro_rate, seed=_seed(1))
+    mag = MagModel(rate_hz=config.mag_rate, seed=_seed(2))
     gnss = GNSSModel(
         rate_hz=config.gnss_rate,
         ref_lat_deg=config.ref_lat_deg,
         ref_lon_deg=config.ref_lon_deg,
         ref_alt_m=config.ref_alt_m,
+        seed=_seed(3),
     )
 
     # Initialize controller
@@ -329,6 +336,11 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
     next_baro = t
     next_mag = t
     next_gnss = t
+    # #459: mag samples are generated at mag_rate and HELD between samples
+    # with their sample timestamp, so the EKF sees the sensor's real cadence
+    # (the FC stamps ekf_mag.time_us with the sensor sample time).
+    held_mag_frd = None
+    mag_sample_time_us = 0
     next_log = t
 
     # Current actuator state
@@ -473,6 +485,10 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                     mag_d.mag_x = mag_meas['mag_x']
                     mag_d.mag_y = -mag_meas['mag_y']
                     mag_d.mag_z = -mag_meas['mag_z']
+                    # #459: this is the first held sample
+                    held_mag_frd = (mag_d.mag_x, mag_d.mag_y, mag_d.mag_z)
+                    mag_sample_time_us = ekf_time_us
+                    next_mag = t + mag_dt
                 # else: zeros → Mahony skips mag correction
 
                 ekf.init(imu_d, gnss_d, mag_d)
@@ -567,14 +583,25 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                 else:
                     gnss_d.time_us = gnss_time_counter  # same as last
 
-                # Mag sample (zeros if disabled → Mahony runs gyro+accel only)
+                # Mag sample (zeros if disabled → Mahony runs gyro+accel only).
+                # #459: a new sample is generated only at mag_rate; between
+                # samples the last one is re-presented with its ORIGINAL
+                # timestamp — matching the FC, where updateCore runs every EKF
+                # tick but iis2mdc_latest_si only refreshes at ~98 Hz. The
+                # EKF's mag freshness gate dedups on time_us.
                 mag_d = EKFMagData()
                 mag_d.time_us = ekf_time_us
                 if config.enable_mag_updates:
-                    mag_meas = mag.measure(q)
-                    mag_d.mag_x = mag_meas['mag_x']
-                    mag_d.mag_y = -mag_meas['mag_y']   # FLU→FRD
-                    mag_d.mag_z = -mag_meas['mag_z']   # FLU→FRD
+                    if t >= next_mag:
+                        next_mag += mag_dt
+                        mag_meas = mag.measure(q)
+                        held_mag_frd = (mag_meas['mag_x'],
+                                        -mag_meas['mag_y'],   # FLU→FRD
+                                        -mag_meas['mag_z'])   # FLU→FRD
+                        mag_sample_time_us = ekf_time_us
+                    if held_mag_frd is not None:
+                        mag_d.time_us = mag_sample_time_us
+                        mag_d.mag_x, mag_d.mag_y, mag_d.mag_z = held_mag_frd
 
                 # Sensor trust: only use accel gravity reference on the pad and
                 # during descent.  During boost the accelerometer reads thrust,
@@ -1119,6 +1146,12 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
                 row['ekf_vel_sigma_n'] = math.sqrt(max(0.0, cov_vel[0]))
                 row['ekf_vel_sigma_e'] = math.sqrt(max(0.0, cov_vel[1]))
                 row['ekf_vel_sigma_d'] = math.sqrt(max(0.0, cov_vel[2]))
+                # Attitude-error sigmas (deg) — index 2 ≈ yaw; used by the
+                # #459 covariance-honesty check.
+                cov_orient = ekf.get_cov_orient()
+                row['ekf_att_sigma_x_deg'] = math.degrees(math.sqrt(max(0.0, cov_orient[0])))
+                row['ekf_att_sigma_y_deg'] = math.degrees(math.sqrt(max(0.0, cov_orient[1])))
+                row['ekf_att_sigma_z_deg'] = math.degrees(math.sqrt(max(0.0, cov_orient[2])))
 
             # Guidance telemetry
             row['guidance_active'] = guidance_active


### PR DESCRIPTION
## Change (#459)

`updateCore` fused the magnetometer on every EKF tick (~480 Hz FC / 1200 Hz sim) even though the IIS2MDC produces new data at ~98 Hz — each real sample was re-fused ~5× (FC) / ~12× (sim), contracting yaw covariance far faster than the sensor's information rate. This adds the same `time_us` freshness gate baro has had since #450. The FC already stamps `ekf_mag.time_us` with the sensor sample time, so hardware needs no producer change.

Second commit makes the sim capable of representing the pathology at all: `MagModel` samples are generated at `mag_rate` and **held with their sample timestamp** between samples (previously: fresh independently-noisy sample with a tick timestamp on every EKF tick), all four sensor models take seeds (`SimConfig.sensor_seed`), and attitude-error sigmas are logged. Defaults unchanged.

## Evidence

**Host test** (`MagSampleFusedOncePerUniqueTimestamp`): re-presenting a held sample is bitwise identical to running those ticks with no mag; verified to FAIL against the ungated EKF. `BaroJosephGoldenTrajectory` golds untouched (fresh timestamps → gate is a no-op). 449/449.

**Steady-state probe** (stationary nose-up, 30 s, both builds, both cadences — heading is the body-x error state when vertical):

| build | mag cadence | heading σ |
|---|---|---|
| ungated | fresh every tick | 0.0626° |
| ungated | held 5 ticks | 0.0626° (re-fuses regardless) |
| gated | fresh every tick | 0.0626° (gate no-op — no regression) |
| gated | held 5 ticks | **0.0902°** (honest, ≈ theory for 5:1) |

**Closed-loop SIL A/B** (deterministic G40-class flight, seed 42, mag 100 Hz vs 1200 Hz EKF ticks; envs built from separate clean worktrees, differentiation verified behaviorally before running):

- Flight outcomes identical (apogee 42.4 m, 6.49 s both).
- Pad heading σ: 0.060° → **0.146°** (2.5× more honest at 12:1). Pad NEES (centered error vs heading σ): ~1316 → ~708 — **overconfidence roughly halved**.
- Pad heading jitter: 2.16° → 3.89° std. Expected physics: the re-fusion acted as statistically-unjustified smoothing; removing it lets the estimate ride the (sim-modeled) gyro/mag noise between real samples. Boost (5.13°→5.08°) and coast (26.4°→26.6°) unchanged.
- Both builds carry a constant ~14° yaw offset (sim's synthetic field declination vs the EKF's WMM value — sim artifact, affects both sides identically; mean-removed for the jitter/NEES metrics).

**Residual finding, out of scope:** even gated, NEES ≫ 1 — yaw error (~1.3°/sample from 0.5 µT noise over a ~22 µT horizontal field) far exceeds the filter's claimed σ. The mag measurement noise R looks optimistic independent of re-fusion; worth its own look if heading honesty matters for guidance.

## Remaining validation

- Bench after merge: `[EKF DIAG]` heading stability on the tabletop (expect slightly more visible wander between 98 Hz samples, honest covariance) and `[TIMING]` ekf avg (should drop a touch — ~380 fewer scalar updates/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
