### PR TITLE
BS bench fixes (#507): NVS init, uplink FIFO + TX window, SoC fallback, BLE command ring, conn params, dup-packet race

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -362,6 +362,18 @@ target_include_directories(test_bs_uplink_queue PRIVATE
 target_link_libraries(test_bs_uplink_queue GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_queue)
 
+# ---------- test_bs_battery_soc ----------
+# Host-side test for the base-station voltage-based SoC fallback (#501): the
+# BQ27Z746 reported 0% on a 4.17 V pack because its coulomb counter was never
+# calibrated. bs_battery_soc.h is pure, so the test just adds base_station/main.
+add_executable(test_bs_battery_soc test_bs_battery_soc.cpp)
+target_include_directories(test_bs_battery_soc PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_battery_soc GTest::gtest_main)
+gtest_discover_tests(test_bs_battery_soc)
+
 # ---------- test_ble_command_ring ----------
 # Host-side test for the shared BLE command intake ring (#517): the intake was a
 # single latch, so a back-to-back command burst (the app's ~13-command connect

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -362,6 +362,19 @@ target_include_directories(test_bs_uplink_queue PRIVATE
 target_link_libraries(test_bs_uplink_queue GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_queue)
 
+# ---------- test_bs_uplink_txwin ----------
+# Host-side test for the base-station uplink TX-window policy (#506): the radio is
+# half-duplex, and a downlink packet (~82 ms on air) cannot fit in the ~49 ms gap
+# between blind retries — so a burst lost essentially every packet that arrived
+# during it. bs_uplink_txwin.h is pure, so the test just adds base_station/main.
+add_executable(test_bs_uplink_txwin test_bs_uplink_txwin.cpp)
+target_include_directories(test_bs_uplink_txwin PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_uplink_txwin GTest::gtest_main)
+gtest_discover_tests(test_bs_uplink_txwin)
+
 # ---------- test_bs_battery_soc ----------
 # Host-side test for the base-station voltage-based SoC fallback (#501): the
 # BQ27Z746 reported 0% on a 4.17 V pack because its coulomb counter was never

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -349,6 +349,19 @@ target_include_directories(test_bs_uplink_policy PRIVATE
 target_link_libraries(test_bs_uplink_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_policy)
 
+# ---------- test_bs_uplink_queue ----------
+# Host-side test for the base-station uplink command FIFO (#502): the uplink was
+# a single slot, so a new command discarded the pending one's remaining retries —
+# and the uplink is blind, so those retries ARE the delivery mechanism.
+# bs_uplink_queue.h is pure, so the test just adds the base_station/main dir.
+add_executable(test_bs_uplink_queue test_bs_uplink_queue.cpp)
+target_include_directories(test_bs_uplink_queue PRIVATE
+    ${SHIM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+)
+target_link_libraries(test_bs_uplink_queue GTest::gtest_main)
+gtest_discover_tests(test_bs_uplink_queue)
+
 # ---------- test_bs_download_policy ----------
 # Host-side test for the base-station cooperative BLE download (#380): chunk
 # planning bounded by open-time file size + the 15 ms notify-drain pacing gate.

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -349,6 +349,20 @@ target_include_directories(test_bs_uplink_policy PRIVATE
 target_link_libraries(test_bs_uplink_policy GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_policy)
 
+# ---------- test_ble_command_ring ----------
+# Host-side test for the shared BLE command intake ring (#517): the intake was a
+# single latch, so a back-to-back command burst (the app's ~13-command connect
+# sync, #366) collapsed to whichever command arrived last. BleCommandRing.h is
+# pure — TR_BLE_To_APP owns the NimBLE locking around it — so the test just adds
+# the component dir.
+add_executable(test_ble_command_ring test_ble_command_ring.cpp)
+target_include_directories(test_ble_command_ring PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_BLE_To_APP
+)
+target_link_libraries(test_ble_command_ring GTest::gtest_main)
+gtest_discover_tests(test_ble_command_ring)
+
 # ---------- test_bs_download_policy ----------
 # Host-side test for the base-station cooperative BLE download (#380): chunk
 # planning bounded by open-time file size + the 15 ms notify-drain pacing gate.

--- a/tests_cpp/test_ble_command_ring.cpp
+++ b/tests_cpp/test_ble_command_ring.cpp
@@ -1,0 +1,259 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include "BleCommandRing.h"
+
+using tr_ble::CommandRing;
+using tr_ble::PendingCommand;
+
+// The #517 fix: BLE command intake was a SINGLE latch. The NimBLE write callback
+// overwrote it unconditionally and the loop task drained it once per iteration,
+// so two commands arriving between two polls lost the first outright. The app's
+// connect-time sync fires ~13 commands back-to-back with no pacing (#366), and
+// any loop stall longer than their ~60-90 ms spacing dropped one.
+//
+// These tests pin the ring that replaces it: commands are delivered in order,
+// each keeps the payload/filename/page that arrived with it, and a full ring
+// drops the newest rather than rotating out older commands the app is waiting on.
+
+namespace {
+
+// Command ids, from onCommandWrite's dispatch chain.
+constexpr uint8_t CMD_FILE_LIST = 2;
+constexpr uint8_t CMD_DELETE    = 3;
+constexpr uint8_t CMD_DOWNLOAD  = 4;
+constexpr uint8_t CMD_SIM_CFG   = 5;
+constexpr uint8_t CMD_SIM_START = 6;
+
+PendingCommand plain(uint8_t cmd) {
+    PendingCommand e;
+    e.cmd = cmd;
+    return e;
+}
+
+PendingCommand withPayload(uint8_t cmd, const uint8_t* p, size_t n) {
+    PendingCommand e;
+    e.cmd = cmd;
+    memcpy(e.payload, p, n);
+    e.payload_len = n;
+    return e;
+}
+
+PendingCommand withDelete(const char* name) {
+    PendingCommand e;
+    e.cmd = CMD_DELETE;
+    snprintf(e.delete_name, sizeof(e.delete_name), "%s", name);
+    return e;
+}
+
+PendingCommand withDownload(const char* name) {
+    PendingCommand e;
+    e.cmd = CMD_DOWNLOAD;
+    snprintf(e.download_name, sizeof(e.download_name), "%s", name);
+    return e;
+}
+
+}  // namespace
+
+// ---- The regression: a second command must not evict the first ----
+
+// Before the fix, a sim-config (cmd 5) followed by a sim-start (cmd 6) before
+// the loop polled left ONLY cmd 6 — the rocket then flew with stale config.
+TEST(BleCommandRing, SecondCommandDoesNotEvictTheFirst) {
+    CommandRing ring;
+    const uint8_t cfg[12] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+    ASSERT_TRUE(ring.push(withPayload(CMD_SIM_CFG, cfg, sizeof(cfg))));
+    ASSERT_TRUE(ring.push(plain(CMD_SIM_START)));
+    EXPECT_EQ(ring.size(), 2u);
+
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_SIM_CFG) << "the config must survive the start that followed it";
+    EXPECT_EQ(out.payload_len, sizeof(cfg));
+    EXPECT_EQ(memcmp(out.payload, cfg, sizeof(cfg)), 0);
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_SIM_START);
+
+    EXPECT_TRUE(ring.empty());
+}
+
+// The #366 pattern: ActiveRocketSyncer fires ~13 config commands back-to-back
+// with no pacing. All of them must survive a loop that never polls in between.
+TEST(BleCommandRing, FullConnectTimeSyncBurstSurvivesAnUndrainedLoop) {
+    CommandRing ring;
+    constexpr int kBurst = 13;
+    for (int i = 0; i < kBurst; i++) {
+        ASSERT_TRUE(ring.push(plain((uint8_t)(20 + i)))) << "command " << i << " of the sync burst";
+    }
+    EXPECT_EQ(ring.size(), (size_t)kBurst);
+
+    for (int i = 0; i < kBurst; i++) {
+        PendingCommand out;
+        ASSERT_TRUE(ring.pop(out));
+        EXPECT_EQ(out.cmd, (uint8_t)(20 + i)) << "burst must drain in order";
+    }
+    EXPECT_TRUE(ring.empty());
+}
+
+// ---- Ordering / wrap ----
+
+TEST(BleCommandRing, DrainsInFifoOrder) {
+    CommandRing ring;
+    for (uint8_t c = 1; c <= 5; c++) ASSERT_TRUE(ring.push(plain(c)));
+
+    for (uint8_t expected = 1; expected <= 5; expected++) {
+        PendingCommand out;
+        ASSERT_TRUE(ring.pop(out));
+        EXPECT_EQ(out.cmd, expected);
+    }
+}
+
+TEST(BleCommandRing, RingWrapsWithoutLosingOrder) {
+    CommandRing ring;
+    for (int round = 0; round < 3; round++) {
+        for (size_t i = 0; i < tr_ble::kRingDepth; i++) {
+            ASSERT_TRUE(ring.push(plain((uint8_t)(i + 1))));
+        }
+        ASSERT_TRUE(ring.full());
+        for (size_t i = 0; i < tr_ble::kRingDepth; i++) {
+            PendingCommand out;
+            ASSERT_TRUE(ring.pop(out));
+            EXPECT_EQ(out.cmd, (uint8_t)(i + 1)) << "round " << round;
+        }
+        EXPECT_TRUE(ring.empty());
+    }
+}
+
+// ---- Full ring: drop the newest, keep what the app is waiting on ----
+
+TEST(BleCommandRing, FullRingRejectsNewestAndKeepsOlderCommands) {
+    CommandRing ring;
+    for (size_t i = 0; i < tr_ble::kRingDepth; i++) {
+        ASSERT_TRUE(ring.push(plain((uint8_t)(i + 1))));
+    }
+    ASSERT_TRUE(ring.full());
+
+    EXPECT_FALSE(ring.push(plain(99)));
+
+    // The rejection must not have displaced anything.
+    EXPECT_EQ(ring.size(), tr_ble::kRingDepth);
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, 1) << "the oldest command must still be first in line";
+}
+
+// ---- Each command keeps the data that arrived with it ----
+
+// The single latch shared one filename buffer across commands, so a delete name
+// could still be live when an unrelated command was consumed. The OC reads
+// getDownloadFilename() on EVERY command, so a leaked name would kick off a
+// spurious multi-second file transfer.
+TEST(BleCommandRing, DeleteAndDownloadNamesDoNotLeakAcrossCommands) {
+    CommandRing ring;
+    ASSERT_TRUE(ring.push(withDelete("old_flight.bin")));
+    ASSERT_TRUE(ring.push(plain(CMD_SIM_START)));
+    ASSERT_TRUE(ring.push(withDownload("flight_42.bin")));
+
+    PendingCommand out;
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_DELETE);
+    EXPECT_STREQ(out.delete_name, "old_flight.bin");
+    EXPECT_STREQ(out.download_name, "") << "a delete must not carry a download target";
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_SIM_START);
+    EXPECT_STREQ(out.delete_name, "") << "the delete name must not leak onto the next command";
+    EXPECT_STREQ(out.download_name, "");
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_DOWNLOAD);
+    EXPECT_STREQ(out.download_name, "flight_42.bin");
+    EXPECT_STREQ(out.delete_name, "");
+}
+
+TEST(BleCommandRing, PayloadsDoNotLeakAcrossCommands) {
+    CommandRing ring;
+    const uint8_t cfg[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+    ASSERT_TRUE(ring.push(withPayload(CMD_SIM_CFG, cfg, sizeof(cfg))));
+    ASSERT_TRUE(ring.push(plain(CMD_SIM_START)));   // carries no payload
+
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.payload_len, 4u);
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.cmd, CMD_SIM_START);
+    EXPECT_EQ(out.payload_len, 0u) << "sim-start must not inherit the config's payload";
+}
+
+TEST(BleCommandRing, FileListPageTravelsWithItsCommand) {
+    CommandRing ring;
+    PendingCommand e = plain(CMD_FILE_LIST);
+    e.file_list_page = 3;
+    ASSERT_TRUE(ring.push(e));
+    ASSERT_TRUE(ring.push(plain(CMD_SIM_START)));
+
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.file_list_page, 3);
+
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.file_list_page, 0) << "page must not leak onto the next command";
+}
+
+// A reused slot must not resurrect the previous occupant's data.
+TEST(BleCommandRing, ReusedSlotDoesNotResurrectStaleData) {
+    CommandRing ring;
+    ASSERT_TRUE(ring.push(withDownload("stale.bin")));
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    ASSERT_STREQ(out.download_name, "stale.bin");
+
+    // Fill and drain enough to come back around to that same slot.
+    for (size_t i = 0; i < tr_ble::kRingDepth; i++) {
+        ASSERT_TRUE(ring.push(plain(CMD_SIM_START)));
+    }
+    for (size_t i = 0; i < tr_ble::kRingDepth; i++) {
+        ASSERT_TRUE(ring.pop(out));
+        EXPECT_EQ(out.cmd, CMD_SIM_START);
+        EXPECT_STREQ(out.download_name, "") << "slot " << i << " resurrected a stale filename";
+        EXPECT_EQ(out.payload_len, 0u);
+    }
+}
+
+// Max-length payload (RollProfileData is the largest at 76 B) round-trips intact.
+TEST(BleCommandRing, MaxPayloadRoundTripsIntact) {
+    CommandRing ring;
+    uint8_t big[tr_ble::kMaxPayload];
+    for (size_t i = 0; i < sizeof(big); i++) big[i] = (uint8_t)(i * 7 + 1);
+
+    ASSERT_TRUE(ring.push(withPayload(66, big, sizeof(big))));
+    PendingCommand out;
+    ASSERT_TRUE(ring.pop(out));
+    EXPECT_EQ(out.payload_len, tr_ble::kMaxPayload);
+    EXPECT_EQ(memcmp(out.payload, big, sizeof(big)), 0);
+}
+
+// ---- Empty-ring safety ----
+
+TEST(BleCommandRing, PopOnEmptyReturnsFalseAndLeavesOutputUntouched) {
+    CommandRing ring;
+    PendingCommand out = plain(0x7E);   // sentinel
+
+    EXPECT_FALSE(ring.pop(out));
+    EXPECT_EQ(out.cmd, 0x7E) << "pop() must not clobber the caller's buffer when empty";
+    EXPECT_TRUE(ring.empty());
+    EXPECT_EQ(ring.size(), 0u);
+}
+
+TEST(BleCommandRing, StartsEmpty) {
+    CommandRing ring;
+    EXPECT_TRUE(ring.empty());
+    EXPECT_FALSE(ring.full());
+    EXPECT_EQ(ring.size(), 0u);
+}

