### PR TITLE
fix(app): fin angles derived from pulse endpoints + travel — inconsistent calibration unrepresentable (#449)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -130,17 +130,16 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var servoBias3: Int16 = 0
     var servoBias4: Int16 = 0
     var servoHz: Int16 = 333
-    // #267: full-travel range. 1000us = fin -60deg, 2000us = +60deg (the servo's
-    // mechanical limit). MUST match config.h SERVO_MIN_US/MAX_US + the firmware
-    // setFinCalibration endpoints, or the commanded-vs-physical fin angle is wrong
-    // (e.g. 1250/1750 would only reach +/-30deg at a +/-60deg command).
+    // #449: the servo calibration is exactly three datasheet numbers — the pulse
+    // endpoints and the total fin travel swept between them. MUST match config.h
+    // SERVO_MIN_US/MAX_US.
     var servoMinUs: Int16 = 1000
     var servoMaxUs: Int16 = 2000
-    // #267: physical fin angle (deg) the servo reaches at servoMinUs / servoMaxUs.
-    // Fin bolts directly to the servo arm (1:1), so this is the servo's mechanical
-    // travel. Sent with the servo config; the FC maps commanded fin-deg across it.
-    var finMinDeg: Float = -60.0
-    var finMaxDeg: Float = 60.0
+    // Total fin deflection (deg) swept between servoMinUs and servoMaxUs: the
+    // servo's rated travel across that pulse range, times the linkage ratio
+    // (1:1 for a fin bolted straight to the arm). finMinDeg/finMaxDeg are
+    // DERIVED from it — see below.
+    var finTravelDeg: Float = 120.0
 
     // MARK: Fin layout
     // Servo→fin mapping + ring orientation, sent as FinConfigData (cmd 66): each
@@ -225,13 +224,44 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     }
 }
 
