### PR TITLE
perf(oc): #519 run the BT low-power clock off the 32.768 kHz crystal so light sleep can actually engage

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -315,7 +315,10 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     // Transaction Collision". Schedule it instead and let the peer go first;
     // loop() fires it once the link has settled.
     conn_param_attempts_ = 0;
-    conn_param_due_ms_   = (uint32_t)millis() + kConnParamDelayMs;
+    // Skip when the app owns the parameter policy (the OC does — see
+    // setAutoConnParams). Otherwise the two requests race and whichever lands
+    // second is rejected with "update already in progress".
+    conn_param_due_ms_   = auto_conn_params_ ? ((uint32_t)millis() + kConnParamDelayMs) : 0;
 }
 
 // #503: Apple's Accessory Design Guidelines are strict about what a peripheral may

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -19,6 +19,18 @@
 
 static const char* BLE_TAG = "BLE";
 
+// LE PHY name for logging (#519 follow-up: 2M doubles the raw data rate).
+static const char* phyName(uint8_t phy)
+{
+    switch (phy)
+    {
+        case BLE_GAP_LE_PHY_1M:    return "1M";
+        case BLE_GAP_LE_PHY_2M:    return "2M";
+        case BLE_GAP_LE_PHY_CODED: return "Coded";
+        default:                   return "?";
+    }
+}
+
 // Spinlock protecting the command ring (#517) against races between the BLE
 // callback (runs on the NimBLE host task) and the main loop reading it.
 static portMUX_TYPE s_cmd_mux = portMUX_INITIALIZER_UNLOCKED;
@@ -207,6 +219,24 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         self->onMtuChanged(event->mtu.conn_handle, event->mtu.value);
         break;
 
+    case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
+        // Report the PHY we ACTUALLY ended up on, not the one we asked for — the
+        // same lesson as the connection interval (#503). 2M doubles the raw rate;
+        // if the peer declines we silently stay on 1M and downloads stay slow, so
+        // this needs to be visible rather than assumed.
+        if (event->phy_updated.status == 0)
+        {
+            ESP_LOGI(BLE_TAG, "PHY now: TX=%s RX=%s",
+                     phyName(event->phy_updated.tx_phy),
+                     phyName(event->phy_updated.rx_phy));
+        }
+        else
+        {
+            ESP_LOGW(BLE_TAG, "PHY update failed, status=%d — staying on 1M",
+                     event->phy_updated.status);
+        }
+        break;
+
     case BLE_GAP_EVENT_CONN_UPDATE:
         // #503: this used to log an unconditional "Connection parameters updated,
         // status=%d" at INFO — which read as success even when it wasn't (the
@@ -253,6 +283,30 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     telem_notify_subscribed_ = false;
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
+
+    // Ask for the LE 2M PHY. This is the throughput lever, and we had never used
+    // it — the controller supports it (boot log: "Feature Config ... BLE_50:1") but
+    // nobody asked, so every connection ran on 1M.
+    //
+    // It matters because #503 made our connection-parameter request spec-legal, and
+    // that cost us speed: the old request was 7.5-20 ms — below iOS's 15 ms floor —
+    // which iOS accepted anyway (status=0) and served at ~15-20 ms. Apple's envelope
+    // (min >= 15 ms AND max >= min + 15 ms) means the tightest LEGAL ask is 15-30,
+    // and iOS grants the top of it: we measure exactly 30 ms. So file downloads got
+    // ~1.5-2x slower as the price of being correct.
+    //
+    // 2M doubles the raw PHY rate and is independent of the connection interval, so
+    // it more than buys that back without going back outside the spec. If the peer
+    // declines, the link simply stays on 1M — hence the PHY_UPDATE_COMPLETE handler,
+    // which logs what we actually got rather than what we hoped for.
+    const int phy_rc = ble_gap_set_prefered_le_phy(conn_handle,
+                                                   BLE_GAP_LE_PHY_2M_MASK,
+                                                   BLE_GAP_LE_PHY_2M_MASK,
+                                                   BLE_GAP_LE_PHY_CODED_ANY);
+    if (phy_rc != 0)
+    {
+        ESP_LOGW(BLE_TAG, "2M PHY request failed to send, rc=%d — staying on 1M", phy_rc);
+    }
 
     // #503: do NOT request the parameter update from inside the connect callback.
     // iOS runs its OWN connection-update procedure immediately after connecting,

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -130,6 +130,18 @@ public:
     // Check if a device is connected
     bool isConnected() const;
 
