### PR TITLE
chore(bs): surface selected board at CMake configure time

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/base_station/main/CMakeLists.txt
@@ -32,6 +32,16 @@ target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)
 # build` compiles the matching main/board/board_v*.h pin map; default is V2.
 # Use a separate build dir per variant (e.g. -B build_v3) — the flag is
 # cached by CMake.
+#
+# NOTE the trap: the build-dir name is cosmetic — the board comes ONLY from
+# this flag. `idf.py -B build_v3 build` (no -DTR_BS_BOARD=3) silently builds
+# V2. Surface the choice at configure time so a missing/wrong flag is visible
+# in the build log, not just from the runtime boot banner.
 if(TR_BS_BOARD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BS_BOARD=${TR_BS_BOARD})
+    message(STATUS "base_station: building for board V${TR_BS_BOARD} (TR_BS_BOARD=${TR_BS_BOARD})")
+else()
+    message(WARNING "base_station: TR_BS_BOARD not set — defaulting to V2. "
+                    "For another board pass -DTR_BS_BOARD=<1|3> (the build-dir "
+                    "name alone does NOT select the board).")
 endif()


### PR DESCRIPTION
Follow-up to #485. The `-B build_v3` build-dir name is cosmetic — `TR_BS_BOARD` is the only thing that selects the board, so `idf.py -B build_v3 build` without `-DTR_BS_BOARD=3` silently builds V2. This bit at the bench: a V2 image got flashed to V3 hardware and was only caught by the runtime boot banner (I2C probe timeouts + a hard LoRa-init stop).

Prints the resolved board at CMake **configure** time so a missing/wrong flag is visible in the build log before flashing:
- `-- base_station: building for board V3 (TR_BS_BOARD=3)` when the flag is set
- a `WARNING: TR_BS_BOARD not set — defaulting to V2 ...` when it isn't

CMake-only, no code/behavior change. Verified both messages fire (default build → warning, `-DTR_BS_BOARD=3` → V3 status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
