### PR TITLE
perf(ble): #524 fix the chunk-drop bug instead of throttling downloads to hide it

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -401,6 +401,21 @@ target_include_directories(test_ble_command_ring PRIVATE
 target_link_libraries(test_ble_command_ring GTest::gtest_main)
 gtest_discover_tests(test_ble_command_ring)
 
+# ---------- test_ble_chunk_size ----------
+# #524: BLE file downloads ran at ~17 kB/s because chunks were sized MTU-maximal
+# (502 B), which puts 516 octets on the wire and fragments as 251 + 251 + 14 — a
+# whole link-layer packet to carry fourteen bytes. Throughput here is bounded by
+# packets per connection event, so that stub cost ~a third of the download.
+# BleChunkSize.h is pure integer arithmetic over (ATT MTU, LL TX octets), so the
+# alignment — and the degenerate links it has to survive — are tested on the host.
+add_executable(test_ble_chunk_size test_ble_chunk_size.cpp)
+target_include_directories(test_ble_chunk_size PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_BLE_To_APP
+)
+target_link_libraries(test_ble_chunk_size GTest::gtest_main)
+gtest_discover_tests(test_ble_chunk_size)
+
 # ---------- test_bs_download_policy ----------
 # Host-side test for the base-station cooperative BLE download (#380): chunk
 # planning bounded by open-time file size + the 15 ms notify-drain pacing gate.

--- a/tests_cpp/test_ble_chunk_size.cpp
+++ b/tests_cpp/test_ble_chunk_size.cpp
@@ -1,0 +1,155 @@
+// Host tests for BleChunkSize.h — the #524 file-transfer chunk sizing.
+//
+// The point of the module is one non-obvious claim: the FASTEST chunk is not the
+// BIGGEST chunk. Downloads are bounded by packets per connection event, so a
+// chunk that overflows into a nearly-empty third link-layer packet is slower than
+// a slightly smaller one that fits in two full packets. These tests pin that.
+
+#include <gtest/gtest.h>
+
+#include "BleChunkSize.h"
+
+using tr_ble::kWireOverhead;
+using tr_ble::maxChunkDataSize;
+
+namespace
+{
+
+// Bytes the link layer actually puts on air for a chunk of `data` bytes:
+// L2CAP(4) + ATT(3) + chunk header(7) + data, split into ll-octet packets.
+int llPacketsFor(size_t data, uint16_t ll)
+{
+    const size_t pdu = data + kWireOverhead;
+    return static_cast<int>((pdu + ll - 1) / ll);  // ceil
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The regression this module exists to fix.
+// ---------------------------------------------------------------------------
+
+// MTU 512 + DLE 251 is the negotiated state on the bench (iOS + ESP32-S3).
+TEST(BleChunkSize, MtuMaximalChunkWastesAThirdPacket)
+{
+    // What the OLD code did: mtu - ATT(3) - header(7).
+    const size_t mtu_maximal = 512 - 3 - 7;
+    ASSERT_EQ(mtu_maximal, 502u);
+
+    // 502 + 14 = 516 octets on the wire -> 251 + 251 + 14. Three packets, and the
+    // third carries fourteen bytes.
+    EXPECT_EQ(llPacketsFor(mtu_maximal, 251), 3);
+}
+
+TEST(BleChunkSize, AlignsToWholeLinkLayerPackets)
+{
+    const size_t chunk = maxChunkDataSize(512, 251);
+
+    EXPECT_EQ(chunk, 488u);                    // 2 * 251 - 14
+    EXPECT_EQ(llPacketsFor(chunk, 251), 2);    // both packets full
+    EXPECT_EQ(chunk + kWireOverhead, 2u * 251);  // exactly, no stub
+}
+
+// The whole justification for giving up payload: useful bytes per packet is the
+// figure of merit, not bytes per chunk.
+TEST(BleChunkSize, TradesPayloadForThroughput)
+{
+    const size_t old_chunk = 502;                 // MTU-maximal
+    const size_t new_chunk = maxChunkDataSize(512, 251);
+
+    EXPECT_LT(new_chunk, old_chunk);              // 2.8% smaller chunk...
+
+    const double old_per_pkt = double(old_chunk) / llPacketsFor(old_chunk, 251);
+    const double new_per_pkt = double(new_chunk) / llPacketsFor(new_chunk, 251);
+
+    EXPECT_NEAR(old_per_pkt, 167.3, 0.1);
+    EXPECT_NEAR(new_per_pkt, 244.0, 0.1);
+    EXPECT_GT(new_per_pkt / old_per_pkt, 1.45);   // ...for ~1.46x the throughput
+}
+
+// ---------------------------------------------------------------------------
+// Invariants that must hold for every link we could end up on.
+// ---------------------------------------------------------------------------
+
+// Smallest MTU we will actually size a chunk against; below this we cannot know
+// the real MTU and fall back (see UnnegotiatedMtuAssumesIosDefault).
+constexpr uint16_t kFirstRealMtu = 31;  // kAttNotifyHdr + kChunkHeader + 20 + 1
+
+TEST(BleChunkSize, NeverExceedsTheMtu)
+{
+    // An oversized notification is not slow, it is broken — the peer drops it.
+    for (uint16_t mtu = kFirstRealMtu; mtu <= 517; ++mtu)
+    {
+        for (uint16_t ll : {uint16_t(27), uint16_t(100), uint16_t(251)})
+        {
+            const size_t chunk = maxChunkDataSize(mtu, ll);
+            EXPECT_LE(chunk + 3u + 7u, mtu) << "mtu=" << mtu << " ll=" << ll;
+        }
+    }
+}
+
+TEST(BleChunkSize, NeverReturnsZero)
+{
+    for (uint16_t mtu = kFirstRealMtu; mtu <= 517; ++mtu)
+    {
+        for (uint16_t ll : {uint16_t(27), uint16_t(100), uint16_t(251)})
+        {
+            EXPECT_GT(maxChunkDataSize(mtu, ll), 0u) << "mtu=" << mtu << " ll=" << ll;
+        }
+    }
+}
+
+// DLE is negotiated per connection and may simply not happen. 27 octets is the
+// floor every BLE link starts at, and we must still produce a sane chunk.
+TEST(BleChunkSize, HandlesLinkWithoutDataLengthExtension)
+{
+    const size_t chunk = maxChunkDataSize(512, 27);
+
+    EXPECT_EQ(chunk, 499u);                   // 19 * 27 - 14
+    EXPECT_EQ(llPacketsFor(chunk, 27), 19);   // all 19 full
+    EXPECT_EQ((chunk + kWireOverhead) % 27, 0u);
+    EXPECT_LE(chunk, 502u);                   // still within MTU 512
+}
+
+// ---------------------------------------------------------------------------
+// Degenerate links: alignment must degrade to "as big as the MTU allows", never
+// to something nonsensical.
+// ---------------------------------------------------------------------------
+
+// iOS's pre-negotiation default MTU is 185: one 251-octet fragment cannot even be
+// filled, so there is nothing to align to.
+TEST(BleChunkSize, SmallMtuFallsBackToMtuMaximal)
+{
+    EXPECT_EQ(maxChunkDataSize(185, 251), 185u - 3 - 7);
+}
+
+// Below kFirstRealMtu we do not have a usable MTU to size against, and the
+// fallback deliberately does NOT fit it: 170 + 10 = 180 bytes needs an MTU of
+// 180, not 23. That is on purpose and predates #524.
+//
+// The reason is #283: effectiveMtu() can report a STALE 0/23 on some iOS
+// reconnect paths that reuse the prior MTU without re-firing BLE_GAP_EVENT_MTU,
+// while the link is really running at 185 or 512. Honouring 23 literally would
+// pin those reconnects to 13-byte chunks — far worse than assuming iOS's 185-byte
+// default and being right almost every time. So: when the MTU is unknown, guess
+// iOS; do not clamp.
+TEST(BleChunkSize, UnnegotiatedMtuAssumesIosDefault)
+{
+    EXPECT_EQ(maxChunkDataSize(23, 251), tr_ble::kFallbackChunkData);  // pre-exchange
+    EXPECT_EQ(maxChunkDataSize(0, 251), tr_ble::kFallbackChunkData);
+
+    // 170 fits iOS's 185-byte default with room to spare — which is the bet.
+    EXPECT_LE(tr_ble::kFallbackChunkData + 3u + 7u, 185u);
+}
+
+// A fragment smaller than the header we must prepend would underflow the
+// alignment arithmetic. Guard it rather than wrap to a huge size_t.
+TEST(BleChunkSize, PathologicalFragmentSizeDoesNotUnderflow)
+{
+    for (uint16_t ll = 0; ll <= kWireOverhead; ++ll)
+    {
+        const size_t chunk = maxChunkDataSize(512, ll);
+        EXPECT_EQ(chunk, 502u) << "ll=" << ll;   // MTU-maximal, not garbage
+        EXPECT_LT(chunk, 1024u);                 // definitely not a wrapped size_t
+    }
+}

--- a/tests_cpp/test_ble_chunk_size.cpp
+++ b/tests_cpp/test_ble_chunk_size.cpp
@@ -73,7 +73,7 @@ TEST(BleChunkSize, TradesPayloadForThroughput)
 
 // Smallest MTU we will actually size a chunk against; below this we cannot know
 // the real MTU and fall back (see UnnegotiatedMtuAssumesIosDefault).
-constexpr uint16_t kFirstRealMtu = 31;  // kAttNotifyHdr + kChunkHeader + 20 + 1
+constexpr uint16_t kFirstRealMtu = tr_ble::kMinUsableMtu + 1;
 
 TEST(BleChunkSize, NeverExceedsTheMtu)
 {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/BleChunkSize.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/BleChunkSize.h
@@ -50,6 +50,10 @@ static constexpr size_t kChunkHeader   = 7;  // offset(4) + length(2) + flags(1)
 // Bytes the link layer must carry in front of every chunk payload.
 static constexpr size_t kWireOverhead = kL2capHeader + kAttNotifyHdr + kChunkHeader;  // 14
 
+// Smallest ATT MTU worth sizing a real chunk against. At or below this we cannot
+// know the true MTU and fall back (see below).
+static constexpr uint16_t kMinUsableMtu = kAttNotifyHdr + kChunkHeader + 20;  // 30
+
 // Chunk size used before the MTU has been negotiated (fits iOS's 185-byte default).
 static constexpr size_t kFallbackChunkData = 170;
 
@@ -62,7 +66,7 @@ static constexpr size_t kFallbackChunkData = 170;
 inline size_t maxChunkDataSize(uint16_t att_mtu, uint16_t ll_tx_octets)
 {
     // Before the MTU exchange lands there is nothing to optimise against.
-    if (att_mtu <= kAttNotifyHdr + kChunkHeader + 20)
+    if (att_mtu <= kMinUsableMtu)
     {
         return kFallbackChunkData;
     }

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/BleChunkSize.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/BleChunkSize.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// ============================================================================
+// #524: how big should a file-transfer chunk be?
+//
+// The obvious answer — "as big as the ATT MTU allows" — is the wrong one, and it
+// is what capped downloads at ~17 kB/s.
+//
+// A chunk notification goes on the wire like this:
+//
+//   [ L2CAP hdr 4 ][ ATT opcode+handle 3 ][ chunk hdr 7 ][ data ... ]
+//   \______________________ one L2CAP PDU _________________________/
+//
+// The link layer then splits that PDU into LL data packets of at most
+// ll_tx_octets — 27 before Data Length Extension, 251 after.
+//
+// Throughput on this link is bounded by PACKETS PER CONNECTION EVENT, not by
+// bytes: iOS grants a 30 ms interval (Apple's envelope makes 15-30 the tightest
+// legal request, and it serves the top), and only a handful of packets move per
+// event. So the figure of merit is USEFUL BYTES PER PACKET.
+//
+// MTU-maximal is pathological for that metric. At MTU 512 it yields 502 data
+// bytes, so the L2CAP PDU is 502 + 14 = 516 octets, which fragments as:
+//
+//       251 + 251 + 14        <-- a whole third packet to carry FOURTEEN bytes
+//
+// Three packets for 502 useful bytes = 167 B/packet. Giving up 14 bytes of
+// payload (502 -> 488) makes the PDU exactly 2 x 251 = 502 octets:
+//
+//       251 + 251             <-- both full
+//
+// Two packets for 488 useful bytes = 244 B/packet. Same airtime, 1.46x the data.
+// It also costs one fewer HCI credit per chunk, so more chunks fit in the
+// controller's outbound queue and more of them ride each event.
+//
+// Kept as a free function on plain integers so it is host-testable — see
+// tests_cpp/test_ble_chunk_size.cpp.
+// ============================================================================
+
+namespace tr_ble
+{
+
+static constexpr size_t kL2capHeader   = 4;  // L2CAP basic header
+static constexpr size_t kAttNotifyHdr  = 3;  // ATT opcode(1) + attribute handle(2)
+static constexpr size_t kChunkHeader   = 7;  // offset(4) + length(2) + flags(1)
+
+// Bytes the link layer must carry in front of every chunk payload.
+static constexpr size_t kWireOverhead = kL2capHeader + kAttNotifyHdr + kChunkHeader;  // 14
+
+// Chunk size used before the MTU has been negotiated (fits iOS's 185-byte default).
+static constexpr size_t kFallbackChunkData = 170;
+
+/// Largest chunk payload that fits the ATT MTU *and* leaves no stub link-layer
+/// packet behind.
+///
+/// @param att_mtu       negotiated ATT MTU (23 until the exchange completes)
+/// @param ll_tx_octets  LL max TX payload from BLE_GAP_EVENT_DATA_LEN_CHG;
+///                      27 (the pre-DLE minimum) if DLE has not been negotiated
+inline size_t maxChunkDataSize(uint16_t att_mtu, uint16_t ll_tx_octets)
+{
+    // Before the MTU exchange lands there is nothing to optimise against.
+    if (att_mtu <= kAttNotifyHdr + kChunkHeader + 20)
+    {
+        return kFallbackChunkData;
+    }
+
+    // Ceiling imposed by the MTU: one ATT notification cannot exceed it.
+    const size_t mtu_limit = static_cast<size_t>(att_mtu) - kAttNotifyHdr - kChunkHeader;
+
+    // A fragment smaller than the header we must prepend is not a real link.
+    // Take the MTU-maximal size and let the LL fragment it however it must.
+    if (ll_tx_octets <= kWireOverhead)
+    {
+        return mtu_limit;
+    }
+
+    // How many WHOLE link-layer packets can we fill without exceeding the MTU?
+    const size_t ll        = static_cast<size_t>(ll_tx_octets);
+    const size_t fragments = (mtu_limit + kWireOverhead) / ll;
+
+    // MTU too small to fill even one fragment — nothing to align to.
+    if (fragments == 0)
+    {
+        return mtu_limit;
+    }
+
+    // Fill exactly that many. <= mtu_limit by construction.
+    return fragments * ll - kWireOverhead;
+}
+
+}  // namespace tr_ble

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -978,6 +978,14 @@ void TR_BLE_To_APP::resetXferStats()
     xfer_burst_ = 0;
 }
 
+int8_t TR_BLE_To_APP::connRssi() const
+{
+    if (!device_connected_) return 0;
+    int8_t rssi = 0;
+    if (ble_gap_conn_rssi(conn_handle_, &rssi) != 0) return 0;
+    return rssi;
+}
+
 size_t TR_BLE_To_APP::getMaxChunkDataSize() const
 {
     // #524: this used to return the MTU-maximal size (mtu - 3 - 7 = 502 at MTU

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -219,6 +219,17 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         self->onMtuChanged(event->mtu.conn_handle, event->mtu.value);
         break;
 
+    case BLE_GAP_EVENT_DATA_LEN_CHG:
+        // #524: report the LL payload size we actually negotiated. 27 octets means
+        // DLE did not take and every 502-byte notification is still fragmenting
+        // ~19 ways — downloads would stay slow while we assumed otherwise. Same
+        // discipline as the connection interval (#503) and the PHY.
+        ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets",
+                 (unsigned)event->data_len_chg.max_tx_octets,
+                 (unsigned)event->data_len_chg.max_tx_time,
+                 (unsigned)event->data_len_chg.max_rx_octets);
+        break;
+
     case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
         // Report the PHY we ACTUALLY ended up on, not the one we asked for — the
         // same lesson as the connection interval (#503). 2M doubles the raw rate;
@@ -283,6 +294,20 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     telem_notify_subscribed_ = false;
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
+
+    // #524: request Data Length Extension. We had never called this, so the link
+    // layer stayed at its 27-byte default PDU and every 502-byte notification was
+    // fragmented into ~19 LL packets, each with its own header and inter-frame
+    // spacing. 251 octets collapses that to two. Purely a request — if the peer
+    // declines, the link simply stays at 27 and nothing breaks.
+    const int dle_rc = ble_gap_set_data_len(conn_handle,
+                                            BLE_HCI_SET_DATALEN_TX_OCTETS_MAX,
+                                            BLE_HCI_SET_DATALEN_TX_TIME_MAX);
+    if (dle_rc != 0)
+    {
+        ESP_LOGW(BLE_TAG, "Data-length extension request failed, rc=%d "
+                          "— staying on 27-byte LL PDUs", dle_rc);
+    }
 
     // Ask for the LE 2M PHY. This is the throughput lever, and we had never used
     // it — the controller supports it (boot log: "Feature Config ... BLE_50:1") but
@@ -946,30 +971,45 @@ bool TR_BLE_To_APP::isConnected() const
 // Helper: send a BLE notification on a given characteristic handle
 // ============================================================================
 
-static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
-                       const uint8_t* data, size_t len)
-{
-    // Keep retries short to avoid stalling the main loop.  The original
-    // 20 × 25 ms (500 ms worst-case) caused 50-60 ms gaps in INA230 power
-    // readings and other time-critical polling.  3 × 5 ms (15 ms max) is
-    // enough for transient BLE controller congestion; sustained congestion
-    // simply drops the notification — telemetry is best-effort anyway.
-    static constexpr int MAX_RETRIES = 3;
-    static constexpr int RETRY_DELAY_MS = 5;
+// #524: the retry budget is now the CALLER's choice, because the two kinds of
+// traffic want opposite things.
+//
+// BEST-EFFORT (telemetry, scan results, cal status): losing a frame is fine —
+// another one is along in a moment — but stalling the main loop is not. A 500 ms
+// retry budget used to blow 50-60 ms holes in INA230 polling and other
+// time-critical work, which is why this was cut to 3 x 5 ms.
+//
+// RELIABLE (file chunks): a dropped chunk is LOST DATA. Applying the best-effort
+// policy to a download meant chunks really were dropped under congestion (the
+// "~50% data loss" the old code fought), so the download loop compensated with a
+// fixed 30 ms delay per chunk to keep the queue too shallow for the drop path to
+// fire — capping transfers at ~16 kB/s and leaving the radio idle ~90% of the
+// time. We were throttling the transfer to hide a data-loss bug instead of fixing
+// it. Waiting is safe here: the OC pauses I2S ingest and I2C service for the whole
+// transfer (beginPhoneIO), so there is no time-critical polling to protect.
+static constexpr int NOTIFY_BEST_EFFORT_RETRIES  = 3;
+static constexpr int NOTIFY_BEST_EFFORT_DELAY_MS = 5;
+static constexpr int NOTIFY_RELIABLE_RETRIES     = 250;  // up to ~500 ms of backpressure
+static constexpr int NOTIFY_RELIABLE_DELAY_MS    = 2;
 
-    for (int attempt = 0; attempt < MAX_RETRIES; attempt++)
+static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
+                       const uint8_t* data, size_t len,
+                       int max_retries = NOTIFY_BEST_EFFORT_RETRIES,
+                       int retry_delay_ms = NOTIFY_BEST_EFFORT_DELAY_MS)
+{
+    for (int attempt = 0; attempt < max_retries; attempt++)
     {
         struct os_mbuf* om = ble_hs_mbuf_from_flat(data, len);
         if (!om)
         {
             // Out of mbufs — wait for BLE controller to drain and retry
-            if (attempt < MAX_RETRIES - 1)
+            if (attempt < max_retries - 1)
             {
-                vTaskDelay(pdMS_TO_TICKS(RETRY_DELAY_MS));
+                vTaskDelay(pdMS_TO_TICKS(retry_delay_ms));
                 continue;
             }
             ESP_LOGE("BLE", "ble_hs_mbuf_from_flat failed after %d retries (len=%u)",
-                     MAX_RETRIES, (unsigned)len);
+                     max_retries, (unsigned)len);
             return BLE_HS_ENOMEM;
         }
 
@@ -977,13 +1017,13 @@ static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
         if (rc == BLE_HS_ENOMEM)
         {
             // Controller queue full — wait and retry
-            if (attempt < MAX_RETRIES - 1)
+            if (attempt < max_retries - 1)
             {
-                vTaskDelay(pdMS_TO_TICKS(RETRY_DELAY_MS));
+                vTaskDelay(pdMS_TO_TICKS(retry_delay_ms));
                 continue;
             }
             ESP_LOGE("BLE", "ble_gatts_notify_custom failed after %d retries, rc=%d",
-                     MAX_RETRIES, rc);
+                     max_retries, rc);
         }
         if (rc != 0 && rc != BLE_HS_ENOMEM)
         {
@@ -1247,10 +1287,10 @@ void TR_BLE_To_APP::sendStorageStats(uint8_t marker, const uint8_t* bytes, size_
     }
 }
 
-void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
+bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
                                    size_t len, bool eof)
 {
-    if (!device_connected_) return;
+    if (!device_connected_) return false;
 
     // Build chunk packet: [offset(4)][length(2)][flags(1)][data(N)]
     const size_t header_size = 7;
@@ -1286,12 +1326,19 @@ void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
         memcpy(chunk_buffer_ + header_size, data, len);
     }
 
-    // Send via BLE notification
-    int rc = notify_data(conn_handle_, file_transfer_val_handle_,
-                         chunk_buffer_, packet_size);
+    // #524: RELIABLE budget — wait for the controller to drain rather than drop.
+    // A dropped file chunk is lost data, unlike a dropped telemetry frame.
+    const int rc = notify_data(conn_handle_, file_transfer_val_handle_,
+                               chunk_buffer_, packet_size,
+                               NOTIFY_RELIABLE_RETRIES, NOTIFY_RELIABLE_DELAY_MS);
     if (rc != 0)
     {
-        ESP_LOGW(BLE_TAG, "File chunk notify failed, rc=%d", rc);
+        // Report it. The caller must abort the transfer rather than carry on and
+        // hand the app a file with a hole in it.
+        ESP_LOGW(BLE_TAG, "File chunk notify FAILED after full backpressure, rc=%d "
+                          "(offset=%lu len=%u)",
+                 rc, (unsigned long)offset, (unsigned)len);
+        return false;
     }
 
     // Minimal debug: only log first and last chunks
@@ -1300,6 +1347,7 @@ void TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
         ESP_LOGI(BLE_TAG, "Chunk offset=%lu, len=%u, eof=%s",
                  (unsigned long)offset, (unsigned)len, eof ? "true" : "false");
     }
+    return true;
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -317,6 +317,9 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     negotiated_mtu_ = 0;  // Reset until MTU exchange completes
     ll_tx_octets_   = 27; // #524: and back to the pre-DLE minimum until DATA_LEN_CHG
     telem_notify_subscribed_ = false;
+    // #524: latch the cadence the peer opened with. CONN_UPDATE only fires on a
+    // CHANGE, so without this the initial parameters would never be recorded.
+    eff_event_ms_ = (desc != nullptr) ? effFromDesc(*desc) : 30;
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
 
@@ -432,15 +435,11 @@ void TR_BLE_To_APP::requestConnParams()
     }
 }
 
