### PR TITLE
fix(oc): #526 a failed download must not present as a complete file

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1134,6 +1134,21 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         let length = UInt16(data[4]) | (UInt16(data[5]) << 8)
         let flags = data[6]
         let isEOF = (flags & 0x01) != 0
+        let isAbort = (flags & 0x02) != 0   // #526
+
+        // #526: the firmware could not finish this transfer (rocket INFLIGHT, a
+        // flash read error, or a BLE send failure). The bytes we have are a
+        // truncated fragment, NOT a complete file. Fail the download and write
+        // nothing — previously an abort arrived as a bare EOF and the partial file
+        // was saved and cached as if it were whole.
+        if isEOF && isAbort {
+            downloadStallTimer?.invalidate()
+            downloadStallTimer = nil
+            print("[DOWNLOAD] ABORTED by device after \(downloadedData.count) bytes")
+            failDownload()
+            return
+        }
+
         if length > 0 && data.count >= 7 + Int(length) {
             let chunkData = data.subdata(in: 7..<(7 + Int(length)))
             downloadedData.append(chunkData)
@@ -1165,6 +1180,20 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             guard let self = self, self.isDownloading else { return }
             self.completeDownload(fromStallTimer: true)
         }
+    }
+
+    // #526: end a download in failure — write nothing, cache nothing, hand the
+    // caller nil. Used when the device signals an abort (EOF|ABORT). Mirrors the
+    // cleanup in completeDownload's failure branches so state can't leak.
+    private func failDownload() {
+        downloadStallTimer?.invalidate()
+        downloadStallTimer = nil
+        let handler = downloadCompletionHandler
+        downloadingFilename = nil
+        downloadedData = Data()
+        downloadCompletionHandler = nil
+        DispatchQueue.main.async { [weak self] in self?.isDownloading = false }
+        handler?(nil)
     }
 
     private func completeDownload(fromStallTimer: Bool = false) {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1404,7 +1404,7 @@ void TR_BLE_To_APP::sendStorageStats(uint8_t marker, const uint8_t* bytes, size_
 }
 
 bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
-                                   size_t len, bool eof)
+                                   size_t len, bool eof, bool abort)
 {
     if (!device_connected_) return false;
 
@@ -1433,8 +1433,9 @@ bool TR_BLE_To_APP::sendFileChunk(uint32_t offset, const uint8_t* data,
     chunk_buffer_[4] = (len >> 0) & 0xFF;
     chunk_buffer_[5] = (len >> 8) & 0xFF;
 
-    // Flags (1 byte): bit 0 = EOF
-    chunk_buffer_[6] = eof ? 0x01 : 0x00;
+    // Flags (1 byte): bit 0 = EOF, bit 1 = ABORT (#526). ABORT only ever rides an
+    // EOF chunk — it means "this is the end AND it failed".
+    chunk_buffer_[6] = (uint8_t)((eof ? kChunkFlagEof : 0) | (abort ? kChunkFlagAbort : 0));
 
     // Data
     if (len > 0 && data != nullptr)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -223,7 +223,17 @@ public:
     // notified even after the full reliable backpressure budget (#524) — the
     // caller must then abort the transfer rather than carry on and hand the app a
     // file with a hole in it. Unlike telemetry, a dropped chunk is lost data.
-    bool sendFileChunk(uint32_t offset, const uint8_t* data, size_t len, bool eof);
+    // GATT file-transfer chunk header flag bits (byte 6 of the 7-byte header).
+    static constexpr uint8_t kChunkFlagEof   = 0x01;  // last chunk of the transfer
+    static constexpr uint8_t kChunkFlagAbort = 0x02;  // #526: transfer FAILED, discard it
+
+    // `abort=true` sets kChunkFlagAbort alongside EOF: the transfer ended because
+    // the firmware could not finish it (INFLIGHT refusal, flash read error, send
+    // failure), NOT because the file was fully sent. The app must FAIL the download
+    // instead of saving the bytes it has. Old apps ignore bit1 and behave as today.
+    // Defaulted so the base-station call sites are unchanged and byte-identical.
+    bool sendFileChunk(uint32_t offset, const uint8_t* data, size_t len, bool eof,
+                       bool abort = false);
 
     // Get the negotiated MTU (after connection established)
     // Returns 0 if not yet negotiated

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -5837,13 +5837,16 @@ static void loop_oc()
         // #383: a download pauses I2S ingest + I2C service for the whole
         // multi-second transfer — mid-flight that would blind the OC and
         // drop the flight data it exists to record. Terminate the request
-        // cleanly with an empty EOF chunk (the app sees a zero-length file
-        // instead of a hung transfer). INFLIGHT-only per design decision.
+        // cleanly. #526: send EOF|ABORT, not a bare EOF — a refusal is NOT a
+        // complete zero-length file. Without the abort bit the app writes the
+        // empty download to disk and reports success (completeDownload's
+        // short-transfer guard is gated on the stall timer, not this path).
+        // INFLIGHT-only per design decision.
         if (download_filename.length() > 0 && latest_rocket_state == INFLIGHT)
         {
             ESP_LOGW("BLE", "Download '%s' refused: rocket INFLIGHT",
                      download_filename.c_str());
-            ble_app.sendFileChunk(0, nullptr, 0, true);
+            ble_app.sendFileChunk(0, nullptr, 0, true, /*abort=*/true);
             download_filename = "";
         }
         if (download_filename.length() > 0)
@@ -5879,7 +5882,8 @@ static void loop_oc()
             if (chunk_data_size == 0)
             {
                 ESP_LOGE("BLE", "chunk data size is 0, aborting download");
-                ble_app.sendFileChunk(0, nullptr, 0, true);  // Send EOF to unblock app
+                // #526: this is a failure, not a completed empty file.
+                ble_app.sendFileChunk(0, nullptr, 0, true, /*abort=*/true);
             }
             else
             {
@@ -5950,7 +5954,7 @@ static void loop_oc()
                 if (!read_ok)
                 {
                     ESP_LOGE("BLE", "File read error, aborting download");
-                    ble_app.sendFileChunk(bytes_sent, nullptr, 0, true);
+                    ble_app.sendFileChunk(bytes_sent, nullptr, 0, true, /*abort=*/true);
                     break;
                 }
                 file_offset += flash_bytes_read;
@@ -6015,11 +6019,11 @@ static void loop_oc()
 
             if (send_failed)
             {
-                // Terminate cleanly so the app sees a truncated file rather than a
-                // hung transfer, and say so — this used to be a silent hole.
+                // #526: EOF|ABORT, not a bare EOF. The app must REJECT the partial
+                // file, not save the truncated bytes and call it complete.
                 ESP_LOGE("BLE", "Download ABORTED after %lu bytes: BLE send failed",
                          (unsigned long)bytes_sent);
-                ble_app.sendFileChunk(bytes_sent, nullptr, 0, true);
+                ble_app.sendFileChunk(bytes_sent, nullptr, 0, true, /*abort=*/true);
             }
             // Send remaining data with EOF flag
             else if (ble_used > 0)
@@ -6032,9 +6036,12 @@ static void loop_oc()
                 ble_app.sendFileChunk(bytes_sent, nullptr, 0, true);
             }
 
-            // Redundant EOF in case the last notification was dropped
+            // Redundant EOF in case the last notification was dropped. #526: it
+            // must carry the SAME abort bit — otherwise a dropped abort-EOF
+            // followed by a bare redundant EOF would resurrect the truncation bug
+            // (the app would complete the partial file as if it were whole).
             delay(50);
-            ble_app.sendFileChunk(bytes_sent, nullptr, 0, true);
+            ble_app.sendFileChunk(bytes_sent, nullptr, 0, true, /*abort=*/send_failed);
 
             uint32_t elapsed_ms = millis() - start_ms;
             float kbps = (elapsed_ms > 0) ? (bytes_sent / 1024.0f) / (elapsed_ms / 1000.0f) : 0;


### PR DESCRIPTION
## What

A failed BLE file download currently presents to the user as a **complete file**. This fixes that. It's the one durable result of the #526 L2CAP investigation, split out as a standalone data-loss fix (the L2CAP transport itself is dropped — see below).

## The bug

Every firmware download abort ends the transfer with a bare EOF chunk, and the app **saves the partial bytes and reports success**: `completeDownload`'s short-transfer guard (`BLEDevice.swift`) is gated on the *stall timer*, so the normal EOF path writes the truncated data to `temporaryDirectory` and hands back a valid URL.

Concretely:
- Arm the rocket (INFLIGHT) and request a download → a **zero-length "flight"** gets cached and CSV'd.
- A mid-transfer flash read error → a **truncated file**, presented as whole.

Same shape as the silent data loss #524 was largely about.

## The fix

Wire: chunk-header **flags bit1 = ABORT** (bit0 = EOF, unchanged). ABORT only ever rides an EOF chunk — "this is the end **and** it failed".

- **FW:** `sendFileChunk(..., bool abort = false)`. The OC sets `abort=true` on all four give-up paths — INFLIGHT refusal, chunk-size-0, flash read error, `send_failed` — **and** on the redundant trailing EOF (a dropped abort-EOF followed by a bare redundant EOF would otherwise resurrect the bug). The `= false` default keeps the base station's three `sendFileChunk` call sites byte-identical on the wire.
- **App:** `EOF && bit1` → `failDownload()`: write nothing, cache nothing, `handler(nil)`, reset state.

**Backward compatible both ways:** old apps ignore bit1 and behave exactly as today (the abort bit is only ever set on paths that are already broken), so old-app/new-firmware is a no-op.

## Why L2CAP is not in this PR

#526 set out to move downloads to an L2CAP connection-oriented channel for a hoped 2–3× speedup. That transport was fully built and works correctly (CRC-verified, no drops), but **on iOS it is no faster than GATT** — iOS schedules ~5 link-layer packets per 30 ms connection event and no more, identically for GATT notifications and L2CAP. A deliberately over-deep buffer (3.7×) moved the rate not at all, ruling out our side. Details posted to #526. The L2CAP work is preserved on a branch but not shipped; this PR keeps only the bugfix, which is independent of all of it.

## Verification

- OC + base station build (CoC compiled out, config unchanged from `main`)
- `tools/check_ble_command_ids.py` PASS
- Host suite 574/574
- App `BUILD SUCCEEDED`
- Bench: with this firmware, arming the rocket and requesting a download shows a **failure** in the app instead of a zero-length "completed" flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