+    // Whether this component should request connection parameters itself on
+    // connect (#503). Default true, which is what the base station wants — it has
+    // no policy of its own.
+    //
+    // The out computer DOES have one (slow 200 ms while idle, fast 30 ms once the
+    // rail is on for file transfer), and the two collide: the bench logged
+    // "GAP update_params: update already in progress ... rc=2" as our deferred
+    // request landed on top of the OC's. The OC happened to win that race, but had
+    // it lost, the idle link would have sat at 30 ms and thrown away most of #519's
+    // power saving. So the OC turns this off and owns the policy end to end.
+    void setAutoConnParams(bool enabled) { auto_conn_params_ = enabled; }
+
     // NimBLE's handle for the current connection; 0xFFFF when not connected.
     // #519: the out computer was calling ble_gap_update_params(0, ...) with a
     // HARDCODED zero because this was never exposed. NimBLE handed out handle 1,
@@ -309,6 +321,7 @@ private:
     // first, then ask — and retry if we still lose the race.
     uint32_t conn_param_due_ms_   = 0;   // 0 = nothing scheduled
     uint8_t  conn_param_attempts_ = 0;
+    bool     auto_conn_params_    = true;  // see setAutoConnParams()
     static constexpr uint32_t kConnParamDelayMs = 1000;  // let iOS settle the link first
     static constexpr uint32_t kConnParamRetryMs = 750;
     static constexpr uint8_t  kConnParamMaxAttempts = 3;

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -130,6 +130,14 @@ public:
     // Check if a device is connected
     bool isConnected() const;
 
+    // NimBLE's handle for the current connection; 0xFFFF when not connected.
+    // #519: the out computer was calling ble_gap_update_params(0, ...) with a
+    // HARDCODED zero because this was never exposed. NimBLE handed out handle 1,
+    // so every one of its connection-parameter requests failed with "connection
+    // not found; conn_handle=0x0000" — including the slow/low-power params that
+    // exist precisely to cut idle power. Callers must pass this, not a literal.
+    uint16_t connHandle() const { return device_connected_ ? conn_handle_ : 0xFFFF; }
+
     // Send telemetry update to connected device
     // Sends JSON via BLE notification
     void sendTelemetry(const TelemetryData& data);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -5263,6 +5263,20 @@ static void setup_oc()
         ESP_LOGW("PWR", "INA230 not found -- battery monitoring disabled");
     }
 