-uint32_t TR_BLE_To_APP::effectiveEventMs() const
+// conn_itvl is in 1.25 ms units. conn_latency is how many connection events the
+// peripheral may SKIP, so real data opportunities are (latency + 1) intervals apart —
+// on the idle link (200 ms, latency 4) that is a full second.
+uint32_t TR_BLE_To_APP::effFromDesc(const struct ble_gap_conn_desc& desc)
 {
-    struct ble_gap_conn_desc desc;
-    if (!device_connected_ || ble_gap_conn_find(conn_handle_, &desc) != 0)
-    {
-        return 30;   // assume the fast link rather than invent a stall
-    }
-    // conn_itvl is in 1.25 ms units. conn_latency is how many events the peripheral
-    // may SKIP, so real data opportunities are (latency + 1) intervals apart.
     const uint32_t itvl_ms = ((uint32_t)desc.conn_itvl * 5u) / 4u;
     const uint32_t eff     = itvl_ms * ((uint32_t)desc.conn_latency + 1u);
     return (eff > 0) ? eff : 30;
@@ -458,9 +457,12 @@ void TR_BLE_To_APP::onConnParamsUpdated(uint16_t conn_handle, int status)
     {
         if (have_desc)
         {
-            ESP_LOGI(BLE_TAG, "Connection parameters now: interval=%.2f ms, latency=%u, timeout=%u ms",
+            eff_event_ms_ = effFromDesc(desc);   // latch: this is the ONLY place it changes
+            ESP_LOGI(BLE_TAG, "Connection parameters now: interval=%.2f ms, latency=%u, "
+                              "timeout=%u ms (%lu ms effective)",
                      (double)desc.conn_itvl * 1.25, (unsigned)desc.conn_latency,
-                     (unsigned)desc.supervision_timeout * 10);
+                     (unsigned)desc.supervision_timeout * 10,
+                     (unsigned long)eff_event_ms_);
         }
         else
         {
@@ -1016,6 +1018,8 @@ size_t TR_BLE_To_APP::maxNotifyBytes() const
 void TR_BLE_To_APP::resetXferStats()
 {
     xfer_ = XferStats{};
+    xfer_.rssi_min = 127;    // so the first real sample wins
+    xfer_.rssi_max = -128;
     xfer_burst_ = 0;
 }
 
@@ -1464,6 +1468,22 @@ bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
     else
     {
         xfer_burst_ = 0;
+    }
+
+    // Track the link, don't just read it once at the end. Bench 2026-07-14 finished a
+    // download at rssi=-107 dBm — the sensitivity floor — where the LL is retransmitting
+    // and each retransmit eats one of the ~4 packet slots per connection event that the
+    // transfer rate is made of. One sample cannot distinguish that from a stray reading.
+    if ((xfer_.chunks % kRssiSampleEveryChunks) == 1)
+    {
+        const int8_t r = connRssi();
+        if (r != 0)
+        {
+            if (r < xfer_.rssi_min) xfer_.rssi_min = r;
+            if (r > xfer_.rssi_max) xfer_.rssi_max = r;
+            xfer_.rssi_sum += r;
+            xfer_.rssi_n++;
+        }
     }
 
     if (rc != 0)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -228,12 +228,30 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         // slow while we assumed otherwise. Same discipline as the connection
         // interval (#503) and the PHY.
         self->ll_tx_octets_ = event->data_len_chg.max_tx_octets;
-        ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets "
-                          "-> chunk %u bytes",
-                 (unsigned)event->data_len_chg.max_tx_octets,
-                 (unsigned)event->data_len_chg.max_tx_time,
-                 (unsigned)event->data_len_chg.max_rx_octets,
-                 (unsigned)self->getMaxChunkDataSize());
+
+        // Quote the resulting chunk size ONLY once the MTU is real. DLE and the
+        // MTU exchange race, and iOS runs DLE first: at this point effectiveMtu()
+        // is usually still 23, so a chunk size printed here would be the 170-byte
+        // pre-MTU fallback — which reads exactly like DLE having failed, on the
+        // very line you would check to see whether it worked. onMtuChanged() logs
+        // the settled size either way.
+        if (self->effectiveMtu() > tr_ble::kMinUsableMtu)
+        {
+            ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets "
+                              "-> chunk %u bytes",
+                     (unsigned)event->data_len_chg.max_tx_octets,
+                     (unsigned)event->data_len_chg.max_tx_time,
+                     (unsigned)event->data_len_chg.max_rx_octets,
+                     (unsigned)self->getMaxChunkDataSize());
+        }
+        else
+        {
+            ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets "
+                              "(chunk size pending MTU exchange)",
+                     (unsigned)event->data_len_chg.max_tx_octets,
+                     (unsigned)event->data_len_chg.max_tx_time,
+                     (unsigned)event->data_len_chg.max_rx_octets);
+        }
         break;
 
     case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -13,6 +13,7 @@
 #include <nimble/nimble_port_freertos.h>
 #include <host/ble_hs.h>
 #include <host/ble_att.h>          // ble_att_mtu — authoritative live MTU (#283)
