### PR TITLE
fix(oc): dirty-marker at activateLogging, not pre-create — stop bench-noise MRAM recoveries (#417)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -405,3 +405,18 @@ target_include_directories(test_dedup_reboot_policy PRIVATE
 )
 target_link_libraries(test_dedup_reboot_policy GTest::gtest_main)
 gtest_discover_tests(test_dedup_reboot_policy)
+
+# ---------- test_mram_dirty_policy ----------
+# Host-side test for the #417 sink-mode dirty-marker gate: the marker means
+# "logging was activated" (launch detect / manual cmd-23 start), not "a log
+# file was pre-created at PRELAUNCH", so a bench power-cut from PRELAUNCH no
+# longer spawns a bogus flight_mram_recovered_*.bin — while a genuine in-flight
+# brownout (#274) still recovers. mram_dirty_policy.h is pure (no SPI/MRAM/LFS),
+# so the test just adds the TR_LogToFlash component dir.
+add_executable(test_mram_dirty_policy test_mram_dirty_policy.cpp)
+target_include_directories(test_mram_dirty_policy PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_LogToFlash
+)
+target_link_libraries(test_mram_dirty_policy GTest::gtest_main)
+gtest_discover_tests(test_mram_dirty_policy)

--- a/tests_cpp/test_mram_dirty_policy.cpp
+++ b/tests_cpp/test_mram_dirty_policy.cpp
@@ -1,0 +1,120 @@
+// #417: MramDirtyPolicy — the sink-mode "dirty" marker must mean "logging was
+// activated" (real launch, or a deliberate manual cmd-23 start), NOT merely "a
+// log file was pre-created at PRELAUNCH". The old behavior set the marker at
+// openLogSession()/pre-create and only cleared it on a clean close, so a bench
+// power-cut from PRELAUNCH (never launched, never cleanly closed) left the
+// marker set and spawned a bogus flight_mram_recovered_*.bin on nearly every
+// power cycle. These tests pin the fixed decision table.
+//
+// Convention mirrored from TR_LogToFlash's lifecycle:
+//   onPreCreate()        -> PRELAUNCH pre-create (must NOT dirty)
+//   onActivate()         -> launch detect / manual cmd-23 start (dirties)
+//   onCloseClean()       -> end-of-flight drain / manual stop (clears)
+//   onRecoveryFinished() -> boot recovery drained (clears)
+// A power-cut is modeled by simply *stopping* — whatever markerShouldBeSet()
+// returns at that point is what survives in non-volatile MRAM to the next boot,
+// which shouldRecoverOnBoot() then gates on.
+
+#include <gtest/gtest.h>
+
+#include "mram_dirty_policy.h"
+
+TEST(MramDirtyPolicy, DefaultsClean)
+{
+    MramDirtyPolicy p;
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// Bench case (a): power-cycle from READY, no session ever opened.
+TEST(MramDirtyPolicy, ReadyPowerCycle_NoRecovery)
+{
+    MramDirtyPolicy p;
+    // (power cut) — nothing happened.
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// Bench case (b) — the #417 regression: PRELAUNCH pre-creates the file, then
+// power is cut before any launch. The marker must NOT survive set.
+TEST(MramDirtyPolicy, PreCreateThenPowerCut_NoRecovery)
+{
+    MramDirtyPolicy p;
+    p.onPreCreate();
+    // (power cut — never launched, never cleanly closed)
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// The genuine #274 case: launch detected (activate), then an in-flight
+// brownout. The surviving marker must gate recovery ON.
+TEST(MramDirtyPolicy, ActivateThenBrownout_Recovers)
+{
+    MramDirtyPolicy p;
+    p.onPreCreate();
+    p.onActivate();
+    // (in-flight brownout)
+    EXPECT_TRUE(p.markerShouldBeSet());
+    EXPECT_TRUE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// Bench case (c): a clean flight — pre-create, activate, clean close. The
+// marker is cleared; a later power-cut leaves nothing to recover.
+TEST(MramDirtyPolicy, CleanFlight_NoRecovery)
+{
+    MramDirtyPolicy p;
+    p.onPreCreate();
+    p.onActivate();
+    EXPECT_TRUE(p.markerShouldBeSet());   // marker live during the flight
+    p.onCloseClean();
+    // (power cut, later)
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// Manual cmd-23 start routes through activate without necessarily a PRELAUNCH
+// pre-create; a power-cut mid manual-logging still has real ring data.
+TEST(MramDirtyPolicy, ManualStartThenPowerCut_Recovers)
+{
+    MramDirtyPolicy p;
+    p.onActivate();   // deliberate manual start
+    // (power cut mid-logging)
+    EXPECT_TRUE(p.markerShouldBeSet());
+    EXPECT_TRUE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// Manual start followed by a manual stop clears the marker like a clean flight.
+TEST(MramDirtyPolicy, ManualStartThenManualStop_NoRecovery)
+{
+    MramDirtyPolicy p;
+    p.onActivate();
+    p.onCloseClean();
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// After a genuine recovery drains at boot, finishing it clears the marker so
+// recovery does not re-fire on the following boot.
+TEST(MramDirtyPolicy, RecoveryFinishedClearsMarker)
+{
+    MramDirtyPolicy p;
+    p.onActivate();
+    EXPECT_TRUE(p.markerShouldBeSet());   // survived a brownout into this boot
+    p.onRecoveryFinished();
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}
+
+// A second, aborted arm cycle after a clean flight must not resurrect the
+// marker on the pre-create step (guards the #417 mechanism across re-arms).
+TEST(MramDirtyPolicy, RearmPreCreateAfterCleanFlight_StaysClean)
+{
+    MramDirtyPolicy p;
+    p.onPreCreate();
+    p.onActivate();
+    p.onCloseClean();
+    // Re-arm: PRELAUNCH again, but power is cut before the next launch.
+    p.onPreCreate();
+    EXPECT_FALSE(p.markerShouldBeSet());
+    EXPECT_FALSE(MramDirtyPolicy::shouldRecoverOnBoot(p.markerShouldBeSet()));
+}

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -1686,7 +1686,8 @@ void TR_LogToFlash::activateLogging()
     // deliberate manual cmd-23 start — both route through activateLogging), so
     // a surviving marker flags a genuine in-flight brownout with real ring data
     // to replay (the #274 case). Cleared symmetrically by closeLogSession().
-    markDirty();
+    dirty_policy_.onActivate();
+    syncDirtyMarker();
     // Arm per-drain diagnostic logs for the first few flushRingToNand
     // drains. Kept small on purpose: these are blocking UART writes (~9 ms
     // each at 115200) inside the launch-critical prelaunch-drain window —
@@ -1723,7 +1724,8 @@ void TR_LogToFlash::closeLogSession()
         }
         file_open = false;
         logging_active = false;
-        clearDirty();
+        dirty_policy_.onCloseClean();   // #417
+        syncDirtyMarker();
         persistBadBlocksIfDirty();
         ring_prelaunch_cap_ = prelaunchCap();
         if (cfg.debug)
@@ -1761,7 +1763,8 @@ void TR_LogToFlash::closeLogSession()
 
     file_open = false;
     logging_active = false;
-    clearDirty();
+    dirty_policy_.onCloseClean();   // #417
+    syncDirtyMarker();
 
     // Flush any new bad-block discoveries to NVS now — no longer in the
     // hot path, and the next session should see the same list.
@@ -1843,6 +1846,18 @@ void TR_LogToFlash::clearDirty()
     lfs_remove(&lfs, "/.dirty");
 }
 
+// #417: mirror the MramDirtyPolicy intent to the physical marker. This is the
+// single write path for the live session — lifecycle transitions update the
+// policy, then call here. markDirty()/clearDirty() remain the hardware writers
+// (LittleFS marker file in non-sink mode, MRAM word in sink mode).
+void TR_LogToFlash::syncDirtyMarker()
+{
+    if (dirty_policy_.markerShouldBeSet())
+        markDirty();
+    else
+        clearDirty();
+}
+
 bool TR_LogToFlash::checkDirtyOnStartup()
 {
     struct lfs_info info;
@@ -1884,7 +1899,8 @@ uint32_t TR_LogToFlash::drainMramToSink()
 void TR_LogToFlash::finishMramRecovery()
 {
     clearRing();
-    clearDirty();   // clears the MRAM marker (sink mode)
+    dirty_policy_.onRecoveryFinished();   // #417
+    syncDirtyMarker();                    // clears the MRAM marker (sink mode)
     pending_mram_recovery_ = false;
 }
 
@@ -2131,7 +2147,10 @@ void TR_LogToFlash::runStartupRecovery()
     // sink into a NAND flight — but the sink (TR_FlightLog) isn't initialized yet
     // at begin() time. Defer: preserve the ring + marker and let the OC drive
     // drainMramToSink() once flightlog.begin() has run.
-    if (cfg.write_sink != nullptr && mram_dirty)
+    // #417: the surviving MRAM marker (set only once logging was activated) is
+    // the boot-time recovery gate — one documented home shared with the tests.
+    if (cfg.write_sink != nullptr &&
+        MramDirtyPolicy::shouldRecoverOnBoot(mram_dirty))
     {
         pending_mram_recovery_ = true;
         if (cfg.debug)
@@ -2375,8 +2394,9 @@ void TR_LogToFlash::flushTaskLoop()
             if (!file_open && !logging_active)
             {
                 openLogSession();   // Creates file on NAND (slow, but we're not in a hurry yet)
-                // #417: do NOT markDirty on pre-create — the session isn't active
-                // yet. activateLogging() sets the marker at launch/manual-start.
+                // #417: pre-create must NOT dirty the marker — the session isn't
+                // active yet. activateLogging() sets it at launch/manual-start.
+                dirty_policy_.onPreCreate();
                 if (cfg.debug) ESP_LOGI(TAG, "Log file pre-created for launch");
             }
             // else: file already open / logging — request is moot; consume it.

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -421,9 +421,8 @@ void TR_LogToFlash::service()
             if (!file_open)
             {
                 openLogSession();
-                markDirty();
             }
-            activateLogging();
+            activateLogging();   // #417: markDirty now lives here
         }
         start_logging_requested = false;
     }
@@ -1678,6 +1677,16 @@ void TR_LogToFlash::activateLogging()
     logging_active = true;
     ring_prelaunch_cap_ = ring_size_;
     end_flight_requested = false;
+
+    // #417: set the dirty marker HERE, not at openLogSession()/pre-create.
+    // A pre-created-but-never-launched session (bench: PRELAUNCH → power cut,
+    // no launch, no clean close) must NOT look "dirty" on the next boot, or it
+    // spawns a bogus flight_mram_recovered_*.bin on nearly every power cycle.
+    // The marker now means "logging was activated" (launch-detect start, or a
+    // deliberate manual cmd-23 start — both route through activateLogging), so
+    // a surviving marker flags a genuine in-flight brownout with real ring data
+    // to replay (the #274 case). Cleared symmetrically by closeLogSession().
+    markDirty();
     // Arm per-drain diagnostic logs for the first few flushRingToNand
     // drains. Kept small on purpose: these are blocking UART writes (~9 ms
     // each at 115200) inside the launch-critical prelaunch-drain window —
@@ -2366,7 +2375,8 @@ void TR_LogToFlash::flushTaskLoop()
             if (!file_open && !logging_active)
             {
                 openLogSession();   // Creates file on NAND (slow, but we're not in a hurry yet)
-                markDirty();
+                // #417: do NOT markDirty on pre-create — the session isn't active
+                // yet. activateLogging() sets the marker at launch/manual-start.
                 if (cfg.debug) ESP_LOGI(TAG, "Log file pre-created for launch");
             }
             // else: file already open / logging — request is moot; consume it.
@@ -2399,9 +2409,8 @@ void TR_LogToFlash::flushTaskLoop()
                 {
                     // File not pre-created — create now (legacy path)
                     openLogSession();
-                    markDirty();
                 }
-                activateLogging();  // Fast — just flips flags, no NAND I/O
+                activateLogging();  // Fast — flips flags + markDirty (#417), no NAND I/O
             }
             // else: already logging — duplicate request; consume it.
             start_logging_requested = false;

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -4,6 +4,7 @@
 #include <compat.h>
 #include <RocketComputerTypes.h>
 #include "lfs.h"
+#include "mram_dirty_policy.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
@@ -526,6 +527,11 @@ private:
     void clearDirty();          // Remove LittleFS marker file on log close
     bool checkDirtyOnStartup(); // Check if previous session was dirty
     bool checkMramDirty();      // #274: read the sink-mode MRAM dirty marker
+
+    // #417: single source of truth for the dirty-marker intent across the log
+    // session lifecycle. syncDirtyMarker() mirrors it to the physical marker.
+    MramDirtyPolicy dirty_policy_;
+    void syncDirtyMarker();
     void clearRing();
     // Internal variant: caller holds push_mutex_. Used by ringPush()'s
     // drop-oldest fallback so it doesn't re-acquire the mutex it already

--- a/tinkerrocket-idf/components/TR_LogToFlash/mram_dirty_policy.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/mram_dirty_policy.h
@@ -1,0 +1,67 @@
+#ifndef MRAM_DIRTY_POLICY_H
+#define MRAM_DIRTY_POLICY_H
+
+// #417 / #274: single source of truth for the sink-mode "dirty" marker.
+//
+// The marker lives in non-volatile MRAM (see cfg.dirty_marker_addr). Its job is
+// to tell the *next* boot that a log session was interrupted mid-flight (an
+// in-flight brownout, #274) so the surviving MRAM ring is replayed into a
+// recovered flight instead of being wiped.
+//
+// The bug (#417): the marker used to be written at openLogSession() — including
+// the PRELAUNCH *pre-create* — and only cleared by a clean closeLogSession().
+// On the bench the flow is PRELAUNCH (pre-create + marker) -> cut power (never
+// launched, never cleanly closed), so the next boot saw the surviving marker
+// and spawned a bogus flight_mram_recovered_*.bin on nearly every power cycle.
+// What it "recovered" was just the ~500 ms prelaunch drop-oldest pad buffer.
+//
+// This policy encodes the fixed semantics: the marker means "logging was
+// ACTIVATED" (real launch detect, or a deliberate manual cmd-23 start — both
+// route through activateLogging), not merely "a file was pre-created". It is a
+// pure RAM state machine with no hardware dependency; TR_LogToFlash drives it
+// from the log-session lifecycle and mirrors markerShouldBeSet() to the
+// physical MRAM marker after each transition. Being hardware-free, it is
+// exercised host-side in test_mram_dirty_policy.cpp.
+//
+// Boot note: this object is fresh RAM at every boot (starts clean). The marker
+// that *survived* power loss is read from hardware (checkMramDirty) and fed to
+// shouldRecoverOnBoot() — the surviving hardware bit, not this live state, is
+// what gates recovery.
+class MramDirtyPolicy
+{
+public:
+    // Log file pre-created at PRELAUNCH. The session is not active yet, so the
+    // marker must stay clean (#417) — a power-cut here has no flight data worth
+    // recovering.
+    void onPreCreate() { /* intentionally does not dirty the marker */ }
+
+    // Logging activated: real launch detect, or a deliberate manual cmd-23
+    // start. From here an interrupted session has genuine ring data (preserved
+    // prelaunch buffer + in-flight frames) that the #274 path should recover.
+    void onActivate() { dirty_ = true; }
+
+    // Clean end-of-session: end-of-flight drain or a manual stop. The ring was
+    // handed off cleanly, so there is nothing to recover on the next boot.
+    void onCloseClean() { dirty_ = false; }
+
+    // The surviving ring has been drained into a recovered flight at boot; clear
+    // the marker so it does not re-fire on the following boot.
+    void onRecoveryFinished() { dirty_ = false; }
+
+    // Desired physical-marker state for the current session. TR_LogToFlash
+    // writes (or clears) the MRAM marker to match after each transition.
+    bool markerShouldBeSet() const { return dirty_; }
+
+    // Boot-time gate: replay the surviving ring iff the marker survived set.
+    // Kept as a named function (rather than a bare bool) so the recovery
+    // decision has one documented home shared by firmware and tests.
+    static bool shouldRecoverOnBoot(bool marker_survived_set)
+    {
+        return marker_survived_set;
+    }
+
+private:
+    bool dirty_ = false;
+};
+
+#endif  // MRAM_DIRTY_POLICY_H


### PR DESCRIPTION
Closes #417.

## Problem

`flight_mram_recovered_<id>.bin` was generated on nearly every power cycle, not just after genuine in-flight brownouts, cluttering the flight index and masking real #274 touchdown recoveries.

**Root cause:** the sink-mode MRAM "dirty" marker conflated *"a log file was opened"* with *"logging was active in flight."* `markDirty()` ran at `openLogSession()` — including the PRELAUNCH **pre-create** — and was only cleared by a clean `closeLogSession()`. The bench flow is PRELAUNCH (pre-create + marker) → cut power (never launched, never cleanly closed) → next boot sees the surviving marker and dutifully replays the ring. What it "recovered" was just the ~500 ms prelaunch drop-oldest pad buffer, not real data.

## Fix

Move the marker set from the three `openLogSession()`-adjacent sites into `activateLogging()`. The marker now means **"logging was activated"** — real launch detect, or a deliberate manual cmd-23 start (both route through `activateLogging`) — not "a file was pre-created."

- Pre-create-then-power-cut (the bench case): no `activateLogging` ran → no marker → no recovery file. ✅
- In-flight brownout (the genuine #274 case): `activateLogging` fired at launch → marker set → recovery still works. ✅
- Clean flight / manual stop: `closeLogSession` clears the marker as before. ✅

## Structure + tests

The decision is routed through a new pure, hardware-free `MramDirtyPolicy` (`components/TR_LogToFlash/mram_dirty_policy.h`) so it has a single source of truth that's testable on the host. `TR_LogToFlash` drives it from the log-session lifecycle (`onPreCreate` / `onActivate` / `onCloseClean` / `onRecoveryFinished`) and mirrors `markerShouldBeSet()` to the physical MRAM marker via a new `syncDirtyMarker()` helper (`markDirty`/`clearDirty` remain the hardware writers). `runStartupRecovery` gates deferred sink recovery through `MramDirtyPolicy::shouldRecoverOnBoot()`.

`tests_cpp/test_mram_dirty_policy.cpp` (9 cases, all green) covers:
- the three bench power-cycle scenarios from the issue — READY, PRELAUNCH-no-launch, clean stop → no recovery
- the genuine #274 in-flight brownout → recovers
- manual cmd-23 start-then-power-cut → recovers; manual start-then-stop → no recovery
- recovery-finished clears the marker
- a re-arm after a clean flight must not resurrect the marker on pre-create

Matches the existing `*_policy` host-test idiom (`test_dedup_reboot_policy`).

## Verification

- OC builds clean on IDF v6 (76% app partition free).
- Host test target `test_mram_dirty_policy` passes 9/9.

The policy test guards the *decision*, not the SPI/MRAM drain, so final sign-off is a bench pass (to be collected with a batch of other changes):

- [ ] Power-cycle from (a) READY, (b) PRELAUNCH-without-launch, (c) after a clean logging stop → confirm **no** `flight_mram_recovered_*.bin` appears.
- [ ] One sim/flight brownout after launch → confirm recovery **still** fires with real ring data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
