### PR TITLE
fix(oc): use the full F35SQB004G — 512 MB flash, not 128 MB

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
@@ -12,10 +12,10 @@
 
 import Foundation
 
-/// Rocket NAND flight-log usage, in 128 KB blocks (wire = 14 bytes, LE packed):
+/// Rocket NAND flight-log usage, in 256 KB blocks (wire = 15 bytes, LE packed):
 ///   [0..1] u16 flight_region_blocks  [2..3] u16 used  [4..5] u16 free
 ///   [6..7] u16 bad  [8..9] u16 system  [10..11] u16 flight_count
-///   [12] u8 block_size_kb  [13] u8 flags(bit0=initialized)
+///   [12..13] u16 block_size_kb  [14] u8 flags(bit0=initialized)
 struct RocketStorageStats: Equatable {
     let flightRegionBlocks: Int
     let usedBlocks: Int
@@ -36,7 +36,7 @@ struct RocketStorageStats: Equatable {
 
     /// Decode the payload *after* the 0xCC discriminator byte.
     static func decode(_ bytes: [UInt8]) -> RocketStorageStats? {
-        guard bytes.count >= 14 else { return nil }
+        guard bytes.count >= 15 else { return nil }
         func u16(_ o: Int) -> Int {
             Int(bytes.withUnsafeBufferPointer {
                 UnsafeRawBufferPointer($0).loadUnaligned(fromByteOffset: o, as: UInt16.self)
@@ -45,7 +45,7 @@ struct RocketStorageStats: Equatable {
         return RocketStorageStats(
             flightRegionBlocks: u16(0), usedBlocks: u16(2), freeBlocks: u16(4),
             badBlocks: u16(6), systemBlocks: u16(8), flightCount: u16(10),
-            blockSizeKB: Int(bytes[12]), initialized: (bytes[13] & 0x01) != 0)
+            blockSizeKB: u16(12), initialized: (bytes[14] & 0x01) != 0)
     }
 }
 

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -50,8 +50,10 @@ FlightIndexEntry makeEntry(uint32_t id, const char* filename,
     return e;
 }
 
-constexpr uint32_t META_A = 1020;
-constexpr uint32_t META_B = 1021;
+// Match the default Config metadata blocks (top of the 2048-block F35SQB004G),
+// so tests that seed the index here line up with a default-config begin().
+constexpr uint32_t META_A = 2044;
+constexpr uint32_t META_B = 2045;
 
 }  // namespace
 
@@ -180,7 +182,7 @@ TEST(TRFlightLogScaffold, BeginAcceptsDefaultConfig) {
     TR_FlightLog::Config cfg;
     EXPECT_EQ(fl.begin(nand, cfg), Status::Ok);
     EXPECT_TRUE(fl.isInitialized());
-    EXPECT_EQ(fl.config().prealloc_blocks, 80);
+    EXPECT_EQ(fl.config().prealloc_blocks, 40);
 }
 
 TEST(TRFlightLogScaffold, BeginRejectsInvertedRegion) {
@@ -350,9 +352,9 @@ TEST(BlockStateBitmap, DeserializeRejectsShortBuffer) {
     EXPECT_FALSE(bm.deserializeFrom(buf, sizeof(buf)));
 }
 
-TEST(BlockStateBitmap, SerializedSizeIs256Bytes) {
-    // Storage layout guard: 1024 blocks * 2 bits = 256 bytes.
-    EXPECT_EQ(BlockStateBitmap::SERIALIZED_SIZE, 256u);
+TEST(BlockStateBitmap, SerializedSizeIs512Bytes) {
+    // Storage layout guard: 2048 blocks * 2 bits = 512 bytes.
+    EXPECT_EQ(BlockStateBitmap::SERIALIZED_SIZE, 512u);
 }
 
 // ================================================================
@@ -731,21 +733,21 @@ TEST(TRFlightLogPrepare, SkipsKnownBadBlocksWhenPicking) {
     TR_FlightLog::Config cfg;
     // Factory-bad a block partway through the first natural prealloc-block range
     // (must be < prealloc_blocks so it actually breaks the first candidate run).
-    nand.injectFactoryBadBlock(cfg.flight_region_start + 50);
+    nand.injectFactoryBadBlock(cfg.flight_region_start + 20);
 
     ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
     uint32_t flight_id = 0;
     ASSERT_EQ(fl.prepareFlight(flight_id), Status::Ok);
 
-    // The chosen start must be >= flight_region_start + 51 (first fresh free
+    // The chosen start must be >= flight_region_start + 21 (first fresh free
     // run after the bad block).
     // Walk the bitmap to find the chosen range.
     uint32_t first_alloc = 0;
     for (uint32_t b = 0; b < NAND_BLOCK_COUNT; ++b) {
         if (fl.bitmap().get(b) == BLOCK_ALLOCATED) { first_alloc = b; break; }
     }
-    EXPECT_EQ(first_alloc, cfg.flight_region_start + 51);
-    EXPECT_EQ(fl.bitmap().get(cfg.flight_region_start + 50), BLOCK_BAD);
+    EXPECT_EQ(first_alloc, cfg.flight_region_start + 21);
+    EXPECT_EQ(fl.bitmap().get(cfg.flight_region_start + 20), BLOCK_BAD);
 }
 
 TEST(TRFlightLogPrepare, NoSpaceWhenInsufficientContiguousFree) {

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -116,7 +116,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
         return false;
     };
 
-    uint8_t page[NAND_PAGE_SIZE];
+    uint8_t* const page = page_buf_;  // off-stack (member); recovery is boot-time single-threaded
     bool index_dirty  = false;
     bool bitmap_dirty = false;
 
@@ -235,7 +235,7 @@ Status TR_FlightLog::scanForBrownoutRecovery() {
         }
 
         // Synthesize a partial flight entry. final_bytes is the logical PAYLOAD
-        // byte count actually flushed to NAND — #273: PAYLOAD_PER_PAGE (2032),
+        // byte count actually flushed to NAND — #273: PAYLOAD_PER_PAGE (4080),
         // NOT NAND_PAGE_SIZE (2048), or the downloader walks past the last real
         // page into PageHeader/0xFF bytes (corrupt tail, size ~0.8% too large).
         constexpr uint32_t PAYLOAD_PER_PAGE = NAND_PAGE_SIZE - sizeof(PageHeader);
@@ -403,8 +403,8 @@ Status TR_FlightLog::writeFrame(const uint8_t* payload, size_t payload_len) {
     if (payload == nullptr && payload_len != 0) return Status::OutOfRange;
     if (payload_len > NAND_PAGE_SIZE - sizeof(PageHeader)) return Status::OutOfRange;
 
-    uint8_t page[NAND_PAGE_SIZE];
-    std::memset(page, 0xFF, sizeof(page));
+    uint8_t* const page = page_buf_;  // off-stack (member); guarded by mutex_ above
+    std::memset(page, 0xFF, NAND_PAGE_SIZE);
 
     PageHeader hdr;
     hdr.crc32      = 0;  // placeholder
@@ -482,7 +482,7 @@ bool TR_FlightLog::retireBlockAndSalvage(uint32_t bad_block, uint32_t rel_block,
     // is retired and the relocation restarts from page 0 into the next block —
     // the source is still readable, so no salvaged page is dropped. Restarts
     // are bounded by the number of blocks available.
-    uint8_t buf[NAND_PAGE_SIZE];
+    uint8_t* const buf = salvage_buf_;  // off-stack (member); live while page_buf_ is held
     const uint32_t max_restarts = active_n_blocks_ + cfg_.extend_blocks + 1;
     uint32_t restarts = 0;
     uint32_t i = 0;
@@ -500,7 +500,7 @@ bool TR_FlightLog::retireBlockAndSalvage(uint32_t bad_block, uint32_t rel_block,
             // unrecoverable. Write a zeroed placeholder so the stream stays
             // aligned (one lost page beats orphaning + shifting everything
             // after it) and flag it.
-            std::memset(buf, 0x00, sizeof(buf));
+            std::memset(buf, 0x00, NAND_PAGE_SIZE);
             ++unrecoverable_page_count_;
             FL_LOGW("salvage: page %lu of retired block %lu unreadable — wrote "
                     "zeroed placeholder to keep the stream aligned (#371)",
@@ -620,7 +620,7 @@ Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
     if (offset >= entry->final_bytes) return Status::Ok;  // EOF, 0 bytes
 
     // Pages written via writeFrame have a 16 B PageHeader at the start, so the
-    // *logical* payload size per NAND page is PAYLOAD_PER_PAGE = 2032 bytes.
+    // *logical* payload size per NAND page is PAYLOAD_PER_PAGE = 4080 bytes.
     // `offset` is a byte index into the concatenated payload stream (what the
     // caller originally enqueued via writeFrame / what iOS expects to
     // download). The mapping hops the 16 B header on each physical page.
@@ -648,7 +648,7 @@ Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
     if (abs_block >= end_block) return Status::Ok;  // logical page past the data
     const uint32_t page_in_blk = pages_left;
 
-    uint8_t page[NAND_PAGE_SIZE];
+    uint8_t* const page = page_buf_;  // off-stack (member); guarded by mutex_ above
     if (!nand_->readPage(abs_block, page_in_blk, page)) return Status::BackendFailed;
 
     // Payload starts right after the PageHeader on the physical page.

--- a/tinkerrocket-idf/components/TR_FlightLog/include/BlockStateBitmap.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/BlockStateBitmap.h
@@ -7,7 +7,7 @@
 
 namespace tr_flightlog {
 
-// 2-bit-per-block state map. 1024 blocks = 256 bytes.
+// 2-bit-per-block state map. 2048 blocks = 512 bytes.
 //
 // Byte layout (little-endian within the byte):
 //   buf[N / 4] bits [(N % 4)*2 .. (N % 4)*2 + 1] = state of block N

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -24,11 +24,13 @@ public:
         // flights without an overflow extend.  Was 256 (32 MB / ~8.5 min): with
         // recovered flights now trimmed (scanForBrownoutRecovery) that headroom
         // is pure waste/fragmentation, and a brownout flight no longer keeps it.
-        uint16_t prealloc_blocks     = 80;    // ~10 MB
-        uint16_t extend_blocks       = 64;    // overflow step (~200 ms stall)
+        // Block is now 256 KB (F35SQB004G), so these are halved vs the old 128 KB
+        // block count to keep the same byte footprint / erase-stall duration.
+        uint16_t prealloc_blocks     = 40;    // ~10 MB
+        uint16_t extend_blocks       = 32;    // overflow step (~200 ms stall)
         uint16_t flight_region_start = 32;    // first block owned by this layer
-        uint16_t flight_region_end   = 1020;  // one past last flight block
-        uint16_t metadata_blocks[4]  = {1020, 1021, 1022, 1023};
+        uint16_t flight_region_end   = 2044;  // one past last flight block
+        uint16_t metadata_blocks[4]  = {2044, 2045, 2046, 2047};
         // #277: wall-clock cap on one brownout-recovery pass so a chip with many
         // large orphaned ranges can't scan for minutes and look hung past the
         // app's 180 s power-on watchdog. Checked at run boundaries (never
@@ -113,7 +115,7 @@ public:
     Status writePage(const uint8_t* page);
 
     // Hot-path helper: wrap `payload` (up to NAND_PAGE_SIZE - sizeof(PageHeader)
-    // = 2032 bytes) in a PageHeader (active flight_id + monotonic seq + CRC32)
+    // = 4080 bytes) in a PageHeader (active flight_id + monotonic seq + CRC32)
     // and program it. This is the recommended write API — pages written via
     // writeFrame are recoverable by the brownout scanner if finalizeFlight is
     // never called.
@@ -149,6 +151,16 @@ private:
     uint32_t salvaged_block_count_    = 0;  // #371: bad blocks whose pages were relocated
     uint32_t unrecoverable_page_count_ = 0; // #371: salvage pages that would not re-read
     bool     flight_active_       = false;
+
+    // Page-sized scratch buffers kept OFF the task stack. At the 4 KB
+    // F35SQB004G page size, the nested writeFrame -> writePageLocked ->
+    // retireBlockAndSalvage path would otherwise put two 4 KB page[] arrays on
+    // the flush task's 8 KB stack at once and overflow it. All uses are
+    // serialized by mutex_ (or run at boot before the flush task exists);
+    // salvage needs its own buffer because it is live while page_buf_ is still
+    // held by the in-progress writeFrame/writePage call.
+    uint8_t  page_buf_[NAND_PAGE_SIZE]    = {};  // writeFrame / readFlightPage / recovery
+    uint8_t  salvage_buf_[NAND_PAGE_SIZE] = {};  // retireBlockAndSalvage only
 
     // Single-producer (any task) / single-consumer (flush task) request flag
     // for the deferred prepareFlight path. `volatile` is sufficient because

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog_types.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog_types.h
@@ -5,11 +5,13 @@
 
 namespace tr_flightlog {
 
-// ---- NAND geometry (ISM6HG256 — matches TR_LogToFlash) ----
-constexpr uint32_t NAND_PAGE_SIZE      = 2048;
+// ---- NAND geometry (FORESEE F35SQB004G, 4 Gbit / 512 MB — matches TR_LogToFlash) ----
+// 4096 B/page x 64 pages/block x 2048 blocks = 512 MB. Must stay identical to the
+// duplicate set in TR_LogToFlash.h (the live raw-SPI driver programs against it).
+constexpr uint32_t NAND_PAGE_SIZE      = 4096;
 constexpr uint32_t NAND_PAGES_PER_BLK  = 64;
-constexpr uint32_t NAND_BLOCK_SIZE     = NAND_PAGE_SIZE * NAND_PAGES_PER_BLK;  // 128 KB
-constexpr uint32_t NAND_BLOCK_COUNT    = 1024;
+constexpr uint32_t NAND_BLOCK_SIZE     = NAND_PAGE_SIZE * NAND_PAGES_PER_BLK;  // 256 KB
+constexpr uint32_t NAND_BLOCK_COUNT    = 2048;
 
 // ---- Block state (2 bits per block in the persistent bitmap) ----
 enum BlockState : uint8_t {

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -161,14 +161,14 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
     lfs_cfg->erase = lfsBlockErase;
     lfs_cfg->sync = lfsBlockSync;
 
-    lfs_cfg->read_size = NAND_PAGE_SIZE;      // 2048
-    lfs_cfg->prog_size = NAND_PAGE_SIZE;      // 2048
-    lfs_cfg->block_size = NAND_BLOCK_SIZE;    // 128KB
+    lfs_cfg->read_size = NAND_PAGE_SIZE;      // 4096
+    lfs_cfg->prog_size = NAND_PAGE_SIZE;      // 4096
+    lfs_cfg->block_size = NAND_BLOCK_SIZE;    // 256KB
     // Default to the full chip; caller may shrink (issue #50 Stage 2c) so the
     // trailing blocks can be owned by TR_FlightLog.
     lfs_cfg->block_count = (cfg.lfs_block_count > 0) ? cfg.lfs_block_count
                                                      : NAND_BLOCK_COUNT;
-    lfs_cfg->cache_size = NAND_PAGE_SIZE;     // 2048
+    lfs_cfg->cache_size = NAND_PAGE_SIZE;     // 4096
     lfs_cfg->lookahead_size = 128;            // 128 bytes = 1024 bits
     lfs_cfg->block_cycles = 500;              // Wear leveling
 
@@ -1707,7 +1707,7 @@ void TR_LogToFlash::closeLogSession()
             // Pad the tail chunk with the existing 0xFF fill from NAND prior
             // state is not possible here (page_buf is just RAM), so we pass
             // whatever bytes we have — the sink (writeFrame) wraps payload
-            // in a PageHeader and programs a full 2048-byte page, zero-
+            // in a PageHeader and programs a full 4096-byte page, zero-
             // padding the unused payload tail. Accepted small loss.
             (void)cfg.write_sink(cfg.write_sink_ctx, page_buf, page_buf_idx);
             page_buf_idx = 0;
@@ -1859,7 +1859,7 @@ bool TR_LogToFlash::checkMramDirty()
 uint32_t TR_LogToFlash::drainMramToSink()
 {
     if (!use_mram_ || cfg.write_sink == nullptr) return 0;
-    constexpr uint32_t kChunk = NAND_PAGE_SIZE - 16u;   // 2032; matches flushRingToNand
+    constexpr uint32_t kChunk = NAND_PAGE_SIZE - 16u;   // 4080; matches flushRingToNand
     uint8_t buf[kChunk];
     uint32_t total = 0;
     for (uint32_t off = 0; off < ring_size_; off += kChunk)
@@ -2157,8 +2157,11 @@ void TR_LogToFlash::runStartupRecovery()
         return;
     }
 
-    // Read MRAM in page-sized chunks and write to LittleFS
-    uint8_t chunk[NAND_PAGE_SIZE];
+    // Read MRAM in page-sized chunks and write to LittleFS. Reuse the idle
+    // page staging member rather than a 4 KB (F35SQB004G page) stack array so
+    // this buffer plus the nested lfsBlockRead page buffer don't both land on
+    // one task stack. Boot-only, single-threaded, staging is idle here.
+    uint8_t* const chunk = page_buf;
     uint32_t offset = 0;
     uint32_t total_written = 0;
     while (offset < ring_size_)

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -25,7 +25,7 @@ struct TR_LogToFlashConfig
     // Optional hot-path write override (issue #50 Stage 2c-3c). When set,
     // the flush task calls `write_sink(write_sink_ctx, payload, len)` for
     // each page drained from the ring instead of lfs_file_write. `len` is
-    // fixed at NAND_PAGE_SIZE - 16 (2032) so the sink can prepend a 16-byte
+    // fixed at NAND_PAGE_SIZE - 16 (4080) so the sink can prepend a 16-byte
     // TR_FlightLog PageHeader and still land on a NAND page boundary. The
     // sink should return true on success; false drops the page (same as an
     // LFS write failure). When the sink is set, periodic lfs_file_sync calls
@@ -223,10 +223,12 @@ private:
     static constexpr uint8_t STAT_PFAIL = 0x08;
     static constexpr uint8_t STAT_EFAIL = 0x04;
 
-    static constexpr uint32_t NAND_PAGE_SIZE = 2048;
+    // FORESEE F35SQB004G, 4 Gbit / 512 MB: 4096 B/page x 64 pages/block x 2048 blocks.
+    // Must stay identical to tr_flightlog:: geometry in TR_FlightLog_types.h.
+    static constexpr uint32_t NAND_PAGE_SIZE = 4096;
     static constexpr uint32_t NAND_PAGES_PER_BLK = 64;
-    static constexpr uint32_t NAND_BLOCK_SIZE = NAND_PAGE_SIZE * NAND_PAGES_PER_BLK;  // 128KB
-    static constexpr uint32_t NAND_BLOCK_COUNT = 1024;
+    static constexpr uint32_t NAND_BLOCK_SIZE = NAND_PAGE_SIZE * NAND_PAGES_PER_BLK;  // 256KB
+    static constexpr uint32_t NAND_BLOCK_COUNT = 2048;
 
     struct __attribute__((packed)) LogMeta
     {
@@ -348,7 +350,7 @@ private:
     // NAND write amplification.  64 pages is the compromise: still cuts
     // the pre-patch 3.7 s loss window in half while letting LFS batch its
     // metadata commits.
-    static constexpr uint32_t SYNC_INTERVAL_PAGES = 64;   // ~128 KB / 1.8 s
+    static constexpr uint32_t SYNC_INTERVAL_PAGES = 64;   // ~256 KB / 1.8 s
     uint32_t pages_since_sync_ = 0;
 
     // Interval-peak timing instrumentation (µs) — reset by

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -940,17 +940,17 @@ static_assert(sizeof(SensorCalStatusData) == 19,
 // reserved = bad + system, free = free_blocks.  Accurate on a DIRECT rocket link.
 typedef struct __attribute__((packed))
 {
-    uint16_t flight_region_blocks;  // total blocks the flight layer manages (~988)
+    uint16_t flight_region_blocks;  // total blocks the flight layer manages (~2012)
     uint16_t used_blocks;           // ALLOCATED (finalized + active flights)
     uint16_t free_blocks;           // FREE
     uint16_t bad_blocks;            // BAD (unusable)
     uint16_t system_blocks;         // LFS + metadata blocks (fixed overhead)
     uint16_t flight_count;          // entries in the flight index
-    uint8_t  block_size_kb;         // NAND block size in KB (128)
+    uint16_t block_size_kb;         // NAND block size in KB (256; u16 — 256 > uint8 max)
     uint8_t  flags;                 // bit0 = flight log initialized
 } RocketStorageStatsData;
-static_assert(sizeof(RocketStorageStatsData) == 14,
-              "RocketStorageStatsData must be 14 bytes");
+static_assert(sizeof(RocketStorageStatsData) == 15,
+              "RocketStorageStatsData must be 15 bytes");
 
 // BS→app flash-space stats for the base station's own log filesystem.  Rides the
 // file_ops characteristic behind a 0xCD discriminator.  Bytes (not blocks) since

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -99,7 +99,7 @@ static TR_LogToFlash logger;
 // writes via writeFrame(), with dual-copy index metadata in blocks 1020-1023
 // and a persistent 3-state bitmap in NVS. TR_LogToFlash keeps the ring/flush
 // machinery and shelled-down 4 MB LFS partition for config; a write_sink
-// fn-pointer routes each drained 2032 B page into flightlog.writeFrame().
+// fn-pointer routes each drained 4080 B page into flightlog.writeFrame().
 static tr_flightlog::TR_NandBackend_esp flightlog_backend;
 static tr_flightlog::TR_FlightLog flightlog;
 static tr_flightlog::NvsBitmapStore flightlog_bitmap_store;
@@ -146,7 +146,7 @@ static SensorHealthState ocStorageHealth()
 
 // Stage 3b (issue #50): BLE file-ops re-backed on TR_FlightLog.
 // Fills up to `max_bytes` of the downloader's scratch buffer by issuing
-// successive readFlightPage calls (each one returns at most 2032 payload
+// successive readFlightPage calls (each one returns at most 4080 payload
 // bytes — the portion of a single NAND page past its PageHeader). Matches
 // the logger.readFileChunk contract: sets eof=true when the last byte of
 // the flight has been read; returns false only on underlying NAND I/O error.
@@ -3908,7 +3908,7 @@ static void printStats()
                 rss.bad_blocks    = (uint16_t)flightlog.bitmap().countInState(tr_flightlog::BLOCK_BAD);
                 rss.system_blocks = (uint16_t)(fcfg.flight_region_start + 4u);  // LFS region + 4 metadata
                 rss.flight_count  = (uint16_t)flightlog.index().size();
-                rss.block_size_kb = (uint8_t)(tr_flightlog::NAND_BLOCK_SIZE / 1024u);
+                rss.block_size_kb = (uint16_t)(tr_flightlog::NAND_BLOCK_SIZE / 1024u);
                 rss.flags         = 0x01;  // initialized
             }
             ble_app.sendStorageStats(0xCC, reinterpret_cast<const uint8_t*>(&rss), sizeof(rss));
@@ -4386,7 +4386,7 @@ void initPeripherals()
 
     // --- LFS shrunk to 4 MB + hot-path write sink (issue #50) ---------------
     // LFS holds 32 blocks for config/placeholder use; TR_FlightLog owns the
-    // remaining 988 blocks plus the metadata blocks 1020-1023. Each 2032 B
+    // remaining 2012 blocks plus the metadata blocks 2044-2047. Each 4080 B
     // chunk the flush task drains from the ring is routed through
     // flightlogWriteSink → flightlog.writeFrame(), which wraps it in a
     // PageHeader (CRC32 + seq + flight_id) and programs one NAND page


### PR DESCRIPTION
## Problem
The rocket computer reported **and used** only **128 MB** of its 4 Gbit / **512 MB** SPI NAND (F35SQB004G). The flight-log geometry constants described a **1 Gbit** chip — page 2048 B (chip is 4096) and 1024 blocks (chip has 2048). The two compounding 2× errors meant the raw-SPI path wrote only the first half of every physical page and never touched the upper 1024 blocks — **¾ of the chip dark**.

The IDF `spi_nand_flash` driver (`nand_foresee.c`) had the right geometry but is **off the flight path**; `TR_LogToFlash`'s bit-banged raw-SPI path is authoritative. The base station reported correctly because it reads live FS geometry at runtime.

## Fix
- Corrected **both** duplicate geometry blocks (`TR_FlightLog_types.h`, `TR_LogToFlash.h`) to page=4096, blocks=2048.
- Extended the flight region + metadata into the upper half; halved `prealloc`/`extend` so the ~10 MB / ~200 ms byte-intent holds at the now-256 KB block.
- Widened `RocketStorageStatsData.block_size_kb` u8→u16 (256 overflowed u8→0): frame 14→15 B; app decoder updated to match.

## Stack safety (page buffers double 2 KB → 4 KB)
`writeFrame`'s page buffer + the nested `retireBlockAndSalvage` buffer would have put 8 KB on the 8 KB flush-task stack during mid-flight bad-block relocation → **overflow**. Both moved to `.bss` member scratch buffers (`flightlog` is a global; all paths serialized by `mutex_`). The boot MRAM→LFS recovery buffer reuses the idle staging member so it no longer stacks with the LFS read callback.

## ⚠️ Destructive migration
Changing page size + block count + metadata location **reformats LittleFS, reseeds the NVS block bitmaps, and relocates the flight index — existing stored flights are lost. Download before flashing.**

## Verification
- `out_computer` firmware (esp32s3, IDF v6.0.1): builds clean; `static_assert(sizeof(RocketStorageStatsData)==15)` passes.
- iOS app: **BUILD SUCCEEDED**.

## Bench checklist (post-merge)
- 512 MB reported in-app; log + read-back at 4080 B/page.
- `oc_loop`/flush stack high-water margin on first boot.
- F35SQB004G OOB bad-block marker column (now 4096) + full-page on-die ECC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)