### PR TITLE
fix(sim): synthesize the IIS2MDC during onboard sim — bench mag was fighting the sim attitude (#463)

### DIFF
--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -106,6 +106,14 @@ void SensorCollectorSim::configureSimRotation(float ism6_rot_z_deg)
              (double)ism6_rot_z_deg, (double)ism6_inv_c_, (double)ism6_inv_s_);
 }
 
+void SensorCollectorSim::configureSimIis2mdcRotation(float rot_z_deg)
+{
+    const float rad = rot_z_deg * (float)M_PI / 180.0f;
+    iis_inv_c_ = cosf(rad);
+    iis_inv_s_ = sinf(rad);
+    ESP_LOGI("SIM", "IIS2MDC rotation: %.1f deg", (double)rot_z_deg);
+}
+
 void SensorCollectorSim::configureSimBoardToRocket(const float R[9])
 {
     // Store the transpose (rocket→board); flag identity to skip the
@@ -214,10 +222,20 @@ bool SensorCollectorSim::getMMC5983MAData(MMC5983MAData& data_out)
 
 bool SensorCollectorSim::getIIS2MDCData(IIS2MDCData& data_out)
 {
-    // No sim model for IIS2MDC yet — pass through real data only.
-    // When sim is active, IIS2MDC frames are simply not produced (sim flights
-    // populate MMC instead via encodeMMC5983MA above).
-    return real_.getIIS2MDCData(data_out);
+    bool have_data = real_.getIIS2MDCData(data_out);
+
+    if (phase_ == SIM_IDLE) return have_data;
+
+    if (!have_data) return false;
+
+    // Replace with simulated magnetometer (#463). This path used to pass the
+    // REAL bench field through during a sim: on IIS2MDC boards (MMC not
+    // populated) the EKF then fused the bench's fixed heading against the
+    // sim's flying attitude every sample — a sustained innovation the
+    // heading-axis gyro bias absorbed (~±20–200 dps at sim start depending
+    // on bench orientation, decaying all flight).
+    encodeIIS2MDC(micros(), data_out);
+    return true;
 }
 
 bool SensorCollectorSim::getGNSSData(GNSSData& data_out)
@@ -529,6 +547,35 @@ void SensorCollectorSim::encodeMMC5983MA(uint32_t time_us, MMC5983MAData& out)
     out.mag_x = (uint32_t)(lroundf(body_x * COUNTS_PER_UT) + 131072);
     out.mag_y = (uint32_t)(lroundf(body_y * COUNTS_PER_UT) + 131072);
     out.mag_z = (uint32_t)(lroundf(body_z * COUNTS_PER_UT) + 131072);
+}
+
+void SensorCollectorSim::encodeIIS2MDC(uint32_t time_us, IIS2MDCData& out)
+{
+    memset(&out, 0, sizeof(out));
+    out.time_us = time_us;
+
+    // Same Earth field + pitch-plane rotation as encodeMMC5983MA (#463).
+    static constexpr float B_NORTH = 22.0f;   // µT
+    static constexpr float B_EAST  =  5.0f;
+    static constexpr float B_DOWN  = 42.0f;
+    static constexpr float COUNTS_PER_UT = 1.0f / 0.15f;   // datasheet 0.15 µT/LSB
+
+    const float sp = sinf(pitch_rad_);
+    const float cp = cosf(pitch_rad_);
+    float body_x =  B_NORTH * sp + B_DOWN * cp;
+    float body_y =  B_EAST;
+    float body_z = -B_NORTH * cp + B_DOWN * sp;
+
+    // Rocket frame → board frame (inverse mounting), then board → sensor
+    // frame (inverse of the converter's sensor→board +Z rotation), so the
+    // forward conversion chain reproduces the simulated field exactly.
+    rocketToBoard(body_x, body_y, body_z);
+    const float sensor_x =  body_x * iis_inv_c_ + body_y * iis_inv_s_;
+    const float sensor_y = -body_x * iis_inv_s_ + body_y * iis_inv_c_;
+
+    out.mag_x = (int16_t)lroundf(sensor_x * COUNTS_PER_UT);
+    out.mag_y = (int16_t)lroundf(sensor_y * COUNTS_PER_UT);
+    out.mag_z = (int16_t)lroundf(body_z   * COUNTS_PER_UT);
 }
 
 void SensorCollectorSim::encodeGNSS(uint32_t time_us, GNSSData& out)

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
@@ -57,6 +57,10 @@ public:
     // ---- Sim control ----
     void configureSim(const SimConfigData& cfg);
     void configureSimRotation(float ism6_rot_z_deg);
+    // #463: sensor→board rotation of the IIS2MDC, so the synthetic mag comes
+    // out geodetically correct after the converter re-applies the forward
+    // rotation (mirrors configureSimRotation for the ISM6).
+    void configureSimIis2mdcRotation(float rot_z_deg);
     // Board→rocket mounting rotation (row-major, v_rocket = R * v_board).
     // The sim's physics are rocket-frame; encoders apply the INVERSE so the
     // forward conversion (chip rotZ, then board→rocket) reproduces the
@@ -106,6 +110,10 @@ private:
     // Inverse rotation (body frame → sensor frame) for ISM6 encoding
     float ism6_inv_c_ = 1.0f;   // cos(config_angle)
     float ism6_inv_s_ = 0.0f;   // sin(config_angle)
+
+    // Inverse rotation (board frame → sensor frame) for IIS2MDC encoding (#463)
+    float iis_inv_c_ = 1.0f;
+    float iis_inv_s_ = 0.0f;
 
     // Inverse board→rocket rotation (rocket frame → board frame), i.e. the
     // transpose of the configured mounting matrix.  Identity by default.
@@ -167,6 +175,7 @@ private:
     void encodeISM6(uint32_t time_us, ISM6HG256Data& out);
     void encodeBMP585(uint32_t time_us, BMP585Data& out);
     void encodeMMC5983MA(uint32_t time_us, MMC5983MAData& out);
+    void encodeIIS2MDC(uint32_t time_us, IIS2MDCData& out);
     void encodeGNSS(uint32_t time_us, GNSSData& out);
 };
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2694,6 +2694,7 @@ static void setup_fc()
     sensor_converter.configureMMC5983MARotationZ(config::MMC5983MA_ROT_Z_DEG);
     sensor_converter.configureIIS2MDCRotationZ(config::IIS2MDC_ROT_Z_DEG);
     sensor_collector.configureSimRotation(config::ISM6HG256_ROT_Z_DEG);
+    sensor_collector.configureSimIis2mdcRotation(config::IIS2MDC_ROT_Z_DEG);
 
     // Board→rocket mounting orientation (converter + sim + OC query payload).
     applyBoardToRocketOrientation(


### PR DESCRIPTION
The onboard sim synthesized the MMC mag but passed the real IIS2MDC through during sims — on IIS2MDC boards the EKF fused the bench's fixed heading against the synthetic flying attitude, winding the heading-axis gyro bias ±20–200 dps at sim start (bench-orientation-dependent sign, decaying all flight). The issue's original discontinuity theory was already covered by the #400 start-edge reset; this was the actual driver.

encodeIIS2MDC mirrors the MMC pattern with the full inverse frame chain (mounting + sensor Z-rotation, plumbed like the ISM6's) at 0.15 µT/LSB. FC builds locally; bench acceptance = sub-1-dps gyro_bias at next sim start.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)