### PR TITLE
feat(bs): V3 base-station PCB support — MAX17303 gauge, MP2672 charger, radio-daughterboard seam

### DIFF
--- a/tinkerrocket-idf/components/TR_MAX17303/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MAX17303/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "TR_MAX17303.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
@@ -1,0 +1,319 @@
+#include <TR_MAX17303.h>
+
+#include <math.h>
+
+static constexpr uint32_t I2C_TIMEOUT_MS = 100;
+static const char* TAG = "MAX17303";
+
+namespace Reg = MAX17303_Reg;
+
+TR_MAX17303::TR_MAX17303(uint8_t addr)
+    : _dev(nullptr),
+      _addr(addr),
+      _devname(0),
+      _cfg(),
+      _data()
+{
+    _data.voltage       = NAN;
+    _data.current       = NAN;
+    _data.soc           = NAN;
+    _data.temperature   = NAN;
+    _data.capacity      = NAN;
+    _data.full_capacity = NAN;
+    _data.prot_status   = 0;
+    _data.chg_fet_on    = false;
+    _data.dis_fet_on    = false;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level I2C
+// ---------------------------------------------------------------------------
+bool TR_MAX17303::readReg(uint8_t reg, uint16_t& value)
+{
+    if (_dev == nullptr) return false;
+    uint8_t buf[2] = {};
+    esp_err_t err = i2c_master_transmit_receive(_dev, &reg, 1, buf, 2,
+                                                I2C_TIMEOUT_MS);
+    if (err != ESP_OK) return false;
+    value = ((uint16_t)buf[1] << 8) | buf[0];  // Little-endian on the wire
+    return true;
+}
+
+bool TR_MAX17303::writeReg(uint8_t reg, uint16_t value)
+{
+    if (_dev == nullptr) return false;
+    uint8_t buf[3] = { reg,
+                       (uint8_t)(value & 0xFF),
+                       (uint8_t)((value >> 8) & 0xFF) };
+    return i2c_master_transmit(_dev, buf, 3, I2C_TIMEOUT_MS) == ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// begin — attach + identify (DevName splits us from a MAX17205 at 0x36)
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17303::begin(i2c_master_bus_handle_t bus,
+                             const TR_MAX17303_Config& cfg,
+                             uint32_t clock_hz)
+{
+    _cfg = cfg;
+
+    i2c_device_config_t dev_cfg = {};
+    dev_cfg.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+    dev_cfg.device_address  = _addr;
+    dev_cfg.scl_speed_hz    = clock_hz;
+
+    esp_err_t err = i2c_master_bus_add_device(bus, &dev_cfg, &_dev);
+    if (err != ESP_OK) return err;
+
+    if (!readReg(Reg::DEV_NAME, _devname))
+    {
+        i2c_master_bus_rm_device(_dev);
+        _dev = nullptr;
+        return ESP_FAIL;
+    }
+
+    // Family field 0x406 (accept older sample revs 0x404/0x405); variant
+    // nibble 7 = MAX17303. A MAX17205 reads a ~0x02xx firmware-rev value
+    // here, so a mismatch means "not this part" — hand the address back.
+    const uint16_t family  = _devname >> 4;
+    const uint16_t variant = _devname & 0xF;
+    if (family != Reg::DEVNAME_FAMILY && family != 0x405 && family != 0x404)
+    {
+        i2c_master_bus_rm_device(_dev);
+        _dev = nullptr;
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (variant != Reg::DEVNAME_VARIANT_303)
+    {
+        // Sibling part (MAX17300/01/02) — same driver works; just say so.
+        ESP_LOGW(TAG, "MAX1730x variant %u (DevName 0x%04X), driving as MAX17303",
+                 (unsigned)variant, _devname);
+    }
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// DesignCap scaling — 1 LSB = 5 µVh / Rsense (0.5 mAh @ 10 mΩ)
+// ---------------------------------------------------------------------------
+uint16_t TR_MAX17303::designCapRaw() const
+{
+    float raw = (float)_cfg.design_mah * 2.0f * (10.0f / _cfg.rsense_mohm);
+    if (raw < 0.0f)     raw = 0.0f;
+    if (raw > 65535.0f) raw = 65535.0f;
+    return (uint16_t)raw;
+}
+
+// ---------------------------------------------------------------------------
+// initIfNeeded
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17303::initIfNeeded()
+{
+    if (_dev == nullptr) return ESP_FAIL;
+
+    uint16_t status = 0;
+    if (!readReg(Reg::STATUS, status))
+    {
+        ESP_LOGE(TAG, "Status read failed during init check");
+        return ESP_FAIL;
+    }
+    const bool por = (status & 0x0002);
+
+    // The chip restores DesignCap from its NV copy at POR. If we have a
+    // configured pack capacity and the restored value is >20% off (fresh
+    // part still on factory NV), re-seed volatile RAM.
+    bool cap_stale = false;
+    if (_cfg.design_mah > 0)
+    {
+        const uint16_t expected = designCapRaw();
+        uint16_t dc = 0;
+        if (readReg(Reg::DESIGN_CAP, dc))
+        {
+            const uint32_t diff = (dc > expected) ? (dc - expected)
+                                                  : (expected - dc);
+            if (diff > (uint32_t)(expected / 5)) cap_stale = true;
+        }
+    }
+
+    if (!por && !cap_stale) return ESP_OK;  // Quiet no-op path
+
+    // Data-not-ready clears 0.4-1.9 s after POR; wait it out first.
+    for (int i = 0; i < 200; ++i)
+    {
+        uint16_t fstat = 0;
+        if (readReg(Reg::FSTAT, fstat) && !(fstat & 0x0001)) break;
+        delay(10);
+    }
+
+    if (cap_stale)
+    {
+        seedCapacityAndRestart();
+    }
+
+    // Clear Status.POR so we don't re-run while the chip stays powered
+    // across MCU reboots. Write-back preserves the other bits.
+    uint16_t status_after = 0;
+    if (readReg(Reg::STATUS, status_after))
+    {
+        writeReg(Reg::STATUS, status_after & ~(uint16_t)0x0002);
+    }
+    return ESP_OK;
+}
+
+// Volatile-RAM capacity seed (no NV writes, no Command-register use):
+// write DesignCap/FullCapRep, then Config2.POR_CMD restarts the fuel-gauge
+// firmware WITHOUT an NV recall so the model picks the new values up.
+esp_err_t TR_MAX17303::seedCapacityAndRestart()
+{
+    const uint16_t design_raw = designCapRaw();
+
+    writeReg(Reg::DESIGN_CAP,   design_raw);
+    writeReg(Reg::FULL_CAP_REP, design_raw);
+
+    uint16_t cfg2 = 0;
+    if (!readReg(Reg::CONFIG2, cfg2)) return ESP_FAIL;
+    writeReg(Reg::CONFIG2, cfg2 | 0x8000);  // POR_CMD, self-clearing
+
+    bool restarted = false;
+    for (int i = 0; i < 100; ++i)
+    {
+        if (readReg(Reg::CONFIG2, cfg2) && !(cfg2 & 0x8000))
+        {
+            restarted = true;
+            break;
+        }
+        delay(10);
+    }
+    // Firmware restart re-runs data collection; wait for DNR again.
+    for (int i = 0; i < 200; ++i)
+    {
+        uint16_t fstat = 0;
+        if (readReg(Reg::FSTAT, fstat) && !(fstat & 0x0001)) break;
+        delay(10);
+    }
+
+    uint16_t dc_back = 0;
+    readReg(Reg::DESIGN_CAP, dc_back);
+    if (dc_back != design_raw || !restarted)
+    {
+        ESP_LOGW(TAG, "capacity seed incomplete: DesignCap readback 0x%04X vs "
+                      "wrote 0x%04X, restart=%s",
+                 dc_back, design_raw, restarted ? "OK" : "TIMEOUT");
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "Seeded %u mAh pack (1S, Rsense %.1f mΩ) in volatile RAM",
+             (unsigned)_cfg.design_mah, (double)_cfg.rsense_mohm);
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+esp_err_t TR_MAX17303::update()
+{
+    if (_dev == nullptr) return ESP_FAIL;
+
+    uint16_t raw = 0;
+
+    // 1S part: VCell IS the pack voltage (78.125 µV/LSB).
+    if (readReg(Reg::VCELL, raw))
+        _data.voltage = (float)raw * 0.078125e-3f;
+
+    // RepSOC (1/256 %) — the chip's reported SOC. Unlike the V1 MAX17205
+    // board there is no known CSP/CSN swap, so no VFSOC workaround here.
+    if (readReg(Reg::REP_SOC, raw))
+        _data.soc = (float)raw / 256.0f;
+
+    if (readReg(Reg::CURRENT, raw))
+    {
+        float cur_ma = (float)(int16_t)raw * 1.5625e-3f / (_cfg.rsense_mohm * 1e-3f);
+        _data.current = _cfg.current_invert ? -cur_ma : cur_ma;
+    }
+
+    if (readReg(Reg::TEMP, raw))
+        _data.temperature = (float)(int16_t)raw / 256.0f;
+
+    const float cap_lsb_mah = 0.5f * (10.0f / _cfg.rsense_mohm);
+    if (readReg(Reg::REP_CAP, raw))
+        _data.capacity = (float)raw * cap_lsb_mah;
+    if (readReg(Reg::FULL_CAP_REP, raw))
+        _data.full_capacity = (float)raw * cap_lsb_mah;
+
+    // Protector observability (the BQ FET saga lesson: always know why the
+    // battery path is open).
+    if (readReg(Reg::PROT_STATUS, raw))
+        _data.prot_status = raw;
+    if (readReg(Reg::HCONFIG2, raw))
+    {
+        _data.chg_fet_on = (raw & (1u << 6)) != 0;  // CHGs
+        _data.dis_fet_on = (raw & (1u << 7)) != 0;  // DISs
+    }
+
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+// Decode ProtStatus fault bits (datasheet Table: ProtStatus 0x0D9).
+static void protStatusToString(uint16_t ps, char* out, size_t out_len)
+{
+    static const struct { uint16_t bit; const char* name; } kBits[] = {
+        {1u << 0,  "Shdn"},    {1u << 1,  "TooColdD"}, {1u << 2,  "ODCP"},
+        {1u << 3,  "UVP"},     {1u << 4,  "TooHotD"},  {1u << 5,  "DieHot"},
+        {1u << 6,  "PermFail"},{1u << 9,  "Qovflw"},   {1u << 10, "OCCP"},
+        {1u << 11, "OVP"},     {1u << 12, "TooColdC"}, {1u << 13, "Full"},
+        {1u << 14, "TooHotC"}, {1u << 15, "ChgWDT"},
+    };
+    out[0] = '\0';
+    if (ps == 0)
+    {
+        snprintf(out, out_len, "none");
+        return;
+    }
+    size_t used = 0;
+    for (const auto& b : kBits)
+    {
+        if (!(ps & b.bit)) continue;
+        used += snprintf(out + used, (used < out_len) ? out_len - used : 0,
+                         "%s%s", (used > 0) ? "," : "", b.name);
+    }
+}
+
+void TR_MAX17303::logDiagnostics(const char* log_tag)
+{
+    if (_dev == nullptr) return;
+    uint16_t raw = 0;
+    const float cap_lsb_mah = 0.5f * (10.0f / _cfg.rsense_mohm);
+
+    ESP_LOGI(log_tag, "[FG-DIAG] --- MAX17303 register dump ---");
+    ESP_LOGI(log_tag, "[FG-DIAG] DevName    (0x21) = 0x%04X", _devname);
+    if (readReg(Reg::STATUS,       raw)) ESP_LOGI(log_tag, "[FG-DIAG] Status     (0x00) = 0x%04X", raw);
+    if (readReg(Reg::REP_SOC,      raw)) ESP_LOGI(log_tag, "[FG-DIAG] RepSOC     (0x06) = %.2f %% (raw=0x%04X)", (float)raw / 256.0f, raw);
+    if (readReg(Reg::REP_CAP,      raw)) ESP_LOGI(log_tag, "[FG-DIAG] RepCap     (0x05) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::FULL_CAP_REP, raw)) ESP_LOGI(log_tag, "[FG-DIAG] FullCapRep (0x10) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::DESIGN_CAP,   raw)) ESP_LOGI(log_tag, "[FG-DIAG] DesignCap  (0x18) = %.0f mAh (raw=0x%04X)", raw * cap_lsb_mah, raw);
+    if (readReg(Reg::CYCLES,       raw)) ESP_LOGI(log_tag, "[FG-DIAG] Cycles     (0x17) = %.2f (25%%/LSB)", (float)raw * 0.25f);
+    if (readReg(Reg::VCELL,        raw)) ESP_LOGI(log_tag, "[FG-DIAG] VCell      (0x1A) = %.1f mV (raw=0x%04X)", (double)((float)raw * 0.078125f), raw);
+    if (readReg(Reg::CURRENT,      raw)) {
+        const int16_t signed_raw = (int16_t)raw;
+        const float ma = (float)signed_raw * 1.5625e-3f / (_cfg.rsense_mohm * 1e-3f);
+        ESP_LOGI(log_tag, "[FG-DIAG] Current    (0x1C) = %d (raw signed) -> %.0f mA chip-frame, %.0f mA app-frame (invert=%d)",
+                 signed_raw, (double)ma,
+                 _cfg.current_invert ? -(double)ma : (double)ma,
+                 _cfg.current_invert);
+    }
+    if (readReg(Reg::TEMP,         raw)) ESP_LOGI(log_tag, "[FG-DIAG] Temp       (0x1B) = %.1f C", (float)(int16_t)raw / 256.0f);
+    if (readReg(Reg::PROT_STATUS,  raw)) {
+        char faults[96];
+        protStatusToString(raw, faults, sizeof(faults));
+        ESP_LOGI(log_tag, "[FG-DIAG] ProtStatus (0xD9) = 0x%04X [%s]", raw, faults);
+    }
+    if (readReg(Reg::HCONFIG2,     raw)) {
+        ESP_LOGI(log_tag, "[FG-DIAG] HConfig2   (0xF5) = 0x%04X  CHG FET=%s DIS FET=%s",
+                 raw, (raw & (1u << 6)) ? "ON" : "OFF",
+                 (raw & (1u << 7)) ? "ON" : "OFF");
+    }
+    ESP_LOGI(log_tag, "[FG-DIAG] Pack: 1S, design %u mAh, Rsense %.1f mΩ",
+             (unsigned)_cfg.design_mah, (double)_cfg.rsense_mohm);
+    ESP_LOGI(log_tag, "[FG-DIAG] --------------------------------");
+}

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
@@ -97,9 +97,12 @@ esp_err_t TR_MAX17303::begin(i2c_master_bus_handle_t bus,
                       "a MAX17303 — claiming it (report this value!)",
                  _devname);
     }
-    else if (variant != Reg::DEVNAME_VARIANT_303)
+    else if (variant != Reg::DEVNAME_VARIANT_303 &&
+             variant != Reg::DEVNAME_VARIANT_303_HW)
     {
-        // Sibling part (MAX17300/01/02) — same driver works; just say so.
+        // Neither the datasheet nibble (0x7) nor the confirmed production
+        // nibble (0xC): could be a sibling part (MAX17300/01/02) — same
+        // driver works, but flag it so a wrong BOM stuff gets noticed.
         ESP_LOGW(TAG, "MAX1730x variant %u (DevName 0x%04X), driving as MAX17303",
                  (unsigned)variant, _devname);
     }

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.cpp
@@ -72,18 +72,32 @@ esp_err_t TR_MAX17303::begin(i2c_master_bus_handle_t bus,
         return ESP_FAIL;
     }
 
-    // Family field 0x406 (accept older sample revs 0x404/0x405); variant
-    // nibble 7 = MAX17303. A MAX17205 reads a ~0x02xx firmware-rev value
-    // here, so a mismatch means "not this part" — hand the address back.
+    // Family field: production silicon reads 0x406, older samples 0x404/
+    // 0x405 — accept the whole 0x40x die-rev range. Variant nibble 7 =
+    // MAX17303. A MAX17205 reads a ~0x02xx firmware-rev value here, so a
+    // mismatch normally means "not this part" — hand the address back...
+    // unless the board header asserts this PCB carries a MAX17303
+    // (assume_when_unidentified): then claim it anyway and log the value,
+    // so an unlisted die rev can't silently demote V3 to the wrong-map
+    // MAX17205 driver (bench 2026-07-10: exactly that happened).
     const uint16_t family  = _devname >> 4;
     const uint16_t variant = _devname & 0xF;
-    if (family != Reg::DEVNAME_FAMILY && family != 0x405 && family != 0x404)
+    const bool is_1730x = (family & 0xFF0) == 0x400;
+    if (!is_1730x)
     {
-        i2c_master_bus_rm_device(_dev);
-        _dev = nullptr;
-        return ESP_ERR_NOT_FOUND;
+        if (!_cfg.assume_when_unidentified)
+        {
+            ESP_LOGI(TAG, "DevName 0x%04X is not a MAX1730x — handing 0x36 back",
+                     _devname);
+            i2c_master_bus_rm_device(_dev);
+            _dev = nullptr;
+            return ESP_ERR_NOT_FOUND;
+        }
+        ESP_LOGW(TAG, "DevName 0x%04X unrecognized, but the board says this is "
+                      "a MAX17303 — claiming it (report this value!)",
+                 _devname);
     }
-    if (variant != Reg::DEVNAME_VARIANT_303)
+    else if (variant != Reg::DEVNAME_VARIANT_303)
     {
         // Sibling part (MAX17300/01/02) — same driver works; just say so.
         ESP_LOGW(TAG, "MAX1730x variant %u (DevName 0x%04X), driving as MAX17303",

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
@@ -1,0 +1,141 @@
+#ifndef TR_MAX17303_H
+#define TR_MAX17303_H
+
+#include <compat.h>
+#include <driver/i2c_master.h>
+
+// MAX17303 ModelGauge m5 EZ fuel gauge with integrated 1-level protector
+// (MAX17300-MAX17303 family, datasheet 19-100463 Rev 6). 1S only — the
+// protector drives two external high-side N-FETs (CHG/DIS).
+//
+// This is NOT a MAX17055/MAX1720x-style part despite sharing the m5 core:
+//  - It self-restores its full configuration + battery model from internal
+//    nonvolatile memory at POR, with no host involvement. There is no
+//    documented ModelCfg.Refresh EZ flow and no HibCfg/soft-wakeup dance.
+//  - Command (0x060) is the NV/SHA command register: a stray write can burn
+//    one of the SEVEN lifetime NV config copies (0xE904) or PERMANENTLY lock
+//    pages (0x6AXX). This driver never touches it.
+//  - RAM config registers (DesignCap etc.) restore from NV each POR; the
+//    driver may re-seed them in volatile RAM (zero NV writes) and apply via
+//    Config2.POR_CMD, which restarts the fuel-gauge firmware WITHOUT an NV
+//    recall.
+//  - Unlike the BQ27Z746 there is no FET_EN ship-state trap: with a battery
+//    attached and no faults the protection FETs conduct out of the box.
+//    FET state is observable in HConfig2 (CHGs/DISs) and fault causes in
+//    ProtStatus.
+//
+// Only the primary I2C address (0x36, registers 0x000-0x0FF) is used. The
+// nonvolatile shadow page behind secondary address 0x0B is intentionally
+// not touched (limited write budget; see above).
+
+namespace MAX17303_Reg {
+    // Note: measurement addresses DIFFER from the MAX1720x map (e.g. VCell
+    // is 0x1A here vs 0x09 there) — do not copy constants across drivers.
+    static constexpr uint8_t STATUS       = 0x00;  // POR bit 1, PA bit 15
+    static constexpr uint8_t REP_CAP      = 0x05;
+    static constexpr uint8_t REP_SOC      = 0x06;  // 1/256 %
+    static constexpr uint8_t FULL_CAP_REP = 0x10;
+    static constexpr uint8_t TTE          = 0x11;  // 5.625 s/LSB
+    static constexpr uint8_t CYCLES       = 0x17;  // 25% of a cycle per LSB
+    static constexpr uint8_t DESIGN_CAP   = 0x18;
+    static constexpr uint8_t AVG_VCELL    = 0x19;
+    static constexpr uint8_t VCELL        = 0x1A;  // 78.125 µV/LSB
+    static constexpr uint8_t TEMP         = 0x1B;  // 1/256 °C signed
+    static constexpr uint8_t CURRENT      = 0x1C;  // 1.5625 µV/Rsense signed
+    static constexpr uint8_t AVG_CURRENT  = 0x1D;
+    static constexpr uint8_t ICHG_TERM    = 0x1E;
+    static constexpr uint8_t DEV_NAME     = 0x21;  // 0x4067 = MAX17303
+    static constexpr uint8_t DIE_TEMP     = 0x34;
+    static constexpr uint8_t V_EMPTY      = 0x3A;
+    static constexpr uint8_t FSTAT        = 0x3D;  // DNR bit 0
+    static constexpr uint8_t COMM_STAT    = 0x61;  // NVBusy/NVError (read-only use)
+    static constexpr uint8_t CONFIG2      = 0xAB;  // POR_CMD bit 15 (self-clearing)
+    static constexpr uint8_t PROT_ALRT    = 0xAF;  // latched fault history
+    static constexpr uint8_t PROT_STATUS  = 0xD9;  // live protector faults
+    static constexpr uint8_t HCONFIG2     = 0xF5;  // CHGs bit 6, DISs bit 7
+
+    // DevName check: bits[15:4] identify the family/silicon rev (0x406 on
+    // production parts, older samples read 0x404/0x405); low nibble is the
+    // variant (7 = MAX17303). MAX1720x parts at the same I2C address read a
+    // firmware-revision-based value (~0x02xx) with device nibble 1/5, so the
+    // family field cleanly separates the two.
+    static constexpr uint16_t DEVNAME_FAMILY      = 0x406;
+    static constexpr uint16_t DEVNAME_VARIANT_303 = 0x7;
+}
+
+struct TR_MAX17303_Data
+{
+    float voltage;        // Cell/pack voltage (1S), V
+    float current;        // mA (positive = charging after optional invert)
+    float soc;            // State-of-charge, % (RepSOC)
+    float temperature;    // °C
+    float capacity;       // Remaining capacity, mAh
+    float full_capacity;  // Full capacity (learned), mAh
+    uint16_t prot_status; // Raw ProtStatus (0 = no faults)
+    bool chg_fet_on;      // HConfig2.CHGs
+    bool dis_fet_on;      // HConfig2.DISs
+};
+
+struct TR_MAX17303_Config
+{
+    uint16_t design_mah     = 2800;   // Pack design capacity; 0 = leave the
+                                      //   chip's NV-restored value untouched
+    float    rsense_mohm    = 10.0f;  // Sense resistor value (host-side
+                                      //   current/capacity scaling only)
+    bool     current_invert = false;  // Flip the *displayed* current sign
+                                      //   (CSP/CSN swap on the PCB)
+};
+
+class TR_MAX17303
+{
+public:
+    explicit TR_MAX17303(uint8_t addr = 0x36);
+
+    // Add device to an existing I2C master bus, then verify DevName. Returns
+    // ESP_ERR_NOT_FOUND (device removed from the bus again) when the part at
+    // this address is not a MAX1730x — the caller can then fall through to
+    // the MAX17205 driver, which shares the address.
+    esp_err_t begin(i2c_master_bus_handle_t bus,
+                    const TR_MAX17303_Config& cfg,
+                    uint32_t clock_hz = 400000);
+
+    // POR handling: wait FStat.DNR, optionally re-seed DesignCap-derived
+    // capacity registers in volatile RAM (applied via Config2.POR_CMD — zero
+    // NV writes), clear Status.POR. Self-gated; safe to call every boot.
+    esp_err_t initIfNeeded();
+
+    // Re-read voltage/current/soc/temperature/capacity/protector state.
+    esp_err_t update();
+
+    const TR_MAX17303_Data& data() const { return _data; }
+    float voltage() const     { return _data.voltage; }
+    float current() const     { return _data.current; }
+    float soc() const         { return _data.soc; }
+    float temperature() const { return _data.temperature; }
+    uint16_t protStatus() const { return _data.prot_status; }
+    // Both protection FETs conducting (battery actually connected to the
+    // system) — the analog of the BQ27Z746 FET check, but observation-only.
+    bool fetsOn() const { return _data.chg_fet_on && _data.dis_fet_on; }
+
+    uint16_t devName() const { return _devname; }
+
+    // Low-level helpers (exposed for diagnostics).
+    bool readReg(uint8_t reg, uint16_t& value);
+    bool writeReg(uint8_t reg, uint16_t value);
+
+    // One-shot diagnostic dump incl. decoded ProtStatus + FET states.
+    void logDiagnostics(const char* log_tag);
+
+    uint16_t designCapRaw() const;
+
+private:
+    esp_err_t seedCapacityAndRestart();
+
+    i2c_master_dev_handle_t _dev;
+    uint8_t                 _addr;
+    uint16_t                _devname;
+    TR_MAX17303_Config      _cfg;
+    TR_MAX17303_Data        _data;
+};
+
+#endif

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
@@ -60,7 +60,14 @@ namespace MAX17303_Reg {
     // firmware-revision-based value (~0x02xx) with device nibble 1/5, so the
     // family field cleanly separates the two.
     static constexpr uint16_t DEVNAME_FAMILY      = 0x406;
-    static constexpr uint16_t DEVNAME_VARIANT_303 = 0x7;
+    // Datasheet (Rev 6) lists variant nibble 0x7 for MAX17303/13, BUT
+    // production MAX17303G+ silicon reads DevName 0x407C — variant nibble
+    // 0xC — bench-confirmed on the V3 base station 2026-07-10 (readings all
+    // sane against this driver's register map). The datasheet's DevName
+    // table is known to disagree with shipped silicon (UG6807 lists yet a
+    // third nibble scheme). Both 0x7 and 0xC are accepted without warning.
+    static constexpr uint16_t DEVNAME_VARIANT_303    = 0x7;   // datasheet
+    static constexpr uint16_t DEVNAME_VARIANT_303_HW = 0xC;   // observed silicon
 }
 
 struct TR_MAX17303_Data

--- a/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
+++ b/tinkerrocket-idf/components/TR_MAX17303/TR_MAX17303.h
@@ -84,6 +84,13 @@ struct TR_MAX17303_Config
                                       //   current/capacity scaling only)
     bool     current_invert = false;  // Flip the *displayed* current sign
                                       //   (CSP/CSN swap on the PCB)
+    bool assume_when_unidentified = false;  // Board-level assertion that the
+                                      //   part at 0x36 IS a MAX17303: claim it
+                                      //   even when DevName reads an unknown
+                                      //   family (a die rev newer than the
+                                      //   0x404-0x406 range seen in the wild),
+                                      //   instead of falling through to the
+                                      //   MAX17205 driver's wrong register map.
 };
 
 class TR_MAX17303

--- a/tinkerrocket-idf/components/TR_MP2672/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_MP2672/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "TR_MP2672.cpp" INCLUDE_DIRS "." REQUIRES esp_driver_i2c TR_Compat PRIV_REQUIRES driver)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)

--- a/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.cpp
+++ b/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.cpp
@@ -1,0 +1,250 @@
+#include <TR_MP2672.h>
+
+static constexpr uint32_t I2C_TIMEOUT_MS = 100;
+static const char* TAG = "MP2672";
+
+namespace Reg = MP2672_Reg;
+
+TR_MP2672::TR_MP2672(uint8_t addr)
+    : _dev(nullptr),
+      _addr(addr),
+      _cfg(),
+      _data(),
+      _config_applied(false)
+{
+}
+
+// ---------------------------------------------------------------------------
+// Low-level I2C — single-byte transactions only (see header)
+// ---------------------------------------------------------------------------
+bool TR_MP2672::readReg(uint8_t reg, uint8_t& value)
+{
+    if (_dev == nullptr) return false;
+    return i2c_master_transmit_receive(_dev, &reg, 1, &value, 1,
+                                       I2C_TIMEOUT_MS) == ESP_OK;
+}
+
+bool TR_MP2672::writeReg(uint8_t reg, uint8_t value)
+{
+    if (_dev == nullptr) return false;
+    uint8_t buf[2] = { reg, value };
+    return i2c_master_transmit(_dev, buf, 2, I2C_TIMEOUT_MS) == ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// Desired register images
+// ---------------------------------------------------------------------------
+uint8_t TR_MP2672::desiredReg00() const
+{
+    // VBATT_PRE fixed at the -0000 default 100b (6.4 V pack / 3.2 V per
+    // cell); bit0 kept 0 (meaning differs between MP2672 and MP2672A —
+    // 0 is safe on both).
+    uint8_t vreg = _cfg.vbatt_reg_code;
+    if (vreg > 6) vreg = 1;  // code 7 is variant-ambiguous (9.0 vs 8.2 V) — refuse
+    return (uint8_t)((vreg << 5) |
+                     (_cfg.charge_enable ? (1u << 4) : 0) |
+                     (0x4 << 1));
+}
+
+uint8_t TR_MP2672::desiredReg01() const
+{
+    // NTC_TYPE = JEITA (the -0000 default; harmless with the fixed NTC
+    // divider), balance thresholds at defaults (3.5 V start, 50 mV).
+    return (uint8_t)(0x80 | (_cfg.icc_code & 0x0F));
+}
+
+uint8_t TR_MP2672::desiredReg02() const
+{
+    // FSW 1.2 MHz (default), watchdog ON at 40 s (host-crash posture: on
+    // expiry the chip reverts to 8.4 V / RISET-clamped defaults and keeps
+    // charging safely), safety timer per config, bit0 = 1 (default on both
+    // variants). Kick bit (6) is OR'd in by service().
+    return (uint8_t)((1u << 7) | (0x1 << 4) |
+                     ((_cfg.chg_timer_code & 0x3) << 1) | 0x01);
+}
+
+// ---------------------------------------------------------------------------
+// applyConfig — write + readback-verify (silent-write-refusal field reports)
+// ---------------------------------------------------------------------------
+bool TR_MP2672::applyConfig()
+{
+    struct { uint8_t reg; uint8_t val; } seq[] = {
+        { Reg::REG01, desiredReg01() },
+        { Reg::REG02, desiredReg02() },
+        { Reg::REG00, desiredReg00() },  // enable last, once limits are in
+    };
+    bool ok = true;
+    for (const auto& w : seq)
+    {
+        uint8_t back = 0xFF;
+        if (!writeReg(w.reg, w.val) || !readReg(w.reg, back) || back != w.val)
+        {
+            // The kick bit self-behavior is undocumented; exclude bit6 from
+            // the REG02 comparison.
+            if (w.reg == Reg::REG02 && (back & ~0x40) == (w.val & ~0x40))
+                continue;
+            ESP_LOGW(TAG, "REG%02X write not verified (wrote 0x%02X, read 0x%02X)",
+                     w.reg, w.val, back);
+            _data.write_verify_fails++;
+            ok = false;
+        }
+    }
+    if (ok)
+    {
+        _data.config_applies++;
+        ESP_LOGI(TAG, "config applied: REG00=0x%02X REG01=0x%02X REG02=0x%02X "
+                      "(%s, vreg code %u, ICC code %u)",
+                 desiredReg00(), desiredReg01(), desiredReg02(),
+                 _cfg.charge_enable ? "charge enabled" : "charge DISABLED",
+                 _cfg.vbatt_reg_code, _cfg.icc_code);
+    }
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// begin
+// ---------------------------------------------------------------------------
+esp_err_t TR_MP2672::begin(i2c_master_bus_handle_t bus,
+                           const TR_MP2672_Config& cfg,
+                           uint32_t clock_hz)
+{
+    _cfg = cfg;
+
+    i2c_device_config_t dev_cfg = {};
+    dev_cfg.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+    dev_cfg.device_address  = _addr;
+    dev_cfg.scl_speed_hz    = clock_hz;
+
+    esp_err_t err = i2c_master_bus_add_device(bus, &dev_cfg, &_dev);
+    if (err != ESP_OK) return err;
+
+    // First reconcile now — detects whether a charge input is already
+    // attached and configures immediately if so.
+    service();
+    ESP_LOGI(TAG, "pack charger driver up (0x%02X): %s", _addr,
+             _data.present ? "chip answering (input present)"
+                           : "no answer — charge input absent (normal)");
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// service — the reconcile pass
+// ---------------------------------------------------------------------------
+void TR_MP2672::service()
+{
+    if (_dev == nullptr) return;
+
+    const bool was_present = _data.present;
+    uint8_t r00 = 0;
+    if (!readReg(Reg::REG00, r00))
+    {
+        // Chip unpowered (VCC LDO runs from VIN): input absent — not an
+        // error. All config was lost; re-apply on next appearance.
+        _data.present = false;
+        _config_applied = false;
+        if (was_present)
+        {
+            ESP_LOGI(TAG, "charge input removed (chip unpowered)");
+            _data.state = MP2672ChargeState::NotCharging;
+            _data.faults = 0;
+            _data.status_raw = 0;
+        }
+        return;
+    }
+    _data.present = true;
+    if (!was_present)
+    {
+        ESP_LOGI(TAG, "charge input attached (REG00=0x%02X on wake)", r00);
+    }
+
+    // (Re)apply config on first contact after plug-in, or when the live
+    // REG00 drifted from desired (watchdog expiry silently reverts it).
+    if (!_config_applied || r00 != desiredReg00())
+    {
+        _config_applied = applyConfig();
+    }
+    else
+    {
+        // Kick the 40 s watchdog by rewriting REG02 with the kick bit.
+        writeReg(Reg::REG02, (uint8_t)(desiredReg02() | 0x40));
+    }
+
+    uint8_t r03 = 0, r04 = 0;
+    if (readReg(Reg::REG03, r03))
+    {
+        const auto new_state = (MP2672ChargeState)((r03 & Reg::CHG_STAT_MASK)
+                                                   >> Reg::CHG_STAT_SHIFT);
+        if (new_state != _data.state)
+        {
+            ESP_LOGI(TAG, "charge state: %s -> %s (REG03=0x%02X)",
+                     stateName(_data.state), stateName(new_state), r03);
+        }
+        _data.state          = new_state;
+        _data.status_raw     = r03;
+        _data.battery_absent = (r03 & Reg::BATTFLOAT_STAT) != 0;
+        _data.in_ppm         = (r03 & Reg::PPM_STAT) != 0;
+        _data.in_thermal_reg = (r03 & Reg::THERM_STAT) != 0;
+        _data.in_vsys_reg    = (r03 & Reg::VSYS_STAT) != 0;
+    }
+    if (readReg(Reg::REG04, r04))
+    {
+        if (r04 != _data.faults && r04 != 0)
+        {
+            ESP_LOGW(TAG, "faults 0x%02X:%s%s%s%s%s ntc=%u", r04,
+                     (r04 & Reg::WD_FAULT)      ? " WD"       : "",
+                     (r04 & Reg::INPUT_FAULT)   ? " INPUT_OVP": "",
+                     (r04 & Reg::THERMSD_FAULT) ? " THERM_SD" : "",
+                     (r04 & Reg::TIMER_FAULT)   ? " SAFETY_TMR" : "",
+                     (r04 & Reg::BAT_FAULT)     ? " BATT_OVP" : "",
+                     (unsigned)(r04 & Reg::NTC_FAULT_MASK));
+        }
+        else if (r04 == 0 && _data.faults != 0)
+        {
+            ESP_LOGI(TAG, "faults cleared");
+        }
+        if (r04 & Reg::WD_FAULT)
+        {
+            // Watchdog expired since last pass — registers reverted; force a
+            // config re-apply next block above on the following service().
+            _config_applied = false;
+        }
+        _data.faults = r04;
+    }
+}
+
+const char* TR_MP2672::stateName(MP2672ChargeState s)
+{
+    switch (s)
+    {
+        case MP2672ChargeState::NotCharging: return "not-charging";
+        case MP2672ChargeState::PreCharge:   return "pre-charge";
+        case MP2672ChargeState::FastCharge:  return "fast-charge (CC/CV)";
+        case MP2672ChargeState::Done:        return "done";
+    }
+    return "?";
+}
+
+void TR_MP2672::logDiagnostics(const char* log_tag)
+{
+    if (_dev == nullptr) return;
+    uint8_t v = 0;
+    ESP_LOGI(log_tag, "[CHG-DIAG] --- MP2672 register dump ---");
+    if (!_data.present)
+    {
+        ESP_LOGI(log_tag, "[CHG-DIAG] chip unpowered (no charge input)");
+        return;
+    }
+    for (uint8_t r = Reg::REG00; r <= Reg::REG04; ++r)
+    {
+        if (readReg(r, v))
+            ESP_LOGI(log_tag, "[CHG-DIAG] REG%02X = 0x%02X", r, v);
+    }
+    ESP_LOGI(log_tag, "[CHG-DIAG] state=%s battery_absent=%d ppm=%d therm=%d "
+                      "vsys=%d applies=%lu verify_fails=%lu",
+             stateName(_data.state), (int)_data.battery_absent,
+             (int)_data.in_ppm, (int)_data.in_thermal_reg,
+             (int)_data.in_vsys_reg,
+             (unsigned long)_data.config_applies,
+             (unsigned long)_data.write_verify_fails);
+    ESP_LOGI(log_tag, "[CHG-DIAG] --------------------------------");
+}

--- a/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.h
+++ b/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.h
@@ -1,0 +1,141 @@
+#ifndef TR_MP2672_H
+#define TR_MP2672_H
+
+#include <compat.h>
+#include <driver/i2c_master.h>
+
+// MPS MP2672 (MP2672GD-0000-Z) — 2-cell-series Li-ion boost charger with
+// cell balancing, used on the V3 base station to charge external 2S rocket
+// flight packs from the 5 V input. I2C 7-bit address 0x4B, five host
+// registers 0x00-0x04 (REG05/06 are factory OTP, not accessible).
+//
+// Driver shape is dictated by three datasheet realities (MP2672 Rev 0.2
+// preliminary + MP2672A Rev 1.0 — "mostly interchangeable" per MPS):
+//  1. VOLATILE CONFIG: the VCC LDO is powered from VIN, so with no charge
+//     input the chip is dead — I2C NACKs mean "input absent", not a bus
+//     fault, and every register resets to -0000 defaults on each plug-in.
+//  2. I2C WATCHDOG: 40 s by default; expiry reverts the WD=Y register bits
+//     to defaults (charging continues at RISET-clamped full scale) and sets
+//     WD_FAULT. We keep the watchdog ON as the host-crash posture and kick
+//     it every service() pass.
+//  3. WRITE VERIFICATION: field reports of parts silently refusing writes —
+//     every write is read back; persistent mismatch is surfaced.
+// => service() is a reconcile-to-desired-state loop: (re)detect the chip,
+//    (re)apply config whenever it POR'd or drifted, kick the watchdog, poll
+//    status/faults, and log transitions under its own tag.
+//
+// Only single-byte transactions are used (the production MP2672A datasheet
+// documents single-byte R/W only; no auto-increment).
+//
+// Current scaling: fast-charge current = full_scale * (5 + code) / 20 where
+// full_scale = 12 kΩ / RISET amps (RISET is a board resistor). Code 0 is
+// therefore always the minimum (25% of full scale) — the safe default until
+// the board's RISET value is confirmed on the bench. The -0000 default is
+// code 15 = full scale, which is also the hardware clamp the pack falls
+// back to if the watchdog fires with a dead host: RISET, not software, is
+// the real current backstop. Choose RISET accordingly.
+
+namespace MP2672_Reg {
+    static constexpr uint8_t REG00 = 0x00;  // VBATT_REG[7:5] CHG_CONFIG[4] VBATT_PRE[3:1]
+    static constexpr uint8_t REG01 = 0x01;  // NTC_TYPE[7] balance[6:4] ICC[3:0]
+    static constexpr uint8_t REG02 = 0x02;  // FSW[7] WD_KICK[6] WD_TIMER[5:4] RST[3] CHG_TMR[2:1]
+    static constexpr uint8_t REG03 = 0x03;  // status (RO)
+    static constexpr uint8_t REG04 = 0x04;  // faults (RO)
+
+    // REG03 status bits
+    static constexpr uint8_t CHG_STAT_SHIFT = 4;   // [5:4]
+    static constexpr uint8_t CHG_STAT_MASK  = 0x30;
+    static constexpr uint8_t PPM_STAT       = 1u << 3;
+    static constexpr uint8_t BATTFLOAT_STAT = 1u << 2;
+    static constexpr uint8_t THERM_STAT     = 1u << 1;
+    static constexpr uint8_t VSYS_STAT      = 1u << 0;
+
+    // REG04 fault bits
+    static constexpr uint8_t WD_FAULT       = 1u << 7;
+    static constexpr uint8_t INPUT_FAULT    = 1u << 6;   // input OVP (>6.0 V)
+    static constexpr uint8_t THERMSD_FAULT  = 1u << 5;
+    static constexpr uint8_t TIMER_FAULT    = 1u << 4;
+    static constexpr uint8_t BAT_FAULT      = 1u << 3;   // battery OVP
+    static constexpr uint8_t NTC_FAULT_MASK = 0x07;
+}
+
+enum class MP2672ChargeState : uint8_t {
+    NotCharging = 0,   // REG03 CHG_STAT 00
+    PreCharge   = 1,   // 01
+    FastCharge  = 2,   // 10 (CC or CV — no separate CV code)
+    Done        = 3,   // 11
+};
+
+struct TR_MP2672_Config
+{
+    // REG00 VBATT_REG[2:0]: pack regulation = 8.3 V + code * 100 mV.
+    // 1 = 8.4 V (4.2 V/cell). Never exceed 1 for LiPo; code 7 is ambiguous
+    // across MP2672/MP2672A silicon (9.0 vs 8.2 V) — the driver refuses it.
+    uint8_t vbatt_reg_code = 1;
+
+    // REG01 ICC[3:0]: fast-charge current = full_scale*(5+code)/20.
+    // Default 0 = minimum (25% of RISET full scale) until RISET is known.
+    uint8_t icc_code = 0;
+
+    // REG02 CHG_TMR[1:0]: fast-charge safety timer. 01 = 8 h (the one
+    // encoding both datasheet revisions agree on).
+    uint8_t chg_timer_code = 1;
+
+    bool charge_enable = true;   // REG00 CHG_CONFIG
+};
+
+struct TR_MP2672_Data
+{
+    bool present = false;            // chip answered on the last service()
+    MP2672ChargeState state = MP2672ChargeState::NotCharging;
+    bool battery_absent = false;     // BATTFLOAT_STAT
+    bool in_ppm = false;             // input voltage-limit regulation
+    bool in_thermal_reg = false;
+    bool in_vsys_reg = false;        // pack below VBATT_PRE or absent
+    uint8_t faults = 0;              // raw REG04
+    uint8_t status_raw = 0;          // raw REG03
+    uint32_t config_applies = 0;     // times config was (re)applied
+    uint32_t write_verify_fails = 0;
+};
+
+class TR_MP2672
+{
+public:
+    explicit TR_MP2672(uint8_t addr = 0x4B);
+
+    // Adds the device to the bus. Succeeds even when the charger is
+    // unpowered (no charge input) — presence is (re)detected per service().
+    esp_err_t begin(i2c_master_bus_handle_t bus,
+                    const TR_MP2672_Config& cfg,
+                    uint32_t clock_hz = 400000);
+
+    // Reconcile pass — call on the battery-poll cadence (a few seconds;
+    // must be well inside the 40 s watchdog). Cheap when unpowered (one
+    // failed read). Logs state/fault/presence transitions.
+    void service();
+
+    const TR_MP2672_Data& data() const { return _data; }
+    bool present() const { return _data.present; }
+    MP2672ChargeState state() const { return _data.state; }
+    static const char* stateName(MP2672ChargeState s);
+
+    // One-shot register dump.
+    void logDiagnostics(const char* log_tag);
+
+    bool readReg(uint8_t reg, uint8_t& value);
+    bool writeReg(uint8_t reg, uint8_t value);
+
+private:
+    uint8_t desiredReg00() const;
+    uint8_t desiredReg01() const;
+    uint8_t desiredReg02() const;   // without the kick bit
+    bool applyConfig();             // write + readback-verify REG01/02/00
+
+    i2c_master_dev_handle_t _dev;
+    uint8_t                 _addr;
+    TR_MP2672_Config        _cfg;
+    TR_MP2672_Data          _data;
+    bool                    _config_applied;
+};
+
+#endif

--- a/tinkerrocket-idf/components/TR_RadioLink/IRadioLink.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/IRadioLink.h
@@ -58,4 +58,25 @@ public:
     virtual void serviceTxWatchdog() = 0;
 
     virtual void getStats(TR_LoRa_Comms::Stats& out) const = 0;
+
+    // ---- Spectrum scan (pre-launch collision avoidance; BS caller, #414) --
+    // Mirrors the TR_LoRa_Comms scan surface exactly (same call-site-audit
+    // rule as above — this is the set the BS application uses). Contract:
+    // startScan() kicks off a sweep (refused mid-TX or mid-scan); the caller
+    // then calls serviceScan() every loop iteration until isScanDone(),
+    // reads the samples, and consumeScanDone()s. A backend must NEVER leave
+    // isScanDone() false forever after a startScan() that returned true —
+    // the BS gates uplink TX on scan state (#379), so a wedged scan mutes
+    // the uplink. On any failure path (modem reboot, lost SCAN_RESULT) the
+    // backend reports done-with-zero-samples instead.
+    // TR_LoRa_Comms::ScanSample is the shared sample currency.
+    virtual bool startScan(float start_mhz, float stop_mhz, uint16_t step_khz,
+                           uint16_t dwell_ms) = 0;
+    virtual void serviceScan() = 0;
+    virtual bool isScanDone() const = 0;
+    virtual void consumeScanDone() = 0;
+    virtual size_t getScanSampleCount() const = 0;
+    virtual const TR_LoRa_Comms::ScanSample* getScanSamples() const = 0;
+    virtual float getScanStartMHz() const = 0;
+    virtual float getScanStepKHz() const = 0;
 };

--- a/tinkerrocket-idf/components/TR_RadioLink/LoRaDirectBackend.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/LoRaDirectBackend.h
@@ -46,6 +46,22 @@ public:
 
     void getStats(TR_LoRa_Comms::Stats& out) const override { lora_.getStats(out); }
 
+    bool startScan(float start_mhz, float stop_mhz, uint16_t step_khz,
+                   uint16_t dwell_ms) override
+    {
+        return lora_.startScan(start_mhz, stop_mhz, step_khz, dwell_ms);
+    }
+    void serviceScan() override { lora_.serviceScan(); }
+    bool isScanDone() const override { return lora_.isScanDone(); }
+    void consumeScanDone() override { lora_.consumeScanDone(); }
+    size_t getScanSampleCount() const override { return lora_.getScanSampleCount(); }
+    const TR_LoRa_Comms::ScanSample* getScanSamples() const override
+    {
+        return lora_.getScanSamples();
+    }
+    float getScanStartMHz() const override { return lora_.getScanStartMHz(); }
+    float getScanStepKHz() const override { return lora_.getScanStepKHz(); }
+
 private:
     TR_LoRa_Comms lora_;
 };

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
@@ -22,6 +22,15 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
 {
     cfg_ = cfg;
     debug_ = debug;
+    // Seed the cached radio params with the host's DESIRED config before we
+    // know whether a modem is attached. If begin() times out (daughterboard
+    // absent/unpowered at boot) but the modem shows up later, its BOOT frame
+    // hot-joins: the handler below re-pushes these values instead of zeros.
+    cfg_freq_mhz_ = freq_mhz;
+    cfg_sf_ = sf;
+    cfg_bw_khz_ = bw_khz;
+    cfg_cr_ = cr;
+    cfg_tx_power_ = tx_power;
 
     if (cfg.act_pin >= 0)
     {
@@ -67,6 +76,9 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
              (int)identity_.max_tx_power_dbm,
              (double)identity_.freq_min_mhz, (double)identity_.freq_max_mhz);
 
+    // A BOOT received during the wait loop above queues a deferred re-push;
+    // moot now — begin() pushes the same config itself right here.
+    config_repush_pending_ = false;
     if (!pushConfig(freq_mhz, sf, bw_khz, cr, tx_power, /*start_rx=*/true,
                     /*ack_timeout_ms=*/500))
     {
@@ -198,6 +210,38 @@ void UartModemBackend::onFrame(uint8_t type, const uint8_t* payload, size_t len)
             break;
         }
 
+        case MSG_SCAN_RESULT:
+        {
+            if (len < sizeof(ScanResultHeader))
+            {
+                break;
+            }
+            ScanResultHeader hdr;
+            memcpy(&hdr, payload, sizeof(hdr));
+            size_t n = hdr.count;
+            if (n > TR_LoRa_Comms::SCAN_MAX_SAMPLES)
+            {
+                n = TR_LoRa_Comms::SCAN_MAX_SAMPLES;
+            }
+            if (n > len - sizeof(hdr))
+            {
+                n = len - sizeof(hdr);
+            }
+            const uint8_t* rssi = payload + sizeof(hdr);
+            for (size_t i = 0; i < n; i++)
+            {
+                scan_samples_[i].freq_mhz =
+                    hdr.start_mhz + (float)i * hdr.step_khz / 1000.0f;
+                scan_samples_[i].rssi_dbm = (int8_t)rssi[i];
+            }
+            scan_start_mhz_ = hdr.start_mhz;
+            scan_step_khz_ = hdr.step_khz;
+            scan_count_ = n;
+            scan_active_ = false;
+            scan_done_ = true;
+            break;
+        }
+
         case MSG_STATUS:
         {
             if (len != sizeof(ModemStatusData))
@@ -222,20 +266,30 @@ void UartModemBackend::onFrame(uint8_t type, const uint8_t* payload, size_t len)
             memcpy(&identity_, payload, sizeof(identity_));
             const bool was_alive = modem_alive_;
             modem_alive_ = true;
-            if (type == MSG_BOOT && was_alive)
+            if (type == MSG_BOOT)
             {
-                // Daughterboard rebooted underneath us (brownout / watchdog):
-                // its queue is empty and its radio is on boot defaults.
-                // Clear the in-flight slot and re-push our config.
-                ESP_LOGW(TAG, "modem REBOOTED — re-pushing radio config");
+                // Daughterboard (re)booted underneath us: either it rebooted
+                // (brownout / watchdog) or it hot-joined after a begin()
+                // timeout. Its queue is empty and its radio is on boot
+                // defaults — clear the in-flight slot, fail any active scan
+                // (its SCAN_RESULT is never coming), and re-push our config.
+                // The push is DEFERRED to service(): pushConfig() polls the
+                // link, and calling it from inside this frame handler would
+                // re-enter link_.poll() mid-chunk.
+                ESP_LOGW(TAG, "modem %s — re-pushing radio config",
+                         was_alive ? "REBOOTED" : "hot-joined");
                 if (tx_in_flight_)
                 {
                     tx_in_flight_ = false;
                     stats_.tx_fail++;
                 }
-                (void)pushConfig(cfg_freq_mhz_, cfg_sf_, cfg_bw_khz_, cfg_cr_,
-                                 cfg_tx_power_, /*start_rx=*/true,
-                                 /*ack_timeout_ms=*/300);
+                if (scan_active_)
+                {
+                    scan_active_ = false;
+                    scan_done_ = true;
+                    scan_count_ = 0;
+                }
+                config_repush_pending_ = true;
             }
             break;
         }
@@ -261,6 +315,15 @@ void UartModemBackend::service()
         return;
     }
     link_.poll(&UartModemBackend::onFrameTrampoline, this);
+
+    // Deferred BOOT config re-push (see onFrame) — outside the poll handler.
+    if (config_repush_pending_ && modem_alive_)
+    {
+        config_repush_pending_ = false;
+        (void)pushConfig(cfg_freq_mhz_, cfg_sf_, cfg_bw_khz_, cfg_cr_,
+                         cfg_tx_power_, /*start_rx=*/true,
+                         /*ack_timeout_ms=*/300);
+    }
 }
 
 bool UartModemBackend::send(const uint8_t* payload, size_t len)
@@ -404,6 +467,61 @@ void UartModemBackend::serviceTxWatchdog()
         stats_.transmitting = false;
         stats_.tx_fail++;
         stats_.tx_watchdog_fires++;
+    }
+}
+
+bool UartModemBackend::startScan(float start_mhz, float stop_mhz,
+                                 uint16_t step_khz, uint16_t dwell_ms)
+{
+    if (!modem_alive_ || scan_active_ || tx_in_flight_ || step_khz == 0 ||
+        stop_mhz <= start_mhz)
+    {
+        // Mirrors the direct driver's refusals (no scan mid-TX/mid-scan);
+        // the caller retries.
+        return false;
+    }
+
+    ScanRequestData d = {};
+    d.start_mhz = start_mhz;
+    d.stop_mhz = stop_mhz;
+    d.step_khz = step_khz;
+    d.dwell_ms = dwell_ms;
+    if (!link_.sendFrame(MSG_START_SCAN, reinterpret_cast<uint8_t*>(&d),
+                         sizeof(d)))
+    {
+        return false;
+    }
+
+    // The modem is silent when it refuses/drops a scan, so bound the wait:
+    // sweep duration (steps x dwell, plus per-step retune overhead) doubled,
+    // plus fixed slack for queueing + the result frame.
+    uint32_t steps = (uint32_t)((stop_mhz - start_mhz) * 1000.0f / step_khz) + 1;
+    if (steps > TR_LoRa_Comms::SCAN_MAX_SAMPLES)
+    {
+        steps = TR_LoRa_Comms::SCAN_MAX_SAMPLES;
+    }
+    scan_deadline_ms_ = millis() + 2 * steps * (dwell_ms + 5) + 3000;
+
+    scan_active_ = true;
+    scan_done_ = false;
+    scan_count_ = 0;
+    scan_start_mhz_ = start_mhz;
+    scan_step_khz_ = step_khz;
+    return true;
+}
+
+void UartModemBackend::serviceScan()
+{
+    // The sweep itself runs on the modem; frames drain via service(). Our
+    // only job here is the never-wedge guarantee (IRadioLink contract):
+    // a lost SCAN_RESULT must not gate the BS uplink forever (#379).
+    if (scan_active_ && (int32_t)(millis() - scan_deadline_ms_) > 0)
+    {
+        ESP_LOGW(TAG, "scan timed out (SCAN_RESULT never arrived) — "
+                      "reporting empty scan");
+        scan_active_ = false;
+        scan_done_ = true;
+        scan_count_ = 0;
     }
 }
 

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
@@ -69,6 +69,25 @@ public:
 
     void getStats(TR_LoRa_Comms::Stats& out) const override;
 
+    // Spectrum scan (#414): START_SCAN is fire-and-forget on the wire —
+    // the modem runs the sweep autonomously and answers with one
+    // SCAN_RESULT frame, which we cache so every query answers locally.
+    // The modem is silent on a refused/dropped scan, so a host-side
+    // deadline (sweep duration + margin) fails the scan as
+    // done-with-zero-samples; a modem BOOT mid-scan does the same.
+    bool startScan(float start_mhz, float stop_mhz, uint16_t step_khz,
+                   uint16_t dwell_ms) override;
+    void serviceScan() override;
+    bool isScanDone() const override { return scan_done_; }
+    void consumeScanDone() override { scan_done_ = false; }
+    size_t getScanSampleCount() const override { return scan_count_; }
+    const TR_LoRa_Comms::ScanSample* getScanSamples() const override
+    {
+        return scan_samples_;
+    }
+    float getScanStartMHz() const override { return scan_start_mhz_; }
+    float getScanStepKHz() const override { return scan_step_khz_; }
+
     // Modem-side identity captured from BOOT/IDENTITY (fw version, chip,
     // capabilities) — surfaced for status/logging.
     const radio_modem::ModemIdentityData& identity() const { return identity_; }
@@ -117,6 +136,18 @@ private:
 
     // STATUS ack tracking for reconfigure()
     uint32_t status_rx_count_ = 0;
+
+    // BOOT config re-push deferred out of the frame handler (see onFrame)
+    bool config_repush_pending_ = false;
+
+    // Scan state (cached SCAN_RESULT; see startScan comment)
+    bool scan_active_ = false;
+    bool scan_done_ = false;
+    uint32_t scan_deadline_ms_ = 0;
+    size_t scan_count_ = 0;
+    float scan_start_mhz_ = 0.0f;
+    float scan_step_khz_ = 0.0f;
+    TR_LoRa_Comms::ScanSample scan_samples_[TR_LoRa_Comms::SCAN_MAX_SAMPLES] = {};
 
     // Stats mirror in TR_LoRa_Comms currency (fed by TX_RESULT / RX_FRAME /
     // STATUS)

--- a/tinkerrocket-idf/projects/base_station/dependencies.lock
+++ b/tinkerrocket-idf/projects/base_station/dependencies.lock
@@ -23,11 +23,11 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.3.2
+    version: 6.0.1
   spi_nand_flash:
     dependencies: []
     source:
-      path: /Users/christianpedersen/Documents/Hobbies/ModelRockets/Code/tinkerrocket-idf/components/spi_nand_flash
+      path: ../../components/spi_nand_flash
       type: local
     version: 1.0.3
 direct_dependencies:
@@ -36,4 +36,4 @@ direct_dependencies:
 - idf
 manifest_hash: f64261c42547eac634a21ceaf9a8c6809f180d102872059d406cdf289483de8d
 target: esp32s3
-version: 2.0.0
+version: 3.0.0

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -11,6 +11,7 @@ idf_component_register(
         TR_LoRa_Comms
         TR_RadioLink
         TR_MAX17205G
+        TR_MAX17303
         TR_BQ27Z746
         TR_OTA
         app_update

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
         TR_RadioLink
         TR_MAX17205G
         TR_MAX17303
+        TR_MP2672
         TR_BQ27Z746
         TR_OTA
         app_update

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -24,3 +24,11 @@ idf_component_register(
         spi_nand_flash_fatfs
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)
+
+# Board revision selection (OC #411 pattern): `idf.py -DTR_BS_BOARD=<1|2|3>
+# build` compiles the matching main/board/board_v*.h pin map; default is V2.
+# Use a separate build dir per variant (e.g. -B build_v3) — the flag is
+# cached by CMake.
+if(TR_BS_BOARD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BS_BOARD=${TR_BS_BOARD})
+endif()

--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -9,6 +9,7 @@ idf_component_register(
         TR_Coordinates
         TR_BLE_To_APP
         TR_LoRa_Comms
+        TR_RadioLink
         TR_MAX17205G
         TR_BQ27Z746
         TR_OTA

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
@@ -51,6 +51,10 @@ struct board_pins
     static constexpr int I2C_SCL_PIN = 37;
     static constexpr int I2C_SDA_PIN = 38;
 
+    // No MAX17303 on this board — 0x36 is the MAX17205; the strict DevName
+    // check keeps the MAX17303 driver from claiming it.
+    static constexpr bool EXPECT_MAX17303 = false;
+
     // --- Flight-pack charger (MP2672): V3-only feature ---
     static constexpr bool HAS_PACK_CHARGER = false;
 };

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// V1 (original) base-station PCB pin map + board topology.
+// Selected with TR_BS_BOARD=1:  idf.py -B build_v1 -DTR_BS_BOARD=1 build
+//
+// Topology: MAX17205 fuel gauge (2S NCR18650B), SD card over SDMMC 4-bit,
+// direct SPI LLCC68 on-board. The fuel gauge itself is still runtime-probed
+// (see main.cpp) so the board headers only carry what silicon can't answer:
+// pins and peripheral presence.
+struct board_pins
+{
+    static constexpr const char* BOARD_NAME = "V1 (original)";
+
+    // --- LoRa radio: direct SPI LLCC68 on-board ---
+    static constexpr bool USE_UART_RADIO_MODEM = false;
+    static constexpr int LORA_SPI_SCK  = 36;
+    static constexpr int LORA_SPI_MISO = 34;
+    static constexpr int LORA_SPI_MOSI = 35;
+    static constexpr int LORA_CS_PIN   = 38;
+    static constexpr int LORA_DIO1_PIN = 18;
+    static constexpr int LORA_RST_PIN  = 37;
+    static constexpr int LORA_BUSY_PIN = 17;
+    static constexpr int LORA_RXEN_PIN = -1;   // no RF switch on the original PCB
+    static constexpr int LORA_DIO2_PIN = -1;
+    static constexpr int LORA_DIO3_PIN = -1;
+
+    // --- Radio daughterboard host link: not present on this board ---
+    static constexpr int LORA_UART_TX_PIN = -1;
+    static constexpr int LORA_UART_RX_PIN = -1;
+    static constexpr int LORA_ACT_PIN     = -1;
+
+    // --- Storage: SD card over SDMMC 4-bit ---
+    static constexpr bool HAS_SDMMC    = true;
+    static constexpr bool HAS_EXT_NAND = false;
+    static constexpr int SD_CLK = 6;
+    static constexpr int SD_CMD = 7;
+    static constexpr int SD_D0  = 5;
+    static constexpr int SD_D1  = 4;
+    static constexpr int SD_D2  = 9;
+    static constexpr int SD_D3  = 8;
+    static constexpr int FLASH_SCK  = -1;   // no external SPI NAND
+    static constexpr int FLASH_MOSI = -1;
+    static constexpr int FLASH_CS   = -1;
+    static constexpr int FLASH_MISO = -1;
+
+    // --- I2C bus (fuel gauge) ---
+    // Carried over unchanged from the pre-board-header config.h ("same pins on
+    // both boards"). NOTE: these overlap LORA_RST_PIN(37)/LORA_CS_PIN(38)
+    // above — that conflict predates this refactor; if V1 hardware is ever
+    // flashed again, verify the gauge bus pins against the V1 schematic.
+    static constexpr int I2C_SCL_PIN = 37;
+    static constexpr int I2C_SDA_PIN = 38;
+
+    // --- Flight-pack charger (MP2672): V3-only feature ---
+    static constexpr bool HAS_PACK_CHARGER = false;
+};

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// V2 base-station PCB pin map + board topology (the board the pre-header
+// config.h called "the new PCB"). This is the DEFAULT board:
+//   idf.py build            (or explicitly: -B build_v2 -DTR_BS_BOARD=2)
+//
+// Topology: BQ27Z746 fuel gauge (1S, runtime-probed at 0x55), FORESEE
+// F35SQB004G SPI NAND for logging (M_* nets, SPI3_HOST — LoRa owns
+// SPI2_HOST), direct SPI LLCC68 on-board with the full RF-switch control
+// set (RXEN/DIO2/DIO3).
+struct board_pins
+{
+    static constexpr const char* BOARD_NAME = "V2 (BQ27Z746 + NAND + direct LLCC68)";
+
+    // --- LoRa radio: direct SPI LLCC68 on-board ---
+    // NOTE: LoRa RST = GPIO33 (differs from BOTH the prior config value 36
+    // and the original-board 37).
+    static constexpr bool USE_UART_RADIO_MODEM = false;
+    static constexpr int LORA_SPI_SCK  = 10;   // L_SCK
+    static constexpr int LORA_SPI_MISO = 13;   // L_MISO
+    static constexpr int LORA_SPI_MOSI = 12;   // L_MOSI
+    static constexpr int LORA_CS_PIN   = 11;   // L_CS
+    static constexpr int LORA_DIO1_PIN = 21;   // L_DIO1
+    static constexpr int LORA_RST_PIN  = 33;   // L_RST
+    static constexpr int LORA_BUSY_PIN = 14;   // L_BUSY
+    static constexpr int LORA_RXEN_PIN = 17;   // L_RXEN (RF switch RX enable)
+    static constexpr int LORA_DIO2_PIN = 18;   // L_DIO2
+    static constexpr int LORA_DIO3_PIN = 3;    // L_DIO3
+
+    // --- Radio daughterboard host link: not present on this board ---
+    static constexpr int LORA_UART_TX_PIN = -1;
+    static constexpr int LORA_UART_RX_PIN = -1;
+    static constexpr int LORA_ACT_PIN     = -1;
+
+    // --- Storage: external SPI NAND (FORESEE F35SQB004G) ---
+    static constexpr bool HAS_SDMMC    = false;
+    static constexpr bool HAS_EXT_NAND = true;
+    static constexpr int FLASH_SCK  = 4;   // M_SCK
+    static constexpr int FLASH_MOSI = 5;   // M_MOSI
+    static constexpr int FLASH_CS   = 6;   // M_FLASH_CS
+    static constexpr int FLASH_MISO = 7;   // M_MISO
+    static constexpr int SD_CLK = -1;      // no SD slot
+    static constexpr int SD_CMD = -1;
+    static constexpr int SD_D0  = -1;
+    static constexpr int SD_D1  = -1;
+    static constexpr int SD_D2  = -1;
+    static constexpr int SD_D3  = -1;
+
+    // --- I2C bus (fuel gauge; SCL_SENS/SDA_SENS nets) ---
+    static constexpr int I2C_SCL_PIN = 37;
+    static constexpr int I2C_SDA_PIN = 38;
+
+    // --- Flight-pack charger (MP2672): V3-only feature ---
+    static constexpr bool HAS_PACK_CHARGER = false;
+};

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
@@ -49,6 +49,9 @@ struct board_pins
     // --- I2C bus (fuel gauge; SCL_SENS/SDA_SENS nets) ---
     static constexpr int I2C_SCL_PIN = 37;
     static constexpr int I2C_SDA_PIN = 38;
+    // No MAX17303 on this board — an 0x36 answer must be a MAX17205 (V1
+    // firmware cross-flashed) and the strict DevName check applies.
+    static constexpr bool EXPECT_MAX17303 = false;
 
     // --- Flight-pack charger (MP2672): V3-only feature ---
     static constexpr bool HAS_PACK_CHARGER = false;

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// V3 base-station PCB pin map + board topology.
+// Selected with TR_BS_BOARD=3:  idf.py -B build_v3 -DTR_BS_BOARD=3 build
+//
+// What changed vs V2:
+//  - Fuel gauge: MAX17303 (1S, ModelGauge m5 + protector) replaces the
+//    BQ27Z746. Runtime-probed at 0x36 and disambiguated from the V1
+//    MAX17205 (same address) via DevName.
+//  - NEW: MP2672 2-cell charger for external rocket flight packs (same I2C
+//    bus as the gauge).
+//  - I2C moves to SDA=33 / SCL=34 (33/34 were LoRa RST / unused on V2).
+//  - Radio: no on-board LLCC68 — the V8 radio daughterboard (#409,
+//    projects/radio_board) connects over UART as a transparent modem,
+//    same topology as the V8 out computer (#410).
+//  - Storage: unchanged from V2 — FORESEE F35SQB004G SPI NAND on the same
+//    M_* nets/pins.
+struct board_pins
+{
+    static constexpr const char* BOARD_NAME = "V3 (MAX17303 + MP2672 + radio daughterboard)";
+
+    // --- LoRa radio: UART daughterboard (#409) — no direct LLCC68 ---
+    static constexpr bool USE_UART_RADIO_MODEM = true;
+    static constexpr int LORA_SPI_SCK  = -1;
+    static constexpr int LORA_SPI_MISO = -1;
+    static constexpr int LORA_SPI_MOSI = -1;
+    static constexpr int LORA_CS_PIN   = -1;
+    static constexpr int LORA_DIO1_PIN = -1;
+    static constexpr int LORA_RST_PIN  = -1;
+    static constexpr int LORA_BUSY_PIN = -1;
+    static constexpr int LORA_RXEN_PIN = -1;
+    static constexpr int LORA_DIO2_PIN = -1;
+    static constexpr int LORA_DIO3_PIN = -1;
+
+    // --- Radio daughterboard host link ---
+    // Schematic labels LoRa_TX (GPIO35) / LoRa_RX (GPIO36): wired as-labeled
+    // (TX net = BS transmit), matching the OC V8 convention. CAUTION: TX/RX
+    // label perspective has been wrong on this schematic family before
+    // (RunCam, #234) — if the daughterboard's BOOT message never arrives on
+    // bring-up, swap these two first.
+    static constexpr int LORA_UART_TX_PIN = 35;  // LoRa_TX (label-perspective)
+    static constexpr int LORA_UART_RX_PIN = 36;  // LoRa_RX (label-perspective)
+    // No daughterboard power-gate net identified on the V3 schematic (the OC
+    // V8 has LoRa_ACT); set if one exists — it's also the recovery hammer for
+    // a wedged daughterboard (#412).
+    static constexpr int LORA_ACT_PIN = -1;
+
+    // --- Storage: external SPI NAND (FORESEE F35SQB004G), same as V2 ---
+    static constexpr bool HAS_SDMMC    = false;
+    static constexpr bool HAS_EXT_NAND = true;
+    static constexpr int FLASH_SCK  = 4;   // M_SCK
+    static constexpr int FLASH_MOSI = 5;   // M_MOSI
+    static constexpr int FLASH_CS   = 6;   // M_FLASH_CS
+    static constexpr int FLASH_MISO = 7;   // M_MISO
+    static constexpr int SD_CLK = -1;      // no SD slot
+    static constexpr int SD_CMD = -1;
+    static constexpr int SD_D0  = -1;
+    static constexpr int SD_D1  = -1;
+    static constexpr int SD_D2  = -1;
+    static constexpr int SD_D3  = -1;
+
+    // --- I2C bus (MAX17303 fuel gauge + MP2672 pack charger) ---
+    static constexpr int I2C_SCL_PIN = 34;
+    static constexpr int I2C_SDA_PIN = 33;
+
+    // --- Flight-pack charger (MP2672GD-0000-Z, external 2S packs) ---
+    static constexpr bool HAS_PACK_CHARGER = true;
+};

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
@@ -62,6 +62,11 @@ struct board_pins
     // --- I2C bus (MAX17303 fuel gauge + MP2672 pack charger) ---
     static constexpr int I2C_SCL_PIN = 34;
     static constexpr int I2C_SDA_PIN = 33;
+    // BOM assertion: the part at 0x36 IS a MAX17303 — claim it even if its
+    // DevName die rev is outside the known 0x404-0x406 range (first bench
+    // boot: an unlisted DevName silently demoted the gauge to the MAX17205
+    // driver's wrong register map).
+    static constexpr bool EXPECT_MAX17303 = true;
 
     // --- Flight-pack charger (MP2672GD-0000-Z, external 2S packs) ---
     static constexpr bool HAS_PACK_CHARGER = true;

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -3,55 +3,40 @@
 #include <cstdint>
 #include <RocketComputerTypes.h>  // LORA_FACTORY_RENDEZVOUS_* (#105)
 
-namespace config
-{
-    // --- Board variant (working toward a single firmware for both PCBs) ---
-    // V2 (=1): new PCB  -> BQ27Z746 gauge, SPI-flash storage, LoRa RST on GPIO33,
-    //                      extra LoRa control lines (RXEN/DIO2/DIO3) wired.
-    // V1 (=0): original -> MAX17205 gauge, SDMMC SD card, original LoRa pin map.
-    // The fuel gauge is auto-detected at runtime (probe 0x55 then 0x36), so it
-    // does NOT depend on this switch. Pins the silicon can't probe (LoRa, storage)
-    // are selected here at compile time for now; moving them to runtime board
-    // detection is the follow-up to fully unify into one binary.
-    #ifndef BS_BOARD_V2
-    #define BS_BOARD_V2 1
-    #endif
+// --- Board revision (OC #411 pattern) ---
+// Pins + peripheral-presence/topology flags live in the per-board headers
+// (main/board/board_v{1,2,3}.h); everything below is board-independent policy
+// and must not fork per revision. Select with a separate build dir per
+// variant (the flag is cached by CMake):
+//   V2 (default): idf.py build
+//   V1 original:  idf.py -B build_v1 -DTR_BS_BOARD=1 build
+//   V3 new PCB:   idf.py -B build_v3 -DTR_BS_BOARD=3 build
+// The fuel gauge is still auto-detected at runtime on the board's I2C bus
+// (BQ27Z746 0x55, then MAX17205/MAX17303 0x36 split by DevName), so it does
+// NOT depend on this switch. Pins the silicon can't probe (LoRa topology,
+// storage, the I2C bus itself) are compile-time.
+#ifndef TR_BS_BOARD
+#define TR_BS_BOARD 2
+#endif
+#if TR_BS_BOARD == 3
+#include "board/board_v3.h"
+#elif TR_BS_BOARD == 2
+#include "board/board_v2.h"
+#elif TR_BS_BOARD == 1
+#include "board/board_v1.h"
+#else
+#error "TR_BS_BOARD must be 1, 2, or 3"
+#endif
 
+struct config : board_pins
+{
     // --- Debug ---
     static constexpr bool DEBUG = true;
     static constexpr uint32_t STATS_PERIOD_MS = 5000;
 
-    // --- LoRa Radio (LLCC68 via RadioLib) ---
-    // Must match OutComputer radio parameters exactly.
-    // The V1 values below are the original-board assignments (previously the
-    // "//" comments here); V2 is the new-PCB schematic. NOTE: on the new board
-    // LoRa RST = GPIO33 (differs from BOTH the prior config value 36 and the
-    // original-board 37).
-#if BS_BOARD_V2
-    static constexpr int LORA_SPI_SCK  = 10;   // L_SCK
-    static constexpr int LORA_SPI_MISO = 13;   // L_MISO
-    static constexpr int LORA_SPI_MOSI = 12;   // L_MOSI
-    static constexpr int LORA_CS_PIN   = 11;   // L_CS
-    static constexpr int LORA_DIO1_PIN = 21;   // L_DIO1
-    static constexpr int LORA_RST_PIN  = 33;   // L_RST
-    static constexpr int LORA_BUSY_PIN = 14;   // L_BUSY
-    // Extra control lines wired on the new PCB (LLCC68):
-    static constexpr int LORA_RXEN_PIN = 17;   // L_RXEN (RF switch RX enable)
-    static constexpr int LORA_DIO2_PIN = 18;   // L_DIO2
-    static constexpr int LORA_DIO3_PIN = 3;    // L_DIO3
-#else
-    static constexpr int LORA_SPI_SCK  = 36;
-    static constexpr int LORA_SPI_MISO = 34;
-    static constexpr int LORA_SPI_MOSI = 35;
-    static constexpr int LORA_CS_PIN   = 38;
-    static constexpr int LORA_DIO1_PIN = 18;
-    static constexpr int LORA_RST_PIN  = 37;
-    static constexpr int LORA_BUSY_PIN = 17;
-    static constexpr int LORA_RXEN_PIN = -1;   // not wired on the original PCB
-    static constexpr int LORA_DIO2_PIN = -1;
-    static constexpr int LORA_DIO3_PIN = -1;
-#endif
-
+    // --- LoRa Radio (LLCC68 via RadioLib, or the UART radio daughterboard) ---
+    // Must match OutComputer radio parameters exactly. Pins + topology
+    // (direct SPI vs UART modem) are in the board headers.
     static constexpr float   LORA_FREQ_MHZ       = 915.0f;
     static constexpr uint8_t LORA_SF              = 8;
     static constexpr float   LORA_BW_KHZ          = 250.0f;
@@ -78,24 +63,10 @@ namespace config
     static constexpr uint32_t UPLINK_RETRY_INTERVAL_MS = 100;   // Delay between retries
 
     // --- Storage ---
-    // V2/new PCB logs to an external SPI NOR flash (M_*, on SPI3_HOST since LoRa
-    // owns SPI2_HOST); V1 uses an SDMMC SD card. Both mount as FAT behind
-    // SD_MOUNT_POINT, so the logging code is backend-agnostic. NOR is assumed
-    // (esp_flash auto-detects JEDEC ID/size); a SPI NAND part would need the
-    // spi_nand_flash component instead.
-#if BS_BOARD_V2
-    static constexpr int FLASH_SCK  = 4;   // M_SCK
-    static constexpr int FLASH_MOSI = 5;   // M_MOSI
-    static constexpr int FLASH_CS   = 6;   // M_FLASH_CS
-    static constexpr int FLASH_MISO = 7;   // M_MISO
-#endif
-    // --- SD Card (SDMMC 4-bit, original PCB) ---
-    static constexpr int SD_CLK  = 6;
-    static constexpr int SD_CMD  = 7;
-    static constexpr int SD_D0   = 5;
-    static constexpr int SD_D1   = 4;
-    static constexpr int SD_D2   = 9;
-    static constexpr int SD_D3   = 8;
+    // V2/V3 log to a FORESEE F35SQB004G SPI NAND (M_* nets, on SPI3_HOST since
+    // LoRa owns SPI2_HOST on V2); V1 uses an SDMMC SD card. Pins + presence
+    // flags (HAS_EXT_NAND / HAS_SDMMC) are in the board headers. Both mount as
+    // FAT behind SD_MOUNT_POINT, so the logging code is backend-agnostic.
 
     // --- LoRa CSV Logging ---
     // Close the log after 5 min of no rocket packets.  Long enough to ride
@@ -122,10 +93,8 @@ namespace config
     // cadence (Long Range preset ≈ 2 Hz) plus a couple of misses.
     static constexpr uint32_t BLE_TELEMETRY_STALE_MS = 3000;
 
-    // --- I2C Bus (fuel gauge; "SCL_SENS/SDA_SENS" on the new-PCB schematic) ---
-    // Same pins on both boards. External pull-ups on-board (internal OFF).
-    static constexpr int      I2C_SCL_PIN       = 37;
-    static constexpr int      I2C_SDA_PIN       = 38;
+    // --- I2C Bus (fuel gauge + V3 pack charger; pins in board headers) ---
+    // External pull-ups on-board (internal OFF).
     static constexpr uint32_t I2C_FREQ_HZ       = 400'000;  // 400 kHz
 
     // --- Device Identity (factory defaults, overridden by NVS on boot) ---
@@ -147,4 +116,4 @@ namespace config
     // (series doubles voltage, capacity stays per-cell). Written to MAX17205
     // DesignCap at boot to seed the ModelGauge m5 algorithm.
     static constexpr uint16_t BATTERY_DESIGN_MAH = 2800;
-}
+};

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -121,4 +121,15 @@ struct config : board_pins
     // (series doubles voltage, capacity stays per-cell). Written to MAX17205
     // DesignCap at boot to seed the ModelGauge m5 algorithm.
     static constexpr uint16_t BATTERY_DESIGN_MAH = 2800;
+
+    // --- Flight-pack charger (MP2672 on V3; gated by HAS_PACK_CHARGER) ---
+    static constexpr uint16_t MP2672_ADDR = 0x4B;
+    // Fast-charge current code (REG01 ICC[3:0]): I = FS*(5+code)/20 with
+    // FS = 12 kΩ / RISET amps — the current scale is set by the board's
+    // RISET resistor, not just this register. Code 0 = the selectable
+    // minimum (25% of full scale); raise only after RISET is confirmed on
+    // the bench, then size for ≲0.5C of the smallest flight pack.
+    static constexpr uint8_t PACK_CHARGE_ICC_CODE = 0;
+    static constexpr uint8_t PACK_VBATT_REG_CODE  = 1;   // 8.4 V pack (4.2 V/cell) — LiPo max
+    static constexpr uint8_t PACK_CHG_TIMER_CODE  = 1;   // 8 h fast-charge safety timer
 };

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -102,13 +102,18 @@ struct config : board_pins
     static constexpr const char* DEVICE_TYPE     = "B";  // "B" = base station
 
     // --- Battery Monitoring ---
-    // Fuel gauge is auto-detected at runtime: BQ27Z746 (new PCB) probed first at
-    // 0x55, then MAX17205 (original PCB) at 0x36. Both addresses are always
-    // defined so one firmware image covers both boards. The MAX17205-specific
-    // seed values (cells/Rsense/design mAh) below are used only on the MAX path;
+    // Fuel gauge is auto-detected at runtime on the board's I2C bus:
+    // BQ27Z746 (V2) probed first at 0x55, then 0x36 — where DevName picks
+    // MAX17303 (V3, 1S + protector) vs MAX17205 (V1, 2S). All addresses are
+    // always defined so one firmware image covers every board's bus. The
+    // seed values (cells/Rsense/design mAh) below feed the MAX drivers;
     // the BQ27Z746 self-gauges from its own data-flash config.
-    static constexpr uint16_t MAX17205_ADDR      = 0x36;     // original PCB gauge
-    static constexpr uint16_t BQ27Z746_ADDR      = 0x55;     // new PCB gauge
+    static constexpr uint16_t MAX17205_ADDR      = 0x36;     // V1 gauge
+    static constexpr uint16_t BQ27Z746_ADDR      = 0x55;     // V2 gauge
+    static constexpr uint16_t MAX17303_ADDR      = 0x36;     // V3 gauge (m5 family
+                                                              //   address, same as
+                                                              //   MAX17205 — DevName
+                                                              //   picks the driver)
     static constexpr int      NUM_BATTERY_CELLS  = 2;        // 2S NCR18650B (original PCB / MAX path)
     static constexpr float    RSENSE_MOHM        = 10.0f;    // Sense resistor (mΩ)
     static constexpr uint32_t PWR_UPDATE_PERIOD_MS = 2000;   // Battery read interval

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3052,6 +3052,7 @@ static void setup_bs()
             m3_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
             m3_cfg.rsense_mohm    = config::RSENSE_MOHM;   // TODO: verify V3 Rsense on the bench
             m3_cfg.current_invert = false;                  // TODO: verify CSP/CSN polarity on V3
+            m3_cfg.assume_when_unidentified = config::EXPECT_MAX17303;
 
             if (max17303_gauge.begin(i2c_bus, m3_cfg, config::I2C_FREQ_HZ) == ESP_OK)
             {

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -32,6 +32,8 @@
 #include "bs_download_policy.h"   // nextChunk()/mayEmitChunk() pacing (#380)
 
 #include <TR_LoRa_Comms.h>
+#include <LoRaDirectBackend.h>
+#include <UartModemBackend.h>
 #include <TR_Sensor_Data_Converter.h>
 #include <TR_Coordinates.h>
 #include <TR_BLE_To_APP.h>
@@ -67,7 +69,16 @@ static inline void maybeMarkOtaValid()
 // Forward declarations
 static const char* rocketStateToString(uint8_t state);
 
-static TR_LoRa_Comms lora_comms;
+// Radio backend seam (#410/#414): direct SPI LLCC68 (V1/V2 boards) or the
+// UART radio-daughterboard modem (V3), selected by the board header. The
+// reference keeps the historical `lora_comms` name so every call site below
+// is untouched; the unused backend is never begun.
+static LoRaDirectBackend lora_direct_backend;
+static UartModemBackend lora_modem_backend;
+static IRadioLink& lora_comms =
+    config::USE_UART_RADIO_MODEM
+        ? static_cast<IRadioLink&>(lora_modem_backend)
+        : static_cast<IRadioLink&>(lora_direct_backend);
 static SensorConverter sensor_converter;
 static TR_Coordinates coord;
 static TR_BLE_To_APP ble_app("TinkerBaseStation");
@@ -3188,34 +3199,66 @@ static void setup_bs()
         ble_app.setName(unit_name);
     }
 
-    // Configure LoRa radio (uses NVS-saved config or factory defaults)
-    TR_LoRa_Comms::Config lora_cfg = {};
-    lora_cfg.enabled           = true;
-    lora_cfg.cs_pin            = config::LORA_CS_PIN;
-    lora_cfg.dio1_pin          = config::LORA_DIO1_PIN;
-    lora_cfg.rst_pin           = config::LORA_RST_PIN;
-    lora_cfg.busy_pin          = config::LORA_BUSY_PIN;
-    // V2 PCB: MCU-driven RX half of the RF switch (was defined but never
-    // driven — RXEN floated in RX). -1 on the original PCB (no switch).
-    lora_cfg.rxen_pin          = config::LORA_RXEN_PIN;
-    lora_cfg.spi_sck           = config::LORA_SPI_SCK;
-    lora_cfg.spi_miso          = config::LORA_SPI_MISO;
-    lora_cfg.spi_mosi          = config::LORA_SPI_MOSI;
-    lora_cfg.spi_host          = SPI2_HOST;
-    lora_cfg.freq_mhz          = lora_freq_mhz;
-    lora_cfg.spreading_factor  = lora_sf;
-    lora_cfg.bandwidth_khz     = lora_bw_khz;
-    lora_cfg.coding_rate       = lora_cr;
-    lora_cfg.preamble_len      = config::LORA_PREAMBLE_LEN;
-    lora_cfg.tx_power_dbm      = lora_tx_power;
-    lora_cfg.crc_on            = config::LORA_CRC_ON;
-    lora_cfg.rx_boosted_gain   = config::LORA_RX_BOOSTED_GAIN;
-    lora_cfg.syncword_private  = config::LORA_SYNCWORD_PRIVATE;
-
-    if (!lora_comms.begin(lora_cfg, config::DEBUG))
+    // Configure LoRa radio (uses NVS-saved config or factory defaults).
+    // Backend per board header (#410 pattern): V3 talks to the radio
+    // daughterboard over UART; V1/V2 drive the on-board LLCC68 over SPI.
+    bool radio_ok = false;
+    if (config::USE_UART_RADIO_MODEM)
     {
-        ESP_LOGE(TAG, "LoRa init FAILED!");
-        while (true) { vTaskDelay(pdMS_TO_TICKS(1000)); }
+        UartModemBackend::Config mcfg = {};
+        mcfg.uart.tx_pin      = config::LORA_UART_TX_PIN;
+        mcfg.uart.rx_pin      = config::LORA_UART_RX_PIN;
+        mcfg.act_pin          = config::LORA_ACT_PIN;
+        mcfg.preamble_len     = config::LORA_PREAMBLE_LEN;
+        mcfg.crc_on           = config::LORA_CRC_ON;
+        mcfg.rx_boosted_gain  = config::LORA_RX_BOOSTED_GAIN;
+        mcfg.syncword_private = config::LORA_SYNCWORD_PRIVATE;
+        radio_ok = lora_modem_backend.begin(mcfg, lora_freq_mhz, lora_sf,
+                                            lora_bw_khz, lora_cr,
+                                            lora_tx_power, config::DEBUG);
+        if (!radio_ok)
+        {
+            // Unlike the direct-SPI boards, a missing daughterboard must not
+            // brick the BS: bench bring-up runs gauge/charger/storage/BLE
+            // without a radio, and the backend hot-joins a modem that BOOTs
+            // later (service() keeps polling the UART).
+            ESP_LOGE(TAG, "LoRa modem init FAILED — continuing radio-less "
+                          "(daughterboard can hot-join)");
+        }
+    }
+    else
+    {
+        TR_LoRa_Comms::Config lora_cfg = {};
+        lora_cfg.enabled           = true;
+        lora_cfg.cs_pin            = config::LORA_CS_PIN;
+        lora_cfg.dio1_pin          = config::LORA_DIO1_PIN;
+        lora_cfg.rst_pin           = config::LORA_RST_PIN;
+        lora_cfg.busy_pin          = config::LORA_BUSY_PIN;
+        // V2 PCB: MCU-driven RX half of the RF switch (was defined but never
+        // driven — RXEN floated in RX). -1 on the original PCB (no switch).
+        lora_cfg.rxen_pin          = config::LORA_RXEN_PIN;
+        lora_cfg.spi_sck           = config::LORA_SPI_SCK;
+        lora_cfg.spi_miso          = config::LORA_SPI_MISO;
+        lora_cfg.spi_mosi          = config::LORA_SPI_MOSI;
+        lora_cfg.spi_host          = SPI2_HOST;
+        lora_cfg.freq_mhz          = lora_freq_mhz;
+        lora_cfg.spreading_factor  = lora_sf;
+        lora_cfg.bandwidth_khz     = lora_bw_khz;
+        lora_cfg.coding_rate       = lora_cr;
+        lora_cfg.preamble_len      = config::LORA_PREAMBLE_LEN;
+        lora_cfg.tx_power_dbm      = lora_tx_power;
+        lora_cfg.crc_on            = config::LORA_CRC_ON;
+        lora_cfg.rx_boosted_gain   = config::LORA_RX_BOOSTED_GAIN;
+        lora_cfg.syncword_private  = config::LORA_SYNCWORD_PRIVATE;
+
+        radio_ok = lora_direct_backend.begin(lora_cfg, config::DEBUG);
+        if (!radio_ok)
+        {
+            // On-board radio is soldered to this PCB — a failed init is a
+            // hardware fault, keep the historical hard stop.
+            ESP_LOGE(TAG, "LoRa init FAILED!");
+            while (true) { vTaskDelay(pdMS_TO_TICKS(1000)); }
+        }
     }
 
     ESP_LOGI(TAG, "LoRa config: %.1f MHz SF%u BW%.0f kHz CR%u %d dBm",
@@ -3226,10 +3269,13 @@ static void setup_bs()
              (int)lora_tx_power);
 
     // Start continuous receive mode
-    if (!lora_comms.startReceive())
+    if (radio_ok && !lora_comms.startReceive())
     {
         ESP_LOGE(TAG, "LoRa startReceive FAILED!");
-        while (true) { vTaskDelay(pdMS_TO_TICKS(1000)); }
+        if (!config::USE_UART_RADIO_MODEM)
+        {
+            while (true) { vTaskDelay(pdMS_TO_TICKS(1000)); }
+        }
     }
 
     // Initialize BLE app interface

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -38,6 +38,7 @@
 #include <TR_Coordinates.h>
 #include <TR_BLE_To_APP.h>
 #include <TR_MAX17205G.h>
+#include <TR_MAX17303.h>
 #include <TR_BQ27Z746.h>
 #include <RocketComputerTypes.h>
 
@@ -120,8 +121,9 @@ static uint32_t last_battery_ms = 0;
 static i2c_master_bus_handle_t i2c_bus = nullptr;
 static TR_MAX17205G fuel_gauge(config::MAX17205_ADDR);
 static TR_BQ27Z746  bq_gauge(config::BQ27Z746_ADDR);
+static TR_MAX17303  max17303_gauge(config::MAX17303_ADDR);  // V3; shares 0x36 with MAX17205, split by DevName
 // Which gauge runtime detection found (one firmware image, both PCBs).
-enum class GaugeKind { None, MAX17205, BQ27Z746 };
+enum class GaugeKind { None, MAX17205, BQ27Z746, MAX17303 };
 static GaugeKind gauge_kind = GaugeKind::None;
 static bool fuel_gauge_present = false;   // true if EITHER gauge is present
 
@@ -523,6 +525,32 @@ static void updateBattery()
         bs_soc         = bq_gauge.soc();
         bs_current     = bq_gauge.current();
         bs_temperature = bq_gauge.temperature();
+    }
+    else if (gauge_kind == GaugeKind::MAX17303)
+    {
+        max17303_gauge.update();
+        bs_voltage     = max17303_gauge.voltage();
+        bs_soc         = max17303_gauge.soc();
+        bs_current     = max17303_gauge.current();
+        bs_temperature = max17303_gauge.temperature();
+
+        // Protector observability (BQ FET saga lesson). No enable action
+        // exists or is needed on this part — the protector runs the FETs —
+        // but log WHY the battery path opened, once per transition.
+        static bool last_fets_on = true;
+        static uint16_t last_prot = 0;
+        const bool fets_on = max17303_gauge.fetsOn();
+        const uint16_t prot = max17303_gauge.protStatus();
+        if (fets_on != last_fets_on || (prot != last_prot && prot != 0))
+        {
+            if (!fets_on || prot != 0)
+                ESP_LOGW(TAG, "MAX17303 protector: FETs %s, ProtStatus=0x%04X",
+                         fets_on ? "on" : "OFF", prot);
+            else
+                ESP_LOGI(TAG, "MAX17303 protector: FETs back on, faults clear");
+        }
+        last_fets_on = fets_on;
+        last_prot = prot;
     }
     else
     {
@@ -3014,36 +3042,60 @@ static void setup_bs()
         }
         else if (i2c_master_probe(i2c_bus, config::MAX17205_ADDR, pdMS_TO_TICKS(50)) == ESP_OK)
         {
-            // Original PCB: MAX17205 gauge.
-            TR_MAX17205G_Config fg_cfg;
-            fg_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
-            fg_cfg.rsense_mohm    = config::RSENSE_MOHM;
-            fg_cfg.current_invert = true;   // CSP/CSN swapped on schematic (U7) vs.
-                                            //   datasheet typical app circuit; flips
-                                            //   displayed current so charge reads
-                                            //   positive. Driver uses VFSOC for SoC
-                                            //   because the chip's m5 can't be told.
-            fg_cfg.num_cells      = config::NUM_BATTERY_CELLS;
+            // 0x36 is shared by two ModelGauge m5 parts: MAX17303 (V3 PCB,
+            // 1S + protector) and MAX17205 (V1 PCB, 2S). Try the MAX17303
+            // driver first — its begin() reads DevName and hands the address
+            // back (ESP_ERR_NOT_FOUND) when the part isn't a MAX1730x.
+            TR_MAX17303_Config m3_cfg;
+            m3_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
+            m3_cfg.rsense_mohm    = config::RSENSE_MOHM;   // TODO: verify V3 Rsense on the bench
+            m3_cfg.current_invert = false;                  // TODO: verify CSP/CSN polarity on V3
 
-            if (fuel_gauge.begin(i2c_bus, fg_cfg, config::I2C_FREQ_HZ) == ESP_OK)
+            if (max17303_gauge.begin(i2c_bus, m3_cfg, config::I2C_FREQ_HZ) == ESP_OK)
             {
-                gauge_kind = GaugeKind::MAX17205;
+                gauge_kind = GaugeKind::MAX17303;
                 fuel_gauge_present = true;
-                ESP_LOGI(TAG, "MAX17205G fuel gauge found on I2C (0x%02X)", config::MAX17205_ADDR);
-                fuel_gauge.initIfNeeded();
+                ESP_LOGI(TAG, "MAX17303 fuel gauge found on I2C (0x%02X), DevName 0x%04X",
+                         config::MAX17303_ADDR, max17303_gauge.devName());
+                max17303_gauge.initIfNeeded();
                 updateBattery();
                 ESP_LOGI(TAG, "Battery: %.2f V, %.1f%% SoC, %.0f mA",
                          (double)bs_voltage, (double)bs_soc, (double)bs_current);
-                fuel_gauge.logDiagnostics(TAG);
+                max17303_gauge.logDiagnostics(TAG);
             }
             else
             {
-                ESP_LOGW(TAG, "MAX17205G probe succeeded but begin() failed");
+                // Original PCB: MAX17205 gauge.
+                TR_MAX17205G_Config fg_cfg;
+                fg_cfg.design_mah     = config::BATTERY_DESIGN_MAH;
+                fg_cfg.rsense_mohm    = config::RSENSE_MOHM;
+                fg_cfg.current_invert = true;   // CSP/CSN swapped on schematic (U7) vs.
+                                                //   datasheet typical app circuit; flips
+                                                //   displayed current so charge reads
+                                                //   positive. Driver uses VFSOC for SoC
+                                                //   because the chip's m5 can't be told.
+                fg_cfg.num_cells      = config::NUM_BATTERY_CELLS;
+
+                if (fuel_gauge.begin(i2c_bus, fg_cfg, config::I2C_FREQ_HZ) == ESP_OK)
+                {
+                    gauge_kind = GaugeKind::MAX17205;
+                    fuel_gauge_present = true;
+                    ESP_LOGI(TAG, "MAX17205G fuel gauge found on I2C (0x%02X)", config::MAX17205_ADDR);
+                    fuel_gauge.initIfNeeded();
+                    updateBattery();
+                    ESP_LOGI(TAG, "Battery: %.2f V, %.1f%% SoC, %.0f mA",
+                             (double)bs_voltage, (double)bs_soc, (double)bs_current);
+                    fuel_gauge.logDiagnostics(TAG);
+                }
+                else
+                {
+                    ESP_LOGW(TAG, "MAX17205G probe succeeded but begin() failed");
+                }
             }
         }
         else
         {
-            ESP_LOGW(TAG, "No fuel gauge found (neither BQ27Z746 0x55 nor MAX17205 0x36) — battery readings unavailable");
+            ESP_LOGW(TAG, "No fuel gauge found (neither BQ27Z746 0x55 nor MAX17205/MAX17303 0x36) — battery readings unavailable");
         }
     }
 

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -39,6 +39,7 @@
 #include <TR_BLE_To_APP.h>
 #include <TR_MAX17205G.h>
 #include <TR_MAX17303.h>