+    // #519: the OC owns its connection-parameter policy — slow (200 ms, latency 4)
+    // while the rail is off to save idle power, fast (30 ms) once it comes on for
+    // file transfer. TR_BLE_To_APP's own connect-time request is for the base
+    // station, which has no policy; here the two collide, and the bench caught it:
+    //
+    //   BLE: Slow (low-power) conn params requested (handle=1)
+    //   NimBLE: GAP update_params: update already in progress; conn_handle=0x0001
+    //   W BLE: Connection param update request failed to send, rc=2
+    //
+    // The OC won that race, but had it lost, the idle link would have stayed at
+    // 30 ms and thrown away most of the power saving. Take ownership instead of
+    // relying on who gets there first.
+    ble_app.setAutoConnParams(false);
+
     // Only BLE starts at boot — everything else is behind PWR_PIN
     if (!ble_app.begin())
     {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -990,14 +990,35 @@ static void enterLowPowerMode()
 {
 #if defined(CONFIG_PM_ENABLE)
     // Low-power idle: 80 MHz max (BLE needs 80 MHz APB), 40 MHz min via DFS.
-    // Light sleep disabled (btLS blocks it; USB-Serial-JTAG incompatible).
+    //
+    // #519: light sleep is now ENABLED here. It used to be off "because btLS
+    // blocks it; USB-Serial-JTAG incompatible" — both reasons are now handled:
+    //
+    //  - "btLS blocks it": the BT controller sets no_light_sleep when its
+    //    low-power clock is the MAIN_XTAL (bt.c). Pointing that clock at the
+    //    board's 32.768 kHz crystal instead (RTC_CLK_SRC_EXT_CRYS +
+    //    BT_CTRL_LPCLK_SEL_EXT_32K_XTAL) means it never sets that flag. This was
+    //    NOT a hardware limitation, it was a config we chose. Bench-confirmed:
+    //    "BLE_INIT: Using external 32.768 kHz crystal/oscillator as clock source".
+    //
+    //  - "USB-Serial-JTAG incompatible": true, but ESP-IDF handles it for us.
+    //    CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION makes the USJ driver hold an
+    //    ESP_PM_NO_LIGHT_SLEEP lock while the USB port is actually connected and
+    //    release it when it is unplugged. So the console keeps working on the
+    //    bench, and light sleep engages in flight when USB is gone — which is the
+    //    only time idle current matters anyway.
+    //
+    // MEASUREMENT GOTCHA: with USB plugged in, that lock is held and the chip will
+    // NOT light-sleep. Idle current has to be measured on battery, USB detached,
+    // or you will see no change and wrongly conclude this did nothing.
     esp_pm_config_t pm_cfg = {};
     pm_cfg.max_freq_mhz = 80;
     pm_cfg.min_freq_mhz = 40;
-    pm_cfg.light_sleep_enable = false;
+    pm_cfg.light_sleep_enable = true;
     esp_err_t pm_err = esp_pm_configure(&pm_cfg);
     if (pm_err == ESP_OK)
-        ESP_LOGI("PWR", "Low-power mode: 80/40 MHz DFS, light sleep OFF");
+        ESP_LOGI("PWR", "Low-power mode: 80/40 MHz DFS, light sleep ON "
+                        "(held off while USB is connected)");
     else
         ESP_LOGE("PWR", "esp_pm_configure failed: %s", esp_err_to_name(pm_err));
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1049,32 +1049,58 @@ static void exitLowPowerMode()
     ESP_LOGI("PWR", "Full performance mode (%d MHz)", CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ);
 }
 
-// Request slow BLE connection parameters for low-power idle.
-// Only called when a connection exists and power is OFF.
-static void requestSlowBLEParams(uint16_t conn_handle)
+// #519: both of these took a conn_handle argument and BOTH call sites passed a
+// literal 0 — while NimBLE had handed out handle 1. So every request failed with
+// "GAP update_params: connection not found; conn_handle=0x0000" and neither the
+// slow (low-power) nor the fast (file-transfer) parameters have EVER been applied.
+// They now take no handle and read the live one from the BLE layer.
+static void applyBLEParams(const char* what, const struct ble_gap_upd_params& params)
+{
+    const uint16_t h = ble_app.connHandle();
+    if (h == 0xFFFF)
+    {
+        ESP_LOGW("BLE", "%s conn params skipped — not connected", what);
+        return;
+    }
+    const int rc = ble_gap_update_params(h, &params);
+    if (rc != 0)
+        ESP_LOGW("BLE", "%s conn param request failed to send, rc=%d (handle=%u)", what, rc, h);
+    else
+        ESP_LOGI("BLE", "%s conn params requested (handle=%u)", what, h);
+    // The negotiated result is reported by TR_BLE_To_APP's CONN_UPDATE handler,
+    // which logs the interval actually in force — the peer is free to counter (#503).
+}
+
+// Slow parameters for low-power idle: fewer BLE wakeups is the single biggest
+// lever on idle current. Within Apple's envelope: min >= 15 ms; max >= min + 15 ms;
+// latency <= 30; itvl_max * (latency + 1) = 1000 ms <= 2 s; supervision timeout
+// (4 s) > itvl_max * (latency + 1) * 3 = 3 s, and <= 6 s.
+static void requestSlowBLEParams()
 {
     struct ble_gap_upd_params params = {};
     params.itvl_min = 0x50;              // 100ms  (units of 1.25ms)
     params.itvl_max = 0xA0;              // 200ms
-    params.latency = 4;                  // Skip up to 4 connection events (~800ms effective)
+    params.latency = 4;                  // Skip up to 4 connection events (~1 s effective)
     params.supervision_timeout = 400;    // 4 seconds (units of 10ms)
     params.min_ce_len = 0;
     params.max_ce_len = 0;
-    ble_gap_update_params(conn_handle, &params);
+    applyBLEParams("Slow (low-power)", params);
 }
 
-// Request fast BLE connection parameters for file transfer.
-// Called when power is turned ON and a connection already exists.
-static void requestFastBLEParams(uint16_t conn_handle)
+// Fast parameters for file transfer.
+// #503: this asked for itvl_min = 0x06 = 7.5 ms, which is BELOW iOS's 15 ms floor
+// and could never be granted — the same bug fixed in TR_BLE_To_APP, living on in a
+// second copy here. Now inside Apple's envelope (15-30 ms), like the shared path.
+static void requestFastBLEParams()
 {
     struct ble_gap_upd_params params = {};
-    params.itvl_min = 0x06;              // 7.5ms  (units of 1.25ms)
-    params.itvl_max = 0x10;              // 20ms
+    params.itvl_min = 0x0C;              // 15ms — iOS minimum; below this is refused
+    params.itvl_max = 0x18;              // 30ms — must be >= min + 15 ms
     params.latency = 0;                  // No slave latency
     params.supervision_timeout = 200;    // 2 seconds (units of 10ms)
     params.min_ce_len = 0;
     params.max_ce_len = 0;
-    ble_gap_update_params(conn_handle, &params);
+    applyBLEParams("Fast (transfer)", params);
 }
 
 static void updateDerivedAltitudeFromBMP()
@@ -5515,7 +5541,7 @@ static void loop_oc()
             // slow params to save power (onConnect always requests fast params,
             // needed for file transfer when powered on).
             if (!pwr_pin_on) {
-                requestSlowBLEParams(0);
+                requestSlowBLEParams();
             }
         }
         ble_was_connected = ble_now;