+#include "BleChunkSize.h"          // #524: LL-fragment-aligned chunk sizing
 #include <host/util/util.h>
 #include <services/gap/ble_svc_gap.h>
 #include <services/gatt/ble_svc_gatt.h>
@@ -122,6 +123,7 @@ static int gatt_access_cb(uint16_t conn_handle, uint16_t attr_handle,
 TR_BLE_To_APP::TR_BLE_To_APP(const char* device_name)
     : device_connected_(false),
       negotiated_mtu_(0),
+      ll_tx_octets_(27),  // #524: pre-DLE minimum until DATA_LEN_CHG says otherwise
       telem_notify_subscribed_(false),
       conn_handle_(0),
       file_list_json_(""),
@@ -220,14 +222,18 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         break;
 
     case BLE_GAP_EVENT_DATA_LEN_CHG:
-        // #524: report the LL payload size we actually negotiated. 27 octets means
-        // DLE did not take and every 502-byte notification is still fragmenting
-        // ~19 ways — downloads would stay slow while we assumed otherwise. Same
-        // discipline as the connection interval (#503) and the PHY.
-        ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets",
+        // #524: the LL payload size is not just a number to report — it is what we
+        // size chunks against, so latch it. 27 octets means DLE did not take and
+        // every notification is still fragmenting ~19 ways; downloads would stay
+        // slow while we assumed otherwise. Same discipline as the connection
+        // interval (#503) and the PHY.
+        self->ll_tx_octets_ = event->data_len_chg.max_tx_octets;
+        ESP_LOGI(BLE_TAG, "LL data length now: TX=%u octets (%u us), RX=%u octets "
+                          "-> chunk %u bytes",
                  (unsigned)event->data_len_chg.max_tx_octets,
                  (unsigned)event->data_len_chg.max_tx_time,
-                 (unsigned)event->data_len_chg.max_rx_octets);
+                 (unsigned)event->data_len_chg.max_rx_octets,
+                 (unsigned)self->getMaxChunkDataSize());
         break;
 
     case BLE_GAP_EVENT_PHY_UPDATE_COMPLETE:
@@ -291,6 +297,7 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     device_connected_ = true;
     conn_handle_ = conn_handle;
     negotiated_mtu_ = 0;  // Reset until MTU exchange completes
+    ll_tx_octets_   = 27; // #524: and back to the pre-DLE minimum until DATA_LEN_CHG
     telem_notify_subscribed_ = false;
 
     ESP_LOGI(BLE_TAG, "Device connected! handle=%u", conn_handle);
@@ -448,6 +455,7 @@ void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
 {
     device_connected_ = false;
     negotiated_mtu_ = 0;
+    ll_tx_octets_ = 27;  // #524: DLE is per-connection; do not carry it into the next one
     telem_notify_subscribed_ = false;
     conn_handle_ = 0;
     // #503: cancel any pending/retrying parameter request — it belongs to the
@@ -948,18 +956,13 @@ size_t TR_BLE_To_APP::maxNotifyBytes() const
 
 size_t TR_BLE_To_APP::getMaxChunkDataSize() const
 {
-    const size_t HEADER_SIZE = 7;   // offset(4) + length(2) + flags(1)
-    const size_t ATT_OVERHEAD = 3;  // ATT notification header
-
-    const uint16_t mtu = effectiveMtu();  // #283: live MTU, not the stale cache
-    if (mtu > (HEADER_SIZE + ATT_OVERHEAD + 20))
-    {
-        // Use negotiated MTU for chunk size
-        return mtu - ATT_OVERHEAD - HEADER_SIZE;
-    }
-
-    // Fallback: conservative 170 bytes (fits in iOS default 185-byte MTU)
-    return 170;
+    // #524: this used to return the MTU-maximal size (mtu - 3 - 7 = 502 at MTU
+    // 512). That is the largest chunk, but not the fastest one: it puts 516 bytes
+    // on the wire, which the link layer sends as 251 + 251 + 14 — a third packet
+    // for fourteen bytes. Throughput here is packets-per-connection-event bound,
+    // so that stub packet was costing ~a third of the download. See BleChunkSize.h.
+    return tr_ble::maxChunkDataSize(effectiveMtu(),  // #283: live MTU, not the stale cache
+                                    ll_tx_octets_);
 }
 
 bool TR_BLE_To_APP::isConnected() const
@@ -987,10 +990,22 @@ bool TR_BLE_To_APP::isConnected() const
 // time. We were throttling the transfer to hide a data-loss bug instead of fixing
 // it. Waiting is safe here: the OC pauses I2S ingest and I2C service for the whole
 // transfer (beginPhoneIO), so there is no time-critical polling to protect.
+//
+// Retry PACING matters as much as the budget. A blocked notification can only
+// clear when the controller drains, and the controller only drains at a
+// connection event — every ~30 ms. Retrying every 2 ms therefore made ~15
+// doomed attempts per event, and each attempt is not free: it allocates an
+// mbuf, copies ~500 bytes into it, calls into the host stack (which logs), and
+// frees it again. All of that runs on the NimBLE host task — the same task that
+// has to do the draining. We were competing with the thing we were waiting for.
+//
+// 5 ms still probes ~6 times per connection event, which is ample to refill the
+// queue promptly after a drain (there are ~25 ms of slack before the next
+// event), at a third of the churn.
 static constexpr int NOTIFY_BEST_EFFORT_RETRIES  = 3;
 static constexpr int NOTIFY_BEST_EFFORT_DELAY_MS = 5;
-static constexpr int NOTIFY_RELIABLE_RETRIES     = 250;  // up to ~500 ms of backpressure
-static constexpr int NOTIFY_RELIABLE_DELAY_MS    = 2;
+static constexpr int NOTIFY_RELIABLE_RETRIES     = 100;  // x 5 ms = ~500 ms of backpressure
+static constexpr int NOTIFY_RELIABLE_DELAY_MS    = 5;
 
 static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
                        const uint8_t* data, size_t len,
@@ -1031,7 +1046,12 @@ static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
         }
         if (attempt > 0 && rc == 0)
         {
-            ESP_LOGI("BLE", "notify_data succeeded after %d retries", attempt);
+            // #524: was ESP_LOGI. Backpressure is the NORMAL state during a file
+            // transfer — every chunk waits for the controller — so at INFO this
+            // printed a console line per chunk, thousands of times, on the host
+            // task in the middle of the transfer's hot path. It is a debug detail,
+            // not news.
+            ESP_LOGD("BLE", "notify_data succeeded after %d retries", attempt);
         }
         return rc;
     }

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -382,15 +382,34 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
 //   slave latency <= 30                           -> 0
 //   supervision timeout: <= 6 s, and greater than
 //     interval_max * (latency + 1) * 3 = 90 ms    -> 2 s (200 * 10 ms)