+#include <TR_MP2672.h>
 #include <TR_BQ27Z746.h>
 #include <RocketComputerTypes.h>
 
@@ -122,6 +123,7 @@ static i2c_master_bus_handle_t i2c_bus = nullptr;
 static TR_MAX17205G fuel_gauge(config::MAX17205_ADDR);
 static TR_BQ27Z746  bq_gauge(config::BQ27Z746_ADDR);
 static TR_MAX17303  max17303_gauge(config::MAX17303_ADDR);  // V3; shares 0x36 with MAX17205, split by DevName
+static TR_MP2672    pack_charger(config::MP2672_ADDR);      // V3 flight-pack charger (HAS_PACK_CHARGER)
 // Which gauge runtime detection found (one firmware image, both PCBs).
 enum class GaugeKind { None, MAX17205, BQ27Z746, MAX17303 };
 static GaugeKind gauge_kind = GaugeKind::None;
@@ -3099,6 +3101,22 @@ static void setup_bs()
         }
     }
 
+    // V3: external flight-pack charger on the same I2C bus as the gauge.
+    // begin() succeeds even with no charge input attached (the chip is
+    // unpowered then); the periodic service() detects plug-in and applies
+    // the charge config each time.
+    if (config::HAS_PACK_CHARGER && i2c_bus != nullptr)
+    {
+        TR_MP2672_Config chg_cfg;
+        chg_cfg.vbatt_reg_code = config::PACK_VBATT_REG_CODE;
+        chg_cfg.icc_code       = config::PACK_CHARGE_ICC_CODE;
+        chg_cfg.chg_timer_code = config::PACK_CHG_TIMER_CODE;
+        if (pack_charger.begin(i2c_bus, chg_cfg, config::I2C_FREQ_HZ) != ESP_OK)
+        {
+            ESP_LOGW(TAG, "MP2672 pack-charger driver init failed");
+        }
+    }
+
     // Load saved LoRa config from NVS (write config.h defaults if empty)
     prefs.begin("lora", false);  // read-write
 
