### PR TITLE
fix(fc): #508 sim pad-frame alignment + gyro-bias observability gate and bound

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -446,3 +446,15 @@ target_include_directories(test_mram_dirty_policy PRIVATE
 )
 target_link_libraries(test_mram_dirty_policy GTest::gtest_main)
 gtest_discover_tests(test_mram_dirty_policy)
+
+# ---------- test_sim_pad_align (#508) ----------
+# Header-only pure math (no ESP/Arduino deps), so there is no component .cpp to
+# compile — the alignment solve was extracted out of SensorCollectorSim precisely
+# so it could be tested on the host.
+add_executable(test_sim_pad_align test_sim_pad_align.cpp)
+target_include_directories(test_sim_pad_align PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_Sensor_Collector_Sim
+)
+target_link_libraries(test_sim_pad_align GTest::gtest_main)
+gtest_discover_tests(test_sim_pad_align)

--- a/tests_cpp/test_ekf.cpp
+++ b/tests_cpp/test_ekf.cpp
@@ -754,15 +754,36 @@ TEST_F(EKFTest, BaroJosephGoldenTrajectory) {
     EXPECT_NEAR(vel[0], 0.024522f, 2e-3f);
     EXPECT_NEAR(vel[1], 0.000624f, 2e-3f);
     EXPECT_NEAR(vel[2], 0.009548f, 2e-3f);
-    const float q_gold[4] = {0.9247040f, 0.0403636f, 0.3780217f, -0.0198218f};
+    // Attitude golden RE-BASELINED for #508 (was {0.9247040, 0.0403636,
+    // 0.3780217, -0.0198218}). This fixture is magnetically INCONSISTENT: it
+    // yaws the gyro at 3 dps while feeding a CONSTANT magnetometer, so the field
+    // does not follow the rotation. That is exactly the inconsistency #508's
+    // gyro-bias observability gate exists to catch, and it fires 18 times over
+    // the 20 s run — correctly refusing to learn gyro bias from a magnetometer
+    // that is lying about the vehicle's rotation.
+    //
+    // This is an improvement, not a regression: the fixture's TRUE gyro bias is
+    // zero, and the estimate went from 0.4985 dps (pre-#508) to 0.3870 dps. The
+    // position, velocity and covariance goldens above are unchanged and still
+    // pass — only attitude moved, because we stopped laundering the bad heading
+    // into the bias. The test keeps its original job: guarding the rank-1 Joseph
+    // integration against float-reassociation drift.
+    const float q_gold[4] = {0.9235595f, 0.0412485f, 0.3807520f, -0.0190893f};
     for (int i = 0; i < 4; i++)
         EXPECT_NEAR(q[i], q_gold[i], 2e-4f) << "q[" << i << "]";
+    // The gyro-bias block (12-14) is RE-BASELINED for #508 and is now slightly
+    // LARGER (was 1.867444e-07, 2.240813e-07, 1.721429e-07). That is the gate
+    // working as designed, not drift: zeroing rows 12-14 of K means the Joseph
+    // update does not shrink the bias covariance on a gated sample, so the filter
+    // correctly reports that it learned less about the bias from a magnetometer
+    // that wasn't following the vehicle's yaw. Every other block (pos/vel/att/
+    // accel-bias) is unchanged within the existing 2% tolerance.
     const float cov_gold[15] = {
-        1.866526e-03f, 1.866525e-03f, 2.964458e-03f,
-        2.649696e-03f, 2.650031e-03f, 2.643718e-03f,
-        3.090044e-06f, 4.691107e-06f, 2.907600e-06f,
-        7.639116e-04f, 1.441619e-03f, 6.485872e-04f,
-        1.867444e-07f, 2.240813e-07f, 1.721429e-07f};
+        1.866526e-03f, 1.866530e-03f, 2.964469e-03f,
+        2.649618e-03f, 2.650011e-03f, 2.643721e-03f,
+        3.068467e-06f, 4.648058e-06f, 2.927017e-06f,
+        7.511995e-04f, 1.435934e-03f, 6.463774e-04f,
+        1.947543e-07f, 2.267617e-07f, 1.819631e-07f};
     for (int i = 0; i < 15; i++)
         EXPECT_NEAR(cov[i], cov_gold[i], 0.02f * cov_gold[i] + 1e-9f)
             << "cov[" << i << "]";