+// Public entry point: caller states what it wants, we remember it, then ask.
+void TR_BLE_To_APP::requestConnParams(uint16_t itvl_min, uint16_t itvl_max,
+                                      uint16_t latency, uint16_t timeout,
+                                      const char* what)
+{
+    cp_itvl_min_ = itvl_min;
+    cp_itvl_max_ = itvl_max;
+    cp_latency_  = latency;
+    cp_timeout_  = timeout;
+    cp_what_     = (what != nullptr) ? what : "Unnamed";
+
+    // A new intent supersedes any in-flight retry of the old one.
+    conn_param_attempts_ = 0;
+    requestConnParams();
+}
+
+// Send whatever the last stated intent was. This is also the collision-retry path,
+// which is exactly why it must NOT hardcode a parameter set (#524): re-asking for
+// 15-30 ms after a SLOW request collided would quietly cancel low-power mode.
 void TR_BLE_To_APP::requestConnParams()
 {
     if (!device_connected_) { conn_param_due_ms_ = 0; return; }
 
     struct ble_gap_upd_params params = {};
-    params.itvl_min = 0x0C;              // 15 ms — iOS's minimum; asking lower is refused
-    params.itvl_max = 0x18;              // 30 ms — must be >= min + 15 ms
-    params.latency = 0;                  // No slave latency
-    params.supervision_timeout = 200;    // 2 seconds (units of 10 ms)
+    params.itvl_min = cp_itvl_min_;
+    params.itvl_max = cp_itvl_max_;
+    params.latency = cp_latency_;
+    params.supervision_timeout = cp_timeout_;
     params.min_ce_len = 0;
     params.max_ce_len = 0;
 
@@ -398,17 +417,33 @@ void TR_BLE_To_APP::requestConnParams()
     const int rc = ble_gap_update_params(conn_handle_, &params);
     if (rc == 0)
     {
-        ESP_LOGI(BLE_TAG, "Requested connection parameters (15-30 ms interval), attempt %u",
-                 (unsigned)conn_param_attempts_);
+        ESP_LOGI(BLE_TAG, "%s conn params requested (%u-%u ms, latency %u), attempt %u",
+                 cp_what_,
+                 (unsigned)(cp_itvl_min_ * 5 / 4), (unsigned)(cp_itvl_max_ * 5 / 4),
+                 (unsigned)cp_latency_, (unsigned)conn_param_attempts_);
         conn_param_due_ms_ = 0;   // wait for the CONN_UPDATE event
     }
     else
     {
-        ESP_LOGW(BLE_TAG, "Connection param update request failed to send, rc=%d", rc);
+        ESP_LOGW(BLE_TAG, "%s conn param request failed to send, rc=%d", cp_what_, rc);
         conn_param_due_ms_ = (conn_param_attempts_ < kConnParamMaxAttempts)
                                  ? (uint32_t)millis() + kConnParamRetryMs
                                  : 0;
     }
+}
+
+uint32_t TR_BLE_To_APP::effectiveEventMs() const
+{
+    struct ble_gap_conn_desc desc;
+    if (!device_connected_ || ble_gap_conn_find(conn_handle_, &desc) != 0)
+    {
+        return 30;   // assume the fast link rather than invent a stall
+    }
+    // conn_itvl is in 1.25 ms units. conn_latency is how many events the peripheral
+    // may SKIP, so real data opportunities are (latency + 1) intervals apart.
+    const uint32_t itvl_ms = ((uint32_t)desc.conn_itvl * 5u) / 4u;
+    const uint32_t eff     = itvl_ms * ((uint32_t)desc.conn_latency + 1u);
+    return (eff > 0) ? eff : 30;
 }
 
 void TR_BLE_To_APP::onConnParamsUpdated(uint16_t conn_handle, int status)
@@ -466,7 +501,13 @@ void TR_BLE_To_APP::onConnParamsUpdated(uint16_t conn_handle, int status)
                  (double)desc.conn_itvl * 1.25);
     }
 
-    conn_param_due_ms_ = retry ? ((uint32_t)millis() + kConnParamRetryMs) : 0;
+    // #524: back off. 0x2A says the PEER already has a transaction in flight; firing
+    // straight back into the same window just collides again — the bench logged four
+    // in a row, then we gave up (kConnParamMaxAttempts) and ran an entire download on
+    // the 200 ms idle link. Give the peer's procedure room to finish.
+    conn_param_due_ms_ = retry
+        ? ((uint32_t)millis() + kConnParamRetryMs * (uint32_t)(conn_param_attempts_ + 1))
+        : 0;
 }
 
 void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
@@ -1036,8 +1077,25 @@ bool TR_BLE_To_APP::isConnected() const
 // event), at a third of the churn.
 static constexpr int NOTIFY_BEST_EFFORT_RETRIES  = 3;
 static constexpr int NOTIFY_BEST_EFFORT_DELAY_MS = 5;
-static constexpr int NOTIFY_RELIABLE_RETRIES     = 100;  // x 5 ms = ~500 ms of backpressure
 static constexpr int NOTIFY_RELIABLE_DELAY_MS    = 5;
+
+// #524: the RELIABLE budget is no longer a constant, because a constant cannot know
+// how often the link actually carries data.
+//
+// It was 500 ms. Bench 2026-07-14: the fast-parameter request lost a collision race
+// with iOS (status=554 four times, then kConnParamMaxAttempts gave up), so a download
+// ran on the IDLE link — 200 ms interval, latency 4. Latency is events the peripheral
+// may SKIP, so the effective period was 200 x (4+1) = ONE SECOND. A 500 ms budget
+// cannot span even a single connection event on that link: every chunk exhausted its
+// retries, and the transfer aborted after 5 kB of an 8.5 MB file.
+//
+// Budget against the EFFECTIVE event period instead, so a slow link makes a download
+// slow rather than impossible:
+//     fast link (30 ms)  -> 240 ms, floored to 500 ms
+//     idle link (1000 ms)-> 8 s
+static constexpr uint32_t NOTIFY_RELIABLE_EVENTS        = 8;      // events worth of patience
+static constexpr uint32_t NOTIFY_RELIABLE_MIN_BUDGET_MS = 500;
+static constexpr uint32_t NOTIFY_RELIABLE_MAX_BUDGET_MS = 10000;  // a stuck link is still a bug
 
 static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
                        const uint8_t* data, size_t len,
@@ -1381,11 +1439,17 @@ bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
     }
 
     // #524: RELIABLE budget — wait for the controller to drain rather than drop.
-    // A dropped file chunk is lost data, unlike a dropped telemetry frame.
+    // A dropped file chunk is lost data, unlike a dropped telemetry frame. Sized
+    // against the link's EFFECTIVE event period, not a constant (see above).
+    uint32_t budget_ms = effectiveEventMs() * NOTIFY_RELIABLE_EVENTS;
+    if (budget_ms < NOTIFY_RELIABLE_MIN_BUDGET_MS) budget_ms = NOTIFY_RELIABLE_MIN_BUDGET_MS;
+    if (budget_ms > NOTIFY_RELIABLE_MAX_BUDGET_MS) budget_ms = NOTIFY_RELIABLE_MAX_BUDGET_MS;
+
     int attempts = 0;
     const int rc = notify_data(conn_handle_, file_transfer_val_handle_,
                                chunk_buffer_, packet_size,
-                               NOTIFY_RELIABLE_RETRIES, NOTIFY_RELIABLE_DELAY_MS,
+                               (int)(budget_ms / NOTIFY_RELIABLE_DELAY_MS),
+                               NOTIFY_RELIABLE_DELAY_MS,
                                &attempts);
 
     // #524 diagnostic. A run of zero-wait sends is the controller queue emptying

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -972,6 +972,12 @@ size_t TR_BLE_To_APP::maxNotifyBytes() const
     return (mtu > 3) ? (size_t)(mtu - 3) : 20;
 }
 