--- a/tests_cpp/test_bs_battery_soc.cpp
+++ b/tests_cpp/test_bs_battery_soc.cpp
@@ -1,0 +1,181 @@
+#include <gtest/gtest.h>
+
+#include "bs_battery_soc.h"
+
+using namespace bs_battery_soc;
+
+// The #501 fix: the BQ27Z746 reported 0% SoC with the pack at 4.17 V and
+// accepting 449 mA (RemainingCapacity=0, FullChargeCapacity=27932 mAh vs a
+// 2800 mAh design). Impedance Track derives RM/FCC/SoC by integrating current,
+// and this part's CC Gain was never calibrated (GAUGE_EN also ships at 0), so
+// all three are garbage while Voltage() — a direct ADC read — stays correct.
+//
+// These tests pin the voltage-based fallback and, just as importantly, the
+// plausibility check that decides when NOT to believe the gauge.
+
+namespace {
+constexpr float kDesignMah = 2800.0f;
+constexpr int   k1S = 1;
+}  // namespace
+
+// ---- The plausibility gate ----
+
+// Exactly the bench reading that opened #501. This must be rejected.
+TEST(BsBatterySoc, TheBenchGaugeReadingIsRejected) {
+    EXPECT_FALSE(gaugeSocPlausible(/*gauge_en=*/false, /*soc=*/0.0f, /*fcc=*/27932.0f,
+                                   kDesignMah, /*pack_v=*/4.172f, k1S));
+}
+
+TEST(BsBatterySoc, GaugingDisabledIsNeverPlausible) {
+    // Even a perfectly reasonable-looking SoC is meaningless if Impedance Track
+    // never ran — nothing integrated the current that produced it.
+    EXPECT_FALSE(gaugeSocPlausible(/*gauge_en=*/false, /*soc=*/75.0f, /*fcc=*/2800.0f,
+                                   kDesignMah, /*pack_v=*/3.95f, k1S));
+}
+
+TEST(BsBatterySoc, WildFullChargeCapacityIsRejected) {
+    // FCC ~10x design — the smoking gun for an uncalibrated coulomb counter.
+    EXPECT_FALSE(gaugeSocPlausible(true, 50.0f, 27932.0f, kDesignMah, 3.71f, k1S));
+    // ...and the other direction (a badly under-learned pack).
+    EXPECT_FALSE(gaugeSocPlausible(true, 50.0f, 800.0f, kDesignMah, 3.71f, k1S));
+}
+
+TEST(BsBatterySoc, ZeroSocOnAFullCellIsRejected) {
+    // 0% at 4.17 V is physically impossible; don't pass it to the app.
+    EXPECT_FALSE(gaugeSocPlausible(true, 0.0f, 2800.0f, kDesignMah, 4.17f, k1S));
+}
+
+TEST(BsBatterySoc, ZeroSocOnAGenuinelyEmptyCellIsAccepted) {
+    // The mirror case: 0% at 3.2 V is real, and must NOT be second-guessed.
+    EXPECT_TRUE(gaugeSocPlausible(true, 0.0f, 2800.0f, kDesignMah, 3.2f, k1S));
+}
+
+TEST(BsBatterySoc, OutOfRangeSocIsRejected) {
+    EXPECT_FALSE(gaugeSocPlausible(true, -1.0f, 2800.0f, kDesignMah, 3.8f, k1S));
+    EXPECT_FALSE(gaugeSocPlausible(true, 101.0f, 2800.0f, kDesignMah, 3.8f, k1S));
+}
+
+TEST(BsBatterySoc, AHealthyLearnedGaugeIsBelieved) {
+    // The whole point of the gate: a working coulomb counter still wins.
+    EXPECT_TRUE(gaugeSocPlausible(true, 72.0f, 2750.0f, kDesignMah, 3.90f, k1S));
+}
+
+// ---- The OCV curve ----
+
+TEST(BsBatterySoc, CurveEndpointsAndClamping) {
+    EXPECT_FLOAT_EQ(socFromCellOcv(4.20f), 100.0f);
+    EXPECT_FLOAT_EQ(socFromCellOcv(3.00f), 0.0f);
+    // Clamped, not extrapolated.
+    EXPECT_FLOAT_EQ(socFromCellOcv(4.35f), 100.0f);
+    EXPECT_FLOAT_EQ(socFromCellOcv(2.50f), 0.0f);
+}
+
+TEST(BsBatterySoc, CurveIsMonotonicNonDecreasing) {
+    float prev = -1.0f;
+    for (float v = 2.9f; v <= 4.3f; v += 0.005f) {
+        const float s = socFromCellOcv(v);
+        EXPECT_GE(s, prev) << "SoC must never fall as voltage rises (v=" << v << ")";
+        EXPECT_GE(s, 0.0f);
+        EXPECT_LE(s, 100.0f);
+        prev = s;
+    }
+}
+
+TEST(BsBatterySoc, InterpolatesBetweenTablePoints) {
+    // Midway between {3.71, 50} and {3.75, 55} -> ~52.5%.
+    EXPECT_NEAR(socFromCellOcv(3.73f), 52.5f, 0.2f);
+}
+
+// The pack that started all this: 4.17 V is nearly full, and must NOT read 0%.
+TEST(BsBatterySoc, TheBenchVoltageReadsNearlyFull) {
+    const float soc = socFromCellOcv(4.172f);
+    EXPECT_GT(soc, 90.0f) << "4.17 V is a nearly full cell — the gauge said 0%";
+    EXPECT_LE(soc, 100.0f);
+}
+
+// ---- IR compensation ----
+
+TEST(BsBatterySoc, IrCompensationIsDisabledAtZeroResistance) {
+    // The base station ships with r_int = 0 because the gauge's current is not
+    // trustworthy — compensating with it would add error, not remove it.
+    EXPECT_FLOAT_EQ(ocvFromTerminal(4.17f, /*current_ma=*/449.0f, /*r=*/0.0f), 4.17f);
+}
+
+TEST(BsBatterySoc, ChargingTerminalVoltageIsCorrectedDown) {
+    // +449 mA into 0.1 Ohm lifts the terminal ~45 mV above true OCV.
+    EXPECT_NEAR(ocvFromTerminal(4.17f, 449.0f, 0.1f), 4.1251f, 1e-3f);
+}
+
+TEST(BsBatterySoc, DischargingTerminalVoltageIsCorrectedUp) {
+    EXPECT_NEAR(ocvFromTerminal(3.70f, -500.0f, 0.1f), 3.75f, 1e-3f);
+}
+
+// ---- The filtered estimator ----
+
+TEST(BsBatterySoc, EstimatorSnapsToTheFirstSampleRatherThanRampingFromZero) {
+    Estimator est(0.1f);
+    EXPECT_FALSE(est.primed());
+
+    const float soc = est.update(4.172f, k1S);
+    EXPECT_TRUE(est.primed());
+    // Must not report a near-empty pack for the first ~10 polls while an EMA
+    // seeded at 0 V crawls upward.
+    EXPECT_GT(soc, 90.0f);
+}
+
+TEST(BsBatterySoc, EstimatorSmoothsATransientVoltageSag) {
+    Estimator est(0.1f);
+    est.update(3.80f, k1S);                 // settled
+    const float before = est.soc();
+
+    // One LoRa TX spike drags the rail down hard for a single sample.
+    const float during = est.update(3.55f, k1S);
+
+    // The estimate should move a little, not collapse to the sagged voltage.
+    const float sag_soc = socFromCellOcv(3.55f);
+    EXPECT_LT(during, before);
+    EXPECT_GT(during, sag_soc + 10.0f) << "one sag sample must not drag SoC to the sag value";
+}
+
+TEST(BsBatterySoc, EstimatorConvergesOnASustainedChange) {
+    Estimator est(0.5f);
+    est.update(4.20f, k1S);
+    for (int i = 0; i < 40; i++) est.update(3.70f, k1S);
+
+    EXPECT_NEAR(est.filteredCellV(), 3.70f, 0.01f);
+    EXPECT_NEAR(est.soc(), socFromCellOcv(3.70f), 1.0f);
+}
+
+TEST(BsBatterySoc, EstimatorTracksADischargeDownward) {
+    Estimator est(0.5f);
+    float prev = est.update(4.20f, k1S);
+    for (float v = 4.15f; v >= 3.40f; v -= 0.05f) {
+        float s = 0.0f;
+        for (int i = 0; i < 10; i++) s = est.update(v, k1S);   // let it settle
+        EXPECT_LE(s, prev + 0.01f) << "SoC must not rise while the pack drains (v=" << v << ")";
+        prev = s;
+    }
+    EXPECT_LT(prev, 30.0f) << "a pack at 3.4 V should read low, giving a usable warning";
+}
+
+TEST(BsBatterySoc, EstimatorHandlesMultiCellPacks) {
+    // A 2S pack at 8.34 V is two 4.17 V cells — the per-cell curve must be used.
+    Estimator est(1.0f);
+    const float soc = est.update(8.344f, /*cells=*/2);
+    EXPECT_NEAR(soc, socFromCellOcv(4.172f), 0.5f);
+}
+
+TEST(BsBatterySoc, EstimatorGuardsAgainstZeroCells) {
+    Estimator est(1.0f);
+    EXPECT_NO_FATAL_FAILURE(est.update(4.17f, /*cells=*/0));   // treated as 1S, no div-by-zero
+}
+
+TEST(BsBatterySoc, ResetClearsTheFilter) {
+    Estimator est(0.1f);
+    est.update(4.20f, k1S);
+    ASSERT_TRUE(est.primed());
+    est.reset();
+    EXPECT_FALSE(est.primed());
+    // Re-primes cleanly on the next sample rather than blending across the reset.
+    EXPECT_NEAR(est.update(3.70f, k1S), socFromCellOcv(3.70f), 0.01f);
+}

--- a/tests_cpp/test_bs_uplink_queue.cpp
+++ b/tests_cpp/test_bs_uplink_queue.cpp
@@ -1,0 +1,252 @@
+#include <gtest/gtest.h>
+
+#include "bs_uplink_queue.h"
+
+using bs_uplink_queue::Entry;
+using bs_uplink_queue::PushResult;
+using bs_uplink_queue::Queue;
+
+// The #502 fix: the uplink was a single slot, so queuing a command overwrote
+// the pending one along with its remaining retries. The uplink is BLIND — the
+// rocket sends no command ACK — so the retry count IS the delivery mechanism.
+// Discarding it directly cuts a command's odds of arriving, silently.
+//
+// These tests pin the FIFO behaviour that replaces the slot: commands drain in
+// order, each keeps its own retry budget, and a full queue drops loudly instead
+// of trampling something real.
+
+namespace {
+
+constexpr uint8_t SYNC    = 0xCA;  // config::UPLINK_SYNC_BYTE
+constexpr uint8_t NID     = 0;
+constexpr uint8_t BCAST   = 0xFF;
+constexpr uint8_t NO_HOP  = 0;     // LORA_NEXT_CH_NO_HOP
+constexpr uint8_t RETRIES = 8;     // config::UPLINK_RETRIES
+
+PushResult push(Queue& q, uint8_t cmd, uint8_t retries = RETRIES,
+                const uint8_t* payload = nullptr, size_t len = 0) {
+    return q.push(SYNC, NID, BCAST, NO_HOP, cmd, payload, len, retries);
+}
+
+// Drain the head command's retries the way serviceUplink() does, and pop it on
+// the pass after the last retry. Returns the number of transmissions it got.
+int drainHead(Queue& q) {
+    int sent = 0;
+    while (Entry* e = q.head()) {
+        if (e->retries_left == 0) { q.pop(); break; }
+        e->retries_left--;
+        sent++;
+    }
+    return sent;
+}
+
+}  // namespace
+
+// ---- The regression: a second command must not eat the first one's retries ----
+
+// Replays the exact bench-log sequence from #502: sim-config (cmd 5) is queued
+// with 8 retries, gets 3 transmissions out, and then sim-start (cmd 6) arrives.
+// Before the fix, cmd 5 was discarded with 5 of its 8 retries unsent.
+TEST(BsUplinkQueue, NewCommandDoesNotDiscardPendingCommandsRetries) {
+    Queue q;
+    ASSERT_EQ(push(q, /*cmd=*/5), PushResult::Queued);
+
+    for (int i = 0; i < 3; i++) q.head()->retries_left--;  // 3 blind TXs went out
+    ASSERT_EQ(q.head()->cmd(), 5);
+    ASSERT_EQ(q.head()->retries_left, 5);
+
+    ASSERT_EQ(push(q, /*cmd=*/6), PushResult::Queued);
+
+    // cmd 5 is still the head and still owns its remaining 5 retries.
+    EXPECT_EQ(q.size(), 2u);
+    EXPECT_EQ(q.head()->cmd(), 5);
+    EXPECT_EQ(q.head()->retries_left, 5);
+
+    // It drains those 5, and only then does cmd 6 get the radio — with its own
+    // full budget of 8, not a truncated one.
+    EXPECT_EQ(drainHead(q), 5);
+    ASSERT_NE(q.head(), nullptr);
+    EXPECT_EQ(q.head()->cmd(), 6);
+    EXPECT_EQ(q.head()->retries_left, 8);
+
+    EXPECT_EQ(drainHead(q), 8);
+    EXPECT_TRUE(q.empty());
+}
+
+// ---- Ordering ----
+
+TEST(BsUplinkQueue, CommandsDrainInFifoOrder) {
+    Queue q;
+    for (uint8_t cmd = 1; cmd <= 4; cmd++) ASSERT_EQ(push(q, cmd), PushResult::Queued);
+
+    for (uint8_t expected = 1; expected <= 4; expected++) {
+        ASSERT_NE(q.head(), nullptr);
+        EXPECT_EQ(q.head()->cmd(), expected);
+        drainHead(q);
+    }
+    EXPECT_TRUE(q.empty());
+}
+
+// The ring must wrap without corrupting order once entries have been popped.
+TEST(BsUplinkQueue, RingWrapsWithoutLosingOrder) {
+    Queue q;
+    // Fill, drain, and refill several times over so head_ wraps past kDepth.
+    for (int round = 0; round < 3; round++) {
+        for (size_t i = 0; i < bs_uplink_queue::kDepth; i++) {
+            ASSERT_EQ(push(q, (uint8_t)(i + 1)), PushResult::Queued);
+        }
+        EXPECT_TRUE(q.full());
+        for (size_t i = 0; i < bs_uplink_queue::kDepth; i++) {
+            ASSERT_NE(q.head(), nullptr);
+            EXPECT_EQ(q.head()->cmd(), (uint8_t)(i + 1)) << "round " << round;
+            drainHead(q);
+        }
+        EXPECT_TRUE(q.empty());
+    }
+}
+
+// ---- busy() is the successor to the old uplink_pending flag ----
+
+TEST(BsUplinkQueue, BusyIsTrueUntilTheQueueFullyDrains) {
+    Queue q;
+    EXPECT_FALSE(q.busy());
+
+    push(q, /*cmd=*/5);
+    push(q, /*cmd=*/6);
+    EXPECT_TRUE(q.busy());
+
+    drainHead(q);
+    EXPECT_TRUE(q.busy()) << "cmd 6 is still queued — the uplink is not done";
+
+    drainHead(q);
+    EXPECT_FALSE(q.busy());
+}
+
+// ---- Full queue: drop the newcomer loudly, never the pending work ----
+
+TEST(BsUplinkQueue, FullQueueRejectsNewCommandAndKeepsExistingOnes) {
+    Queue q;
+    for (size_t i = 0; i < bs_uplink_queue::kDepth; i++) {
+        ASSERT_EQ(push(q, (uint8_t)(i + 1)), PushResult::Queued);
+    }
+    ASSERT_TRUE(q.full());
+
+    EXPECT_EQ(push(q, /*cmd=*/99), PushResult::RejectedFull);
+
+    // The rejection must not have displaced anything: same depth, same head.
+    EXPECT_EQ(q.size(), bs_uplink_queue::kDepth);
+    EXPECT_EQ(q.head()->cmd(), 1);
+    EXPECT_EQ(q.head()->retries_left, RETRIES);
+}
+
+// ---- #286: oversized payloads are rejected, not truncated ----
+
+TEST(BsUplinkQueue, OversizedPayloadIsRejectedNotTruncated) {
+    Queue q;
+    uint8_t payload[bs_uplink_queue::kMaxPayload + 1] = {};
+
+    EXPECT_EQ(push(q, /*cmd=*/7, RETRIES, payload, sizeof(payload)),
+              PushResult::RejectedOversized);
+    EXPECT_TRUE(q.empty()) << "a rejected command must not occupy a slot";
+}
+
+TEST(BsUplinkQueue, MaxSizePayloadIsAccepted) {
+    Queue q;
+    uint8_t payload[bs_uplink_queue::kMaxPayload] = {};
+    payload[0] = 0xAB;
+    payload[bs_uplink_queue::kMaxPayload - 1] = 0xCD;
+
+    ASSERT_EQ(push(q, /*cmd=*/7, RETRIES, payload, sizeof(payload)), PushResult::Queued);
+    const Entry* e = q.head();
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->len, bs_uplink_queue::kHeaderBytes + bs_uplink_queue::kMaxPayload);
+    EXPECT_EQ(e->buf[bs_uplink_queue::kHeaderBytes], 0xAB);
+    EXPECT_EQ(e->buf[e->len - 1], 0xCD);
+}
+
+// An oversized payload must be reported as oversized even when the queue is
+// also full — otherwise the operator gets told "queue full" for a command that
+// could never have been sent at any depth.
+TEST(BsUplinkQueue, OversizedIsReportedEvenWhenQueueIsFull) {
+    Queue q;
+    for (size_t i = 0; i < bs_uplink_queue::kDepth; i++) push(q, (uint8_t)(i + 1));
+    ASSERT_TRUE(q.full());
+
+    uint8_t payload[bs_uplink_queue::kMaxPayload + 1] = {};
+    EXPECT_EQ(push(q, /*cmd=*/99, RETRIES, payload, sizeof(payload)),
+              PushResult::RejectedOversized);
+}
+
+// ---- Wire format: the header the rocket parses ----
+
+TEST(BsUplinkQueue, BuildsTheV2WireHeader) {
+    Queue q;
+    const uint8_t payload[3] = {0x11, 0x22, 0x33};
+    ASSERT_EQ(q.push(SYNC, /*nid=*/7, /*target_rid=*/42, /*next_ch=*/0,
+                     /*cmd=*/10, payload, sizeof(payload), RETRIES),
+              PushResult::Queued);
+
+    const Entry* e = q.head();
+    ASSERT_NE(e, nullptr);
+    // [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
+    EXPECT_EQ(e->buf[0], 0xCA);
+    EXPECT_EQ(e->buf[1], 7);
+    EXPECT_EQ(e->buf[2], 42);
+    EXPECT_EQ(e->buf[3], 0);
+    EXPECT_EQ(e->buf[4], 10);
+    EXPECT_EQ(e->buf[5], 3);
+    EXPECT_EQ(e->buf[6], 0x11);
+    EXPECT_EQ(e->buf[7], 0x22);
+    EXPECT_EQ(e->buf[8], 0x33);
+    EXPECT_EQ(e->len, bs_uplink_queue::kHeaderBytes + 3u);
+    EXPECT_EQ(e->cmd(), 10);
+}
+
+TEST(BsUplinkQueue, ZeroLengthPayloadIsHeaderOnly) {
+    Queue q;
+    ASSERT_EQ(push(q, /*cmd=*/6), PushResult::Queued);  // e.g. sim-start
+    const Entry* e = q.head();
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->len, bs_uplink_queue::kHeaderBytes);
+    EXPECT_EQ(e->buf[5], 0);
+}
+
+// Each entry owns its own buffer — a later push must not scribble on the
+// packet bytes of one already queued (the single-slot bug, in miniature).
+TEST(BsUplinkQueue, QueuedEntriesDoNotShareBuffers) {
+    Queue q;
+    const uint8_t a[2] = {0xAA, 0xAA};
+    const uint8_t b[2] = {0xBB, 0xBB};
+    ASSERT_EQ(push(q, /*cmd=*/5, RETRIES, a, sizeof(a)), PushResult::Queued);
+    ASSERT_EQ(push(q, /*cmd=*/6, RETRIES, b, sizeof(b)), PushResult::Queued);
+
+    const Entry* first = q.head();
+    EXPECT_EQ(first->cmd(), 5);
+    EXPECT_EQ(first->buf[6], 0xAA);
+    EXPECT_EQ(first->buf[7], 0xAA);
+}
+
+// ---- Retry budgets are per-command ----
+
+TEST(BsUplinkQueue, EachCommandKeepsItsOwnRetryBudget) {
+    Queue q;
+    push(q, /*cmd=*/1, /*retries=*/2);  // heartbeat-style: fewer retries, low airtime
+    push(q, /*cmd=*/5, /*retries=*/8);  // config: full budget
+
+    EXPECT_EQ(drainHead(q), 2);
+    ASSERT_NE(q.head(), nullptr);
+    EXPECT_EQ(q.head()->retries_left, 8);
+    EXPECT_EQ(drainHead(q), 8);
+    EXPECT_TRUE(q.empty());
+}
+
+// ---- Empty-queue safety ----
+
+TEST(BsUplinkQueue, HeadIsNullAndPopIsSafeWhenEmpty) {
+    Queue q;
+    EXPECT_EQ(q.head(), nullptr);
+    q.pop();  // must not underflow
+    EXPECT_TRUE(q.empty());
+    EXPECT_EQ(q.size(), 0u);
+    EXPECT_EQ(q.head(), nullptr);
+}

