### PR TITLE
fix(oc): restore slow BLE link after an idle-time download + guard a stale power sdkconfig (#524, #519)

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -979,6 +979,40 @@ static void readINA230Power()
 }
 
 // ---------------------------------------------------------------------------
+//  #519 power-config guard — fail the BUILD, not the ammeter.
+//
+//  sdkconfig is generated and OVERRIDES sdkconfig.defaults, so a checkout whose
+//  sdkconfig predates a defaults change silently builds current source against
+//  the old config. Third bite of this trap (after #518, #519): on 2026-07-15 a
+//  rebuild from a stale sdkconfig shipped MAIN_XTAL as the BT low-power clock —
+//  the controller then holds a permanent no_light_sleep PM lock, light sleep
+//  never engages, and OC idle sat at ~7 mA instead of ~1 mA with no warning
+//  anywhere. Each symbol below is one the OC's idle-power contract rides on.
+//
+//  If this fires, do NOT edit sdkconfig — regenerate it from the authoritative
+//  defaults:  rm sdkconfig && idf.py build
+//  If you are intentionally changing the power config, change
+//  sdkconfig.defaults and update this guard in the same commit.
+// ---------------------------------------------------------------------------
+#if defined(ESP_PLATFORM)
+#if !defined(CONFIG_PM_ENABLE)
+#error "Stale sdkconfig: CONFIG_PM_ENABLE missing — DFS + light sleep compile out entirely. rm sdkconfig && idf.py build (#519)"
+#endif
+#if !defined(CONFIG_FREERTOS_USE_TICKLESS_IDLE)
+#error "Stale sdkconfig: CONFIG_FREERTOS_USE_TICKLESS_IDLE missing — esp_pm_configure(light_sleep_enable) will fail at runtime. rm sdkconfig && idf.py build (#519)"
+#endif
+#if !defined(CONFIG_RTC_CLK_SRC_EXT_CRYS)
+#error "Stale sdkconfig: RTC slow clock is not the 32.768 kHz crystal (CONFIG_RTC_CLK_SRC_EXT_CRYS) — prerequisite for the BT 32k LP clock. rm sdkconfig && idf.py build (#519)"
+#endif
+#if !defined(CONFIG_BT_CTRL_LPCLK_SEL_EXT_32K_XTAL)
+#error "Stale sdkconfig: BT low-power clock is not the 32 kHz crystal (CONFIG_BT_CTRL_LPCLK_SEL_EXT_32K_XTAL) — the controller holds no_light_sleep forever and idle is ~7 mA, not ~1 mA. rm sdkconfig && idf.py build (#519)"
+#endif
+#if !defined(CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION)
+#error "Stale sdkconfig: CONFIG_USJ_NO_AUTO_LS_ON_CONNECTION missing — light sleep will kill the USB console on the bench. rm sdkconfig && idf.py build (#519)"
+#endif
+#endif  // ESP_PLATFORM
+
+// ---------------------------------------------------------------------------
 //  Low-power mode helpers
 //  Called at boot and when power rail is turned OFF.
 //  NOTE: Light sleep, BT modem sleep, and reduced TX power disabled —

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6115,6 +6115,21 @@ static void loop_oc()
             s_xfer_next_reprint_ms  = millis() + XFER_REPRINT_EVERY_MS;
             } // else (chunk_data_size > 0)
             endPhoneIO();
+
+            // #524 follow-up: ensureFastLinkForTransfer() above moves an FC-off
+            // download onto the FAST link, and nothing asked for the slow set back
+            // — the slow request only fires on the connect edge — so after one
+            // idle-time download the OC sat at the fast link's ~7 mA instead of
+            // ~1 mA until the app disconnected. Mirror the connect-edge policy:
+            // rail off -> slow link. Sits after endPhoneIO() so it also covers the
+            // abort paths (chunk size 0, flash read error, send_failed), which all
+            // run after the fast-link switch. A redundant ask when the link never
+            // left slow is one LL procedure, not a loop: requestConnParams records
+            // the intent and collision-retries the SAME set.
+            if (!pwr_pin_on && ble_app.isConnected())
+            {
+                requestSlowBLEParams();
+            }
         }
 
         // Flight simulator commands — relay to FlightComputer via I2C


### PR DESCRIPTION
Two low-risk follow-ups from the 2026-07-15 "OC idle 1 → 7 mA" investigation.

**Background.** The 7 mA regression itself was *not* a source bug — it was a stale
generated `sdkconfig` in a checkout that predated #519's `sdkconfig.defaults`
change, so a rebuild silently used the pre-#519 power config (`MAIN_XTAL` LP
clock → controller holds `no_light_sleep` forever → light sleep never engages).
Regenerating the config fixed the baseline. These two commits address the parts
that *are* code:

**1. `fix(oc)` — restore the slow BLE link after an idle-time download.**
#524's `ensureFastLinkForTransfer()` moves an FC-off download onto the fast link
(15–30 ms, latency 0) and nothing ever asked for the slow set back — the slow
request only fires on the connect edge, and rail-off is a full reset. So a single
download while the FC is powered off left the OC idling at the fast link's ~7 mA
until the app disconnected. Now the download block re-requests the slow set when
it ends with the rail still off, placed after `endPhoneIO()` so the abort paths
(chunk-size 0, flash read error, send-failed) are covered too. One call suffices —
`requestConnParams` records the intent and collision-retries the same set (#524).
Baseline idle (no download) was already ~1 mA; this closes the post-download case.

**2. `build(oc)` — fail the build on a stale power sdkconfig, not the ammeter.**
This trap has now bitten three times (#518, #519, and the 7 mA regression above).
A preprocessor guard over the five symbols the OC idle contract rides on
(`PM_ENABLE`, `FREERTOS_USE_TICKLESS_IDLE`, `RTC_CLK_SRC_EXT_CRYS`,
`BT_CTRL_LPCLK_SEL_EXT_32K_XTAL`, `USJ_NO_AUTO_LS_ON_CONNECTION`) turns any
missing one into a compile error that names the symbol and says
`rm sdkconfig && idf.py build`. Gated on `ESP_PLATFORM` so host tests are
unaffected. No runtime effect.

**Risk: low.** One file (`out_computer/main/main.cpp`), +49 lines, no wire-format
or struct changes, no effect on the base station (its `sendFileChunk` call sites
are untouched).

**Verification.**
- Slow-params fix + guard both compile from a freshly-regenerated (correct)
  `sdkconfig` — clean IDF v6 build, exit 0. CI's `out_computer` build re-proves
  this from a clean checkout (regenerates `sdkconfig` from defaults), which is
  exactly the guard's happy path.
- Guard logic tested four ways at the preprocessor level: silent on the good
  config; fires (first at `RTC_CLK_SRC_EXT_CRYS`, the real regression symbol) on
  the *actual* stale Jul-12 config that caused this; fires deeper-stale at
  `TICKLESS_IDLE`; inert with no `ESP_PLATFORM` (host builds).
- Runtime behavior of the slow-params fix is **bench-pending**: after an FC-off
  download, expect `Slow (low-power) conn params requested` → `Connection
  parameters now: … (1000 ms effective)` and idle back to ~1 mA **on battery,
  USB detached** (the `USJ_NO_AUTO_LS` lock holds light sleep off while USB is
  connected).

Both are follow-ups to already-merged #524 / #519 (no closing keywords — those
issues are already resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