@@ -3880,6 +3898,13 @@ static void loop_bs()
         if (!ble_app.isOtaActive())
         {
             updateBattery();
+            // V3: reconcile the flight-pack charger (presence detect, config
+            // re-apply after plug-in / watchdog, 40 s WD kick, status/fault
+            // transition logs). Cheap no-op while no charge input is present.
+            if (config::HAS_PACK_CHARGER)
+            {
+                pack_charger.service();
+            }
         }
 
         // Always push base station stats to BLE, even without LoRa packets,

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -145,14 +145,13 @@ static bool     uplink_pending = false;
 static const char* SD_MOUNT_POINT = "/sdcard";
 static sdmmc_card_t* sd_card = nullptr;
 static bool using_internal_flash = false;
-static bool using_external_flash = false;   // V2: FAT on the external SPI flash
-#if BS_BOARD_V2
+static bool using_external_flash = false;   // V2/V3: FAT on the external SPI flash
 static spi_device_handle_t      s_ext_spi = nullptr;
 static spi_nand_flash_device_t *s_nand    = nullptr;
 
 // Mount a FAT filesystem (Dhara wear-leveling FTL) on the external SPI NAND
-// flash used for logging on the new PCB (M_* pins on SPI3_HOST; LoRa owns
-// SPI2_HOST). The chip is a FORESEE F35SQB004G (mfr 0xCD, 512 MB), supported via
+// flash used for logging on the V2/V3 PCBs (M_* pins on SPI3_HOST; LoRa owns
+// SPI2_HOST on V2). The chip is a FORESEE F35SQB004G (mfr 0xCD, 512 MB), supported via
 // the vendored+patched spi_nand_flash component (components/spi_nand_flash/src/
 // devices/nand_foresee.c). On success repoints SD_MOUNT_POINT and sets
 // using_external_flash; otherwise returns the error so the caller falls back to