--- a/tests_cpp/test_bs_uplink_txwin.cpp
+++ b/tests_cpp/test_bs_uplink_txwin.cpp
@@ -1,0 +1,242 @@
+#include <gtest/gtest.h>
+
+#include "bs_uplink_txwin.h"
+
+using namespace bs_uplink_txwin;
+
+// The #506 fix: the radio is half-duplex, so every blind uplink retry is a deaf
+// window. The 2026-07-14 bench run measured the cost exactly — the ONLY downlink
+// loss in a clean 92 s flight (3 packets; zero CRC/length/net-id drops) fell
+// inside the cmd5+cmd6 blind-TX burst.
+//
+// It is arithmetic, not luck. At SF8/BW250/CR4-5 a downlink packet is ~82 ms on
+// air, while the gaps between 100 ms-spaced retries are only ~49 ms — an 82 ms
+// packet cannot fit in a 49 ms gap, so a burst loses essentially EVERY packet
+// that arrives during it. The fix is to transmit inside the quiet stretch between
+// the rocket's ~500 ms telemetry packets.
+
+namespace {
+
+// Measured on the bench: 502 ms median inter-packet interval.
+constexpr uint32_t kBenchPeriod = 502;
+
+Params benchParams(uint32_t tx_airtime = 52) {
+    Params p;
+    p.period_ms     = kBenchPeriod;
+    p.tx_airtime_ms = tx_airtime;
+    p.rx_reserve_ms = 140;
+    p.link_stale_ms = 2000;
+    p.max_defer_ms  = 1500;
+    return p;
+}
+
+}  // namespace
+
+// ---- Time-on-air: the numbers the whole fix rests on ----
+
+// If these are wrong the window is wrong, so pin them against the Semtech formula.
+TEST(BsUplinkTxwin, TimeOnAirMatchesTheBenchRadioConfig) {
+    // SF8, BW250 kHz, CR 4/5 — the configured link (log: "915.0 MHz SF8 BW250 CR5").
+    EXPECT_NEAR(timeOnAirMs(46, 8, 250.0f, 5), 82u, 2u);   // downlink telemetry
+    EXPECT_NEAR(timeOnAirMs(22, 8, 250.0f, 5), 51u, 2u);   // uplink sim-config (6+16)
+    EXPECT_NEAR(timeOnAirMs(6,  8, 250.0f, 5), 31u, 2u);   // uplink sim-start / heartbeat
+}
+
+// The core arithmetic of the bug: the retry gap is smaller than a downlink packet.
+TEST(BsUplinkTxwin, ARetryGapCannotFitADownlinkPacket) {
+    const uint32_t downlink = timeOnAirMs(46, 8, 250.0f, 5);
+    const uint32_t uplink   = timeOnAirMs(22, 8, 250.0f, 5);
+    const uint32_t gap      = 100 - uplink;   // 100 ms retry interval
+    EXPECT_LT(gap, downlink)
+        << "if this ever passes, blind retries would be survivable and #506 is moot";
+}
+
+TEST(BsUplinkTxwin, TimeOnAirGrowsWithPayloadAndSpreadingFactor) {
+    EXPECT_GT(timeOnAirMs(40, 8, 250.0f, 5), timeOnAirMs(6, 8, 250.0f, 5));
+    EXPECT_GT(timeOnAirMs(22, 10, 250.0f, 5), timeOnAirMs(22, 8, 250.0f, 5));
+    EXPECT_GT(timeOnAirMs(22, 8, 125.0f, 5), timeOnAirMs(22, 8, 250.0f, 5));  // narrower BW
+    EXPECT_GT(timeOnAirMs(22, 8, 250.0f, 8), timeOnAirMs(22, 8, 250.0f, 5));  // heavier FEC
+}
+
+TEST(BsUplinkTxwin, TimeOnAirHandlesDegenerateInputs) {
+    EXPECT_GT(timeOnAirMs(0, 8, 250.0f, 5), 0u);        // header+preamble only
+    EXPECT_GT(timeOnAirMs(22, 99, 250.0f, 99), 0u);     // clamped, no div-by-zero
+    EXPECT_GT(timeOnAirMs(22, 8, 0.0f, 5), 0u);         // bad BW falls back
+}
+
+// ---- The window ----
+
+// Right after a packet lands, the air is ours.
+TEST(BsUplinkTxwin, TransmitsImmediatelyAfterAPacketArrives) {
+    const auto p = benchParams();
+    EXPECT_TRUE(mayStartTx(/*now=*/1000, /*last_rx=*/1000, /*deferred=*/0, p));
+    EXPECT_TRUE(mayStartTx(1100, 1000, 100, p));
+    EXPECT_TRUE(mayStartTx(1200, 1000, 200, p));
+    EXPECT_TRUE(mayStartTx(1300, 1000, 300, p));
+}
+
+// ...and we shut up before the next one is due.
+TEST(BsUplinkTxwin, StaysQuietWhenTheNextDownlinkPacketIsDue) {
+    const auto p = benchParams();
+    // window_end = 502 - 140 - 52 = 310 ms
+    EXPECT_TRUE (mayStartTx(1310, 1000, 310, p));
+    EXPECT_FALSE(mayStartTx(1311, 1000, 311, p));
+    EXPECT_FALSE(mayStartTx(1450, 1000, 450, p));  // packet inbound about now
+}
+
+// A transmission must be judged by when it FINISHES, not when it starts — a long
+// channel-set push has to start earlier than a short sim-start.
+TEST(BsUplinkTxwin, ABiggerPacketGetsASmallerWindow) {
+    const auto small = benchParams(timeOnAirMs(6,  8, 250.0f, 5));   // ~31 ms
+    const auto big   = benchParams(timeOnAirMs(33, 8, 250.0f, 5));   // ~66 ms
+
+    // At age 320 ms the short packet still fits; the long one would run into the
+    // inbound downlink, so it waits.
+    EXPECT_TRUE (mayStartTx(1320, 1000, 320, small));
+    EXPECT_FALSE(mayStartTx(1320, 1000, 320, big));
+}
+
+TEST(BsUplinkTxwin, WindowTracksAFasterTelemetryCadence) {
+    auto p = benchParams();
+    p.period_ms = 250;   // rocket doubled its rate
+    // window_end = 250 - 140 - 52 = 58 ms — much tighter, but still exists.
+    EXPECT_TRUE (mayStartTx(1050, 1000, 50, p));
+    EXPECT_FALSE(mayStartTx(1100, 1000, 100, p));
+}
+
+// ---- Liveness: the uplink is BLIND and carries pyro/camera/logging commands.
+//      A command that never goes out is far worse than a dropped telemetry row. ----
+
+TEST(BsUplinkTxwin, TransmitsFreelyBeforeWeHaveEverHeardTheRocket) {
+    // last_rx == 0: rendezvous / recovery must be able to shout into the void.
+    EXPECT_TRUE(mayStartTx(50000, /*last_rx=*/0, /*deferred=*/9999, benchParams()));
+}
+
+TEST(BsUplinkTxwin, TransmitsFreelyOnceTheLinkGoesStale) {
+    const auto p = benchParams();
+    // 2 s of silence: there is no downlink to protect, and this is exactly when we
+    // most need to transmit (silence recovery pushing the rocket home).
+    EXPECT_TRUE(mayStartTx(1000 + 2000, 1000, 0, p));
+    EXPECT_TRUE(mayStartTx(1000 + 5000, 1000, 0, p));
+}
+
+TEST(BsUplinkTxwin, BackstopFiresRatherThanStarveACommand) {
+    const auto p = benchParams();
+    // Deep inside the downlink slot — normally we'd hold off...
+    EXPECT_FALSE(mayStartTx(1450, 1000, /*deferred=*/0, p));
+    // ...but not forever. After max_defer_ms the command goes out regardless.
+    EXPECT_TRUE(mayStartTx(1450, 1000, /*deferred=*/1500, p));
+}
+
+TEST(BsUplinkTxwin, NeverDeadlocksWhenNoWindowCanExist) {
+    auto p = benchParams();
+    p.period_ms = 150;    // reserve(140) + airtime(52) > period: no gap is possible
+    // Must fall through to "transmit", not block every pass forever.
+    EXPECT_TRUE(mayStartTx(1000, 1000, 0, p));
+    EXPECT_TRUE(mayStartTx(1100, 1000, 100, p));
+    EXPECT_TRUE(mayStartTx(1140, 1000, 140, p));
+}
+
+// ---- Cadence learning ----
+
+TEST(BsUplinkTxwin, LearnsTheRocketsCadence) {
+    RxCadence c;
+    EXPECT_FALSE(c.valid());
+    EXPECT_EQ(c.periodMs(), kDefaultPeriodMs) << "falls back to the configured rate";
+
+    uint32_t t = 1000;
+    for (int i = 0; i < 12; i++) { c.onPacket(t); t += 502; }
+    EXPECT_TRUE(c.valid());
+    EXPECT_NEAR(c.periodMs(), 502u, 5u);
+    EXPECT_EQ(c.lastMs(), t - 502);
+}
+
+TEST(BsUplinkTxwin, NeedsTwoIntervalsBeforeItIsTrusted) {
+    RxCadence c;
+    c.onPacket(1000);
+    EXPECT_FALSE(c.valid()) << "one packet is not an interval";
+    c.onPacket(1500);
+    EXPECT_FALSE(c.valid()) << "one interval is not a cadence";
+    c.onPacket(2000);
+    EXPECT_TRUE(c.valid());
+}
+
+// The bench log contained a duplicate packet logged 8 ms apart — that is not a
+// cadence, and must not drag the estimate toward zero.
+TEST(BsUplinkTxwin, IgnoresDuplicatePacketsAndLongDropouts) {
+    RxCadence c;
+    uint32_t t = 1000;
+    for (int i = 0; i < 8; i++) { c.onPacket(t); t += 500; }
+    const uint32_t settled = c.periodMs();
+    ASSERT_NEAR(settled, 500u, 5u);
+
+    c.onPacket(t);          // normal packet
+    c.onPacket(t + 8);      // duplicate, 8 ms later — ignore
+    EXPECT_NEAR(c.periodMs(), settled, 5u);
+
+    c.onPacket(t + 8 + 9000);   // long dropout — not a cadence either
+    EXPECT_NEAR(c.periodMs(), settled, 5u);
+}
+
+TEST(BsUplinkTxwin, AdaptsWhenTheCadenceGenuinelyChanges) {
+    RxCadence c;
+    uint32_t t = 1000;
+    for (int i = 0; i < 10; i++) { c.onPacket(t); t += 500; }
+    ASSERT_NEAR(c.periodMs(), 500u, 5u);
+
+    for (int i = 0; i < 30; i++) { c.onPacket(t); t += 250; }
+    EXPECT_NEAR(c.periodMs(), 250u, 10u) << "must follow a real rate change";
+}
+
+TEST(BsUplinkTxwin, ResetClearsTheEstimate) {
+    RxCadence c;
+    uint32_t t = 1000;
+    for (int i = 0; i < 5; i++) { c.onPacket(t); t += 500; }
+    ASSERT_TRUE(c.valid());
+    c.reset();
+    EXPECT_FALSE(c.valid());
+    EXPECT_EQ(c.lastMs(), 0u);
+    EXPECT_EQ(c.periodMs(), kDefaultPeriodMs);
+}
+
+// ---- End to end: replay the bench burst and show no packet is stepped on ----
+
+// 8 retries at 100 ms against the measured 502 ms cadence. Every transmission
+// must land in a gap, and the command must still finish promptly.
+TEST(BsUplinkTxwin, ReplayOfTheBenchBurstStepsOnNoDownlinkPacket) {
+    const uint32_t period   = 502;
+    const uint32_t dl_air   = timeOnAirMs(46, 8, 250.0f, 5);   // ~82 ms
+    const uint32_t ul_air   = timeOnAirMs(22, 8, 250.0f, 5);   // ~51 ms
+    Params p = benchParams(ul_air);
+    p.period_ms = period;
+
+    // The rocket's packet N is on the air over [tx_start, tx_start + dl_air];
+    // we timestamp it at the END, so last_rx = tx_start + dl_air.
+    uint32_t last_rx = 10000;
+    uint32_t now     = last_rx;
+    uint32_t last_tx = 0;
+    int retries_left = 8;
+    int collisions   = 0;
+    int sent         = 0;
+
+    // Simulate 3 telemetry cycles, 1 ms steps.
+    for (uint32_t step = 0; step < 3 * period && retries_left > 0; step++, now++) {
+        // Next downlink packet occupies [last_rx + period - dl_air, last_rx + period].
+        const uint32_t dl_start = last_rx + period - dl_air;
+        const uint32_t dl_end   = last_rx + period;
+        if (now == dl_end) { last_rx = now; continue; }   // packet received
+
+        if (last_tx != 0 && (now - last_tx) < 100) continue;   // retry interval
+        if (!mayStartTx(now, last_rx, /*deferred=*/0, p)) continue;
+
+        // We transmit over [now, now + ul_air]. Does it overlap the inbound packet?
+        if (now + ul_air >= dl_start && now <= dl_end) collisions++;
+        last_tx = now;
+        retries_left--;
+        sent++;
+    }
+
+    EXPECT_EQ(collisions, 0) << "an uplink retry landed on top of a downlink packet";
+    EXPECT_EQ(retries_left, 0) << "the command must still get all 8 retries out";
+    EXPECT_EQ(sent, 8);
+}

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/BleCommandRing.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/BleCommandRing.h
@@ -1,0 +1,85 @@
+#pragma once
+
+// BLE command ring (#517).
+//
+// The app's command intake used to be a SINGLE latch: the NimBLE write callback
+// overwrote `pending_command_` unconditionally, and the loop task drained it
+// once per iteration. Two commands arriving between two polls lost the first
+// outright — and the app's connect-time sync fires ~13 commands back-to-back
+// with no pacing (#366), so any loop stall longer than their ~60-90 ms spacing
+// dropped one. #221 papered over that by shortening the OC loop period; giving
+// the buffer depth is the actual fix.
+//
+// Each entry carries the command AND everything that travels with it. Exactly
+// one of {payload, file_list_page, delete_name, download_name} is populated per
+// command (onCommandWrite's dispatch chain is mutually exclusive), but they are
+// distinct fields so a delete target can never be handed back as a download
+// target. Keeping them per-entry also closes the gap #384 left open: the
+// filename/page accessors used to read the live latch, so a BLE write landing
+// between getCommand() and getDeleteFilename() could swap the name mid-handler.
+//
+// Pure — no NimBLE / ESP-IDF / FreeRTOS dependencies — so the host gtest can
+// drive it directly. TR_BLE_To_APP owns the locking: push() and pop() are each
+// called inside the s_cmd_mux critical section, which is what preserves #384's
+// "a command and its payload travel as one atomic unit" guarantee.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace tr_ble {
+
+inline constexpr size_t kMaxPayload  = 80;  // max = RollProfileData, 76 bytes
+inline constexpr size_t kMaxFilename = 64;
+
+// 16 comfortably holds the ~13-command connect-time sync burst (#366) even when
+// the loop is stalled through all of it — OC cmd-8 log recovery blocks loop_oc
+// for 30-90 s.
+inline constexpr size_t kRingDepth = 16;
+
+struct PendingCommand
+{
+    uint8_t cmd            = 0;
+    uint8_t payload[kMaxPayload] = {};
+    size_t  payload_len    = 0;
+    uint8_t file_list_page = 0;
+    char    delete_name[kMaxFilename]   = {};
+    char    download_name[kMaxFilename] = {};
+};
+
+class CommandRing
+{
+public:
+    bool   empty() const { return count_ == 0; }
+    bool   full()  const { return count_ == kRingDepth; }
+    size_t size()  const { return count_; }
+
+    // Append. Returns false (and keeps the ring untouched) when full — the
+    // caller drops the NEWEST command rather than rotating out older ones the
+    // app sent first and is still waiting on.
+    bool push(const PendingCommand& e)
+    {
+        if (full()) return false;
+        entries_[(head_ + count_) % kRingDepth] = e;
+        count_++;
+        return true;
+    }
+
+    // Pop the OLDEST entry into `out`. Returns false and leaves `out` untouched
+    // when empty.
+    bool pop(PendingCommand& out)
+    {
+        if (empty()) return false;
+        out   = entries_[head_];
+        head_ = (head_ + 1) % kRingDepth;
+        count_--;
+        return true;
+    }
+
+private:
+    PendingCommand entries_[kRingDepth];
+    size_t head_  = 0;   // next to consume
+    size_t count_ = 0;
+};
+
+}  // namespace tr_ble

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -19,7 +19,7 @@
 
 static const char* BLE_TAG = "BLE";
 
-// Spinlock protecting pending_command_ against races between the BLE
+// Spinlock protecting the command ring (#517) against races between the BLE
 // callback (runs on the NimBLE host task) and the main loop reading it.
 static portMUX_TYPE s_cmd_mux = portMUX_INITIALIZER_UNLOCKED;
 
@@ -112,10 +112,6 @@ TR_BLE_To_APP::TR_BLE_To_APP(const char* device_name)
       negotiated_mtu_(0),
       telem_notify_subscribed_(false),
       conn_handle_(0),
-      pending_command_(0),
-      pending_file_list_page_(0),
-      pending_delete_filename_(""),
-      pending_download_filename_(""),
       file_list_json_(""),
       chunk_buffer_(nullptr),
       chunk_buffer_size_(0),
@@ -374,7 +370,7 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
     char    name_local[64];
     bool    have_delete = false, have_download = false;
     int     page_local  = -1;
-    uint8_t payload_local[sizeof(pending_payload_)];
+    uint8_t payload_local[tr_ble::kMaxPayload];
     size_t  payload_len_local = 0;
     bool    have_payload = false;
 
@@ -480,31 +476,39 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
         have_payload = true;
     }
 
-    // #384: commit the command AND everything that travels with it in one
-    // critical section, so bs_loop can never pair a command with a different
-    // write's payload/filename/page.
-    uint8_t overwritten = 0;
-    portENTER_CRITICAL(&s_cmd_mux);
-    overwritten = pending_command_;
+    // Build the entry in a local first — the parse/copy work stays OUT of the
+    // critical section, which now only has to do the ring push.
+    tr_ble::PendingCommand entry;   // zero-initialised: empty payload/name/page
+    entry.cmd = cmd;
     if (have_payload)
     {
-        memcpy(pending_payload_, payload_local, payload_len_local);
-        pending_payload_len_ = payload_len_local;
+        memcpy(entry.payload, payload_local, payload_len_local);
+        entry.payload_len = payload_len_local;
     }
-    if (page_local >= 0)   pending_file_list_page_ = (uint8_t)page_local;
-    if (have_delete)       strlcpy(pending_delete_filename_,   name_local, sizeof(pending_delete_filename_));
-    if (have_download)     strlcpy(pending_download_filename_, name_local, sizeof(pending_download_filename_));
-    pending_command_ = cmd;
+    if (page_local >= 0)   entry.file_list_page = (uint8_t)page_local;
+    if (have_delete)       strlcpy(entry.delete_name,   name_local, sizeof(entry.delete_name));
+    if (have_download)     strlcpy(entry.download_name, name_local, sizeof(entry.download_name));
+
+    // #384: the command and everything travelling with it are committed in ONE
+    // critical section, so the loop task can never pair a command with a
+    // different write's payload/filename/page.
+    // #517: append to the ring instead of overwriting a single latch.
+    portENTER_CRITICAL(&s_cmd_mux);
+    const bool   queued = cmd_ring_.push(entry);
+    const size_t depth  = cmd_ring_.size();
     portEXIT_CRITICAL(&s_cmd_mux);
