### PR TITLE
OC flight-log auto-evict rolling buffer (#315) + saved-files navigation & multi-select

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1081,9 +1081,6 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
-    func nextPage() { requestFileList(page: currentPage + 1) }
-    func previousPage() { if currentPage > 0 { requestFileList(page: currentPage - 1) } }
-
     func deleteFile(_ filename: String) {
         guard let characteristic = commandCharacteristic,
               let peripheral = peripheral else { return }

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1093,6 +1093,14 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         downloadStates.removeValue(forKey: filename)
     }
 
+    /// Bulk delete for multi-select. Each name is an independent cmd-3 write;
+    /// CoreBluetooth serializes the `.withResponse` writes on its own queue, so
+    /// the firmware processes them one at a time. The caller should refresh the
+    /// file list afterward (totals/pagination shift once the deletes land).
+    func deleteFiles(_ filenames: [String]) {
+        for name in filenames { deleteFile(name) }
+    }
+
     func downloadFile(_ filename: String, completion: @escaping (URL?) -> Void) {
         guard let characteristic = commandCharacteristic,
               let peripheral = peripheral else {

--- a/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift
@@ -15,7 +15,7 @@ import Foundation
 /// Rocket NAND flight-log usage, in 256 KB blocks (wire = 15 bytes, LE packed):
 ///   [0..1] u16 flight_region_blocks  [2..3] u16 used  [4..5] u16 free
 ///   [6..7] u16 bad  [8..9] u16 system  [10..11] u16 flight_count
-///   [12..13] u16 block_size_kb  [14] u8 flags(bit0=initialized)
+///   [12..13] u16 block_size_kb  [14] u8 flags(bit0=initialized, bit1=auto-evicted)
 struct RocketStorageStats: Equatable {
     let flightRegionBlocks: Int
     let usedBlocks: Int
@@ -25,6 +25,10 @@ struct RocketStorageStats: Equatable {
     let flightCount: Int
     let blockSizeKB: Int
     let initialized: Bool
+    /// #315: the rolling-buffer auto-evict has deleted at least one oldest flight
+    /// this session to reclaim space at arm time (RSS_FLAG_AUTO_EVICTED, bit1).
+    /// Surfaces that the card rolled rather than silently dropping data.
+    let autoEvicted: Bool
 
     private var blockBytes: Int { blockSizeKB * 1024 }
     /// Full managed chip = flight region + fixed system overhead.
@@ -45,7 +49,8 @@ struct RocketStorageStats: Equatable {
         return RocketStorageStats(
             flightRegionBlocks: u16(0), usedBlocks: u16(2), freeBlocks: u16(4),
             badBlocks: u16(6), systemBlocks: u16(8), flightCount: u16(10),
-            blockSizeKB: u16(12), initialized: (bytes[14] & 0x01) != 0)
+            blockSizeKB: u16(12), initialized: (bytes[14] & 0x01) != 0,
+            autoEvicted: (bytes[14] & 0x02) != 0)
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1007,13 +1007,15 @@ struct StorageBarView: View {
                 card(title: "Rocket Storage",
                      subtitle: "\(s.flightCount) flight\(s.flightCount == 1 ? "" : "s")",
                      used: s.usedBytes, reserved: s.reservedBytes, free: s.freeBytes,
-                     total: s.totalBytes)
+                     total: s.totalBytes,
+                     autoEvicted: s.autoEvicted)
             }
         }
     }
 
     private func card(title: String, subtitle: String,
-                      used: Int, reserved: Int, free: Int, total: Int) -> some View {
+                      used: Int, reserved: Int, free: Int, total: Int,
+                      autoEvicted: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text(title).font(.headline)
@@ -1026,6 +1028,17 @@ struct StorageBarView: View {
                 if reserved > 0 { legend(Color(.systemGray2), "Reserved", reserved) }
                 legend(.green, "Free", free)
                 Spacer()
+            }
+            // #315: rolling-buffer note. When the card fills, the OC auto-deletes
+            // the oldest flight(s) at arm time to make room — surface it so the
+            // operator knows data rolled off rather than being silently dropped.
+            if autoEvicted {
+                HStack(spacing: 5) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                    Text("Auto-reclaimed oldest flight(s) this session")
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
             }
         }
         .padding()

--- a/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
@@ -14,9 +14,22 @@ struct FileManagerView: View {
     @State private var fileToDelete: FileInfo?
     @State private var showDeleteConfirm = false
 
+    // Multi-select for bulk delete. `selection` holds file names (FileInfo.id),
+    // so it survives paging — you can select across pages and the count in the
+    // action bar reflects the full set even when some aren't on the visible page.
+    @State private var isSelecting = false
+    @State private var selection: Set<String> = []
+    @State private var showBulkDeleteConfirm = false
+
     // ESP32 already excludes recovery files from the BLE file list
     private var displayedFiles: [FileInfo] {
         device.files
+    }
+
+    // True when every file on the current page is selected (drives Select-all vs
+    // Deselect-all). False for an empty page so the toggle reads "Select all".
+    private var allOnPageSelected: Bool {
+        !displayedFiles.isEmpty && displayedFiles.allSatisfy { selection.contains($0.name) }
     }
 
     // Both firmwares paginate the BLE file list at 5 entries/page
@@ -74,19 +87,29 @@ struct FileManagerView: View {
                         }
                     }
                     Spacer()
-                    Button(action: {
-                        print("Requesting file list...")
-                        device.requestFileList(page: device.currentPage)
-                    }) {
-                        HStack {
-                            Image(systemName: "arrow.clockwise")
-                            Text("Refresh")
+                    if isSelecting {
+                        Button("Cancel") { exitSelection() }
+                            .foregroundColor(.blue)
+                    } else {
+                        if !displayedFiles.isEmpty {
+                            Button("Select") { isSelecting = true }
+                                .foregroundColor(.blue)
+                                .padding(.trailing, 4)
                         }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
+                        Button(action: {
+                            print("Requesting file list...")
+                            device.requestFileList(page: device.currentPage)
+                        }) {
+                            HStack {
+                                Image(systemName: "arrow.clockwise")
+                                Text("Refresh")
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(8)
+                        }
                     }
                 }
                 .padding()
@@ -146,25 +169,36 @@ struct FileManagerView: View {
                 } else {
                     List {
                         ForEach(displayedFiles) { file in
-                            FileRow(
-                                file: file,
-                                onDelete: {
-                                    fileToDelete = file
-                                    showDeleteConfirm = true
-                                },
-                                onDownload: {
-                                    print("Download button tapped for: \(file.name)")
+                            if isSelecting {
+                                Button {
+                                    toggleSelection(file.name)
+                                } label: {
+                                    FileRow(file: file, onDelete: {}, onDownload: {},
+                                            device: device, selectionMode: true,
+                                            isSelected: selection.contains(file.name))
+                                }
+                                .buttonStyle(.plain)
+                            } else {
+                                FileRow(
+                                    file: file,
+                                    onDelete: {
+                                        fileToDelete = file
+                                        showDeleteConfirm = true
+                                    },
+                                    onDownload: {
+                                        print("Download button tapped for: \(file.name)")
 
-                                    device.downloadAndCacheFlight(file.name) { success in
-                                        if success {
-                                            print("[DOWNLOAD] Success: \(file.name)")
-                                        } else {
-                                            print("[DOWNLOAD] Failed: \(file.name)")
+                                        device.downloadAndCacheFlight(file.name) { success in
+                                            if success {
+                                                print("[DOWNLOAD] Success: \(file.name)")
+                                            } else {
+                                                print("[DOWNLOAD] Failed: \(file.name)")
+                                            }
                                         }
-                                    }
-                                },
-                                device: device
-                            )
+                                    },
+                                    device: device
+                                )
+                            }
                         }
                     }
                     .listStyle(InsetGroupedListStyle())
@@ -184,6 +218,13 @@ struct FileManagerView: View {
                             Text("Are you sure you want to delete \"\(file.displayTitle)\" from the \(device.isBaseStation ? "base station" : "rocket")? This cannot be undone.")
                         }
                     }
+                    .alert("Delete \(selection.count) \(device.isBaseStation ? "LoRa Log" : "Flight")\(selection.count == 1 ? "" : "s")?",
+                           isPresented: $showBulkDeleteConfirm) {
+                        Button("Delete", role: .destructive) { deleteSelected() }
+                        Button("Cancel", role: .cancel) {}
+                    } message: {
+                        Text("Are you sure you want to delete \(selection.count) \(device.isBaseStation ? "log" : "flight")\(selection.count == 1 ? "" : "s") from the \(device.isBaseStation ? "base station" : "rocket")? This cannot be undone.")
+                    }
 
                     // Pagination — numbered page navigator so many saved files
                     // are easy to jump through (not just Prev/Next one at a time).
@@ -194,6 +235,37 @@ struct FileManagerView: View {
                             hasMore: device.hasMoreFiles,
                             onSelect: { device.requestFileList(page: UInt8(clamping: $0)) }
                         )
+                        .padding(.horizontal)
+                        .padding(.bottom, isSelecting ? 4 : 10)
+                    }
+
+                    // Multi-select action bar.
+                    if isSelecting {
+                        HStack {
+                            Button(allOnPageSelected ? "Deselect all" : "Select all") {
+                                if allOnPageSelected {
+                                    displayedFiles.forEach { selection.remove($0.name) }
+                                } else {
+                                    displayedFiles.forEach { selection.insert($0.name) }
+                                }
+                            }
+                            .foregroundColor(.blue)
+
+                            Spacer()
+
+                            Button(action: { showBulkDeleteConfirm = true }) {
+                                HStack(spacing: 6) {
+                                    Image(systemName: "trash")
+                                    Text("Delete\(selection.isEmpty ? "" : " (\(selection.count))")")
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(selection.isEmpty ? Color.gray : Color.red)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                            }
+                            .disabled(selection.isEmpty)
+                        }
                         .padding(.horizontal)
                         .padding(.bottom, 10)
                     }
@@ -215,6 +287,24 @@ struct FileManagerView: View {
             // Rebuild download states from cache when file list updates
             device.rebuildDownloadStates(for: files.map { $0.name })
         }
+    }
+
+    private func toggleSelection(_ name: String) {
+        if selection.contains(name) { selection.remove(name) } else { selection.insert(name) }
+    }
+
+    private func exitSelection() {
+        isSelecting = false
+        selection.removeAll()
+    }
+
+    private func deleteSelected() {
+        let names = Array(selection)
+        device.deleteFiles(names)
+        exitSelection()
+        // Resync from the device: a bulk delete can empty the current page or
+        // shift the total, so jump back to the first page.
+        device.requestFileList(page: 0)
     }
 }
 
@@ -326,9 +416,20 @@ struct FileRow: View {
     let onDelete: () -> Void
     let onDownload: () -> Void
     @ObservedObject var device: BLEDevice
+    // In selection mode the per-row Download/Delete buttons give way to a leading
+    // checkmark and the whole row acts as a selection toggle (handled by the
+    // caller wrapping this in a Button).
+    var selectionMode: Bool = false
+    var isSelected: Bool = false
 
     var body: some View {
         HStack {
+            if selectionMode {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundColor(isSelected ? .blue : .secondary)
+            }
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(file.displayTitle)
                     .font(.body)
@@ -340,21 +441,24 @@ struct FileRow: View {
 
             Spacer()
 
-            // Download button
-            Button(action: onDownload) {
-                downloadButtonContent
-            }
-            .buttonStyle(BorderlessButtonStyle())
-            .disabled(downloadButtonDisabled)
+            if !selectionMode {
+                // Download button
+                Button(action: onDownload) {
+                    downloadButtonContent
+                }
+                .buttonStyle(BorderlessButtonStyle())
+                .disabled(downloadButtonDisabled)
 
-            // Delete button
-            Button(action: onDelete) {
-                Image(systemName: "trash")
-                    .foregroundColor(.red)
+                // Delete button
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(BorderlessButtonStyle())
             }
-            .buttonStyle(BorderlessButtonStyle())
         }
         .padding(.vertical, 4)
+        .contentShape(Rectangle())
     }
 
     // Download button content based on state

--- a/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FileManagerView.swift
@@ -19,6 +19,30 @@ struct FileManagerView: View {
         device.files
     }
 
+    // Both firmwares paginate the BLE file list at 5 entries/page
+    // (FILES_PER_PAGE in out_computer + base_station config).
+    private static let filesPerPage = 5
+
+    /// Authoritative total page count when we know the full file count, else nil.
+    /// The rocket's storage stats report `flightCount` (== the flight-log index
+    /// size, which is exactly what the file list paginates over), so we can show
+    /// a fixed numbered navigator. The base station reports no count, so its
+    /// navigator is discovered page-by-page instead (see FilePageNavigator).
+    private var totalFilePages: Int? {
+        guard !device.isBaseStation,
+              let s = device.rocketStorage, s.initialized else { return nil }
+        return FilePageNavigator.totalPages(forFileCount: s.flightCount,
+                                            pageSize: Self.filesPerPage)
+    }
+
+    /// Show the navigator whenever there's more than one page. With a known
+    /// total this also hides it (and the phantom "next") for an exactly-full
+    /// single page, which the count==pageSize "hasMore" heuristic can't.
+    private var showPagination: Bool {
+        if let total = totalFilePages { return total > 1 }
+        return device.currentPage > 0 || device.hasMoreFiles
+    }
+
     var body: some View {
         VStack(spacing: 20) {
             if !device.isConnected {
@@ -35,8 +59,12 @@ struct FileManagerView: View {
                     VStack(alignment: .leading) {
                         Text(device.isBaseStation ? "LoRa Logs" : "Flights")
                             .font(.headline)
-                        if device.currentPage > 0 || device.hasMoreFiles {
-                            Text("Page \(device.currentPage + 1)")
+                        if let total = totalFilePages, total > 1 {
+                            Text("Page \(Int(device.currentPage) + 1) of \(total)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else if device.currentPage > 0 || device.hasMoreFiles {
+                            Text("Page \(Int(device.currentPage) + 1)")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         } else {
@@ -157,41 +185,15 @@ struct FileManagerView: View {
                         }
                     }
 
-                    // Pagination controls
-                    if device.currentPage > 0 || device.hasMoreFiles {
-                        HStack(spacing: 20) {
-                            Button(action: {
-                                device.previousPage()
-                            }) {
-                                HStack {
-                                    Image(systemName: "chevron.left")
-                                    Text("Previous")
-                                }
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 8)
-                                .background(device.currentPage > 0 ? Color.blue : Color.gray)
-                                .foregroundColor(.white)
-                                .cornerRadius(8)
-                            }
-                            .disabled(device.currentPage == 0)
-
-                            Spacer()
-
-                            Button(action: {
-                                device.nextPage()
-                            }) {
-                                HStack {
-                                    Text("Next")
-                                    Image(systemName: "chevron.right")
-                                }
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 8)
-                                .background(device.hasMoreFiles ? Color.blue : Color.gray)
-                                .foregroundColor(.white)
-                                .cornerRadius(8)
-                            }
-                            .disabled(!device.hasMoreFiles)
-                        }
+                    // Pagination — numbered page navigator so many saved files
+                    // are easy to jump through (not just Prev/Next one at a time).
+                    if showPagination {
+                        FilePageNavigator(
+                            currentPage: Int(device.currentPage),
+                            totalPages: totalFilePages,
+                            hasMore: device.hasMoreFiles,
+                            onSelect: { device.requestFileList(page: UInt8(clamping: $0)) }
+                        )
                         .padding(.horizontal)
                         .padding(.bottom, 10)
                     }
@@ -213,6 +215,109 @@ struct FileManagerView: View {
             // Rebuild download states from cache when file list updates
             device.rebuildDownloadStates(for: files.map { $0.name })
         }
+    }
+}
+
+// Numbered page bar for the saved-files list. Tapping a number jumps straight
+// to that page; chevrons step one at a time. Two modes:
+//   • totalPages known (rocket, from flightCount) → fixed pills 1…N, so you can
+//     jump to any page including the last.
+//   • totalPages nil (base station reports no count) → pills are discovered as
+//     you page forward (1…current, plus a "…" while more remain).
+// The row scrolls horizontally and keeps the current page centered.
+struct FilePageNavigator: View {
+    let currentPage: Int          // 0-based
+    let totalPages: Int?          // nil when the device reports no total
+    let hasMore: Bool             // used only in the discovered (nil-total) mode
+    let onSelect: (Int) -> Void
+
+    // 0-based page indices to render.
+    private var pageIndices: [Int] {
+        Self.pageIndices(currentPage: currentPage, totalPages: totalPages, hasMore: hasMore)
+    }
+
+    private var canGoNext: Bool {
+        Self.canGoNext(currentPage: currentPage, totalPages: totalPages, hasMore: hasMore)
+    }
+
+    // --- Pure paging logic (unit-tested; see FilePageNavigatorTests) ---
+
+    /// Total pages for a known file count, paginated at `pageSize`. At least 1.
+    static func totalPages(forFileCount count: Int, pageSize: Int) -> Int {
+        guard pageSize > 0 else { return 1 }
+        return max(1, (count + pageSize - 1) / pageSize)
+    }
+
+    static func pageIndices(currentPage: Int, totalPages: Int?, hasMore: Bool) -> [Int] {
+        if let total = totalPages, total > 0 { return Array(0..<total) }
+        let last = currentPage + (hasMore ? 1 : 0)
+        return Array(0...max(0, last))
+    }
+
+    static func canGoNext(currentPage: Int, totalPages: Int?, hasMore: Bool) -> Bool {
+        if let total = totalPages { return currentPage < total - 1 }
+        return hasMore
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            chevron("chevron.left", enabled: currentPage > 0) {
+                onSelect(currentPage - 1)
+            }
+
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(pageIndices, id: \.self) { p in
+                            pagePill(p).id(p)
+                        }
+                        if totalPages == nil && hasMore {
+                            Text("…")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 2)
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                }
+                .onChange(of: currentPage) { p in
+                    withAnimation { proxy.scrollTo(p, anchor: .center) }
+                }
+                .onAppear { proxy.scrollTo(currentPage, anchor: .center) }
+            }
+
+            chevron("chevron.right", enabled: canGoNext) {
+                onSelect(currentPage + 1)
+            }
+        }
+    }
+
+    private func pagePill(_ p: Int) -> some View {
+        let isCurrent = (p == currentPage)
+        return Button {
+            if !isCurrent { onSelect(p) }
+        } label: {
+            Text("\(p + 1)")
+                .font(.subheadline.weight(isCurrent ? .semibold : .regular))
+                .frame(minWidth: 34, minHeight: 34)
+                .background(isCurrent ? Color.blue : Color(.systemGray5))
+                .foregroundColor(isCurrent ? .white : .primary)
+                .clipShape(Circle())
+        }
+        .disabled(isCurrent)
+        .accessibilityLabel("Page \(p + 1)")
+    }
+
+    private func chevron(_ system: String, enabled: Bool,
+                         action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: system)
+                .frame(width: 34, height: 34)
+                .background(enabled ? Color.blue : Color(.systemGray4))
+                .foregroundColor(.white)
+                .clipShape(Circle())
+        }
+        .disabled(!enabled)
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
@@ -10,6 +10,15 @@ import SwiftUI
 struct FlightLogsView: View {
     @State private var cachedFlights: [CachedFlight] = []
 
+    // Multi-select for bulk delete of locally cached flights (id = filename).
+    @State private var isSelecting = false
+    @State private var selection: Set<String> = []
+    @State private var showBulkDeleteConfirm = false
+
+    private var allSelected: Bool {
+        !cachedFlights.isEmpty && cachedFlights.allSatisfy { selection.contains($0.id) }
+    }
+
     var body: some View {
         Group {
             if cachedFlights.isEmpty {
@@ -28,17 +37,84 @@ struct FlightLogsView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                List {
-                    ForEach(cachedFlights) { flight in
-                        NavigationLink(destination: FlightDetailView(flight: flight, onDelete: {
-                            FileCache.shared.deleteCachedFlight(flight)
-                            cachedFlights = FileCache.shared.listCachedFlights()
-                        })) {
-                            FlightLogRow(flight: flight)
+                VStack(spacing: 0) {
+                    // Select / Cancel (+ Select all while selecting).
+                    HStack {
+                        if isSelecting {
+                            Button(allSelected ? "Deselect all" : "Select all") {
+                                if allSelected {
+                                    selection.removeAll()
+                                } else {
+                                    selection = Set(cachedFlights.map { $0.id })
+                                }
+                            }
+                            Spacer()
+                            Button("Cancel") { exitSelection() }
+                        } else {
+                            Spacer()
+                            Button("Select") { isSelecting = true }
                         }
                     }
+                    .foregroundColor(.blue)
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+
+                    List {
+                        ForEach(cachedFlights) { flight in
+                            if isSelecting {
+                                Button {
+                                    toggleSelection(flight.id)
+                                } label: {
+                                    HStack {
+                                        Image(systemName: selection.contains(flight.id)
+                                              ? "checkmark.circle.fill" : "circle")
+                                            .font(.title3)
+                                            .foregroundColor(selection.contains(flight.id) ? .blue : .secondary)
+                                        FlightLogRow(flight: flight)
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                            } else {
+                                NavigationLink(destination: FlightDetailView(flight: flight, onDelete: {
+                                    FileCache.shared.deleteCachedFlight(flight)
+                                    cachedFlights = FileCache.shared.listCachedFlights()
+                                })) {
+                                    FlightLogRow(flight: flight)
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(InsetGroupedListStyle())
+
+                    // Bulk delete action bar.
+                    if isSelecting {
+                        HStack {
+                            Spacer()
+                            Button(action: { showBulkDeleteConfirm = true }) {
+                                HStack(spacing: 6) {
+                                    Image(systemName: "trash")
+                                    Text("Delete\(selection.isEmpty ? "" : " (\(selection.count))")")
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(selection.isEmpty ? Color.gray : Color.red)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                            }
+                            .disabled(selection.isEmpty)
+                        }
+                        .padding(.horizontal)
+                        .padding(.vertical, 8)
+                    }
                 }
-                .listStyle(InsetGroupedListStyle())
+                .alert("Delete \(selection.count) Flight\(selection.count == 1 ? "" : "s")?",
+                       isPresented: $showBulkDeleteConfirm) {
+                    Button("Delete", role: .destructive) { deleteSelected() }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("Are you sure you want to delete \(selection.count) downloaded flight\(selection.count == 1 ? "" : "s")? This removes the local copy only.")
+                }
             }
         }
         .navigationTitle("Flight Logs")
@@ -46,6 +122,22 @@ struct FlightLogsView: View {
         .onAppear {
             cachedFlights = FileCache.shared.listCachedFlights()
         }
+    }
+
+    private func toggleSelection(_ id: String) {
+        if selection.contains(id) { selection.remove(id) } else { selection.insert(id) }
+    }
+
+    private func exitSelection() {
+        isSelecting = false
+        selection.removeAll()
+    }
+
+    private func deleteSelected() {
+        let toDelete = cachedFlights.filter { selection.contains($0.id) }
+        for flight in toDelete { FileCache.shared.deleteCachedFlight(flight) }
+        exitSelection()
+        cachedFlights = FileCache.shared.listCachedFlights()
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketAppTests/FilePageNavigatorTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/FilePageNavigatorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Pure paging logic behind the saved-files page navigator. The rocket knows its
+/// total file count (→ fixed 1…N pills); the base station doesn't (→ pages
+/// discovered as you advance). These guard the off-by-one-prone arithmetic.
+final class FilePageNavigatorTests: XCTestCase {
+
+    // MARK: total pages from a known file count (rocket)
+
+    func testTotalPagesCeilDivision() {
+        let ps = 5
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 0, pageSize: ps), 1)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 1, pageSize: ps), 1)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 5, pageSize: ps), 1)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 6, pageSize: ps), 2)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 10, pageSize: ps), 2)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 11, pageSize: ps), 3)
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 26, pageSize: ps), 6)
+    }
+
+    func testTotalPagesGuardsZeroPageSize() {
+        XCTAssertEqual(FilePageNavigator.totalPages(forFileCount: 10, pageSize: 0), 1)
+    }
+
+    // MARK: known-total mode (rocket) — all pages shown, jump anywhere
+
+    func testKnownTotalShowsAllPages() {
+        XCTAssertEqual(
+            FilePageNavigator.pageIndices(currentPage: 2, totalPages: 4, hasMore: false),
+            [0, 1, 2, 3])
+    }
+
+    func testKnownTotalNextDisabledOnLastPage() {
+        XCTAssertTrue(FilePageNavigator.canGoNext(currentPage: 0, totalPages: 3, hasMore: true))
+        XCTAssertTrue(FilePageNavigator.canGoNext(currentPage: 1, totalPages: 3, hasMore: false))
+        XCTAssertFalse(FilePageNavigator.canGoNext(currentPage: 2, totalPages: 3, hasMore: true))
+    }
+
+    func testKnownTotalIgnoresHasMoreHeuristic() {
+        // Exactly-full single page: count==pageSize makes the wire "hasMore"
+        // heuristic true, but a known total of 1 must not offer a phantom page 2.
+        XCTAssertEqual(
+            FilePageNavigator.pageIndices(currentPage: 0, totalPages: 1, hasMore: true),
+            [0])
+        XCTAssertFalse(FilePageNavigator.canGoNext(currentPage: 0, totalPages: 1, hasMore: true))
+    }
+
+    // MARK: discovered mode (base station) — grows with hasMore
+
+    func testDiscoveredModeRevealsNextWhenMore() {
+        // On page 0 with more to come: show pages 1 and 2 (0-based 0,1).
+        XCTAssertEqual(
+            FilePageNavigator.pageIndices(currentPage: 0, totalPages: nil, hasMore: true),
+            [0, 1])
+        XCTAssertTrue(FilePageNavigator.canGoNext(currentPage: 0, totalPages: nil, hasMore: true))
+    }
+
+    func testDiscoveredModeStopsWhenNoMore() {
+        // On page 2 (0-based) with nothing more: pages 1…3 known, no next.
+        XCTAssertEqual(
+            FilePageNavigator.pageIndices(currentPage: 2, totalPages: nil, hasMore: false),
+            [0, 1, 2])
+        XCTAssertFalse(FilePageNavigator.canGoNext(currentPage: 2, totalPages: nil, hasMore: false))
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/RocketStorageStatsTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/RocketStorageStatsTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// Wire-format decode for the 0xCC RocketStorageStats frame. The payload passed
+/// to `decode` is the 15 bytes AFTER the discriminator byte, LE-packed, mirroring
+/// RocketStorageStatsData in RocketComputerTypes.h. Guards the flags byte in
+/// particular: bit0 = initialized, bit1 = auto-evicted (#315).
+final class RocketStorageStatsTests: XCTestCase {
+
+    /// Build a 15-byte LE payload from the seven u16 fields + flags byte.
+    private func frame(flightRegion: UInt16, used: UInt16, free: UInt16,
+                       bad: UInt16, system: UInt16, flightCount: UInt16,
+                       blockSizeKB: UInt16, flags: UInt8) -> [UInt8] {
+        var b: [UInt8] = []
+        for v in [flightRegion, used, free, bad, system, flightCount, blockSizeKB] {
+            b.append(UInt8(v & 0xFF))
+            b.append(UInt8(v >> 8))
+        }
+        b.append(flags)
+        return b
+    }
+
+    func testDecodeFieldsFromFullFrame() {
+        let bytes = frame(flightRegion: 2012, used: 800, free: 1200,
+                          bad: 3, system: 36, flightCount: 10,
+                          blockSizeKB: 256, flags: 0x01)
+        let s = RocketStorageStats.decode(bytes)
+        XCTAssertNotNil(s)
+        XCTAssertEqual(s?.flightRegionBlocks, 2012)
+        XCTAssertEqual(s?.usedBlocks, 800)
+        XCTAssertEqual(s?.freeBlocks, 1200)
+        XCTAssertEqual(s?.badBlocks, 3)
+        XCTAssertEqual(s?.systemBlocks, 36)
+        XCTAssertEqual(s?.flightCount, 10)
+        XCTAssertEqual(s?.blockSizeKB, 256)
+        XCTAssertEqual(s?.initialized, true)
+        XCTAssertEqual(s?.autoEvicted, false)
+        // Byte accounting derives from block count × block size.
+        XCTAssertEqual(s?.usedBytes, 800 * 256 * 1024)
+        XCTAssertEqual(s?.freeBytes, 1200 * 256 * 1024)
+    }
+
+    func testFlagsBitsDecodeIndependently() {
+        func flagsOf(_ f: UInt8) -> (Bool, Bool) {
+            let s = RocketStorageStats.decode(
+                frame(flightRegion: 1, used: 0, free: 1, bad: 0, system: 0,
+                      flightCount: 0, blockSizeKB: 256, flags: f))
+            return (s?.initialized ?? false, s?.autoEvicted ?? false)
+        }
+        XCTAssertEqual(flagsOf(0x00).0, false); XCTAssertEqual(flagsOf(0x00).1, false)
+        XCTAssertEqual(flagsOf(0x01).0, true);  XCTAssertEqual(flagsOf(0x01).1, false)
+        XCTAssertEqual(flagsOf(0x02).0, false); XCTAssertEqual(flagsOf(0x02).1, true)
+        XCTAssertEqual(flagsOf(0x03).0, true);  XCTAssertEqual(flagsOf(0x03).1, true)
+        // Unknown high bits are ignored (forward-compatible wire format).
+        XCTAssertEqual(flagsOf(0xFF).0, true);  XCTAssertEqual(flagsOf(0xFF).1, true)
+    }
+
+    func testShortFrameReturnsNil() {
+        // 14 bytes is one short of the 15-byte layout.
+        XCTAssertNil(RocketStorageStats.decode([UInt8](repeating: 0, count: 14)))
+    }
+}

--- a/tests_cpp/test_tr_flightlog_core.cpp
+++ b/tests_cpp/test_tr_flightlog_core.cpp
@@ -1529,6 +1529,252 @@ TEST(TRFlightLogRename, UnknownFilenameReturnsNotFound) {
 }
 
 // ================================================================
+// #315 rolling-buffer auto-eviction. When Config::auto_evict_oldest is set,
+// prepareFlight reclaims space by deleting the oldest finalized flight(s) at
+// arm time — until the new flight fits, an index slot is free, and the
+// free-block headroom floor is restored. Off by default; never touches the
+// active flight; fails loudly (NoSpace) when nothing eligible remains.
+// ================================================================
+
+namespace {
+// Prepare + finalize a flight that KEEPS its whole prealloc range, so a small
+// flight region fills predictably. finalizeFlight trims the tail to the pages
+// actually spanned; passing final_bytes = (allocated blocks × block bytes)
+// keeps every block. Returns prepare's status on prepare failure, else
+// finalize's status.
+Status flyFullFlight(TR_FlightLog& fl, const char* name) {
+    uint32_t id = 0;
+    Status st = fl.prepareFlight(id);
+    if (st != Status::Ok) return st;
+    const uint32_t full_bytes =
+        fl.activeBlockCount() * NAND_PAGES_PER_BLK * NAND_PAGE_SIZE;
+    return fl.finalizeFlight(name, full_bytes);
+}
+
+// A tiny flight region that fits exactly `n_flights` full flights of `prealloc`
+// blocks each, so the "card full" boundary is deterministic.
+TR_FlightLog::Config smallRegionCfg(uint16_t prealloc, uint16_t n_flights) {
+    TR_FlightLog::Config cfg;
+    cfg.prealloc_blocks     = prealloc;
+    cfg.extend_blocks       = prealloc;   // unused here; keep it in-region
+    cfg.flight_region_start = 32;
+    cfg.flight_region_end   =
+        static_cast<uint16_t>(32 + prealloc * n_flights);
+    return cfg;
+}
+}  // namespace
+
+TEST(TRFlightLogAutoEvict, EvictOldestUntilFitReclaimsAndRecords) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    auto cfg = smallRegionCfg(4, 3);
+    cfg.auto_evict_oldest = true;   // target 0 → reclaim only just enough to fit
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    // Fill the card: 3 full flights, region now has no room for a 4th.
+    ASSERT_EQ(flyFullFlight(fl, "flight_001.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_002.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_003.bin"), Status::Ok);
+    ASSERT_EQ(fl.index().size(), 3u);
+
+    // Arm a 4th: with auto-evict, prepareFlight reclaims the oldest (id 1) and
+    // succeeds; the flight then finalizes normally.
+    ASSERT_EQ(flyFullFlight(fl, "flight_004.bin"), Status::Ok);
+
+    EXPECT_EQ(fl.autoEvictedCount(), 1u);
+    EXPECT_EQ(fl.lastEvictedFlightId(), 1u);
+    EXPECT_EQ(fl.index().findByFilename("flight_001.bin"), nullptr);  // evicted
+    EXPECT_NE(fl.index().findByFilename("flight_002.bin"), nullptr);  // survives
+    EXPECT_NE(fl.index().findByFilename("flight_004.bin"), nullptr);  // recorded
+    EXPECT_EQ(fl.index().size(), 3u);  // rolled: 2, 3, 4
+}
+
+TEST(TRFlightLogAutoEvict, NeverEvictsActiveFlight) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    auto cfg = smallRegionCfg(4, 3);
+    cfg.auto_evict_oldest = true;
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    // Two finalized flights, then a 3rd left ACTIVE (prepared, not finalized) so
+    // the region is full with one flight in progress.
+    ASSERT_EQ(flyFullFlight(fl, "flight_001.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_002.bin"), Status::Ok);
+    uint32_t active_id = 0;
+    ASSERT_EQ(fl.prepareFlight(active_id), Status::Ok);
+    ASSERT_TRUE(fl.isFlightActive());
+    const uint32_t active_start = fl.activeStartBlock();
+
+    // A second prepareFlight while one is active must refuse (Error) BEFORE any
+    // eviction — the active flight and both finalized flights stay untouched.
+    uint32_t id2 = 0;
+    EXPECT_EQ(fl.prepareFlight(id2), Status::Error);
+    EXPECT_EQ(fl.autoEvictedCount(), 0u);
+    EXPECT_EQ(fl.index().size(), 2u);
+    EXPECT_NE(fl.index().findByFilename("flight_001.bin"), nullptr);
+    EXPECT_NE(fl.index().findByFilename("flight_002.bin"), nullptr);
+    for (uint32_t b = active_start; b < active_start + 4; ++b) {
+        EXPECT_EQ(fl.bitmap().get(b), BLOCK_ALLOCATED) << "block " << b;
+    }
+}
+
+TEST(TRFlightLogAutoEvict, IndexFullTriggersEviction) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    TR_FlightLog::Config cfg;
+    cfg.prealloc_blocks     = 1;
+    cfg.flight_region_start = 32;
+    cfg.flight_region_end   = 32 + 200;   // ample block space — index is the limit
+    cfg.auto_evict_oldest   = true;
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    // Fill the index to capacity (128); block space is NOT the constraint.
+    for (size_t i = 0; i < FlightIndex::MAX_ENTRIES; ++i) {
+        char name[24];
+        std::snprintf(name, sizeof(name), "flight_%03zu.bin", i);
+        ASSERT_EQ(flyFullFlight(fl, name), Status::Ok);
+    }
+    ASSERT_EQ(fl.index().size(), FlightIndex::MAX_ENTRIES);
+
+    // One more flight: blocks are available but the index is full. Auto-evict
+    // must reclaim an index slot (deleting the oldest) so this flight records.
+    ASSERT_EQ(flyFullFlight(fl, "flight_new.bin"), Status::Ok);
+    EXPECT_EQ(fl.autoEvictedCount(), 1u);
+    EXPECT_EQ(fl.lastEvictedFlightId(), 1u);  // flight_000 got flight_id 1
+    EXPECT_EQ(fl.index().size(), FlightIndex::MAX_ENTRIES);  // still full, rolled
+    EXPECT_EQ(fl.index().findByFilename("flight_000.bin"), nullptr);
+    EXPECT_NE(fl.index().findByFilename("flight_new.bin"), nullptr);
+}
+
+TEST(TRFlightLogAutoEvict, NoEligibleFlightStillFailsLoud) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    TR_FlightLog::Config cfg;
+    cfg.prealloc_blocks     = 4;
+    cfg.flight_region_start = 32;
+    cfg.flight_region_end   = 40;         // 8 blocks
+    cfg.auto_evict_oldest   = true;
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    // Fragment the region so no 4-block contiguous free run exists, with an
+    // EMPTY index (nothing eligible to evict).
+    ASSERT_EQ(fl.markBlockBad(34), Status::Ok);
+    ASSERT_EQ(fl.markBlockBad(38), Status::Ok);
+
+    uint32_t id = 0;
+    EXPECT_EQ(fl.prepareFlight(id), Status::NoSpace);  // loud, not a silent no-op
+    EXPECT_EQ(fl.autoEvictedCount(), 0u);
+    EXPECT_FALSE(fl.isFlightActive());
+}
+
+TEST(TRFlightLogAutoEvict, DisabledByDefaultLeavesFullCardFailing) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    auto cfg = smallRegionCfg(4, 3);   // auto_evict_oldest stays false (default)
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+
+    ASSERT_EQ(flyFullFlight(fl, "flight_001.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_002.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_003.bin"), Status::Ok);
+
+    uint32_t id = 0;
+    EXPECT_EQ(fl.prepareFlight(id), Status::NoSpace);
+    EXPECT_EQ(fl.autoEvictedCount(), 0u);
+    EXPECT_EQ(fl.index().size(), 3u);  // nothing deleted
+}
+
+TEST(TRFlightLogAutoEvict, FreeTargetReclaimsMultipleFlights) {
+    // Fill the region completely with auto-evict OFF, then reboot with the
+    // headroom floor ON so the first arm faces a full card and must evict
+    // MULTIPLE oldest flights at once to reach the target (not just enough to
+    // fit one prealloc). (With the floor on during a fill, eviction instead
+    // happens incrementally per-arm — the steady-state rolling buffer — which
+    // never presents a full card to a single arm; this reboot isolates the
+    // batch-reclaim path.)
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    {
+        TR_FlightLog fl;
+        auto cfg = smallRegionCfg(4, 6);   // region fits 6 full flights
+        ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+        for (int i = 1; i <= 6; ++i) {
+            char name[24];
+            std::snprintf(name, sizeof(name), "flight_%03d.bin", i);
+            ASSERT_EQ(flyFullFlight(fl, name), Status::Ok);
+        }
+        ASSERT_EQ(fl.index().size(), 6u);  // region full
+    }
+
+    TR_FlightLog fl2;
+    auto cfg2 = smallRegionCfg(4, 6);
+    cfg2.auto_evict_oldest = true;
+    cfg2.auto_evict_target_free_blocks = 8;  // keep 2 flights' worth free
+    ASSERT_EQ(fl2.begin(nand, cfg2, &store), Status::Ok);
+    ASSERT_EQ(fl2.index().size(), 6u);       // full card carried across reboot
+
+    // First arm: reaching the 8-free-block floor requires evicting the two
+    // oldest flights (ids 1 and 2), not just the single one needed to fit.
+    uint32_t id = 0;
+    ASSERT_EQ(fl2.prepareFlight(id), Status::Ok);
+    EXPECT_EQ(fl2.autoEvictedCount(), 2u);
+    EXPECT_EQ(fl2.lastEvictedFlightId(), 2u);
+    EXPECT_EQ(fl2.index().findByFilename("flight_001.bin"), nullptr);
+    EXPECT_EQ(fl2.index().findByFilename("flight_002.bin"), nullptr);
+    EXPECT_NE(fl2.index().findByFilename("flight_003.bin"), nullptr);
+}
+
+TEST(TRFlightLogAutoEvict, DeferredPrepareAlsoEvicts) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    TR_FlightLog fl;
+    auto cfg = smallRegionCfg(4, 3);
+    cfg.auto_evict_oldest = true;
+    ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_001.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_002.bin"), Status::Ok);
+    ASSERT_EQ(flyFullFlight(fl, "flight_003.bin"), Status::Ok);
+
+    // The Core-0 deferred path (requestPrepareFlight + service) runs the same
+    // prepareFlightLocked, so it must evict too.
+    fl.requestPrepareFlight();
+    uint32_t id = 0;
+    Status st = Status::Error;
+    EXPECT_TRUE(fl.servicePendingPrepareFlight(id, st));
+    EXPECT_EQ(st, Status::Ok);
+    EXPECT_TRUE(fl.isFlightActive());
+    EXPECT_EQ(fl.autoEvictedCount(), 1u);
+    EXPECT_EQ(fl.lastEvictedFlightId(), 1u);
+}
+
+TEST(TRFlightLogAutoEvict, EvictionPersistsAcrossReboot) {
+    FakeNandBackend nand;
+    MemoryBitmapStore store;
+    auto cfg = smallRegionCfg(4, 3);
+    cfg.auto_evict_oldest = true;
+    {
+        TR_FlightLog fl;
+        ASSERT_EQ(fl.begin(nand, cfg, &store), Status::Ok);
+        ASSERT_EQ(flyFullFlight(fl, "flight_001.bin"), Status::Ok);
+        ASSERT_EQ(flyFullFlight(fl, "flight_002.bin"), Status::Ok);
+        ASSERT_EQ(flyFullFlight(fl, "flight_003.bin"), Status::Ok);
+        ASSERT_EQ(flyFullFlight(fl, "flight_004.bin"), Status::Ok);  // evicts 001
+        ASSERT_EQ(fl.autoEvictedCount(), 1u);
+    }
+    // Reboot: the eviction (index remove + bitmap free) was persisted.
+    TR_FlightLog fl2;
+    ASSERT_EQ(fl2.begin(nand, cfg, &store), Status::Ok);
+    EXPECT_EQ(fl2.index().findByFilename("flight_001.bin"), nullptr);
+    EXPECT_NE(fl2.index().findByFilename("flight_004.bin"), nullptr);
+    EXPECT_EQ(fl2.index().size(), 3u);
+    EXPECT_EQ(fl2.autoEvictedCount(), 0u);  // per-session counter resets on begin
+}
+
+// ================================================================
 // writeFrame + brownout scanner / recovery
 // ================================================================
 

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -352,6 +352,76 @@ bool TR_FlightLog::servicePendingPrepareFlight(uint32_t& id_out, Status& status_
     return true;
 }
 
+bool TR_FlightLog::evictOldestLocked() {
+    // Pick the smallest flight_id in the index — the oldest finalized flight.
+    // Skip the active flight defensively: it is never appended to the index
+    // until finalizeFlight, so in practice there is nothing to skip here, but
+    // the guard documents that an in-progress allocation is never a candidate.
+    size_t   best_idx = index_.size();
+    uint32_t best_id  = UINT32_MAX;
+    for (size_t i = 0; i < index_.size(); ++i) {
+        const FlightIndexEntry& e = index_.at(i);
+        if (flight_active_ && e.flight_id == active_flight_id_) continue;
+        if (e.flight_id < best_id) { best_id = e.flight_id; best_idx = i; }
+    }
+    if (best_idx >= index_.size()) return false;  // nothing eligible to evict
+
+    // Copy the filename out before delete: removeByFilename shifts + zeroes the
+    // entry array, invalidating the reference returned by index_.at().
+    char name[sizeof(index_.at(best_idx).filename)];
+    std::strncpy(name, index_.at(best_idx).filename, sizeof(name));
+    name[sizeof(name) - 1] = '\0';
+
+    if (deleteFlightLocked(name) != Status::Ok) return false;
+    ++auto_evicted_count_;
+    last_evicted_flight_id_ = best_id;
+    FL_LOGW("#315 auto-evict: deleted oldest flight id=%lu (%s)",
+            (unsigned long)best_id, name);
+    return true;
+}
+
+uint32_t TR_FlightLog::evictOldestToTargetLocked() {
+    // Cap the requested headroom at the region size so a mis-set target can't
+    // spin the loop forever trying to free more blocks than the region holds.
+    const uint32_t region_blocks =
+        static_cast<uint32_t>(cfg_.flight_region_end - cfg_.flight_region_start);
+    uint32_t target_free = cfg_.auto_evict_target_free_blocks;
+    if (target_free > region_blocks) target_free = region_blocks;
+
+    // Free blocks WITHIN the flight region — not bitmap_.countInState(BLOCK_FREE),
+    // which also counts the always-free pre-region (LFS) and metadata blocks and
+    // would let the target be met without ever evicting. Scoped so the headroom
+    // floor is measured against the space this layer actually manages.
+    auto region_free = [this]() -> uint32_t {
+        uint32_t f = 0;
+        for (uint32_t b = cfg_.flight_region_start; b < cfg_.flight_region_end; ++b) {
+            if (bitmap_.get(b) == BLOCK_FREE) ++f;
+        }
+        return f;
+    };
+
+    uint32_t evicted = 0;
+    while (true) {
+        // All three goals must hold for the pending flight to record cleanly:
+        //  - a contiguous prealloc run exists (else prepareFlight returns NoSpace)
+        //  - an index slot is free (else finalizeFlight can't append the entry)
+        //  - free-block headroom is at/above the rolling-buffer floor
+        uint32_t start = 0;
+        const bool have_run = bitmap_.findContiguousFree(
+            cfg_.prealloc_blocks, cfg_.flight_region_start,
+            cfg_.flight_region_end, start);
+        const bool index_room = index_.size() < FlightIndex::MAX_ENTRIES;
+        const bool meets_target = region_free() >= target_free;
+        if (have_run && index_room && meets_target) break;
+
+        // Reclaim one more oldest flight; stop if the index holds nothing
+        // eligible (prepareFlight then still fails loudly with NoSpace).
+        if (!evictOldestLocked()) break;
+        ++evicted;
+    }
+    return evicted;
+}
+
 Status TR_FlightLog::prepareFlight(uint32_t& flight_id_out) {
     FlightLogLockGuard guard(mutex_);
     return prepareFlightLocked(flight_id_out);
@@ -359,7 +429,18 @@ Status TR_FlightLog::prepareFlight(uint32_t& flight_id_out) {
 
 Status TR_FlightLog::prepareFlightLocked(uint32_t& flight_id_out) {
     if (!initialized_) return Status::NotInitialized;
-    if (flight_active_)  return Status::Error;  // already flying
+    if (flight_active_)  return Status::Error;  // already flying — never evict an active flight
+
+    // #315: rolling-buffer auto-eviction. Before picking a range, reclaim space
+    // by deleting the oldest finalized flight(s) — enough for this prealloc to
+    // fit, for an index slot to be free, and to restore the free-block headroom
+    // floor. Off by default (opt-in). No flight is active here (guarded above),
+    // so eviction can never touch an in-progress allocation. Best-effort: if the
+    // index holds nothing eligible the findContiguousFree below still fails
+    // loudly with NoSpace rather than arming a flight that can't be logged.
+    if (cfg_.auto_evict_oldest) {
+        evictOldestToTargetLocked();
+    }
 
     uint32_t start = 0;
     if (!bitmap_.findContiguousFree(cfg_.prealloc_blocks,
@@ -690,6 +771,10 @@ Status TR_FlightLog::readFlightPage(const char* filename, uint32_t offset,
 
 Status TR_FlightLog::deleteFlight(const char* filename) {
     FlightLogLockGuard guard(mutex_);
+    return deleteFlightLocked(filename);
+}
+
+Status TR_FlightLog::deleteFlightLocked(const char* filename) {
     if (!initialized_)       return Status::NotInitialized;
     if (filename == nullptr) return Status::OutOfRange;
 

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -39,6 +39,22 @@ public:
         // Monotonic-ms source for the budget; nullptr uses the built-in source
         // (esp_timer on hardware, 0 on host so the budget is inert in tests).
         uint32_t (*now_ms)()         = nullptr;
+
+        // #315: rolling-buffer auto-eviction. When true, prepareFlight reclaims
+        // space by deleting the oldest finalized flight(s) at arm time until the
+        // new flight fits, an index slot is free, AND at least
+        // auto_evict_target_free_blocks remain free. Default OFF (opt-in):
+        // deleting an un-downloaded flight is destructive, so it stays gated
+        // until bench-trusted. The active/in-progress flight is never a candidate
+        // (it isn't in the index until finalizeFlight), and eviction runs only
+        // here — before launch — never mid-flight. Evictions are counted
+        // (autoEvictedCount) so the OC can surface them; never silent.
+        bool     auto_evict_oldest             = false;
+        // Free-block headroom to restore at arm time when auto_evict_oldest is on.
+        // Eviction continues oldest-first until FREE blocks reach this floor, so
+        // the card keeps a rolling buffer instead of evicting one flight per arm.
+        // Clamped to the flight region; 0 means "reclaim only just enough to fit".
+        uint16_t auto_evict_target_free_blocks = 0;
     };
 
     TR_FlightLog() = default;
@@ -76,6 +92,15 @@ public:
     // to stay 0; a non-zero value flags genuine, unavoidable loss).
     uint32_t  salvagedBlockCount()    const { return salvaged_block_count_; }
     uint32_t  unrecoverablePageCount() const { return unrecoverable_page_count_; }
+
+    // #315 rolling-buffer eviction telemetry. autoEvictedCount(): cumulative
+    // number of finalized flights auto-deleted since begin() to make room at arm
+    // time (stays 0 unless Config::auto_evict_oldest). lastEvictedFlightId():
+    // flight_id of the most recently auto-evicted flight (0 if none). The OC
+    // surfaces both in the storage-stats telemetry + a log line so a rolling
+    // eviction is observable, never silent.
+    uint32_t  autoEvictedCount()      const { return auto_evicted_count_; }
+    uint32_t  lastEvictedFlightId()   const { return last_evicted_flight_id_; }
 
     // Pre-launch: pick + erase a free contiguous range. May stall ~770 ms.
     // Writes the assigned flight_id to `flight_id_out` on success.
@@ -150,6 +175,8 @@ private:
     uint32_t extension_count_     = 0;
     uint32_t salvaged_block_count_    = 0;  // #371: bad blocks whose pages were relocated
     uint32_t unrecoverable_page_count_ = 0; // #371: salvage pages that would not re-read
+    uint32_t auto_evicted_count_      = 0;  // #315: flights auto-deleted to make room
+    uint32_t last_evicted_flight_id_  = 0;  // #315: id of the most recent auto-evict
     bool     flight_active_       = false;
 
     // Page-sized scratch buffers kept OFF the task stack. At the 4 KB
@@ -181,6 +208,23 @@ private:
     // twice on one thread.
     Status prepareFlightLocked(uint32_t& flight_id_out);
     Status writePageLocked(const uint8_t* page);
+
+    // Lock-held delete: frees the flight's blocks, removes its index entry, and
+    // persists both. The public deleteFlight() wraps this; it is also the
+    // eviction primitive (evictOldestLocked deletes via this path). Assumes
+    // mutex_ is held so the non-recursive lock is never taken twice.
+    Status deleteFlightLocked(const char* filename);
+
+    // #315 rolling buffer. evictOldestLocked deletes the single oldest eligible
+    // (finalized, non-active) flight and returns true, or false when the index
+    // holds nothing eligible. evictOldestToTargetLocked repeats it oldest-first
+    // until the pending prealloc fits, an index slot is free, AND free blocks
+    // reach cfg_.auto_evict_target_free_blocks — or nothing eligible remains;
+    // it returns the number of flights evicted. Both assume mutex_ is held and
+    // are reached only from prepareFlightLocked (arm time — no active flight to
+    // hit, since the active allocation is never in the index).
+    bool     evictOldestLocked();
+    uint32_t evictOldestToTargetLocked();
 
     // On a mid-block program failure, retire `bad_block` (relative index
     // `rel_block`) and relocate the `valid_pages` pages already written at its

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -952,6 +952,14 @@ typedef struct __attribute__((packed))
 static_assert(sizeof(RocketStorageStatsData) == 15,
               "RocketStorageStatsData must be 15 bytes");
 
+// RocketStorageStatsData.flags bits.  Wire-compatible: the app ignores unknown
+// bits, so new flags don't bump the format.
+static constexpr uint8_t RSS_FLAG_INITIALIZED  = (1u << 0);  // flight log up
+// #315: at least one oldest-flight auto-eviction has run since boot (rolling
+// buffer reclaimed space to arm a flight). Surfaces the event so a silently
+// dropped-then-reclaimed card is observable in the app's storage view.
+static constexpr uint8_t RSS_FLAG_AUTO_EVICTED = (1u << 1);
+
 // BS→app flash-space stats for the base station's own log filesystem.  Rides the
 // file_ops characteristic behind a 0xCD discriminator.  Bytes (not blocks) since
 // the backend may be SD/FAT (GB) or SPIFFS (MB).  reserved is FS overhead =

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -294,10 +294,24 @@ static void flightlogFlushTaskHook(void* /*ctx*/)
 {
     uint32_t id = 0;
     tr_flightlog::Status st = tr_flightlog::Status::Ok;
+    const uint32_t evicted_before = flightlog.autoEvictedCount();
     if (flightlog.servicePendingPrepareFlight(id, st))
     {
         if (st == tr_flightlog::Status::Ok)
         {
+            // #315: if this arm auto-evicted to make room, surface it (never
+            // silent). The RSS_FLAG_AUTO_EVICTED storage-stats bit carries it to
+            // the app; this log line records which flight(s) went.
+            const uint32_t evicted_now = flightlog.autoEvictedCount() - evicted_before;
+            if (evicted_now > 0)
+            {
+                ESP_LOGW("FLIGHTLOG",
+                         "#315 auto-evict: reclaimed %u oldest flight(s) (last id=%u) "
+                         "to arm; %u free blocks remain",
+                         (unsigned)evicted_now,
+                         (unsigned)flightlog.lastEvictedFlightId(),
+                         (unsigned)flightlog.bitmap().countInState(tr_flightlog::BLOCK_FREE));
+            }
             ESP_LOGI("FLIGHTLOG",
                      "prepareFlight OK (deferred): id=%u, range=[%u..%u), pages=%u",
                      (unsigned)id,
@@ -4045,7 +4059,9 @@ static void printStats()
                 rss.system_blocks = (uint16_t)(fcfg.flight_region_start + 4u);  // LFS region + 4 metadata
                 rss.flight_count  = (uint16_t)flightlog.index().size();
                 rss.block_size_kb = (uint16_t)(tr_flightlog::NAND_BLOCK_SIZE / 1024u);
-                rss.flags         = 0x01;  // initialized
+                rss.flags         = RSS_FLAG_INITIALIZED;
+                if (flightlog.autoEvictedCount() > 0)  // #315: rolling-buffer evicted this session
+                    rss.flags |= RSS_FLAG_AUTO_EVICTED;
             }
             ble_app.sendStorageStats(0xCC, reinterpret_cast<const uint8_t*>(&rss), sizeof(rss));
         }
@@ -4563,6 +4579,19 @@ void initPeripherals()
         // blocks) — most flights then never extend mid-flight (the extend path's
         // NAND erase + bitmap persist is the in-flight hiccup we want to avoid).
         fl_cfg.prealloc_blocks = 80;
+        // #315: rolling-buffer auto-eviction. When the card fills, prepareFlight
+        // reclaims space at arm time by deleting the oldest finalized flight(s)
+        // — never the in-progress one — down to a free-block headroom floor, so
+        // the operator never hand-deletes and the pre-launch storage verdict
+        // stays green. Destructive by nature (an un-downloaded flight can be
+        // dropped), so it's a deliberate opt-in; it's surfaced via a log line +
+        // the RSS_FLAG_AUTO_EVICTED storage-stats bit, never silent. Target ~10%
+        // of the flight region (~2.5 preallocs of headroom).
+        constexpr uint32_t kAutoEvictTargetFreePct = 10;
+        fl_cfg.auto_evict_oldest = true;
+        fl_cfg.auto_evict_target_free_blocks = static_cast<uint16_t>(
+            static_cast<uint32_t>(fl_cfg.flight_region_end - fl_cfg.flight_region_start) *
+            kAutoEvictTargetFreePct / 100u);
         flightlog_bitmap_store.bind(&flightlog_backend,
                                     fl_cfg.metadata_blocks[2],
                                     fl_cfg.metadata_blocks[3]);


### PR DESCRIPTION
Closes #315.

## Firmware — #315 auto-evict rolling buffer (OC)
When the NAND flight-log card fills, `prepareFlight` now reclaims space at arm time by deleting the oldest finalized flight(s) — a rolling buffer of the most recent flights, so the operator never hand-manages the card.

- `TR_FlightLog::Config::auto_evict_oldest` (default OFF) + `auto_evict_target_free_blocks`. `prepareFlightLocked` evicts oldest-first until a contiguous prealloc run fits, an index slot is free, AND region-free blocks reach the floor; fails loudly with `NoSpace` when nothing eligible remains (never a silent no-op).
- Never touches the active/in-progress flight (guarded before the evict loop; the active allocation isn't in the index). Free floor is measured **within the flight region**, not whole-chip `countInState(FREE)`.
- `deleteFlight` split into a lock-held `deleteFlightLocked` reused as the evict primitive; `autoEvictedCount()` / `lastEvictedFlightId()` surface it.
- **Enabled on the OC** with a ~10% free-block target (~2.5 preallocs of headroom). Surfaced never silent: a flush-hook `ESP_LOGW` + a new `RSS_FLAG_AUTO_EVICTED` storage-stats bit (wire-compatible; `RocketStorageStatsData` still 15 B).
- 8 host gtests (`TRFlightLogAutoEvict.*`) cover all four acceptance cases (evict-oldest-until-fit, never-evict-active, index-full eviction, no-eligible-flight fails loud) plus default-off, batch-to-target, deferred-path, persist-across-reboot.

> Behavior note: a full card now stays **green** on the #278 pre-launch storage verdict (it auto-reclaims) instead of red — visibility is preserved via the log line + the telemetry flag.

## App — related saved-files improvements
1. **Auto-evict flag surfaced** — `RocketStorageStats.autoEvicted` (flags bit1) → a subtle "Auto-reclaimed oldest flight(s) this session" caption on the Rocket Storage card. `RocketStorageStatsTests` covers the decode.
2. **Numbered page navigator** on the Flights / LoRa Logs list — jump straight to any page instead of Prev/Next one at a time. Rocket uses the authoritative total from `flightCount` (fixed 1…N pills, and fixes the exactly-full phantom next page); base station discovers pages as you advance. Pure paging logic unit-tested (`FilePageNavigatorTests`).
3. **Multi-select + bulk delete** on all three surfaces — rocket flights, base-station LoRa logs (`FileManagerView`), and downloaded flights (`FlightLogsView`). Select → checkmark rows → Select-all + Delete (N) with a confirm. On-device selection is keyed by filename so it persists across pages; bulk delete issues sequential cmd-3 writes and resyncs.

## Verification
- Host gtests green (26 in the touched flight-log suites, incl. the 8 new).
- OC firmware builds clean (idf v6.0).
- iOS app builds clean; 10 app tests pass on the simulator.

## Bench-pending
Needs a flash to a rocket to confirm eviction on real NAND at a near-full card, and an on-device pass over the bulk-delete flow (sequential BLE deletes). Not yet bench-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