@@ -206,7 +205,6 @@ static esp_err_t mountExternalFlashFat()
     ESP_LOGI(TAG, "External-flash FAT mounted at %s", SD_MOUNT_POINT);
     return ESP_OK;
 }
-#endif  // BS_BOARD_V2
 static const char* SPIFFS_PARTITION_LABEL = "spiffs";
 
 // CSV logging state
@@ -2811,6 +2809,10 @@ static void setup_bs()
     delay(500);
     ESP_LOGI(TAG, "======================================");
     ESP_LOGI(TAG, "  TinkerRocket Base Station");
+    // Board banner = the wrong-build-dir flash guard (same lesson as the
+    // FC/OC -B build_v8 gotcha): if this line doesn't match the physical
+    // board, stop and flash the right variant.
+    ESP_LOGI(TAG, "  Board: %s (TR_BS_BOARD=%d)", config::BOARD_NAME, TR_BS_BOARD);
     ESP_LOGI(TAG, "======================================");
 
     // OTA boot-state check (#8). If this image was just OTA-installed it
@@ -2842,52 +2844,55 @@ static void setup_bs()
     setenv("TZ", "UTC0", 1);
     tzset();
 
-    // Initialize storage. V2 (new PCB) -> wear-leveled FAT on the external SPI
-    // flash; V1 -> SD over SDMMC 4-bit. Either way, fall back to SPIFFS on
+    // Initialize storage. V2/V3 -> wear-leveled FAT on the external SPI NAND;
+    // V1 -> SD over SDMMC 4-bit. Either way, fall back to SPIFFS on
     // internal flash. Logging is backend-agnostic (uses SD_MOUNT_POINT + the
     // standard file API), so only the mount differs per board.
     {
-        esp_err_t ret;
-#if BS_BOARD_V2
-        ret = mountExternalFlashFat();   // logs its own info; repoints SD_MOUNT_POINT on success
-#else
-        sdmmc_host_t host = SDMMC_HOST_DEFAULT();
-        host.max_freq_khz = SDMMC_FREQ_DEFAULT;
-
-        sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
-        slot.width = 4;
-        slot.clk = (gpio_num_t)config::SD_CLK;
-        slot.cmd = (gpio_num_t)config::SD_CMD;
-        slot.d0  = (gpio_num_t)config::SD_D0;
-        slot.d1  = (gpio_num_t)config::SD_D1;
-        slot.d2  = (gpio_num_t)config::SD_D2;
-        slot.d3  = (gpio_num_t)config::SD_D3;
-        slot.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
-
-        esp_vfs_fat_sdmmc_mount_config_t mount_cfg = {};
-        mount_cfg.format_if_mount_failed = false;
-        mount_cfg.max_files = 5;
-        mount_cfg.allocation_unit_size = 16 * 1024;
-
-        ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot, &mount_cfg, &sd_card);
-        if (ret == ESP_OK)
+        esp_err_t ret = ESP_ERR_NOT_FOUND;
+        if (config::HAS_EXT_NAND)
         {
-            sdmmc_card_print_info(stdout, sd_card);
+            ret = mountExternalFlashFat();   // logs its own info; repoints SD_MOUNT_POINT on success
+        }
+        else if (config::HAS_SDMMC)
+        {
+            sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+            host.max_freq_khz = SDMMC_FREQ_DEFAULT;
 
-            FATFS* fs;
-            DWORD free_clust;
-            if (f_getfree("0:", &free_clust, &fs) == FR_OK)
+            sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
+            slot.width = 4;
+            slot.clk = (gpio_num_t)config::SD_CLK;
+            slot.cmd = (gpio_num_t)config::SD_CMD;
+            slot.d0  = (gpio_num_t)config::SD_D0;
+            slot.d1  = (gpio_num_t)config::SD_D1;
+            slot.d2  = (gpio_num_t)config::SD_D2;
+            slot.d3  = (gpio_num_t)config::SD_D3;
+            slot.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
+
+            esp_vfs_fat_sdmmc_mount_config_t mount_cfg = {};
+            mount_cfg.format_if_mount_failed = false;
+            mount_cfg.max_files = 5;
+            mount_cfg.allocation_unit_size = 16 * 1024;
+
+            ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot, &mount_cfg, &sd_card);
+            if (ret == ESP_OK)
             {
-                uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
-                uint64_t free_bytes = (uint64_t)free_clust * fs->csize * fs->ssize;
-                uint64_t used = total - free_bytes;
-                ESP_LOGI(TAG, "SD card mounted: %llu MB total, %llu MB used, %llu MB free",
-                         (unsigned long long)(total / (1024 * 1024)),
-                         (unsigned long long)(used / (1024 * 1024)),
-                         (unsigned long long)(free_bytes / (1024 * 1024)));
+                sdmmc_card_print_info(stdout, sd_card);
+
+                FATFS* fs;
+                DWORD free_clust;
+                if (f_getfree("0:", &free_clust, &fs) == FR_OK)
+                {
+                    uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
+                    uint64_t free_bytes = (uint64_t)free_clust * fs->csize * fs->ssize;
+                    uint64_t used = total - free_bytes;
+                    ESP_LOGI(TAG, "SD card mounted: %llu MB total, %llu MB used, %llu MB free",
+                             (unsigned long long)(total / (1024 * 1024)),
+                             (unsigned long long)(used / (1024 * 1024)),
+                             (unsigned long long)(free_bytes / (1024 * 1024)));
+                }
             }
         }