@@ -5879,7 +5905,7 @@ static void loop_oc()
                 // Restore fast BLE connection params for file transfer
                 if (ble_app.isConnected())
                 {
-                    requestFastBLEParams(0);
+                    requestFastBLEParams();
                 }
             }
             else

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -18,7 +18,52 @@ CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
 # BLE controller modem sleep — radio powers down between BLE events
 CONFIG_BT_CTRL_MODEM_SLEEP=y
 CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
-CONFIG_BT_CTRL_LPCLK_SEL_MAIN_XTAL=y
+
+# (#519) Run the BT low-power clock off the board's 32.768 kHz crystal instead of
+# the main XTAL. This is NOT just about powering down a crystal — read the
+# controller source (components/bt/controller/esp32c3/bt.c, which the S3 shares):
+#
+#     } else if (s_lp_cntl.lpclk_sel == ESP_BT_SLEEP_CLOCK_MAIN_XTAL) {
+#     #if !CONFIG_BT_CTRL_MAIN_XTAL_PU_DURING_LIGHT_SLEEP
+#         s_lp_cntl.no_light_sleep = 1;
+#     #endif
+#
+# On MAIN_XTAL without that option — which is what we shipped — the controller sets
+# no_light_sleep, so LIGHT SLEEP IS BLOCKED ENTIRELY while BLE is on. PM_ENABLE and
+# tickless idle above were enabled but could never actually engage; the CPU just
+# idled at the DFS minimum (loop_oc's own comment says exactly this). With a working
+# 32 kHz crystal the controller never sets that flag, and light sleep becomes
+# possible with BLE active. THAT is the power win.
+#
+# Safe by construction: the controller verifies the crystal is really oscillating
+# (rtc_clk_slow_src_get() != SOC_RTC_SLOW_CLK_SRC_XTAL32K) and falls back to the
+# main XTAL with a warning if it is not — so an unpopulated or dead crystal degrades
+# to today's behaviour rather than breaking BLE. The boot log says which path was
+# taken, so this is self-diagnosing:
+#   OK  -> I BT: "Using external 32.768 kHz crystal/oscillator as clock source"
+#   BAD -> W BT: "32.768kHz XTAL not detected, fall back to main XTAL ..."
+# Likewise the RTC itself: "If the crystal could not start, it will be switched to
+# internal RC" (esp_hw_support Kconfig.rtc).
+#
+# EXT_32K_XTAL depends on the RTC slow clock being the crystal, so RTC_CLK_SRC must
+# be set first — no project in this repo had ever set it, so the whole fleet was
+# running its RTC on the internal RC and the crystal was unused hardware.
+CONFIG_RTC_CLK_SRC_EXT_CRYS=y
+CONFIG_BT_CTRL_LPCLK_SEL_EXT_32K_XTAL=y
+
+# (#519) Crystal watchdog. Making the 32.768 kHz crystal the RTC/BLE clock source
+# introduces a failure mode we did not have before: if it stops oscillating, the
+# BLE sleep-clock reference stops with it. A tuning-fork crystal is precisely the
+# part that can quit under launch shock and vibration, and this rides a rocket.
+# ESP_XT_WDT detects the oscillation failure in hardware and automatically switches
+# to BACKUP32K_CLK (plus an interrupt) rather than leaving the clock dead. Cheap
+# insurance; without it there is no recovery path.
+CONFIG_ESP_XT_WDT=y
+CONFIG_ESP_XT_WDT_BACKUP_CLK_ENABLE=y
+
+# NOTE if the bench boot log says "32.768kHz XTAL not detected": the first knob to
+# try is CONFIG_ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES (default 0 on S3), which
+# kicks the crystal with a 32 kHz square wave to help it start.
 
 # (#518) CONFIG_BT_NIMBLE_SLEEP_ENABLE=y used to sit here under a "NimBLE host
 # sleep support" comment. No such kconfig symbol exists in ESP-IDF — it is not in

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -13,7 +13,47 @@ CONFIG_BT_NIMBLE_ROLE_BROADCASTER=y
 # Compiled in but only activated at runtime during low-power mode
 CONFIG_PM_ENABLE=y
 CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
-CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=3
+
+# (#519) Light-sleep tick accounting. The first battery run panicked immediately:
+#
+#   assert failed: vTaskStepTick tasks.c:3068
+#     (( xTickCount + xTicksToJump ) <= xNextTaskUnblockTime)
+#   #3 vTaskStepTick (xTicksToJump=4)
+#   #4 pm_step_tick (xExpectedIdleTime=3)   <- allowed 3 ticks, actually slept 4
+#
+# Cause: FREERTOS_HZ is 1000, so a tick is 1 ms, and IDLE_TIME_BEFORE_SLEEP was 3
+# — we were dropping into light sleep for THREE MILLISECONDS at a time. The wakeup
+# overhead alone (cache misses, the 80/40 MHz DFS switch, flash latency — all three
+# named in esp_pm's own Kconfig help) is around a millisecond, so a 3 ms sleep
+# reliably overshoots by a tick, pm_step_tick tries to jump 4, and FreeRTOS aborts.
+# It only shows up on battery because USB holds the no-light-sleep lock.
+#
+# Two changes, one to remove the cause and one to survive it:
+#
+# 1. Don't take pointless naps. 3 ms of sleep against ~1 ms of entry/exit overhead
+#    is mostly waste even when it works. 10 ms means we only sleep when there is
+#    something to gain, and the overhead becomes a small fraction rather than a
+#    third. The OC idles for long stretches here (BLE at 200 ms interval, latency
+#    4; oc_loop wakes every 20 ms), so there is still plenty of sleep to be had.
+CONFIG_FREERTOS_IDLE_TIME_BEFORE_SLEEP=10
+
+# 2. Belt and braces: this option exists for exactly this assert ("prevent
+#    vTaskStepTick() assertion failure when actual wakeup overhead exceeds
+#    estimation"). It clamps slept_ticks to the expected value when the overshoot
+#    is within tolerance. Default is OFF. Our measured overshoot was 1 tick;
+#    tolerance 3 leaves margin without being so loose that a genuine bug hides.
+#    Cost is that xTickCount can lag esp_timer by a tick in rare cases — which is
+#    acceptable HERE and only here: light sleep runs solely in the rail-off idle
+#    state. exitLowPowerMode() disables it and locks the CPU at full speed before
+#    anything flies, so tick accounting can never affect flight timing.
+CONFIG_PM_LIGHTSLEEP_TICK_OVERFLOW_PROTECTION=y
+CONFIG_PM_LIGHTSLEEP_TICK_OVERFLOW_TOLERANCE=3
+
+# Attack the overhead itself rather than only tolerating it: keep the sleep/wake
+# path in IRAM so it is not paying flash-cache misses on every wakeup. This is the
+# root cause the Kconfig help lists first, and shrinking it shrinks the overshoot.
+CONFIG_PM_SLP_IRAM_OPT=y
+CONFIG_PM_RTOS_IDLE_OPT=y
 
 # BLE controller modem sleep — radio powers down between BLE events
 CONFIG_BT_CTRL_MODEM_SLEEP=y

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -65,6 +65,16 @@ CONFIG_ESP_XT_WDT_BACKUP_CLK_ENABLE=y
 # try is CONFIG_ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES (default 0 on S3), which
 # kicks the crystal with a 32 kHz square wave to help it start.
 