@@ -802,4 +823,167 @@ TEST_F(EKFTest, MagSampleFusedOncePerUniqueTimestamp) {
     a.getCovOrient(ca);  b.getCovOrient(cb);
     for (int i = 0; i < 4; i++) EXPECT_EQ(qa[i], qb[i]) << "quat[" << i << "]";
     for (int i = 0; i < 3; i++) EXPECT_EQ(ca[i], cb[i]) << "covOrient[" << i << "]";
+}
+
+// ====================================================================
+// #508 — gyro-bias observability gate + physical bound
+//
+// The bench failure: a flat board makes rocket-frame gravity jump ~81° the
+// instant sim data replaces real data. accel/mag had no consistency test, so
+// the Kalman gain laundered that inconsistency into gyro bias via the
+// attitude↔bias cross-covariance — -190 dps, ~100x beyond anything physical.
+// Launch then gates accel/mag off, freezing the bias in for the whole ascent.
+//
+// The same laundering happens on a REAL pad from a bump, wind sway, a steel
+// rail deflecting the mag, or a stale hard-iron cal — the sim just made it
+// extreme enough to see.
+// ====================================================================
+
+// Nose-up fixture with gravity rotated by `off_deg` away from the nose — i.e.
+// the board is not resting where the filter thinks it is.
+static EkfIMUData makeTiltedIMU(uint32_t time_us, float off_deg) {
+    EkfIMUData imu;
+    imu.time_us = time_us;
+    const float r = off_deg * (float)M_PI / 180.0f;
+    imu.acc_x = 9.807 * std::cos(r);      // along nose
+    imu.acc_y = 0.0;
+    imu.acc_z = 9.807 * std::sin(r);      // leaked perpendicular
+    imu.gyro_x = 0.0; imu.gyro_y = 0.0; imu.gyro_z = 0.0;
+    return imu;
+}
+
+static void settleNoseUp(GpsInsEKF& ekf, uint32_t& t) {
+    ekf.init(makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t));
+    for (int i = 0; i < 2000; i++) {
+        t += 2500;   // 400 Hz
+        ekf.update(true, makeNoseUpIMU(t), makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+}
+
+TEST(EkfGyroBias508, ConvergedPadBiasIsSmallAndHealthy) {
+    // Baseline: a consistent stationary pad must still converge to ~zero bias,
+    // and must report healthy. If this regresses, the gate is too tight.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    settleNoseUp(ekf, t);
+
+    EXPECT_LT(ekf.gyroBiasMaxDps(), 1.0f);
+    EXPECT_EQ(ekf.gyroBiasClipCount(), 0u);
+    EXPECT_TRUE(ekf.gyroBiasHealthy());
+}
+
+TEST(EkfGyroBias508, FrameStepNoLongerDivergesTheBias) {
+    // Reproduce the bench event: converge on a consistent pad, then hand the
+    // filter a gravity vector 81° away with the gyro still reading zero — the
+    // real→sim handover. Before #508 this drove the bias to -190 dps.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    settleNoseUp(ekf, t);
+    ASSERT_LT(ekf.gyroBiasMaxDps(), 1.0f);
+
+    for (int i = 0; i < 2000; i++) {           // 5 s of the inconsistent frame
+        t += 2500;
+        ekf.update(true, makeTiltedIMU(t, 81.0f), makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+
+    // The gate must have fired, and the bias must stay essentially uncorrupted.
+    // Unfixed, this scenario drove it to -190 dps; the LATCHING gate holds the
+    // coupling cut through the whole attitude slew, so almost nothing leaks in.
+    EXPECT_GT(ekf.gyroBiasGateTrips(), 0u);
+    EXPECT_LT(ekf.gyroBiasMaxDps(), 1.0f) << "inconsistency still laundered into the bias";
+}
+
+TEST(EkfGyroBias508, GateTripsAreVisibleToThePreLaunchCheck) {
+    // Even when the bias survives intact, a tripping gate means the filter is
+    // being fed accel/mag data inconsistent with its state — a bad mounting, a
+    // steel rail deflecting the mag, a stale hard-iron cal. The scorecard must be
+    // able to see that, because launch freezes whatever the bias holds.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    settleNoseUp(ekf, t);
+    ASSERT_EQ(ekf.gyroBiasGateTrips(), 0u);    // clean pad trips nothing
+
+    for (int i = 0; i < 2000; i++) {
+        t += 2500;
+        ekf.update(true, makeTiltedIMU(t, 81.0f), makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+    EXPECT_GT(ekf.gyroBiasGateTrips(), 0u);
+}
+
+TEST(EkfGyroBias508, GenuineBiasIsStillLearnedAndOutOfSpecIsFlagged) {
+    // The gate must not blind the filter to a REAL gyro bias — that would be a
+    // bad trade. A gyro with a true 8 dps offset must still be learned exactly
+    // (so attitude is compensated), with no gate trips, and reported out-of-spec
+    // so a suspect sensor is caught before flight.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    EkfIMUData imu = makeNoseUpIMU(t);
+    imu.gyro_x = 8.0;                          // real, consistent 8 dps offset
+    ekf.init(imu, makeStationaryGNSS(t), makeNoseUpMag(t));
+    for (int i = 0; i < 4000; i++) {
+        t += 2500;
+        EkfIMUData u = makeNoseUpIMU(t);
+        u.gyro_x = 8.0;
+        ekf.update(true, u, makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+
+    EXPECT_NEAR(ekf.gyroBiasMaxDps(), 8.0f, 0.5f);   // learned, not suppressed
+    EXPECT_EQ(ekf.gyroBiasGateTrips(), 0u);          // consistent data — no trips
+    EXPECT_FALSE(ekf.gyroBiasHealthy());             // but out of spec → no-go
+}
+
+TEST(EkfGyroBias508, AttitudeStillCorrectsThroughTheGate) {
+    // The gate must cut the gyro-bias coupling ONLY — attitude has to keep
+    // correcting, or genuinely re-orienting the rocket on the rail would leave
+    // the filter stuck on a stale attitude. This is the anti-regression test.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    settleNoseUp(ekf, t);
+
+    // Physically re-orient by 30° and hold. The filter must follow the gravity
+    // vector to the new attitude.
+    for (int i = 0; i < 4000; i++) {
+        t += 2500;
+        ekf.update(true, makeTiltedIMU(t, 30.0f), makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+
+    // Body-frame gravity should now line up with the measurement: the estimated
+    // gravity direction must have swung ~30° off the nose.
+    float q[4];
+    ekf.getQuaternion(q);
+    // Rotate NED-down into body: g_body ∝ third column of T_NED2B.
+    const float gx = 2.0f * (q[1]*q[3] - q[0]*q[2]);
+    const float gz = q[0]*q[0] - q[1]*q[1] - q[2]*q[2] + q[3]*q[3];
+    const float off = std::atan2(std::fabs(gz), std::fabs(gx)) * 180.0f / (float)M_PI;
+    EXPECT_NEAR(off, 30.0f, 8.0f) << "attitude failed to track the re-orientation";
+}
+
+TEST(EkfGyroBias508, BoundIsABackstopOnAnyPath) {
+    // Even init is a path: initCore seeds the bias from the raw gyro reading
+    // ("assume stationary"), so initialising while the vehicle is being handled
+    // bakes that rate straight in. It must be clamped, not trusted.
+    GpsInsEKF ekf;
+    EkfIMUData imu = makeNoseUpIMU(0);
+    imu.gyro_x = 250.0;   // deg/s — being waved around at init
+    imu.gyro_y = -300.0;
+    ekf.init(imu, makeStationaryGNSS(0), makeNoseUpMag(0));
+
+    EXPECT_LE(ekf.gyroBiasMaxDps(), 10.1f);    // clamped to the envelope
+    EXPECT_GT(ekf.gyroBiasClipCount(), 0u);    // and it says the bound bit
+    EXPECT_FALSE(ekf.gyroBiasHealthy());       // so this is a no-go
+}
+
+TEST(EkfGyroBias508, GateDoesNotFireOnNormalPadNoise) {
+    // A small, legitimate tilt (5°) must pass the gate untouched — otherwise the
+    // filter would never learn a real bias. NIS ≈ 3 here vs the gate at 25.
+    GpsInsEKF ekf;
+    uint32_t t = 0;
+    settleNoseUp(ekf, t);
+    const uint32_t trips_before = ekf.gyroBiasGateTrips();
+
+    for (int i = 0; i < 400; i++) {
+        t += 2500;
+        ekf.update(true, makeTiltedIMU(t, 5.0f), makeStationaryGNSS(t), makeNoseUpMag(t));
+    }
+    EXPECT_EQ(ekf.gyroBiasGateTrips(), trips_before) << "gate is too tight";
 }

--- a/tests_cpp/test_sim_pad_align.cpp
+++ b/tests_cpp/test_sim_pad_align.cpp
@@ -1,0 +1,262 @@
+#include <gtest/gtest.h>
+
+#include "SimPadAlign.h"
+
+#include <cmath>
+
+using namespace sim_pad_align;
+
+namespace {
+
+// The sim's on-rail pad attitude (matches SensorCollectorSim's constants).
+constexpr float LAUNCH_ANGLE_RAD = 85.0f * 3.14159265f / 180.0f;
+constexpr float B_NORTH = 22.0f;
+constexpr float B_EAST  =  5.0f;
+constexpr float B_DOWN  = 42.0f;
+
+void simRef(float up[3], float mag[3])
+{
+    simPadReference(LAUNCH_ANGLE_RAD, B_NORTH, B_EAST, B_DOWN, up, mag);
+}
+
+float dot3(const float a[3], const float b[3])
+{
+    return a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
+}
+
+float angleBetweenDeg(const float a[3], const float b[3])
+{
+    float u[3] = {a[0], a[1], a[2]};
+    float v[3] = {b[0], b[1], b[2]};
+    normalize3(u);
+    normalize3(v);
+    float c = dot3(u, v);
+    if (c >  1.0f) c =  1.0f;
+    if (c < -1.0f) c = -1.0f;
+    return std::acos(c) * (180.0f / 3.14159265f);
+}
+
+// Component of m perpendicular to up — the only part a HEADING-ONLY mag update
+// consumes. This is what must be continuous across the sim handover.
+void horizontal(const float m[3], const float up[3], float out[3])
+{
+    float u[3] = {up[0], up[1], up[2]};
+    normalize3(u);
+    const float d = dot3(m, u);
+    out[0] = m[0] - d * u[0];
+    out[1] = m[1] - d * u[1];
+    out[2] = m[2] - d * u[2];
+    normalize3(out);
+}
+
+void rotate(const float R[9], const float v[3], float out[3])
+{
+    out[0] = v[0]; out[1] = v[1]; out[2] = v[2];
+    applyRotation(R, out[0], out[1], out[2]);
+}
+
+// The bench case that produced the -190 dps excursion: board lying flat, so
+// gravity sits ~86° off the configured +X nose axis.
+void flatBenchPad(float up[3], float mag[3])
+{
+    const float off = 86.1f * 3.14159265f / 180.0f;
+    up[0] = std::cos(off); up[1] = 0.0f; up[2] = std::sin(off);
+    // A plausible bench field with a DIFFERENT dip than the sim's canonical one.
+    mag[0] = 28.0f; mag[1] = -6.0f; mag[2] = 33.0f;
+    const float n = std::sqrt(mag[0]*mag[0] + mag[1]*mag[1] + mag[2]*mag[2]);
+    mag[0] *= 44.3f / n; mag[1] *= 44.3f / n; mag[2] *= 44.3f / n;
+}
+
+}  // namespace
+
+// ================================================================
+// The reference the alignment maps FROM must match what the encoders emit.
+// ================================================================
+
+TEST(SimPadAlign, PadReferenceMatchesEncoderOutput) {
+    float up[3], mag[3];
+    simRef(up, mag);
+    // Gravity along the rail at 85° nose-up.
+    EXPECT_NEAR(up[0], std::sin(LAUNCH_ANGLE_RAD), 1e-5);
+    EXPECT_NEAR(up[2], std::cos(LAUNCH_ANGLE_RAD), 1e-5);
+    // Field: this is the vector the bench log actually recorded at t=0
+    // (25.65, 4.95, 39.90 µT) — pins the reference to real observed data.
+    EXPECT_NEAR(mag[0], 25.6f, 0.2f);
+    EXPECT_NEAR(mag[1],  5.0f, 0.1f);
+    EXPECT_NEAR(mag[2], 39.9f, 0.2f);
+}
+
+// ================================================================
+// The two invariants that matter: the EKF's accel update and its (heading-only)
+// mag update must both see ZERO step across the real→sim handover.
+// ================================================================
+
+TEST(SimPadAlign, FlatBenchGravityStepGoesToZero) {
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    // Before alignment there is a large gravity step. Note it is NOT the 86.1°
+    // the [ORIENT] check prints: that is measured off the NOSE (+X), while the
+    // sim's rail sits LAUNCH_ANGLE=85° from it — so the step the EKF actually
+    // eats at handover is 86.1 − 5 = 81.1°.
+    EXPECT_NEAR(angleBetweenDeg(up_sim, up_meas), 81.1f, 0.5f);
+
+    float R[9];
+    bool used_mag = false;
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, mag_meas, R, &used_mag));
+    EXPECT_TRUE(used_mag);
+
+    float up_aligned[3];
+    rotate(R, up_sim, up_aligned);
+    EXPECT_LT(angleBetweenDeg(up_aligned, up_meas), 0.01f);   // was 86.1°
+}
+
+TEST(SimPadAlign, FlatBenchHeadingStepGoesToZero) {
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    float R[9];
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, mag_meas, R));
+
+    float mag_aligned[3];
+    rotate(R, mag_sim, mag_aligned);
+
+    // The mag update is heading-only, so what must match is the projection
+    // perpendicular to gravity. TRIAD makes this exact.
+    float h_sim[3], h_meas[3];
+    horizontal(mag_aligned, up_meas, h_sim);
+    horizontal(mag_meas,    up_meas, h_meas);
+    EXPECT_LT(angleBetweenDeg(h_sim, h_meas), 0.01f);
+}
+
+TEST(SimPadAlign, ResidualIsDipOnlyWhichHeadingUpdateNeverSees) {
+    // The sim's canonical field and a real bench field generally have different
+    // magnetic dip. TRIAD cannot (and need not) reconcile that — it survives as a
+    // dip mismatch, which a heading-only update does not consume. Assert it is
+    // confined there: the FULL vector still differs, while heading does not.
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    float R[9];
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, mag_meas, R));
+    float mag_aligned[3];
+    rotate(R, mag_sim, mag_aligned);
+
+    EXPECT_GT(angleBetweenDeg(mag_aligned, mag_meas), 1.0f);   // dip differs
+    float h_sim[3], h_meas[3];
+    horizontal(mag_aligned, up_meas, h_sim);
+    horizontal(mag_meas,    up_meas, h_meas);
+    EXPECT_LT(angleBetweenDeg(h_sim, h_meas), 0.01f);          // heading does not
+}
+
+// ================================================================
+// Must not change behaviour when there is nothing to fix.
+// ================================================================
+
+TEST(SimPadAlign, BoardAlreadyOnRailYieldsIdentity) {
+    float up_sim[3], mag_sim[3];
+    simRef(up_sim, mag_sim);
+
+    float R[9];
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_sim, mag_sim, R));
+    EXPECT_LT(rotationAngleDeg(R), 0.01f);
+    for (int i = 0; i < 9; ++i) {
+        EXPECT_NEAR(R[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-4) << "R[" << i << "]";
+    }
+}
+
+// ================================================================
+// Degradation: a missing / dead magnetometer must still kill the gravity step.
+// ================================================================
+
+TEST(SimPadAlign, NullMagFallsBackToGravityOnly) {
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    float R[9];
+    bool used_mag = true;
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, nullptr, R, &used_mag));
+    EXPECT_FALSE(used_mag);
+
+    float up_aligned[3];
+    rotate(R, up_sim, up_aligned);
+    EXPECT_LT(angleBetweenDeg(up_aligned, up_meas), 0.01f);   // gravity still exact
+}
+
+TEST(SimPadAlign, ImplausibleMagFallsBackToGravityOnly) {
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    float dead[3] = {0.0f, 0.0f, 0.0f};          // dead magnetometer
+    float huge[3] = {500.0f, 0.0f, 0.0f};        // saturated / hard-iron blown
+    EXPECT_FALSE(magIsPlausible(dead));
+    EXPECT_FALSE(magIsPlausible(huge));
+
+    for (float* m : {dead, huge}) {
+        float R[9];
+        bool used_mag = true;
+        ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, m, R, &used_mag));
+        EXPECT_FALSE(used_mag);
+        float up_aligned[3];
+        rotate(R, up_sim, up_aligned);
+        EXPECT_LT(angleBetweenDeg(up_aligned, up_meas), 0.01f);
+    }
+}
+
+TEST(SimPadAlign, DegenerateGravityIsRejected) {
+    float up_sim[3], mag_sim[3];
+    simRef(up_sim, mag_sim);
+    float zero[3] = {0.0f, 0.0f, 0.0f};
+    float R[9];
+    EXPECT_FALSE(solvePadAlignment(up_sim, mag_sim, zero, nullptr, R));
+    // R must be left as identity so an un-solvable alignment is a no-op, not a
+    // garbage rotation applied to every synthetic sample.
+    for (int i = 0; i < 9; ++i) EXPECT_NEAR(R[i], (i % 4 == 0) ? 1.0f : 0.0f, 1e-6);
+}
+
+// ================================================================
+// R must be a proper rotation, or it would shear every synthetic vector.
+// ================================================================
+
+TEST(SimPadAlign, SolvedRotationIsOrthonormalWithUnitDeterminant) {
+    float up_sim[3], mag_sim[3], up_meas[3], mag_meas[3];
+    simRef(up_sim, mag_sim);
+    flatBenchPad(up_meas, mag_meas);
+
+    float R[9];
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, mag_meas, R));
+
+    // R·Rᵀ == I
+    for (int r = 0; r < 3; ++r) {
+        for (int c = 0; c < 3; ++c) {
+            const float d = R[r*3+0]*R[c*3+0] + R[r*3+1]*R[c*3+1] + R[r*3+2]*R[c*3+2];
+            EXPECT_NEAR(d, (r == c) ? 1.0f : 0.0f, 1e-4);
+        }
+    }
+    const float det = R[0]*(R[4]*R[8] - R[5]*R[7])
+                    - R[1]*(R[3]*R[8] - R[5]*R[6])
+                    + R[2]*(R[3]*R[7] - R[4]*R[6]);
+    EXPECT_NEAR(det, 1.0f, 1e-4);   // +1, not a reflection
+}
+
+TEST(SimPadAlign, AntiparallelGravityIsHandled) {
+    // Board upside-down relative to the rail: gravity exactly opposite. The
+    // Rodrigues fallback must still produce a valid 180° rotation, not NaN.
+    float up_sim[3], mag_sim[3];
+    simRef(up_sim, mag_sim);
+    float up_meas[3] = {-up_sim[0], -up_sim[1], -up_sim[2]};
+
+    float R[9];
+    ASSERT_TRUE(solvePadAlignment(up_sim, mag_sim, up_meas, nullptr, R));
+    for (int i = 0; i < 9; ++i) EXPECT_FALSE(std::isnan(R[i]));
+
+    float up_aligned[3];
+    rotate(R, up_sim, up_aligned);
+    EXPECT_LT(angleBetweenDeg(up_aligned, up_meas), 0.01f);
+    EXPECT_NEAR(rotationAngleDeg(R), 180.0f, 0.5f);
+}

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -102,7 +102,16 @@ void GpsInsEKF::initCore(EkfIMUData imu_data,
 
     pEst_D_rrm_[0]=pMeas_D_rrm[0]; pEst_D_rrm_[1]=pMeas_D_rrm[1]; pEst_D_rrm_[2]=pMeas_D_rrm[2];
     vEst_NED_mps_[0]=vMeas_NED[0]; vEst_NED_mps_[1]=vMeas_NED[1]; vEst_NED_mps_[2]=vMeas_NED[2];
+
+    // Coarse "assume stationary" seed: whatever the gyro reads at init IS the
+    // bias. #508: that is unbounded — init while the vehicle is being handled or
+    // rotated and the rate is baked straight into the bias state. Clamp it into
+    // the physical envelope, and start the health counters clean.
+    gbias_gate_trips_ = 0;
+    gbias_clip_count_ = 0;
+    gbias_gate_hold_until_us_ = 0;
     wBias_rps_[0]=wMeas[0]; wBias_rps_[1]=wMeas[1]; wBias_rps_[2]=wMeas[2];
+    clampGyroBias();
 
     // Initial quaternion: nose-up vertical (same as constructor)
     quat_BL_[0] = 0.707107f; quat_BL_[1] = 0.0f;
@@ -606,7 +615,8 @@ void GpsInsEKF::stabilizeP() {
 // P is exactly symmetric on entry (every update ends with an explicit
 // symmetrize), so K = P*H^T*S^-1 can be read from HP^T bit-identically.
 void GpsInsEKF::applyScalarMeasUpdate(const int* hidx, const float* hval,
-                                      int hn, float y, float R, float s_min)
+                                      int hn, float y, float R, float s_min,
+                                      bool gate_gyro_bias)
 {
     // HP = H*P (1x15), snapshotted before P is modified
     float HP[15] = {};
@@ -627,6 +637,19 @@ void GpsInsEKF::applyScalarMeasUpdate(const int* hidx, const float* hval,
     float K[15];
     for (int i = 0; i < 15; i++) K[i] = HP[i] * S_inv;
 
+    // ── #508: gyro-bias observability gate (scalar form; see accelMeasUpdate) ──
+    // NIS = y²/S. Cut the gyro-bias coupling when the measurement is
+    // inconsistent with the state, so an off heading (steel rail, stale
+    // hard-iron cal) can't be laundered into the bias. Every other state still
+    // corrects normally.
+    if (gate_gyro_bias) {
+        const float nis = (y * y) * S_inv;
+        if (!(nis <= GBIAS_GATE_NIS_SCALAR)) tripGyroBiasGate();  // negated: catches NaN
+    }
+    if (gate_gyro_bias && gyroBiasGateHeld()) {
+        K[12] = 0.0f; K[13] = 0.0f; K[14] = 0.0f;
+    }
+
     // State correction xk = K*y — position via curvature radii, velocity,
     // biases, attitude via left-multiplied error quaternion (the shared
     // convention across all measurement updates).
@@ -643,6 +666,7 @@ void GpsInsEKF::applyScalarMeasUpdate(const int* hidx, const float* hval,
         aBias_mps2_[i]   += xk[i + 9];
         wBias_rps_[i]    += xk[i + 12];
     }
+    clampGyroBias();   // #508 backstop: no path may leave a non-physical bias
 
     float quatDelta[4] = {1.0f, xk[6], xk[7], xk[8]};
     normalizeQuaternion(quatDelta, quatDelta);
@@ -730,6 +754,27 @@ void GpsInsEKF::accelMeasUpdate(const float aMeas[3]) {
             for (int k = 0; k < 3; k++)
                 K[i][j] += PHt[i][k] * S_inv[k*3+j];
 
+    // ── #508: gyro-bias observability gate ──
+    // NIS = yᵀ·S⁻¹·y. A gravity innovation this far from what P predicts is not
+    // an attitude error the bias can explain — it's a bad measurement (pad bump,
+    // wind sway, a frame change). Gyro bias is observable only through slow,
+    // CONSISTENT drift, so cut its coupling for this update: zero rows 12-14 of
+    // K. Attitude (and accel bias) still correct in full, so a genuine
+    // re-orientation on the rail converges exactly as before. Joseph form below
+    // is valid for any gain, so P stays consistent — and with these rows zeroed
+    // the bias covariance is NOT reduced, so the filter keeps reporting the bias
+    // as un-learned. That is what the pre-launch scorecard reads.
+    float nis = 0.0f;
+    for (int i = 0; i < 3; i++)
+        for (int j = 0; j < 3; j++)
+            nis += y[i] * S_inv[i*3+j] * y[j];
+    if (!(nis <= GBIAS_GATE_NIS_VEC)) tripGyroBiasGate();   // negated: catches NaN too
+    if (gyroBiasGateHeld()) {
+        for (int j = 0; j < 3; j++) {
+            K[12][j] = 0.0f; K[13][j] = 0.0f; K[14][j] = 0.0f;
+        }
+    }
+
     // State correction: xk = K * y
     float xk[15] = {};
     for (int i = 0; i < 15; i++)
@@ -748,6 +793,7 @@ void GpsInsEKF::accelMeasUpdate(const float aMeas[3]) {
         aBias_mps2_[i] += xk[i + 9];
         wBias_rps_[i] += xk[i + 12];
     }
+    clampGyroBias();   // #508 backstop: no path may leave a non-physical bias
 
     // Quaternion correction
     float quatDelta[4] = {1.0f, xk[6], xk[7], xk[8]};
@@ -897,7 +943,7 @@ void GpsInsEKF::magMeasUpdate(const float aMeas[3], const float magMeas[3]) {
     //    |H|=2 ⇒ S ≥ R_mag_ at any attitude, so the s_min gate is NaN-safety.
     const int   hidx[3] = {6, 7, 8};
     const float hval[3] = {2.0f*d[0], 2.0f*d[1], 2.0f*d[2]};
-    applyScalarMeasUpdate(hidx, hval, 3, y, R_eff, 1e-9f);
+    applyScalarMeasUpdate(hidx, hval, 3, y, R_eff, 1e-9f, /*gate_gyro_bias=*/true);
 }
 
 // ─── Heading update from GNSS velocity course ───────────────────────
@@ -923,7 +969,7 @@ void GpsInsEKF::velCourseHeadingUpdate(const float vMeas_NED[3]) {
     const float R_course = 0.05f;   // ~13° course noise (rad²)
     const int   hidx[3] = {6, 7, 8};
     const float hval[3] = {2.0f*d[0], 2.0f*d[1], 2.0f*d[2]};
-    applyScalarMeasUpdate(hidx, hval, 3, y, R_course, 1e-9f);
+    applyScalarMeasUpdate(hidx, hval, 3, y, R_course, 1e-9f, /*gate_gyro_bias=*/true);
 }
 
 // ─── Heading update by body↔world lateral-acceleration matching ─────
@@ -956,7 +1002,7 @@ void GpsInsEKF::accelMatchHeadingUpdate(const float aMeas[3], const float aWorld
     const float R_am = 0.20f;   // ~26° (rad²) — GNSS-derived accel is noisy
     const int   hidx[3] = {6, 7, 8};
     const float hval[3] = {2.0f*d[0], 2.0f*d[1], 2.0f*d[2]};
-    applyScalarMeasUpdate(hidx, hval, 3, y, R_am, 1e-9f);
+    applyScalarMeasUpdate(hidx, hval, 3, y, R_am, 1e-9f, /*gate_gyro_bias=*/true);
 }
 
 // ─── Measurement Update (GNSS correction) ───────────────────────────
@@ -1134,6 +1180,7 @@ void GpsInsEKF::measUpdate(double pMeas_D_rrm[3], float vMeas_NED_mps[3]) {
         aBias_mps2_[i]+=xk[i+9];
         wBias_rps_[i]+=xk[i+12];
     }
+    clampGyroBias();   // #508 backstop: no path may leave a non-physical bias
 
     // Attitude correction (K rows 6-8 already gated by cos²(pitch) above)
     float quatDelta[4]={1.0f, xk[6], xk[7], xk[8]};

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -155,6 +155,52 @@ public:
     void getCovAccelBias(float (&r)[3]) const { r[0]=P_[9][9]; r[1]=P_[10][10]; r[2]=P_[11][11]; }
     void getCovRotRateBias(float (&r)[3]) const { r[0]=P_[12][12]; r[1]=P_[13][13]; r[2]=P_[14][14]; }
 
+    // ─── #508: gyro-bias health, for the pre-launch go/no-go ───────
+    //
+    // These exist because accel/mag updates are gated OFF for the whole flight:
+    // whatever the gyro bias holds at launch is FROZEN IN and integrates into
+    // attitude at that rate for the entire ascent (a 5 dps error → 5°/s → ~50°
+    // by apogee on a 10 s climb), and guidance keys off attitude. So a bias that
+    // is large, still un-learned, or has been clipped is a genuine no-go — and
+    // before this there was nothing that could tell you.
+
+    // Largest |gyro-bias| component, deg/s. A healthy ISM6 sits well under 2.
+    float gyroBiasMaxDps() const {
+        float m = 0.0f;
+        for (int i = 0; i < 3; ++i) {
+            const float a = std::fabs(wBias_rps_[i]);
+            if (a > m) m = a;
+        }
+        return m * RAD2DEG;
+    }
+
+    // Largest gyro-bias 1σ, deg/s — how well the bias has actually been learned.
+    // Stays high precisely when the observability gate has been cutting the
+    // bias coupling, which is the case we must not launch on.
+    float gyroBiasSigmaMaxDps() const {
+        float m = 0.0f;
+        for (int i = 12; i <= 14; ++i) {
+            const float v = P_[i][i];
+            if (v > m) m = v;
+        }
+        return std::sqrt(m) * RAD2DEG;
+    }
+
+    // True when the bias estimate is physically plausible and the bound never had
+    // to bite. Note the sigma bound is a guard against a genuinely diverged
+    // covariance (it can reach ~5.7 dps at the P cap), NOT a convergence test:
+    // gyro bias is only weakly observable on a stationary, consistent pad — with
+    // no rotation there is little information to separate bias from attitude — so
+    // sigma sits near ~0.9 dps even when fully settled. That is expected.
+    bool gyroBiasHealthy(float max_dps = 3.0f, float max_sigma_dps = 2.0f) const {
+        return gbias_clip_count_ == 0
+            && gyroBiasMaxDps()      <= max_dps
+            && gyroBiasSigmaMaxDps() <= max_sigma_dps;
+    }
+
+    uint32_t gyroBiasGateTrips() const { return gbias_gate_trips_; }
+    uint32_t gyroBiasClipCount() const { return gbias_clip_count_; }
+
     // ─── Bulk state save/restore (reboot recovery) ─────────────────
     void getState(EkfStateSnapshot& s) const {
         std::memcpy(s.pos_rrm,     pEst_D_rrm_,   sizeof(s.pos_rrm));
@@ -321,8 +367,15 @@ private:
     // state correction (pos/vel/bias/quat), and updates P in Joseph form
     // exploiting the rank-1 structure of K*H.  Used by the baro-altitude and
     // the three heading updates (mag, GNSS course, accel-match).
+    // `gate_gyro_bias` (#508) arms the gyro-bias observability gate. Set it ONLY
+    // for measurements that carry ATTITUDE information (the three heading
+    // updates) — those are the ones whose inconsistency can be laundered into
+    // the bias. Baro measures altitude: its gyro-bias coupling is incidental, and
+    // a large baro innovation during a climb is the filter lagging, not a bad
+    // measurement, so gating there would fire constantly for no reason.
     void applyScalarMeasUpdate(const int* hidx, const float* hval, int hn,
-                               float y, float R, float s_min);
+                               float y, float R, float s_min,
+                               bool gate_gyro_bias = false);
 
     // Kalman matrices
     float quat_BL_[4];
@@ -382,6 +435,85 @@ private:
     static constexpr float P_MAX_ATT   = 10.0f;   // ~180 deg sigma
     static constexpr float P_MAX_ABIAS = 10.0f;   // ~3 m/s² sigma
     static constexpr float P_MAX_GBIAS = 0.01f;   // ~6 deg/s sigma
+
+    // ── #508: gyro-bias observability gate + physical bound ──────────────
+    //
+    // Gyro bias is a PHYSICAL sensor parameter: the ISM6's zero-rate offset is
+    // ~±1 dps typical, a few dps over temperature. It is observable ONLY through
+    // slow, CONSISTENT attitude drift — a large transient innovation carries no
+    // gyro-bias information at all; it means the attitude is off, or the
+    // measurement is bad (pad bump, wind sway, a steel rail deflecting the mag,
+    // a stale hard-iron cal, a wrong mounting setting).
+    //
+    // But accel/mag are the only updates that touch attitude, and K = P·Hᵀ·S⁻¹
+    // is 15×N — so the correction reaches gyro bias through the attitude↔bias
+    // cross-covariance whether or not H names those columns. Unlike the GNSS
+    // update (NIS-gated since #174), accel/mag had NO consistency test, so an
+    // inconsistent measurement was laundered straight into the bias state.
+    // Observed on the bench: -190 dps, ~100x beyond anything physical. Because
+    // accel/mag updates are gated off in flight, whatever the bias holds at
+    // launch is FROZEN IN and integrates into attitude for the whole ascent.
+    //
+    // Fix: when the innovation is inconsistent with the state (NIS above the
+    // gate), zero ONLY the gyro-bias rows of K. Attitude still corrects in full
+    // — so genuinely re-orienting the rocket on the rail still works — but the
+    // bias cannot absorb the inconsistency. Joseph form is valid for ANY gain,
+    // not just the optimal one, so P stays consistent and PSD; and since those
+    // rows are zeroed, the bias covariance is NOT reduced, so the filter
+    // correctly reports that it has not learned the bias.
+    //
+    // Thresholds are deliberately generous — they must not fire in normal
+    // operation, only on the wild innovations that indicate a bad measurement.
+    // Reference: R_accel_ = 0.25 (σ ≈ 0.5 m/s²). A legitimate 5° pad tilt gives
+    // NIS ≈ 3 (passes); the 81° frame step gives NIS ≈ 380 (trips).
+    // Chi-squared 99.9% thresholds for the innovation's DOF — a textbook NIS
+    // gate, not a tuned number. A legitimate 5° pad tilt sits at NIS ≈ 3 (passes);
+    // the 81° frame step is ≈ 380 (trips).
+    static constexpr float GBIAS_GATE_NIS_VEC    = 16.27f;  // chi2(3, 0.999)
+    static constexpr float GBIAS_GATE_NIS_SCALAR = 10.83f;  // chi2(1, 0.999)
+
+    // The gate LATCHES. Cutting the coupling only while NIS is above threshold
+    // is not enough: as the attitude slews toward a genuinely new gravity vector
+    // the innovation shrinks back under the gate, and the filter then absorbs the
+    // remaining "attitude moved but the gyro reported nothing" discrepancy into
+    // the bias — which is precisely the laundering we are trying to stop. So once
+    // a trip occurs, hold the bias coupling cut until the measurements have been
+    // consistent for a dwell, i.e. until the slew has finished. Sized to comfortably
+    // outlast the accel update's attitude time constant.
+    static constexpr uint32_t GBIAS_GATE_HOLD_US = 2000000u;   // 2 s
+    uint32_t gbias_gate_hold_until_us_ = 0;
+
+    // True while the gyro-bias coupling is held cut (gate tripped recently).
+    inline bool gyroBiasGateHeld() const {
+        return gbias_gate_hold_until_us_ != 0 && tPrev_us_ < gbias_gate_hold_until_us_;
+    }
+    // Arm/refresh the hold and count the trip.
+    inline void tripGyroBiasGate() {
+        ++gbias_gate_trips_;
+        gbias_gate_hold_until_us_ = tPrev_us_ + GBIAS_GATE_HOLD_US;
+    }
+
+    // Hard physical bound on the gyro-bias state (rad/s). A backstop: no
+    // estimate outside a real gyro's envelope is a bias, whatever path produced
+    // it. ±10 dps is ~5-10x the ISM6 spec — generous enough never to clip a
+    // genuine bias, tight enough that no path can reach -190 dps.
+    static constexpr float GYRO_BIAS_MAX_RPS = 10.0f * (float)(M_PI / 180.0);
+
+    // Clamp the gyro-bias state into its physical envelope. Called after every
+    // state correction. Counts clips so the pre-launch scorecard can see that
+    // the estimator has been driven somewhere impossible (#508).
+    inline void clampGyroBias() {
+        for (int i = 0; i < 3; ++i) {
+            if (wBias_rps_[i] >  GYRO_BIAS_MAX_RPS) {
+                wBias_rps_[i] =  GYRO_BIAS_MAX_RPS; ++gbias_clip_count_;
+            } else if (wBias_rps_[i] < -GYRO_BIAS_MAX_RPS) {
+                wBias_rps_[i] = -GYRO_BIAS_MAX_RPS; ++gbias_clip_count_;
+            }
+        }
+    }
+
+    uint32_t gbias_gate_trips_ = 0;   // updates whose gyro-bias coupling was cut
+    uint32_t gbias_clip_count_ = 0;   // times the bound actually bit
 
     // Helper methods
     void Quat2Euler(float q[4], float euler[3]);

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/SimPadAlign.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/SimPadAlign.h
@@ -1,0 +1,190 @@
+#pragma once
+//
+//  SimPadAlign.h — pad-frame alignment for the firmware sim (#508).
+//
+//  The sim's physics assume the rocket is standing on the rail
+//  (pitch = LAUNCH_ANGLE_RAD). On a bench the board is usually lying flat, so at
+//  the instant synthetic data replaces real data the rocket-frame gravity vector
+//  jumps by ~90°. The EKF still has accel/mag updates live on the pad, and the
+//  only state that can explain "large attitude correction, no measured rate" is
+//  the gyro bias — which slams to a physically impossible value (-190 dps was
+//  observed) and is then FROZEN IN at launch, because accel/mag updates are
+//  gated off for the whole flight. The attitude solution never recovers.
+//
+//  Rather than clamp the symptom, remove the discontinuity: solve the fixed
+//  rotation that carries the sim's assumed pad attitude onto the board's ACTUAL
+//  resting attitude, and rotate every synthetic body-frame vector (accel, gyro,
+//  mag) by it. The handover is then continuous by construction.
+//
+//  Why this is safe for the trajectory: rotating the body-frame vectors AND the
+//  implied attitude by the same R leaves world-frame acceleration unchanged
+//    R_wb(q·Rᵀ)·(R·a_body) == R_wb(q)·a_body
+//  so GNSS/baro need no adjustment — the simulated flight path is identical, only
+//  the body frame is re-expressed.
+//
+//  Solved with TRIAD from two vector pairs (gravity + field). TRIAD makes the
+//  gravity direction and the field's projection PERPENDICULAR to gravity exact.
+//  That is precisely what the two EKF updates consume — the accel update levels
+//  attitude, and the mag update is heading-only — so both see a zero step. Any
+//  residual is confined to magnetic dip (the sim's canonical field vs the bench's
+//  real one), which a heading-only update never looks at.
+//
+//  Pure math, no ESP/Arduino dependencies, so it is host-testable
+//  (tests_cpp/test_sim_pad_align.cpp).
+//
+
+#include <math.h>
+
+namespace sim_pad_align {
+
+inline bool normalize3(float v[3])
+{
+    const float n = sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (!(n > 1e-6f)) return false;
+    v[0] /= n; v[1] /= n; v[2] /= n;
+    return true;
+}
+
+inline void cross3(const float a[3], const float b[3], float out[3])
+{
+    out[0] = a[1] * b[2] - a[2] * b[1];
+    out[1] = a[2] * b[0] - a[0] * b[2];
+    out[2] = a[0] * b[1] - a[1] * b[0];
+}
+
+// Orthonormal triad from a primary vector p and a secondary reference s:
+//   t1 = p̂ ; t2 = (t1 × s)̂ ; t3 = t1 × t2
+// Stored row-major with t1,t2,t3 as COLUMNS. False if p and s are parallel.
+inline bool triad(const float p[3], const float s[3], float M[9])
+{
+    float t1[3] = {p[0], p[1], p[2]};
+    if (!normalize3(t1)) return false;
+    float t2[3];
+    cross3(t1, s, t2);
+    if (!normalize3(t2)) return false;   // degenerate: p ∥ s
+    float t3[3];
+    cross3(t1, t2, t3);
+    M[0] = t1[0]; M[1] = t2[0]; M[2] = t3[0];
+    M[3] = t1[1]; M[4] = t2[1]; M[5] = t3[1];
+    M[6] = t1[2]; M[7] = t2[2]; M[8] = t3[2];
+    return true;
+}
+
+// R = A * Bᵀ (row-major 3x3).
+inline void mulABt(const float A[9], const float B[9], float R[9])
+{
+    for (int r = 0; r < 3; ++r)
+        for (int c = 0; c < 3; ++c)
+            R[r * 3 + c] = A[r * 3 + 0] * B[c * 3 + 0]
+                         + A[r * 3 + 1] * B[c * 3 + 1]
+                         + A[r * 3 + 2] * B[c * 3 + 2];
+}
+
+inline void setIdentity(float R[9])
+{
+    for (int i = 0; i < 9; ++i) R[i] = (i % 4 == 0) ? 1.0f : 0.0f;
+}
+
+// Minimal rotation carrying unit â onto unit b̂ (Rodrigues), handling the
+// parallel and antiparallel degeneracies.
+inline void rotationBetween(const float a[3], const float b[3], float R[9])
+{
+    float v[3];
+    cross3(a, b, v);
+    const float c  = a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    const float s2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+
+    if (s2 < 1e-12f)
+    {
+        if (c > 0.0f) { setIdentity(R); return; }        // already aligned
+        // Antiparallel: 180° about any axis ⊥ a.
+        float axis[3] = {1.0f, 0.0f, 0.0f};
+        if (fabsf(a[0]) > 0.9f) { axis[0] = 0.0f; axis[1] = 1.0f; }
+        float p[3];
+        cross3(a, axis, p);
+        normalize3(p);
+        const float x = p[0], y = p[1], z = p[2];
+        R[0] = 2*x*x-1; R[1] = 2*x*y;   R[2] = 2*x*z;
+        R[3] = 2*x*y;   R[4] = 2*y*y-1; R[5] = 2*y*z;
+        R[6] = 2*x*z;   R[7] = 2*y*z;   R[8] = 2*z*z-1;
+        return;
+    }
+
+    const float k = (1.0f - c) / s2;    // R = I + [v]x + [v]x² (1-c)/s²
+    const float vx = v[0], vy = v[1], vz = v[2];
+    R[0] = 1.0f + k * (-vz*vz - vy*vy);  R[1] = -vz + k * (vx*vy);            R[2] =  vy + k * (vx*vz);
+    R[3] =  vz  + k * (vx*vy);           R[4] = 1.0f + k * (-vz*vz - vx*vx);  R[5] = -vx + k * (vy*vz);
+    R[6] = -vy  + k * (vx*vz);           R[7] =  vx + k * (vy*vz);            R[8] = 1.0f + k * (-vy*vy - vx*vx);
+}
+
+// The sim's own pad attitude, in ROCKET frame, at `launch_angle_rad`.
+// At rest the accelerometer reads specific force: +g along "up".
+inline void simPadReference(float launch_angle_rad,
+                            float b_north, float b_east, float b_down,
+                            float up_out[3], float mag_out[3])
+{
+    const float sp = sinf(launch_angle_rad);
+    const float cp = cosf(launch_angle_rad);
+    up_out[0]  = sp;   up_out[1] = 0.0f;   up_out[2] = cp;
+    mag_out[0] =  b_north * sp + b_down * cp;
+    mag_out[1] =  b_east;
+    mag_out[2] = -b_north * cp + b_down * sp;
+}
+
+// True when |m| looks like an Earth field (µT). Guards against a dead/saturated
+// magnetometer poisoning the alignment.
+inline bool magIsPlausible(const float m[3])
+{
+    const float m2 = m[0]*m[0] + m[1]*m[1] + m[2]*m[2];
+    return m2 >= (15.0f * 15.0f) && m2 <= (80.0f * 80.0f);
+}
+
+// Solve the rotation carrying the sim's pad frame onto the measured one.
+// `mag_sim` / `mag_meas` may be null (or implausible) → falls back to aligning
+// gravity alone, which still removes the attitude step; only the heading step
+// survives. Returns false (R = identity) if gravity itself is unusable.
+inline bool solvePadAlignment(const float up_sim[3], const float mag_sim[3],
+                              const float up_meas[3], const float mag_meas[3],
+                              float R[9], bool* used_mag_out = nullptr)
+{
+    setIdentity(R);
+    if (used_mag_out) *used_mag_out = false;
+    if (up_sim == nullptr || up_meas == nullptr) return false;
+
+    float us[3] = {up_sim[0],  up_sim[1],  up_sim[2]};
+    float um[3] = {up_meas[0], up_meas[1], up_meas[2]};
+    if (!normalize3(us) || !normalize3(um)) return false;
+
+    if (mag_sim != nullptr && mag_meas != nullptr && magIsPlausible(mag_meas))
+    {
+        float Ms[9], Mm[9];
+        if (triad(us, mag_sim, Ms) && triad(um, mag_meas, Mm))
+        {
+            mulABt(Mm, Ms, R);                       // maps sim → measured
+            if (used_mag_out) *used_mag_out = true;
+            return true;
+        }
+    }
+
+    rotationBetween(us, um, R);                      // gravity-only fallback
+    return true;
+}
+
+// Rotation angle of R in degrees (0 for identity).
+inline float rotationAngleDeg(const float R[9])
+{
+    float c = (R[0] + R[4] + R[8] - 1.0f) * 0.5f;
+    if (c >  1.0f) c =  1.0f;
+    if (c < -1.0f) c = -1.0f;
+    return acosf(c) * (180.0f / 3.14159265f);
+}
+
+inline void applyRotation(const float R[9], float& x, float& y, float& z)
+{
+    const float rx = R[0] * x + R[1] * y + R[2] * z;
+    const float ry = R[3] * x + R[4] * y + R[5] * z;
+    const float rz = R[6] * x + R[7] * y + R[8] * z;
+    x = rx; y = ry; z = rz;
+}
+
+}  // namespace sim_pad_align

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -10,6 +10,7 @@
 //
 
 #include "TR_Sensor_Collector_Sim.h"
+#include "SimPadAlign.h"
 #include <cmath>
 // SensorCollector.h no longer transitively pulls in compat.h, but this
 // file still uses the Arduino-shim millis()/micros() heavily.  Pulled
@@ -132,6 +133,43 @@ void SensorCollectorSim::configureSimBoardToRocket(const float R[9])
     b2r_identity_ = identity;
 }
 
+void SensorCollectorSim::simPadReference(float up_out[3], float mag_out[3]) const
+{
+    sim_pad_align::simPadReference(LAUNCH_ANGLE_RAD, B_NORTH, B_EAST, B_DOWN,
+                                   up_out, mag_out);
+}
+
+void SensorCollectorSim::configureSimPadAlignment(const float up_rocket[3],
+                                                  const float mag_rocket[3])
+{
+    float up_sim[3], mag_sim[3];
+    simPadReference(up_sim, mag_sim);
+
+    bool used_mag = false;
+    const bool ok = sim_pad_align::solvePadAlignment(
+        up_sim, mag_sim, up_rocket, mag_rocket, pad_align_, &used_mag);
+
+    if (!ok)
+    {
+        pad_align_identity_ = true;
+        ESP_LOGW("SIM", "pad align: measured gravity unusable — sim starts "
+                        "UNALIGNED (expect a gyro-bias excursion, #508)");
+        return;
+    }
+
+    pad_align_identity_ = false;
+    ESP_LOGI("SIM", "pad align: %.1f deg (%s) — sim frame carried onto the "
+                    "board's resting attitude; no handover step",
+             (double)padAlignmentAngleDeg(),
+             used_mag ? "gravity+field" : "gravity only");
+}
+
+float SensorCollectorSim::padAlignmentAngleDeg() const
+{
+    if (pad_align_identity_) return 0.0f;
+    return sim_pad_align::rotationAngleDeg(pad_align_);
+}
+
 void SensorCollectorSim::startSim(float ground_pressure_pa)
 {
     if (!configured_)
@@ -162,6 +200,10 @@ void SensorCollectorSim::startSim(float ground_pressure_pa)
 void SensorCollectorSim::stopSim()
 {
     phase_ = SIM_IDLE;
+    // Drop the pad alignment: it belongs to the attitude the board was resting
+    // at for THAT run, and a stale one would skew the next sim start.
+    pad_align_identity_ = true;
+    for (int i = 0; i < 9; ++i) pad_align_[i] = (i % 4 == 0) ? 1.0f : 0.0f;
     Serial.println("[SIM] Stopped");
 }
 
@@ -464,6 +506,11 @@ void SensorCollectorSim::encodeISM6(uint32_t time_us, ISM6HG256Data& out)
     float body_ay = 0.0f;
     float body_az = sf_vert * cp;  // perpendicular
 
+    // Carry the sim's pad frame onto the board's actual resting attitude (#508)
+    // so the real→sim handover has no gravity/attitude step.  Identity unless a
+    // pad alignment was solved.
+    applyPadAlign(body_ax, body_ay, body_az);
+
     // Rocket frame → board frame (inverse of the mounting orientation;
     // identity for the standard +X-nose mounting).
     rocketToBoard(body_ax, body_ay, body_az);
@@ -495,6 +542,10 @@ void SensorCollectorSim::encodeISM6(uint32_t time_us, ISM6HG256Data& out)
     float gyro_body_x_dps = 0.0f;
     float gyro_body_y_dps = pitch_rate_rps_ * (180.0f / 3.14159265f);
     float gyro_body_z_dps = 0.0f;
+    // Same rigid rotation as the accel: the body rates must be expressed in the
+    // same re-oriented frame or the attitude the EKF integrates won't match the
+    // gravity vector it sees (#508).
+    applyPadAlign(gyro_body_x_dps, gyro_body_y_dps, gyro_body_z_dps);
     rocketToBoard(gyro_body_x_dps, gyro_body_y_dps, gyro_body_z_dps);
 
     const float sensor_gx =  gyro_body_x_dps * ism6_inv_c_ + gyro_body_y_dps * ism6_inv_s_;
@@ -529,9 +580,6 @@ void SensorCollectorSim::encodeMMC5983MA(uint32_t time_us, MMC5983MAData& out)
     //   body_x =  North * sin(pitch) + Down * cos(pitch)
     //   body_y =  East
     //   body_z = -North * cos(pitch) + Down * sin(pitch)
-    static constexpr float B_NORTH = 22.0f;   // µT
-    static constexpr float B_EAST  =  5.0f;
-    static constexpr float B_DOWN  = 42.0f;
     static constexpr float COUNTS_PER_UT = 131072.0f / 800.0f;
 
     const float sp = sinf(pitch_rad_);
@@ -539,6 +587,10 @@ void SensorCollectorSim::encodeMMC5983MA(uint32_t time_us, MMC5983MAData& out)
     float body_x =  B_NORTH * sp + B_DOWN * cp;
     float body_y =  B_EAST;
     float body_z = -B_NORTH * cp + B_DOWN * sp;
+
+    // Pad-frame alignment (#508) — keeps the field continuous across the
+    // real→sim handover, so no heading step winds the gyro bias either.
+    applyPadAlign(body_x, body_y, body_z);
 
     // Rocket frame → board frame (inverse mounting orientation), matching
     // the forward board→rocket rotation the converter now applies to mag.
@@ -555,9 +607,6 @@ void SensorCollectorSim::encodeIIS2MDC(uint32_t time_us, IIS2MDCData& out)
     out.time_us = time_us;
 
     // Same Earth field + pitch-plane rotation as encodeMMC5983MA (#463).
-    static constexpr float B_NORTH = 22.0f;   // µT
-    static constexpr float B_EAST  =  5.0f;
-    static constexpr float B_DOWN  = 42.0f;
     static constexpr float COUNTS_PER_UT = 1.0f / 0.15f;   // datasheet 0.15 µT/LSB
 
     const float sp = sinf(pitch_rad_);
@@ -565,6 +614,9 @@ void SensorCollectorSim::encodeIIS2MDC(uint32_t time_us, IIS2MDCData& out)
     float body_x =  B_NORTH * sp + B_DOWN * cp;
     float body_y =  B_EAST;
     float body_z = -B_NORTH * cp + B_DOWN * sp;
+
+    // Pad-frame alignment (#508) — see encodeISM6.
+    applyPadAlign(body_x, body_y, body_z);
 
     // Rocket frame → board frame (inverse mounting), then board → sensor
     // frame (inverse of the converter's sensor→board +Z rotation), so the

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.h
@@ -66,6 +66,36 @@ public:
     // forward conversion (chip rotZ, then board→rocket) reproduces the
     // simulated values regardless of the configured mounting.
     void configureSimBoardToRocket(const float R[9]);
+
+    // Pad-frame alignment (#508). The sim's physics assume the rocket stands on
+    // the rail (pitch = LAUNCH_ANGLE_RAD), but on a bench the board is usually
+    // lying flat — so at the instant sim data replaces real data the rocket-frame
+    // gravity vector jumps by ~90°. The EKF has accel/mag updates live on the pad
+    // and can only explain a large attitude correction with no measured rate by
+    // blaming the gyro bias, which then slams to a physically impossible value and
+    // is frozen in at launch (accel/mag are gated off in flight) — wrecking
+    // attitude for the whole run.
+    //
+    // Fix the discontinuity at the source: pass the board's ACTUAL resting
+    // attitude (rocket-frame "up" from the orientation estimator, plus the
+    // rocket-frame mag) and we solve for the fixed rotation that carries the
+    // sim's pad attitude onto it. Every synthetic body-frame vector (accel, gyro,
+    // mag) is then rotated by it, so the handover is continuous by construction.
+    //
+    // Rotating the body-frame vectors AND the implied attitude by the same R
+    // leaves world-frame acceleration unchanged, so GNSS/baro need no adjustment
+    // — the simulated trajectory is identical, only the body frame is re-expressed.
+    //
+    // `up_rocket` is the unit specific-force ("up") direction in rocket frame.
+    // `mag_rocket` is the rocket-frame field in µT; pass nullptr (or a
+    // non-physical magnitude) to align on gravity alone.
+    void configureSimPadAlignment(const float up_rocket[3], const float mag_rocket[3]);
+
+    // True once a pad alignment has been solved (diagnostics / tests).
+    bool  hasPadAlignment() const { return !pad_align_identity_; }
+    // Angle of the pad-alignment rotation, degrees (0 when identity).
+    float padAlignmentAngleDeg() const;
+
     void startSim(float ground_pressure_pa);
     void stopSim();
     bool isSimActive() const;
@@ -131,6 +161,28 @@ private:
         x = bx; y = by; z = bz;
     }
 
+    // Pad-frame alignment (#508), applied to every synthetic ROCKET-frame vector
+    // before rocketToBoard(). Identity until configureSimPadAlignment() runs, so
+    // an un-aligned sim behaves exactly as before.
+    float pad_align_[9] = {1.0f, 0.0f, 0.0f,
+                           0.0f, 1.0f, 0.0f,
+                           0.0f, 0.0f, 1.0f};
+    bool  pad_align_identity_ = true;
+
+    inline void applyPadAlign(float &x, float &y, float &z) const
+    {
+        if (pad_align_identity_) return;
+        const float rx = pad_align_[0] * x + pad_align_[1] * y + pad_align_[2] * z;
+        const float ry = pad_align_[3] * x + pad_align_[4] * y + pad_align_[5] * z;
+        const float rz = pad_align_[6] * x + pad_align_[7] * y + pad_align_[8] * z;
+        x = rx; y = ry; z = rz;
+    }
+
+    // The sim's own pad-attitude reference vectors in rocket frame, at
+    // pitch = LAUNCH_ANGLE_RAD. These are what configureSimPadAlignment maps
+    // ONTO the measured pad vectors.
+    void simPadReference(float up_out[3], float mag_out[3]) const;
+
     // GNSS fallback timer (for indoor testing without GPS fix)
     uint32_t last_gnss_real_us_ = 0;
     uint32_t gnss_timer_us_     = 0;
@@ -144,6 +196,13 @@ private:
     static constexpr float CD             = 0.5f;
     static constexpr float REFERENCE_AREA = 0.0019635f; // pi * 0.025^2 (50mm dia)
     static constexpr float PRELAUNCH_DURATION_MS = 5000.0f;
+
+    // Synthetic Earth field at ~38N (NED, µT). Shared by both mag encoders and
+    // by simPadReference() so the alignment reference cannot drift from what the
+    // encoders actually emit.
+    static constexpr float B_NORTH = 22.0f;
+    static constexpr float B_EAST  =  5.0f;
+    static constexpr float B_DOWN  = 42.0f;
 
     // Attitude dynamics defaults (typical model rocket)
     static constexpr float LAUNCH_ANGLE_RAD = 85.0f * 3.14159265f / 180.0f;  // 5° from vertical

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -6402,6 +6402,36 @@ static void loop_fc()
                 const bool converged = att_var < config::EKF_ATT_VAR_OK &&
                                        vel_var < config::EKF_VEL_VAR_OK;
                 ekf_st = (ekf.isHealthy() && converged) ? SH_OK : SH_DEGRADED;
+
+                // #508: the gyro bias is FROZEN IN at launch — accel/mag updates
+                // are gated off for the whole flight, so whatever it holds when we
+                // leave the pad integrates into attitude at that rate for the
+                // entire ascent (5 dps → 5°/s → ~50° by apogee on a 10 s climb),
+                // and guidance keys off attitude.  Two independent no-go signals:
+                //
+                //   1. the estimate itself is out of spec / the bound had to bite
+                //      (gyroBiasHealthy: |bias| ≤ 3 dps, sigma sane, 0 clips), or
+                //   2. the observability gate is TRIPPING on the pad — meaning the
+                //      filter is being fed accel/mag data inconsistent with its own
+                //      state (bad mounting, a steel rail deflecting the mag, a stale
+                //      hard-iron cal).  The bias may have survived intact, but the
+                //      setup is wrong and you want to know BEFORE it gets frozen.
+                //
+                // Amber rather than red: it degrades attitude/guidance, it does not
+                // by itself endanger recovery.
+                static uint32_t last_gbias_trips   = 0;
+                static uint32_t gbias_trip_seen_ms = 0;
+                const uint32_t trips_now = ekf.gyroBiasGateTrips();
+                if (trips_now != last_gbias_trips) {
+                    last_gbias_trips   = trips_now;
+                    gbias_trip_seen_ms = now_ms;
+                }
+                const bool gbias_tripping_recently =
+                    gbias_trip_seen_ms != 0 && (now_ms - gbias_trip_seen_ms) < 5000U;
+
+                if ((!ekf.gyroBiasHealthy() || gbias_tripping_recently) && ekf_st == SH_OK) {
+                    ekf_st = SH_DEGRADED;
+                }
             }
             sh = shSet(sh, SH_EKF_SHIFT, ekf_st);
 
@@ -6653,13 +6683,22 @@ static void loop_fc()
                           (double)pitch_deg,
                           (double)yaw_deg,
                           (double)cos2p);
-            ESP_LOGI(TAG, "[EKF DIAG] mag[%s]=%.1fuT(%s) gyro_bias=[%.3f,%.3f,%.3f]dps",
+            // #508: trips/clips make a laundered bias visible on the console — a
+            // healthy pad shows 0/0. Non-zero trips mean accel/mag data
+            // inconsistent with the filter's state is arriving; clips mean the
+            // physical bound had to bite, which should never happen in the field.
+            ESP_LOGI(TAG, "[EKF DIAG] mag[%s]=%.1fuT(%s) gyro_bias=[%.3f,%.3f,%.3f]dps "
+                          "(sig=%.2f trips=%u clips=%u %s)",
                           mag_src,
                           (double)mag_uT,
                           mag_status,
                           (double)(gb[0] * 180.0f / (float)M_PI),
                           (double)(gb[1] * 180.0f / (float)M_PI),
-                          (double)(gb[2] * 180.0f / (float)M_PI));
+                          (double)(gb[2] * 180.0f / (float)M_PI),
+                          (double)ekf.gyroBiasSigmaMaxDps(),
+                          (unsigned)ekf.gyroBiasGateTrips(),
+                          (unsigned)ekf.gyroBiasClipCount(),
+                          ekf.gyroBiasHealthy() ? "OK" : "NO-GO");
         }
     }
 

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1475,8 +1475,19 @@ static constexpr float ORIENT_ACCEPT_TOL_DEG = 5.0f;
 
 // One completed pad-gravity window: decide whether the active board→rocket
 // rotation still matches how the rocket is actually sitting on the rail.
