### PR TITLE
Clear all compile warnings (FC + OC + iOS) and complete IIS2MDC rate diagnostic

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -7,7 +7,11 @@
 //
 
 import Foundation
-import CoreBluetooth
+// CoreBluetooth predates Swift concurrency: CBPeripheral et al. aren't marked
+// Sendable, so capturing them in @Sendable closures (e.g. the OTA backpressure
+// continuation below) warns. @preconcurrency suppresses those module-level
+// Sendable warnings — the CB objects are only ever touched on the main actor.
+@preconcurrency import CoreBluetooth
 import Combine
 import UIKit
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -678,7 +678,9 @@ nonisolated struct FlightSummary: Codable, Sendable {
 
 /// Round a float32 to `digits` significant figures so the JSON shows clean
 /// gains (e.g. 0.04, not 0.039999999105930) instead of float32→Double noise.
-private func sigFig(_ v: Float, _ digits: Int = 6) -> Double {
+/// `nonisolated` (pure math, no shared state) so the nonisolated `FlightSettings`
+/// initializers can call it without a main-actor hop under default MainActor isolation.
+private nonisolated func sigFig(_ v: Float, _ digits: Int = 6) -> Double {
     let d = Double(v)
     if d == 0 || !d.isFinite { return d }
     let mag = floor(log10(abs(d)))

--- a/TinkerRocketApp/TinkerRocketApp/Models/LandingPredictor.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/LandingPredictor.swift
@@ -134,7 +134,7 @@ final class LandingPredictor: ObservableObject {
         // Once LANDED is asserted, freeze the last prediction so the map
         // pin doesn't twitch on noise as the rocket sits on the ground.
         if t.landed_flag {
-            if !landed, var last = prediction {
+            if !landed, let last = prediction {
                 landed = true
                 let frozen = LandingPrediction(
                     landing: last.landing, descentTrack: last.descentTrack,
@@ -143,7 +143,6 @@ final class LandingPredictor: ObservableObject {
                     computedAt: now, sampleAt: last.sampleAt
                 )
                 prediction = frozen
-                _ = last
             }
             return
         }

--- a/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
@@ -29,8 +29,13 @@ class TickCounter: ObservableObject {
         stop()
         tick = 0
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            // Bind an immutable local here (in the timer's nonisolated closure)
+            // so the Task captures a `let`, not the mutable `[weak self]` var —
+            // referencing the captured var inside the concurrent Task is a Swift 6
+            // error.
+            guard let self else { return }
             Task { @MainActor in
-                self?.tick += 1
+                self.tick += 1
             }
         }
     }

--- a/tinkerrocket-idf/components/RadioLib/CMakeLists.txt
+++ b/tinkerrocket-idf/components/RadioLib/CMakeLists.txt
@@ -20,10 +20,11 @@ if(ESP_PLATFORM)
     REQUIRES esp_driver_gpio driver
   )
 
-  # RadioLib (vendored) trips GCC-14's -Woverloaded-virtual: PhysicalLayer base
-  # methods are hidden by derived overloads. It's upstream third-party code, so
-  # downgrade that one warning from error rather than patch their sources (#88, 6.0).
-  target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=overloaded-virtual)
+  # RadioLib (vendored) trips GCC's -Woverloaded-virtual: PhysicalLayer base
+  # methods are hidden by derived overloads. It's upstream third-party code we've
+  # chosen not to patch (#88), so silence the warning entirely at the component
+  # boundary rather than touch their sources — keeps our build warning-clean.
+  target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-overloaded-virtual)
 
   return()
 endif()

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -337,7 +337,7 @@ void TR_LoRa_Comms::pollDio1()
     // Check DIO1 pin state directly
     if (gpio_get_level((gpio_num_t)dio1_pin_) == 1)
     {
-        isr_count_++;
+        isr_count_ = isr_count_ + 1;  // volatile: '++' deprecated in C++20 (-Wvolatile)
         if (rx_mode_)
         {
             rx_done_ = true;
@@ -460,12 +460,14 @@ bool TR_LoRa_Comms::reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_
     rx_mode_ = false;
     rx_done_ = false;
 
-    // Save old config for rollback on partial failure
+    // Save old config for rollback on partial failure. setOutputPower is the
+    // final step, so there's no successful step after it to unwind — its
+    // failure leaves the prior power setting untouched and nothing to restore
+    // (hence no old_pwr saved here).
     const float   old_bw   = cfg_bw_khz_;
     const uint8_t old_sf   = cfg_sf_;
     const float   old_freq = cfg_freq_mhz_;
     const uint8_t old_cr   = cfg_cr_;
-    const int8_t  old_pwr  = cfg_tx_power_;
     int steps_done = 0;
 
     // LLCC68 validates SF against the current BW, so set BW first
@@ -721,7 +723,7 @@ void IRAM_ATTR TR_LoRa_Comms::onDio1ISR()
 {
     if (instance_ != nullptr)
     {
-        instance_->isr_count_++;
+        instance_->isr_count_ = instance_->isr_count_ + 1;  // volatile: '++' deprecated in C++20 (-Wvolatile)
         if (instance_->rx_mode_)
         {
             instance_->rx_done_ = true;

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -1,7 +1,15 @@
 #pragma once
 
 #include <compat.h>
+// RadioLib (vendored) trips -Woverloaded-virtual: its module classes hide
+// PhysicalLayer base methods by design. Suppress it just for this include so
+// every consumer of this header (main.cpp, TR_LoRa_Comms.cpp) stays
+// warning-clean without patching upstream sources (#88). RadioLib's own .cpp
+// files are handled by the same suppression in components/RadioLib/CMakeLists.txt.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #include <RadioLib.h>
+#pragma GCC diagnostic pop
 #include "EspHal.h"
 
 class TR_LoRa_Comms

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -68,7 +68,9 @@ void TR_ServoControl::begin() {
         channel_conf.gpio_num   = servo_pin_[i];
         channel_conf.speed_mode = LEDC_MODE;
         channel_conf.channel    = LEDC_CHANNELS[i];
-        channel_conf.intr_type  = LEDC_INTR_DISABLE;
+        // intr_type removed: deprecated in IDF v6 (the driver handles the LEDC
+        // interrupt internally). channel_conf is zero-initialized above, which
+        // is equivalent to the old LEDC_INTR_DISABLE (== 0) anyway.
         channel_conf.timer_sel  = LEDC_TIMERS[i];
         channel_conf.duty       = 0;
         channel_conf.hpoint     = 0;

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
@@ -21,6 +21,9 @@ esp_err_t TR_UART_Link::begin(const Config& cfg)
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .rx_flow_ctrl_thresh = 0,
         .source_clk = UART_SCLK_DEFAULT,
+        // Zero the sleep-power flags (allow_pd / backup_before_sleep) added in
+        // IDF v6 — we don't power-gate this UART across light sleep.
+        .flags = {},
     };
 
     esp_err_t err = uart_driver_install(cfg.port,

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -5430,7 +5430,12 @@ static void loop_fc()
                     for (int i = 0; i < 4; ++i)
                         if (!(f.azimuth_deg[i] >= -360.0f && f.azimuth_deg[i] <= 360.0f)) ok = false;
                     if (ok) {
-                        control_mixer.setFinLayout(f.azimuth_deg, f.reverse_mask,
+                        // Copy out of the packed FinConfigData into an aligned
+                        // local before passing — &f.azimuth_deg[0] is a
+                        // potentially-unaligned pointer (-Waddress-of-packed-member).
+                        float az[4];
+                        memcpy(az, f.azimuth_deg, sizeof(az));
+                        control_mixer.setFinLayout(az, f.reverse_mask,
                                                    f.roll_reverse_mask);
                         ESP_LOGI(TAG, "[FIN CFG] az=[%.0f %.0f %.0f %.0f] rev=0x%X rollrev=0x%X",
                                       (double)f.azimuth_deg[0], (double)f.azimuth_deg[1],
@@ -5623,9 +5628,9 @@ static void loop_fc()
                     float a_cmd_e = -K_tilt * nose_east;
                     float a_cmd_ned[3] = { a_cmd_n, a_cmd_e, 0.0f };
 
-                    float r00 = 1.0f - 2.0f*(q2g*q2g + q3g*q3g);
-                    float r10 = 2.0f*(q1g*q2g + q0g*q3g);
-                    float r20 = 2.0f*(q1g*q3g - q0g*q2g);
+                    // First column (r00/r10/r20 — body-forward axis) is unused
+                    // here: a_cmd_ned has no down component, so only the right
+                    // and down body projections below are needed.
                     float r01 = 2.0f*(q1g*q2g - q0g*q3g);
                     float r11 = 1.0f - 2.0f*(q1g*q1g + q3g*q3g);
                     float r21 = 2.0f*(q2g*q3g + q0g*q1g);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1219,6 +1219,7 @@ static uint32_t prev_msg_count_query = 0;
 static uint32_t prev_msg_count_ism6 = 0;
 static uint32_t prev_msg_count_bmp = 0;
 static uint32_t prev_msg_count_mmc = 0;
+static uint32_t prev_msg_count_iis2mdc = 0;
 static uint32_t prev_msg_count_gnss = 0;
 static uint32_t prev_msg_count_non_sensor = 0;
 static uint32_t prev_msg_count_power = 0;
@@ -4112,6 +4113,7 @@ static void printStats()
     const uint32_t d_ism6 = msg_count_ism6 - prev_msg_count_ism6;
     const uint32_t d_bmp = msg_count_bmp - prev_msg_count_bmp;
     const uint32_t d_mmc = msg_count_mmc - prev_msg_count_mmc;
+    const uint32_t d_iis2mdc = msg_count_iis2mdc - prev_msg_count_iis2mdc;
     const uint32_t d_gnss = msg_count_gnss - prev_msg_count_gnss;
     const uint32_t d_non_sensor = msg_count_non_sensor - prev_msg_count_non_sensor;
     const uint32_t d_power = msg_count_power - prev_msg_count_power;
@@ -4123,6 +4125,7 @@ static void printStats()
     const float hz_ism6 = (float)d_ism6 * hz_scale;
     const float hz_bmp = (float)d_bmp * hz_scale;
     const float hz_mmc = (float)d_mmc * hz_scale;
+    const float hz_iis2mdc = (float)d_iis2mdc * hz_scale;
     const float hz_gnss = (float)d_gnss * hz_scale;
     const float hz_non_sensor = (float)d_non_sensor * hz_scale;
     const float hz_power = (float)d_power * hz_scale;
@@ -4133,6 +4136,7 @@ static void printStats()
     prev_msg_count_ism6 = msg_count_ism6;
     prev_msg_count_bmp = msg_count_bmp;
     prev_msg_count_mmc = msg_count_mmc;
+    prev_msg_count_iis2mdc = msg_count_iis2mdc;
     prev_msg_count_gnss = msg_count_gnss;
     prev_msg_count_non_sensor = msg_count_non_sensor;
     prev_msg_count_power = msg_count_power;
@@ -4211,11 +4215,12 @@ static void printStats()
                   (double)((float)last_query_cfg.ism6_rot_z_cdeg / 100.0f),
                   (double)((float)last_query_cfg.mmc_rot_z_cdeg / 100.0f),
                   (unsigned)last_query_cfg.format_version);
-    ESP_LOGI("OC", "msg Hz q/ism6/bmp/mmc/gnss/ns/pwr/st/en/unk=%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f",
+    ESP_LOGI("OC", "msg Hz q/ism6/bmp/mmc/iis2mdc/gnss/ns/pwr/st/en/unk=%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f/%.1f",
                   (double)hz_query,
                   (double)hz_ism6,
                   (double)hz_bmp,
                   (double)hz_mmc,
+                  (double)hz_iis2mdc,
                   (double)hz_gnss,
                   (double)hz_non_sensor,
                   (double)hz_power,
@@ -4252,7 +4257,7 @@ static void printStats()
         static uint32_t prev_replay = 0;
         uint32_t d_replay = dedup_replay_drops - prev_replay;
         prev_replay = dedup_replay_drops;
-        uint32_t d_parsed = msg_count_ism6 + msg_count_bmp + msg_count_mmc + msg_count_non_sensor + msg_count_gnss;
+        uint32_t d_parsed = msg_count_ism6 + msg_count_bmp + msg_count_mmc + msg_count_iis2mdc + msg_count_non_sensor + msg_count_gnss;
         static uint32_t prev_total_parsed = 0;
         uint32_t d_p = d_parsed - prev_total_parsed;
         // Calculate non-zero byte percentage

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1219,7 +1219,6 @@ static uint32_t prev_msg_count_query = 0;
 static uint32_t prev_msg_count_ism6 = 0;
 static uint32_t prev_msg_count_bmp = 0;
 static uint32_t prev_msg_count_mmc = 0;
-static uint32_t prev_msg_count_iis2mdc = 0;
 static uint32_t prev_msg_count_gnss = 0;
 static uint32_t prev_msg_count_non_sensor = 0;
 static uint32_t prev_msg_count_power = 0;
@@ -1254,7 +1253,7 @@ static inline IRAM_ATTR void rxPush(uint8_t b)
     const size_t next = (rx_head + 1U) % RX_STREAM_RING;
     if (next == rx_tail)
     {
-        rx_ring_overflow_drops++;
+        rx_ring_overflow_drops = rx_ring_overflow_drops + 1;  // volatile: '++' deprecated in C++20 (-Wvolatile)
         return;
     }
     rx_ring[rx_head] = b;
@@ -2415,7 +2414,7 @@ static IRAM_ATTR bool i2sRecvCallback(const uint8_t* buf, size_t len, void* user
     // declaration for rationale.
     if (i2s_ingest_paused) return false;
 
-    dma_cb_count++;
+    dma_cb_count = dma_cb_count + 1;  // volatile: '++' deprecated in C++20 (-Wvolatile)
     dma_total_bytes += len;
 
     // Count non-zero bytes for diagnostics
@@ -4242,7 +4241,7 @@ static void printStats()
     {
         static uint32_t prev_dma_cb = 0, prev_ring_ovf = 0,
                          prev_dedup_eq = 0, prev_dedup_lt = 0,
-                         prev_stale = 0, prev_parsed = 0;
+                         prev_stale = 0;
         static uint64_t prev_dma_bytes = 0;
         uint32_t d_cb = dma_cb_count - prev_dma_cb;
         uint64_t d_bytes = raw_i2c_bytes - prev_dma_bytes;


### PR DESCRIPTION
## Summary

Clears **all** compile warnings in our own code across the three build targets, and completes one diagnostic that was found dead-coded during the sweep. Each target was clean-built and re-verified warning-free.

- **Flight computer** (ESP-IDF v6.0.1 / riscv32 GCC 13.2): 0 warnings in our code
- **Out computer** (ESP-IDF v6.0.1): 0 warnings in our code
- **iOS app** (Debug, iOS Simulator): 0 source warnings, `** BUILD SUCCEEDED **`

RadioLib's `overloaded-virtual` warnings (vendored third-party) are suppressed at the component boundary — upstream sources are **not** patched (consistent with #88).

## Commits

### `fix(fw)` — FC + OC warnings
Shared components (fixes both firmwares):
- **TR_ServoControl_ledc_mult**: drop deprecated `ledc_channel_config_t::intr_type` (IDF v6 handles the LEDC interrupt internally; struct is zero-init'd)
- **TR_UART_Link**: initialize the new `uart_config_t::flags` (sleep-power) bitfield
- **TR_LoRa_Comms**: volatile `isr_count_ ++` → `= x + 1` (`-Wvolatile`, C++20); drop unused `old_pwr` rollback save (setOutputPower is the terminal step — its failure leaves nothing to unwind)
- **TR_LoRa_Comms.h**: localize `-Wno-overloaded-virtual` to the vendored `RadioLib.h` include so consumers stay clean without patching upstream

FC main: drop unused rotation-matrix first column (`r00/r10/r20`); copy packed `FinConfigData.azimuth_deg` into an aligned local before passing (`-Waddress-of-packed-member`).

OC main: volatile `++` → `= x + 1` on `rx_ring_overflow_drops`, `dma_cb_count`; drop unused `prev_msg_count_iis2mdc` and orphaned `prev_parsed`.

### `fix(app)` — iOS warnings (Swift concurrency)
All were main-actor-isolation diagnostics under the target's default MainActor isolation:
- **CSVGenerator**: mark pure `sigFig()` `nonisolated` (~20 sites)
- **BLEDevice**: `@preconcurrency import CoreBluetooth` (non-Sendable `CBPeripheral` capture in the OTA backpressure continuation)
- **PyroTestView**: bind an immutable `self` in the timer's nonisolated closure so the inner `Task` captures a `let`, not the `[weak self]` var (Swift 6 error)
- **LandingPredictor**: `var last` → `let last` + drop a vestigial `_ = last`

### `feat(oc)` — report IIS2MDC message rate in per-second diagnostics
Removing the dead `prev_msg_count_iis2mdc` above surfaced that the OC's ~1 Hz "msg Hz" report and the `parsed=` health sum track the **old-PCB MMC** magnetometer but not the **new-PCB IIS2MDC**, even though IIS2MDC frames are received, dedup/stale-filtered, logged to flash, and counted. On current hardware there was no live "is the mag stream flowing?" readout. Wires `msg_count_iis2mdc` through the same path as `mmc`. Pure diagnostics — no change to logging, telemetry, or control.

⚠️ **Changes the `"msg Hz …"` serial log format string** (adds one field + label). Update any tooling that scrapes that line.

## Test plan
- [x] `idf.py build` flight_computer — clean, 0 warnings in our code
- [x] `idf.py build` out_computer — clean, 0 warnings in our code
- [x] `xcodebuild build` TinkerRocketApp (iOS Simulator) — `** BUILD SUCCEEDED **`, 0 source warnings
- [ ] Bench: confirm the new `iis2mdc` Hz field reads a sane rate on a new PCB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