-    if (overwritten != 0)
+
+    if (!queued)
     {
-        // Previous command not yet consumed — it was overwritten wholesale
-        // (command + latches together, so at least never mismatched).
-        ESP_LOGW(BLE_TAG, "Overwriting unconsumed cmd %u with %u",
-                 overwritten, cmd);
+        // The loop task isn't draining (a multi-second blocking op, or it died).
+        // Drop the NEWEST: the older commands are the ones the app sent first
+        // and is still waiting on, so rotating them out would be worse.
+        ESP_LOGE(BLE_TAG, "Command ring full (%u) — cmd %u DROPPED",
+                 (unsigned)tr_ble::kRingDepth, cmd);
+        return;
     }
 
-    ESP_LOGI(BLE_TAG, "Received command: %u", cmd);
+    ESP_LOGI(BLE_TAG, "Received command: %u (queued, depth=%u)", cmd, (unsigned)depth);
 }
 
 // ============================================================================
@@ -878,47 +882,56 @@ void TR_BLE_To_APP::sendTelemetry(const TelemetryData& data)
 
 uint8_t TR_BLE_To_APP::getCommand()
 {
-    // #384: consume the command and snapshot its payload in the SAME critical
-    // section — a later BLE write can then only replace the pending latch,
-    // never the copy this command's handler reads via getCommandPayload().
+    // #384: consume the command and snapshot everything travelling with it in
+    // the SAME critical section — a later BLE write can then only append to the
+    // ring, never mutate the copy this command's handler is about to read via
+    // getCommandPayload() / getDeleteFilename() / getDownloadFilename() /
+    // getFileListPage().
+    // #517: pop the OLDEST entry rather than clearing a single latch, so a
+    // burst of commands is delivered in order instead of collapsing to the last.
     portENTER_CRITICAL(&s_cmd_mux);
-    uint8_t cmd = pending_command_;
-    pending_command_ = 0;
-    consumed_payload_len_ = pending_payload_len_;
-    memcpy(consumed_payload_, pending_payload_, sizeof(consumed_payload_));
+    const bool got = cmd_ring_.pop(consumed_);
     portEXIT_CRITICAL(&s_cmd_mux);
-    return cmd;
+
+    if (!got)
+    {
+        consumed_ = tr_ble::PendingCommand{};   // no command: empty payload/name/page
+        return 0;
+    }
+    return consumed_.cmd;
 }
+
+// The three accessors below read the loop-task-only snapshot taken by
+// getCommand(), so they need no lock: the NimBLE task can no longer reach the
+// data this command's handler is using. (They used to read the live latch under
+// the mux, which still let a BLE write arriving mid-handler swap the filename
+// or page out from under it — the gap #384 left open.)
 
 uint8_t TR_BLE_To_APP::getFileListPage()
 {
-    portENTER_CRITICAL(&s_cmd_mux);
-    uint8_t page = pending_file_list_page_;
-    pending_file_list_page_ = 0;
-    portEXIT_CRITICAL(&s_cmd_mux);
+    uint8_t page = consumed_.file_list_page;
+    consumed_.file_list_page = 0;   // "clears after reading" contract
     return page;
 }
 
 String TR_BLE_To_APP::getDeleteFilename()
 {
-    // Copy out under the mux; build the String (heap) only after exiting the
-    // critical section.
-    char buf[sizeof(pending_delete_filename_)];
-    portENTER_CRITICAL(&s_cmd_mux);
-    strlcpy(buf, pending_delete_filename_, sizeof(buf));
-    pending_delete_filename_[0] = '\0';
-    portEXIT_CRITICAL(&s_cmd_mux);
-    return String(buf);
+    // Empty unless the command just consumed was a delete (cmd 3) — the name
+    // belongs to that entry, so it can't leak onto an unrelated command the
+    // way the shared latch could.
+    String name(consumed_.delete_name);
+    consumed_.delete_name[0] = '\0';   // "clears after reading" contract
+    return name;
 }
 
 String TR_BLE_To_APP::getDownloadFilename()
 {
-    char buf[sizeof(pending_download_filename_)];
-    portENTER_CRITICAL(&s_cmd_mux);
-    strlcpy(buf, pending_download_filename_, sizeof(buf));
-    pending_download_filename_[0] = '\0';
-    portEXIT_CRITICAL(&s_cmd_mux);
-    return String(buf);
+    // Empty unless the command just consumed was a download (cmd 4). The OC
+    // calls this on EVERY command (main.cpp: after the cmd dispatch chain), so
+    // a stale name here would kick off a spurious file transfer.
+    String name(consumed_.download_name);
+    consumed_.download_name[0] = '\0';   // "clears after reading" contract
+    return name;
 }
 
 void TR_BLE_To_APP::sendConfigJSON(const String& json)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -208,8 +208,14 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         break;
 
     case BLE_GAP_EVENT_CONN_UPDATE:
-        ESP_LOGI(BLE_TAG, "Connection parameters updated, status=%d",
-                 event->conn_update.status);
+        // #503: this used to log an unconditional "Connection parameters updated,
+        // status=%d" at INFO — which read as success even when it wasn't (the
+        // 2026-07-14 bench logged status=554 and nobody noticed), and which never
+        // said what interval we actually ENDED UP with. status=0 only means the
+        // procedure completed; the peer is free to counter with its own values,
+        // and iOS always will. Report the negotiated interval, not the request.
+        self->onConnParamsUpdated(event->conn_update.conn_handle,
+                                  event->conn_update.status);
         break;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
@@ -248,24 +254,112 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
 
-    // Request fast connection parameters from iOS for high-throughput transfer.
+    // #503: do NOT request the parameter update from inside the connect callback.
+    // iOS runs its OWN connection-update procedure immediately after connecting,
+    // and firing ours into the middle of it collides: the 2026-07-14 bench logged
+    // status=554, which is NimBLE's HCI base (0x200) + 0x2A = "Different
+    // Transaction Collision". Schedule it instead and let the peer go first;
+    // loop() fires it once the link has settled.
+    conn_param_attempts_ = 0;
+    conn_param_due_ms_   = (uint32_t)millis() + kConnParamDelayMs;
+}
+
+// #503: Apple's Accessory Design Guidelines are strict about what a peripheral may
+// ask for, and iOS rejects anything outside them. We were asking for 7.5 ms, which
+// is below iOS's 15 ms floor — so even without the collision it could never have
+// been granted, and the "Requested fast connection parameters (7.5-20ms)" log line
+// was describing something that was never going to happen.
+//
+//   interval min  >= 15 ms                        -> 0x0C (12 * 1.25 ms)
+//   interval max  >= interval min + 15 ms         -> 0x18 (24 * 1.25 ms = 30 ms)
+//   slave latency <= 30                           -> 0
+//   supervision timeout: <= 6 s, and greater than
+//     interval_max * (latency + 1) * 3 = 90 ms    -> 2 s (200 * 10 ms)
+void TR_BLE_To_APP::requestConnParams()
+{
+    if (!device_connected_) { conn_param_due_ms_ = 0; return; }
+
     struct ble_gap_upd_params params = {};
-    params.itvl_min = 0x06;              // 7.5ms  (units of 1.25ms)
-    params.itvl_max = 0x10;              // 20ms   (units of 1.25ms)
+    params.itvl_min = 0x0C;              // 15 ms — iOS's minimum; asking lower is refused
+    params.itvl_max = 0x18;              // 30 ms — must be >= min + 15 ms
     params.latency = 0;                  // No slave latency
-    params.supervision_timeout = 200;    // 2 seconds (units of 10ms)
+    params.supervision_timeout = 200;    // 2 seconds (units of 10 ms)
     params.min_ce_len = 0;
     params.max_ce_len = 0;
 
-    int rc = ble_gap_update_params(conn_handle, &params);
+    conn_param_attempts_++;
+    const int rc = ble_gap_update_params(conn_handle_, &params);
     if (rc == 0)
     {
-        ESP_LOGI(BLE_TAG, "Requested fast connection parameters (7.5-20ms interval)");
+        ESP_LOGI(BLE_TAG, "Requested connection parameters (15-30 ms interval), attempt %u",
+                 (unsigned)conn_param_attempts_);
+        conn_param_due_ms_ = 0;   // wait for the CONN_UPDATE event
     }
     else
     {
-        ESP_LOGW(BLE_TAG, "Connection param update request failed, rc=%d", rc);
+        ESP_LOGW(BLE_TAG, "Connection param update request failed to send, rc=%d", rc);
+        conn_param_due_ms_ = (conn_param_attempts_ < kConnParamMaxAttempts)
+                                 ? (uint32_t)millis() + kConnParamRetryMs
+                                 : 0;
     }
+}
+
+void TR_BLE_To_APP::onConnParamsUpdated(uint16_t conn_handle, int status)
+{
+    // Report what we ACTUALLY got. status==0 means the procedure completed, not
+    // that the peer honoured our request — iOS routinely counters with its own
+    // values, so the negotiated interval is the only number worth logging.
+    struct ble_gap_conn_desc desc;
+    const bool have_desc = (ble_gap_conn_find(conn_handle, &desc) == 0);
+
+    if (status == 0)
+    {
+        if (have_desc)
+        {
+            ESP_LOGI(BLE_TAG, "Connection parameters now: interval=%.2f ms, latency=%u, timeout=%u ms",
+                     (double)desc.conn_itvl * 1.25, (unsigned)desc.conn_latency,
+                     (unsigned)desc.supervision_timeout * 10);
+        }
+        else
+        {
+            ESP_LOGI(BLE_TAG, "Connection parameters updated (peer accepted)");
+        }
+        conn_param_due_ms_ = 0;
+        return;
+    }
+
+    // Decode the failure instead of printing a bare number. NimBLE returns HCI
+    // errors offset by BLE_HS_ERR_HCI_BASE (0x200), which is why the raw value
+    // looks like a nonsense "554".
+    const char* why = "unknown";
+    bool collision = false;
+    if (status >= BLE_HS_ERR_HCI_BASE && status < BLE_HS_ERR_HCI_BASE + 0x100)
+    {
+        switch (status - BLE_HS_ERR_HCI_BASE)
+        {
+            case 0x0C: why = "command disallowed"; break;
+            case 0x1E: why = "invalid LMP parameters"; break;
+            case 0x23: why = "LMP/LL transaction collision"; collision = true; break;
+            case 0x2A: why = "different transaction collision"; collision = true; break;
+            case 0x3B: why = "unacceptable connection parameters"; break;
+            default: break;
+        }
+    }
+
+    const bool retry = collision && (conn_param_attempts_ < kConnParamMaxAttempts);
+    ESP_LOGW(BLE_TAG, "Connection param update REJECTED: status=%d (HCI 0x%02X: %s)%s",
+             status,
+             (status >= BLE_HS_ERR_HCI_BASE) ? (unsigned)(status - BLE_HS_ERR_HCI_BASE) : 0u,
+             why,
+             retry ? " — retrying" : "");
+
+    if (have_desc)
+    {
+        ESP_LOGW(BLE_TAG, "  link stays at interval=%.2f ms (peer's choice)",
+                 (double)desc.conn_itvl * 1.25);
+    }
+
+    conn_param_due_ms_ = retry ? ((uint32_t)millis() + kConnParamRetryMs) : 0;
 }
 
 void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
@@ -274,6 +368,11 @@ void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
     negotiated_mtu_ = 0;
     telem_notify_subscribed_ = false;
     conn_handle_ = 0;
+    // #503: cancel any pending/retrying parameter request — it belongs to the
+    // connection that just went away, and firing it on the next one's handle
+    // would be wrong.
+    conn_param_due_ms_ = 0;
+    conn_param_attempts_ = 0;
     ESP_LOGW(BLE_TAG, "Device DISCONNECTED, reason=%d", reason);
 
     // Restart advertising so new devices can connect
@@ -712,6 +811,21 @@ bool TR_BLE_To_APP::begin()
 
 void TR_BLE_To_APP::loop()
 {
+    // #503: deferred connection-parameter request. Fired from here, on the main
+    // loop, rather than from the connect callback — so it lands AFTER iOS has
+    // finished its own connection-update procedure instead of colliding with it.
+    if (conn_param_due_ms_ != 0 && device_connected_)
+    {
+        const uint32_t now = (uint32_t)millis();
+        // Same wraparound tolerance as the OTA timer below.
+        const bool elapsed = (now >= conn_param_due_ms_) ||
+                             ((conn_param_due_ms_ - now) > 0x7FFFFFFFu);
+        if (elapsed)
+        {
+            requestConnParams();
+        }
+    }
+
     // BLE stack handles events via callbacks on the NimBLE host task.
     // Only OTA's deferred-restart watchdog needs poll-style handling here.
     if (ota_pending_restart_at_ms_ != 0)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -294,6 +294,16 @@ private:
     // Set by the OTA_FINISH handler after the ready_to_boot notification
     // flushes so the iOS app sees the new partition selection.
     uint32_t ota_pending_restart_at_ms_ = 0;
+
+    // #503: deferred connection-parameter request. Firing it from the connect
+    // callback collided with iOS's own connection-update procedure (bench:
+    // status=554 = HCI 0x2A "different transaction collision"). Let the peer go
+    // first, then ask — and retry if we still lose the race.
+    uint32_t conn_param_due_ms_   = 0;   // 0 = nothing scheduled
+    uint8_t  conn_param_attempts_ = 0;
+    static constexpr uint32_t kConnParamDelayMs = 1000;  // let iOS settle the link first
+    static constexpr uint32_t kConnParamRetryMs = 750;
+    static constexpr uint8_t  kConnParamMaxAttempts = 3;
     // Throttle the per-chunk "writing" status notifications. Updated on
     // every successful chunk; we notify at most ~2 Hz so the BLE notify
     // queue isn't saturated mid-flash.
@@ -349,6 +359,10 @@ private:
     void onConnect(uint16_t conn_handle, const struct ble_gap_conn_desc* desc);
     void onDisconnect(uint16_t conn_handle, int reason);
     void onMtuChanged(uint16_t conn_handle, uint16_t mtu);
+    // #503: connection-parameter negotiation. Deferred out of the connect
+    // callback so it doesn't collide with the peer's own update procedure.
+    void requestConnParams();
+    void onConnParamsUpdated(uint16_t conn_handle, int status);
     void onCommandWrite(const uint8_t* data, size_t length);
 
     // Start/restart BLE advertising

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -16,6 +16,7 @@ using String = std::string;     // API-compatible subset used by callers
 #include <cstdint>
 #include <cstddef>
 
+#include "BleCommandRing.h"      // #517: depth for the command intake
 #include "TR_OTA_Receiver.h"
 #include "TR_OTA_Backend_esp.h"
 
@@ -146,8 +147,8 @@ public:
     // #384: return the loop-task snapshot taken atomically by getCommand(),
     // not the live latch — a second BLE write between getCommand() and this
     // call could otherwise swap (or tear) the payload under the command.
-    const uint8_t* getCommandPayload() const { return consumed_payload_; }
-    size_t getCommandPayloadLength() const { return consumed_payload_len_; }
+    const uint8_t* getCommandPayload() const { return consumed_.payload; }
+    size_t getCommandPayloadLength() const { return consumed_.payload_len; }
 
     // Get pending delete filename (empty if none)
     // Clears the filename after reading
@@ -237,23 +238,20 @@ private:
     volatile uint16_t negotiated_mtu_;
     volatile bool telem_notify_subscribed_;  // central enabled notifications on telemetry/config char
     volatile uint16_t conn_handle_;          // NimBLE connection handle
-    // #384: every latch below is written on the NimBLE host task and read on
-    // bs_loop. They are all committed/consumed inside the same s_cmd_mux
-    // critical section as pending_command_, so a command and its payload/
-    // filename travel as one atomic unit. The filenames are fixed buffers —
-    // the old String members did heap operations from two tasks with no
-    // lock, which risks allocator corruption, not just a swapped name.
-    volatile uint8_t pending_command_;
-    volatile uint8_t pending_file_list_page_;
-    char pending_delete_filename_[64] = {};
-    char pending_download_filename_[64] = {};
-    uint8_t pending_payload_[80] = {};   // Raw payload for commands with data (max = RollProfileData 76 bytes)
-    size_t  pending_payload_len_ = 0;
-    // Loop-task-only snapshot of the payload, filled by getCommand() under
-    // the mux; getCommandPayload() reads this so later BLE writes can't
-    // mutate it mid-use.
-    uint8_t consumed_payload_[80] = {};
-    size_t  consumed_payload_len_ = 0;
+    // #517: a RING, not a single latch (see BleCommandRing.h). It used to be
+    // one slot overwritten by the NimBLE write callback, so two commands
+    // arriving between two loop polls lost the first outright.
+    //
+    // #384 (keep): the ring is written on the NimBLE host task and read on the
+    // loop task; push() and pop() each run inside the s_cmd_mux critical
+    // section, so a command and its payload/filename/page still travel as one
+    // atomic unit and can never be mismatched.
+    tr_ble::CommandRing cmd_ring_;
+
+    // Loop-task-only snapshot, filled by getCommand() under the mux. The
+    // payload/filename/page accessors read THIS, never the ring, so a later
+    // BLE write can't mutate what the current command's handler is using.
+    tr_ble::PendingCommand consumed_;
     String file_list_json_;              // Persistent storage for file list
     uint8_t* chunk_buffer_;              // Persistent storage for file chunks
     size_t chunk_buffer_size_;

--- a/tinkerrocket-idf/components/TR_BQ27Z746/TR_BQ27Z746.cpp
+++ b/tinkerrocket-idf/components/TR_BQ27Z746/TR_BQ27Z746.cpp
@@ -113,6 +113,7 @@ esp_err_t TR_BQ27Z746::readFetStatus()
     _data.dsg_fet_on    = !(opA & Reg::OPA_XDSG);
     _data.safety_active = (opA & Reg::OPA_SS) != 0;
     _data.fet_en        = (mfg & Reg::MFG_FET_EN) != 0;
+    _data.gauge_en      = (mfg & Reg::MFG_GAUGE_EN) != 0;
     return ESP_OK;
 }
 
@@ -313,6 +314,20 @@ void TR_BQ27Z746::logDiagnostics(const char* log_tag)
     ESP_LOGI(tag, "BQ27Z746 devtype=0x%04X  V=%.3f I=%.0fmA SOC=%.0f%% T=%.1fC Rem=%.0f/%.0f mAh",
              _device_type, (double)_data.voltage, (double)_data.current, (double)_data.soc,
              (double)_data.temperature, (double)_data.capacity, (double)_data.full_capacity);