+# (#519) The other half of the reason light sleep was off. enterLowPowerMode()'s
+# comment cited "USB-Serial-JTAG incompatible" — which is true, the USJ peripheral
+# does not survive light sleep. But IDF solves it: with this option the USJ driver
+# holds an ESP_PM_NO_LIGHT_SLEEP lock for exactly as long as the USB port is
+# actually connected (it watches for SOF packets), and releases it on unplug. So
+# the serial console keeps working on the bench, and light sleep engages in flight
+# once USB is gone — which is the only time idle current matters.
+# Default is 'n', which is why we were carrying a hand-rolled "just don't sleep".
+CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION=y
+
 # (#518) CONFIG_BT_NIMBLE_SLEEP_ENABLE=y used to sit here under a "NimBLE host
 # sleep support" comment. No such kconfig symbol exists in ESP-IDF — it is not in
 # the bt component's Kconfig and not in its sdkconfig.rename map — so kconfgen


### PR DESCRIPTION
**Bench result: OC idle current 22 mA → ~1 mA.**

The issue asked for one thing (use the 32.768 kHz crystal). The bench found **four independent blockers**, each of which made the next one invisible. Every one had to go before a single mA moved.

## 1. The crystal was never used — and that blocked light sleep entirely

No project in this repo has ever set `CONFIG_RTC_CLK_SRC`, so the whole fleet ran its RTC on the internal RC and the crystal was unused hardware. That forced the BT low-power clock onto `MAIN_XTAL`, and from the controller source (`bt/controller/esp32c3/bt.c`, shared by the S3):

```c
} else if (s_lp_cntl.lpclk_sel == ESP_BT_SLEEP_CLOCK_MAIN_XTAL) {
#if !CONFIG_BT_CTRL_MAIN_XTAL_PU_DURING_LIGHT_SLEEP
    s_lp_cntl.no_light_sleep = 1;
#endif
```

That is exactly the config we shipped, so **light sleep was blocked outright whenever BLE was on**. `PM_ENABLE` and `FREERTOS_USE_TICKLESS_IDLE` were both enabled but could never engage. The pre-fix firmware even says so out loud:

```
W BLE_INIT: light sleep mode will not be able to apply when bluetooth is enabled.
```

`loop_oc`'s own comment ("light sleep is disabled while BLE is on, so the CPU idles at 40 MHz regardless") reads like a hardware fact — it was describing a self-inflicted config constraint.

**Bench-confirmed the crystal is present and starts:** `BLE_INIT: Using external 32.768 kHz crystal/oscillator as clock source`. Also enables `ESP_XT_WDT`, because making the crystal the clock source creates a failure mode we did not have before — a tuning-fork crystal is precisely what quits under launch vibration, and this rides a rocket.

## 2. The app was still refusing to sleep

`enterLowPowerMode()` passed `light_sleep_enable = false`, citing *"btLS blocks it; USB-Serial-JTAG incompatible"*. The first reason died with (1). The second is real — but ESP-IDF already solves it and we weren't using the solution: `CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION` (default **n**) holds a no-light-sleep lock only while USB is *physically plugged in*, and releases it on unplug. Console keeps working on the bench; light sleep engages in flight.

## 3. The OC's connection-parameter requests had **never worked** — and this is where the measured saving came from

```
I (7163) BLE: Device connected! handle=1
I (8055) NimBLE: GAP update_params: connection not found; conn_handle=0x0000
```

Both call sites passed a **hardcoded `0`** while NimBLE had issued handle **1**, and the return code was discarded. So `requestSlowBLEParams` — the idle power saver, 100–200 ms interval with latency 4 — has never once been applied. We were paying a ~30 ms connection interval while idle, believing we were on 200 ms.