+void TR_BLE_To_APP::resetXferStats()
+{
+    xfer_ = XferStats{};
+    xfer_burst_ = 0;
+}
+
 size_t TR_BLE_To_APP::getMaxChunkDataSize() const
 {
     // #524: this used to return the MTU-maximal size (mtu - 3 - 7 = 502 at MTU
@@ -1028,10 +1034,12 @@ static constexpr int NOTIFY_RELIABLE_DELAY_MS    = 5;
 static int notify_data(uint16_t conn_handle, uint16_t attr_handle,
                        const uint8_t* data, size_t len,
                        int max_retries = NOTIFY_BEST_EFFORT_RETRIES,
-                       int retry_delay_ms = NOTIFY_BEST_EFFORT_DELAY_MS)
+                       int retry_delay_ms = NOTIFY_BEST_EFFORT_DELAY_MS,
+                       int* attempts_out = nullptr)  // #524: how long we were blocked
 {
     for (int attempt = 0; attempt < max_retries; attempt++)
     {
+        if (attempts_out) *attempts_out = attempt;
         struct os_mbuf* om = ble_hs_mbuf_from_flat(data, len);
         if (!om)
         {
@@ -1366,9 +1374,26 @@ bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
 
     // #524: RELIABLE budget — wait for the controller to drain rather than drop.
     // A dropped file chunk is lost data, unlike a dropped telemetry frame.
+    int attempts = 0;
     const int rc = notify_data(conn_handle_, file_transfer_val_handle_,
                                chunk_buffer_, packet_size,
-                               NOTIFY_RELIABLE_RETRIES, NOTIFY_RELIABLE_DELAY_MS);
+                               NOTIFY_RELIABLE_RETRIES, NOTIFY_RELIABLE_DELAY_MS,
+                               &attempts);
+
+    // #524 diagnostic. A run of zero-wait sends is the controller queue emptying
+    // into us; its length is the queue depth in chunks. See XferStats.
+    xfer_.chunks++;
+    xfer_.retries_total += (uint32_t)attempts;
+    if ((uint32_t)attempts > xfer_.retries_max) xfer_.retries_max = (uint32_t)attempts;
+    if (attempts == 0)
+    {
+        if (++xfer_burst_ > xfer_.burst_max) xfer_.burst_max = xfer_burst_;
+    }
+    else
+    {
+        xfer_burst_ = 0;
+    }
+
     if (rc != 0)
     {
         // Report it. The caller must abort the transfer rather than carry on and

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -250,6 +250,28 @@ public:
     // Falls back to 170 if the MTU has not been negotiated yet.
     size_t getMaxChunkDataSize() const;
 
+    // #524 bench diagnostic. We know the transfer is bounded by packets per
+    // connection event (~4.4 of a possible ~21). What we do NOT know is WHY, and
+    // there are two very different answers:
+    //
+    //   - the controller's outbound queue is shallow, so we cannot keep enough
+    //     data staged for iOS to drain a full event  -> maybe tunable, or
+    //   - iOS simply refuses to pull more notifications per event  -> nothing we
+    //     do on this side matters, and the answer is an L2CAP channel.
+    //
+    // burst_max separates them: it is the longest run of chunks the stack accepted
+    // with ZERO waiting, i.e. how many chunks actually fit in the queue. If it is
+    // ~2, we are queue-limited. If it is deep and we are still slow, iOS is the cap.
+    struct XferStats
+    {
+        uint32_t chunks;         // notifications sent
+        uint32_t retries_total;  // summed backpressure waits
+        uint32_t retries_max;    // worst single chunk
+        uint32_t burst_max;      // longest run accepted with no wait == queue depth
+    };
+    void resetXferStats();
+    XferStats xferStats() const { return xfer_; }
+
     // True from OTA_BEGIN until the session ends (finish→reboot, abort, or
     // failure). main.cpp gates I2C battery-gauge polling on this so the
     // esp_ota_begin() flash erase doesn't collide with the I2C bus (#17).
@@ -258,6 +280,9 @@ public:
 private:
     static constexpr size_t MAX_DEVICE_NAME_LEN = 29;   // BLE adv name limit
     char device_name_[MAX_DEVICE_NAME_LEN + 1];          // mutable, null-terminated
+
+    XferStats xfer_{};        // #524 diagnostic, reset at each download
+    uint32_t  xfer_burst_{0}; // current run of zero-wait sends
 
     volatile bool device_connected_;
     volatile uint16_t negotiated_mtu_;

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -272,6 +272,12 @@ public:
     void resetXferStats();
     XferStats xferStats() const { return xfer_; }
 
+    // Live RSSI of the phone link, dBm (0 if not connected / unavailable). A weak
+    // link means the link layer is silently retransmitting, which eats exactly the
+    // per-event packet budget the transfer is bounded by — so it is a candidate
+    // explanation any time throughput drops without the code changing.
+    int8_t connRssi() const;
+
     // True from OTA_BEGIN until the session ends (finish→reboot, abort, or
     // failure). main.cpp gates I2C battery-gauge polling on this so the
     // esp_ota_begin() flash erase doesn't collide with the I2C bus (#17).

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -272,6 +272,21 @@ public:
     void resetXferStats();
     XferStats xferStats() const { return xfer_; }
 
+    // Ask the peer for a parameter set, and REMEMBER it so a collision retry re-asks
+    // for the same one. Units are raw BLE: interval in 1.25 ms, timeout in 10 ms.
+    // `what` is a label for the log ("Fast (transfer)", "Slow (low-power)").
+    void requestConnParams(uint16_t itvl_min, uint16_t itvl_max,
+                           uint16_t latency, uint16_t timeout, const char* what);
+
+    // How often the link ACTUALLY carries data, in ms: interval x (latency + 1).
+    //
+    // Latency is the number of connection events the peripheral may skip, so this —
+    // not the interval — is the real cadence. On the idle link (200 ms, latency 4)
+    // it is a FULL SECOND. Anything that waits on the controller draining must be
+    // measured against this, or it will time out on a perfectly healthy link.
+    // Returns 30 (the fast link) if the parameters cannot be read.
+    uint32_t effectiveEventMs() const;
+
     // Live RSSI of the phone link, dBm (0 if not connected / unavailable). A weak
     // link means the link layer is silently retransmitting, which eats exactly the
     // per-event packet budget the transfer is bounded by — so it is a candidate
@@ -363,9 +378,25 @@ private:
     uint32_t conn_param_due_ms_   = 0;   // 0 = nothing scheduled
     uint8_t  conn_param_attempts_ = 0;
     bool     auto_conn_params_    = true;  // see setAutoConnParams()
+
+    // #524: WHAT we last asked for, so a collision retry re-asks for the SAME set.
+    // The retry used to re-send a hardcoded 15-30 ms / latency 0 no matter what the
+    // caller had wanted — so a SLOW (low-power) request that lost a collision race
+    // would come back as a FAST one and silently undo low-power mode. Defaults are
+    // the fast set, which is what the shared/auto path asks for.
+    uint16_t cp_itvl_min_ = 0x0C;   // 15 ms (1.25 ms units)
+    uint16_t cp_itvl_max_ = 0x18;   // 30 ms
+    uint16_t cp_latency_  = 0;
+    uint16_t cp_timeout_  = 200;    // 2 s (10 ms units)
+    const char* cp_what_  = "Default";
+
     static constexpr uint32_t kConnParamDelayMs = 1000;  // let iOS settle the link first
+    // #524: 0x2A means the PEER has a transaction in flight. Retrying straight back
+    // into the same window just collides again — the bench logged four in a row, then
+    // we gave up and ran a whole download on the 200 ms idle link. Back off instead
+    // (750, 1500, 2250 ...) and allow more tries.
     static constexpr uint32_t kConnParamRetryMs = 750;
-    static constexpr uint8_t  kConnParamMaxAttempts = 3;
+    static constexpr uint8_t  kConnParamMaxAttempts = 6;
     // Throttle the per-chunk "writing" status notifications. Updated on
     // every successful chunk; we notify at most ~2 Hz so the BLE notify
     // queue isn't saturated mid-flash.

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -268,6 +268,16 @@ public:
         uint32_t retries_total;  // summed backpressure waits
         uint32_t retries_max;    // worst single chunk
         uint32_t burst_max;      // longest run accepted with no wait == queue depth
+
+        // Link quality sampled DURING the transfer, not once at the end. A single
+        // end-of-run reading cannot tell a genuinely bad link from a stray sample,
+        // and the difference matters: at the sensitivity floor the link layer
+        // retransmits, and each retransmit burns one of the ~4 packet slots per
+        // connection event that the whole transfer rate is made of.
+        int8_t   rssi_min;
+        int8_t   rssi_max;
+        int32_t  rssi_sum;
+        uint32_t rssi_n;
     };
     void resetXferStats();
     XferStats xferStats() const { return xfer_; }
@@ -284,8 +294,14 @@ public:
     // not the interval — is the real cadence. On the idle link (200 ms, latency 4)
     // it is a FULL SECOND. Anything that waits on the controller draining must be
     // measured against this, or it will time out on a perfectly healthy link.
-    // Returns 30 (the fast link) if the parameters cannot be read.
-    uint32_t effectiveEventMs() const;
+    // Returns 30 (the fast link) if the parameters are not known yet.
+    //
+    // Cached, NOT queried. It used to call ble_gap_conn_find() — which takes the
+    // NimBLE host lock — and sendFileChunk calls this once per chunk, so a download
+    // was grabbing the host stack's own lock ~19,000 times while that same host task
+    // was trying to drain the queue we were waiting on. The value only changes when
+    // the parameters change, so it is latched in onConnect/onConnParamsUpdated.
+    uint32_t effectiveEventMs() const { return eff_event_ms_; }
 
     // Live RSSI of the phone link, dBm (0 if not connected / unavailable). A weak
     // link means the link layer is silently retransmitting, which eats exactly the
@@ -304,6 +320,13 @@ private:
 
     XferStats xfer_{};        // #524 diagnostic, reset at each download
     uint32_t  xfer_burst_{0}; // current run of zero-wait sends
+
+    // Latched link cadence, interval x (latency + 1) ms. See effectiveEventMs().
+    volatile uint32_t eff_event_ms_ = 30;
+
+    // Sample RSSI every N chunks — often enough to see a link go bad mid-transfer,
+    // rare enough that taking the host lock for it costs nothing.
+    static constexpr uint32_t kRssiSampleEveryChunks = 256;
 
     volatile bool device_connected_;
     volatile uint16_t negotiated_mtu_;
@@ -455,6 +478,7 @@ private:
     // #503: connection-parameter negotiation. Deferred out of the connect
     // callback so it doesn't collide with the peer's own update procedure.
     void requestConnParams();
+    static uint32_t effFromDesc(const struct ble_gap_conn_desc& desc);
     void onConnParamsUpdated(uint16_t conn_handle, int status);
     void onCommandWrite(const uint8_t* data, size_t length);
 

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -245,8 +245,9 @@ public:
         return device_connected_ && effectiveMtu() > 23 && telem_notify_subscribed_;
     }
 
-    // Get max data bytes per BLE chunk (MTU - ATT overhead - our header)
-    // Falls back to 170 if MTU not yet negotiated
+    // Max data bytes per BLE file chunk. NOT simply "MTU minus headers" — that
+    // wastes a whole link-layer packet on a 14-byte stub. See BleChunkSize.h.
+    // Falls back to 170 if the MTU has not been negotiated yet.
     size_t getMaxChunkDataSize() const;
 
     // True from OTA_BEGIN until the session ends (finish→reboot, abort, or
@@ -260,6 +261,11 @@ private:
 
     volatile bool device_connected_;
     volatile uint16_t negotiated_mtu_;
+    // #524: LL max TX payload from BLE_GAP_EVENT_DATA_LEN_CHG. 27 is the pre-DLE
+    // minimum every link starts at, so it is the safe assumption until the peer
+    // agrees to more. getMaxChunkDataSize() sizes chunks to a whole number of
+    // these, which is where the download throughput is.
+    volatile uint16_t ll_tx_octets_;
     volatile bool telem_notify_subscribed_;  // central enabled notifications on telemetry/config char
     volatile uint16_t conn_handle_;          // NimBLE connection handle
     // #517: a RING, not a single latch (see BleCommandRing.h). It used to be

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -219,7 +219,11 @@ public:
     // data: chunk data
     // len: chunk length
     // eof: true if this is the last chunk
-    void sendFileChunk(uint32_t offset, const uint8_t* data, size_t len, bool eof);
+    // Send one file-transfer chunk. Returns false if the chunk could NOT be
+    // notified even after the full reliable backpressure budget (#524) — the
+    // caller must then abort the transfer rather than carry on and hand the app a
+    // file with a hole in it. Unlike telemetry, a dropped chunk is lost data.
+    bool sendFileChunk(uint32_t offset, const uint8_t* data, size_t len, bool eof);
 
     // Get the negotiated MTU (after connection established)
     // Returns 0 if not yet negotiated

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -5851,7 +5851,24 @@ static void loop_oc()
             beginPhoneIO();  // pause I2C servicing + I2S ingest during blocking flash reads
             ESP_LOGI("BLE", "Download file request: %s", download_filename.c_str());
 
-            // #524: the link must be the fast one before we stream a single byte.
+            // #524: read RSSI on the QUIET link, before we put any load on it.
+            //
+            // The 2026-07-14 run reported -107 dBm with the phone six inches away and
+            // real antennas on both ends — which is ~60 dB of loss that the physics does
+            // not allow. So this is very likely NOT a weak link but a broken instrument:
+            // ble_gap_conn_rssi() issues HCI_Read_RSSI, a command inherited from Classic
+            // Bluetooth whose LE behaviour on the ESP32 controller we have never checked.
+            //
+            // This line settles it without a single guess: if the QUIET link also reads
+            // ~-107 at six inches, HCI_Read_RSSI is not usable here and every rssi= number
+            // in the XFER line must be thrown away. Cross-check against the app, which
+            // reads its own RSSI from CoreBluetooth (BLEDevice.connectedRSSI).
+            ESP_LOGI("BLE", "Link before transfer: %lu ms effective, rssi=%d dBm "
+                            "(cross-check against the app's own RSSI — if these disagree, "
+                            "believe the app)",
+                     (unsigned long)ble_app.effectiveEventMs(), (int)ble_app.connRssi());
+
+            // The link must be the fast one before we stream a single byte.
             ensureFastLinkForTransfer();
 
             // Dynamic chunk size based on negotiated MTU (falls back to 170 if not yet negotiated)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -5744,11 +5744,26 @@ static void loop_oc()
             uint32_t start_ms = millis();
             bool eof = false;
 
-            // Delay between every BLE notification (matches Legacy base station
-            // pacing).  The bursty 3-at-a-time batch scheme overwhelmed the iOS
-            // BLE notification queue, causing ~50% data loss.  A consistent
-            // per-chunk delay keeps the queue shallow and reliable.
-            const unsigned long CHUNK_DELAY_MS = 30;
+            // #524: there is no per-chunk delay any more.
+            //
+            // There used to be a fixed 30 ms one, with this rationale: "the bursty
+            // 3-at-a-time batch scheme overwhelmed the iOS BLE notification queue,
+            // causing ~50% data loss. A consistent per-chunk delay keeps the queue
+            // shallow and reliable."
+            //
+            // The data loss was real, but the delay was treating the symptom. File
+            // chunks went out through the same best-effort notify path as telemetry,
+            // which retries 3 x 5 ms and then DROPS the notification — fine for a
+            // telemetry frame, data loss for a file. So the queue was kept shallow
+            // enough that the drop path never fired, which pinned the transfer to one
+            // notification per connection event: 502 B / 30 ms ~ 16 kB/s, with the
+            // radio idle ~90% of the time.
+            //
+            // sendFileChunk now applies real backpressure instead — it waits for the
+            // controller to drain rather than dropping — and returns false only if it
+            // genuinely could not send. So chunks can be fed as fast as the stack
+            // accepts them (several per connection event), with no drops.
+            bool send_failed = false;
 
             while (!eof)
             {
@@ -5791,10 +5806,16 @@ static void loop_oc()
                     // Complete frame found — flush BLE buffer if this frame won't fit
                     if (ble_used > 0 && ble_used + frame_size > chunk_data_size)
                     {
-                        ble_app.sendFileChunk(bytes_sent, ble_buf, ble_used, false);
+                        if (!ble_app.sendFileChunk(bytes_sent, ble_buf, ble_used, false))
+                        {
+                            // #524: could not send even after full backpressure. Do
+                            // NOT keep going — that would hand the app a file with a
+                            // hole in it and call it a success.
+                            send_failed = true;
+                            break;
+                        }
                         bytes_sent += ble_used;
                         ble_used = 0;
-                        delay(CHUNK_DELAY_MS);
                     }
 
                     // Append frame to BLE buffer
@@ -5804,6 +5825,8 @@ static void loop_oc()
                     pos += frame_size;
                 }
 
+                if (send_failed) break;   // #524: abort the transfer, don't limp on
+
                 // Move unparsed bytes to start of buffer for next iteration
                 carryover = buf_len - pos;
                 if (carryover > 0 && pos > 0)
@@ -5812,8 +5835,16 @@ static void loop_oc()
                 }
             }
 
