### PR TITLE
fix(bs): MP2672 write-refusal fallback — kick-first recovery + monitor-only mode

### DIFF
--- a/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.cpp
+++ b/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.cpp
@@ -68,6 +68,13 @@ uint8_t TR_MP2672::desiredReg02() const
 // ---------------------------------------------------------------------------
 bool TR_MP2672::applyConfig()
 {
+    // Kick the watchdog FIRST: an expired watchdog latches WD_FAULT (seen
+    // whenever the host was silent >40 s — e.g. across a reflash), and the
+    // kick is the only documented interaction with that state. Doing it
+    // before the config writes gives a fault-latched chip its best chance
+    // of accepting them.
+    (void)writeReg(Reg::REG02, (uint8_t)(desiredReg02() | 0x40));
+
     struct { uint8_t reg; uint8_t val; } seq[] = {
         { Reg::REG01, desiredReg01() },
         { Reg::REG02, desiredReg02() },
@@ -77,14 +84,20 @@ bool TR_MP2672::applyConfig()
     for (const auto& w : seq)
     {
         uint8_t back = 0xFF;
-        if (!writeReg(w.reg, w.val) || !readReg(w.reg, back) || back != w.val)
+        const bool wrote = writeReg(w.reg, w.val);
+        const bool read  = wrote && readReg(w.reg, back);
+        if (!wrote || !read || back != w.val)
         {
             // The kick bit self-behavior is undocumented; exclude bit6 from
             // the REG02 comparison.
-            if (w.reg == Reg::REG02 && (back & ~0x40) == (w.val & ~0x40))
+            if (read && w.reg == Reg::REG02 && (back & ~0x40) == (w.val & ~0x40))
                 continue;
-            ESP_LOGW(TAG, "REG%02X write not verified (wrote 0x%02X, read 0x%02X)",
-                     w.reg, w.val, back);
+            if (!wrote || !read)
+                ESP_LOGW(TAG, "REG%02X %s failed (I2C)", w.reg,
+                         wrote ? "readback" : "write");
+            else
+                ESP_LOGW(TAG, "REG%02X write ACKed but ignored (wrote 0x%02X, "
+                              "read 0x%02X)", w.reg, w.val, back);
             _data.write_verify_fails++;
             ok = false;
         }
@@ -155,13 +168,43 @@ void TR_MP2672::service()
     if (!was_present)
     {
         ESP_LOGI(TAG, "charge input attached (REG00=0x%02X on wake)", r00);
+        // Fresh power-up of the chip: give writes a fresh chance even if a
+        // previous session concluded they were refused (transient vs strap).
+        _write_locked = false;
+        _data.write_locked = false;
+        _apply_fail_streak = 0;
     }
 
     // (Re)apply config on first contact after plug-in, or when the live
     // REG00 drifted from desired (watchdog expiry silently reverts it).
-    if (!_config_applied || r00 != desiredReg00())
+    if (_write_locked)
+    {
+        // Monitor-only: the chip ACKs but ignores register writes (bench
+        // 2026-07-11). Known causes: CV pin strapped for STANDALONE mode
+        // (host register control requires CV = VCC; charge parameters then
+        // come from the RISET/CV pins, which is safe) or an OTP-locked
+        // non-A MP2672 (unresolved MPS forum report). Either way charging
+        // runs at hardware-set limits; we just watch status/faults.
+    }
+    else if (!_config_applied || r00 != desiredReg00())
     {
         _config_applied = applyConfig();
+        if (_config_applied)
+        {
+            _apply_fail_streak = 0;
+        }
+        else if (++_apply_fail_streak >= 3)
+        {
+            _write_locked = true;
+            _data.write_locked = true;
+            ESP_LOGE(TAG, "register writes ACKed but ignored after %u attempts "
+                          "— falling back to MONITOR-ONLY. Likely the CV pin is "
+                          "strapped for standalone mode (host control needs "
+                          "CV=VCC) or the part is write-locked. Charging "
+                          "continues at pin-set defaults (RISET is the current "
+                          "clamp); status/fault polling unaffected.",
+                     (unsigned)_apply_fail_streak);
+        }
     }
     else
     {

--- a/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.h
+++ b/tinkerrocket-idf/components/TR_MP2672/TR_MP2672.h
@@ -96,6 +96,9 @@ struct TR_MP2672_Data
     uint8_t status_raw = 0;          // raw REG03
     uint32_t config_applies = 0;     // times config was (re)applied
     uint32_t write_verify_fails = 0;
+    bool write_locked = false;       // chip ACKs but ignores register writes →
+                                     //   monitor-only mode (CV standalone strap
+                                     //   or OTP-locked part; see service())
 };
 
 class TR_MP2672
@@ -136,6 +139,8 @@ private:
     TR_MP2672_Config        _cfg;
     TR_MP2672_Data          _data;
     bool                    _config_applied;
+    bool                    _write_locked = false;
+    uint8_t                 _apply_fail_streak = 0;
 };
 
 #endif


### PR DESCRIPTION
Bench follow-up on the V3 board: the MP2672 **ACKs register writes but ignores them** (REG02 reads back its `0x95` default no matter what's written; REG01 sits at `0x4F`), while reads work fine. The driver retried its config-apply every poll pass, warning twice every 2 s forever.

## Changes
- `applyConfig()` kicks the watchdog **first** (`REG02 | 0x40`) — `WD_FAULT` was latched at boot (host silent >40 s across the reflash) and the kick is the only documented interaction with that state, so a fault-latched chip gets its best chance of accepting the writes.
- Distinct logs for I2C-failed vs ACKed-but-ignored writes.
- **Three failed applies → monitor-only mode**: one ERROR naming the known causes, then no more writes; status/fault polling continues. Safe either way — RISET is the hardware current clamp, charging runs at pin-set limits.
- A fresh chip power-up (charge-input re-attach) resets the lockout, so a transient can't latch it permanently.

## Likely root cause (hardware, to verify on the schematic)
Host/I2C register control on the MP2672 requires the **CV pin tied to VCC**; CV through a resistor to AGND selects **standalone mode** where charge parameters come from the RISET/CV pins and register writes are display-only. The alternative is the unresolved MPS-forum report of OTP-write-locked non-A MP2672 parts. Checking the CV net decides it.

Builds clean: BS V3 (IDF v6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
