### PR TITLE
fix(oc): flight-log bitmap to NAND (no cache-disable stall) + 20 MB prealloc (#398)

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -272,6 +272,32 @@ target_include_directories(test_tr_flightlog_core PRIVATE
 target_link_libraries(test_tr_flightlog_core GTest::gtest_main Threads::Threads)
 gtest_discover_tests(test_tr_flightlog_core)
 
+# ---------- test_nand_bitmap_store (#398) ----------
+# NAND-backed dual-copy bitmap store — replaces the NVS store on the OC so the
+# frequent bitmap persists never touch internal flash (whose compaction erase
+# cache-disabled core 1). Uses FakeNandBackend + CRC (calcCRC32).
+add_executable(test_nand_bitmap_store
+    test_nand_bitmap_store.cpp
+    fakes/fake_nand_backend.cpp
+    ${LIB_DIR}/TR_FlightLog/NandBitmapStore.cpp
+    ${LIB_DIR}/CRC/CRC.cpp
+    ${LIB_DIR}/CRC/CRC8.cpp
+    ${LIB_DIR}/CRC/CRC12.cpp
+    ${LIB_DIR}/CRC/CRC16.cpp
+    ${LIB_DIR}/CRC/CRC32.cpp
+    ${LIB_DIR}/CRC/CRC64.cpp
+    ${LIB_DIR}/CRC/CrcFastReverse.cpp
+    ${LIB_DIR}/CRC/FastCRC32.cpp
+)
+target_include_directories(test_nand_bitmap_store PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_FlightLog/include
+    ${LIB_DIR}/CRC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(test_nand_bitmap_store GTest::gtest_main Threads::Threads)
+gtest_discover_tests(test_nand_bitmap_store)
+
 # ---------- test_tr_ota (#8 phase 2) ----------
 # Host coverage for TR_OTA_Receiver: state machine, offset/size validation,
 # SHA-256 verification, callback fan-out. Real esp_ota_* is replaced with

--- a/tests_cpp/test_nand_bitmap_store.cpp
+++ b/tests_cpp/test_nand_bitmap_store.cpp
@@ -1,0 +1,138 @@
+// #398: NandBitmapStore — persist the TR_FlightLog 3-state block bitmap to two
+// NAND metadata blocks (dual-copy, newest-sequence wins) instead of NVS, so the
+// frequent prepareFlight/extend/bad-block saves never hit internal flash (whose
+// erase-driven cache-disable stalled core 1 during NVS compaction).
+//
+// These tests pin the durability contract: roundtrip, newest-wins across the
+// two blocks, power-safe fallback when the newest copy is interrupted/corrupt,
+// and the fresh-chip / migration path (both blocks blank -> load() == false).
+
+#include <gtest/gtest.h>
+
+#include "NandBitmapStore.h"
+#include "TR_FlightLog_types.h"
+#include "fakes/fake_nand_backend.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using tr_flightlog::NandBitmapStore;
+using tr_flightlog::NAND_PAGE_SIZE;
+using tr_flightlog_test::FakeNandBackend;
+
+namespace {
+
+constexpr uint32_t BLK_A = 2046;
+constexpr uint32_t BLK_B = 2047;
+constexpr size_t   BITMAP_LEN = 512;   // >= BlockStateBitmap::SERIALIZED_SIZE
+
+// A recognizable bitmap payload that varies with `seed`.
+std::vector<uint8_t> makeBitmap(uint8_t seed, size_t len = BITMAP_LEN) {
+    std::vector<uint8_t> v(len);
+    for (size_t i = 0; i < len; ++i) v[i] = static_cast<uint8_t>(seed + (i * 7));
+    return v;
+}
+
+}  // namespace
+
+TEST(NandBitmapStore, SaveLoadRoundtrip) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    auto in = makeBitmap(0x11);
+    ASSERT_TRUE(store.save(in.data(), in.size()));
+
+    std::vector<uint8_t> out(BITMAP_LEN, 0);
+    ASSERT_TRUE(store.load(out.data(), out.size()));
+    EXPECT_EQ(out, in);
+}
+
+TEST(NandBitmapStore, NewestSequenceWinsAcrossBlocks) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    // Five saves alternate between the two blocks; load must always return the
+    // most recent one.
+    for (uint8_t s = 1; s <= 5; ++s) {
+        auto in = makeBitmap(s);
+        ASSERT_TRUE(store.save(in.data(), in.size())) << "save " << int(s);
+        std::vector<uint8_t> out(BITMAP_LEN, 0);
+        ASSERT_TRUE(store.load(out.data(), out.size()));
+        EXPECT_EQ(out, in) << "after save " << int(s);
+    }
+}
+
+TEST(NandBitmapStore, InterruptedSaveKeepsLastGoodSnapshot) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    auto a = makeBitmap(0xA0);   // seq 1 -> BLK_A
+    auto b = makeBitmap(0xB0);   // seq 2 -> BLK_B
+    ASSERT_TRUE(store.save(a.data(), a.size()));
+    ASSERT_TRUE(store.save(b.data(), b.size()));
+
+    // Next save targets the OLDER block (BLK_A). Make its page program fail so
+    // the save is interrupted after the erase — BLK_A is now blank/invalid.
+    auto c = makeBitmap(0xC0);
+    nand.injectProgramFailOnce(BLK_A, 0);
+    EXPECT_FALSE(store.save(c.data(), c.size()));
+
+    // The newest COMPLETE snapshot (b, seq 2 on BLK_B) must survive.
+    std::vector<uint8_t> out(BITMAP_LEN, 0);
+    ASSERT_TRUE(store.load(out.data(), out.size()));
+    EXPECT_EQ(out, b);
+}
+
+TEST(NandBitmapStore, CorruptNewestFallsBackToOlder) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    auto a = makeBitmap(0x1A);   // seq 1 -> BLK_A
+    auto b = makeBitmap(0x2B);   // seq 2 -> BLK_B
+    ASSERT_TRUE(store.save(a.data(), a.size()));
+    ASSERT_TRUE(store.save(b.data(), b.size()));
+
+    // Make the newest copy (BLK_B) unreadable -> CRC/validity fails -> the
+    // store must fall back to the older-but-valid BLK_A.
+    nand.injectReadErrorPersistent(BLK_B, 0);
+    std::vector<uint8_t> out(BITMAP_LEN, 0);
+    ASSERT_TRUE(store.load(out.data(), out.size()));
+    EXPECT_EQ(out, a);
+}
+
+TEST(NandBitmapStore, FreshBlocksReturnFalse) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    // Migration / first-boot: both metadata blocks blank (erased) -> no valid
+    // snapshot -> load() returns false so begin() seeds a fresh bitmap.
+    nand.eraseBlock(BLK_A);
+    nand.eraseBlock(BLK_B);
+
+    std::vector<uint8_t> out(BITMAP_LEN, 0);
+    EXPECT_FALSE(store.load(out.data(), out.size()));
+}
+
+TEST(NandBitmapStore, UnboundStoreFailsCleanly) {
+    NandBitmapStore store;   // never bound to a backend
+    auto in = makeBitmap(0x33);
+    EXPECT_FALSE(store.save(in.data(), in.size()));
+    std::vector<uint8_t> out(BITMAP_LEN, 0);
+    EXPECT_FALSE(store.load(out.data(), out.size()));
+}
+
+TEST(NandBitmapStore, ShorterStoredBitmapZeroPadsLoadBuffer) {
+    FakeNandBackend nand;
+    NandBitmapStore store(&nand, BLK_A, BLK_B);
+
+    // Firmware that shrank the bitmap: store 256 B, load into 512 B — the tail
+    // must be zero-filled, not garbage.
+    auto in = makeBitmap(0x55, 256);
+    ASSERT_TRUE(store.save(in.data(), in.size()));
+
+    std::vector<uint8_t> out(512, 0xEE);
+    ASSERT_TRUE(store.load(out.data(), out.size()));
+    for (size_t i = 0; i < 256; ++i) EXPECT_EQ(out[i], in[i]) << "byte " << i;
+    for (size_t i = 256; i < 512; ++i) EXPECT_EQ(out[i], 0) << "pad byte " << i;
+}

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -1178,6 +1178,94 @@ TEST(TRFlightLogFinalize, PersistsIndexAcrossReboot) {
     EXPECT_STREQ(fl2.index().at(0).filename, "flight_001.bin");
 }
 