+            if (send_failed)
+            {
+                // Terminate cleanly so the app sees a truncated file rather than a
+                // hung transfer, and say so — this used to be a silent hole.
+                ESP_LOGE("BLE", "Download ABORTED after %lu bytes: BLE send failed",
+                         (unsigned long)bytes_sent);
+                ble_app.sendFileChunk(bytes_sent, nullptr, 0, true);
+            }
             // Send remaining data with EOF flag
-            if (ble_used > 0)
+            else if (ble_used > 0)
             {
                 ble_app.sendFileChunk(bytes_sent, ble_buf, ble_used, true);
                 bytes_sent += ble_used;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1339,15 +1339,62 @@ static inline uint8_t rxPop()
     return b;
 }
 
+// #524: hold the CPU at full speed and out of light sleep while we are serving
+// the phone.
+//
+// A download runs for MINUTES entirely inside enterLowPowerMode()'s regime:
+// 80/40 MHz DFS with light sleep armed. Neither is free here. Throughput is set
+// by how many packets we land in each 30 ms connection event, and a core that is
+// asleep — or at 40 MHz — when the event opens cannot refill the controller's
+// queue in time to fill it.
+//
+// The 34.7 kB/s bench result was measured over USB, where
+// CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION holds a NO_LIGHT_SLEEP lock on our behalf,
+// so light sleep never actually engaged during that test. On battery it would,
+// and we would quietly hand part of the win back. Hold the locks ourselves rather
+// than depend on a USB cable being plugged in — the same "measure it on battery"
+// trap as #519, in mirror image.
+//
+// Costs nothing real: idle current only matters when nobody is talking to us, and
+// during a transfer the radio is busy regardless.
+#if defined(CONFIG_PM_ENABLE)
+static esp_pm_lock_handle_t s_phone_io_cpu_lock = nullptr;  // ESP_PM_CPU_FREQ_MAX
+static esp_pm_lock_handle_t s_phone_io_ls_lock  = nullptr;  // ESP_PM_NO_LIGHT_SLEEP
+
+static void phoneIoPmAcquire()
+{
+    if (s_phone_io_cpu_lock == nullptr)
+    {
+        esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX,   0, "phone_io_cpu", &s_phone_io_cpu_lock);
+        esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "phone_io_ls",  &s_phone_io_ls_lock);
+    }
+    if (s_phone_io_cpu_lock) esp_pm_lock_acquire(s_phone_io_cpu_lock);
+    if (s_phone_io_ls_lock)  esp_pm_lock_acquire(s_phone_io_ls_lock);
+}
+static void phoneIoPmRelease()
+{
+    if (s_phone_io_ls_lock)  esp_pm_lock_release(s_phone_io_ls_lock);
+    if (s_phone_io_cpu_lock) esp_pm_lock_release(s_phone_io_cpu_lock);
+}
+#else
+static inline void phoneIoPmAcquire() {}
+static inline void phoneIoPmRelease() {}
+#endif
+
 // beginPhoneIO / endPhoneIO — bracket a phone-serving operation (file
 // list / delete / download). Pauses both I2C servicing (flash_op_active)
 // and I2S ingest (i2s_ingest_paused), then drains the rx ring on resume
 // so stale sensor bytes from before the pause aren't processed as if
 // they were current. Must be called from a single task (oc_loop).
+//
+// esp_pm locks are counting, and every begin has a matching end on every path
+// (the download loop breaks out, it never returns), so the PM lock cannot leak
+// and strand us at full power.
 static inline void beginPhoneIO()
 {
     i2s_ingest_paused = true;
     flash_op_active   = true;
+    phoneIoPmAcquire();
 }
 static inline void endPhoneIO()
 {
@@ -1355,6 +1402,7 @@ static inline void endPhoneIO()
     rx_tail = rx_head;
     i2s_ingest_paused = false;
     flash_op_active   = false;
+    phoneIoPmRelease();
 }
 
 // The FC reads exactly FC_COMBINED_READ_SIZE bytes per I2C poll.
@@ -5744,6 +5792,14 @@ static void loop_oc()
             uint32_t start_ms = millis();
             bool eof = false;
 
+            // #524 diagnostic: split the wall clock between the two things a
+            // download actually does. The NAND read path is bit-banged, so its
+            // share is a genuine unknown — if flash owns a meaningful slice of the
+            // transfer then no amount of BLE tuning will show up.
+            uint64_t flash_us = 0;
+            uint64_t ble_us   = 0;
+            ble_app.resetXferStats();
+
             // #524: there is no per-chunk delay any more.
             //
             // There used to be a fixed 30 ms one, with this rationale: "the bursty
@@ -5769,9 +5825,11 @@ static void loop_oc()
             {
                 // Read next block from flash, appended after any carryover bytes
                 size_t flash_bytes_read = 0;
+                const uint32_t t_flash = micros();
                 bool read_ok = flightlogReadChunk(download_filename.c_str(), file_offset,
                                                   read_buf + carryover, FLASH_READ_SIZE,
                                                   flash_bytes_read, eof);
+                flash_us += (uint32_t)(micros() - t_flash);
                 if (!read_ok)
                 {
                     ESP_LOGE("BLE", "File read error, aborting download");
@@ -5806,7 +5864,10 @@ static void loop_oc()
                     // Complete frame found — flush BLE buffer if this frame won't fit
                     if (ble_used > 0 && ble_used + frame_size > chunk_data_size)
                     {
-                        if (!ble_app.sendFileChunk(bytes_sent, ble_buf, ble_used, false))
+                        const uint32_t t_ble = micros();
+                        const bool sent = ble_app.sendFileChunk(bytes_sent, ble_buf, ble_used, false);
+                        ble_us += (uint32_t)(micros() - t_ble);
+                        if (!sent)
                         {
                             // #524: could not send even after full backpressure. Do
                             // NOT keep going — that would hand the app a file with a
@@ -5863,6 +5924,26 @@ static void loop_oc()
             ESP_LOGI("BLE", "Download complete: %lu frames, %lu bytes in %.1fs (%.1f KB/s)",
                           (unsigned long)frames_sent, (unsigned long)bytes_sent,
                           elapsed_ms / 1000.0f, kbps);
+
+            // #524 diagnostic — reads as: where did the time go, and why can't we
+            // put more packets in each connection event?
+            //
+            //   flash%  large       -> the bit-banged NAND read is a real cost and
+            //                          BLE tuning is chasing the wrong thing
+            //   qdepth ~2 chunks    -> the controller's outbound queue is the cap;
+            //                          there may be a knob
+            //   qdepth deep + slow  -> iOS just won't drain more per event, and the
+            //                          only way past it is an L2CAP channel (#526)
+            const auto xs = ble_app.xferStats();
+            const float total_ms = (elapsed_ms > 0) ? (float)elapsed_ms : 1.0f;
+            ESP_LOGW("BLE", "XFER: flash=%llu ms (%.0f%%)  ble=%llu ms (%.0f%%)  |  "
+                            "chunks=%lu  waits=%lu (max %lu)  |  queue depth=%lu chunks",
+                     (unsigned long long)(flash_us / 1000),
+                     100.0f * (flash_us / 1000.0f) / total_ms,
+                     (unsigned long long)(ble_us / 1000),
+                     100.0f * (ble_us / 1000.0f) / total_ms,
+                     (unsigned long)xs.chunks, (unsigned long)xs.retries_total,
+                     (unsigned long)xs.retries_max, (unsigned long)xs.burst_max);
             } // else (chunk_data_size > 0)
             endPhoneIO();
         }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1361,25 +1361,64 @@ static inline uint8_t rxPop()
 static esp_pm_lock_handle_t s_phone_io_cpu_lock = nullptr;  // ESP_PM_CPU_FREQ_MAX
 static esp_pm_lock_handle_t s_phone_io_ls_lock  = nullptr;  // ESP_PM_NO_LIGHT_SLEEP
 
+// Did the locks actually engage? A silently-failed esp_pm_lock_create() would look
+// exactly like "light sleep was never the problem", and we would draw the opposite
+// conclusion from the same evidence. So report it rather than assume it.
+static bool s_phone_io_pm_held = false;
+
 static void phoneIoPmAcquire()
 {
-    if (s_phone_io_cpu_lock == nullptr)
+    if (s_phone_io_cpu_lock == nullptr && s_phone_io_ls_lock == nullptr)
     {
-        esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX,   0, "phone_io_cpu", &s_phone_io_cpu_lock);
-        esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "phone_io_ls",  &s_phone_io_ls_lock);
+        const esp_err_t e1 = esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX,   0,
+                                                "phone_io_cpu", &s_phone_io_cpu_lock);
+        const esp_err_t e2 = esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0,
+                                                "phone_io_ls",  &s_phone_io_ls_lock);
+        if (e1 != ESP_OK || e2 != ESP_OK)
+        {
+            ESP_LOGE("PWR", "phone-IO PM lock create FAILED (cpu=%d ls=%d) — transfers "
+                            "will light-sleep on battery", (int)e1, (int)e2);
+        }
     }