+// Latest filtered pad "up" (specific-force) direction in ROCKET frame, from the
+// orientation estimator. Cached so the sim can align its pad frame to how the
+// board is ACTUALLY resting when a sim run starts (#508).
+static float pad_up_rocket[3]   = {0.0f, 0.0f, 0.0f};
+static bool  pad_up_rocket_valid = false;
+
 static void handleOrientationEstimate(const float up_rocket[3])
 {
+    pad_up_rocket[0] = up_rocket[0];
+    pad_up_rocket[1] = up_rocket[1];
+    pad_up_rocket[2] = up_rocket[2];
+    pad_up_rocket_valid = true;
+
     float cx = up_rocket[0];
     if (cx > 1.0f) cx = 1.0f;
     if (cx < -1.0f) cx = -1.0f;
@@ -4340,6 +4351,29 @@ static void loop_fc()
                     sensor_collector.configureSim(defaults);
                     ESP_LOGW(TAG, "[SIM] No config received, using defaults");
                 }
+                // #508: carry the sim's pad frame onto the board's ACTUAL resting
+                // attitude before the first synthetic sample. Without this, a
+                // bench board lying flat makes rocket-frame gravity jump ~90° the
+                // instant sim data replaces real data; the EKF (accel/mag updates
+                // still live on the pad) can only explain that step by blaming the
+                // gyro bias, which slams to ~-190 dps and is then frozen in at
+                // launch — wrecking attitude for the whole flight.
+                if (pad_up_rocket_valid)
+                {
+                    const float mag_rocket[3] = {
+                        (float)iis2mdc_latest_si.mag_x_uT,
+                        (float)iis2mdc_latest_si.mag_y_uT,
+                        (float)iis2mdc_latest_si.mag_z_uT };
+                    sensor_collector.configureSimPadAlignment(
+                        pad_up_rocket, have_iis2mdc_si ? mag_rocket : nullptr);
+                }
+                else
+                {
+                    ESP_LOGW(TAG, "[SIM] no pad orientation estimate yet — starting "
+                                  "UNALIGNED; expect a gyro-bias excursion if the "
+                                  "board isn't nose-up (#508)");
+                }
+
                 sensor_collector.startSim(ground_pressure_pa);
                 ESP_LOGI(TAG, "[SIM] Start cmd received, sim active=%s ground_p=%.0f",
                               sensor_collector.isSimActive() ? "YES" : "NO",


### PR DESCRIPTION
Closes #508.

Two independent fixes. The first removes the sim discontinuity that exposed the problem; the second addresses the real-flight defect it revealed, which stands on its own merits.

## 1. Align the sim's pad frame to the board's resting attitude

`startSim()` hard-set `pitch_rad_ = LAUNCH_ANGLE_RAD` (85°) — it assumed the rocket was standing on the rail regardless of how the board was actually resting. On a bench the board lies flat, so rocket-frame gravity jumped ~81° the instant synthetic data replaced real data (the `[ORIENT] pad gravity 86.1° off nose` warning was already telling us this — 86.1° off the nose minus the 5° rail angle).

Now we solve (TRIAD) the fixed rotation carrying the sim's assumed pad attitude onto the board's ACTUAL resting attitude — measured pad gravity from the orientation estimator plus the rocket-frame field — and rotate every synthetic body-frame vector (accel, gyro, mag) by it. The handover then has no step at all.

Two properties make this safe rather than a hack:

- **GNSS/baro need no change.** Rotating the body vectors AND the implied attitude by the same `R` leaves world-frame acceleration invariant (`R_wb(q·Rᵀ)·(R·a) == R_wb(q)·a`), so the simulated trajectory is identical — only the body frame is re-expressed.
- **TRIAD makes exactly the two quantities the EKF consumes exact**: gravity (which the accel update levels against) and the field's projection perpendicular to gravity (all a *heading-only* mag update looks at). Both see a zero step. The residual is confined to magnetic dip — the sim's canonical field vs the bench's real one — which a heading-only update never reads.

The solve is extracted into `SimPadAlign.h` as pure, dependency-free math so it is host-testable. Degrades safely: no/dead/saturated mag → gravity-only alignment; degenerate gravity → identity no-op. Identity when the board is already on the rail, so a correctly-oriented run is unchanged.

**10 host tests**: gravity step 81° → 0.0000°, heading step → 0.0000°, residual proven dip-only, identity on the rail, all fallbacks, and `R` proven orthonormal with det +1.

## 2. Stop laundering bad measurements into the gyro bias

This is the real-flight half, and it is **not** sim-specific.

- **Asymmetry.** The GNSS update has been NIS-gated since #174. `accelMeasUpdate` and `magMeasUpdate` — the ONLY updates that touch attitude, and the only path through which gyro bias is observable — had **no consistency test at all**. Any innovation, however absurd, was accepted at full Kalman gain.
- **The bias is reached via cross-covariance.** accel's `H` doesn't even name columns 12-14, but `K = P·Hᵀ·S⁻¹` is 15xN, so the correction reaches gyro bias through the attitude↔bias cross-covariance. That coupling is what makes bias observable at all — and it was an unbounded path for garbage.
- **`wBias_rps_` had no bound**, and `initCore` seeds it from the raw gyro reading ("assume stationary"), so initialising while the vehicle is handled bakes that rate straight in.

A real pad supplies exactly these inconsistencies with no sim involved: a steel rail deflecting the magnetometer, wind sway or a bump, a stale hard-iron cal, a mis-set mounting orientation. Then **launch gates accel/mag off**, so whatever the bias holds is frozen in and integrates into attitude for the entire climb — 5 dps → 5°/s → ~50° by apogee — and guidance keys off attitude.

### Fix: gate the COUPLING, not the measurement

Rejecting a large innovation would break legitimate re-orientation on the rail. Instead, on a high-NIS sample we zero **only rows 12-14 of K**. Attitude and accel bias still correct in full. This is sound because **Joseph form is valid for ANY gain**, not just the optimal one — so `P` stays consistent and PSD; and with those rows zeroed the bias covariance is *not* reduced, so the filter correctly keeps reporting the bias as un-learned.

- NIS thresholds are chi2 99.9% for the DOF (16.27 vec / 10.83 scalar) — textbook, not tuned.
- **The gate latches (2 s).** Cutting only while NIS is high was not enough: as attitude slews toward a genuinely new gravity vector the innovation drops back under the gate and the filter absorbs the remaining "attitude moved but the gyro said nothing" into the bias — the very laundering we are stopping. Latching holds it cut through the whole slew: residual **2.5 → 0.12 dps**.
- **Scoped to attitude-bearing updates only** (accel + the three heading updates). Baro measures altitude; a large baro innovation in a climb is the filter lagging, not a bad measurement.
- **Hard physical bound** on `wBias_rps_` (±10 dps, ~5-10x the ISM6 spec) at every correction site and at init. A backstop — no estimate outside a real gyro's envelope is a bias, whatever produced it.
- **Pre-launch scorecard** (`SH_EKF`) goes amber when the bias is out of spec / clipped, OR when the gate is tripping on the pad (the setup is wrong even if the bias survived). `[EKF DIAG]` now prints `sig/trips/clips` + `OK|NO-GO`.

## Verification

- **Synthetic pad disturbance** (the 81° step): gyro bias **-190 dps → 0.122 dps**.
- **A genuine 8 dps gyro bias is still learned exactly**, zero gate trips, and reported out-of-spec. The gate does not blind the filter to real biases.
- **4 real flights replayed** through the shared `TR_GpsInsEKF.cpp`, honouring the firmware's in-flight AHRS gate: **2 bit-identical, 2 differing by <0.06 dps** bias / Δq ≈ 0.002. No regression — the gate simply does not fire on consistent data.
- **502/502 host tests pass**; FC builds clean on idf v6.0.

### One golden was re-baselined — please look

`BaroJosephGoldenTrajectory` (attitude + the gyro-bias covariance block). Re-baselining a golden is how real regressions get buried, so this was verified to be an *improvement* before touching it: that fixture yaws the gyro at 3 dps while feeding a **constant** magnetometer, so it is magnetically inconsistent and the gate correctly fires 18x. The fixture's true bias is zero, and the estimate **improved from 0.4985 → 0.3870 dps**. Position/velocity/accel-bias goldens are unchanged; only attitude and the bias covariance moved, both in the designed direction (zeroed K rows mean the bias covariance is correctly not reduced). Reasons are recorded in the test.

## Bench-pending

Not yet flashed. On a healthy pad the new diagnostic should read `trips=0 clips=0 OK`; a sim start should log `[SIM] pad align: N deg (gravity+field)` and the gyro bias should stay near zero instead of hitting -190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
