### PR TITLE
Servo #407 follow-ups: anti-backlash neutral settle, test-stop wake window, app default + jog-range fixes

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -87,8 +87,11 @@ struct DiscoveredDevice: Identifiable {
 struct RocketConfig {
     var servoBias1: Int16 = 85
     var servoHz: Int16 = 333
-    var servoMinUs: Int16 = 1250
-    var servoMaxUs: Int16 = 1750
+    // #407: match RocketProfile (the source of truth) and config.h
+    // SERVO_MIN_US/MAX_US = 1000/2000. The old 1250/1750 disagreed with the
+    // profile default and, paired with the ±60° fin cal, under-deflected ~2×.
+    var servoMinUs: Int16 = 1000
+    var servoMaxUs: Int16 = 2000
     var pidKp: Float = 0.08
     var pidKi: Float = 0.005
     var pidKd: Float = 0.003

--- a/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FinLayoutView.swift
@@ -19,6 +19,11 @@ struct FinLayoutView: View {
     let reverse: [Bool]            // per-servo (1-4) tilt (pitch/yaw) reverse
     let rollReverse: [Bool]        // per-servo (1-4) roll reverse (independent)
     let canJog: Bool
+    // Fin-angle endpoints the jog may command, from the active profile's fin
+    // calibration (#407) — same clamp ServoTestView uses, so a narrow-travel
+    // model never jogs past its calibrated deflection. Defaults to ±20°.
+    var finMinDeg: Double = -20
+    var finMaxDeg: Double = 20
     let onSetRingMode: (UInt8) -> Void
     let onSetServoAtSlot: ([Int]) -> Void
     let onSetReverse: ([Bool]) -> Void
@@ -193,7 +198,13 @@ struct FinLayoutView: View {
         guard idx >= 0 && idx < 4 else { return }
         var angles = [0.0, 0.0, 0.0, 0.0]
         // Apply the per-servo reverse so the jog reflects the controller's "+".
-        angles[idx] = (reverse.indices.contains(idx) && reverse[idx]) ? -deg : deg
+        let target = (reverse.indices.contains(idx) && reverse[idx]) ? -deg : deg
+        // Clamp the commanded angle to the profile's fin-cal range (#407) so the
+        // jog can't over-deflect on a narrow-travel model. The FC clamps too, but
+        // matching it here keeps the app honest about what it sends.
+        let lo = Swift.min(finMinDeg, finMaxDeg)
+        let hi = Swift.max(finMinDeg, finMaxDeg)
+        angles[idx] = Swift.min(Swift.max(target, lo), hi)
         device.sendServoTestAngles(angles)
     }
     private func jogStop() { device.sendServoTestStop() }

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -792,6 +792,8 @@ struct SettingsView: View {
                 reverse: profile.finReverse,
                 rollReverse: profile.finRollReverse,
                 canJog: device.isConnected && !device.isBaseStation && device.telemetry.pwr_pin_on,
+                finMinDeg: Double(profile.finMinDeg),
+                finMaxDeg: Double(profile.finMaxDeg),
                 onSetRingMode: { m in updateProfile { $0.finRingMode = m }; applyFinConfig() },
                 onSetServoAtSlot: { s in updateProfile { $0.finServoAtSlot = s }; applyFinConfig() },
                 onSetReverse: { r in updateProfile { $0.finReverse = r }; applyFinConfig() },

--- a/tests/bench/servo_bench_notes.md
+++ b/tests/bench/servo_bench_notes.md
@@ -1,0 +1,64 @@
+# Servo bench notes
+
+Pad-time servo behaviour and the hardware-vs-software triage procedure, for
+bench-testing the fin-tab servos before a flight day. Companion to the
+in-app **Servo Test** and **Fin Layout** views. See issues #345 / #406 / #407.
+
+## What the firmware does on the pad
+
+- **Boot.** The servos wiggle one at a time (`0→1→2→3`, ~350 ms each) so only
+  one inrush spike hits the shared rail at a time, then settle at the
+  *trimmed* neutral (0° through the fin calibration, **not** the raw pulse
+  midpoint) and hold it for ~6 s before the pad relax kicks in. So on boot you
+  should see each tab sweep, then all four sit straight for a few seconds.
+- **Pad trim previews live.** Applying a servo config / trim from the app on
+  the pad drives the tabs to the freshly-trimmed neutral and holds it ~6 s
+  (the `servo_pad_wake_until_ms` wake window) instead of relaxing immediately —
+  so you can see where the trim actually lands.
+- **Anti-backlash settle (#407).** Every pad-time "go to neutral" (boot settle,
+  trim preview, servo-test stop) approaches neutral from a *consistent* side:
+  the tab is driven a few degrees past neutral, then settled back over a couple
+  of loop ticks. This loads the gear mesh the same way each time, so the rest
+  position is repeatable even on a slightly worn servo. It masks **mild**
+  backlash only — it is **not** a substitute for replacing a servo with gross
+  hysteresis (see below).
+- **Pad relax.** Outside those wake windows the servos are relaxed (0 % duty,
+  no pulse train) to cut ~150 mA/servo of holding current; they re-energise
+  automatically at launch detect.
+
+## `[SERVO TEST]` serial line — hardware-vs-software triage
+
+Each servo-test command prints the commanded angles and the per-channel pulse
+widths actually written to the LEDC hardware:
+
+```
+[SERVO TEST] Angles: [0.0, 0.0, 0.0, 0.0] deg -> pulses [1500, 1500, 1500, 1500] us
+```
+
+The `-> pulses [...] us` are the **software ground truth** (angle → fin
+calibration → +bias → clamp). Use them to split hardware faults from software:
+
+- Pulses look right but the **tab doesn't move / lands off** → mechanical
+  (linkage, gear backlash, worn pot, dead servo, no power on that pin).
+- Pulses look **wrong** → software (fin cal, bias, servo min/max µs, or the
+  profile's range/cal pair). Check the active profile's servo min/max µs vs its
+  fin travel; the app defaults are 1000–2000 µs ↔ ±60°.
+
+## Two-direction hysteresis test (backlash / servo-health check)
+
+To decide whether a servo needs replacing (e.g. servo 3, ~10° hysteresis,
+issue #407):
+
+1. From **Servo Test**, command the servo to **+20°**, then back to **0°**.
+   Note where the tab physically lands.
+2. Command the same servo to **−20°**, then back to **0°**. Note the tab again.
+3. The two `0°` positions **must land identically**. The `-> pulses` are the
+   same both times (software commands the same neutral), so any *physical*
+   divergence is mechanical slop — gear backlash or a worn pot.
+
+A repeatable divergence of several degrees (≈10° on the failed servo 3) means
+gear backlash / worn pot: no trim value or firmware change makes it repeatable,
+and in flight the roll controller commands through the dead zone (limit-cycling
+/ soft authority). **Replace the servo before flying it on a control fin** and
+re-run this test on the replacement — it must pass (identical landing) before
+that slot is trusted.

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.cpp
@@ -189,6 +189,31 @@ void TR_ServoControl::setServoAngles(const float angles[4]) {
     }
 }
 
+void TR_ServoControl::beginNeutralSettle(uint32_t now_ms) {
+    // Phase 1: drive a few degrees past neutral on every channel (a higher
+    // pulse — usFromFinDeg is monotonic — so all four load their gear mesh from
+    // the same side).  setServoAngles clamps to the fin-cal range, so a narrow
+    // cal simply parks at its endpoint.  serviceNeutralSettle() completes the
+    // move to neutral once kNeutralSettleHoldMs has elapsed.
+    const float overshoot[4] = {
+        kNeutralSettleOvershootDeg, kNeutralSettleOvershootDeg,
+        kNeutralSettleOvershootDeg, kNeutralSettleOvershootDeg };
+    setServoAngles(overshoot);
+    neutral_settle_active_ = true;
+    neutral_settle_at_ms_  = now_ms + kNeutralSettleHoldMs;
+}
+
+void TR_ServoControl::serviceNeutralSettle(uint32_t now_ms) {
+    if (!neutral_settle_active_) return;
+    // Signed compare so the tick counter can wrap safely (same idiom as the
+    // pad-relax wake gate in main.cpp).
+    if ((int32_t)(now_ms - neutral_settle_at_ms_) < 0) return;  // still overshooting
+    // Phase 2: settle to the commanded neutral, approached from the high side.
+    const float neutral[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    setServoAngles(neutral);
+    neutral_settle_active_ = false;
+}
+
 int TR_ServoControl::saturateCommand(int command) {
     if (command < servo_min_us) return servo_min_us;
     if (command > servo_max_us) return servo_max_us;

--- a/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
+++ b/tinkerrocket-idf/components/TR_ServoControl_ledc_mult/TR_ServoControl_ledc_mult.h
@@ -46,6 +46,28 @@ public:
     bool isIdle() const { return is_idle_; }
     // set each servo to an individual angle (degrees), bypassing PID
     void setServoAngles(const float angles[4]);
+
+    // ── Anti-backlash neutral settle (#407) ──
+    // Park the tabs at neutral repeatably despite mild gear backlash by always
+    // approaching from the SAME side: beginNeutralSettle() drives a few degrees
+    // past neutral (loading the gear mesh one way), then serviceNeutralSettle(),
+    // called each loop tick, drops to neutral once the overshoot has been held
+    // long enough to take up the slack.  Non-blocking — no delays; the two-phase
+    // move is timed across ticks via the caller's now_ms.  Matches the boot
+    // wiggle, which already ends by approaching mid from the max (high) side.
+    // Intended only for pad-time "go to neutral and hold" moments (boot settle,
+    // trim preview, test stow) — never the flight control path, which repositions
+    // every tick and drives through the backlash continuously.
+    void beginNeutralSettle(uint32_t now_ms);
+    void serviceNeutralSettle(uint32_t now_ms);
+    bool isNeutralSettling() const { return neutral_settle_active_; }
+    // Degrees past neutral to load the backlash before settling.  Clamped to the
+    // fin-cal range by setServoAngles(), so a narrow cal just approaches from its
+    // own endpoint.
+    static constexpr float    kNeutralSettleOvershootDeg = 6.0f;
+    // How long to hold the overshoot before the settle-back command (ms) — long
+    // enough for an 8 g servo to physically take up the slack.
+    static constexpr uint32_t kNeutralSettleHoldMs       = 200;
     // last computed roll command (deg)
     float getRollCmdDeg();
     // last computed pulse width (µs) of servo1
@@ -190,6 +212,11 @@ private:
     // (setPulse/setServoAngles), which re-asserts a real duty and so resumes
     // PWM without an explicit wake step.
     bool is_idle_ = false;
+
+    // Anti-backlash neutral settle (#407): true between beginNeutralSettle()
+    // (overshoot commanded) and serviceNeutralSettle() dropping to neutral.
+    bool     neutral_settle_active_ = false;
+    uint32_t neutral_settle_at_ms_  = 0;   // tick at/after which to settle
 
     // LEDC channels/timers for four servos
     static constexpr int LEDC_CHANNEL_COUNT = 4;

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2856,8 +2856,10 @@ static void setup_fc()
             // leaves the tabs off the trimmed straight position.  Drive through
             // the same setServoAngles() path the flight/servo-test neutral uses
             // so the boot rest position matches exactly what was trimmed.
-            const float neutral[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-            servo_control.setServoAngles(neutral);
+            // #407: settle via the anti-backlash approach (overshoot then back)
+            // so the boot rest position is repeatable on a slightly worn servo;
+            // the per-tick serviceNeutralSettle() below completes it.
+            servo_control.beginNeutralSettle(time_ms());
             // Hold that trimmed neutral briefly before the pad relax kicks in, so
             // the operator can see/verify the tabs sit straight on boot instead
             // of going limp the instant READY starts.
@@ -4215,8 +4217,11 @@ static void loop_fc()
                         // and flight neutral use — so the preview shows the tab
                         // exactly where a 0-command holds it, not the raw pulse
                         // midpoint (which differs under an asymmetric fin cal).
-                        const float neutral[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-                        servo_control.setServoAngles(neutral);
+                        // #407: approach it anti-backlash (overshoot then settle)
+                        // so the preview is repeatable even on a slightly worn
+                        // servo; serviceNeutralSettle() completes it over the next
+                        // ticks, inside the wake window armed just below.
+                        servo_control.beginNeutralSettle(now_ms);
                         servo_pad_wake_until_ms = now_ms + config::SERVO_PAD_TRIM_WAKE_MS;
                     }
 
@@ -5274,8 +5279,15 @@ static void loop_fc()
             else if (out_pending_command == SERVO_TEST_STOP)
             {
                 servo_test_active = false;
-                servo_control.stowControl();
-                ESP_LOGI(TAG, "[SERVO TEST] Stopped - servos stowed");
+                // #407: stow via the anti-backlash approach (overshoot then
+                // settle to the fin-cal neutral, same as boot/trim) and arm the
+                // pad wake window so the stowed neutral stays driven ~6 s.
+                // Without the wake window the next READY/PRELAUNCH tick idle()s
+                // the servos and a loaded linkage droops within a tick, so the
+                // operator never sees where the test actually stowed.
+                servo_control.beginNeutralSettle(now_ms);
+                servo_pad_wake_until_ms = now_ms + config::SERVO_PAD_TRIM_WAKE_MS;
+                ESP_LOGI(TAG, "[SERVO TEST] Stopped - servos stowed (anti-backlash), wake armed");
             }
             else if (out_pending_command == ROLL_PROFILE_PENDING)
             {
@@ -5727,6 +5739,11 @@ static void loop_fc()
             }
             case READY:
             {
+                // Advance an in-progress anti-backlash neutral settle (#407)
+                // started by boot-settle or a pad trim; a no-op otherwise.  Runs
+                // before the relax gate so it completes within the wake window.
+                if (servo_enabled) servo_control.serviceNeutralSettle(now_ms);
+
                 // Relax the servos on the pad: cut the pulse train so the
                 // digital servos stop drawing ~150 mA of holding current while
                 // we wait for GNSS/launch.  Re-asserted each tick (idempotent);
@@ -5773,6 +5790,10 @@ static void loop_fc()
             }
             case PRELAUNCH:
             {
+                // Advance an in-progress anti-backlash neutral settle (#407),
+                // e.g. a trim applied while sitting in PRELAUNCH; no-op otherwise.
+                if (servo_enabled) servo_control.serviceNeutralSettle(now_ms);
+
                 // Stay relaxed through the pad wait; the INFLIGHT control path
                 // re-drives (and so re-energises) the servos the instant
                 // launch_flag flips below.  Held off during the pad-trim wake


### PR DESCRIPTION
Implements the firmware, app, and docs follow-ups from the servo bench session (#407). Leaves the **hardware** item (replace servo 3) and no closing keyword so #407 stays open to track it.

## Firmware — anti-backlash neutral settle + servo-test wake window
New non-blocking driver primitive in `TR_ServoControl`:
- `beginNeutralSettle(now_ms)` drives ~6° past neutral (higher pulse on every channel → loads the gear mesh from one side), then `serviceNeutralSettle(now_ms)` — called each READY/PRELAUNCH tick — settles to the fin-cal neutral once the overshoot has been held ~200 ms. Timed across loop ticks via the caller's `now_ms`, so **no `esp_timer` dependency** (the driver isn't in the sim wheel). Matches the boot wiggle, which already approaches mid from the high side.
- Wired into the two pad-time "park at neutral and hold" paths: **boot-settle** and **trim-preview** (replacing the plain `setServoAngles(neutral)`).
- **`SERVO_TEST_STOP`** now does the anti-backlash settle **and arms the pad wake window**, so the stowed neutral stays driven ~6 s instead of drooping the instant READY/PRELAUNCH `idle()`s the servos.
- **Never on the flight path** — the settle is only armed from pad/bench events, so it can't fire in INFLIGHT (where the roll controller repositions every tick and drives through backlash continuously).
- This masks *mild* backlash so trim previews are repeatable on a slightly worn servo. It is **not** a fix for servo 3's ~10° hysteresis — that servo still needs replacing.

## App
- **`BLETypes.swift`**: `RocketConfig.servoMinUs/MaxUs` default `1250/1750 → 1000/2000`, matching `RocketProfile` (the source of truth) and `config.h`. The old default paired with the ±60° fin cal could silently under-deflect ~2× on a config readback that omits the `smn/smx` keys.
- **`FinLayoutView`**: the fin-layout jog (fixed ±10° absolute buttons) now clamps to the profile's `[finMinDeg, finMaxDeg]`, threaded from the SettingsView call site — matching what ServoTestView already did.

## Docs
- `tests/bench/servo_bench_notes.md`: pad-time servo behaviour, the `[SERVO TEST] -> pulses` hardware-vs-software triage, and the two-direction hysteresis test (+20°→0° vs −20°→0° must land identically) used to catch backlash / a worn pot.

## Note on the "lint/assert (range, cal) consistency" sub-item
Not added — **moot since #449**, which derives `finMinDeg/finMaxDeg` from `finTravelDeg`, making an inconsistent (µs-range, degrees) pair unrepresentable. An assert would be dead code.

## Verification
- Flight computer firmware builds clean under ESP-IDF v6.0.1 (`idf.py build`, 81% flash free).
- iOS app builds clean (`xcodebuild`, generic iOS device).
- **Bench-pending**: the anti-backlash overshoot/settle timing and the test-stop hold want a bench check on real servos before flying.

## Still open on #407 (not in this PR)
- **Hardware**: replace servo 3 (~10° mechanical hysteresis); verify the replacement passes the two-direction hysteresis test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