+// #398: when the bitmap store comes up empty but the index survives on NAND
+// (fresh chip, NVS wipe, or the one-time NVS->NAND bitmap migration), begin()
+// must reconstruct the ALLOCATED state of every indexed flight from the index
+// — otherwise findContiguousFree (bitmap-only) hands out blocks that still hold
+// a flight and the next flight overwrites it.
+TEST(TRFlightLogMigration, FreshBitmapReconstructsAllocationsFromIndex) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+
+    // Session 1: log a flight so its block range lands in the on-NAND index.
+    {
+        TR_FlightLog fl;
+        ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+        uint32_t id = 0;
+        ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+        ASSERT_EQ(fl.finalizeFlight("flight_001.bin", 5 * NAND_PAGE_SIZE), Status::Ok);
+    }
+
+    // Simulate the migration: bitmap persistence is gone, index stays on NAND.
+    store.forgetSaved();
+
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    ASSERT_EQ(fl2.index().size(), 1u);
+    const auto& e = fl2.index().at(0);
+
+    // The indexed flight's blocks must read ALLOCATED, not FREE.
+    for (uint32_t b = e.start_block; b < e.start_block + e.n_blocks; ++b) {
+        EXPECT_EQ(fl2.bitmap().get(b), BLOCK_ALLOCATED) << "reconstructed block " << b;
+    }
+
+    // And a fresh flight must be allocated clear of the existing one.
+    uint32_t id2 = 0;
+    ASSERT_EQ(fl2.prepareFlight(id2), Status::Ok);
+    const uint32_t nb  = fl2.activeBlockCount();
+    const uint32_t sb  = fl2.activeStartBlock();
+    const bool disjoint = (sb + nb <= e.start_block) ||
+                          (sb >= static_cast<uint32_t>(e.start_block) + e.n_blocks);
+    EXPECT_TRUE(disjoint) << "new flight [" << sb << "," << (sb + nb)
+                          << ") overlaps existing [" << e.start_block << ","
+                          << (e.start_block + e.n_blocks) << ")";
+}
+
+// #398: a device migrated by an EARLIER build persisted a bitmap that lacks the
+// index reconciliation, so it comes up "restored" but missing existing flights'
+// allocations. begin() must self-heal it on a restored boot too (not only on a
+// fresh seed) and re-persist the corrected bitmap.
+TEST(TRFlightLogMigration, RestoredBitmapMissingAllocationIsSelfHealed) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+
+    // Session 1: one flight -> its range lands in the on-NAND index.
+    {
+        TR_FlightLog fl;
+        ASSERT_EQ(fl.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+        uint32_t id = 0;
+        ASSERT_EQ(fl.prepareFlight(id), Status::Ok);
+        ASSERT_EQ(fl.finalizeFlight("flight_001.bin", 5 * NAND_PAGE_SIZE), Status::Ok);
+    }
+
+    // Overwrite the store with an all-FREE bitmap while the index survives on
+    // NAND — exactly the state left by a pre-reconciliation build's migration.
+    {
+        BlockStateBitmap blank;  // all FREE
+        uint8_t buf[BlockStateBitmap::SERIALIZED_SIZE];
+        blank.serializeTo(buf, sizeof(buf));
+        store.save(buf, sizeof(buf));
+    }
+    const size_t saves_before = store.saveCount();
+
+    // Restored boot: bitmap loads but is missing flight_001 -> must self-heal.
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, TR_FlightLog::Config{}, &store), Status::Ok);
+    ASSERT_EQ(fl2.index().size(), 1u);
+    const auto& e = fl2.index().at(0);
+    for (uint32_t b = e.start_block; b < e.start_block + e.n_blocks; ++b) {
+        EXPECT_EQ(fl2.bitmap().get(b), BLOCK_ALLOCATED) << "healed block " << b;
+    }
+    EXPECT_GT(store.saveCount(), saves_before) << "self-heal must re-persist";
+
+    uint32_t id2 = 0;
+    ASSERT_EQ(fl2.prepareFlight(id2), Status::Ok);
+    const uint32_t sb = fl2.activeStartBlock(), nb = fl2.activeBlockCount();
+    const bool disjoint = (sb + nb <= e.start_block) ||
+                          (sb >= static_cast<uint32_t>(e.start_block) + e.n_blocks);
+    EXPECT_TRUE(disjoint);
+}
+
 TEST(TRFlightLogList, EmptyIndexReturnsZero) {
     FakeNandBackend nand;
     MemoryBitmapStore store;

--- a/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_FlightLog/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "TR_FlightLog.cpp" "BlockStateBitmap.cpp" "FlightIndex.cpp" "WireFormat.cpp" "TR_NandBackend_esp.cpp" "NvsBitmapStore.cpp"
+    SRCS "TR_FlightLog.cpp" "BlockStateBitmap.cpp" "FlightIndex.cpp" "WireFormat.cpp" "TR_NandBackend_esp.cpp" "NvsBitmapStore.cpp" "NandBitmapStore.cpp"
     INCLUDE_DIRS "include"
     REQUIRES TR_Compat CRC TR_LogToFlash TR_NVS
 )