+// MARK: - Fin calibration (#449)
+//
+// The servo response is linear in pulse width, so the fin angle at any pulse is
+// fully determined by the two endpoints and the travel between them. Storing the
+// endpoint ANGLES separately (as this type used to) allowed a pair that describes
+// no physical servo — e.g. 1250/1750 µs declared as ±60°, which the FC then used
+// as calibration and drove to half the commanded deflection. Deriving them makes
+// that state unrepresentable.
 extension RocketProfile {
-    /// Physical fin angle (deg) a servo pulse reaches on the 1:1 fin-to-servo-
-    /// arm line from #267: 1000 µs = −60°, 1500 µs = 0°, 2000 µs = +60°.
-    /// Used to migrate pre-#267 profiles whose JSON has pulse limits but no
-    /// fin-angle keys (#378) — static and pure so the migration is unit-tested.
-    static func finDegForPulse(_ us: Int16) -> Float {
-        (Float(us) - 1500.0) * (120.0 / 1000.0)
+    /// Rated travel of a standard hobby servo: 120° across a 1000 µs span
+    /// (1000→2000 µs), 1:1 fin linkage. Only used to seed `finTravelDeg` for a
+    /// profile that predates the field (#267 line).
+    static let standardFinDegPerUs: Float = 120.0 / 1000.0
+
+    /// Default travel for the given endpoints, assuming a standard servo.
+    /// 1000/2000 → 120°, 1250/1750 → 60°.
+    static func standardFinTravelDeg(minUs: Int16, maxUs: Int16) -> Float {
+        Float(maxUs - minUs) * standardFinDegPerUs
+    }
+
+    /// Pulse (µs) at zero fin deflection — the midpoint of the endpoints.
+    /// Per-servo mechanical trim rides on top of this via `servoBiasN`.
+    var servoCenterUs: Float { Float(servoMinUs) + Float(servoMaxUs - servoMinUs) / 2.0 }
+
+    /// Slope of the calibration line, °/µs. Zero-span profiles yield 0.
+    var finDegPerUs: Float {
+        let span = Float(servoMaxUs - servoMinUs)
+        return span == 0 ? 0 : finTravelDeg / span
+    }
+
+    /// Physical fin angle (deg) reached at `servoMinUs` — always −travel/2.
+    var finMinDeg: Float { -finTravelDeg / 2.0 }
+    /// Physical fin angle (deg) reached at `servoMaxUs` — always +travel/2.
+    var finMaxDeg: Float { finTravelDeg / 2.0 }
+
+    /// Physical fin angle (deg) this profile's servo reaches at `us`.
+    func finDeg(forPulse us: Int16) -> Float {
+        (Float(us) - servoCenterUs) * finDegPerUs
     }
 }
 
@@ -285,20 +315,16 @@ extension RocketProfile {
         servoHz = try c.decodeIfPresent(Int16.self, forKey: .servoHz) ?? defaults.servoHz
         servoMinUs = try c.decodeIfPresent(Int16.self, forKey: .servoMinUs) ?? defaults.servoMinUs
         servoMaxUs = try c.decodeIfPresent(Int16.self, forKey: .servoMaxUs) ?? defaults.servoMaxUs
-        // #378: pre-#267 profiles carry pulse limits (e.g. the old 1250/1750
-        // defaults) but no fin-angle keys. Backfilling the angles with the new
-        // ±60° defaults paired old pulses with full-travel angles, so the FC's
-        // commanded-vs-physical fin mapping was off ~2× (~half roll/guidance
-        // authority, silently). Derive the missing angles from the pulses via
-        // the 1:1 servo-arm line instead (1000 µs = −60°, 2000 µs = +60°, per
-        // the #267 calibration above): the pair is then self-consistent and
-        // the hardware's actual travel is unchanged — 1250/1750 correctly
-        // becomes ±30°, and absent pulses still yield the ±60° defaults.
-        // Profiles that already carry angle keys are untouched.
-        finMinDeg = try c.decodeIfPresent(Float.self, forKey: .finMinDeg)
-            ?? RocketProfile.finDegForPulse(servoMinUs)
-        finMaxDeg = try c.decodeIfPresent(Float.self, forKey: .finMaxDeg)
-            ?? RocketProfile.finDegForPulse(servoMaxUs)
+        // #449: the legacy `finMinDeg`/`finMaxDeg` keys are deliberately NOT read.
+        // They were free-form user input and are exactly the values that could
+        // contradict the pulse limits — every profile written before this build
+        // carries 1250/1750 µs paired with ±60°, which is no physical servo (that
+        // pulse span sweeps 60° total on a standard arm). Reading them back would
+        // preserve the 2×-off calibration the FC was flying. Seed the travel from
+        // the endpoints on the standard-servo line instead; a non-standard servo
+        // is one field edit away, and thereafter the stored value is honoured.
+        finTravelDeg = try c.decodeIfPresent(Float.self, forKey: .finTravelDeg)
+            ?? RocketProfile.standardFinTravelDeg(minUs: servoMinUs, maxUs: servoMaxUs)
         finRingMode = try c.decodeIfPresent(UInt8.self, forKey: .finRingMode) ?? defaults.finRingMode
         let finSlots = try c.decodeIfPresent([Int].self, forKey: .finServoAtSlot) ?? defaults.finServoAtSlot
         finServoAtSlot = finSlots.count == 4 ? finSlots : defaults.finServoAtSlot

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -36,8 +36,7 @@ struct SettingsView: View {
     @State private var sServoHz = ""
     @State private var sServoMinUs = ""
     @State private var sServoMaxUs = ""
-    @State private var sFinMinDeg = ""
-    @State private var sFinMaxDeg = ""
+    @State private var sFinTravelDeg = ""
     @State private var sPidKp = ""
     @State private var sPidKi = ""
     @State private var sPidKd = ""
@@ -123,7 +122,7 @@ struct SettingsView: View {
     // MARK: - Focus-driven self-apply (#144)
 
     private enum EditField: Hashable {
-        case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax, finMin, finMax
+        case bias1, bias2, bias3, bias4, servoHz, servoMin, servoMax, finTravel
         case pidKp, pidKi, pidKd, pidMin, pidMax
         case rollDelay
         case rateCap
@@ -134,11 +133,36 @@ struct SettingsView: View {
         case pyroValue(Int)   // ch index 0..3
     }
 
+    /// Fin-angle range implied by the pulse + travel fields as they are being
+    /// edited. The endpoint angles are derived, never typed (#449); showing them
+    /// live is what makes narrowing the pulse range visibly narrow the fins —
+    /// the mismatch this used to silently allow flew as a 2× calibration error.
+    @ViewBuilder private var finCalibrationReadout: some View {
+        let mn = parseDouble(sServoMinUs, fallback: Double(profile.servoMinUs))
+        let mx = parseDouble(sServoMaxUs, fallback: Double(profile.servoMaxUs))
+        let travel = parseDouble(sFinTravelDeg, fallback: Double(profile.finTravelDeg))
+        let span = mx - mn
+        HStack {
+            Text("Fin Range")
+            Spacer()
+            if span <= 0 {
+                Text("Max Pulse must exceed Min Pulse")
+                    .foregroundColor(.red)
+            } else {
+                Text(String(format: "%+.1f\u{00B0} \u{2026} %+.1f\u{00B0}   (%.3f\u{00B0}/\u{00B5}s)",
+                            -travel / 2.0, travel / 2.0, travel / span))
+                    .foregroundColor(.secondary)
+                    .monospacedDigit()
+            }
+        }
+        .font(.subheadline)
+    }
+
     private enum EditGroup { case servo, pid, rollControl, guidance, rollWaypoints, pyro }
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
-        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax, .finMin, .finMax: return .servo
+        case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax, .finTravel: return .servo
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay, .rateCap, .kpAngle, .integralSep: return .rollControl
         case .guidTargetAlt, .guidNavGain, .guidMaxAccel, .guidAccelToFin, .guidMaxFin, .guidMinSpeed: return .guidance
@@ -395,9 +419,9 @@ struct SettingsView: View {
             stringRow("Frequency", text: $sServoHz, field: .servoHz, unit: "Hz")
             stringRow("Min Pulse", text: $sServoMinUs, field: .servoMin, unit: "\u{00B5}s")
             stringRow("Max Pulse", text: $sServoMaxUs, field: .servoMax, unit: "\u{00B5}s")
-            stringRow("Min Fin Angle", text: $sFinMinDeg, field: .finMin, unit: "deg")
-            stringRow("Max Fin Angle", text: $sFinMaxDeg, field: .finMax, unit: "deg")
-            Text("Fin-angle calibration: the physical fin deflection at Min/Max Pulse \u{2014} the servo's mechanical travel (fin bolts 1:1 to the arm). The controller maps a commanded fin angle onto the pulse that produces it, so e.g. 1000/2000\u{00B5}s = \u{2212}60/+60\u{00B0}.")
+            stringRow("Fin Travel", text: $sFinTravelDeg, field: .finTravel, unit: "deg")
+            finCalibrationReadout
+            Text("Servo datasheet values: the pulse endpoints and the TOTAL fin deflection swept between them (servo travel \u{00D7} linkage ratio; 1:1 for a fin bolted straight to the arm). The controller maps a commanded fin angle onto the pulse that produces it, so these three numbers set the real authority \u{2014} narrowing the pulse range narrows the fins.")
                 .font(.caption).foregroundColor(.secondary)
         }
 
@@ -1009,8 +1033,7 @@ struct SettingsView: View {
         sServoHz = formatInt(Double(p.servoHz))
         sServoMinUs = formatInt(Double(p.servoMinUs))
         sServoMaxUs = formatInt(Double(p.servoMaxUs))
-        sFinMinDeg = formatDecimal(Double(p.finMinDeg))
-        sFinMaxDeg = formatDecimal(Double(p.finMaxDeg))
+        sFinTravelDeg = formatDecimal(Double(p.finTravelDeg))
         sPidKp = formatDecimal(Double(p.pidKp))
         sPidKi = formatDecimal(Double(p.pidKi))
         sPidKd = formatDecimal(Double(p.pidKd))
@@ -1127,14 +1150,16 @@ struct SettingsView: View {
         let hz = Int16(clamping: Int(parseDouble(sServoHz, fallback: Double(profile.servoHz)).rounded()))
         let mn = Int16(clamping: Int(parseDouble(sServoMinUs, fallback: Double(profile.servoMinUs)).rounded()))
         let mx = Int16(clamping: Int(parseDouble(sServoMaxUs, fallback: Double(profile.servoMaxUs)).rounded()))
-        let fmn = Float(parseDouble(sFinMinDeg, fallback: Double(profile.finMinDeg)))
-        let fmx = Float(parseDouble(sFinMaxDeg, fallback: Double(profile.finMaxDeg)))
+        let travel = Float(parseDouble(sFinTravelDeg, fallback: Double(profile.finTravelDeg)))
 
         updateProfile {
             $0.servoBias1 = b1; $0.servoBias2 = b2; $0.servoBias3 = b3; $0.servoBias4 = b4
             $0.servoHz = hz; $0.servoMinUs = mn; $0.servoMaxUs = mx
-            $0.finMinDeg = fmn; $0.finMaxDeg = fmx
+            $0.finTravelDeg = travel
         }
+        // #449: the endpoint angles the FC calibrates against are derived from the
+        // travel, never typed — so the pair it receives always describes a real servo.
+        let fmn = -travel / 2, fmx = travel / 2
         if device.isConnected {
             device.sendServoConfig(biases: [b1, b2, b3, b4], hz: hz, minUs: mn, maxUs: mx,
                                    finMinDeg: fmn, finMaxDeg: fmx)

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketProfileMigrationTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketProfileMigrationTests.swift
@@ -1,77 +1,132 @@
 import XCTest
 @testable import TinkerRocketApp
 
-/// Regression tests for #378: pre-#267 profile JSON carries servo pulse limits
-/// (old defaults 1250/1750 µs) but no finMinDeg/finMaxDeg keys. The decoder
-/// used to backfill the missing angles with the new ±60° defaults, pairing
-/// "1250–1750 µs ↔ ±60°" — a mapping whose commanded-vs-physical fin angle is
-/// off ~2×, so an untouched old profile silently flew with about half the
-/// roll/guidance authority the gains were retuned for. The migration now
-/// derives missing angles from the pulses via the 1:1 servo-arm line
-/// (1000 µs = −60°, 2000 µs = +60°), keeping the pair self-consistent without
-/// changing the hardware's actual travel.
+/// #449: the servo calibration is three datasheet numbers — the pulse endpoints
+/// and the TOTAL fin travel swept between them. The endpoint angles are derived,
+/// so a profile can no longer describe a servo that does not exist.
+///
+/// This supersedes the #378 migration these tests used to cover. #378 derived the
+/// angles only when the JSON *omitted* them and deliberately left an explicit pair
+/// alone — which is how `1250/1750 µs ↔ ±60°` (no physical servo: that span sweeps
+/// 60° total on a standard arm) survived in the flying profile and made the FC
+/// drive half the commanded deflection. The stale keys are now ignored outright.
 final class RocketProfileMigrationTests: XCTestCase {
 
     private func decode(_ json: String) throws -> RocketProfile {
         try JSONDecoder().decode(RocketProfile.self, from: json.data(using: .utf8)!)
     }
 
-    // MARK: - The pulse→angle line itself
+    // MARK: - The standard-servo seed line
 
-    func testFinDegForPulse_CanonicalLine() {
-        XCTAssertEqual(RocketProfile.finDegForPulse(1000), -60.0, accuracy: 0.001)
-        XCTAssertEqual(RocketProfile.finDegForPulse(1500), 0.0, accuracy: 0.001)
-        XCTAssertEqual(RocketProfile.finDegForPulse(2000), 60.0, accuracy: 0.001)
-        XCTAssertEqual(RocketProfile.finDegForPulse(1250), -30.0, accuracy: 0.001)
-        XCTAssertEqual(RocketProfile.finDegForPulse(1750), 30.0, accuracy: 0.001)
+    func testStandardFinTravel_CanonicalSpans() {
+        XCTAssertEqual(RocketProfile.standardFinTravelDeg(minUs: 1000, maxUs: 2000), 120.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.standardFinTravelDeg(minUs: 1250, maxUs: 1750), 60.0, accuracy: 0.001)
+        XCTAssertEqual(RocketProfile.standardFinTravelDeg(minUs: 1100, maxUs: 1900), 96.0, accuracy: 0.001)
     }
 
-    // MARK: - The #378 regression
+    // MARK: - Endpoints are derived, always symmetric about the travel
 
-    func testPre267Profile_OldDefaultPulses_GetConsistentAngles() throws {
-        // The exact case from the issue: old defaults, no fin-angle keys.
-        let p = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750}"#)
+    func testEndpointAngles_AreHalfTheTravel() {
+        var p = RocketProfile.makeDefault(name: "Fresh")
+        XCTAssertEqual(p.finMinDeg, -60.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 60.0, accuracy: 0.001)
+
+        p.finTravelDeg = 90.0            // e.g. a 90°-travel servo
+        XCTAssertEqual(p.finMinDeg, -45.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 45.0, accuracy: 0.001)
+    }
+
+    func testFinDegForPulse_WalksTheCalibrationLine() {
+        var p = RocketProfile.makeDefault(name: "Std")   // 1000/2000 µs, 120°
+        XCTAssertEqual(p.finDeg(forPulse: 1000), -60.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDeg(forPulse: 1500), 0.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDeg(forPulse: 1750), 30.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDeg(forPulse: 2000), 60.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDegPerUs, 0.12, accuracy: 0.0001)
+
+        // Narrowed endpoints on the same servo: the fin sweeps proportionally less.
+        p.servoMinUs = 1250; p.servoMaxUs = 1750
+        p.finTravelDeg = RocketProfile.standardFinTravelDeg(minUs: 1250, maxUs: 1750)
+        XCTAssertEqual(p.finDeg(forPulse: 1250), -30.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDeg(forPulse: 1500), 0.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDeg(forPulse: 1750), 30.0, accuracy: 0.001)
+        XCTAssertEqual(p.finDegPerUs, 0.12, accuracy: 0.0001, "same servo, same slope")
+    }
+
+    func testNonStandardServo_TravelIsHonoured() {
+        // A 90°-travel servo driven across the full 1000–2000 µs span: the slope
+        // is NOT the 0.12 °/µs standard line, and nothing in the model assumes it.
+        var p = RocketProfile.makeDefault(name: "SG90-ish")
+        p.finTravelDeg = 90.0
+        XCTAssertEqual(p.finDegPerUs, 0.09, accuracy: 0.0001)
+        XCTAssertEqual(p.finDeg(forPulse: 2000), 45.0, accuracy: 0.001)
+    }
+
+    func testZeroSpan_DoesNotDivideByZero() {
+        var p = RocketProfile.makeDefault(name: "Degenerate")
+        p.servoMinUs = 1500; p.servoMaxUs = 1500
+        XCTAssertEqual(p.finDegPerUs, 0.0)
+        XCTAssertEqual(p.finDeg(forPulse: 1800), 0.0)
+        XCTAssertFalse(p.finDeg(forPulse: 1800).isNaN)
+    }
+
+    // MARK: - Decoding: stale angle keys are ignored (the #449 inversion)
+
+    func testFlyingProfile_StaleExplicitAngles_AreIgnored() throws {
+        // The exact pair every flight report carried: 1250/1750 µs declared ±60°.
+        // Under #378 this was "explicit user data, untouched" and the FC flew a
+        // 2×-off calibration. It must now resolve to the physical ±30°.
+        let p = try decode(#"{"name":"RollyPoly","servoMinUs":1250,"servoMaxUs":1750,"finMinDeg":-60,"finMaxDeg":60}"#)
         XCTAssertEqual(p.servoMinUs, 1250)
         XCTAssertEqual(p.servoMaxUs, 1750)
+        XCTAssertEqual(p.finTravelDeg, 60.0, accuracy: 0.001)
         XCTAssertEqual(p.finMinDeg, -30.0, accuracy: 0.001,
-                       "1250 µs physically reaches −30°, not the ±60° default")
+                       "1250 µs physically reaches −30°; the stored −60° was fiction")
         XCTAssertEqual(p.finMaxDeg, 30.0, accuracy: 0.001)
     }
 
-    func testPre267Profile_CustomPulses_GetProportionalAngles() throws {
-        // A user-tuned old profile keeps its physical travel, correctly labeled.
+    func testLegacyProfile_PulsesOnly_SeedsStandardTravel() throws {
+        let p = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750}"#)
+        XCTAssertEqual(p.finMinDeg, -30.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 30.0, accuracy: 0.001)
+    }
+
+    func testLegacyProfile_CustomPulses_SeedProportionalTravel() throws {
         let p = try decode(#"{"name":"Custom","servoMinUs":1100,"servoMaxUs":1900}"#)
+        XCTAssertEqual(p.finTravelDeg, 96.0, accuracy: 0.001)
         XCTAssertEqual(p.finMinDeg, -48.0, accuracy: 0.001)
         XCTAssertEqual(p.finMaxDeg, 48.0, accuracy: 0.001)
     }
 
     func testProfileWithoutAnyServoKeys_KeepsFullTravelDefaults() throws {
-        // No pulses AND no angles: defaults are 1000/2000 ↔ ±60 — the formula
-        // reproduces the defaults exactly, so nothing changes for new profiles.
         let p = try decode(#"{"name":"Fresh"}"#)
         XCTAssertEqual(p.servoMinUs, 1000)
         XCTAssertEqual(p.servoMaxUs, 2000)
+        XCTAssertEqual(p.finTravelDeg, 120.0, accuracy: 0.001)
         XCTAssertEqual(p.finMinDeg, -60.0, accuracy: 0.001)
-        XCTAssertEqual(p.finMaxDeg, 60.0, accuracy: 0.001)
     }
 
-    func testPost267Profile_ExplicitAngles_Untouched() throws {
-        // A profile that already carries angle keys is never rewritten — even
-        // if the pair looks odd, explicit user data wins.
-        let p = try decode(
-            #"{"name":"Tuned","servoMinUs":1250,"servoMaxUs":1750,"finMinDeg":-25.5,"finMaxDeg":27.0}"#)
-        XCTAssertEqual(p.finMinDeg, -25.5, accuracy: 0.001)
-        XCTAssertEqual(p.finMaxDeg, 27.0, accuracy: 0.001)
+    func testExplicitTravel_SurvivesDecode() throws {
+        // Once a user states their servo's travel it is authoritative — the
+        // standard-servo seed applies only when the key is absent.
+        let p = try decode(#"{"name":"NineZero","servoMinUs":1000,"servoMaxUs":2000,"finTravelDeg":90}"#)
+        XCTAssertEqual(p.finTravelDeg, 90.0, accuracy: 0.001)
+        XCTAssertEqual(p.finMaxDeg, 45.0, accuracy: 0.001)
     }
 
-    func testMigratedProfile_RoundTripsStable() throws {
-        // Once migrated and re-saved, the angles are explicit — decoding the
-        // re-encoded JSON must not shift values again (idempotence).
-        let migrated = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750}"#)
-        let reencoded = try JSONEncoder().encode(migrated)
-        let again = try JSONDecoder().decode(RocketProfile.self, from: reencoded)
-        XCTAssertEqual(again.finMinDeg, migrated.finMinDeg, accuracy: 0.001)
-        XCTAssertEqual(again.finMaxDeg, migrated.finMaxDeg, accuracy: 0.001)
+    // MARK: - Round trip
+
+    func testRoundTrip_IsStable_AndDropsDerivedKeys() throws {
+        let migrated = try decode(#"{"name":"OldBird","servoMinUs":1250,"servoMaxUs":1750,"finMinDeg":-60,"finMaxDeg":60}"#)
+        let data = try JSONEncoder().encode(migrated)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertFalse(json.contains("finMinDeg"), "derived angles must not be persisted")
+        XCTAssertFalse(json.contains("finMaxDeg"))
+        XCTAssertTrue(json.contains("finTravelDeg"))
+
+        let again = try JSONDecoder().decode(RocketProfile.self, from: data)
+        XCTAssertEqual(again.finTravelDeg, migrated.finTravelDeg, accuracy: 0.001)
+        XCTAssertEqual(again.finMinDeg, -30.0, accuracy: 0.001)
         XCTAssertEqual(again.servoMinUs, 1250)
     }
 }


### PR DESCRIPTION
## Change (#449, reshaped)

The servo calibration becomes exactly three datasheet numbers — **min pulse, max pulse, total fin travel across that span** — and the endpoint angles are derived (`∓travel/2`), never typed. The state that flew a 2× calibration error (`1250/1750 µs` declared `±60°`) is no longer representable.

- `RocketProfile`: `finMinDeg`/`finMaxDeg` become computed; new stored `finTravelDeg` (default 120°). `finDeg(forPulse:)`/`finDegPerUs` expose the calibration line for any consumer.
- **Decoder inversion**: the legacy JSON angle keys are deliberately ignored (they are exactly the values that were wrong); `finTravelDeg` seeds from the standard-servo line (0.12 °/µs × span) when absent, so every existing profile resolves to its *physical* travel on first load — the flying profile's 1250/1750 becomes ±30°.
- **Settings UI**: the two angle fields are replaced by one "Fin Travel" field plus a live read-only "Fin Range" readout (`−30.0° … +30.0° (0.120°/µs)`), so narrowing the pulse range visibly narrows the fins — the intent of the original warning, without a warning.
- **Wire format & firmware unchanged**: cmd 12 still carries endpoint angles; they're now consistent by construction. No FC changes.

## Flight-relevant consequence — read before next controlled flight

On the next connect push after this lands, the FC's calibration corrects: a commanded degree produces a physical degree. All previous flights ran a plant with **half** the modeled authority, and the flight-proven roll gains (Kp=0.2, Ki=0.04) were tuned against that weak plant — **effective loop gain doubles**. Recommend a closed-loop sim pass (or start at half gains) before the next roll-controlled flight. Alternatively, widening pulses to 1000/2000 restores the full ±60° the gains' tuning era assumed the fins had — the new readout makes either choice explicit.

## Tests

App suite green (`** TEST SUCCEEDED **`). `RocketProfileMigrationTests` rewritten for the new model, 11 cases: standard seed line, derived endpoints, non-standard 90° servo honoured, zero-span safety, **stale-key inversion on the exact flying-profile JSON**, and round-trip stability with derived keys dropped from the encoding.

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