-    ESP_LOGI(tag, "  BattStatus=0x%04X  FET_EN=%d CHG=%d DSG=%d SafetyActive=%d",
-             _data.batt_status, _data.fet_en, _data.chg_fet_on, _data.dsg_fet_on, _data.safety_active);
+    ESP_LOGI(tag, "  BattStatus=0x%04X  FET_EN=%d GAUGE_EN=%d CHG=%d DSG=%d SafetyActive=%d",
+             _data.batt_status, _data.fet_en, _data.gauge_en,
+             _data.chg_fet_on, _data.dsg_fet_on, _data.safety_active);
+
+    // #501: say out loud why SoC/capacity can't be believed, rather than leaving
+    // a bare "SOC=0%" in the log for someone to take at face value.
+    if (!_data.gauge_en)
+    {
+        ESP_LOGW(tag, "  GAUGE_EN=0 -> Impedance Track gauging is OFF. SOC/Rem/FullCap above are "
+                      "NOT gauged values (voltage/temp are still valid).");
+    }
+    if (_data.full_capacity > 0.0f && _data.capacity <= 0.0f && _data.voltage > 3.5f)
+    {
+        ESP_LOGW(tag, "  RemainingCapacity=0 at %.2f V — gauge state is unlearned/garbage, "
+                      "not an empty pack.", (double)_data.voltage);
+    }
 }

--- a/tinkerrocket-idf/components/TR_BQ27Z746/TR_BQ27Z746.h
+++ b/tinkerrocket-idf/components/TR_BQ27Z746/TR_BQ27Z746.h
@@ -68,6 +68,10 @@ struct TR_BQ27Z746_Data
     bool chg_fet_on;      // !XCHG  (CHG FET conducting)
     bool dsg_fet_on;      // !XDSG  (DSG FET conducting)
     bool fet_en;          // ManufacturingStatus FET_EN (autonomous FET control)
+    bool gauge_en;        // ManufacturingStatus GAUGE_EN — Impedance Track gauging.
+                          //   Ships at 0. While it is 0 the gauge never integrates
+                          //   current, so soc/capacity/full_capacity are meaningless
+                          //   even though voltage/temperature are fine (#501).
     bool safety_active;   // OperationStatus SS (a protection is active)
 };
 
@@ -108,6 +112,10 @@ public:
     float soc() const         { return _data.soc; }
     float temperature() const { return _data.temperature; }
     bool  fetsEnabled() const { return _data.fet_en; }
+    // False => Impedance Track gauging is off, so soc()/capacity()/full_capacity
+    // are not gauged values at all. Callers must not report them as SoC (#501).
+    bool  gaugingEnabled() const { return _data.gauge_en; }
+    float fullCapacity() const   { return _data.full_capacity; }
     bool  chgFetOn() const    { return _data.chg_fet_on; }
     bool  dsgFetOn() const    { return _data.dsg_fet_on; }
 

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -257,6 +257,27 @@ bool TR_LoRa_Comms::readPacket(uint8_t* buf, size_t maxLen, size_t& len)
         return false;
     }
 
+    // #520: rx_done_ is only a HINT. It has two racing writers — the DIO1 ISR
+    // (edge-triggered, fires once per packet) and pollDio1() (the missed-interrupt
+    // fallback, which latches on the DIO1 *level*). The radio holds DIO1 asserted
+    // until readData() below clears the RxDone IRQ, several SPI transactions after
+    // we clear rx_done_ — so there is a window where rx_done_ is false while DIO1
+    // is still high, and a level-based latch landing in it re-arms the flag for a
+    // packet we ALREADY consumed. The next call would then re-read the SX126x
+    // buffer, which still holds that packet, and hand back a byte-identical
+    // duplicate (bench: same seq, same RSSI/SNR to 0.1 dB, ~9 ms later).
+    //
+    // So ask the radio, not the flag. DIO1 is masked to RxDone only, so a set
+    // RX_DONE bit means a genuinely new packet is waiting.
+    if (!(radio_->getIrqFlags() & RADIOLIB_SX126X_IRQ_RX_DONE))
+    {
+        portDISABLE_INTERRUPTS();
+        rx_done_ = false;
+        portENABLE_INTERRUPTS();
+        stats_.rx_spurious++;
+        return false;
+    }
+
     // Clear the flag atomically w.r.t. the DIO1 ISR so we never lose
     // an rx_done_ that fires between the check above and this assignment.
     portDISABLE_INTERRUPTS();

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -53,6 +53,12 @@ public:
         uint32_t rx_count = 0;
         uint32_t rx_crc_fail = 0;
         uint32_t rx_len_drop = 0;  // #288: RX dropped for bad length (0 or > maxLen)
+        // #520: rx_done_ was latched but the radio had no packet — a stale DIO1
+        // level re-armed the flag for a packet already consumed. Caught and
+        // discarded instead of re-reading the SX126x buffer (which produced
+        // byte-identical duplicate packets). Nonzero here is EXPECTED and healthy:
+        // it means the race is still happening and is being caught.
+        uint32_t rx_spurious = 0;
         uint32_t isr_count = 0;
         uint32_t tx_watchdog_fires = 0;  // tx_ongoing_ force-cleared by watchdog (#105)
         float last_rssi = 0.0f;

--- a/tinkerrocket-idf/components/TR_NVS/include/TR_NVS.h
+++ b/tinkerrocket-idf/components/TR_NVS/include/TR_NVS.h
@@ -3,6 +3,12 @@
  *
  * Wraps ESP-IDF nvs_flash API with an interface matching
  * the Arduino Preferences class used throughout the codebase.