--- a/tinkerrocket-idf/components/TR_FlightLog/NandBitmapStore.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/NandBitmapStore.cpp
@@ -1,0 +1,98 @@
+#include "NandBitmapStore.h"
+
+#include "TR_FlightLog_types.h"  // NAND_PAGE_SIZE
+#include "CRC.h"                 // calcCRC32 (same as FlightIndex)
+
+#include <cstring>
+#include <memory>
+#include <new>
+
+namespace tr_flightlog {
+
+// CRC covers everything after the crc32 field: magic + sequence + length +
+// payload (matches FlightIndex's compute_crc convention). Header is private, so
+// this member helper keeps the span in one place.
+size_t NandBitmapStore::crcSpan(size_t payload_len) {
+    return sizeof(Header) - sizeof(uint32_t) + payload_len;
+}
+
+bool NandBitmapStore::readSlot(uint32_t block, uint32_t& seq_out,
+                               uint8_t* out, size_t len) {
+    seq_out = 0;
+    if (!nand_) return false;
+
+    std::unique_ptr<uint8_t[]> page(new (std::nothrow) uint8_t[NAND_PAGE_SIZE]);
+    if (!page) return false;
+    if (!nand_->readPage(block, 0, page.get())) return false;
+
+    Header hdr;
+    std::memcpy(&hdr, page.get(), sizeof(hdr));
+    if (hdr.magic != kMagic) return false;
+    if (hdr.length == 0 || hdr.length > NAND_PAGE_SIZE - sizeof(Header)) return false;
+
+    const uint32_t got = calcCRC32(page.get() + sizeof(uint32_t), crcSpan(hdr.length));
+    if (got != hdr.crc32) return false;
+
+    seq_out = hdr.sequence;
+    if (out) {
+        const size_t n = (len < hdr.length) ? len : hdr.length;
+        std::memcpy(out, page.get() + sizeof(Header), n);
+        if (len > hdr.length) std::memset(out + hdr.length, 0, len - hdr.length);
+    }
+    return true;
+}
+
+bool NandBitmapStore::load(uint8_t* buf, size_t len) {
+    if (!nand_ || !buf || len == 0) return false;
+
+    uint32_t seq_a = 0, seq_b = 0;
+    const bool a = readSlot(block_a_, seq_a, nullptr, 0);
+    const bool b = readSlot(block_b_, seq_b, nullptr, 0);
+    if (!a && !b) return false;
+
+    // Prefer the higher sequence; on a tie or single-valid, pick that one.
+    const uint32_t block = (a && (!b || seq_a >= seq_b)) ? block_a_ : block_b_;
+    uint32_t seq = 0;
+    if (!readSlot(block, seq, buf, len)) return false;
+    last_sequence_ = seq;
+    return true;
+}
+
+bool NandBitmapStore::save(const uint8_t* buf, size_t len) {
+    if (!nand_ || !buf || len == 0 || len > NAND_PAGE_SIZE - sizeof(Header)) return false;
+
+    // Target the older / invalid block so the newest valid snapshot survives a
+    // power loss mid-erase or mid-program (power-safe dual copy).
+    uint32_t seq_a = 0, seq_b = 0;
+    const bool a = readSlot(block_a_, seq_a, nullptr, 0);
+    const bool b = readSlot(block_b_, seq_b, nullptr, 0);
+    uint32_t target;
+    if (!a)      target = block_a_;
+    else if (!b) target = block_b_;
+    else         target = (seq_a <= seq_b) ? block_a_ : block_b_;
+
+    const uint32_t newest   = (a || b) ? (seq_a > seq_b ? seq_a : seq_b) : 0;
+    const uint32_t next_seq = newest + 1;
+
+    std::unique_ptr<uint8_t[]> page(new (std::nothrow) uint8_t[NAND_PAGE_SIZE]);
+    if (!page) return false;
+    std::memset(page.get(), 0xFF, NAND_PAGE_SIZE);
+
+    Header hdr;
+    hdr.crc32    = 0;
+    hdr.magic    = kMagic;
+    hdr.sequence = next_seq;
+    hdr.length   = static_cast<uint32_t>(len);
+    std::memcpy(page.get(), &hdr, sizeof(hdr));
+    std::memcpy(page.get() + sizeof(hdr), buf, len);
+
+    const uint32_t crc = calcCRC32(page.get() + sizeof(uint32_t), crcSpan(len));
+    std::memcpy(page.get(), &crc, sizeof(crc));
+
+    if (!nand_->eraseBlock(target))       return false;
+    if (!nand_->programPage(target, 0, page.get())) return false;
+    last_sequence_ = next_seq;
+    return true;
+}
+
+}  // namespace tr_flightlog

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -72,7 +72,8 @@ Status TR_FlightLog::begin(TR_NandBackend& nand, const Config& cfg,
     }
 
     // Try to restore bitmap from persistent store. If nothing saved (or wrong