-    if (s_phone_io_cpu_lock) esp_pm_lock_acquire(s_phone_io_cpu_lock);
-    if (s_phone_io_ls_lock)  esp_pm_lock_acquire(s_phone_io_ls_lock);
+    const esp_err_t a1 = s_phone_io_cpu_lock ? esp_pm_lock_acquire(s_phone_io_cpu_lock)
+                                             : ESP_FAIL;
+    const esp_err_t a2 = s_phone_io_ls_lock  ? esp_pm_lock_acquire(s_phone_io_ls_lock)
+                                             : ESP_FAIL;
+    s_phone_io_pm_held = (a1 == ESP_OK && a2 == ESP_OK);
+    if (!s_phone_io_pm_held)
+    {
+        ESP_LOGE("PWR", "phone-IO PM lock acquire FAILED (cpu=%d ls=%d)", (int)a1, (int)a2);
+    }
 }
 static void phoneIoPmRelease()
 {
     if (s_phone_io_ls_lock)  esp_pm_lock_release(s_phone_io_ls_lock);
     if (s_phone_io_cpu_lock) esp_pm_lock_release(s_phone_io_cpu_lock);
+    s_phone_io_pm_held = false;
 }
 #else
+static bool s_phone_io_pm_held = false;
 static inline void phoneIoPmAcquire() {}
 static inline void phoneIoPmRelease() {}
 #endif
+
+// #524: the XFER diagnostic is worthless if you cannot READ it — and on battery you
+// cannot, because the console is USB-Serial-JTAG: unplugging the cable takes the
+// console with it. That is exactly the run we most need to see (battery downloads
+// measured ~2.7x slower than USB).
+//
+// So latch the last transfer's summary and keep re-emitting it for a few minutes.
+// That is long enough to finish a battery download, plug USB back in, and attach a
+// monitor WITHOUT resetting the board:
+//
+//     idf.py -p <PORT> monitor --no-reset
+//
+// (a plain `idf.py monitor` resets the chip and you lose it).
+static char     s_xfer_summary[256]     = {0};
+static uint32_t s_xfer_reprint_until_ms = 0;
+static uint32_t s_xfer_next_reprint_ms  = 0;
+static constexpr uint32_t XFER_REPRINT_WINDOW_MS = 240000;  // 4 min to get a cable in
+static constexpr uint32_t XFER_REPRINT_EVERY_MS  = 15000;
 
 // beginPhoneIO / endPhoneIO — bracket a phone-serving operation (file
 // list / delete / download). Pauses both I2C servicing (flash_op_active)
@@ -4059,6 +4098,17 @@ static inline void logTaskCpuDeltas(uint32_t) {}   // stats facility not compile
 static void printStats()
 {
     const uint32_t now = millis();
+
+    // #524: re-emit the last transfer's summary for a few minutes so a BATTERY
+    // download can still be read back — plug USB in afterwards and attach with
+    // `idf.py monitor --no-reset`. See s_xfer_summary.
+    if (s_xfer_summary[0] != '\0' && (int32_t)(s_xfer_reprint_until_ms - now) > 0 &&
+        (int32_t)(now - s_xfer_next_reprint_ms) >= 0)
+    {
+        s_xfer_next_reprint_ms = now + XFER_REPRINT_EVERY_MS;
+        ESP_LOGW("BLE", "%s", s_xfer_summary);
+    }
+
     if ((now - last_stats_ms) < config::STATS_PERIOD_MS)
     {
         return;
@@ -5925,25 +5975,44 @@ static void loop_oc()
                           (unsigned long)frames_sent, (unsigned long)bytes_sent,
                           elapsed_ms / 1000.0f, kbps);
 
-            // #524 diagnostic — reads as: where did the time go, and why can't we
-            // put more packets in each connection event?
+            // #524 diagnostic — where did the time go, and why can't we put more
+            // packets in each connection event?
             //
-            //   flash%  large       -> the bit-banged NAND read is a real cost and
+            //   flash% large        -> the bit-banged NAND read is a real cost and
             //                          BLE tuning is chasing the wrong thing
             //   qdepth ~2 chunks    -> the controller's outbound queue is the cap;
             //                          there may be a knob
             //   qdepth deep + slow  -> iOS just won't drain more per event, and the
             //                          only way past it is an L2CAP channel (#526)
+            //
+            // pm= and rssi= exist to explain the battery-vs-USB gap (battery measured
+            // ~2.7x slower). They separate the two candidate causes, which point in
+            // opposite directions:
+            //   pm=0                -> the PM lock never engaged; we ARE light-sleeping
+            //                          through the transfer and the fix is here
+            //   pm=1 + rssi much
+            //   worse than on USB   -> PM is fine and the link is the problem (the LL
+            //                          is silently retransmitting, eating the per-event
+            //                          packet budget) — a rail/antenna issue, not code
             const auto xs = ble_app.xferStats();
             const float total_ms = (elapsed_ms > 0) ? (float)elapsed_ms : 1.0f;
-            ESP_LOGW("BLE", "XFER: flash=%llu ms (%.0f%%)  ble=%llu ms (%.0f%%)  |  "
-                            "chunks=%lu  waits=%lu (max %lu)  |  queue depth=%lu chunks",
+            snprintf(s_xfer_summary, sizeof(s_xfer_summary),
+                     "XFER: %.1f KB/s  flash=%llu ms (%.0f%%)  ble=%llu ms (%.0f%%)  |  "
+                     "chunks=%lu  waits=%lu (max %lu)  |  queue depth=%lu chunks  |  "
+                     "pm=%d rssi=%d dBm",
+                     kbps,
                      (unsigned long long)(flash_us / 1000),
                      100.0f * (flash_us / 1000.0f) / total_ms,
                      (unsigned long long)(ble_us / 1000),
                      100.0f * (ble_us / 1000.0f) / total_ms,
                      (unsigned long)xs.chunks, (unsigned long)xs.retries_total,
-                     (unsigned long)xs.retries_max, (unsigned long)xs.burst_max);
+                     (unsigned long)xs.retries_max, (unsigned long)xs.burst_max,
+                     s_phone_io_pm_held ? 1 : 0, (int)ble_app.connRssi());
+            ESP_LOGW("BLE", "%s", s_xfer_summary);
+
+            // Keep saying it, so a battery run can be read back over USB afterwards.
+            s_xfer_reprint_until_ms = millis() + XFER_REPRINT_WINDOW_MS;
+            s_xfer_next_reprint_ms  = millis() + XFER_REPRINT_EVERY_MS;
             } // else (chunk_data_size > 0)
             endPhoneIO();
         }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6046,10 +6046,11 @@ static void loop_oc()
             //                          packet budget) — a rail/antenna issue, not code
             const auto xs = ble_app.xferStats();
             const float total_ms = (elapsed_ms > 0) ? (float)elapsed_ms : 1.0f;
+            const int rssi_avg = (xs.rssi_n > 0) ? (int)(xs.rssi_sum / (int32_t)xs.rssi_n) : 0;
             snprintf(s_xfer_summary, sizeof(s_xfer_summary),
                      "XFER: %.1f KB/s  flash=%llu ms (%.0f%%)  ble=%llu ms (%.0f%%)  |  "
                      "chunks=%lu  waits=%lu (max %lu)  |  queue depth=%lu chunks  |  "
-                     "link=%lu ms pm=%d rssi=%d dBm",
+                     "link=%lu ms pm=%d  rssi avg=%d min=%d max=%d dBm (n=%lu)",
                      kbps,
                      (unsigned long long)(flash_us / 1000),
                      100.0f * (flash_us / 1000.0f) / total_ms,
@@ -6058,8 +6059,20 @@ static void loop_oc()
                      (unsigned long)xs.chunks, (unsigned long)xs.retries_total,
                      (unsigned long)xs.retries_max, (unsigned long)xs.burst_max,
                      (unsigned long)ble_app.effectiveEventMs(),
-                     s_phone_io_pm_held ? 1 : 0, (int)ble_app.connRssi());
+                     s_phone_io_pm_held ? 1 : 0,
+                     rssi_avg, (int)xs.rssi_min, (int)xs.rssi_max,
+                     (unsigned long)xs.rssi_n);
             ESP_LOGW("BLE", "%s", s_xfer_summary);
+
+            // A link at the sensitivity floor is retransmitting, and every retransmit
+            // costs one of the ~4 packet slots per connection event that the transfer
+            // rate is made of. Say so, rather than leaving it to be spotted.
+            if (xs.rssi_n > 0 && rssi_avg < -85)
+            {
+                ESP_LOGW("BLE", "  ^ link was WEAK (avg %d dBm). Expect the LL to be "
+                                "retransmitting; move the phone closer before comparing "
+                                "this number to anything.", rssi_avg);
+            }
 
             // Keep saying it, so a battery run can be read back over USB afterwards.
             s_xfer_reprint_until_ms = millis() + XFER_REPRINT_WINDOW_MS;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1054,21 +1054,23 @@ static void exitLowPowerMode()
 // "GAP update_params: connection not found; conn_handle=0x0000" and neither the
 // slow (low-power) nor the fast (file-transfer) parameters have EVER been applied.
 // They now take no handle and read the live one from the BLE layer.
+// #524: go through TR_BLE_To_APP rather than calling ble_gap_update_params() here.
+// It records the requested set, so when iOS rejects with a transaction collision the
+// retry re-asks for THE SAME set. Calling the HCI directly bypassed that: the retry
+// path had its own hardcoded 15-30 ms, so a SLOW request that lost a collision race
+// came back as a FAST one and silently cancelled low-power mode.
+//
+// The negotiated result is reported by TR_BLE_To_APP's CONN_UPDATE handler, which logs
+// the interval actually in force — the peer is free to counter (#503).
 static void applyBLEParams(const char* what, const struct ble_gap_upd_params& params)
 {
-    const uint16_t h = ble_app.connHandle();
-    if (h == 0xFFFF)
+    if (ble_app.connHandle() == 0xFFFF)
     {
         ESP_LOGW("BLE", "%s conn params skipped — not connected", what);
         return;
     }
-    const int rc = ble_gap_update_params(h, &params);
-    if (rc != 0)
-        ESP_LOGW("BLE", "%s conn param request failed to send, rc=%d (handle=%u)", what, rc, h);
-    else
-        ESP_LOGI("BLE", "%s conn params requested (handle=%u)", what, h);
-    // The negotiated result is reported by TR_BLE_To_APP's CONN_UPDATE handler,
-    // which logs the interval actually in force — the peer is free to counter (#503).
+    ble_app.requestConnParams(params.itvl_min, params.itvl_max,
+                              params.latency, params.supervision_timeout, what);
 }
 
 // Slow parameters for low-power idle: fewer BLE wakeups is the single biggest
@@ -1101,6 +1103,50 @@ static void requestFastBLEParams()
     params.min_ce_len = 0;
     params.max_ce_len = 0;
     applyBLEParams("Fast (transfer)", params);