-#endif
         if (ret != ESP_OK)
         {
             ESP_LOGW(TAG, "Primary storage mount failed (0x%x) — falling back to internal flash (SPIFFS)",


### PR DESCRIPTION
Adds firmware support for the new **V3 base-station PCB** while keeping the existing boards buildable from the same tree. Bench-validated on real V3 hardware (see below).

## What's new
- **Per-board headers (V1/V2/V3)** replacing the `BS_BOARD_V2` macro, OC `#411` style. `struct config : board_pins`, selected by `TR_BS_BOARD` (default 2). Storage compile-guards became runtime `HAS_EXT_NAND` / `HAS_SDMMC` branches. Boot banner prints the board name as the wrong-image flash guard.
  - `idf.py build` → V2 · `-B build_v1 -DTR_BS_BOARD=1` → V1 · `-B build_v3 -DTR_BS_BOARD=3` → V3
- **Radio backend seam (`#414`)** — the BS now drives its radio through `IRadioLink` like the OC (`#410`): direct SPI LLCC68 on V1/V2, the UART daughterboard modem on V3. Extended the seam with the spectrum-scan surface the BS uses (direct backend delegates; modem backend sends `START_SCAN` / caches `SCAN_RESULT` with a never-wedge deadline for the `#379` uplink gate). A V3 with no daughterboard boots radio-less and hot-joins a modem that `BOOT`s later.
- **`TR_MAX17303`** gauge driver (1S ModelGauge m5 + protector). No MAX17055-style EZ init (self-restores from NV; the `0x060` command register is left untouched — 7-copy NV budget + permanent locks). DevName splits it from the V1 MAX17205 at the shared `0x36` address; V3 board header asserts the part so an unlisted die rev can't demote it.
- **`TR_MP2672`** flight-pack charger driver (2S boost charger @ `0x4B`, `HAS_PACK_CHARGER`). Reconcile-on-poll: config is volatile (lost each unplug), 40 s I2C watchdog kept on + kicked, every write readback-verified. Safe defaults (8.4 V, minimum charge current until RISET confirmed).

## Bench results (V3 hardware, 2026-07-10)
Clean bring-up: NAND detect/format/mount + write test OK · MAX17303 reading correctly (4.18 V, sane current/temp, no protector faults, FETs on) · MP2672 alive + config-verified · BLE advertising with live battery telemetry · radio-less soft-continue worked. Confirmed the production MAX17303 DevName is `0x407C` (datasheet lists `0x4067`) and recorded it as known-good.

## Heads-up
- **ESP-IDF**: the BS hadn't been rebuilt since the `#88` v6 migration and no longer compiles on 5.3.2 (shared `TR_I2C_Interface` uses the v6-only slave API). `dependencies.lock` now records 6.0.1; build with `~/esp/esp-idf-v6.0`.
- Remaining bench TODOs (flagged in code): MAX17303 Rsense + CSP/CSN polarity, MP2672 RISET before raising charge current, LoRa TX/RX label-perspective when the daughterboard is back.

## Build matrix
BS V1/V2/V3 + OC V7/V8 + FC V7/V8 + radio_board — all clean on IDF v6.0 (rebased onto current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