-    // size) start fresh and seed from the NAND backend's bad-block oracle.
+    // size) start fresh and seed from the NAND backend's bad-block oracle. When
+    // fresh, defer persisting until after the index reconciliation below.
     uint8_t buf[BlockStateBitmap::SERIALIZED_SIZE];
     bool restored = bitmap_store_ && bitmap_store_->load(buf, sizeof(buf));
     if (restored) {
@@ -80,13 +81,36 @@ Status TR_FlightLog::begin(TR_NandBackend& nand, const Config& cfg,
     } else {
         bitmap_.clear();
         seedBitmapFromBackend();
-        persistBitmap();
     }
 
     Status idx_st = index_.load(*nand_, cfg_.metadata_blocks[0], cfg_.metadata_blocks[1]);
     if (idx_st != Status::Ok && idx_st != Status::CrcMismatch) return idx_st;
     // CrcMismatch on a fresh chip (or both copies corrupt) is recoverable;
     // the index is already cleared and we proceed with an empty one.
+
+    // Reconcile the bitmap against the index on every boot: any block an
+    // indexed flight owns but the bitmap thinks is FREE gets promoted to
+    // ALLOCATED. A restored bitmap is normally already consistent, but a fresh
+    // seed (fresh chip / NVS wipe / the one-time NVS->NAND migration, #398) — or
+    // a bitmap that was persisted before this reconciliation existed — has lost
+    // those allocations. findContiguousFree is bitmap-only, so without this the
+    // next flight would allocate over an indexed one and overwrite it. Running
+    // every boot self-heals such a bitmap (e.g. a device already migrated by an
+    // earlier build). BAD blocks are left untouched. Persist only when we
+    // actually changed something, or on a fresh seed (to store the seeded bad
+    // blocks).
+    size_t promoted = 0;
+    for (size_t i = 0; i < index_.size(); ++i) {
+        const FlightIndexEntry& e = index_.at(i);
+        const uint32_t end = static_cast<uint32_t>(e.start_block) + e.n_blocks;
+        for (uint32_t b = e.start_block; b < end && b < NAND_BLOCK_COUNT; ++b) {
+            if (bitmap_.get(b) == BLOCK_FREE) {
+                bitmap_.set(b, BLOCK_ALLOCATED);
+                ++promoted;
+            }
+        }
+    }
+    if (!restored || promoted > 0) persistBitmap();
 
     initialized_ = true;
 

--- a/tinkerrocket-idf/components/TR_FlightLog/include/NandBitmapStore.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/NandBitmapStore.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "TR_BitmapStore.h"
+#include "TR_NandBackend.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace tr_flightlog {
+
+// TR_BitmapStore backed by two NAND metadata blocks (dual-copy, newest-sequence
+// wins) — mirrors FlightIndex's power-safe scheme.
+//
+// #398: persisting the 3-state block bitmap here instead of NVS keeps every
+// prepareFlight / extend / bad-block persist OFF internal flash. The NVS path
+// (Preferences.putBytes + nvs_commit) periodically compacted a 4 KB sector,
+// and an internal-flash erase disables the CPU cache on BOTH cores (IDF spins
+// an esp_ipc stub on the other core), which froze core 1 — the parser and
+// loop_oc stalled ~100 ms. A NAND write is on the external SPI bus and never
+// touches the cache. The serialized bitmap (<= NAND_PAGE_SIZE - header) fits in
+// one NAND page, so each save is one erase + one page program.
+//
+// Migration: on the first boot after switching from NVS, both metadata blocks
+// read back with no valid magic, so load() returns false; TR_FlightLog::begin
+// then seeds a fresh bitmap from the backend's bad-block oracle and persists it
+// here. The physical bad-block history lives in the backend (its own map), so
+// nothing is lost — only the in-RAM ALLOCATED state is reset, which is correct
+// on a clean boot.
+class NandBitmapStore : public TR_BitmapStore {
+public:
+    NandBitmapStore() = default;
+    NandBitmapStore(TR_NandBackend* nand, uint32_t block_a, uint32_t block_b)
+        : nand_(nand), block_a_(block_a), block_b_(block_b) {}
+
+    // main.cpp constructs the store as a static before the NAND backend exists,
+    // so binding is deferred to just before flightlog.begin().
+    void bind(TR_NandBackend* nand, uint32_t block_a, uint32_t block_b) {
+        nand_ = nand; block_a_ = block_a; block_b_ = block_b;
+    }
+
+    bool load(uint8_t* buf, size_t len) override;
+    bool save(const uint8_t* buf, size_t len) override;
+
+    // Newest sequence number seen at the last successful load/save (diagnostic).
+    uint32_t lastSequence() const { return last_sequence_; }
+
+private:
+    // page 0 layout: [Header][payload...]. crc32 is first so it can cover the
+    // rest of the page exactly like FlightIndex's MetadataHeader.
+    struct Header {
+        uint32_t crc32;     // CRC32 over bytes [4 .. sizeof(Header)+length-1]
+        uint32_t magic;     // kMagic
+        uint32_t sequence;  // monotonic; higher wins
+        uint32_t length;    // payload byte count
+    };
+    static constexpr uint32_t kMagic = 0x424D5031u;  // 'BMP1'
+
+    // Byte span the crc32 field covers for a given payload length.
+    static size_t crcSpan(size_t payload_len);
+
+    // Read page 0 of `block`. On a valid, CRC-good snapshot: set seq_out and,
+    // when out != nullptr, copy up to `len` payload bytes (zero-padding any
+    // tail beyond the stored length). Returns false on any invalidity.
+    bool readSlot(uint32_t block, uint32_t& seq_out, uint8_t* out, size_t len);
+
+    TR_NandBackend* nand_ = nullptr;
+    uint32_t block_a_ = 0;
+    uint32_t block_b_ = 0;
+    uint32_t last_sequence_ = 0;
+};
+
+}  // namespace tr_flightlog

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -64,6 +64,7 @@ static inline std::string itos(int v)
 #include <TR_FlightLog.h>
 #include <TR_NandBackend_esp.h>
 #include <NvsBitmapStore.h>