+ *
+ * Failures are reported, not swallowed (#500).  This class used to ignore
+ * every nvs_* return code, so a base station whose NVS had never been
+ * initialised read back the caller's defaults and dropped every write on
+ * the floor without a single log line.  Reads that miss return the default
+ * (a key that was never written is normal); anything else is logged.
  */
 #pragma once
 
@@ -13,7 +19,7 @@
 
 class Preferences {
 public:
-    Preferences() : handle_(0), opened_(false) {}
+    Preferences() : handle_(0), opened_(false), read_only_(false) {}
 
     ~Preferences() { end(); }
 
@@ -21,17 +27,34 @@ public:
     {
         if (opened_) end();
         esp_err_t err = nvs_open(ns, readOnly ? NVS_READONLY : NVS_READWRITE, &handle_);
-        opened_ = (err == ESP_OK);
+        opened_    = (err == ESP_OK);
         read_only_ = readOnly;
+        if (!opened_)
+        {
+            handle_ = 0;
+            // A read-only open of a namespace nobody has written yet is an
+            // ordinary "nothing saved" — callers seed defaults and move on.
+            // Every other failure means NVS itself is unusable.
+            if (readOnly && err == ESP_ERR_NVS_NOT_FOUND)
+                ESP_LOGD(TAG_, "namespace '%s' not present yet", ns);
+            else
+                ESP_LOGE(TAG_, "open('%s') failed: %s — settings will NOT persist",
+                         ns, esp_err_to_name(err));
+        }
         return opened_;
     }
 
     void end()
     {
         if (opened_) {
-            if (!read_only_) nvs_commit(handle_);
+            if (!read_only_) {
+                esp_err_t err = nvs_commit(handle_);
+                if (err != ESP_OK)
+                    ESP_LOGE(TAG_, "commit failed: %s — changes lost", esp_err_to_name(err));
+            }
             nvs_close(handle_);
             opened_ = false;
+            handle_ = 0;
         }
     }
 
@@ -39,9 +62,7 @@ public:
 
     bool getBool(const char* key, bool def = false)
     {
-        uint8_t val = def ? 1 : 0;
-        nvs_get_u8(handle_, key, &val);
-        return val != 0;
+        return getUChar(key, def ? 1 : 0) != 0;
     }
 
     int8_t getChar(const char* key, int8_t def = 0)
@@ -51,9 +72,9 @@ public:
 
     uint8_t getUChar(const char* key, uint8_t def = 0)
     {
-        uint8_t val = def;
-        nvs_get_u8(handle_, key, &val);
-        return val;
+        if (!opened_) return def;
+        uint8_t val;
+        return readFailed_(key, nvs_get_u8(handle_, key, &val)) ? def : val;
     }
 
     int16_t getShort(const char* key, int16_t def = 0)
@@ -63,9 +84,9 @@ public:
 
     uint16_t getUShort(const char* key, uint16_t def = 0)
     {
-        uint16_t val = def;
-        nvs_get_u16(handle_, key, &val);
-        return val;
+        if (!opened_) return def;
+        uint16_t val;
+        return readFailed_(key, nvs_get_u16(handle_, key, &val)) ? def : val;
     }
 
     int32_t getInt(const char* key, int32_t def = 0)
@@ -75,16 +96,16 @@ public:
 
     uint32_t getUInt(const char* key, uint32_t def = 0)
     {
-        uint32_t val = def;
-        nvs_get_u32(handle_, key, &val);
-        return val;
+        if (!opened_) return def;
+        uint32_t val;
+        return readFailed_(key, nvs_get_u32(handle_, key, &val)) ? def : val;
     }
 
     float getFloat(const char* key, float def = 0.0f)
     {
+        if (!opened_) return def;
         uint32_t raw;
-        memcpy(&raw, &def, sizeof(raw));
-        nvs_get_u32(handle_, key, &raw);
+        if (readFailed_(key, nvs_get_u32(handle_, key, &raw))) return def;
         float result;
         memcpy(&result, &raw, sizeof(result));
         return result;
@@ -92,20 +113,21 @@ public:
 
     size_t getBytesLength(const char* key)
     {
+        if (!opened_) return 0;
         size_t len = 0;
-        esp_err_t err = nvs_get_blob(handle_, key, NULL, &len);
-        return (err == ESP_OK) ? len : 0;
+        return readFailed_(key, nvs_get_blob(handle_, key, NULL, &len)) ? 0 : len;
     }
 
     size_t getBytes(const char* key, void* buf, size_t maxLen)
     {
+        if (!opened_) return 0;
         size_t len = maxLen;
-        esp_err_t err = nvs_get_blob(handle_, key, buf, &len);
-        return (err == ESP_OK) ? len : 0;
+        return readFailed_(key, nvs_get_blob(handle_, key, buf, &len)) ? 0 : len;
     }
 
     bool isKey(const char* key)
     {
+        if (!opened_) return false;
         // Try to get as blob first (covers most types)
         size_t len = 0;
         esp_err_t err = nvs_get_blob(handle_, key, NULL, &len);
@@ -126,7 +148,7 @@ public:
 
     void putBool(const char* key, bool val)
     {
-        nvs_set_u8(handle_, key, val ? 1 : 0);
+        putUChar(key, val ? 1 : 0);
     }
 
     void putChar(const char* key, int8_t val)
@@ -136,7 +158,8 @@ public:
 
     void putUChar(const char* key, uint8_t val)
     {
-        nvs_set_u8(handle_, key, val);
+        if (!opened_) return;
+        checkWrite_(key, nvs_set_u8(handle_, key, val));
     }
 
     void putShort(const char* key, int16_t val)
@@ -146,7 +169,8 @@ public:
 
     void putUShort(const char* key, uint16_t val)
     {
-        nvs_set_u16(handle_, key, val);
+        if (!opened_) return;
+        checkWrite_(key, nvs_set_u16(handle_, key, val));
     }
 
     void putInt(const char* key, int32_t val)
@@ -156,33 +180,57 @@ public:
 
     void putUInt(const char* key, uint32_t val)
     {
-        nvs_set_u32(handle_, key, val);
+        if (!opened_) return;
+        checkWrite_(key, nvs_set_u32(handle_, key, val));
     }
 
     void putFloat(const char* key, float val)
     {
+        if (!opened_) return;
         uint32_t raw;
         memcpy(&raw, &val, sizeof(raw));
-        nvs_set_u32(handle_, key, raw);
+        checkWrite_(key, nvs_set_u32(handle_, key, raw));
     }
 
     size_t putBytes(const char* key, const void* buf, size_t len)
     {
-        esp_err_t err = nvs_set_blob(handle_, key, buf, len);
-        return (err == ESP_OK) ? len : 0;
+        if (!opened_) return 0;
+        return checkWrite_(key, nvs_set_blob(handle_, key, buf, len)) ? len : 0;
     }
 
     bool remove(const char* key)
     {
+        if (!opened_) return false;
         return nvs_erase_key(handle_, key) == ESP_OK;
     }
 
     bool clear()
     {
+        if (!opened_) return false;
         return nvs_erase_all(handle_) == ESP_OK;
     }
 
 private:
+    static constexpr const char* TAG_ = "NVS";
+
+    // true when the read did not produce a value, so the caller substitutes
+    // its default.  A missing key is the normal "never written" case and stays
+    // quiet; a corrupt/unopened/wrong-type store is not, and says so.
+    static bool readFailed_(const char* key, esp_err_t err)
+    {
+        if (err == ESP_OK) return false;
+        if (err != ESP_ERR_NVS_NOT_FOUND)
+            ESP_LOGW(TAG_, "read '%s' failed: %s — using default", key, esp_err_to_name(err));
+        return true;
+    }
+
+    static bool checkWrite_(const char* key, esp_err_t err)
+    {
+        if (err == ESP_OK) return true;
+        ESP_LOGE(TAG_, "write '%s' failed: %s", key, esp_err_to_name(err));
+        return false;
+    }
+
     nvs_handle_t handle_;
     bool opened_;
     bool read_only_;

--- a/tinkerrocket-idf/projects/base_station/main/bs_battery_soc.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_battery_soc.h
@@ -1,0 +1,174 @@
+#pragma once
+
+// Voltage-based state-of-charge estimator (#501).
+//
+// The BQ27Z746's own SoC is unusable on this board: it reported 0% with the
+// pack at 4.17 V and accepting 449 mA, with RemainingCapacity=0 and
+// FullChargeCapacity=27932 mAh against a 2800 mAh design (~10x).
+//
+// Root cause is the CURRENT path, not the driver — TR_BQ27Z746.cpp reads RSOC /
+// RemainingCapacity / FullChargeCapacity straight through with no scaling. The
+// gauge's CC Gain (data flash 0x4006) still sits at its factory default and has
+// never been calibrated against a known current (the driver header says so), and
+// ManufacturingStatus[GAUGE_EN] ships at 0. An Impedance-Track gauge derives
+// RM/FCC/SoC by integrating current, so a wrong (or ungauged) current makes all
+// three garbage — while Voltage(), a direct ADC read, stays correct.
+//
+// So: estimate SoC from voltage. It is less accurate than a *working* coulomb
+// counter but it is honest, and it degrades gracefully — which beats reporting a
+// confident 0% into the app on a full pack, with no low-battery warning.
+//
+// Pure — no ESP-IDF / hardware dependencies — so the host gtest drives it
+// directly. Same pattern as bs_uplink_queue.h / bs_uplink_policy.h.
+
+#include <cstddef>
+
+namespace bs_battery_soc {
+
+// Rest (open-circuit) voltage -> SoC for one Li-ion cell at room temperature.
+// Generic LiCoO2/graphite curve, which is what the 18650 packs here are. The
+// knee below ~3.5 V is steep and the 3.6-4.0 V plateau is flat — that flatness
+// is the fundamental accuracy limit of any voltage-only method, and the reason
+// this is a fallback rather than the preferred approach.
+struct OcvPoint
+{
+    float volts;
+    float soc;  // percent
+};
+
+inline constexpr OcvPoint kOcvCurve[] = {
+    {3.00f,   0.0f},
+    {3.35f,   5.0f},
+    {3.45f,  10.0f},
+    {3.51f,  15.0f},
+    {3.55f,  20.0f},
+    {3.58f,  25.0f},
+    {3.60f,  30.0f},
+    {3.63f,  35.0f},
+    {3.65f,  40.0f},
+    {3.68f,  45.0f},
+    {3.71f,  50.0f},
+    {3.75f,  55.0f},
+    {3.79f,  60.0f},
+    {3.83f,  65.0f},
+    {3.87f,  70.0f},
+    {3.92f,  75.0f},
+    {3.97f,  80.0f},
+    {4.02f,  85.0f},
+    {4.08f,  90.0f},
+    {4.13f,  95.0f},
+    {4.20f, 100.0f},
+};
+
+inline constexpr size_t kOcvCurveN = sizeof(kOcvCurve) / sizeof(kOcvCurve[0]);
+
+inline constexpr float kCellEmptyV = 3.00f;
+inline constexpr float kCellFullV  = 4.20f;
+
+// Piecewise-linear lookup, clamped at both ends. Input is PER-CELL open-circuit
+// volts.
+inline float socFromCellOcv(float ocv_v)
+{
+    if (ocv_v <= kOcvCurve[0].volts)              return kOcvCurve[0].soc;
+    if (ocv_v >= kOcvCurve[kOcvCurveN - 1].volts) return kOcvCurve[kOcvCurveN - 1].soc;
+
+    for (size_t i = 1; i < kOcvCurveN; i++)
+    {
+        if (ocv_v <= kOcvCurve[i].volts)
+        {
+            const OcvPoint& lo = kOcvCurve[i - 1];
+            const OcvPoint& hi = kOcvCurve[i];
+            const float span = hi.volts - lo.volts;
+            if (span <= 0.0f) return lo.soc;
+            const float t = (ocv_v - lo.volts) / span;
+            return lo.soc + t * (hi.soc - lo.soc);
+        }
+    }
+    return kOcvCurve[kOcvCurveN - 1].soc;
+}
+
+// Terminal volts -> open-circuit volts, removing the IR offset.
+//
+// current_ma is POSITIVE when charging (the gauge's convention). Charging lifts
+// the terminal above the true OCV, discharging drags it below, so OCV = V - I*R.
+//
+// Pass r_int_ohm = 0 to DISABLE this, which is what the base station does today:
+// compensating with the BQ27Z746's uncalibrated current would inject a scaling
+// error rather than remove one. Wired up and tested so it can be switched on the
+// moment CC Gain is calibrated (#501 follow-up).
+inline float ocvFromTerminal(float terminal_v, float current_ma, float r_int_ohm)
+{
+    if (r_int_ohm <= 0.0f) return terminal_v;
+    return terminal_v - (current_ma / 1000.0f) * r_int_ohm;
+}
+
+// Is the gauge's OWN SoC believable? If yes, prefer it — a learned coulomb
+// counter beats a voltage guess. Every clause below is something the 2026-07-14
+// bench log actually violated.
+inline bool gaugeSocPlausible(bool gauge_en,
+                              float soc_pct,
+                              float fcc_mah,
+                              float design_mah,
+                              float pack_v,
+                              int   cells)
+{
+    // Impedance Track disabled -> RM/FCC/SoC were never gauged at all.
+    if (!gauge_en) return false;
+
+    if (soc_pct < 0.0f || soc_pct > 100.0f) return false;
+
+    // A learned FullChargeCapacity sits near design. 27932 vs 2800 does not.
+    if (design_mah > 0.0f)
+    {
+        if (fcc_mah < 0.5f * design_mah) return false;
+        if (fcc_mah > 1.5f * design_mah) return false;
+    }
+
+    // 0% while the cells are plainly not empty — the headline symptom.
+    if (cells > 0 && soc_pct <= 0.0f && (pack_v / (float)cells) > 3.5f) return false;
+
+    return true;
+}
+
+// Exponentially-smoothed voltage -> SoC. Smoothing is on the VOLTAGE, not the
+// SoC, so the curve's steep knee isn't flattened by the filter.
+class Estimator
+{
+public:
+    // alpha: EMA weight for each new sample (0..1]. 0.1 at the base station's
+    // ~1 Hz battery poll gives a ~10 s time constant — long enough to ride out
+    // TX current spikes, short enough to track a real discharge.
+    explicit Estimator(float alpha = 0.1f) : alpha_(alpha) {}
+
+    // pack_v: measured terminal volts across the whole pack.
+    // cells:  cells in series (BQ27Z746 board is 1S).
+    // Returns the SoC estimate in percent.
+    float update(float pack_v, int cells, float current_ma = 0.0f, float r_int_ohm = 0.0f)
+    {
+        if (cells <= 0) cells = 1;
+        const float cell_v = ocvFromTerminal(pack_v, current_ma, r_int_ohm) / (float)cells;
+
+        if (!primed_)
+        {
+            filtered_cell_v_ = cell_v;   // snap on the first sample, don't ramp from 0
+            primed_ = true;
+        }
+        else
+        {
+            filtered_cell_v_ += alpha_ * (cell_v - filtered_cell_v_);
+        }
+        return socFromCellOcv(filtered_cell_v_);
+    }
+
+    bool  primed() const          { return primed_; }
+    float filteredCellV() const   { return filtered_cell_v_; }
+    float soc() const             { return primed_ ? socFromCellOcv(filtered_cell_v_) : 0.0f; }
+    void  reset()                 { primed_ = false; filtered_cell_v_ = 0.0f; }
+
+private:
+    float alpha_;
+    float filtered_cell_v_ = 0.0f;
+    bool  primed_          = false;
+};
+
+}  // namespace bs_battery_soc

--- a/tinkerrocket-idf/projects/base_station/main/bs_uplink_queue.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_uplink_queue.h
@@ -1,0 +1,111 @@
+#pragma once
+
+// Base-station uplink command FIFO (#502).
+//
+// The uplink used to be a single slot: queuing a command overwrote whatever
+// was pending, along with its remaining retries. Because the uplink is BLIND —
+// the rocket sends no command ACK — the retry count *is* the delivery
+// mechanism, so discarding retries directly cuts a command's odds of arriving.
+// The bench log caught the sim-config (cmd 5) getting 3 of its 8 transmissions
+// out before sim-start (cmd 6) clobbered it. Same class of bug as #366 on the
+// OC side.
+//
+// This is the FIFO that replaces the slot: commands drain in order, each
+// keeping its own retry budget, and a genuinely full queue drops loudly rather
+// than silently trampling a pending command.
+//
+// Pure — no ESP-IDF / FreeRTOS / radio dependencies — so the host gtest can
+// drive it directly. Same pattern as bs_uplink_policy.h / bs_log_policy.h.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace bs_uplink_queue {
+
+// Wire format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
+inline constexpr size_t kHeaderBytes = 6;
+inline constexpr size_t kMaxPacket   = 40;  // cmd 15 channel-set push needs 27 payload at BW=125
+// 1 byte of slack, matching the pre-FIFO bound so #286's reject threshold is unchanged.
+inline constexpr size_t kMaxPayload  = kMaxPacket - kHeaderBytes - 1;  // 33
+
+// Depth 8 covers the bursts the app actually sends (config-then-start is 2;
+// a full profile sync is a handful) with room to spare. Each entry is ~44 B,
+// so the whole FIFO is ~350 B of static RAM.
+inline constexpr size_t kDepth = 8;
+
+// Byte offset of the command id inside a built packet.
+inline constexpr size_t kCmdOffset = 4;
+
+enum class PushResult : uint8_t
+{
+    Queued,
+    RejectedOversized,  // #286: reject rather than truncate into a malformed command
+    RejectedFull,
+};
+
+struct Entry
+{
+    uint8_t buf[kMaxPacket];
+    size_t  len          = 0;
+    uint8_t retries_left = 0;
+
+    uint8_t cmd() const { return buf[kCmdOffset]; }
+};
+
+class Queue
+{
+public:
+    bool   empty() const { return count_ == 0; }
+    bool   full()  const { return count_ == kDepth; }
+    size_t size()  const { return count_; }
+
+    // True while any command is queued or mid-retry. This is the successor to
+    // the old `uplink_pending` flag: callers use it to mean "the uplink is
+    // busy, don't start something else on the radio".
+    bool busy() const { return count_ != 0; }
+
+    PushResult push(uint8_t sync_byte, uint8_t network_id, uint8_t target_rid,
+                    uint8_t next_channel, uint8_t cmd,
+                    const uint8_t* payload, size_t payload_len, uint8_t retries)
+    {
+        // Checked before the full() test so an oversized payload is reported as
+        // oversized regardless of queue depth, and never displaces a real entry.
+        if (payload_len > kMaxPayload) return PushResult::RejectedOversized;
+        if (full())                    return PushResult::RejectedFull;
+
+        Entry& e = slots_[(head_ + count_) % kDepth];
+        e.buf[0] = sync_byte;
+        e.buf[1] = network_id;
+        e.buf[2] = target_rid;
+        e.buf[3] = next_channel;
+        e.buf[4] = cmd;
+        e.buf[5] = (uint8_t)payload_len;
+        if (payload_len > 0 && payload != nullptr)
+        {
+            memcpy(&e.buf[kHeaderBytes], payload, payload_len);
+        }
+        e.len          = kHeaderBytes + payload_len;
+        e.retries_left = retries;
+        count_++;
+        return PushResult::Queued;
+    }
+
+    // Command currently transmitting; nullptr when idle.
+    Entry*       head()       { return count_ ? &slots_[head_] : nullptr; }
+    const Entry* head() const { return count_ ? &slots_[head_] : nullptr; }
+
+    void pop()
+    {
+        if (count_ == 0) return;
+        head_ = (head_ + 1) % kDepth;
+        count_--;
+    }
+
+private:
+    Entry  slots_[kDepth];
+    size_t head_  = 0;
+    size_t count_ = 0;
+};
+
+}  // namespace bs_uplink_queue

--- a/tinkerrocket-idf/projects/base_station/main/bs_uplink_txwin.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_uplink_txwin.h
@@ -1,0 +1,178 @@
+#pragma once
+
+// Uplink transmit-window policy (#506) — stop the blind-TX burst deafening the
+// receiver.
+//
+// The radio is half-duplex: while the base station transmits an uplink it cannot
+// hear the rocket. The 2026-07-14 bench run measured the cost exactly — the ONLY
+// downlink loss in a clean 92 s flight (3 packets, and zero CRC/length/net-id
+// drops) fell inside the cmd5+cmd6 blind-TX burst.
+//
+// It is not bad luck, it is arithmetic. At SF8/BW250/CR4-5:
+//
+//     downlink telemetry (46 B)  ~82 ms on air
+//     uplink sim-config  (22 B)  ~51 ms on air
+//     retry interval                100 ms
+//
+// so the RX gaps between retries are only 100 - 51 = ~49 ms, and an 82 ms packet
+// CANNOT fit in a 49 ms gap. During a burst the BS doesn't lose some packets, it
+// loses essentially all of them. Simply spacing the retries wider doesn't fix
+// that — it just stretches the deaf window.
+//
+// What does fix it: the rocket transmits on a fixed ~500 ms cadence, so once we
+// have received a packet we know exactly when the next one is due, and the air is
+// quiet in between. Transmit inside that quiet stretch and the downlink is never
+// stepped on. This is the same insight the hop safe-window already encodes
+// (HOP_BS_TX_SAFE_WINDOW_MS in main.cpp) — but that one is gated on hop_active_,
+// so it does nothing when hopping is off, which is exactly when the bench run lost
+// its packets.
+//
+// It should also improve UPLINK delivery: right after the rocket's own TX is
+// precisely when the rocket is listening.
+//
+// Pure — no ESP-IDF / radio dependencies — so the host gtest drives it directly.
+// Same pattern as bs_uplink_queue.h / bs_uplink_policy.h.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace bs_uplink_txwin {
+
+// ---------------------------------------------------------------------------
+// LoRa time-on-air (Semtech AN1200.13). Needed because the usable window shrinks
+// by however long OUR packet takes — a 33-byte channel-set push occupies the air
+// far longer than a 0-byte sim-start.
+// ---------------------------------------------------------------------------
+inline uint32_t timeOnAirMs(size_t payload_len, uint8_t sf, float bw_khz,
+                            uint8_t cr /* 5..8 => 4/5..4/8 */,
+                            uint8_t preamble_syms = 8)
+{
+    if (sf < 6)   sf = 6;
+    if (sf > 12)  sf = 12;
+    if (bw_khz <= 0.0f) bw_khz = 125.0f;
+
+    // cr is the denominator form used in config (5 == 4/5). The formula wants 1..4.
+    int cr_idx = (int)cr - 4;
+    if (cr_idx < 1) cr_idx = 1;
+    if (cr_idx > 4) cr_idx = 4;
+
+    const float ts_ms = (float)(1u << sf) / bw_khz;      // symbol time, ms (bw in kHz)
+    const float preamble_ms = ((float)preamble_syms + 4.25f) * ts_ms;
+
+    // Low-data-rate optimise kicks in when a symbol is long (SF11/12 @125k).
+    const int de = (ts_ms >= 16.0f) ? 1 : 0;
+
+    const int num = 8 * (int)payload_len - 4 * (int)sf + 28 + 16;   // explicit header, CRC on
+    const int den = 4 * ((int)sf - 2 * de);
+    int n_payload = 0;
+    if (num > 0 && den > 0)
+    {
+        n_payload = ((num + den - 1) / den) * (cr_idx + 4);   // ceil(num/den) * (CR+4)
+    }
+    const float payload_ms = (float)(8 + n_payload) * ts_ms;
+
+    return (uint32_t)(preamble_ms + payload_ms + 0.5f);
+}
+
+// ---------------------------------------------------------------------------
+// Rocket downlink cadence, learned from RX timestamps. Learned rather than
+// hardcoded so a telemetry-rate change can't silently invalidate the window.
+// ---------------------------------------------------------------------------
+inline constexpr uint32_t kDefaultPeriodMs = 500;   // 2 Hz, the configured rate
+inline constexpr uint32_t kMinPlausibleMs  = 100;
+inline constexpr uint32_t kMaxPlausibleMs  = 2000;
+
+class RxCadence
+{
+public:
+    // Call on every accepted downlink packet.
+    void onPacket(uint32_t now_ms)
+    {
+        if (last_ms_ != 0)
+        {
+            const uint32_t delta = now_ms - last_ms_;
+            // Ignore duplicates/bursts and long dropouts — neither is the cadence.
+            if (delta >= kMinPlausibleMs && delta <= kMaxPlausibleMs)
+            {
+                if (samples_ == 0) period_ms_ = (float)delta;
+                else               period_ms_ += 0.25f * ((float)delta - period_ms_);
+                if (samples_ < 255) samples_++;
+            }
+        }
+        last_ms_ = now_ms;
+    }
+
+    // Two clean intervals before we trust it enough to gate transmissions on it.
+    // Until then the caller should not gate at all — there is no established
+    // telemetry stream to protect, and holding commands back would be all cost
+    // and no benefit.
+    bool valid() const { return samples_ >= 2; }
+
+    // Timestamp of the last packet in the cadence stream — the phase anchor.
+    uint32_t lastMs() const { return last_ms_; }
+
+    uint32_t periodMs() const
+    {
+        return valid() ? (uint32_t)(period_ms_ + 0.5f) : kDefaultPeriodMs;
+    }
+
+    void reset() { last_ms_ = 0; period_ms_ = 0.0f; samples_ = 0; }
+
+private:
+    uint32_t last_ms_   = 0;
+    float    period_ms_ = 0.0f;
+    uint8_t  samples_   = 0;
+};
+
+// ---------------------------------------------------------------------------
+// The gate.
+// ---------------------------------------------------------------------------
+struct Params
+{
+    uint32_t period_ms      = kDefaultPeriodMs;  // measured downlink cadence
+    uint32_t tx_airtime_ms  = 52;                // OUR packet's time on air
+    uint32_t rx_reserve_ms  = 140;               // keep clear for the inbound packet
+                                                 //   (~82 ms on air + margin)
+    uint32_t link_stale_ms  = 2000;              // no packet this long => no link to protect
+    uint32_t max_defer_ms   = 1500;              // liveness backstop, see below
+};
+
+// May we START an uplink transmission right now?
+//
+// last_rx_ms == 0 means we have never heard the rocket.
+// deferred_for_ms is how long THIS command has already been held back by this gate.
+//
+// Liveness matters more than tidiness here: the uplink is blind and carries
+// safety-relevant commands (pyro arm, camera, logging). A command that never goes
+// out is far worse than a dropped telemetry row, so every path that cannot find a
+// safe window falls through to "transmit anyway" rather than blocking.
+inline bool mayStartTx(uint32_t now_ms,
+                       uint32_t last_rx_ms,
+                       uint32_t deferred_for_ms,
+                       const Params& p)
+{
+    // No link yet — rendezvous / recovery / silence-recovery must be able to TX,
+    // and there is no downlink to protect anyway.
+    if (last_rx_ms == 0) return true;
+
+    const uint32_t age = now_ms - last_rx_ms;
+
+    // Rocket has gone quiet. Nothing to step on, and this is exactly when we most
+    // need to shout (recovery pushes).
+    if (age >= p.link_stale_ms) return true;
+
+    // Backstop: never let the gate starve a command indefinitely (e.g. a cadence
+    // estimate that leaves no usable window, or a pathological loop timing).
+    if (deferred_for_ms >= p.max_defer_ms) return true;
+
+    // The next downlink packet is due at last_rx_ms + period, and needs the air
+    // clear for rx_reserve_ms before that. Our transmission occupies
+    // [now, now + tx_airtime]. Require it to finish first.
+    const uint32_t needed = p.rx_reserve_ms + p.tx_airtime_ms;
+    if (needed >= p.period_ms) return true;   // no window can exist — don't deadlock
+
+    const uint32_t window_end = p.period_ms - needed;
+    return age <= window_end;
+}
+
+}  // namespace bs_uplink_txwin

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -122,6 +122,19 @@ struct config : board_pins
     // DesignCap at boot to seed the ModelGauge m5 algorithm.
     static constexpr uint16_t BATTERY_DESIGN_MAH = 2800;
 
+    // --- Voltage-based SoC fallback (#501) ---
+    // The BQ27Z746 is a 1S gauge, so its Voltage() IS the cell voltage.
+    static constexpr int   BQ27Z746_CELLS = 1;
+    // Pack internal resistance (Ω) used to back out IR offset from the terminal
+    // voltage. ZERO = compensation DISABLED, which is deliberate: the gauge's CC
+    // Gain (data flash 0x4006) has never been calibrated against a known current,
+    // so its current reading would inject a scaling error rather than remove one.
+    // Set this once CC Gain is calibrated — the path is implemented and tested.
+    static constexpr float BATTERY_INTERNAL_R_OHM = 0.0f;
+    // EMA weight per battery poll (PWR_UPDATE_PERIOD_MS = 2 s) → ~20 s time
+    // constant: rides out LoRa TX current spikes, still tracks a real discharge.
+    static constexpr float SOC_FILTER_ALPHA = 0.1f;
+
     // --- Flight-pack charger (MP2672 on V3; gated by HAS_PACK_CHARGER) ---
     static constexpr uint16_t MP2672_ADDR = 0x4B;
     // Fast-charge current code (REG01 ICC[3:0]): I = FS*(5+code)/20 with

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -62,6 +62,25 @@ struct config : board_pins
     static constexpr uint8_t  UPLINK_RETRIES           = 8;     // TX attempts per command
     static constexpr uint32_t UPLINK_RETRY_INTERVAL_MS = 100;   // Delay between retries
 
+    // --- Uplink TX window (#506) ---
+    // The radio is half-duplex, so every uplink retry is a deaf window. At
+    // SF8/BW250 a downlink packet is ~82 ms on air while the gaps between retries
+    // are only ~49 ms — an 82 ms packet cannot fit in a 49 ms gap, so a blind
+    // burst loses essentially EVERY packet that arrives during it (bench-measured:
+    // 3 of 3). Rather than firing blind, transmit inside the quiet stretch between
+    // the rocket's ~500 ms telemetry packets. See bs_uplink_txwin.h.
+    //
+    // Air to keep clear ahead of the next expected downlink packet: its ~82 ms of
+    // time-on-air plus margin for cadence jitter and TX/RX turnaround.
+    static constexpr uint32_t UPLINK_RX_RESERVE_MS = 140;
+    // No packet for this long => no downlink worth protecting; transmit freely.
+    // Also the case where we most need to (silence recovery, rendezvous).
+    static constexpr uint32_t UPLINK_LINK_STALE_MS = 2000;
+    // Liveness backstop: never let the window gate starve a command. The uplink is
+    // blind and carries safety-relevant commands, so a command that never goes out
+    // is far worse than a dropped telemetry row.
+    static constexpr uint32_t UPLINK_MAX_DEFER_MS  = 1500;
+
     // --- Storage ---
     // V2/V3 log to a FORESEE F35SQB004G SPI NAND (M_* nets, on SPI3_HOST since
     // LoRa owns SPI2_HOST on V2); V1 uses an SDMMC SD card. Pins + presence

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1481,9 +1481,14 @@ static void printTelemetry(const LoRaDataSI& data, float rssi, float snr,
     else
         snprintf(hop_str, sizeof(hop_str), "%u", (unsigned)data.next_channel_idx);
 
-    ESP_LOGI(TAG, "[RX] %s | alt=%.0fm spd=%.1fm/s | %.0fdBm SNR=%.1f | sats=%u | %.2fV %.0f%% | nextCh=%s",
+    // #504: spd= used to be fed data.max_speed, so a landed rocket read 99 m/s —
+    // alarming to watch, and flatly contradicted by the CSV (speed=1.0,
+    // max_speed=99.0). Print the live speed under spd=, and keep the peak under
+    // its own max= label, which is what you actually want side by side on the bench.
+    ESP_LOGI(TAG, "[RX] %s | alt=%.0fm spd=%.1fm/s max=%.1fm/s | %.0fdBm SNR=%.1f | sats=%u | %.2fV %.0f%% | nextCh=%s",
              rocketStateToString(data.rocket_state),
              (double)data.pressure_alt,
+             (double)data.speed,
              (double)data.max_speed,
              (double)rssi,
              (double)snr,

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1545,11 +1545,15 @@ static void printStats()
         snprintf(last_pkt_str, sizeof(last_pkt_str), "never");
     }
 
-    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | len drop: %lu | low-SNR drop: %lu | netid drop: %lu | log wr-fail: %lu | ISR: %lu | rx_mode: %d | TX wdog: %lu | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
+    // #520: dup-rx = stale DIO1 latches caught before they could re-read the
+    // radio buffer and emit a byte-identical duplicate packet. Nonzero is
+    // EXPECTED and healthy — it means the race still occurs and is being caught.
+    ESP_LOGI(TAG, "[STATS] RX: %lu pkts (%.1f Hz) | CRC fail: %lu | len drop: %lu | dup-rx caught: %lu | low-SNR drop: %lu | netid drop: %lu | log wr-fail: %lu | ISR: %lu | rx_mode: %d | TX wdog: %lu | Last RSSI: %.0f dBm SNR: %.1f dB | Last pkt %s",
              (unsigned long)ls.rx_count,
              (double)rx_hz,
              (unsigned long)ls.rx_crc_fail,
              (unsigned long)ls.rx_len_drop,
+             (unsigned long)ls.rx_spurious,
              (unsigned long)lora_low_snr_drops,
              (unsigned long)lora_netid_mismatch_drops,
              (unsigned long)log_write_fail_count,

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -31,6 +31,7 @@
 #include "bs_log_policy.h"        // parseSequentialFilename() (#137)
 #include "bs_uplink_policy.h"     // mayTransmitUplink() scan gate (#379)
 #include "bs_uplink_queue.h"      // uplink command FIFO (#502)
+#include "bs_uplink_txwin.h"      // TX-in-the-RX-gap window policy (#506)
 #include "bs_battery_soc.h"       // voltage-based SoC fallback (#501)
 #include "bs_download_policy.h"   // nextChunk()/mayEmitChunk() pacing (#380)
 
@@ -165,6 +166,16 @@ static uint32_t uplink_last_tx_ms = 0;
 // mask-drift paths keep their original meaning: don't touch the radio, and
 // don't consider a relay finished, until the queue has fully drained.
 static inline bool uplinkBusy() { return uplink_q.busy(); }
+
+// #506: the rocket's downlink cadence, learned from RX timestamps, so uplink
+// retries can be fired into the quiet stretch between telemetry packets instead
+// of straight over the top of them.
+static bs_uplink_txwin::RxCadence rx_cadence;
+static uint32_t uplink_defer_start_ms = 0;   // when the head command was first held back
+static uint32_t uplink_tx_count       = 0;   // TXs actually emitted (stats)
+static uint32_t uplink_tx_airtime_ms  = 0;   // cumulative uplink time-on-air (stats)
+static uint32_t uplink_defer_count    = 0;   // passes deferred to protect the downlink
+static uint32_t uplink_defer_override = 0;   // liveness backstop fired (should be ~0)
 
 // Storage mount state. Preferred backend is SD over SDMMC; if that fails at boot
 // we fall back to SPIFFS on internal flash (partitions.csv: "spiffs", ~5 MB).
@@ -1549,6 +1560,19 @@ static void printStats()
              (double)ls.last_snr,
              last_pkt_str);
 
+    // Uplink airtime (#506).  The radio is half-duplex, so uplink time-on-air is
+    // time we are deaf — and it used to be silently charged to the downlink loss
+    // counters above, making a self-inflicted hole look like an RF problem. txwin
+    // = retries held back to land in the gap between telemetry packets; forced =
+    // the liveness backstop transmitting over the downlink anyway (want ~0).
+    ESP_LOGI(TAG, "[UPLINK] TX: %lu sent, %lu ms airtime | txwin: %lu deferred, %lu forced | rocket cadence: %u ms%s",
+             (unsigned long)uplink_tx_count,
+             (unsigned long)uplink_tx_airtime_ms,
+             (unsigned long)uplink_defer_count,
+             (unsigned long)uplink_defer_override,
+             (unsigned)rx_cadence.periodMs(),
+             rx_cadence.valid() ? "" : " (est, not yet learned)");
+
     // Base-station battery.  The (est) marker says the SoC came from the voltage
     // curve rather than the gauge's coulomb count (#501) — without it, a plausible
     // number gives no hint that the gauge underneath it is untrustworthy.
@@ -1705,6 +1729,7 @@ static void serviceUplink()
         // startReceive() here: it would reset rx_done_ and drop any downlink
         // packet that arrived between the TX completion and this point.
         uplink_q.pop();  // next queued command (if any) starts on the following pass
+        uplink_defer_start_ms = 0;  // #506: don't carry this command's defer clock over
         return;
     }
 
@@ -1731,8 +1756,45 @@ static void serviceUplink()
         return;  // radio busy, or a scan owns the channel — retry next pass
     }
 
+    // #506: the radio is half-duplex, so this TX is a deaf window. At SF8/BW250 a
+    // downlink packet is ~82 ms on air and the gaps between our retries are only
+    // ~49 ms, so a blind burst loses essentially EVERY packet that arrives during
+    // it (bench-measured: 3 of 3, and they were the run's ONLY losses). Fire into
+    // the quiet stretch between the rocket's ~500 ms telemetry packets instead.
+    // Transmitting right after the rocket's own TX is also when it is listening,
+    // so this should help uplink delivery too.
+    bs_uplink_txwin::Params win;
+    win.period_ms     = rx_cadence.periodMs();
+    win.tx_airtime_ms = bs_uplink_txwin::timeOnAirMs(tx->len, lora_sf, lora_bw_khz, lora_cr);
+    win.rx_reserve_ms = config::UPLINK_RX_RESERVE_MS;
+    win.link_stale_ms = config::UPLINK_LINK_STALE_MS;
+    win.max_defer_ms  = config::UPLINK_MAX_DEFER_MS;
+
+    // No established telemetry cadence yet => nothing to protect; don't gate.
+    const uint32_t rx_anchor = rx_cadence.valid() ? rx_cadence.lastMs() : 0;
+    if (uplink_defer_start_ms == 0) uplink_defer_start_ms = now;
+    const uint32_t deferred_for = now - uplink_defer_start_ms;
+
+    if (!bs_uplink_txwin::mayStartTx(now, rx_anchor, deferred_for, win))
+    {
+        uplink_defer_count++;
+        return;  // inside the rocket's next downlink slot — wait for the gap
+    }
+    if (deferred_for >= win.max_defer_ms && rx_anchor != 0)
+    {
+        // The liveness backstop fired: we transmitted over the downlink rather
+        // than starve a blind, safety-relevant command. Should be ~0 in practice;
+        // if it climbs, the cadence estimate or the reserve is wrong.
+        uplink_defer_override++;
+        ESP_LOGW(TAG, "[UPLINK] cmd=%u: TX window never opened for %ums — transmitting anyway",
+                 (unsigned)tx->cmd(), (unsigned)deferred_for);
+    }
+
     if (lora_comms.send(tx->buf, tx->len))
     {
+        uplink_defer_start_ms = 0;   // this attempt got out; re-arm for the next
+        uplink_tx_count++;
+        uplink_tx_airtime_ms += win.tx_airtime_ms;
         tx->retries_left--;
         uplink_last_tx_ms = now;
         // #285: "blind" + "unconfirmed" so the log is not mistaken for an ACK.
@@ -3624,6 +3686,10 @@ static void loop_bs()
             else
             {
                 last_packet_ms = millis();  // netid-matched proof of life (#384)
+                // #506: learn the downlink cadence from the TELEMETRY stream only.
+                // Beacons are sporadic (~2 s) and would corrupt the estimate; this
+                // is the steady ~500 ms stream whose gaps the uplink aims for.
+                rx_cadence.onPacket(last_packet_ms);
 
                 // Route to per-rocket tracker
                 int slot = findOrAllocRocket(decoded.rocket_id);

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -9,6 +9,7 @@
 #include <esp_partition.h>        // esp_ota_get_running_partition for rollback gate (#8)
 #include <esp_vfs_fat.h>
 #include <esp_spiffs.h>
+#include <nvs_flash.h>            // nvs_flash_init — must run before any Preferences use (#500)
 #include <sdmmc_cmd.h>
 #include <driver/sdmmc_host.h>
 #include <driver/spi_common.h>
@@ -2847,6 +2848,24 @@ static void serviceAutoAcquire()
 
 static void setup_bs()
 {
+    // NVS first — before BLE/LoRa and before any Preferences use (#500).
+    // The BS was missing the block OC/FC have always had, so nvs_open()
+    // returned ESP_ERR_NVS_NOT_INITIALIZED: every Preferences read fell
+    // back to the caller's default and every write no-op'd, silently. The
+    // PHY couldn't cache its RF calibration either, forcing a full recal
+    // on every boot.
+    esp_err_t nvs_err = nvs_flash_init();
+    if (nvs_err == ESP_ERR_NVS_NO_FREE_PAGES || nvs_err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        nvs_flash_erase();
+        nvs_err = nvs_flash_init();
+    }
+    if (nvs_err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "[NVS] nvs_flash_init failed: %s — settings will NOT persist",
+                 esp_err_to_name(nvs_err));
+    }
+
     delay(500);
     ESP_LOGI(TAG, "======================================");
     ESP_LOGI(TAG, "  TinkerRocket Base Station");

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "bs_log_policy.h"        // parseSequentialFilename() (#137)
 #include "bs_uplink_policy.h"     // mayTransmitUplink() scan gate (#379)
+#include "bs_uplink_queue.h"      // uplink command FIFO (#502)
 #include "bs_download_policy.h"   // nextChunk()/mayEmitChunk() pacing (#380)
 
 #include <TR_LoRa_Comms.h>
@@ -147,12 +148,18 @@ static char    unit_id_hex[9] = {0};              // last 4 bytes of MAC as "a1b
 static char    unit_name[24]  = "TinkerBaseStation"; // default until NVS loads
 static uint8_t network_id     = config::DEFAULT_NETWORK_ID;
 
-// LoRa uplink state (BaseStation → OutComputer)
-static uint8_t  uplink_buf[40];   // 6-byte header + up to ~33 bytes payload (cmd 15 channel-set push needs 27 at BW=125)
-static size_t   uplink_len = 0;
-static uint8_t  uplink_retries_left = 0;
+// LoRa uplink state (BaseStation → OutComputer).
+// #502: a FIFO, not a single slot — see bs_uplink_queue.h. The uplink is blind
+// (no command ACK from the rocket), so a command's retries ARE its delivery;
+// overwriting a pending command threw those away.
+static bs_uplink_queue::Queue uplink_q;
 static uint32_t uplink_last_tx_ms = 0;
-static bool     uplink_pending = false;
+
+// "The uplink is busy" — successor to the old `uplink_pending` flag. True while
+// anything is queued or mid-retry, so the transaction / recovery / heartbeat /
+// mask-drift paths keep their original meaning: don't touch the radio, and
+// don't consider a relay finished, until the queue has fully drained.
+static inline bool uplinkBusy() { return uplink_q.busy(); }
 
 // Storage mount state. Preferred backend is SD over SDMMC; if that fails at boot
 // we fall back to SPIFFS on internal flash (partitions.csv: "spiffs", ~5 MB).
@@ -1578,62 +1585,64 @@ static void buildUplinkPacket(uint8_t cmd, const uint8_t* payload, size_t payloa
                               uint8_t target_rid = 0xFF,
                               uint8_t retries = config::UPLINK_RETRIES)
 {
-    // #286: reject (do NOT truncate) an oversized payload.  Truncating would
-    // send a malformed command with a wrong-but-consistent length and no error
-    // surfaced.  Checked first so a rejected command also leaves any
-    // already-pending uplink untouched.
-    constexpr size_t kMaxUplinkPayload = sizeof(uplink_buf) - 6 - 1;  // header + 1 B slack = 33
-    if (payload_len > kMaxUplinkPayload)
+    // An idle queue transmits immediately; a busy one keeps pacing off the last
+    // TX so a queued command can't fire back-to-back with the one ahead of it.
+    const bool was_idle = uplink_q.empty();
+
+    const auto res = uplink_q.push(config::UPLINK_SYNC_BYTE,   // 0xCA
+                                   network_id, target_rid,
+                                   LORA_NEXT_CH_NO_HOP,        // phase 1: hop logic deferred
+                                   cmd, payload, payload_len, retries);
+
+    switch (res)
     {
-        ESP_LOGE(TAG, "[UPLINK] cmd=%u payload %u B exceeds max %u — REJECTED, not queued",
-                 cmd, (unsigned)payload_len, (unsigned)kMaxUplinkPayload);
-        return;
+        case bs_uplink_queue::PushResult::RejectedOversized:
+            // #286: reject (do NOT truncate) an oversized payload.  Truncating
+            // would send a malformed command with a wrong-but-consistent length
+            // and no error surfaced.  The queue checks this before anything else,
+            // so a rejected command leaves the pending ones untouched.
+            ESP_LOGE(TAG, "[UPLINK] cmd=%u payload %u B exceeds max %u — REJECTED, not queued",
+                     cmd, (unsigned)payload_len, (unsigned)bs_uplink_queue::kMaxPayload);
+            return;
+
+        case bs_uplink_queue::PushResult::RejectedFull:
+            // #502: the queue is the fix for silent clobbering, so a genuinely
+            // full queue must be loud rather than quietly dropping the oldest.
+            ESP_LOGE(TAG, "[UPLINK] queue full (%u) — cmd=%u DROPPED, not queued",
+                     (unsigned)bs_uplink_queue::kDepth, cmd);
+            return;
+
+        case bs_uplink_queue::PushResult::Queued:
+            break;
     }
 
-    if (uplink_pending)
-    {
-        ESP_LOGW(TAG, "[UPLINK] Discarding pending cmd=%u, replacing with cmd=%u",
-                 uplink_buf[4], cmd);
-    }
-    // Uplink format v2: [0xCA][network_id][target_rid][next_channel_idx][cmd][len][payload...]
-    uplink_buf[0] = config::UPLINK_SYNC_BYTE;  // 0xCA
-    uplink_buf[1] = network_id;
-    uplink_buf[2] = target_rid;
-    uplink_buf[3] = LORA_NEXT_CH_NO_HOP;       // phase 1: hop logic deferred
-    uplink_buf[4] = cmd;
-    uplink_buf[5] = (uint8_t)payload_len;
-    if (payload_len > 0 && payload != nullptr)
-    {
-        memcpy(&uplink_buf[6], payload, payload_len);
-    }
-    uplink_len = 6 + payload_len;
-    uplink_retries_left = retries;
-    uplink_pending = true;
-    uplink_last_tx_ms = 0;
-    ESP_LOGI(TAG, "[UPLINK] Queued cmd=%u -> rid=%u payload=%u bytes, %u retries",
-             cmd, target_rid, (unsigned)payload_len, (unsigned)retries);
+    if (was_idle) uplink_last_tx_ms = 0;
+
+    ESP_LOGI(TAG, "[UPLINK] Queued cmd=%u -> rid=%u payload=%u bytes, %u retries (queue=%u)",
+             cmd, target_rid, (unsigned)payload_len, (unsigned)retries,
+             (unsigned)uplink_q.size());
 }
 
 static void serviceUplink()
 {
-    if (!uplink_pending || uplink_retries_left == 0)
+    bs_uplink_queue::Entry* tx = uplink_q.head();
+    if (tx == nullptr) return;  // nothing queued
+
+    if (tx->retries_left == 0)
     {
-        if (uplink_pending)
-        {
-            // #285: the uplink is blind fire-and-retry — the rocket sends no
-            // command ACK, so completing all retries is NOT proof of delivery.
-            // Log it honestly so the operator does not read retry completion as
-            // success.  (Safety-relevant rocket state — pyro armed/fired,
-            // camera, logging — is confirmed separately via the rocket's own
-            // telemetry echo, not via this path.)
-            ESP_LOGW(TAG, "[UPLINK] cmd=%u: blind retries exhausted — delivery "
-                          "UNCONFIRMED (rocket sends no ACK)",
-                     (unsigned)uplink_buf[4]);
-            // service() already auto-entered RX after the last TX.  Do NOT call
-            // startReceive() here: it would reset rx_done_ and drop any downlink
-            // packet that arrived between the TX completion and this point.
-            uplink_pending = false;
-        }
+        // #285: the uplink is blind fire-and-retry — the rocket sends no
+        // command ACK, so completing all retries is NOT proof of delivery.
+        // Log it honestly so the operator does not read retry completion as
+        // success.  (Safety-relevant rocket state — pyro armed/fired,
+        // camera, logging — is confirmed separately via the rocket's own
+        // telemetry echo, not via this path.)
+        ESP_LOGW(TAG, "[UPLINK] cmd=%u: blind retries exhausted — delivery "
+                      "UNCONFIRMED (rocket sends no ACK)",
+                 (unsigned)tx->cmd());
+        // service() already auto-entered RX after the last TX.  Do NOT call
+        // startReceive() here: it would reset rx_done_ and drop any downlink
+        // packet that arrived between the TX completion and this point.
+        uplink_q.pop();  // next queued command (if any) starts on the following pass
         return;
     }
 
@@ -1650,23 +1659,23 @@ static void serviceUplink()
     // #379: gate the transmit on radio-ready AND not-scanning. A TX during a
     // frequency scan goes out on the scan's dwell channel (silently missing the
     // rocket, no ACK to catch it) and corrupts that pass's RSSI — so defer.
-    // Returning here before send() preserves uplink_retries_left, so the command
+    // Returning here before send() preserves retries_left, so the command
     // fires once the scan completes instead of being lost. Mirrors
     // serviceHeartbeat's scan_passes_remaining_ gate.
-    if (!bs_uplink_policy::mayTransmitUplink(uplink_pending, uplink_retries_left,
+    if (!bs_uplink_policy::mayTransmitUplink(/*uplink_pending=*/true, tx->retries_left,
                                              scan_passes_remaining_,
                                              lora_comms.canSend()))
     {
         return;  // radio busy, or a scan owns the channel — retry next pass
     }
 
-    if (lora_comms.send(uplink_buf, uplink_len))
+    if (lora_comms.send(tx->buf, tx->len))
     {
-        uplink_retries_left--;
+        tx->retries_left--;
         uplink_last_tx_ms = now;
         // #285: "blind" + "unconfirmed" so the log is not mistaken for an ACK.
-        ESP_LOGI(TAG, "[UPLINK] blind TX, %u attempt(s) left (unconfirmed, no ACK)",
-                 uplink_retries_left);
+        ESP_LOGI(TAG, "[UPLINK] blind TX cmd=%u, %u attempt(s) left (unconfirmed, no ACK)",
+                 (unsigned)tx->cmd(), tx->retries_left);
     }
     else
     {
@@ -1780,10 +1789,13 @@ static void serviceLoRaTransaction()
         case LoRaTxnState::RELAYING:
         {
             const uint32_t now = millis();
-            // serviceUplink() clears uplink_pending once the last retry has
+            // serviceUplink() drains the queue once the last retry has
             // fired; at that point the rocket has either joined NEW or not.
             // TXN_MAX_RELAY_MS is a safety net in case uplink state is stuck.
-            const bool relay_done   = !uplink_pending;
+            // Waiting for the whole queue (not just this command) also keeps
+            // any command queued behind us from firing after the reconfigure
+            // below has already retuned the radio to the NEW channel.
+            const bool relay_done   = !uplinkBusy();
             const bool relay_timeout = (now - txn_phase_start_ms) > TXN_MAX_RELAY_MS;
             if (!relay_done && !relay_timeout) return;
 
@@ -2136,7 +2148,7 @@ static void serviceRecovery()
             // Give uplink retries time to land on the current channel
             // before we hop back to NVS — otherwise the rocket might miss
             // the push command and we'd just rediscover it next cycle.
-            if (!uplink_pending ||
+            if (!uplinkBusy() ||
                 (now - recovery_phase_start_ms) > TXN_MAX_RELAY_MS)
             {
                 recoveryEnd("pushed rocket home");
@@ -2196,7 +2208,7 @@ static void serviceHeartbeat()
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (scan_passes_remaining_ != 0)           return;  // #136: don't TX mid-scan
-    if (uplink_pending)                        return;  // Don't clobber a real cmd
+    if (uplinkBusy())                          return;  // Don't compete with a real cmd
     // While hopping, only TX in the safe window right after a fresh
     // rocket RX — see HOP_BS_TX_SAFE_WINDOW_MS comment.  With slow-hop
     // dwell=4 (#105 follow-up) the rocket stays on a channel for 2 s,
@@ -2501,7 +2513,7 @@ static void serviceMaskDriftRepush()
 {
     if (!chset_drift_repush_pending) return;
     // Only push when nothing else is using the radio for TX.
-    if (uplink_pending)                        return;
+    if (uplinkBusy())                          return;
     if (lora_txn_state != LoRaTxnState::IDLE)  return;
     if (recovery_state != RecoveryState::IDLE) return;
     // Cooldown: don't re-push more than once every CHSET_DRIFT_REPUSH_COOLDOWN_MS.
@@ -2615,7 +2627,7 @@ static void serviceCoordinatedScan()
             // Cmd 16 retries still going — push out the grace anchor so
             // we wait COORD_SCAN_PAUSE_GRACE_MS after the *last* retry,
             // not after we queued the command.
-            if (uplink_pending)
+            if (uplinkBusy())
             {
                 coord_scan_phase_ms_ = now;
                 return;
@@ -2660,7 +2672,7 @@ static void serviceCoordinatedScan()
             // and (a) sets scan_results_valid_ = true, (b) queues cmd 15
             // via applyAndPushChannelSet().  Either signal works as a
             // transition trigger; combining them is most precise.
-            if (scan_results_valid_ && uplink_pending)
+            if (scan_results_valid_ && uplinkBusy())
             {
                 coord_scan_state_    = CoordScanState::PUSHING_CHSET;
                 coord_scan_phase_ms_ = now;
@@ -2669,7 +2681,7 @@ static void serviceCoordinatedScan()
         }
         case CoordScanState::PUSHING_CHSET:
         {
-            if (uplink_pending) return;  // cmd 15 retries still going
+            if (uplinkBusy()) return;  // cmd 15 retries still going
             // Cmd 15 has been delivered (or all retries exhausted).
             // Rocket should resume hopping when its pause deadline hits.
             // Snapshot hop_last_rx_ms_ so we can detect a fresh RX.
@@ -4308,7 +4320,7 @@ static void loop_bs()
             {
                 ESP_LOGW(TAG, "[BLE] Scan rejected: coordinated scan already in progress");
             }
-            else if (uplink_pending)
+            else if (uplinkBusy())
             {
                 ESP_LOGW(TAG, "[BLE] Scan rejected: uplink busy — retry shortly");
             }
@@ -4357,8 +4369,8 @@ static void loop_bs()
     serviceUplink();
 
     // Advance the transactional reconfigure state machine (issue #71).
-    // Must run after serviceUplink so we observe uplink_pending transitions
-    // to false in the same loop iteration they happen.
+    // Must run after serviceUplink so we observe the uplink queue draining
+    // to empty in the same loop iteration it happens.
     serviceLoRaTransaction();
 
     // Silence recovery runs after the transaction service so a freshly

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -31,6 +31,7 @@
 #include "bs_log_policy.h"        // parseSequentialFilename() (#137)
 #include "bs_uplink_policy.h"     // mayTransmitUplink() scan gate (#379)
 #include "bs_uplink_queue.h"      // uplink command FIFO (#502)
+#include "bs_battery_soc.h"       // voltage-based SoC fallback (#501)
 #include "bs_download_policy.h"   // nextChunk()/mayEmitChunk() pacing (#380)
 
 #include <TR_LoRa_Comms.h>
@@ -120,6 +121,10 @@ static float bs_voltage = NAN;
 static float bs_soc = NAN;
 static float bs_current = NAN;
 static float bs_temperature = NAN;
+// #501: true when bs_soc came from the voltage curve rather than the gauge's own
+// coulomb count, because the gauge's SoC failed the plausibility check.
+static bool  bs_soc_estimated = false;
+static bs_battery_soc::Estimator bq_soc_estimator(config::SOC_FILTER_ALPHA);
 static uint32_t last_battery_ms = 0;
 static i2c_master_bus_handle_t i2c_bus = nullptr;
 static TR_MAX17205G fuel_gauge(config::MAX17205_ADDR);
@@ -532,9 +537,50 @@ static void updateBattery()
         bq_gauge.update();
         maintainBatteryFets();
         bs_voltage     = bq_gauge.voltage();
-        bs_soc         = bq_gauge.soc();
         bs_current     = bq_gauge.current();
         bs_temperature = bq_gauge.temperature();
+
+        // #501: this gauge reported 0% SoC on a 4.17 V pack, with
+        // RemainingCapacity=0 and FullChargeCapacity ~10x design. Impedance Track
+        // derives all three by integrating current, and this part's CC Gain was
+        // never calibrated (and GAUGE_EN ships at 0), so they are garbage — while
+        // Voltage() is a direct ADC read and is correct. Prefer the gauge when it
+        // is actually believable; otherwise estimate from voltage, which is at
+        // least honest and gives us a low-battery warning.
+        const bool gauge_ok = bs_battery_soc::gaugeSocPlausible(
+            bq_gauge.gaugingEnabled(), bq_gauge.soc(), bq_gauge.fullCapacity(),
+            (float)config::BATTERY_DESIGN_MAH, bs_voltage, config::BQ27Z746_CELLS);
+
+        if (gauge_ok)
+        {
+            bs_soc           = bq_gauge.soc();
+            bs_soc_estimated = false;
+        }
+        else
+        {
+            bs_soc = bq_soc_estimator.update(bs_voltage, config::BQ27Z746_CELLS,
+                                             bs_current, config::BATTERY_INTERNAL_R_OHM);
+            bs_soc_estimated = true;
+        }
+
+        // Say it once, and again only if the verdict flips — the operator needs to
+        // know whether the number on the app is gauged or inferred.
+        static int last_verdict = -1;
+        const int verdict = gauge_ok ? 1 : 0;
+        if (verdict != last_verdict)
+        {
+            if (gauge_ok)
+                ESP_LOGI(TAG, "[BATT] BQ27Z746 gauge SoC is plausible — using it (%.0f%%)",
+                         (double)bs_soc);
+            else
+                ESP_LOGW(TAG, "[BATT] BQ27Z746 SoC not trustworthy "
+                              "(GAUGE_EN=%d, raw SOC=%.0f%%, FullCap=%.0f vs design %u mAh) — "
+                              "falling back to voltage estimate (#501)",
+                         bq_gauge.gaugingEnabled(), (double)bq_gauge.soc(),
+                         (double)bq_gauge.fullCapacity(),
+                         (unsigned)config::BATTERY_DESIGN_MAH);
+            last_verdict = verdict;
+        }
     }
     else if (gauge_kind == GaugeKind::MAX17303)
     {
@@ -1497,6 +1543,17 @@ static void printStats()
              (double)ls.last_rssi,
              (double)ls.last_snr,
              last_pkt_str);
+
+    // Base-station battery.  The (est) marker says the SoC came from the voltage
+    // curve rather than the gauge's coulomb count (#501) — without it, a plausible
+    // number gives no hint that the gauge underneath it is untrustworthy.
+    if (fuel_gauge_present)
+    {
+        ESP_LOGI(TAG, "[BATT] %.2f V | %.0f%% SoC (%s) | %.0f mA | %.1f C",
+                 (double)bs_voltage, (double)bs_soc,
+                 bs_soc_estimated ? "est from voltage" : "gauge",
+                 (double)bs_current, (double)bs_temperature);
+    }
 
     // Hop diagnostics (#105).  hop_active=Y/N is the live link state; the
     // session counters reflect the *current* session and reset on each

--- a/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
@@ -3,6 +3,12 @@ CONFIG_IDF_TARGET="esp32s3"
 # BLE / NimBLE
 CONFIG_BT_ENABLED=y
 CONFIG_BT_NIMBLE_ENABLED=y
+# #505: at INFO, NimBLE emits three lines per telemetry notify (~2/s for the whole
+# session) — "GATT procedure initiated: notify; att_handle=16". In a 96 s bench run
+# that was the overwhelming majority of the console and it buried the BS's own
+# [RX]/[STATS]/[UPLINK]/[BATT] lines, which are the ones you actually watch during
+# a flight. Also costs CPU + UART bandwidth on the hot notify path.
+CONFIG_BT_NIMBLE_LOG_LEVEL_WARNING=y
 CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
 CONFIG_BT_NIMBLE_ROLE_PERIPHERAL=y
 CONFIG_BT_NIMBLE_ROLE_CENTRAL=n

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -5244,13 +5244,16 @@ static void setup_oc()
 // LFS_TIMING / STALL_THRESHOLD_US instrumentation in TR_LogToFlash.cpp.
 static constexpr int64_t LOOP_STALL_THRESHOLD_US = 100'000;  // 100 ms
 
-// Idle (FC-off / low-power) loop period.  loop_oc drains the single-slot BLE
-// command buffer (pending_command_) once per iteration via ble_app.getCommand(),
-// so the loop must cycle faster than connect-time commands arrive (~60-90 ms
-// apart) or a burst overwrites itself — the root cause of #221 (was delay(1000)).
-// 20 ms keeps the loop responsive with negligible power cost (light sleep is
-// disabled while BLE is on, so the CPU idles at 40 MHz either way).  This is the
-// only knob: raise it if bench idle-current measurement ever shows it matters.
+// Idle (FC-off / low-power) loop period.  loop_oc drains ONE BLE command per
+// iteration via ble_app.getCommand().  This used to be a correctness
+// constraint: the BLE command buffer was a single slot, so a loop slower than
+// the ~60-90 ms connect-time command spacing let a burst overwrite itself —
+// the root cause of #221 (was delay(1000)).  #517 gave that buffer depth, so a
+// burst now queues instead of collapsing and correctness no longer rides on the
+// loop period.  20 ms stays for RESPONSIVENESS (a 16-deep ring still drains one
+// command per pass, and in-loop connection setup lagged up to 1 s at delay(1000)),
+// with negligible power cost — light sleep is disabled while BLE is on, so the
+// CPU idles at 40 MHz either way.
 static constexpr uint32_t IDLE_LOOP_DELAY_MS = 20;
 
 #define LOOP_STALL_INSTR(name, expr) do {                                       \
@@ -5458,15 +5461,15 @@ static void loop_oc()
             }
         }
 
-        // Yield to FreeRTOS.  This was delay(1000) for power, but the BLE
-        // command buffer (pending_command_) is single-slot and is only drained
-        // below via ble_app.getCommand() — a 1 s loop period let a connect-time
-        // command burst overwrite itself (only the last survived) and lagged
-        // in-loop connection setup up to 1 s, surfacing as flaky connects /
-        // dropped config+cal sync (#221).  Light sleep is disabled while BLE is
-        // on, so the CPU idles at 40 MHz (DFS min) regardless and the long delay
-        // saved little real power.  Stay responsive so the slot is drained as
-        // fast as commands arrive (~60-90 ms apart on connect).
+        // Yield to FreeRTOS.  This was delay(1000) for power; a 1 s loop period
+        // let a connect-time command burst overwrite the then-single-slot BLE
+        // command buffer (only the last survived) and lagged in-loop connection
+        // setup up to 1 s, surfacing as flaky connects / dropped config+cal sync
+        // (#221).  The buffer is now a ring (#517) so a burst queues rather than
+        // collapsing, but stay responsive anyway: one command drains per pass,
+        // and connection setup still runs in this loop.  Light sleep is disabled
+        // while BLE is on, so the CPU idles at 40 MHz (DFS min) regardless and
+        // the long delay saved little real power.
         delay(IDLE_LOOP_DELAY_MS);
 
     }


### PR DESCRIPTION
Works down the base-station bench findings tracked in #507, plus three defects found while doing so (#517, #520, and the log that was hiding #503).

Landed as one PR rather than one-per-issue because the fixes were bench-verified **together** on the V2 board across three sim flights — several of them interact (fixing #502 made #506 measurably worse, which is how #506 got quantified), so splitting them would mean shipping changes no run ever exercised in combination.

## Bench-confirmed on hardware

Three sim flights on the V2 base station (`bs_bench.log` + `lora_*.csv`, 2026-07-14):

| Issue | Fix | Evidence |
|---|---|---|
| #500 | `nvs_flash_init()` was never called on the BS — every persistent setting silently reverted to `config.h` each boot | No more `[CFG] LoRa NVS empty`, no schema-mismatch, no `phy_init: NVS has not been initialized`. Schema version read back from a prior boot. |
| #501 | BQ27Z746 reported **0% SoC on a 4.17 V pack** | Root cause confirmed on the bench: the new diagnostic printed **`GAUGE_EN=0`** — Impedance Track gauging was simply off. SoC now reads 98% (voltage estimate) instead of 0%. |
| #502 | Uplink was a single slot; a new command discarded the pending one's retries (the uplink is *blind*, so retries **are** delivery) | `Queued cmd=6 ... (queue=2)` with no "Discarding pending" — cmd 5 drained all 8 retries, *then* cmd 6 took its full 8. |
| #504 | `[RX]` printed `max_speed` under the `spd=` label (a landed rocket read 99 m/s) | `LANDED \| spd=0.0m/s max=99.0m/s` |
| #505 | NimBLE INFO logging buried the BS's own output | 4 NimBLE lines in a whole run, all from BS init. |
| #506 | Blind-TX uplink bursts deafened the receiver | **0 packets lost, twice** (was 3). See below. |
| #517 | Shared BLE command intake was a single latch — a burst dropped all but the last | Zero `Overwriting unconsumed cmd`. |

### #506 is the interesting one

It is **arithmetic, not RF**. At SF8/BW250/CR4-5 a downlink packet is ~82 ms on air, while the gaps between 100 ms-spaced retries are only ~49 ms — **an 82 ms packet cannot fit in a 49 ms gap**, so a blind burst loses essentially *every* packet that arrives during it, not some. The issue's own suggestion (space the retries out) would not have worked; it just stretches the deaf window.

The fix is phase alignment: fire retries into the quiet stretch between the rocket's telemetry packets. Predicted 854 ms to deliver a command vs 800 ms blind; the radio did **851 ms**. Cost: ~51 ms of latency. Benefit: the 3-packet hole became **zero**, twice, with `txwin: 0 forced` — the liveness backstop never fired.

## Bench-pending

- **#503** — three bugs, and the third hid the other two. We asked iOS for a 7.5 ms interval (**below its 15 ms floor**, so never grantable), fired the request from inside the connect callback (collided with iOS's own update: `status=554` = HCI `0x2A`), and then logged an unconditional `INFO: Connection parameters updated, status=%d` — which reads as success even on failure, **and `status=0` only means the procedure completed, not that iOS honoured the request**. Now asks for 15-30 ms per Apple's guidelines, defers 1 s out of the callback with retries, and logs the interval *actually in force*.
- **#520** — duplicate telemetry packets. `rx_done_` has two racing writers: an **edge**-triggered DIO1 ISR and `pollDio1()`, which latches on the **level**. `readPacket()` cleared the flag before the radio's IRQ was cleared, so a level latch in that window re-armed it for an already-consumed packet and the next read pulled the same packet back out of the SX126x buffer — byte-identical, *including RSSI/SNR to 0.1 dB*, which is what ruled out a real second reception. Fixed by asking the radio (`getIrqFlags()`) instead of trusting the flag.

  **Honest status: the guard is in place but was NOT exercised.** The last run had zero duplicates *and* `dup-rx caught: 0`, and `ISR == RX + TX` exactly — so no stale latch occurred at all. At the historical rate (~0.8%/packet) there was a ~22% chance of that by luck. The fix is sound and cheap, but unproven; it needs another run or two to catch the race.

## Also in here

- `TR_NVS` no longer swallows failures (part of #500): `begin()` reports errors, the getters honour the `nvs_get_*` return code. A read-only open of a never-written namespace stays quiet, because `NvsBitmapStore::load()` relies on that being an ordinary miss.
- Four new pure, host-tested policy modules following the existing `bs_*_policy.h` idiom: `bs_uplink_queue.h`, `bs_uplink_txwin.h`, `bs_battery_soc.h`, `BleCommandRing.h`.

## Scope

`TR_LoRa_Comms` and `TR_BLE_To_APP` are shared, so #503, #517 and #520 land on the **out computer** too (the flight computer has no BLE and no LoRa — it takes commands relayed from the OC over I2C). base_station (V2 + V3), out_computer and flight_computer all build clean with no new warnings.

**565/565 host gtests pass** (up from 493 on main; 72 new).

## Not included

- #518 (BLE modem sleep never enabled — `CONFIG_BT_NIMBLE_SLEEP_ENABLE` is not a real kconfig symbol) is deliberately on its own branch: changing BLE sleep behaviour could destabilise the link and would have confounded these results.
- #519 (the 32.768 kHz crystal is never used — no project sets `RTC_CLK_SRC`, costing idle power on the OC) is open and unstarted.

Closes #500
Closes #501
Closes #502
Closes #503
Closes #504
Closes #505
Closes #506
Closes #517
Closes #520

Tracking issue: #507 (left open deliberately — it carries no closing keyword by design; close it once you're happy the children are all settled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