+}
+
+// #524: never start a transfer on the idle link.
+//
+// Bench 2026-07-14: the Power-On fast-param request lost a collision race with iOS
+// (status=554 x4), the retry budget ran out, and the link stayed at 200 ms / latency 4
+// — a ONE SECOND effective event period, 33x slower than the fast link. The download
+// that followed aborted after 5 kB of an 8.5 MB file.
+//
+// This is very likely also the original "~50% data loss" that the old fixed 30 ms
+// per-chunk delay was invented to hide: a download on the idle link drains 33x slower,
+// so of course the notify queue overflowed. The delay throttled the producer enough to
+// survive it, and we spent years believing the phone could not keep up.
+//
+// So: ask again, at the point where it actually matters, and give the peer a moment to
+// answer before streaming. Not fatal if it never lands — sendFileChunk's budget now
+// scales with the link, so a slow transfer completes rather than aborting — but say so.
+static constexpr uint32_t FAST_LINK_EVENT_MS_MAX = 60;    // 30 ms interval, latency 0, + slack
+static constexpr uint32_t FAST_LINK_WAIT_MS      = 3000;
+
+static void ensureFastLinkForTransfer()
+{
+    if (ble_app.effectiveEventMs() <= FAST_LINK_EVENT_MS_MAX) return;   // already fast
+
+    ESP_LOGW("BLE", "Link too slow for a transfer (%lu ms effective) — asking for fast params",
+             (unsigned long)ble_app.effectiveEventMs());
+    requestFastBLEParams();
+
+    // Waiting here is free: this is a ground operation, and oc_loop is already given
+    // over to the transfer.
+    const uint32_t deadline = millis() + FAST_LINK_WAIT_MS;
+    while ((int32_t)(deadline - millis()) > 0)
+    {
+        delay(50);
+        if (ble_app.effectiveEventMs() <= FAST_LINK_EVENT_MS_MAX)
+        {
+            ESP_LOGI("BLE", "Link now %lu ms effective — starting transfer",
+                     (unsigned long)ble_app.effectiveEventMs());
+            return;
+        }
+    }
+    ESP_LOGW("BLE", "Fast params never took (still %lu ms effective) — transfer will be SLOW "
+                    "but will complete",
+             (unsigned long)ble_app.effectiveEventMs());
 }
 
 static void updateDerivedAltitudeFromBMP()
@@ -5805,9 +5851,13 @@ static void loop_oc()
             beginPhoneIO();  // pause I2C servicing + I2S ingest during blocking flash reads
             ESP_LOGI("BLE", "Download file request: %s", download_filename.c_str());
 
+            // #524: the link must be the fast one before we stream a single byte.
+            ensureFastLinkForTransfer();
+
             // Dynamic chunk size based on negotiated MTU (falls back to 170 if not yet negotiated)
             const size_t chunk_data_size = ble_app.getMaxChunkDataSize();
-            ESP_LOGI("BLE", "Chunk data size: %u", (unsigned)chunk_data_size);
+            ESP_LOGI("BLE", "Chunk data size: %u  (link %lu ms effective)",
+                     (unsigned)chunk_data_size, (unsigned long)ble_app.effectiveEventMs());
 
             if (chunk_data_size == 0)
             {
@@ -5999,7 +6049,7 @@ static void loop_oc()
             snprintf(s_xfer_summary, sizeof(s_xfer_summary),
                      "XFER: %.1f KB/s  flash=%llu ms (%.0f%%)  ble=%llu ms (%.0f%%)  |  "
                      "chunks=%lu  waits=%lu (max %lu)  |  queue depth=%lu chunks  |  "
-                     "pm=%d rssi=%d dBm",
+                     "link=%lu ms pm=%d rssi=%d dBm",
                      kbps,
                      (unsigned long long)(flash_us / 1000),
                      100.0f * (flash_us / 1000.0f) / total_ms,
@@ -6007,6 +6057,7 @@ static void loop_oc()
                      100.0f * (ble_us / 1000.0f) / total_ms,
                      (unsigned long)xs.chunks, (unsigned long)xs.retries_total,
                      (unsigned long)xs.retries_max, (unsigned long)xs.burst_max,
+                     (unsigned long)ble_app.effectiveEventMs(),
                      s_phone_io_pm_held ? 1 : 0, (int)ble_app.connRssi());
             ESP_LOGW("BLE", "%s", s_xfer_summary);
 

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6081,14 +6081,26 @@ static void loop_oc()
                      (unsigned long)xs.rssi_n);
             ESP_LOGW("BLE", "%s", s_xfer_summary);
 
-            // A link at the sensitivity floor is retransmitting, and every retransmit
-            // costs one of the ~4 packet slots per connection event that the transfer
-            // rate is made of. Say so, rather than leaving it to be spotted.
-            if (xs.rssi_n > 0 && rssi_avg < -85)
+            // JUDGE THE LINK BY max, NOT avg OR min. Bench 2026-07-14, phone six inches
+            // away: quiet link -64 dBm; during the transfer avg=-79 min=-113 max=-59
+            // over 74 samples.
+            //
+            // -113 dBm is BELOW the receiver's noise floor — it is not a measurement.
+            // HCI_Read_RSSI reports whatever the controller last saw, and under load that
+            // includes idle moments between connection events, so the low samples are
+            // junk. The MAX tracks the quiet-link reading (-59 vs -64), and that is the
+            // real link quality.
+            //
+            // This is not a nitpick: a single such outlier (-107) was used to explain away
+            // a slow run, and it explained nothing — three later runs on the same hardware
+            // all hit 35 KB/s. If you are about to blame RSSI for a slow transfer, look at
+            // max first, and check the app's own CoreBluetooth RSSI before believing it.
+            if (xs.rssi_n > 0 && xs.rssi_max < -85)
             {
-                ESP_LOGW("BLE", "  ^ link was WEAK (avg %d dBm). Expect the LL to be "
-                                "retransmitting; move the phone closer before comparing "
-                                "this number to anything.", rssi_avg);
+                ESP_LOGW("BLE", "  ^ link genuinely WEAK (best sample %d dBm). The LL will "
+                                "be retransmitting, and every retransmit costs one of the "
+                                "~4 packet slots per connection event that the transfer "
+                                "rate is made of.", (int)xs.rssi_max);
             }
 
             // Keep saying it, so a battery run can be read back over USB afterwards.

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -9,6 +9,19 @@ CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
 CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
 CONFIG_BT_NIMBLE_ROLE_BROADCASTER=y
 
+# (#524) Deepen the mbuf pool used to queue notifications. A file-transfer chunk is
+# ~509 bytes and chains several blocks, so at the IDF defaults (MSYS_1 12x256,
+# MSYS_2 24x320) only a handful of notifications can be in flight before
+# ble_hs_mbuf_from_flat() returns NULL. That shallow pool is the congestion the old
+# fixed 30 ms per-chunk delay was dodging.
+#
+# Now that sendFileChunk applies real backpressure instead of dropping, a shallow
+# pool no longer loses data — it just makes us wait. A deeper one lets several
+# notifications ride each connection event, which is where the throughput is.
+# Cost is ~13 KB of heap; the OC has ~159 KB free.
+CONFIG_BT_NIMBLE_MSYS_1_BLOCK_COUNT=24
+CONFIG_BT_NIMBLE_MSYS_2_BLOCK_COUNT=48
+
 # === POWER MANAGEMENT ===
 # Compiled in but only activated at runtime during low-power mode
 CONFIG_PM_ENABLE=y

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -9,6 +9,16 @@ CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
 CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
 CONFIG_BT_NIMBLE_ROLE_BROADCASTER=y
 
+# (#524) Silence NimBLE's INFO chatter. #505 did this for the base station and
+# stopped there — the OC was left at INFO, where every ble_gatts_notify_custom()
+# call prints "GATT procedure initiated: notify". That is once per NOTIFICATION,
+# including the ones that fail with ENOMEM and get retried, so a download turned
+# into hundreds of console lines a second. Worse, they are emitted on the NimBLE
+# host task, which is the task that has to drain the controller queue we are
+# waiting on: the logging was throttling the very transfer it was reporting.
+# WARNING still surfaces anything that actually went wrong.
+CONFIG_BT_NIMBLE_LOG_LEVEL_WARNING=y
+
 # (#524) Deepen the mbuf pool used to queue notifications. A file-transfer chunk is
 # ~509 bytes and chains several blocks, so at the IDF defaults (MSYS_1 12x256,
 # MSYS_2 24x320) only a handful of notifications can be in flight before


### PR DESCRIPTION
**Measured baseline: 8.52 MB took 10 min 10 s = 14.3 kB/s.**

That matches the prediction from the code alone (~16 kB/s: one 502-byte notification per 30 ms) to within the flash-read and frame-parsing overhead — so **the fixed per-chunk delay accounts for essentially all of the transfer time.** The radio is idle ~93% of those ten minutes.

## We were throttling downloads to hide a data-loss bug

The delay in the OC download loop:

```cpp
// The bursty 3-at-a-time batch scheme overwhelmed the iOS BLE notification
// queue, causing ~50% data loss. A consistent per-chunk delay keeps the
// queue shallow and reliable.
const unsigned long CHUNK_DELAY_MS = 30;
```

The data loss was real. But file chunks went out through the *same* notify path as telemetry, whose policy is:

```cpp
// sustained congestion simply drops the notification
// — telemetry is best-effort anyway.
static constexpr int MAX_RETRIES = 3;
```

Three tries, then **drop**. Correct for a telemetry frame (stale in 500 ms); wrong for a file chunk (that is lost data). So bursting genuinely dropped chunks, and the 30 ms delay was added to keep the mbuf queue too shallow for the drop path to ever fire. The `// Redundant EOF in case the last notification was dropped` a few lines below says the same thing out loud.

## Fix

1. **`notify_data()` takes a retry budget**, so the two traffic types get opposite policies. Telemetry keeps BEST-EFFORT (3 × 5 ms then drop) — that short budget exists for a real reason: a 500 ms one used to blow 50-60 ms holes in INA230 polling. File chunks get RELIABLE (250 × 2 ms) and **wait** for the controller to drain. Safe here: the OC already pauses I2S ingest and I2C service for the whole transfer (`beginPhoneIO`), so there is no time-critical polling to protect.
2. **`sendFileChunk()` returns bool.** If a chunk cannot go out even after full backpressure, the download **aborts loudly with a clean EOF** — the app gets a truncated file it can detect rather than a silent hole it cannot.
3. **`CHUNK_DELAY_MS` deleted.** With drops impossible, chunks feed as fast as the stack accepts them — several per connection event instead of one.
4. **Data Length Extension requested.** `ble_gap_set_data_len()` was called **nowhere**, so the link layer sat at its 27-byte default PDU and every 502-byte notification fragmented into ~19 LL packets. 251 octets collapses that to two.
5. **Deeper mbuf pool** (MSYS_1 12→24, MSYS_2 24→48, ~13 KB heap). That shallow default pool *was* the congestion the delay was dodging; with backpressure it no longer costs data, only speed.

## Report what we actually got

`BLE_GAP_EVENT_DATA_LEN_CHG` now logs the **negotiated** LL payload size. A link still stuck at 27 octets would leave downloads slow while we assumed otherwise — the same failure mode that hid the connection interval (#503) and the PHY (#519) for so long.

## Scope

**out_computer only.** The base station uses a cooperative one-chunk-per-loop-pass design because `bs_loop` must keep servicing LoRa, so it cannot simply block on backpressure without starving the radio. Same bug, different fix — left as a follow-up rather than risking the LoRa link.

out_computer and base_station both build clean.

## Bench

The OC already logs `Download complete: N bytes in Xs (Y KB/s)`, so before/after is a direct read. Check for `LL data length now: TX=251 octets` on connect — if it says 27, DLE did not take.

Baseline to beat: **14.3 kB/s**.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)