+#include <NandBitmapStore.h>   // #398: bitmap on NAND (not NVS) — no cache-disable stall
 #include <WireFormat.h>
 // FlightSimulator.h removed — sim now runs on FlightComputer via TR_Sensor_Collector_Sim
 
@@ -102,7 +103,7 @@ static TR_LogToFlash logger;
 // fn-pointer routes each drained 4080 B page into flightlog.writeFrame().
 static tr_flightlog::TR_NandBackend_esp flightlog_backend;
 static tr_flightlog::TR_FlightLog flightlog;
-static tr_flightlog::NvsBitmapStore flightlog_bitmap_store;
+static tr_flightlog::NandBitmapStore flightlog_bitmap_store;  // #398: NAND-backed, bound in initPeripherals
 
 // Phone time sync (BLE Command 9) — used for flight-filename timestamps
 // so each flight gets a unique filename instead of the hardcoded
@@ -4545,12 +4546,24 @@ void initPeripherals()
 
     // --- TR_FlightLog begin (issue #50) -------------------------------------
     // SPI bus + physical bad-block bitmap are initialized by logger.begin();
-    // flightlog.begin() loads the persistent 3-state bitmap from NVS and the
-    // newest-valid of the dual-copy index from metadata blocks 1020-1023.
+    // flightlog.begin() loads the newest-valid of the dual-copy index from the
+    // metadata blocks, plus the 3-state block bitmap. #398: the bitmap now
+    // persists to NAND (metadata blocks [2]/[3], = 2046/2047) instead of NVS,
+    // so prepareFlight/extend/bad-block saves never hit internal flash and can't
+    // trigger the NVS-compaction cache-disable that stalled core 1.
     flightlog_backend = tr_flightlog::TR_NandBackend_esp(&logger);
     {
+        tr_flightlog::TR_FlightLog::Config fl_cfg{};
+        // #398 / #492: the 3840 Hz stream makes larger files and the 512 MB
+        // chip has ample headroom, so pre-allocate ~20 MB up front (80 × 256 KB
+        // blocks) — most flights then never extend mid-flight (the extend path's
+        // NAND erase + bitmap persist is the in-flight hiccup we want to avoid).
+        fl_cfg.prealloc_blocks = 80;
+        flightlog_bitmap_store.bind(&flightlog_backend,
+                                    fl_cfg.metadata_blocks[2],
+                                    fl_cfg.metadata_blocks[3]);
         auto st = flightlog.begin(flightlog_backend,
-                                  tr_flightlog::TR_FlightLog::Config{},
+                                  fl_cfg,
                                   &flightlog_bitmap_store);
         if (st == tr_flightlog::Status::Ok)
         {


### PR DESCRIPTION
Fixes the last substantive item of #398 — the PRELAUNCH core-1 stall the profiler caught — and bench-confirmed on hardware.

## Root cause (from the profiler + code trace)

The `ipc1[c1 p24]` stall at PRELAUNCH (100 ms `loop_oc` + 77.9 ms `parser_max`) was **NVS flash compaction**: every `prepareFlight` / `extend` / bad-block calls `TR_FlightLog::persistBitmap()` → `NvsBitmapStore` → `Preferences.putBytes` + `nvs_commit`, a ~512 B blob write to the **internal-flash NVS** partition. NVS periodically compacts a 4 KB sector (erase); an internal-flash erase disables the CPU cache on **both** cores (IDF spins an `esp_ipc` stub on the other core), freezing core 1 — the parser (p6) and `loop_oc` (p5) stall. Independent of the NAND SPI mutex (`spih` was 1.25 ms), which is why the earlier SPI-mutex analysis cleared the wrong thing.

## Fix

- **`NandBitmapStore`** (new): persists the 3-state block bitmap to two NAND metadata blocks (2046/2047, previously reserved & unused) — dual-copy, newest-sequence-wins, CRC'd, mirroring `FlightIndex`. NAND is external SPI, so it never touches the cache. The bitmap (≤512 B) fits one page → one erase + one page program per save.
- **OC** binds it and bumps prealloc **40 → 80 blocks (~10 → ~20 MB)**: the 3840 Hz stream makes larger files and the 512 MB chip (#492) has headroom, so most flights never extend mid-flight.
- **Migration is automatic** — first boot finds no valid magic in 2046/2047, so `load()` returns false and `begin()` seeds fresh; physical bad blocks live in the backend, so nothing is lost.
- **Bitmap↔index reconciliation on every boot** (`fdaf18c`): a fresh seed (fresh chip / NVS wipe / this migration) loses existing flights' ALLOCATED state, and `findContiguousFree` is bitmap-only, so the next flight would overwrite an indexed one. `begin()` now promotes FREE→ALLOCATED for every indexed range (BAD sticky) and persists only when it changes something — self-healing a device already migrated by an earlier build. Found while bench-testing this PR.

## Verification

**Bench (build `fdaf18c`, sim flight to LANDED):**
- `ipc1`: **0 occurrences**. PRELAUNCH `loop_oc` stall: **gone**. `parser_max` at PRELAUNCH: **77.9 ms → 5.5 ms**. Only stall left is the 4.36 s power-on (= item 2).
- prealloc **80** confirmed (`range=[91..171) pages=80`); allocation lands cleanly after the previous flight's trimmed range (reconciliation working).
- 8.9 MB flight, **0 extensions**, `rx_ovf=0`, clean finalize. Migration boot came up clean (0 bad blocks, index intact).

**Host tests (all green):**
- `test_nand_bitmap_store` (7): roundtrip, newest-wins, interrupted-save keeps last good, corrupt-newest fallback, fresh-chip migration, unbound, zero-pad.
- `test_tr_flightlog_core` +2: `FreshBitmapReconstructsAllocationsFromIndex`, `RestoredBitmapMissingAllocationIsSelfHealed`. Full flightlog suite 28/28 (filtered) / 104+ overall.
- OC builds clean on IDF v6 (73% app partition free).

Remaining #398 scope after this: **item 2** (`initPeripherals` ~4–5 s power-on stall, boot-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
