### PR TITLE
fix(fc): close the silent #474 logging hole — deepen ISM6 queue + log a drop flag

### DIFF
--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -183,6 +183,8 @@ NSF2_PITCH_APOGEE     = (1 << 1)
 NSF2_MASTER_APOGEE    = (1 << 2)
 NSF2_REBOOT_RECOVERY  = (1 << 3)
 NSF2_GUIDANCE_ENABLED = (1 << 4)
+NSF2_ORIENT_THRUST_MISMATCH = (1 << 5)
+NSF2_FC_IMU_DROP      = (1 << 6)  # #474: FC loop stalled -> ISM6 queue overflow (sticky)
 
 # Pyro status byte bits — paired (CONT, FIRED) per channel.  Layout must match
 # the PSF_* constants in TR_RocketComputerTypes/RocketComputerTypes.h.  An
@@ -553,6 +555,7 @@ def parse_binary_file(filepath):
                     "apogee_flag":        bool(apogee_flags_b & NSF2_MASTER_APOGEE),
                     "reboot_recovery":    bool(apogee_flags_b & NSF2_REBOOT_RECOVERY),
                     "guidance_enabled":   bool(apogee_flags_b & NSF2_GUIDANCE_ENABLED),
+                    "fc_imu_drop":        bool(apogee_flags_b & NSF2_FC_IMU_DROP),
                 })
 
             elif msg_type == MSG_NON_SENSOR:

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -74,15 +74,20 @@ TEST(RocketComputerTypes, NSF_FlagBits_NoOverlap) {
 
 TEST(RocketComputerTypes, NSF2_ApogeeFlagBits_NoOverlap) {
     // apogee_flags byte: 3 apogee detector bits + 2 relocated signals
-    // (reboot_recovery, guidance_enabled) that used to live in pyro_status.
+    // (reboot_recovery, guidance_enabled) that used to live in pyro_status,
+    // plus the orientation-mismatch flag (bit 5) and the #474 FC IMU-drop
+    // witness (bit 6).
     uint8_t all = NSF2_GPS_APOGEE | NSF2_PITCH_APOGEE | NSF2_MASTER_APOGEE |
-                  NSF2_REBOOT_RECOVERY | NSF2_GUIDANCE_ENABLED;
-    EXPECT_EQ(all, 0x1F);  // bits 0-4 used
-    EXPECT_EQ(__builtin_popcount(NSF2_GPS_APOGEE),       1);
-    EXPECT_EQ(__builtin_popcount(NSF2_PITCH_APOGEE),     1);
-    EXPECT_EQ(__builtin_popcount(NSF2_MASTER_APOGEE),    1);
-    EXPECT_EQ(__builtin_popcount(NSF2_REBOOT_RECOVERY),  1);
-    EXPECT_EQ(__builtin_popcount(NSF2_GUIDANCE_ENABLED), 1);
+                  NSF2_REBOOT_RECOVERY | NSF2_GUIDANCE_ENABLED |
+                  NSF2_ORIENT_THRUST_MISMATCH | NSF2_FC_IMU_DROP;
+    EXPECT_EQ(all, 0x7F);  // bits 0-6 used, none overlapping
+    EXPECT_EQ(__builtin_popcount(NSF2_GPS_APOGEE),            1);
+    EXPECT_EQ(__builtin_popcount(NSF2_PITCH_APOGEE),          1);
+    EXPECT_EQ(__builtin_popcount(NSF2_MASTER_APOGEE),         1);
+    EXPECT_EQ(__builtin_popcount(NSF2_REBOOT_RECOVERY),       1);
+    EXPECT_EQ(__builtin_popcount(NSF2_GUIDANCE_ENABLED),      1);
+    EXPECT_EQ(__builtin_popcount(NSF2_ORIENT_THRUST_MISMATCH), 1);
+    EXPECT_EQ(__builtin_popcount(NSF2_FC_IMU_DROP),           1);
 }
 
 TEST(RocketComputerTypes, PSF_FlagBits_NoOverlap) {

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1224,6 +1224,13 @@ static constexpr uint8_t NSF2_GUIDANCE_ENABLED = (1u << 4);  // FC's live guidan
 // orientation is NOT corrected mid-flight — this flags the mismatch for
 // telemetry and post-flight analysis (suspect attitude-derived data).
 static constexpr uint8_t NSF2_ORIENT_THRUST_MISMATCH = (1u << 5);
+// FC loop stalled long enough to overflow the ISM6 IMU handoff queue and drop
+// samples this session (#474).  Sticky: set once ism6_queue_drops > 0 and stays
+// set, so the previously-silent all-stream logging hole (a blocking I2C poll
+// starving the single-threaded sensor loop) is now recorded in the flight log
+// instead of vanishing with no counter.  Post-flight witness; the app ignores
+// this bit.  Pairs with the deepened ISM6_QUEUE_DEPTH that should keep it clear.
+static constexpr uint8_t NSF2_FC_IMU_DROP = (1u << 6);
 
 // Pyro status byte — 4 channels × (continuity, fired) = exactly 8 bits.
 static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -215,17 +215,32 @@ private:
     // consumer when it starts draining — the ~4 s of pre-loop boot produce
     // thousands of meaningless pre-consumer drops otherwise).
     QueueHandle_t ism6Queue = nullptr;
-    // 64 samples = ~16.7 ms of buffer at 3840 Hz (33 ms at 1920) — sized so the
-    // user-selectable top rate keeps the same stall tolerance the depth-32
-    // queue gave 1920 Hz (a measured 47.7 ms I2C-recovery stall overflowed
-    // even 32 at 1920; the [GAP DIAG] imu_q_drops gauge stays the witness).
-    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 64;
+    // 256 samples = ~67 ms of buffer at 3840 Hz (~133 ms at 1920) — sized to
+    // ABSORB the worst-case ground-state consumer stall, not merely tolerate a
+    // fraction of it.  loop_fc() services the I2C command poll inline, and its
+    // masterRead carries a 50 ms timeout (#399: aborting mid-read desyncs the OC
+    // slave TX ring, so it can't be shortened) plus up to ~15 ms of config-read
+    // retries — a ~65 ms stall.  The earlier depth-64 (33 ms @1920) let that
+    // stall silently drop IMU samples at the logging handoff (#474: a 34.6 ms
+    // all-stream hole at activateLogging with zero recorded counters); the
+    // 47.7 ms I2C-recovery stall overflowed even 64.  256 covers the full stall
+    // at every user-selectable rate, so the SPI-fed queue buffers straight
+    // through it and loop_fc drains the burst on the next pass (the 512-deep
+    // I2S TX queue absorbs it).  Witnesses: the [GAP DIAG] imu_q_drops serial
+    // gauge plus the logged NSF2_FC_IMU_DROP flag if any drop still occurs.
+    static constexpr UBaseType_t ISM6_QUEUE_DEPTH = 256;
     volatile uint32_t ism6_queue_drops = 0;
 
 public:
     // Zero the drop counter (and nothing else).  Called once by the consumer
     // when it begins draining, so the gauge counts only consumer-era drops.
     void resetIsm6QueueDrops() { ism6_queue_drops = 0; }
+
+    // Consumer-era IMU-queue drop count since the last resetIsm6QueueDrops().
+    // Nonzero means loop_fc() stalled long enough to overflow the handoff queue
+    // and lose IMU samples — the FC-side witness for the #474 silent hole. Read
+    // by the NonSensor builder to set the logged NSF2_FC_IMU_DROP flag.
+    uint32_t getIsm6QueueDrops() const { return ism6_queue_drops; }
 
     // Runtime IMU logging-rate change (user setting, BLE cmd 67): reprograms
     // the ISM6HG256 ODR on all three channels and the derived period. Safe

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -6279,6 +6279,14 @@ static void loop_fc()
         if (reboot_recovery_telem)        non_sensor_data.apogee_flags |= NSF2_REBOOT_RECOVERY;
         if (guidance_enabled)             non_sensor_data.apogee_flags |= NSF2_GUIDANCE_ENABLED;
         if (orient_thrust_mismatch)       non_sensor_data.apogee_flags |= NSF2_ORIENT_THRUST_MISMATCH;
+        // #474: sticky witness for a stalled sensor loop.  Nonzero drops mean
+        // loop_fc() blocked long enough (an I2C poll/config-read) to overflow the
+        // ISM6 handoff queue and lose IMU samples — the previously-silent all-
+        // stream logging hole.  Read the HW collector (owns the queue + counter,
+        // reset once at loop start) so the deepened queue's residual, if any, is
+        // recorded in the log rather than vanishing.
+        if (sensor_collector_hw.getIsm6QueueDrops() > 0)
+            non_sensor_data.apogee_flags |= NSF2_FC_IMU_DROP;
         // Snapshot pyro state under spinlock for telemetry. With per-fire
         // arming the global "armed" bit just mirrors the live PYRO_ARM pin.
         bool arm_now;


### PR DESCRIPTION
Closes #474

## Problem
The ~35 ms **all-stream** data hole at `activateLogging()` (#474) is FC-side and structural. `loop_fc()` is single-threaded and services the I2C command poll inline, where the status `masterRead` carries a 50 ms timeout (#399 — aborting mid-read desyncs the OC slave TX ring, so it can't be shortened) plus up to ~15 ms of config-read retries. That ~65 ms worst-case stall starved the SPI-fed ISM6 handoff queue (depth 64 ≈ 33 ms) and the latest-wins reads of every other sensor, dropping ~3.4 KB of frames with **zero recorded counters** — on the same path a real flight takes at launch detect (T-0).

The specific trigger was fixed incidentally by #473 (the 0xF5 config-relay bug that caused failing CFG READs). This PR closes the underlying structural class and makes any recurrence observable.

## Changes
- **Deepen `ISM6_QUEUE_DEPTH` 64 → 256** — the SPI-fed IMU queue now absorbs the full worst-case ground/seam poll stall at *every* user-selectable rate (~67 ms @3840 Hz, ~133 ms @1920 Hz). `loop_fc` drains the burst on the next pass; the 512-deep I2S TX queue absorbs it. ~4 KB extra RAM. This is the prior "bound them" lever (32→64 was the last bump).
- **Add a sticky `NSF2_FC_IMU_DROP` flag** (`apogee_flags` bit 6, previously free — **no wire resize**, `NonSensorData` stays 48 B) set whenever `ism6_queue_drops > 0`, via a new `SensorCollector::getIsm6QueueDrops()`. A residual FC-loop stall is now **recorded in the flight log** instead of vanishing silently.
- Decode it as `fc_imu_drop` in `plot_flight_data_mini.py`, and make the `NSF2` bit-overlap gtest comprehensive (was stale at bits 0–4; now 0–6).

Deliberately **not** touched: the I2C poll timeouts (load-bearing per #399/#402) and the single-threaded command dispatch (high-risk to split on flight firmware).

## Verification
- FC firmware builds clean (IDF v6, ESP32-P4). C++ gtests pass, incl. `StructSizes_MatchConstants` (confirms 48 B unchanged) and the updated overlap guard.
- **Bench run** `flight_20260712_113019` (fw `6c9338f`, manual start, **3840 Hz** worst case):
  - FC serial: `imu_q_drops=0` throughout, incl. the full connect config burst — every `[CFG READ]` hits #473's `[cached]` attempt-0 fast path, no retries, no `[I2C] RESYNC`.
  - Recorded `.bin`: 0 bad CRC / 75,557 frames; **ISM6 gap-free, max dt 0.818 ms** (vs 34.59 ms in the repro); OC ring `drop_oldest`/overruns/bad_sof all 0; **`NSF2_FC_IMU_DROP` 0/7,439** (observability verified end-to-end).
  - Design confirmed by a benign ~9 ms BMP/NonSensor hiccup at t+10.6 s that ISM6 sailed through gap-free (queue absorbed it; the low-rate latest-wins streams show the known residual).

## Known residual / caveat
- Lower-rate latest-wins streams (BMP/mag/power) can still gap a few samples during a rare ground-state poll stall — inherent to their single-slot design, out of scope here.
- The bench run did not *force* the OC-sluggish corner (no CFG retries/RESYNC observed) and never went INFLIGHT — a strong no-repro/no-regression result at the worst-case rate, like the prior 4k acceptance run, not a forced worst case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
