### PR TITLE
fix(fc): don't push FC_IDENTITY during a sim — 2.008 s log-gap source

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -4090,7 +4090,18 @@ static void loop_fc()
             // message type so it bypasses the OC's timestamp dedup. Skipped while
             // an image is streaming in (the version can't change mid-OTA and the
             // OC already has it — keep the OTA control bus quiet). #8 Phase 4.
-            if (!fc_ota_data_mode)
+            //
+            // Also skipped during a SIM: the #393 exception keeps this poll block
+            // running through a sim's INFLIGHT (for SIM_STOP), so this extra I2C
+            // transaction would fire every ~8 polls (2.008 s = 8 × the ~251 ms
+            // polled interval). loop_fc() is single-threaded, so that transaction
+            // stalls the loop long enough (>5 ms) to punch a gap into the
+            // synthetic sensor stream — which, unlike the real path, is re-stamped
+            // with micros() at drain time, so a loop stall shows up as a timestamp
+            // gap across ISM6/BMP/NonSensor together. The version can't change on a
+            // bench sim and the OC already cached it from the pre-sim READY/
+            // PRELAUNCH pushes, so there is nothing to relay mid-sim.
+            if (!fc_ota_data_mode && !sensor_collector.isSimActive())
             {
                 static uint32_t fc_id_throttle = 1000;  // fire on first poll, then ~2 s
                 if (++fc_id_throttle >= 8)


### PR DESCRIPTION
## What

During an onboard **sim**, the FC log shows ~5 ms timestamp gaps across ISM6/BMP/NonSensor every **2.008 s**. This gates the every-~2 s `FC_IDENTITY` I2C push behind `!isSimActive()`, removing the periodic loop stall that produced them.

## Root cause (bench-confirmed on `flight_20260711_095241`)

- The 13 gaps phase-lock to an exact **2.0085 s grid** (fit σ 3.4 ms over 84 s) = **8 × the ~251 ms** OC-status-query poll interval, and BMP585 + NonSensor gap at all 13 points *simultaneously* → a whole-`loop_fc()` stall.
- The `#393` exception keeps that poll running through a sim's INFLIGHT (for `SIM_STOP`). Inside it, the FC pushes its firmware version to the OC every ~8 polls (`main.cpp:4093`) — the *only* every-8-poll action in the block. `loop_fc()` is single-threaded, so that extra I2C transaction stalls the loop >5 ms.
- On the **real path** the hardware IMU queue absorbs the stall (samples keep chip sample-time) → the bench recording from the same boot (`flight_20260711_101437`, same 3792 Hz) is gap-free. In **sim**, `getISM6HG256Data` re-stamps each synthetic sample with `micros()` at drain time (`TR_Sensor_Collector_Sim.cpp:186`), so the stall becomes a visible gap + post-stall burst.

## Fix

Gate the push on `!sensor_collector.isSimActive()`. The FC version can't change on a bench sim and the OC already cached it from the pre-sim READY/PRELAUNCH pushes (it only re-publishes to the app on a *change*), so nothing is lost. Real flights never run this poll block in INFLIGHT, so they're unaffected.

## Verification

- **Compile-verified**: `idf.py build` (IDF v6.0), ESP32-P4 image links, no `main.cpp` warnings.
- **Behavioral confirmation pending a sim rerun** on this build: expect the 13 >5 ms gaps gone. Residual sub-5 ms burstiness (the 250 ms poll's `masterRead` stays — that's the known sim generation-time-stamp quirk, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)