Root cause of the root cause: `TR_BLE_To_APP` never exposed the handle, so there was nothing correct to pass. Added `connHandle()`.

**The 22 → 15 mA measured over USB came entirely from this**, since USB inhibits light sleep. Light sleep contributed nothing to that reading.

Also fixes a second copy of #503 hiding here: `requestFastBLEParams` asked for 7.5 ms, below iOS's 15 ms floor and never grantable.

## 4. Light sleep then panicked instantly on battery

"Not discoverable on battery" was a boot loop. The coredump:

```
assert failed: vTaskStepTick tasks.c:3068
  (( xTickCount + xTicksToJump ) <= xNextTaskUnblockTime)
#3 vTaskStepTick (xTicksToJump=4)        ← actually slept 4 ticks
#4 pm_step_tick (xExpectedIdleTime=3)    ← was allowed 3
```

`FREERTOS_HZ` is 1000 (1 ms tick) and `IDLE_TIME_BEFORE_SLEEP` was 3 — **we were light-sleeping for three milliseconds at a time**, against a wakeup overhead of roughly a millisecond (cache misses, the 80/40 MHz DFS switch, flash latency — all three named in esp_pm's own Kconfig help). It overshoots by a tick essentially every time.

That `3` was harmless for years *because light sleep never engaged*. Enabling it made a latent, never-exercised value suddenly load-bearing.

Fixed three ways: `IDLE_TIME_BEFORE_SLEEP` 3 → 10 (don't take pointless naps), `PM_SLP_IRAM_OPT` + `PM_RTOS_IDLE_OPT` (cut the wakeup overhead at source), and `PM_LIGHTSLEEP_TICK_OVERFLOW_PROTECTION` + tolerance 3 — the option that exists for precisely this assert, default **off**.

Its documented cost (`xTickCount` may lag `esp_timer` by a tick) is acceptable **here and only here**: light sleep runs solely in the rail-off idle state. `exitLowPowerMode()` disables it and locks the CPU at full speed before anything flies, so tick slop can never touch flight timing.

## Also in here

- **LE 2M PHY** — never used in this project's history. The controller supports it (`BLE_50:1`) but nobody asked, so every connection ran on 1M. Bench: `PHY now: TX=2M RX=2M`. Same lesson as #503 applied — `BLE_GAP_EVENT_PHY_UPDATE_COMPLETE` logs the PHY we actually got, so a silent fallback to 1M is visible rather than assumed.
- **Two conn-param requesters racing.** The bench caught `GAP update_params: update already in progress; rc=2` — the OC's slow params and `TR_BLE_To_APP`'s deferred request fighting. The OC won by ordering luck; had it lost, the idle link would have sat at 30 ms and thrown away most of the saving, looking like a normal successful update. Added `setAutoConnParams(bool)` (default true, BS unchanged); the OC now owns its policy end to end. That warning was only visible *because* #503 made the failure path loud.

## Verification

Every config change verified in the **regenerated** `sdkconfig`, never assumed — `sdkconfig` is generated and untracked, and an existing one silently overrides `sdkconfig.defaults`, which is the trap that hid #518 for years.

Bench, on hardware: crystal in use, `Light sleep: ENABLED`, 2M PHY negotiated, slow idle params applied (`interval=200.00 ms, latency=4`), fast transfer params applied (`interval=30.00 ms`), no panic on battery, device discoverable.

**Idle current 22 mA → ~1 mA.** Honest caveat: that is **at the INA230's resolution floor** — with the 2 mΩ shunt, one ADC count is ~1.25 mA, so "almost 0" means "under ~1–2 mA". The collapse is real (voltage and SoC stayed valid, and the failed-read path is rejected as battery-N/A rather than reported as 0 mA), but a µA meter is needed for an exact figure.

Base station deliberately unchanged: #518 left it on `MAIN_XTAL`, so its BT controller still blocks light sleep, and it does not use low-power mode anyway.

## Not fixed here

BLE file transfers are still slow — but **not** for the reason I first assumed. A hardcoded 30 ms per-chunk delay caps downloads at ~16 kB/s at any connection interval, and it exists to work around a chunk-drop bug rather than fix it. Filed separately as #524.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
