### PR TITLE
fix(bs): #518 enable BLE controller modem sleep; drop the kconfig symbol that never existed

### DIFF
--- a/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/base_station/sdkconfig.defaults
@@ -20,8 +20,27 @@ CONFIG_PM_ENABLE=y
 CONFIG_PM_DFS_INIT_AUTO=y
 CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
 CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
-CONFIG_BT_NIMBLE_SLEEP_ENABLE=y
 CONFIG_ESP_PHY_MAC_BB_PD=y
+
+# BLE controller modem sleep — radio powers down between BLE events (#518).
+# This block used to be a single CONFIG_BT_NIMBLE_SLEEP_ENABLE=y, which is NOT a
+# real kconfig symbol (absent from the bt component's Kconfig AND from its
+# sdkconfig.rename map), so kconfgen silently dropped it and the BS shipped with
+# BT_CTRL_MODEM_SLEEP=0 — the controller never slept between BLE events. The
+# sleep knob is controller-side, not NimBLE-host-side. These are the same three
+# lines the out_computer has been running, so this is a proven config, not a new one.
+#
+# On the LPCLK choice: LPCLK_SEL_RTC_SLOW is ruled out by IDF's own help — the
+# internal 136 kHz RC is far outside the 500 ppm BLE needs to hold a connection.
+# LPCLK_SEL_EXT_32K_XTAL would use the board's 32.768 kHz crystal and is the
+# better answer for idle power (the main crystal can stay powered down), but it
+# needs CONFIG_RTC_CLK_SRC_EXT_CRYS=y, which no project has ever set — the whole
+# fleet runs the RTC on the internal RC. That is being addressed separately, and
+# on the OUT COMPUTER first, where low-power mode is actually used; the BS does
+# not use low-power mode, so MAIN_XTAL is the right trade here.
+CONFIG_BT_CTRL_MODEM_SLEEP=y
+CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+CONFIG_BT_CTRL_LPCLK_SEL_MAIN_XTAL=y
 
 # Flash
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -20,8 +20,12 @@ CONFIG_BT_CTRL_MODEM_SLEEP=y
 CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
 CONFIG_BT_CTRL_LPCLK_SEL_MAIN_XTAL=y
 
-# NimBLE host sleep support
-CONFIG_BT_NIMBLE_SLEEP_ENABLE=y
+# (#518) CONFIG_BT_NIMBLE_SLEEP_ENABLE=y used to sit here under a "NimBLE host
+# sleep support" comment. No such kconfig symbol exists in ESP-IDF — it is not in
+# the bt component's Kconfig and not in its sdkconfig.rename map — so kconfgen
+# silently ignored it. The real knob is the controller-side BT_CTRL_MODEM_SLEEP
+# block above, which is already correct here. Removed rather than replaced: this
+# is a no-op for the generated config, verified by diffing sdkconfig.json.
 
 # PHY power down during sleep
 CONFIG_ESP_PHY_MAC_BB_PD=y


### PR DESCRIPTION
Both the base station and the out computer set `CONFIG_BT_NIMBLE_SLEEP_ENABLE=y` under a "sleep support" comment. **No such kconfig symbol exists in ESP-IDF** — it is absent from the bt component's Kconfig *and* from its `sdkconfig.rename` map, so it was never a valid name that got renamed. kconfgen silently ignored it:

```
warning: unknown kconfig symbol 'BT_NIMBLE_SLEEP_ENABLE' assigned to 'y'
```

It went unnoticed because `sdkconfig` is **generated and untracked, and an existing `sdkconfig` overrides `sdkconfig.defaults`** — so kconfgen only re-reads the defaults (and only then emits the warning) when sdkconfig is regenerated. It surfaced while regenerating it for #505.

The sleep knob is **controller-side, not NimBLE-host-side**. The out_computer already had the correct block and was sleeping properly; the base station had only the dead line, so it shipped with `BT_CTRL_MODEM_SLEEP=0` — the BLE controller never slept between events, on a battery-powered device.

- **base_station**: add the three real symbols. Verified in the regenerated config, not assumed: `BT_CTRL_MODEM_SLEEP` False→True, `SLEEP_MODE_EFF` 0→1, `SLEEP_CLOCK_EFF` 0→1.
- **out_computer**: remove the dead line only — its real config was already correct, so this must be a no-op. Confirmed by diffing the full generated `sdkconfig.json` before/after: **0 differing keys**.

`MAIN_XTAL` (matching the OC's proven config) rather than the 32.768 kHz crystal: `LPCLK_SEL_RTC_SLOW` is ruled out by IDF's own help (the internal 136 kHz RC is far outside the 500 ppm BLE needs to hold a connection), and `EXT_32K_XTAL` needs `CONFIG_RTC_CLK_SRC_EXT_CRYS=y`, which **no project has ever set** — the whole fleet runs its RTC on the internal RC and the crystal goes unused. That is worth real power on the out computer, where low-power mode is actually used, so it is filed separately as #519 rather than smuggled in here. The base station does not use low-power mode, which is why MAIN_XTAL is the right trade for it.

flight_computer and radio_board were swept and are clean.

**Bench-pending**, and it needs a real bench check rather than a green build: BLE stability (hold an app connection through a full sim flight — a power win that drops the link is a regression) and an idle-current measurement before/after, which is the only proof the change did anything.

Rebased onto main after #521 merged, so this binary also carries all the bench-confirmed #507 fixes.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)