### PR TITLE
lora: re-enable frequency hopping as a selectable link mode (#150)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1499,6 +1499,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             cfg.loraCR = (dict["lcr"] as? Int).map { UInt8($0) }
             cfg.loraTxPower = (dict["lpw"] as? Int).map { Int8($0) }
             cfg.loraHopDisabled = dict["lhd"] as? Bool   // #106 (nil if device doesn't report it)
+            cfg.loraHopDwell = dict["lhdw"] as? Int      // #150 (0 = hopping unavailable)
             if let existing = self.rocketConfig {
                 cfg.pyro1Enabled = existing.pyro1Enabled
                 cfg.pyro1TriggerMode = existing.pyro1TriggerMode

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -111,6 +111,10 @@ struct RocketConfig {
     var loraCR: UInt8? = nil
     var loraTxPower: Int8? = nil
     var loraHopDisabled: Bool? = nil   // #106 fixed-frequency override (BS-controlled)
+    // #150: firmware-computed hop dwell for the current modulation.
+    // 0 = hopping not legally possible at this preset (GUI greys the
+    // option); nil = device doesn't report it (pre-#150 firmware).
+    var loraHopDwell: Int? = nil
     var pyro1Enabled: Bool = false
     var pyro1TriggerMode: UInt8 = 0
     var pyro1TriggerValue: Float = 1.0

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -79,6 +79,12 @@ struct TelemetryData: Codable {
     // LoRa signal quality (base station only)
     var rssi: Float?                  // LoRa RSSI dBm
     var snr: Float?                   // LoRa SNR dB
+    // #150: hop-state surface.  hop_channel only arrives while the BS is
+    // following a hop schedule; netid_drops only once the BS has dropped
+    // packets on a network-id mismatch (a rising count = a device is on
+    // the wrong network id — the failure that used to be silent).
+    var hop_channel: Int?
+    var netid_drops: Int?
 
     // Base station (base station only)
     var bs_soc: Float?                // Base station SOC %
@@ -254,6 +260,8 @@ struct TelemetryData: Codable {
         case roll_cmd = "rcmd"
         case q0, q1, q2, q3
         case rssi, snr
+        case hop_channel = "hch"
+        case netid_drops = "nidd"
         case bs_soc = "bsoc"
         case bs_voltage = "bvol"
         case bs_current = "bcur"
@@ -319,6 +327,8 @@ struct TelemetryData: Codable {
         q3 = try c.decodeIfPresent(Float.self, forKey: .q3)
         rssi = try c.decodeIfPresent(Float.self, forKey: .rssi)
         snr = try c.decodeIfPresent(Float.self, forKey: .snr)
+        hop_channel = try c.decodeIfPresent(Int.self, forKey: .hop_channel)
+        netid_drops = try c.decodeIfPresent(Int.self, forKey: .netid_drops)
         bs_soc = try c.decodeIfPresent(Float.self, forKey: .bs_soc)
         bs_voltage = try c.decodeIfPresent(Float.self, forKey: .bs_voltage)
         bs_current = try c.decodeIfPresent(Float.self, forKey: .bs_current)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -431,7 +431,11 @@ struct ConnectedDashboardView: View {
 
             if showRocketViews {
                 RocketStateView(state: device.telemetry.state,
-                                hopping: device.telemetry.hop_channel != nil)
+                                hopBadge: hopBadge(
+                                    isBaseStation: device.isBaseStation,
+                                    hopModeOn: device.rocketConfig?.loraHopDisabled == false,
+                                    hopChannel: device.telemetry.hop_channel,
+                                    state: device.telemetry.state))
                     .opacity(staleOpacity)
             }
 
@@ -698,13 +702,32 @@ struct DeviceChipBar: View {
     }
 }
 
+// #150: the three honest hop states the tile can report.  Derived from the
+// mode readback (lhd), the live-following signal (hch — only present while
+// the BS is actually walking the schedule), and the rocket state:
+//   armed    = mode on, rocket in READY/INIT — hopping starts at PRELAUNCH
+//              by design, nothing is wrong (this wait is usually GPS)
+//   engaging = mode on, rocket in a hop state, schedule not followed yet —
+//              the handoff is in flight (normally 1-3 s; a missed bootstrap
+//              self-heals within ~60 s)
+//   active   = the BS is following the schedule
+enum HopBadge {
+    case armed, engaging, active
+}
+
+func hopBadge(isBaseStation: Bool, hopModeOn: Bool,
+              hopChannel: Int?, state: String) -> HopBadge? {
+    guard isBaseStation, hopModeOn else { return nil }
+    if hopChannel != nil { return .active }
+    switch state {
+    case "PRELAUNCH", "INFLIGHT", "LANDED": return .engaging
+    default: return .armed
+    }
+}
+
 struct RocketStateView: View {
     let state: String
-    // #150: true while the BS is actively following the rocket's hop
-    // schedule (driven by the "hch" telemetry key, which only arrives
-    // during a live hop session — the mode merely being enabled in
-    // Settings doesn't light this up).
-    var hopping: Bool = false
+    var hopBadge: HopBadge? = nil
 
     // #382 (display-only): the wire states READY and PRELAUNCH both mean "on
     // the pad" — READY is still waiting on the OC/GNSS gates, PRELAUNCH means
@@ -747,10 +770,21 @@ struct RocketStateView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundColor(ready ? .green : .orange)
             }
-            if hopping {
+            switch hopBadge {
+            case .active:
                 Label("Frequency Hopping", systemImage: "dot.radiowaves.left.and.right")
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.blue)
+            case .engaging:
+                Label("Hopping — engaging…", systemImage: "dot.radiowaves.left.and.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.orange)
+            case .armed:
+                Label("Hopping armed — starts at PRELAUNCH", systemImage: "dot.radiowaves.left.and.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            case nil:
+                EmptyView()
             }
             Text("Rocket State")
                 .font(.caption)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -21,6 +21,7 @@ enum DashboardSheet: Identifiable {
     case settings
     case servoTest
     case driftCast
+    case frequencyScan   // #150: restored (removed in #136)
 
     var id: Int { hashValue }
 }
@@ -245,6 +246,14 @@ struct DashboardView: View {
                         ServoTestView(device: device,
                                       finMinDeg: Double(profileStore.activeProfile?.finMinDeg ?? -20),
                                       finMaxDeg: Double(profileStore.activeProfile?.finMaxDeg ?? 20))
+                    }
+                case .frequencyScan:
+                    // #150: restored — the scan pipeline (cmd 60 → 0xAA
+                    // blob → scanSamples) survived #136 intact; while
+                    // hopping, the BS runs it as a coordinated scan and
+                    // pushes the resulting skip-mask via cmd 15.
+                    if let device = fleet.activeDevice {
+                        NavigationView { FrequencyScanView(device: device) }
                     }
                 }
             }
@@ -2101,6 +2110,28 @@ struct TestingControlsView: View {
                     .cornerRadius(10)
                 }
                 .disabled(!canStartGroundTest)
+
+                // #150: Frequency Scan (restored from the #136 removal).
+                // BS-only — the scan runs on the base station's radio; in
+                // hopping mode the firmware coordinates a hop pause and
+                // pushes the resulting channel mask to the rocket.
+                if device.isBaseStation {
+                    Button {
+                        activeSheet = .frequencyScan
+                    } label: {
+                        HStack {
+                            Image(systemName: "waveform.badge.magnifyingglass")
+                            Text("Frequency Scan")
+                        }
+                        .font(.system(.body, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .foregroundColor(.white)
+                        .background(device.isConnected ? Color.purple : Color.purple.opacity(0.4))
+                        .cornerRadius(10)
+                    }
+                    .disabled(!device.isConnected)
+                }
             }
         }
         .padding()
@@ -2386,6 +2417,16 @@ struct SignalStrengthView: View {
                     valueText: bleText
                 )
             }
+
+            // #150: network-id mismatch drops — the failure that used to be
+            // a silent "Searching for rocket…".  Only rendered once the BS
+            // reports a non-zero count.
+            if isBaseStation, let drops = telemetry.netid_drops, drops > 0 {
+                Label("NetID mismatch: \(drops) packets dropped — a device is on the wrong network ID (see Settings ▸ Network)",
+                      systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
         }
         .padding()
         .frame(maxWidth: .infinity)
@@ -2397,6 +2438,11 @@ struct SignalStrengthView: View {
 
     private var loraText: String {
         guard let rssi = telemetry.rssi else { return "--" }
+        // #150: while hopping, show the live channel index next to the
+        // signal so the operator can see both ends walking the schedule.
+        if let hch = telemetry.hop_channel {
+            return String(format: "%.0f ch%d", rssi, hch)
+        }
         return String(format: "%.0f", rssi)
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -430,7 +430,8 @@ struct ConnectedDashboardView: View {
             }
 
             if showRocketViews {
-                RocketStateView(state: device.telemetry.state)
+                RocketStateView(state: device.telemetry.state,
+                                hopping: device.telemetry.hop_channel != nil)
                     .opacity(staleOpacity)
             }
 
@@ -699,6 +700,11 @@ struct DeviceChipBar: View {
 
 struct RocketStateView: View {
     let state: String
+    // #150: true while the BS is actively following the rocket's hop
+    // schedule (driven by the "hch" telemetry key, which only arrives
+    // during a live hop session — the mode merely being enabled in
+    // Settings doesn't light this up).
+    var hopping: Bool = false
 
     // #382 (display-only): the wire states READY and PRELAUNCH both mean "on
     // the pad" — READY is still waiting on the OC/GNSS gates, PRELAUNCH means
@@ -740,6 +746,11 @@ struct RocketStateView: View {
                 Label(text, systemImage: ready ? "checkmark.seal.fill" : "hourglass")
                     .font(.caption.weight(.semibold))
                     .foregroundColor(ready ? .green : .orange)
+            }
+            if hopping {
+                Label("Frequency Hopping", systemImage: "dot.radiowaves.left.and.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.blue)
             }
             Text("Rocket State")
                 .font(.caption)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
@@ -16,6 +16,13 @@ struct DeviceProvisioningSheet: View {
     @State private var rocketIDInput: Int = 1
     @State private var initialized = false
 
+    // #150: the app's network (from onboarding).  Pushed to the device on
+    // provision; the device persists it across reboots now, and the
+    // Settings Network section shows the device's own readback so a
+    // mismatch can never hide again.
+    @AppStorage("networkName") private var networkName: String = ""
+    @AppStorage("networkID") private var networkID: Int = 0
+
     var body: some View {
         NavigationView {
             Form {
@@ -50,9 +57,20 @@ struct DeviceProvisioningSheet: View {
                     }
                 }
 
-                // Network section hidden in #136 — see SettingsView for
-                // the rationale.  Both ends now force a default network
-                // ID at boot, so there's nothing to push from here.
+                // #150: Network section restored — the firmware persists
+                // nid across reboots now (with a one-time migration that
+                // guards against the #133-era silent drift).
+                if networkID > 0 {
+                    Section(header: Text("Network"),
+                            footer: Text("All your devices are set to this network. Devices only hear each other on the same network ID.")) {
+                        HStack {
+                            Text(networkName.isEmpty ? "Not set" : networkName)
+                            Spacer()
+                            Text("ID: \(networkID)")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
 
                 Section {
                     Button {
@@ -100,10 +118,12 @@ struct DeviceProvisioningSheet: View {
         // Send name to device
         device.sendSetUnitName(trimmed)
 
-        // Network ID push removed in #136 — firmware boots to a hardcoded
-        // default and cmd 9 only takes effect for the current session, so
-        // pushing here would just lull the user into thinking they're on
-        // a custom network until the next power cycle.
+        // #150: push the network ID (cmd 41) — the firmware persists it in
+        // identity NVS across reboots now, so the push is durable.  The
+        // Settings Network section verifies via the device's readback.
+        if networkID > 0 {
+            device.sendSetNetworkID(UInt8(clamping: networkID))
+        }
 
         // Send rocket ID (rockets only)
         if !device.isBaseStation {

--- a/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift
@@ -133,7 +133,20 @@ struct FrequencyScanView: View {
                     summary
                 }
 
-                if let quiet = quietestSample {
+                if hoppingMode {
+                    // #150: while hopping there is no single frequency to
+                    // move to — the firmware refuses cmd 10 mid-hop, and
+                    // the scan's real product is the channel-quality mask
+                    // it pushes to the rocket automatically (cmd 15).
+                    // Offering Apply here would report success for a
+                    // change the firmware rejects.
+                    Section("Auto-Apply") {
+                        Label("Hopping mode: the scan result was applied automatically as a channel mask — noisy channels are skipped and the link keeps hopping. No frequency move is needed.",
+                              systemImage: "checkmark.circle")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else if let quiet = quietestSample {
                     Section("Auto-Apply") {
                         Button {
                             showApplyConfirm = true
@@ -181,6 +194,11 @@ struct FrequencyScanView: View {
     /// the rocket beacons in and disables again if it goes silent.
     private var applyRefusal: BLEDevice.AutoApplyRefusal? {
         device.autoApplyRefusalReason()
+    }
+
+    /// #150: link is in frequency-hopping mode (readback truth).
+    private var hoppingMode: Bool {
+        device.rocketConfig?.loraHopDisabled == false
     }
 
     private func applyQuietest() {

--- a/TinkerRocketApp/TinkerRocketApp/Views/OnboardingView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/OnboardingView.swift
@@ -20,12 +20,22 @@ func fnv1a8(_ string: String) -> UInt8 {
     return UInt8(folded)
 }
 
+/// #150: the wire network ID for a name.  0 is reserved — it's both the
+/// firmware factory default and the app's "unset" sentinel, so a name that
+/// happens to hash to 0 (1-in-256) would silently disable the provisioning
+/// push and the mismatch badge.  Remap it to 1.
+func networkIdForName(_ name: String) -> UInt8 {
+    let raw = fnv1a8(name)
+    return raw == 0 ? 1 : raw
+}
+
 struct OnboardingView: View {
     @AppStorage("networkName") private var networkName: String = ""
     @AppStorage("networkID") private var networkID: Int = -1
     @AppStorage("hasOnboarded") private var hasOnboarded: Bool = false
 
     @State private var nameInput: String = ""
+    @State private var previewID: UInt8 = 0   // #150: live fnv1a8 preview
 
     var body: some View {
         VStack(spacing: 32) {
@@ -53,11 +63,20 @@ struct OnboardingView: View {
                 TextField("e.g. My Backyard, Skyhawks Club", text: $nameInput)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .autocapitalization(.words)
+                    .onChange(of: nameInput) { newValue in
+                        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        previewID = trimmed.isEmpty ? 0 : networkIdForName(trimmed)
+                    }
 
-                // Network ID preview hidden in #136 — both ends now force
-                // a hardcoded default network_id at boot.  Network name is
-                // kept as a friendly label for the user's setup but no
-                // longer maps to a wire ID until #150 brings hopping back.
+                // #150: live network-ID preview (restored from #136).  The
+                // ID is what actually goes over the air — devices are set
+                // to it during provisioning, and it now persists across
+                // reboots on the device side.
+                if !nameInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("Network ID: \(previewID)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
             .padding(.horizontal, 32)
 
@@ -65,7 +84,7 @@ struct OnboardingView: View {
                 let trimmed = nameInput.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { return }
                 networkName = trimmed
-                networkID = Int(fnv1a8(trimmed))
+                networkID = Int(networkIdForName(trimmed))   // #150: never 0
                 hasOnboarded = true
             } label: {
                 Text("Continue")

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -77,6 +77,18 @@ struct SettingsView: View {
     @State private var txPowerDbm: Int = 12
     @State private var txPowerSendWork: DispatchWorkItem?
 
+    // #150: link mode (BS only) — device state, NOT a profile field.  The
+    // picker pushes cmd 17 on change; hydration from the lhd readback
+    // snaps it back if the firmware refuses (e.g. lhdw == 0).
+    @State private var linkModeHopping = false
+    // A hop DISABLE commits ~1.5 s after the tap (the BS drains its uplink
+    // retries on the hop channel first) — readbacks arriving inside that
+    // window still say "hopping" and would flip the picker back against
+    // the user's tap.  Hold hydration briefly after a tap; the commit
+    // readback lands after the hold and settles the true state.
+    @State private var linkModeTouchedAt: Date?
+    private static let linkModeHydrationHoldS: TimeInterval = 3.0
+
     @FocusState private var focusedField: EditField?
     @State private var lastFocusedField: EditField?
 
@@ -252,10 +264,17 @@ struct SettingsView: View {
             .onChange(of: unitSystem) { _ in reloadPyroValueStrings() }
             .onDisappear { flushPendingEdits() }
             .onReceive(device.$rocketConfig.compactMap { $0 }) { cfg in
-                // Only LoRa TX power is hydrated from the rocket now — every
-                // other setting is owned by the profile (app is source of
-                // truth) so we no longer pull config back into local state.
+                // Only device-owned LoRa state is hydrated from readback —
+                // every other setting is owned by the profile (app is source
+                // of truth) so we no longer pull config back into local state.
                 if let pwr = cfg.loraTxPower { txPowerDbm = Int(pwr) }
+                // #150: skip lhd hydration inside the post-tap hold window
+                // (see linkModeTouchedAt) so mid-drain readbacks can't flip
+                // the picker against the user's tap.
+                if let hd = cfg.loraHopDisabled,
+                   linkModeTouchedAt.map({ Date().timeIntervalSince($0) > Self.linkModeHydrationHoldS }) ?? true {
+                    linkModeHopping = !hd
+                }
             }
         }
     }
@@ -292,6 +311,43 @@ struct SettingsView: View {
         }
 
         loRaSections
+        networkSection
+    }
+
+    // #150: Network (restored from #136, with the drift bug fixed).  The
+    // app stores the human-friendly name; the DEVICE's readback nid
+    // (config_identity) is the truth about what's on the air.  The old UI
+    // displayed only the app-local @AppStorage copy, which is exactly what
+    // made the #133 nid drift undebuggable — hence the mismatch badge and
+    // one-tap sync against the readback.
+    @ViewBuilder
+    private var networkSection: some View {
+        Section(header: Text("Network"), footer: Text(networkFooter)) {
+            HStack {
+                Text(appNetworkName.isEmpty ? "Not set" : appNetworkName)
+                Spacer()
+                Text("ID: \(appNetworkID)")
+                    .foregroundColor(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text("Device reports")
+                Spacer()
+                if deviceNidMismatch {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                }
+                Text("ID: \(device.networkID)")
+                    .foregroundColor(deviceNidMismatch ? .orange : .secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            if deviceNidMismatch {
+                Button("Set device to \"\(appNetworkName)\" (ID \(appNetworkID))") {
+                    device.sendSetNetworkID(UInt8(clamping: appNetworkID))
+                }
+                .disabled(!device.isConnected)
+            }
+        }
     }
 
     // Firmware update entry. Shown for any connected device (#8): Phase 2
@@ -322,8 +378,21 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var loRaSections: some View {
+        // #150: Fixed vs Hopping link-mode picker.  Applies on change (no
+        // Apply button, #144); non-focusable control keeps this section
+        // safe next to live readback (#361).
+        Section(header: Text("Link Mode"), footer: Text(linkModeFooter)) {
+            Picker("Link Mode", selection: linkModeBinding) {
+                Text("Fixed Channel").tag(false)
+                Text("Frequency Hopping").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .disabled(device.autoApplyRefusalReason() != nil ||
+                      (hopUnavailable && !linkModeHopping))
+        }
+
         Section(header: Text("LoRa Frequency"),
-                footer: Text("Base station picks the quietest channel automatically at boot. Both devices should report the same frequency.")) {
+                footer: Text("Both devices meet on the factory channel at boot. Both should report the same frequency.")) {
             HStack {
                 Text("Current")
                 Spacer()
@@ -343,7 +412,10 @@ struct SettingsView: View {
                         .font(.system(.body, design: .monospaced))
                 }
             }
-            .disabled(device.autoApplyRefusalReason() != nil)
+            // #150: also locked while hopping — TX power rides cmd 10,
+            // which the firmware refuses mid-hop (a change would silently
+            // snap back).  Switch to Fixed first.
+            .disabled(device.autoApplyRefusalReason() != nil || linkModeHopping)
             .onChange(of: txPowerDbm) { scheduleTxPowerSend($0) }
         }
     }
@@ -383,7 +455,13 @@ struct SettingsView: View {
         case .control:  controlSections
         case .camera:   cameraSections
         case .pyro:     pyroSections
-        case .general:  generalSections
+        case .general:
+            generalSections
+            // #150: the network surface must exist on ROCKETS too — the
+            // cmd-41 sync only reaches the device the app is connected
+            // to, so a drifted rocket nid would otherwise be visible only
+            // as the BS's rising drop counter, with no in-app fix.
+            networkSection
         }
     }
 
@@ -1294,6 +1372,59 @@ struct SettingsView: View {
 
     // MARK: - LoRa TX power (base station only)
 
+    // #150: network identity (app side; onboarding writes these).
+    @AppStorage("networkName") private var appNetworkName: String = ""
+    @AppStorage("networkID") private var appNetworkID: Int = 0
+
+    private var deviceNidMismatch: Bool {
+        // unitID empty = no config_identity readback yet — don't render
+        // "identity unknown" as a confident mismatch at ID 0.
+        appNetworkID > 0 && !device.unitID.isEmpty &&
+        device.networkID != UInt8(clamping: appNetworkID)
+    }
+
+    private var networkFooter: String {
+        if deviceNidMismatch {
+            return "This device is on a different network ID than the app expects — it can't hear your other devices. Tap to sync it (a rising NetID Drops count on the dashboard is the same problem seen from the other side)."
+        }
+        return "Devices only hear each other on the same network ID. Set during onboarding; pushed to each device when provisioned."
+    }
+
+    // #150: hopping is unavailable when the firmware reports dwell 0 for
+    // the current modulation (a packet wouldn't fit the FCC occupancy
+    // window).  nil (pre-#150 firmware) is treated as available.
+    private var hopUnavailable: Bool {
+        (device.rocketConfig?.loraHopDwell ?? 1) == 0
+    }
+
+    private var linkModeFooter: String {
+        // Surface WHY the picker is locked (same pattern as txPowerFooter)
+        // instead of greying silently.
+        if let refusal = device.autoApplyRefusalReason() {
+            return refusal.rawValue
+        }
+        if hopUnavailable {
+            return "Frequency hopping isn't available at the current radio settings — a packet wouldn't fit the FCC dwell window."
+        }
+        return linkModeHopping
+            ? "FCC-compliant hopping across the channel set. The rocket follows automatically; switching modes takes a few seconds."
+            : "Single fixed channel — the default."
+    }
+
+    private var linkModeBinding: Binding<Bool> {
+        Binding(
+            get: { linkModeHopping },
+            set: { newValue in
+                guard newValue != linkModeHopping else { return }
+                linkModeHopping = newValue
+                linkModeTouchedAt = Date()   // #150: hold off hydration (see onReceive)
+                if device.isConnected {
+                    device.sendLoRaHopDisabled(!newValue)
+                }
+            }
+        )
+    }
+
     private func scheduleTxPowerSend(_ newValue: Int) {
         txPowerSendWork?.cancel()
         let work = DispatchWorkItem {
@@ -1308,6 +1439,9 @@ struct SettingsView: View {
     private var txPowerFooter: some View {
         if let refusal = device.autoApplyRefusalReason() {
             Text(refusal.rawValue).foregroundColor(.orange)
+        } else if linkModeHopping {
+            Text("TX power changes are locked while hopping — switch Link Mode to Fixed Channel first.")
+                .foregroundColor(.orange)
         } else {
             Text("Sets transmit power on both the base station and the rocket. The base station relays the change over LoRa, verifies the rocket joined the new setting, and rolls both sides back if it can't be reached.")
         }

--- a/TinkerRocketApp/TinkerRocketAppTests/NetworkIdTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/NetworkIdTests.swift
@@ -1,0 +1,49 @@
+//
+//  NetworkIdTests.swift
+//  TinkerRocketAppTests
+//
+//  #150: the network-name → network-ID mapping is the contract between
+//  onboarding (preview), provisioning (push), and the firmware's identity
+//  NVS.  Pin it so a refactor can't silently re-map every fielded device.
+//
+
+import XCTest
+@testable import TinkerRocketApp
+
+final class NetworkIdTests: XCTestCase {
+
+    func testFnv1a8_Deterministic() {
+        // Same input, same ID — across calls and instances.
+        XCTAssertEqual(fnv1a8("Skyhawks Club"), fnv1a8("Skyhawks Club"))
+        XCTAssertEqual(fnv1a8(""), fnv1a8(""))
+    }
+
+    func testFnv1a8_KnownVector() {
+        // Golden pin: FNV-1a 32-bit of "a" is 0xE40C292C; XOR-folded to
+        // 8 bits: 0x2C ^ 0x29 ^ 0x0C ^ 0xE4 = 0xED.  If this fails, the
+        // hash changed and every provisioned device's ID mapping breaks.
+        XCTAssertEqual(fnv1a8("a"), 0xED)
+    }
+
+    func testFnv1a8_DistinguishesTypicalNames() {
+        // Not a collision-resistance proof (8 bits can't be) — just a
+        // sanity check that obvious sibling names don't collide.
+        XCTAssertNotEqual(fnv1a8("My Backyard"), fnv1a8("Skyhawks Club"))
+    }
+
+    func testNetworkIdForName_NeverZero() {
+        // 0 is reserved: it's the firmware factory default AND the app's
+        // "unset" sentinel — a name hashing to 0 would silently disable
+        // the provisioning push and the mismatch badge.  networkIdForName
+        // remaps that 1-in-256 case to 1; everything else passes through.
+        XCTAssertEqual(networkIdForName("a"), fnv1a8("a"))
+        // Brute-force a zero-hash input to prove the remap engages.
+        var zeroName: String?
+        for i in 0..<100_000 {
+            let candidate = "net\(i)"
+            if fnv1a8(candidate) == 0 { zeroName = candidate; break }
+        }
+        let name = try! XCTUnwrap(zeroName, "expected a zero-hash name within 100k candidates (p ≈ 1-(255/256)^100000 ≈ 1)")
+        XCTAssertEqual(networkIdForName(name), 1)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -37,6 +37,26 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(telemetry.state, "INFLIGHT")
     }
 
+    func testJSONDecode_HopStateKeys() throws {
+        // #150: "hch" (current hop channel) and "nidd" (network-id
+        // mismatch drops) ride the droppable tail of the telemetry JSON —
+        // present only while hopping / after drops, so both decode paths
+        // (present and absent) matter.
+        let with = """
+        {"st":"PRELAUNCH","hch":42,"nidd":7}
+        """.data(using: .utf8)!
+        let t1 = try JSONDecoder().decode(TelemetryData.self, from: with)
+        XCTAssertEqual(t1.hop_channel, 42)
+        XCTAssertEqual(t1.netid_drops, 7)
+
+        let without = """
+        {"st":"PRELAUNCH"}
+        """.data(using: .utf8)!
+        let t2 = try JSONDecoder().decode(TelemetryData.self, from: without)
+        XCTAssertNil(t2.hop_channel, "fixed-mode frames omit hch entirely")
+        XCTAssertNil(t2.netid_drops, "healthy-nid frames omit nidd entirely")
+    }
+
     func testJSONDecode_MissingOptionals_NoCrash() throws {
         let json = "{}".data(using: .utf8)!
         // Should not crash - optionals just nil, non-optionals fall back to

--- a/docs/plans/150-fhss-reenable.md
+++ b/docs/plans/150-fhss-reenable.md
@@ -31,10 +31,38 @@ default) vs *Frequency hopping* (the #133 scheme, re-enabled and hardened).
 - Network-ID flow restored (name UI → fnv1a8 → cmd 41 push; boot force
   lifted; identity NVS migrates instead of wiping; nid-mismatch drops are
   counted and surfaced to the app as `nidd`).
-- BS→rocket **mode resync**: if frame evidence contradicts the BS's mode for
-  ≥6 consecutive frames (10 s cooldown), the BS re-uplinks cmd 17. Rendezvous
-  visits and coordinated-scan pauses legitimately stamp `NO_HOP`, hence the
-  consecutive-frames filter.
+- BS→rocket **mode resync**: if frame evidence contradicts the BS's mode, the
+  BS re-uplinks cmd 17 (10 s cooldown). Direction A (BS hopping, rocket says
+  `NO_HOP` in a hop state) needs a 6-frame streak; direction B (BS fixed,
+  rocket announces hopping) acts immediately.
+- **`0xFE` off-schedule sentinel** (review fix): rendezvous-visit and
+  scan-pause frames stamp `next_channel_idx = 0xFE` ("hopping, momentarily
+  off-schedule") instead of `NO_HOP`. A fixed-mode BS gets its direction-B
+  evidence exactly while the rocket is parked and *listening* on the shared
+  rendezvous — the one window a cmd-17 push can land — and a following BS
+  knows not to misread the visit. Requires both ends flashed together (same
+  coordinated-re-flash rule the dwell change already imposes).
+- **Graceful hop disable** (review fix): a cmd-17 disable taken while the BS
+  is following a hop drains its 8 uplink retries *on the hop channel* before
+  the BS flips, retunes, and sends the config readback (≤1.5 s). The naive
+  order retuned away before the first retry fired, so the rocket essentially
+  never heard the disable.
+- **CR link gate** (review fix): dwell is CR-dependent, but a CR-only cmd-10
+  change is unverifiable over the air (explicit-header RX decodes any payload
+  CR, so the transaction's commit criterion is CR-blind) — a one-sided commit
+  would silently give the two ends different dwells. Hopping is therefore
+  only offered at the factory CR (4/5); any other CR computes `lhdw` = 0.
+- **Implicit home-channel skip** (review fix): hop-session transition packets
+  (activation bootstrap, visit/pause re-bootstraps) transmit on
+  `lora_freq_mhz` outside the schedule. If that frequency is also a hop-grid
+  channel, a transition packet plus a scheduled dwell visit could stack past
+  the 400 ms occupancy line in one window — so both ends implicitly skip the
+  coincident grid slot (withheld only if it would breach the channel floor).
+  The factory 915.0 is off-grid at BW250, so today's default is unaffected.
+- **cmd-60 scan gating** (review fix): the coordinated-pause scan path is
+  only taken in hopping mode — in fixed mode a recently-heard LANDED rocket
+  (LANDED now being a hop state) would otherwise trigger a pointless cmd-16 +
+  a RESUMING stall that #136 never had.
 
 ## 2. Regulatory survey (worldwide, per tinkerbug's request)
 
@@ -160,7 +188,52 @@ the start channel before hopping begins (needs short-preamble or
 start-channel rotation; SF11 is clean), and packets that long mean ~0.3 Hz
 telemetry — a tracking/recovery mode, not live telemetry.
 
-## 7. Reliability notes (what re-enabling actually risks)
+## 7. Reliability notes + adversarial review outcome
+
+A 27-agent adversarial review (5 dimension-focused finders, every finding
+verified by 2 independent skeptics) ran over the firmware diff before bench
+time. 9 findings confirmed, all addressed:
+
+1. **nid resurrection (critical, fixed)**: the #136 nid boot-force was
+   RAM-only, so fielded devices still store the divergent #133-era nids
+   (rocket 180 / BS 0) that the force had masked for months. Deleting the
+   force would have made them live on the first post-flash boot — a total,
+   silent link kill with no over-the-air recovery (both directions are
+   nid-filtered). Fix: the identity v0→v1 migration resets nid to the
+   compile-time default exactly once (the pre-upgrade *effective* nid was
+   always the default, so this is the behavior-preserving migration); `un`
+   and `rid` are preserved.
+2. **Direction-B resync undeliverable (critical, fixed)**: visit/pause frames
+   stamped `NO_HOP`, and 915.0 is off the hop grid, so a fixed BS never got
+   usable evidence nor a delivery window. Fixed by the `0xFE` sentinel: the
+   evidence arrives on frames sent while the rocket is parked on the
+   rendezvous *listening*, and the push queued off that frame lands in the
+   same visit.
+3. **cmd-17 disable ordering (critical, fixed)**: the BS retuned to the
+   static channel before its own disable retries fired. Fixed by the
+   graceful drain (retries complete on the hop channel first).
+4. **BS power-cycle rejoin only at factory rendezvous (major, mitigated)**:
+   a rebooted BS re-acquires a hopping rocket via the post-visit bootstrap on
+   `lora_freq_mhz` — which works whenever the operating channel is the
+   factory 915 (today: always; there is no shipped UI that moves it).
+   Residual corner once the scan UI returns: if the session moved the
+   channel and the BS reboots, telemetry degrades to visit bursts until the
+   *rocket* is power-cycled — the retained rendezvous boot force then resets
+   `lora_freq_mhz` to 915 and the pair re-converges. Documented, accepted.
+5. **LANDED scan parity break (minor, fixed)**: cmd-60 gated on
+   `!lora_hop_disabled` so fixed-mode post-flight scans run direct, as in
+   #136.
+6. **CR-dependent dwell divergence (major, fixed)**: CR link gate (above).
+7. **Bootstrap occupancy stacking (major, fixed)**: implicit home-channel
+   skip (above); the one-time activation bootstrap on the off-grid factory
+   915 cannot stack with any scheduled visit.
+8/9. Duplicates/variants of 4 and 5 — covered by the same fixes.
+
+Refuted by the verifiers (no change): the direction-A streak-vs-visit-length
+concern (visit frames no longer stamp `NO_HOP` at all), and a suspected
+stale-modulation window in the hop-follow during cmd-10 VERIFYING.
+
+Standing reliability notes:
 
 - #133's redesign was never field-validated; the biggest hazard family is the
   DIO1 edge-ISR/level-poll flag protocol around `hopToFrequencyMHz()` — the
@@ -170,10 +243,13 @@ telemetry — a tracking/recovery mode, not live telemetry.
 - Stale NVS `hopdis=0` from pre-#150 cmd-17 experiments would have booted
   devices straight into hopping once the boot force lifted —
   `LORA_NVS_SCHEMA_VERSION` v4 wipes it; defaults flip to disabled.
-- The #133-era nid regression (schema wipe → BS nid=0 vs rocket nid=180 →
-  silent 100 % packet drop) is triple-guarded: identity NVS migrates instead
-  of wiping, the drop counter is user-visible (`nidd`), and the network-name
-  UI shows the device-readback nid rather than an app-local copy.
+- Post-upgrade nid drift can no longer be silent: identity NVS migrates (with
+  the one-time v0 reset above), the drop counter is user-visible (`nidd`),
+  and the network-name UI shows the device-readback nid rather than an
+  app-local copy.
+- Mixed-version fleets are NOT supported across this change (0xFE sentinel +
+  dwell derivation both moved): flash BS and rocket together — the same rule
+  #133's shared-dwell constant already imposed.
 
 ## 8. Bench evidence
 

--- a/docs/plans/150-fhss-reenable.md
+++ b/docs/plans/150-fhss-reenable.md
@@ -1,0 +1,188 @@
+# #150 — LoRa frequency hopping re-enable: design + regulatory analysis
+
+Status: implementation on branch `lora/150-fhss-gui`. Bench evidence sections
+are filled in after Seam A/B runs (placeholders marked ⏳).
+
+This is the design record #150 asked for: the worldwide regulatory survey, the
+FCC compliance math for the existing #133 hop scheme, the concrete diffs needed
+to make it compliant, and the alternatives we rejected. The user-facing change
+is an iOS **link-mode picker**: *Fixed channel* (today's #136 scheme, still the
+default) vs *Frequency hopping* (the #133 scheme, re-enabled and hardened).
+
+## 1. What ships
+
+- `lora_hop_disabled` (cmd 17, end-to-end plumbing already existed) becomes a
+  user-facing link mode. Boot honors NVS (`hopdis`, default **1** = fixed);
+  the #136 boot force is gone. The #136 rendezvous-preset boot force stays —
+  fixed-mode behavior is unchanged.
+- **Adaptive dwell** replaces the compile-time `LORA_HOP_DWELL_PACKETS = 4`:
+  `loraHopDwellForConfig(sf, bw, frame_len, cr)` derives packets-per-channel
+  from real airtime, clamped to [0..4]; 0 = hopping not permitted at that
+  modulation (firmware refuses cmd-17 enable, app greys the option via the
+  `lhdw` config-JSON key).
+- `shouldHopInState()` gains LANDED (2 Hz telemetry continues after landing;
+  a fixed channel would carry ~2.1 s of airtime per 10 s — 5× the FCC bound).
+- Name beacons are suppressed while hopping (they would ride hop channels the
+  BS already follows, and at SF10 a single beacon inside a dwell visit blows
+  the occupancy line).
+- Channel set: hopping uses **all channels** by default (69 at BW250); the
+  restored Frequency Scan view can push a noise skip-mask (cmd 15) whose
+  active count is floored at `loraFhssMinChannels` (50 at BW ≤ 250 kHz).
+- Network-ID flow restored (name UI → fnv1a8 → cmd 41 push; boot force
+  lifted; identity NVS migrates instead of wiping; nid-mismatch drops are
+  counted and surfaced to the app as `nidd`).
+- BS→rocket **mode resync**: if frame evidence contradicts the BS's mode for
+  ≥6 consecutive frames (10 s cooldown), the BS re-uplinks cmd 17. Rendezvous
+  visits and coordinated-scan pauses legitimately stamp `NO_HOP`, hence the
+  consecutive-frames filter.
+
+## 2. Regulatory survey (worldwide, per tinkerbug's request)
+
+| Region | Rule | Hopping requirements | Power | Consequence for us |
+|---|---|---|---|---|
+| US — FCC 15.247 | 902–928 MHz | 20 dB BW ≥ 250 kHz → **≥ 25 channels**, ≤ 0.4 s occupancy per frequency per **10 s**; 20 dB BW < 250 kHz → **≥ 50 channels**, per **20 s**. Spacing ≥ max(25 kHz, 20 dB BW); hop channel BW ≤ 500 kHz | 0.25 W (25–49 ch), **1 W (≥ 50 ch)** | The design target. We hold ≥ 50 active channels at BW ≤ 250 → 1 W-tier-ready (chip max is 22 dBm today). |
+| Canada — ISED RSS-247 | 902–928 MHz | Harmonized with FCC 15.247 | same | US design carries over unchanged. |
+| EU — ETSI EN 300 220-2 | 863–870 MHz | FHSS requires ~≥ 47 channels of ≤ 100 kHz occupied BW, **and duty-cycle limits (0.1 %/1 % by sub-band) still apply to the whole transmission** (or polite spectrum access LBT+AFA) | ≤ 25 mW typical; 500 mW only in 869.4–869.65 @ 10 % | Hopping buys nothing in EU — wrong band, wrong channel width, and no duty/power relief. EU operation = fixed sub-band + duty cycle. Hopping stays a region-gated feature; our 902–928 plan is US/CA-only. |
+| Australia — ACMA LIPD 2025 | 915–928 MHz | FHSS transmitters **and** digital-modulation transmitters both authorized | 1 W EIRP either way | Hopping optional (no power benefit). Needs a 915–928 channel subset — a future channel-plan table entry, not a redesign (the plan constants are already centralized). |
+| New Zealand — GURL (short-range devices) | 915–928 MHz | similar to AU (verify before enabling) | ~1 W | Same subset as AU. |
+| Japan — ARIB STD-T108 | 920–928 MHz | Channelized, LBT (≥ 128 µs carrier sense) | 20 mW class | Hopping is not the compliance mechanism; out of scope. |
+
+Key corrections to #150's framing that came out of this survey:
+
+1. **The occupancy limit binds transmit airtime, not wall-clock residency.**
+   "0.4 s within 10 s" is the accumulated time *transmitting* on a frequency
+   inside the window. Dwelling (radio tuned, mostly listening) is free.
+2. **The issue's "0.4 s in 20 s" is the < 250 kHz case.** At our 250 kHz
+   channels the window is 10 s (still 0.4 s occupancy).
+3. **Fixed-channel 250 kHz LoRa is not DTS.** 15.247(a)(2) digital-modulation
+   (DTS) operation requires ≥ 500 kHz of 6 dB bandwidth. A fixed 125/250 kHz
+   LoRa carrier falls to 15.249 (≈ 0.75 mW ERP) or amateur Part 97 (licensed).
+   The in-tree comments claiming "we operate as DTS, no dwell limit" were
+   wrong in both directions and have been rewritten. Practical upshot:
+   **hopping is the properly-compliant higher-power mode**; fixed mode is the
+   low-power / EU / bench mode — which is exactly why both stay selectable.
+4. BW500 fixed-channel *is* DTS-eligible (≈ 500 kHz 6 dB BW) — the one preset
+   where fixed mode legitimately reaches 1 W. Worth remembering if a "Fast"
+   preset returns.
+
+## 3. FCC compliance math for the #133 scheme
+
+Operating point: band plan 902–928 MHz, spacing 1.5×BW (69 channels at
+BW250), SF8/BW250/CR4:5, preamble 12, 66-byte telemetry frame
+(`sizeof(LoRaData)`, static-asserted), unconditional 2 Hz cadence.
+
+Airtime (Semtech AN1200.13, `loraTimeOnAirMs`, shared by the OC scheduler, BS
+follower, and the host tests):
+
+| Modulation | ToA (66 B) | Dwell (≤ 390 ms budget) | Per-visit occupancy | Notes |
+|---|---|---|---|---|
+| SF7/BW250 | 64 ms | 4 | 256 ms | |
+| SF8/BW250 (default) | 112 ms | 3 | 336 ms | old fixed dwell=4 → 448 ms = **over the line**; this is the #150 dwell fix |
+| SF9/BW250 | 203 ms | 1 | 203 ms | +2.5 dB range rung |
+| SF10/BW250 | 386 ms | 1 | 386 ms | **+5 dB long-range rung**, 14 ms margin — frame growth breaks this first (gtest-pinned) |
+| SF11+/BW250, SF9+/BW125 | > 390 ms | 0 | — | hopping refused; fixed mode only |
+| SF7/BW125 | 127 ms | 3 | 381 ms | 20 s window applies (BW < 250) |
+| BW500 SF7–SF11 | 32–345 ms | 4/4/3/2/1 | ≤ 345 ms | |
+
+- **Budget = 390 ms, not 400**: headroom for formula-vs-measured drift while
+  keeping the SF10/BW250 rung. (An earlier plan draft said 380, computed
+  against a stale 62-byte frame note; the real frame is 66 B → 386 ms, so 380
+  would have silently dropped the long-range rung.) The binding check is the
+  `ComplianceInvariant` gtest: `dwell × ToA ≤ 400 ms` for every configurable
+  modulation.
+- **Revisit bound**: per-visit occupancy is sufficient because a full cycle
+  (`n_active × dwell / 2 Hz`) outlasts the window even at the floor count:
+  worst case 25 × 1 / 2 = 12.5 s ≥ 10 s (BW500), 50 × 1 / 2 = 25 s ≥ 20 s
+  (BW125). Gtest-pinned. **Raising the telemetry rate re-opens this** —
+  BW125 hopping stops being legal near 4 Hz; the tests carry that warning.
+- **Equal channel use**: the seq-anchored round-robin is exactly uniform over
+  whole cycles from any epoch (reboot/seq-reset included); the u16 wrap adds
+  at most one dwell-window of spread per 65536-packet epoch. Both gtest-pinned.
+- **Channel count**: 69 ≥ 50 at BW250 with an empty mask; `loraSelectChannelSet`
+  floors masked sets at 50 (BW ≤ 250) / 25 (BW500). ≥ 50 active also satisfies
+  the 1 W FHSS power tier — relevant only if a PA ever lands (LLCC68 tops out
+  at 22 dBm ≈ 158 mW, inside the 0.25 W tier regardless).
+- **Hopping in all transmitting states**: PRELAUNCH/INFLIGHT/LANDED all hop.
+  INIT/READY (and MAG_CAL) remain on the rendezvous channel: that is the
+  acquisition phase, and beacon cadence there is the fixed-mode story, not
+  the FHSS story.
+- **BS side**: the BS transmits only inside the 150 ms post-RX safe window on
+  the channel it follows, ~one heartbeat per 10 s plus user commands — far
+  under the occupancy line on any single frequency.
+
+## 4. Range policy (user decision, 2026-07-15)
+
+Adaptive dwell keeps SF8→SF10 @ BW250 hopping-legal — the "BW250 ladder":
+SF9 ≈ +2.5 dB, SF10 ≈ +5 dB over today, and SF10/BW250 sits only ~3 dB short
+of the old BW125 MaxRange preset (halving BW costs 3 dB of sensitivity but
+halves airtime — the winning trade under a dwell cap). The true max-range
+corner (BW125 @ SF10+, SF11+) cannot fit a single packet in the window and
+stays **fixed-channel only**, with the GUI explaining why.
+
+With a future 1 W front-end, hopping SF10/BW250 @ 30 dBm out-ranges fixed
+SF10/BW125 @ 22 dBm by ~5 dB — long-term, hopping is the range play, not the
+range sacrifice.
+
+## 5. Rejected alternatives
+
+- **App-layer packet fragmentation** (split the frame across 4–5 short
+  packets on different channels to reach BW125): the preamble dominates at
+  high SF — a 16-byte fragment at SF10/BW125 still costs ~290 ms, the frame
+  needs 4–5 fragments ≈ 1.2–1.4 s total airtime, telemetry falls to ~0.5 Hz,
+  any lost fragment costs the whole frame, and both ends grow a
+  fragmentation/reassembly protocol. ~3 dB for a lot of machinery. Rejected.
+- **Automatic post-acquire noise scan** (the original #133 flow): re-adds the
+  scan state machine to the critical path for marginal default-channel
+  quality. Hopping starts on the full channel set instead; the manual scan
+  remains available. (Scan-and-move helpers stay in source, unused.)
+- **Reducing preamble or trimming the frame to widen the dwell budget**:
+  coordinated-reflash risk on the acquisition path for margin we don't need
+  once the budget is airtime-derived.
+
+## 6. Future path: true mid-packet FHSS on an SX1276 daughterboard
+
+The LLCC68 (SX126x family) cannot retune mid-packet (`SetRfFrequency` is
+standby-only), and Semtech's LR-FHSS is transmit-only — neither carries a
+two-way link. The **SX127x** line is the only LoRa silicon with genuine
+intra-packet hopping: `RegHopPeriod` sets a hop period in symbols, the radio
+raises `FhssChangeChannel` at each boundary, the host retunes while the modem
+keeps demodulating, and the receiver follows in lockstep from the shared
+table.
+
+The V8 radio daughterboard (#409, `projects/radio_board/`, `IRadioLink` UART
+modem) is the natural home: an SX1276 board variant services the hop
+interrupts locally on the daughterboard (hard-real-time work stays off the
+host), exposes the same UART protocol plus a hop-table/config message, and
+makes SF11/BW125 — with care SF12 — hopping-legal at up to 1 W with the
+130-channel BW125 plan: roughly +8–12 dB over the BW250 ladder top (2.5–4×
+distance). Caveats recorded now: at SF12 the preamble alone dwells ~0.5 s on
+the start channel before hopping begins (needs short-preamble or
+start-channel rotation; SF11 is clean), and packets that long mean ~0.3 Hz
+telemetry — a tracking/recovery mode, not live telemetry.
+
+## 7. Reliability notes (what re-enabling actually risks)
+
+- #133's redesign was never field-validated; the biggest hazard family is the
+  DIO1 edge-ISR/level-poll flag protocol around `hopToFrequencyMHz()` — the
+  same family as the #520 rx_done double-latch (root-fixed in #521 for the
+  steady-state RX path). The TX-stuck watchdog mitigation stays; Bench Seam A
+  soaks the hot retune path on both backends (direct SPI and UART modem).
+- Stale NVS `hopdis=0` from pre-#150 cmd-17 experiments would have booted
+  devices straight into hopping once the boot force lifted —
+  `LORA_NVS_SCHEMA_VERSION` v4 wipes it; defaults flip to disabled.
+- The #133-era nid regression (schema wipe → BS nid=0 vs rocket nid=180 →
+  silent 100 % packet drop) is triple-guarded: identity NVS migrates instead
+  of wiping, the drop counter is user-visible (`nidd`), and the network-name
+  UI shows the device-readback nid rather than an app-local copy.
+
+## 8. Bench evidence
+
+⏳ Seam A (firmware, pre-app): fixed-mode regression, SF8 dwell-3 soak ≥ 30 min
+(crc_fail / low_snr / TX-wdog / drift-repush / observed-loss), SF9 dwell-1
+soak with heartbeat traffic, OC-reboot resync heal, UART-modem pair soak,
+BS power-cycle during LANDED-hop.
+
+⏳ Seam B (E2E with app): onboarding + provisioning with network name, mode
+picker both directions, mid-hop manual scan (cmd-16 pause → cmd-15 mask →
+floor holds), deliberate nid mismatch → `nidd` visible instead of silent
+blackout.

--- a/docs/plans/150-fhss-reenable.md
+++ b/docs/plans/150-fhss-reenable.md
@@ -304,6 +304,29 @@ Standing reliability notes:
 - End state: both ends restored to flight-standard 915/SF8/fixed, all
   counters clean.
 
+### Dwell-1 uplink fix — VERIFIED 2026-07-15 (commit ed6a41d)
+
+Root cause of the burst misses: the flat `UPLINK_RX_RESERVE_MS = 140` was
+sized for SF8's ~82 ms downlink; at SF9 (~203 ms) the TX-window gate
+sanctioned attempts colliding with the head of the next downlink, and at
+dwell-1 one collision breaks the hop-follow.  Fixed with an
+airtime-derived reserve + a no-TX-while-retune-pending guard.  Automated
+repro (3 disable/enable cycles at SF9/dwell-1): every cmd-17 delivered
+same-second (was 0/8 per burst), BS followed each re-activation at +1 s.
+Mode toggles: ~40–75 s → ~1–3 s.
+
+### iOS Phases 4–5 — DONE (commit b0c9d9a), adversarially reviewed
+
+32-agent review, 12 confirmed findings, all fixed pre-commit — notably:
+Frequency-Scan Auto-Apply and the TX-power stepper are hidden/locked
+while hopping (both ride cmd 10, which the firmware refuses mid-hop and
+the app previously reported as success); the network section + sync is
+device-agnostic (a BS-only sync could split the fleet with no in-app fix
+for a drifted rocket); `networkIdForName` remaps fnv1a8's 1-in-256
+zero-hash to 1 (0 collides with the firmware default and the app's unset
+sentinel); the hop/nidd readouts live on the real dashboard card (first
+draft put them on a never-instantiated view).  Simulator suite: 181/181.
+
 ### Seam B — ⏳ pending (E2E with app, after Phases 4–5)
 
 Onboarding + provisioning with network name, mode picker both directions

--- a/docs/plans/150-fhss-reenable.md
+++ b/docs/plans/150-fhss-reenable.md
@@ -253,12 +253,61 @@ Standing reliability notes:
 
 ## 8. Bench evidence
 
-⏳ Seam A (firmware, pre-app): fixed-mode regression, SF8 dwell-3 soak ≥ 30 min
-(crc_fail / low_snr / TX-wdog / drift-repush / observed-loss), SF9 dwell-1
-soak with heartbeat traffic, OC-reboot resync heal, UART-modem pair soak,
-BS power-cycle during LANDED-hop.
+### Seam A — RUN 2026-07-15 (BS V2 + OC V7 full rocket stack, ~2.5 h): PASS
 
-⏳ Seam B (E2E with app): onboarding + provisioning with network name, mode
-picker both directions, mid-hop manual scan (cmd-16 pause → cmd-15 mask →
-floor holds), deliberate nid mismatch → `nidd` visible instead of silent
-blackout.
+- **Boot/migration**: schema-v4 wipe + identity-migration *effects* verified
+  (nid=0, hopdis=1 defaults, schema stamps current); the one-time migration
+  log lines raced past capture attach both times (USB-CDC port timing) —
+  verified via readback instead.
+- **Fixed-mode regression**: byte-identical to #136 — 2.4 Hz RX, 0 CRC
+  fail, 0 netid drop, heartbeats + TX-window (learned cadence 501–505 ms).
+- **SF8/dwell-3 soak**: 30 min, **3,596 packets, 0 loss, 0 CRC, 0 TX-wdog,
+  0 silence, 0 drift-repush** across ~1,200 live retunes (no #521-class
+  incident). Beacon suppression held the entire session (last beacon RX =
+  the second hopping engaged).
+- **SF9/dwell-1 sessions**: 1,123 + 593 + more packets, all 0 loss —
+  hop-every-packet timing holds. Adaptive dwell observed live: `lhdw`
+  3 ↔ 1 tracked cmd-10 SF changes, computed by the firmware itself.
+- **cmd-10 transactional moves**: SF8→SF9→SF8, verify-on-NEW + COMMIT both
+  directions.
+- **Graceful disable drain**: multiple clean passes — `draining retries on
+  the hop channel first` → rocket applied same-second → `drain complete —
+  fixed mode` ≤1.5 s.
+- **BS power-cycle mid-hop**: fully autonomous recovery in ~70 s (silence
+  fallback → rendezvous visit → post-visit bootstrap re-anchor), hop mode
+  persisted through the reboot via NVS.
+- **OC reboot mid-hop** (via reflash): BS silence-fallback fired, full
+  re-acquire after power-on + GPS refix; recovery push-home reconciled the
+  SF split (boot-forced SF8 rocket vs SF9 BS) as designed.
+- **0xFE machinery exercised live**: visit frames + post-visit bootstrap
+  rejoins after both power-cycle scenarios.
+- **Bench findings → fixed same session** (commit 51f134d): (1) enable
+  handoff collided with the BS's own cmd-17 mirror-retry train → rocket
+  now defers activation 1.5 s; (2) the single bootstrap frame was eaten by
+  three different BS-deaf windows (retry train, heartbeat TX, recovery
+  reconfigure racing a slow-rendezvous quiet window) → every (re)bootstrap
+  now sends a dwell-count of packets announcing the schedule-entry channel
+  (occupancy = one dwell visit, FCC-neutral); (3) heartbeat-vs-bootstrap
+  race → BS holds heartbeats 4 s after sending an enable. Post-fix enable
+  handoff measured at ~1 s (activation → BS follow).
+- **Open follow-up (issue chip filed)**: dwell-1 uplink *burst* delivery is
+  intermittent — two 8-retry cmd-17 trains were fully missed while
+  heartbeats delivered ~50%; self-heals ≤60 s via visit + resync, and the
+  flight-standard SF8/dwell-3 preset is unaffected (338/338-session uplink
+  health). Also observed (pre-existing, not #150): the BS recovery cycle
+  and the rocket slow-rendezvous duty cycle can starve each other's
+  windows around state transitions.
+- **Not run**: BS V3 + OC V8 UART-modem pair (V8 radio daughterboard
+  parked on the respin); a full LANDED sim-flight variant — the LANDED
+  machinery is identical to the PRELAUNCH cases exercised, deferred to
+  Seam B.
+- End state: both ends restored to flight-standard 915/SF8/fixed, all
+  counters clean.
+
+### Seam B — ⏳ pending (E2E with app, after Phases 4–5)
+
+Onboarding + provisioning with network name, mode picker both directions
+(now expecting ~1–3 s handoffs), mid-hop manual scan (cmd-16 pause →
+cmd-15 mask → floor holds), deliberate nid mismatch → `nidd` visible
+instead of silent blackout, LANDED sim flight, UART-modem pair when the
+V8 radio board returns.

--- a/docs/plans/150-fhss-reenable.md
+++ b/docs/plans/150-fhss-reenable.md
@@ -327,10 +327,35 @@ zero-hash to 1 (0 collides with the firmware default and the app's unset
 sentinel); the hop/nidd readouts live on the real dashboard card (first
 draft put them on a never-instantiated view).  Simulator suite: 181/181.
 
-### Seam B — ⏳ pending (E2E with app, after Phases 4–5)
+### Seam B — RUN 2026-07-16 morning (app-driven E2E): PASS
 
-Onboarding + provisioning with network name, mode picker both directions
-(now expecting ~1–3 s handoffs), mid-hop manual scan (cmd-16 pause →
-cmd-15 mask → floor holds), deliberate nid mismatch → `nidd` visible
-instead of silent blackout, LANDED sim flight, UART-modem pair when the
-V8 radio board returns.
+1. **Settings surfaces** ✅ — Link Mode picker, FCC footer, TX-power lock
+   while hopping, Network section with mismatch badge all rendered and
+   behaved as designed (user screenshots).
+2. **Mode toggling from the app** ✅ — mode applied <1 s; the observed
+   "slow engage" was decomposed into (a) dormant-by-design in READY
+   (GPS refix ≈ 2.5 min) and (b) one lost-handoff heal — both now
+   narrated by the three-state tile badge (armed / engaging… / active).
+3. **Mid-hop Frequency Scan** ✅ — coordinated pause (cmd 16 received
+   same-second) → 5-pass scan → `65/69 channels active (min FCC floor
+   50)` mask push (cmd 15 received) → resume.  Finding: the BS's push
+   landed at the rocket's resume deadline (pause clock starts at cmd-16
+   receipt, BS spends ~2 s confirming the park first) → resume-bootstrap
+   collision, ~46 s fallback heal.  Fixed: pause slack 2 s → 5 s.
+4. **NetID mismatch drill** ✅ — BS synced to 122 while rocket at 0:
+   orange dashboard banner with live drop count (64 → 137), stale
+   telemetry as expected; rocket-side sync restored the link.  Finding:
+   the lifetime counter kept the banner up after healing — fixed by
+   reporting drops over BLE only within 30 s of the last actual drop.
+   nid persistence across a rocket power-cycle observed (`nid=122` on
+   boot).
+5. **Full sim flight** ✅ — PRELAUNCH hop engage in ~1 s of the state
+   transition (3-packet bootstrap), continuous session through boost
+   (max 99 m/s) and descent with **2 packets lost, 1 CRC, 0 wdog, 0 nid
+   drops**, and the first live **LANDED-mode hopping** (`nextCh`
+   advancing after touchdown) — the FCC change #150 exists for.
+   Cosmetic finding fixed: the entry-channel announce in bootstrap
+   frames false-fired the mask-drift warn on session-start frames.
+
+Still deferred: UART-modem pair (BS V3 + OC V8) until the V8 radio
+daughterboard respin returns.

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -371,6 +371,9 @@ add_executable(test_bs_uplink_txwin test_bs_uplink_txwin.cpp)
 target_include_directories(test_bs_uplink_txwin PRIVATE
     ${SHIM_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../tinkerrocket-idf/projects/base_station/main
+    # bs_uplink_txwin.h delegates its time-on-air to the shared
+    # loraTimeOnAirMs (#150) so BS window math and hop-dwell math agree
+    ${LIB_DIR}/TR_RocketComputerTypes
 )
 target_link_libraries(test_bs_uplink_txwin GTest::gtest_main)
 gtest_discover_tests(test_bs_uplink_txwin)

--- a/tests_cpp/test_bs_uplink_txwin.cpp
+++ b/tests_cpp/test_bs_uplink_txwin.cpp
@@ -64,6 +64,20 @@ TEST(BsUplinkTxwin, TimeOnAirHandlesDegenerateInputs) {
     EXPECT_GT(timeOnAirMs(22, 8, 0.0f, 5), 0u);         // bad BW falls back
 }
 
+TEST(BsUplinkTxwin, DelegatesToTheSharedLoraTimeOnAir) {
+    // #150 moved the formula into RocketComputerTypes.h so the hop-dwell
+    // math and the TX-window math cannot drift apart.  Pin the delegation
+    // (this call site keeps its historical preamble-8 default).
+    const size_t lens[] = {0, 6, 22, 46, 66};
+    for (uint8_t sf = 7; sf <= 11; sf++) {
+        for (size_t len : lens) {
+            EXPECT_EQ(timeOnAirMs(len, sf, 250.0f, 5),
+                      loraTimeOnAirMs(len, sf, 250.0f, 5, 8))
+                << "sf=" << (int)sf << " len=" << len;
+        }
+    }
+}
+
 // ---- The window ----
 
 // Right after a packet lands, the air is ours.

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -365,22 +365,25 @@ TEST(LoraPickQuietestChannel, TiesFavorLowerIndex) {
 // Issues #40 / #41: per-packet channel hopping — state gate
 // ============================================================================
 
-TEST(ShouldHopInState, OnlyPrelaunchAndInflight) {
-    // Hopping is intentionally gated to the two states where the rocket
-    // is committed to its modulation config and isn't in a recovery /
-    // pre-handshake situation.  Ground states (READY/LANDED/INIT) stay
-    // on the static channel so config and recovery work as before.
+TEST(ShouldHopInState, TelemetryStatesHopGroundSetupStatesDont) {
+    // #150: every state that streams full-rate (2 Hz) telemetry hops —
+    // that's what keeps per-frequency airtime under the FCC 15.247 FHSS
+    // occupancy bound.  LANDED transmits just as hard as INFLIGHT, so it
+    // hops too (parking 2 Hz on one channel is ~2.1 s per 10 s, 5x the
+    // 0.4 s bound).  Ground setup states (INIT/READY/MAG_CAL) stay on
+    // the static channel so config and the initial handshake stay simple.
     EXPECT_FALSE(shouldHopInState(INITIALIZATION));
     EXPECT_FALSE(shouldHopInState(READY));
     EXPECT_TRUE (shouldHopInState(PRELAUNCH));
     EXPECT_TRUE (shouldHopInState(INFLIGHT));
-    EXPECT_FALSE(shouldHopInState(LANDED));
+    EXPECT_TRUE (shouldHopInState(LANDED));
+    EXPECT_FALSE(shouldHopInState(MAG_CALIBRATION));
 }
 
 TEST(ShouldHopInState, Uint8OverloadMatchesEnum) {
     // The BS receives state numerically from the LoRa downlink, so the
     // uint8_t overload must agree bit-for-bit with the enum overload.
-    for (uint8_t s = 0; s <= 4; s++)
+    for (uint8_t s = 0; s <= 5; s++)
     {
         EXPECT_EQ(shouldHopInState(s),
                   shouldHopInState((RocketState)s)) << "state=" << (int)s;
@@ -611,10 +614,13 @@ TEST(RocketLikelyHopping, RecentHopStateTrue) {
 }
 
 TEST(RocketLikelyHopping, RecentNonHopStateFalse) {
-    // Recent RX but in READY/INIT/LANDED — direct scan path is correct.
+    // Recent RX but in READY/INIT — direct scan path is correct.
     EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, READY,         10000));
     EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, INITIALIZATION,10000));
-    EXPECT_FALSE(rocketLikelyHopping(false, 95000, 100000, LANDED,        10000));
+    // #150: LANDED hops now (2 Hz telemetry continues after landing), so a
+    // recent LANDED packet means a scan must take the coordinated-pause
+    // path — a direct scan would drop the link mid-schedule.
+    EXPECT_TRUE (rocketLikelyHopping(false, 95000, 100000, LANDED,        10000));
 }
 
 // ============================================================================
@@ -1032,4 +1038,218 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 87u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
+}
+
+// ============================================================================
+// Issue #150: adaptive FCC hop dwell — airtime-derived, compliance-bounded
+// ============================================================================
+// FCC 15.247 FHSS binds accumulated TRANSMIT AIRTIME on any single
+// frequency: < 0.4 s per 10 s window at channel BW >= 250 kHz, per 20 s
+// window below.  The schedule satisfies it per-visit (`dwell` packets on
+// one channel) as long as one full cycle outlasts the window, so a channel
+// is never revisited inside it.  Both halves are pinned here against the
+// shared airtime formula that the OC scheduler and BS follower use.
+
+namespace fhss150 {
+// Production telemetry frame: sizeof(LoRaData), pinned at 66 by the
+// header's static_asserts.  Growing the frame has a real regulatory cost —
+// it pushes the SF10/BW250 long-range rung over the dwell budget first —
+// so the table below fails deliberately if it changes.
+constexpr size_t  kTelemFrameLen = SIZE_OF_LORA_DATA;
+constexpr uint8_t kCr            = LORA_FACTORY_RENDEZVOUS_CR;  // 4/5 on both ends
+// = out_computer config.h LORA_TX_RATE_HZ.  Telemetry is an unconditional
+// 2 Hz in every transmitting state.  If the rate ever rises, re-derive the
+// revisit bound below — BW125 hopping stops being legal near 4 Hz.
+constexpr float   kTxRateHz      = 2.0f;
+// Current name-beacon frame (sync + id + name).  Update if it grows.
+constexpr size_t  kBeaconLen     = 23;
+
+inline uint32_t telemToaMs(uint8_t sf, float bw_khz) {
+    return loraTimeOnAirMs(kTelemFrameLen, sf, bw_khz, kCr,
+                           LORA_TELEM_PREAMBLE_SYMS);
+}
+inline uint32_t fccWindowSec(float bw_khz) {
+    return (bw_khz >= 250.0f) ? 10u : 20u;
+}
+}  // namespace fhss150
+
+TEST(LoraTimeOnAir, PinsTheNumbersTheDwellTableRestsOn) {
+    using namespace fhss150;
+    // Semtech AN1200.13 at the production frame (66 B, preamble 12, CR4/5).
+    EXPECT_NEAR(telemToaMs(8,  250.0f), 112.0, 2.0);
+    EXPECT_NEAR(telemToaMs(9,  250.0f), 203.0, 2.0);
+    // The long-range rung: 14 ms under the FCC 400 ms occupancy line.
+    EXPECT_NEAR(telemToaMs(10, 250.0f), 386.0, 3.0);
+    // SF11 @ BW250 cannot fit even one packet in the budget.
+    EXPECT_GT(telemToaMs(11, 250.0f), LORA_HOP_DWELL_BUDGET_MS);
+}
+
+TEST(LoraHopDwell, AdaptiveTable) {
+    using namespace fhss150;
+    // The ladder the iOS picker exposes (0 = hopping unavailable, GUI
+    // greys the option).  Derived, not designed — if any row changes,
+    // either the frame grew or someone touched the budget: both are
+    // regulatory decisions that must be made consciously.
+    struct Row { uint8_t sf; float bw; uint8_t dwell; };
+    const Row rows[] = {
+        {7,  250.0f, 4}, {8,  250.0f, 3}, {9,  250.0f, 1},
+        {10, 250.0f, 1},                       // the +5 dB long-range rung
+        {11, 250.0f, 0}, {12, 250.0f, 0},
+        {7,  125.0f, 3}, {8,  125.0f, 1}, {9,  125.0f, 0}, {10, 125.0f, 0},
+        {7,  500.0f, 4}, {8,  500.0f, 4}, {9,  500.0f, 3},
+        {10, 500.0f, 2}, {11, 500.0f, 1}, {12, 500.0f, 0},
+    };
+    for (const auto& r : rows) {
+        EXPECT_EQ(loraHopDwellForConfig(r.sf, r.bw, kTelemFrameLen, kCr),
+                  r.dwell)
+            << "SF" << (int)r.sf << "/BW" << r.bw
+            << " toa=" << telemToaMs(r.sf, r.bw) << " ms";
+    }
+}
+
+TEST(LoraHopDwell, ComplianceInvariant) {
+    using namespace fhss150;
+    // The binding check: for EVERY modulation the firmware can be
+    // configured into, either hopping is refused (dwell 0) or a full
+    // dwell visit stays under the FCC 400 ms occupancy line.
+    const float bws[] = {125.0f, 250.0f, 500.0f};
+    for (uint8_t sf = 6; sf <= 12; sf++) {
+        for (float bw : bws) {
+            const uint8_t d = loraHopDwellForConfig(sf, bw, kTelemFrameLen, kCr);
+            if (d == 0) continue;
+            EXPECT_LE(d * telemToaMs(sf, bw), 400u)
+                << "SF" << (int)sf << "/BW" << bw << " dwell=" << (int)d;
+        }
+    }
+}
+
+TEST(LoraHopDwell, FullCycleRevisitOutlastsTheFccWindow) {
+    using namespace fhss150;
+    // Per-visit occupancy is only sufficient if a channel is never
+    // revisited inside the window.  Worst case is the FCC floor channel
+    // count (skip-mask at its most aggressive) at the production TX rate.
+    const float bws[] = {125.0f, 250.0f, 500.0f};
+    for (uint8_t sf = 6; sf <= 12; sf++) {
+        for (float bw : bws) {
+            const uint8_t d = loraHopDwellForConfig(sf, bw, kTelemFrameLen, kCr);
+            if (d == 0) continue;
+            const float cycle_s =
+                (float)loraFhssMinChannels(bw) * (float)d / kTxRateHz;
+            EXPECT_GE(cycle_s, (float)fccWindowSec(bw))
+                << "SF" << (int)sf << "/BW" << bw << " dwell=" << (int)d;
+        }
+    }
+}
+
+TEST(LoraHopDwell, BeaconSuppressionDuringHopIsLoadBearing) {
+    using namespace fhss150;
+    // Name beacons transmit every 2 s in non-INFLIGHT states.  If one
+    // rode a hop-dwell channel visit at the long-range rung, the visit
+    // would blow the occupancy line — which is exactly why the OC
+    // suppresses beacons while hop_active_ (they'd ride hop channels the
+    // BS already follows, so they add nothing either).
+    const uint8_t d10 = loraHopDwellForConfig(10, 250.0f, kTelemFrameLen, kCr);
+    ASSERT_GT(d10, 0);
+    const uint32_t beacon_toa =
+        loraTimeOnAirMs(kBeaconLen, 10, 250.0f, kCr, LORA_TELEM_PREAMBLE_SYMS);
+    EXPECT_GT(d10 * telemToaMs(10, 250.0f) + beacon_toa, 400u)
+        << "if this passes, beacon suppression stopped being load-bearing";
+    // Even at SF8 (dwell 3) a beacon would leave ~zero margin: 336+61=397.
+    const uint32_t beacon8 =
+        loraTimeOnAirMs(kBeaconLen, 8, 250.0f, kCr, LORA_TELEM_PREAMBLE_SYMS);
+    EXPECT_LE(3 * telemToaMs(8, 250.0f) + beacon8, 400u);
+}
+
+TEST(LoraHopChannelForSeq, ExactUniformityOverFullCycles) {
+    // FCC: "each frequency used equally on the average".  The
+    // deterministic round-robin is EXACTLY uniform over whole cycles —
+    // every active channel gets k*dwell packets, masked channels get 0 —
+    // from ANY starting seq.  start=0 doubles as the rocket-reboot
+    // (seq reset) case: a reboot restarts the schedule but cannot bias
+    // long-run channel use.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    constexpr uint8_t n = 69;             // BW250 table
+    for (uint8_t i = 0; i < 19; i++) {    // mask 19 → n_active = 50 (floor)
+        loraSkipMaskSet(mask, (uint8_t)(i * 3 + 1));
+    }
+    constexpr uint8_t  dwell    = 3;      // = loraHopDwellForConfig @ SF8/BW250
+    constexpr uint16_t n_active = 50;
+    constexpr uint16_t cycle    = dwell * n_active;
+    constexpr uint16_t k        = 3;
+    const uint16_t starts[] = {0, 12345};
+    for (uint16_t start : starts) {
+        uint32_t counts[256] = {0};
+        for (uint32_t s = start; s < (uint32_t)start + k * cycle; s++) {
+            counts[loraHopChannelForSeq((uint16_t)s, dwell, mask, n)]++;
+        }
+        for (uint8_t c = 0; c < n; c++) {
+            if (loraSkipMaskTest(mask, c)) {
+                EXPECT_EQ(counts[c], 0u) << "masked ch " << (int)c
+                                         << " start=" << start;
+            } else {
+                EXPECT_EQ(counts[c], (uint32_t)(k * dwell))
+                    << "active ch " << (int)c << " start=" << start;
+            }
+        }
+    }
+}
+
+TEST(LoraHopChannelForSeq, U16WrapKeepsLongRunUseNearUniform) {
+    // 65536 is not a whole number of cycles, so each u16 epoch hands at
+    // most one extra dwell-window to some channels.  Bound the spread —
+    // this is the long-run "equal use on average" property across seq
+    // wraps.
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    constexpr uint8_t n     = 69;
+    constexpr uint8_t dwell = 3;
+    uint32_t counts[256] = {0};
+    for (uint32_t s = 0; s < 65536; s++) {
+        counts[loraHopChannelForSeq((uint16_t)s, dwell, mask, n)]++;
+    }
+    uint32_t mn = UINT32_MAX, mx = 0;
+    for (uint8_t c = 0; c < n; c++) {
+        if (counts[c] < mn) mn = counts[c];
+        if (counts[c] > mx) mx = counts[c];
+    }
+    EXPECT_LE(mx - mn, (uint32_t)dwell);
+}
+
+TEST(LoraHopSchedule, ManualScanHandoffKeepsFloorAndCoverage) {
+    using namespace fhss150;
+    // The pure-function path a user's manual Frequency Scan takes while
+    // hopping (#150, settled decision 3): hostile scan → channel-set
+    // selection enforces the FCC floor → the seq schedule then cycles
+    // EXACTLY the surviving active set.
+    const uint8_t n = loraChannelCount(250.0f);
+    ASSERT_GE(n, 50u);
+    float  freqs[139];
+    int8_t rssi[139];
+    for (uint8_t i = 0; i < n; i++) {
+        freqs[i] = loraChannelMHz(250.0f, i);
+        rssi[i]  = (i % 5 == 0) ? -100 : -50;   // most channels loud
+    }
+    LoRaChannelSetSelection out{};
+    loraSelectChannelSet(freqs, rssi, n, 250.0f, &out);
+
+    uint16_t n_active = 0;
+    for (uint8_t i = 0; i < out.n_channels; i++) {
+        if (!loraSkipMaskTest(out.skip_mask, i)) n_active++;
+    }
+    ASSERT_GE(n_active, loraFhssMinChannels(250.0f));
+
+    const uint8_t dwell = loraHopDwellForConfig(8, 250.0f, kTelemFrameLen, kCr);
+    ASSERT_GT(dwell, 0);
+    uint32_t counts[256] = {0};
+    const uint32_t cycle = (uint32_t)dwell * n_active;
+    for (uint32_t s = 0; s < cycle; s++) {
+        counts[loraHopChannelForSeq((uint16_t)s, dwell, out.skip_mask,
+                                    out.n_channels)]++;
+    }
+    for (uint8_t c = 0; c < out.n_channels; c++) {
+        if (loraSkipMaskTest(out.skip_mask, c)) {
+            EXPECT_EQ(counts[c], 0u) << "masked ch " << (int)c;
+        } else {
+            EXPECT_EQ(counts[c], (uint32_t)dwell) << "active ch " << (int)c;
+        }
+    }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -1253,3 +1253,86 @@ TEST(LoraHopSchedule, ManualScanHandoffKeepsFloorAndCoverage) {
         }
     }
 }
+
+// ============================================================================
+// Issue #150 review fixes: CR link gate, home-channel skip, 0xFE sentinel
+// ============================================================================
+
+TEST(LoraHopDwell, LinkGateRefusesNonFactoryCr) {
+    using namespace fhss150;
+    // CR-only cmd-10 changes are unverifiable over the air (explicit-header
+    // RX decodes any payload CR, so the transaction's commit criterion is
+    // CR-blind) — a one-sided CR commit would give the two ends different
+    // dwells with no heal short of reboot.  The link gate refuses hopping
+    // at any CR but the factory one, so no packet-loss pattern can split
+    // the schedule.
+    EXPECT_EQ(loraHopDwellForLink(8, 250.0f, kTelemFrameLen,
+                                  LORA_FACTORY_RENDEZVOUS_CR),
+              loraHopDwellForConfig(8, 250.0f, kTelemFrameLen,
+                                    LORA_FACTORY_RENDEZVOUS_CR));
+    for (uint8_t cr = 6; cr <= 8; cr++) {
+        EXPECT_EQ(loraHopDwellForLink(8, 250.0f, kTelemFrameLen, cr), 0)
+            << "cr=" << (int)cr;
+    }
+}
+
+TEST(LoraHomeChannelSkip, OffGridFactoryRendezvousIsNoOp) {
+    // 915.0 sits between BW250 grid channels (902.125 + 0.375k), so the
+    // factory default never coincides and the skip is a no-op there.
+    EXPECT_EQ(loraGridIndexOfFreq(250.0f, LORA_FACTORY_RENDEZVOUS_MHZ), -1);
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    EXPECT_FALSE(loraApplyHomeChannelSkip(mask, 250.0f,
+                                          LORA_FACTORY_RENDEZVOUS_MHZ));
+    for (size_t i = 0; i < LORA_SKIP_MASK_MAX_BYTES; i++) {
+        EXPECT_EQ(mask[i], 0u);
+    }
+}
+
+TEST(LoraHomeChannelSkip, OnGridHomeIsExcludedFromTheSchedule) {
+    // A scan-applied operating frequency CAN land exactly on a grid
+    // channel; hop-session transition packets transmit on it outside the
+    // schedule, so the coincident slot is implicitly skipped on both ends
+    // — otherwise a transition packet plus a scheduled dwell visit could
+    // stack past the FCC 400 ms occupancy line in one window.
+    const float home = loraChannelMHz(250.0f, 34);   // 914.875 MHz, on-grid
+    EXPECT_EQ(loraGridIndexOfFreq(250.0f, home), 34);
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    ASSERT_TRUE(loraApplyHomeChannelSkip(mask, 250.0f, home));
+    EXPECT_TRUE(loraSkipMaskTest(mask, 34));
+    const uint8_t n = loraChannelCount(250.0f);
+    for (uint16_t s = 0; s < (uint16_t)(4 * n); s++) {
+        EXPECT_NE(loraHopChannelForSeq(s, 3, mask, n), 34) << "seq=" << s;
+    }
+}
+
+TEST(LoraHomeChannelSkip, WithheldAtTheFccFloor) {
+    // The implicit skip must never take the active count below the FCC
+    // floor — in that corner the coincidence risk is accepted and the
+    // floor wins.
+    const uint8_t n     = loraChannelCount(250.0f);
+    const uint8_t floor_ = loraFhssMinChannels(250.0f);
+    ASSERT_GT(n, floor_);
+    uint8_t mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
+    uint8_t masked = 0;
+    for (uint8_t i = 0; i < n && masked < (uint8_t)(n - floor_); i++) {
+        if (i == 34) continue;              // keep the home channel active
+        loraSkipMaskSet(mask, i);
+        masked++;
+    }
+    // Exactly `floor_` channels remain active; the skip must be withheld.
+    EXPECT_FALSE(loraApplyHomeChannelSkip(mask, 250.0f,
+                                          loraChannelMHz(250.0f, 34)));
+    EXPECT_FALSE(loraSkipMaskTest(mask, 34));
+}
+
+TEST(LoraHopSentinels, OffScheduleMarkerCannotCollideWithChannelIndices) {
+    // 0xFE ("hopping, momentarily off-schedule") and 0xFF ("not hopping")
+    // must stay clear of every real channel index at every bandwidth —
+    // loraChannelCount caps at 253 to guarantee it.
+    EXPECT_NE(LORA_NEXT_CH_HOP_OFFSCHEDULE, LORA_NEXT_CH_NO_HOP);
+    EXPECT_LE(loraChannelCount(125.0f), 253);
+    EXPECT_LE(loraChannelCount(250.0f), 253);
+    EXPECT_LE(loraChannelCount(500.0f), 253);
+    EXPECT_GT((int)LORA_NEXT_CH_HOP_OFFSCHEDULE,
+              (int)loraChannelCount(125.0f));
+}

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1736,6 +1736,17 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("rssi", data.rssi, 0);
     addFloat("snr", data.snr, 1);
 
+    // #150: hop-state surface.  "hch" (current hop channel index) is only
+    // emitted while the BS is actually following a hop schedule; "nidd"
+    // (network-id mismatch drops) only once any occurred.  Fixed-mode
+    // frames with a healthy nid pay zero bytes for either.
+    if (data.hop_active) {
+        addUint("hch", data.hop_channel_idx);
+    }
+    if (data.netid_drops > 0) {
+        addUint("nidd", data.netid_drops);
+    }
+
     // Base station
     addFloat("bsoc", data.bs_soc, 1);
     addFloat("bvol", data.bs_voltage, 2);

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -63,6 +63,15 @@ public:
         float rssi;             // LoRa RSSI dBm
         float snr;              // LoRa SNR dB
 
+        // #150: hop-state surface (base station only; zero-defaults keep
+        // FC/OC direct connections silent).  hop_channel_idx is only
+        // meaningful while hop_active; netid_drops counts RX packets the
+        // network-id filter dropped (nid-drift diagnostic — the #133-era
+        // drift bug was invisible because these drops were silent).
+        bool     hop_active = false;
+        uint8_t  hop_channel_idx = 0;
+        uint32_t netid_drops = 0;
+
         // Base station (only meaningful when connected via base station)
         float bs_soc;           // Base station battery SOC %
         float bs_voltage;       // Base station battery voltage V

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -150,7 +150,22 @@ static inline bool shouldHopInState(uint8_t s)
 static constexpr float   LORA_BAND_LO_MHZ        = 902.0f;  // US ISM band low edge
 static constexpr float   LORA_BAND_HI_MHZ        = 928.0f;  // US ISM band high edge
 static constexpr float   LORA_CHANNEL_SPACING_X  = 1.5f;    // spacing as multiple of BW
-static constexpr uint8_t LORA_NEXT_CH_NO_HOP     = 0xFF;    // sentinel: don't hop
+static constexpr uint8_t LORA_NEXT_CH_NO_HOP     = 0xFF;    // sentinel: not hopping
+
+// #150: second sentinel — "hop session active, but this frame is
+// momentarily off-schedule" (rendezvous visit or coordinated-scan pause).
+// Distinguishes a genuinely-fixed rocket (0xFF) from a hopping one that a
+// listening BS has lost: a fixed-mode BS hearing 0xFE has immediate
+// mode-mismatch evidence while the rocket is parked and LISTENING on the
+// shared rendezvous — exactly the window where a cmd-17 push can land —
+// and a hop-enabled BS knows to hold its channel for the rocket's return
+// rather than treating the frame as "not hopping".  Real channel indices
+// top out at 130 (BW125); loraChannelCount caps at 253 so neither
+// sentinel can collide.  Requires both ends flashed together (same
+// coordinated-re-flash rule the dwell change already imposes); an old BS
+// would misread 0xFE as a channel index and get a 0.0 MHz sentinel from
+// loraChannelMHz.
+static constexpr uint8_t LORA_NEXT_CH_HOP_OFFSCHEDULE = 0xFE;
 
 // ============================================================================
 // LoRa factory rendezvous (#105 follow-up): a single shared known-good config
@@ -192,7 +207,7 @@ static inline uint8_t loraChannelCount(float bw_khz)
     const float span     = max_f - min_f;
     const int   n        = (int)(span / spacing) + 1;
     if (n < 1)   return 0;
-    if (n > 255) return 255;  // cap so idx fits in the 1-byte header field
+    if (n > 253) return 253;  // cap below the 0xFE/0xFF header sentinels
     return (uint8_t)n;
 }
 
@@ -380,6 +395,52 @@ static inline void loraSkipMaskSet(uint8_t* mask, uint8_t idx)
     mask[idx >> 3] |= (uint8_t)(1u << (idx & 7));
 }
 
+// #150: index of the hop-grid channel whose center coincides with
+// freq_mhz (10 kHz tolerance), or -1.  The factory rendezvous 915.0 is
+// deliberately OFF the BW250 grid (channels sit at 902.125 + 0.375k),
+// but a scan-applied operating frequency can land exactly on a grid
+// channel.
+static inline int16_t loraGridIndexOfFreq(float bw_khz, float freq_mhz)
+{
+    const uint8_t n = loraChannelCount(bw_khz);
+    for (uint8_t i = 0; i < n; i++)
+    {
+        const float c = loraChannelMHz(bw_khz, i);
+        const float d = (c > freq_mhz) ? (c - freq_mhz) : (freq_mhz - c);
+        if (d < 0.010f) return (int16_t)i;
+    }
+    return -1;
+}
+
+// #150: implicit "home channel" skip.  Hop-session transition packets
+// (bootstraps after activation, rendezvous visits, scan pauses) transmit
+// on lora_freq_mhz OUTSIDE the seq-anchored schedule.  If that frequency
+// is also a grid channel the schedule visits, a transition packet plus a
+// scheduled dwell visit can stack inside one FCC window and exceed the
+// 400 ms occupancy line (e.g. SF8/BW250: 336 + 112 = 448 ms).  Fix: both
+// ends implicitly skip the coincident grid slot so the schedule never
+// dwells on the home frequency.  The skip is withheld when it would take
+// the active count below the FCC floor (that corner requires a
+// floor-tight mask AND an on-grid home — accept the residual and keep
+// the floor).  Apply to a caller-owned mask copy; returns true if a bit
+// was set.  Pure — both ends compute identically from (bw, home freq).
+static inline bool loraApplyHomeChannelSkip(uint8_t* mask, float bw_khz,
+                                            float home_freq_mhz)
+{
+    const int16_t idx = loraGridIndexOfFreq(bw_khz, home_freq_mhz);
+    if (idx < 0) return false;
+    if (loraSkipMaskTest(mask, (uint8_t)idx)) return false;
+    const uint8_t n = loraChannelCount(bw_khz);
+    uint8_t active = 0;
+    for (uint8_t i = 0; i < n; i++)
+    {
+        if (!loraSkipMaskTest(mask, i)) active++;
+    }
+    if (active <= loraFhssMinChannels(bw_khz)) return false;
+    loraSkipMaskSet(mask, (uint8_t)idx);
+    return true;
+}
+
 // Given the current channel index and a skip-mask, returns the next
 // active (non-skipped) channel index, wrapping at n_channels.  Used by
 // both sides when computing next_channel_idx for the hop header.  If
@@ -458,10 +519,6 @@ static constexpr uint16_t LORA_TELEM_PREAMBLE_SYMS = 12;  // = LORA_PREAMBLE_LEN
 // budget => hopping is not permitted at this config (e.g. SF9+ @ BW125,
 // SF11+ @ BW250) — firmware refuses the cmd-17 enable and the app greys
 // the option (config JSON key "lhdw" == 0).
-//
-// Both ends derive dwell from the cmd-10-synced (sf, bw, cr) plus the
-// compile-time frame size, so they cannot disagree — the same property
-// that keeps the channel table itself in agreement.
 static inline uint8_t loraHopDwellForConfig(uint8_t sf, float bw_khz,
                                             size_t frame_len,
                                             uint8_t cr = LORA_FACTORY_RENDEZVOUS_CR)
@@ -471,6 +528,24 @@ static inline uint8_t loraHopDwellForConfig(uint8_t sf, float bw_khz,
     if (toa == 0 || toa > LORA_HOP_DWELL_BUDGET_MS) return 0;
     const uint32_t d = LORA_HOP_DWELL_BUDGET_MS / toa;
     return (d > LORA_HOP_DWELL_MAX) ? LORA_HOP_DWELL_MAX : (uint8_t)d;
+}
+
+// Link-level dwell gate — what the firmware actually calls (#150 review).
+// sf/bw agreement is guaranteed by the cmd-10 transaction (a divergence
+// there kills the link and rolls back), but CR is NOT verifiable: the
+// explicit-header PHY decodes any payload coding rate, so the cmd-10
+// commit criterion is CR-blind and a one-sided CR-only commit leaves a
+// fully working link whose two ends would compute DIFFERENT dwells
+// (SF8/BW250: 3 at CR5 vs 2 at CR8 — schedule divergence with no heal
+// short of reboot).  Rather than make CR load-bearing, hopping is only
+// offered at the factory CR: any other CR computes dwell 0 (hopping
+// unavailable, app greys the option via "lhdw"), which no packet-loss
+// pattern can turn into a silent schedule split.
+static inline uint8_t loraHopDwellForLink(uint8_t sf, float bw_khz,
+                                          size_t frame_len, uint8_t cr)
+{
+    if (cr != LORA_FACTORY_RENDEZVOUS_CR) return 0;
+    return loraHopDwellForConfig(sf, bw_khz, frame_len, cr);
 }
 
 // Seq-anchored hop schedule (#105 follow-up).  Both sides compute the

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -95,22 +95,28 @@ static inline bool shouldBeaconInState(RocketState s)
 }
 
 // Whether per-packet channel hopping should be active in this state.
-// PRELAUNCH and INFLIGHT only — ground states (READY/LANDED/INITIALIZATION)
-// stay on the static configured channel so configuration, recovery, and
-// initial handshake stay simple and predictable.
+// PRELAUNCH, INFLIGHT, and LANDED — every state where the rocket streams
+// telemetry at the full unconditional 2 Hz cadence.  Ground setup states
+// (READY/INITIALIZATION/MAG_CALIBRATION) stay on the static configured
+// channel so configuration and the initial handshake stay simple and
+// predictable.
 //
 // Hopping starts at PRELAUNCH (rather than INFLIGHT) so the behaviour gets
 // real ground-test airtime before the rocket leaves the pad — that's the
 // window where defects are cheap to find.
 //
-// Edge case: a post-flight LANDED → PRELAUNCH transition (rocket regains
-// GPS without a power cycle) would also activate hopping, which is
-// suboptimal for recovery.  The existing rendezvous fallback recovers
-// from this gracefully if it ever happens; revisit with a sticky
-// "post-flight" gate if it bites.
+// LANDED hops too (#150): telemetry keeps its 2 Hz cadence after landing,
+// and parking ~2.1 s of accumulated airtime per 10 s on ONE frequency is
+// 5x the FCC 15.247 FHSS occupancy bound (0.4 s per 10 s window).
+// Recovery is not hurt: the BS keeps following the schedule, and if the
+// BS power-cycles, the rocket's hop-silence fallback periodically
+// revisits the rendezvous channel where the rebooted BS is waiting.
+// This also erases the old LANDED → PRELAUNCH re-hop edge case that used
+// to be documented here — both states hop now, so the transition is a
+// no-op for the hop schedule.
 static inline bool shouldHopInState(RocketState s)
 {
-    return s == PRELAUNCH || s == INFLIGHT;
+    return s == PRELAUNCH || s == INFLIGHT || s == LANDED;
 }
 
 static inline bool shouldHopInState(uint8_t s)
@@ -130,10 +136,12 @@ static inline bool shouldHopInState(uint8_t s)
 // half-BW guard from its neighbours.  Channel 0 sits half a BW above the
 // low band edge; the last channel sits half a BW below the high edge.  The
 // US 902-928 MHz ISM band fits 35/69/130 channels at the Fast/250kHz/Max
-// Range presets respectively.  All three counts comfortably exceed the
-// FCC Part 15.247 FHSS thresholds (25 channels for BW > 250 kHz, 50 for
-// BW ≤ 250 kHz) — though we operate as digital modulation (DTS), not
-// FHSS, so those thresholds are headroom rather than a binding constraint.
+// Range presets respectively.  All three counts exceed the FCC Part
+// 15.247 FHSS minimums (25 channels at >= 250 kHz-wide channels, 50
+// below), which are BINDING whenever hopping is enabled (#150).  At
+// BW <= 250 kHz we additionally hold >= 50 active channels — the
+// threshold for the 1 W FHSS power tier.  See
+// docs/plans/150-fhss-reenable.md for the full compliance analysis.
 //
 // next_channel_idx in the LoRa header is 1 byte (0..N-1).  The sentinel
 // LORA_NEXT_CH_NO_HOP means "stay on the current channel for one more
@@ -287,7 +295,7 @@ static inline float loraMinValidSnrDb(uint8_t sf)
 // Compute observed packet-loss between two consecutive RXes on the BS,
 // from the rocket's free-running TX sequence counter (#105).  Widened to
 // 16-bit seq in proto v4 (slow-hop seq-anchored hop schedule needs the
-// extra range — see LORA_HOP_DWELL_PACKETS).
+// extra range — see loraHopDwellForConfig()).
 //
 //   prev_seq_signed  : last seq seen (cast from uint16_t), or -1 if no
 //                      prior packet (first contact).  Caller stores as
@@ -347,10 +355,15 @@ static inline bool rocketLikelyHopping(bool hop_active,
     return shouldHopInState(last_rocket_state);
 }
 
-// FCC Part 15.247 minimum channel count for FHSS classification.  We
-// operate as digital modulation (DTS) so this isn't strictly binding,
-// but keeping ≥ this many channels active also preserves the diversity
-// that motivates hopping in the first place.
+// FCC Part 15.247 minimum active-channel floor for FHSS operation —
+// BINDING while hopping is enabled (#150).  The rule (15.247(a)(1)):
+// >= 25 hopping frequencies when the 20 dB channel bandwidth is
+// >= 250 kHz, >= 50 below that.  We hold a floor of 50 at BW <= 250 kHz
+// (stricter than the rule requires at BW250) because 50+ channels is
+// also what unlocks the 1 W FHSS power tier.  Note fixed-channel mode
+// is NOT the "DTS" alternative the old comment here claimed: DTS
+// requires >= 500 kHz of 6 dB bandwidth, which a 125/250 kHz LoRa
+// carrier does not have.  See docs/plans/150-fhss-reenable.md.
 static inline uint8_t loraFhssMinChannels(float bw_khz)
 {
     return (bw_khz <= 250.0f) ? 50 : 25;
@@ -384,6 +397,82 @@ static inline uint8_t loraNextActiveChannelIdx(
     return (uint8_t)((current_idx + 1) % n_channels);
 }
 
+// ============================================================================
+// LoRa time-on-air + FCC hop-dwell derivation (#150)
+// ============================================================================
+// Semtech AN1200.13 airtime formula, shared so the OC (which schedules
+// the hop), the BS (which follows it), and the host tests all compute
+// the SAME number.  bs_uplink_txwin.h delegates here for its TX-window
+// math — do not fork the formula.
+static inline uint32_t loraTimeOnAirMs(size_t payload_len, uint8_t sf, float bw_khz,
+                                       uint8_t cr /* 5..8 => 4/5..4/8 */,
+                                       uint16_t preamble_syms)
+{
+    if (sf < 6)   sf = 6;
+    if (sf > 12)  sf = 12;
+    if (bw_khz <= 0.0f) bw_khz = 125.0f;
+
+    // cr is the denominator form used in config (5 == 4/5). The formula wants 1..4.
+    int cr_idx = (int)cr - 4;
+    if (cr_idx < 1) cr_idx = 1;
+    if (cr_idx > 4) cr_idx = 4;
+
+    const float ts_ms = (float)(1u << sf) / bw_khz;      // symbol time, ms (bw in kHz)
+    const float preamble_ms = ((float)preamble_syms + 4.25f) * ts_ms;
+
+    // Low-data-rate optimise kicks in when a symbol is long (SF11/12 @125k).
+    const int de = (ts_ms >= 16.0f) ? 1 : 0;
+
+    const int num = 8 * (int)payload_len - 4 * (int)sf + 28 + 16;   // explicit header, CRC on
+    const int den = 4 * ((int)sf - 2 * de);
+    int n_payload = 0;
+    if (num > 0 && den > 0)
+    {
+        n_payload = ((num + den - 1) / den) * (cr_idx + 4);   // ceil(num/den) * (CR+4)
+    }
+    const float payload_ms = (float)(8 + n_payload) * ts_ms;
+
+    return (uint32_t)(preamble_ms + payload_ms + 0.5f);
+}
+
+// FCC 15.247 FHSS dwell rule: accumulated transmit airtime on any single
+// frequency must stay under 0.4 s within any 10 s window (channel BW
+// >= 250 kHz; 20 s window below 250 kHz).  For our schedule the bound is
+// the per-VISIT airtime — dwell packets in a row on one channel — since
+// the full-cycle revisit interval (n_active x dwell / TX rate) is far
+// longer than the window (the FullCycleRevisitBound gtest pins that).
+//
+// The budget is 390 ms, not 400: headroom for formula-vs-measured drift,
+// while still admitting the long-range SF10/BW250 rung whose single
+// 66-byte packet is ~386 ms.  Any frame growth pushes SF10 over budget
+// and the AdaptiveTable gtest will fail — that is deliberate: growing
+// the telemetry frame has a real regulatory cost and should be a
+// conscious decision.
+static constexpr uint32_t LORA_HOP_DWELL_BUDGET_MS = 390;
+static constexpr uint8_t  LORA_HOP_DWELL_MAX       = 4;   // #133 slow-hop robustness cap
+static constexpr uint16_t LORA_TELEM_PREAMBLE_SYMS = 12;  // = LORA_PREAMBLE_LEN in both config.h
+
+// Packets-per-channel dwell for the seq-anchored schedule, derived from
+// actual airtime so the FCC occupancy bound holds at every modulation
+// preset (#150).  Returns 0 when even a single packet exceeds the
+// budget => hopping is not permitted at this config (e.g. SF9+ @ BW125,
+// SF11+ @ BW250) — firmware refuses the cmd-17 enable and the app greys
+// the option (config JSON key "lhdw" == 0).
+//
+// Both ends derive dwell from the cmd-10-synced (sf, bw, cr) plus the
+// compile-time frame size, so they cannot disagree — the same property
+// that keeps the channel table itself in agreement.
+static inline uint8_t loraHopDwellForConfig(uint8_t sf, float bw_khz,
+                                            size_t frame_len,
+                                            uint8_t cr = LORA_FACTORY_RENDEZVOUS_CR)
+{
+    const uint32_t toa = loraTimeOnAirMs(frame_len, sf, bw_khz, cr,
+                                         LORA_TELEM_PREAMBLE_SYMS);
+    if (toa == 0 || toa > LORA_HOP_DWELL_BUDGET_MS) return 0;
+    const uint32_t d = LORA_HOP_DWELL_BUDGET_MS / toa;
+    return (d > LORA_HOP_DWELL_MAX) ? LORA_HOP_DWELL_MAX : (uint8_t)d;
+}
+
 // Seq-anchored hop schedule (#105 follow-up).  Both sides compute the
 // physical channel for a given TX seq deterministically from this
 // function — no chained handoff via next_channel_idx.  If the BS misses
@@ -396,8 +485,8 @@ static inline uint8_t loraNextActiveChannelIdx(
 //
 // dwell == 1 reduces to the original "advance every TX" behaviour;
 // dwell >= 2 keeps the rocket on a channel for `dwell` consecutive
-// packets before advancing.  See LORA_HOP_DWELL_PACKETS for the
-// production value.
+// packets before advancing.  The production value is derived per
+// modulation preset by loraHopDwellForConfig() above (#150).
 //
 // Pure helper, host-testable.  O(n_channels) lookup — fine for n ≤ 144.
 static inline uint8_t loraHopChannelForSeq(
@@ -1313,7 +1402,26 @@ static_assert(sizeof(i24le_t) == 3, "i24le_t must be 3 bytes");
 //   v3: dropped rdv_mhz NVS key (rendezvous freq is now compile-time
 //       hardcoded to LORA_FACTORY_RENDEZVOUS_MHZ; cmd 15 no longer
 //       carries a rendezvous freq either).
-static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 3;
+//   v4: #150 hopping re-enable — boot no longer force-overrides
+//       lora_hop_disabled, and the NVS default flips to 1 (fixed mode).
+//       A stale hopdis=0 left over from pre-#150 cmd-17 developer
+//       experiments would otherwise silently boot the device straight
+//       into hopping; the wipe clears it.
+static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 4;
+
+// Identity NVS schema version (#150).  The "identity" namespace (unit
+// name `un`, network id `nid`, and on the OC `rid`) versions SEPARATELY
+// from the "lora" namespace, and on mismatch it MIGRATES rather than
+// wipes.  A wipe here is what caused the #133-era field regression: the
+// lora-namespace schema bump wiped storage, the BS came back on nid=0
+// while the rocket kept nid=180, and the network-id RX filter silently
+// dropped every packet.  Migration policy: never destroy `un` (user
+// data); reset `nid`/`rid` to compile-time defaults only if a future
+// version actually changes those keys' layout; always log the migration
+// loudly.
+//   v1: first versioned layout (un/nid/rid semantics unchanged from the
+//       unversioned era; absent/0 stored version just writes v1).
+static constexpr uint8_t IDENTITY_NVS_SCHEMA_VERSION = 1;
 
 // LoRa protocol version — bump on frame format changes.
 //   v1: original 60-byte frame with 2-byte routing header.
@@ -1327,20 +1435,29 @@ static constexpr uint8_t LORA_NVS_SCHEMA_VERSION = 3;
 //       16 bits covers any (BW, dwell) combination we'd reasonably pick.
 static constexpr uint8_t LORA_PROTO_VERSION = 4;
 
-// Slow-hop dwell — how many consecutive packets the rocket transmits on a
-// single channel before advancing.  At 2 Hz TX with dwell=4, channel
-// changes every 2 s instead of every 500 ms.  This gives the BS up to
-// (dwell-1) consecutive missed packets per channel before it falls out of
-// sync, eliminates BS-side TX-vs-retune races (heartbeat retries no
-// longer collide with hop boundaries), and reduces per-cycle radio churn
-// 4x.  Both rocket and BS compile against the same value; bumping it
-// requires a coordinated re-flash.
+// Slow-hop dwell (#133) — how many consecutive packets the rocket
+// transmits on a single channel before advancing.  Dwell > 1 gives the
+// BS up to (dwell-1) consecutive missed packets per channel before it
+// falls out of sync, eliminates BS-side TX-vs-retune races (heartbeat
+// retries no longer collide with hop boundaries), and reduces per-cycle
+// radio churn.
 //
-// FCC compliance: we operate as DTS, not FHSS, so there is no specific
-// per-channel dwell-time limit.  At dwell=4 + 2 Hz we still hit every
-// channel inside 140 s (BW=250, 69 channels), enough interference
-// diversity for our use case.
-static constexpr uint8_t LORA_HOP_DWELL_PACKETS = 4;
+// #150: the production dwell is no longer a compile-time constant — it
+// is derived per modulation preset by loraHopDwellForConfig() (defined
+// with the hop helpers above) so the FCC 15.247 FHSS occupancy bound
+// (< 0.4 s of airtime on any one frequency per window) holds at every
+// preset.  At SF8/BW250 with the 66-byte telemetry frame that yields
+// dwell 3 (~336 ms per channel visit).  The old fixed dwell=4 exceeded
+// the bound (~448 ms), and the comment that used to live here claiming
+// "we operate as DTS, so there is no dwell limit" was wrong on both
+// counts: hopping must satisfy the FHSS occupancy rule, and a fixed
+// 250 kHz LoRa carrier is not DTS-eligible either (DTS requires
+// >= 500 kHz of 6 dB bandwidth).  See docs/plans/150-fhss-reenable.md.
+//
+// DEPRECATED alias — kept only so pre-#150 call sites compile until the
+// OC/BS migrations later in this branch replace them.  Do not use in
+// new code.  TODO(#150): delete once the main.cpp call sites are gone.
+static constexpr uint8_t LORA_HOP_DWELL_PACKETS = LORA_HOP_DWELL_MAX;
 
 // LoRa name beacon sync byte (distinguishes from telemetry by size + prefix)
 static constexpr uint8_t LORA_BEACON_SYNC = 0xBE;

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1453,11 +1453,6 @@ static constexpr uint8_t LORA_PROTO_VERSION = 4;
 // counts: hopping must satisfy the FHSS occupancy rule, and a fixed
 // 250 kHz LoRa carrier is not DTS-eligible either (DTS requires
 // >= 500 kHz of 6 dB bandwidth).  See docs/plans/150-fhss-reenable.md.
-//
-// DEPRECATED alias — kept only so pre-#150 call sites compile until the
-// OC/BS migrations later in this branch replace them.  Do not use in
-// new code.  TODO(#150): delete once the main.cpp call sites are gone.
-static constexpr uint8_t LORA_HOP_DWELL_PACKETS = LORA_HOP_DWELL_MAX;
 
 // LoRa name beacon sync byte (distinguishes from telemetry by size + prefix)
 static constexpr uint8_t LORA_BEACON_SYNC = 0xBE;

--- a/tinkerrocket-idf/projects/base_station/main/bs_uplink_txwin.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_uplink_txwin.h
@@ -36,42 +36,25 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "RocketComputerTypes.h"  // loraTimeOnAirMs — shared with the #150 hop-dwell math
+
 namespace bs_uplink_txwin {
 
 // ---------------------------------------------------------------------------
 // LoRa time-on-air (Semtech AN1200.13). Needed because the usable window shrinks
 // by however long OUR packet takes — a 33-byte channel-set push occupies the air
 // far longer than a 0-byte sim-start.
+//
+// #150: delegates to the shared implementation in RocketComputerTypes.h so the
+// TX-window math and the hop-dwell math cannot drift apart. The default
+// preamble stays 8 (pre-#150 behaviour of this call site); the hop-dwell path
+// pins the true telemetry preamble via LORA_TELEM_PREAMBLE_SYMS.
 // ---------------------------------------------------------------------------
 inline uint32_t timeOnAirMs(size_t payload_len, uint8_t sf, float bw_khz,
                             uint8_t cr /* 5..8 => 4/5..4/8 */,
                             uint8_t preamble_syms = 8)
 {
-    if (sf < 6)   sf = 6;
-    if (sf > 12)  sf = 12;
-    if (bw_khz <= 0.0f) bw_khz = 125.0f;
-
-    // cr is the denominator form used in config (5 == 4/5). The formula wants 1..4.
-    int cr_idx = (int)cr - 4;
-    if (cr_idx < 1) cr_idx = 1;
-    if (cr_idx > 4) cr_idx = 4;
-
-    const float ts_ms = (float)(1u << sf) / bw_khz;      // symbol time, ms (bw in kHz)
-    const float preamble_ms = ((float)preamble_syms + 4.25f) * ts_ms;
-
-    // Low-data-rate optimise kicks in when a symbol is long (SF11/12 @125k).
-    const int de = (ts_ms >= 16.0f) ? 1 : 0;
-
-    const int num = 8 * (int)payload_len - 4 * (int)sf + 28 + 16;   // explicit header, CRC on
-    const int den = 4 * ((int)sf - 2 * de);
-    int n_payload = 0;
-    if (num > 0 && den > 0)
-    {
-        n_payload = ((num + den - 1) / den) * (cr_idx + 4);   // ceil(num/den) * (CR+4)
-    }
-    const float payload_ms = (float)(8 + n_payload) * ts_ms;
-
-    return (uint32_t)(preamble_ms + payload_ms + 0.5f);
+    return loraTimeOnAirMs(payload_len, sf, bw_khz, cr, preamble_syms);
 }
 
 // ---------------------------------------------------------------------------

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -70,9 +70,20 @@ struct config : board_pins
     // 3 of 3). Rather than firing blind, transmit inside the quiet stretch between
     // the rocket's ~500 ms telemetry packets. See bs_uplink_txwin.h.
     //
-    // Air to keep clear ahead of the next expected downlink packet: its ~82 ms of
-    // time-on-air plus margin for cadence jitter and TX/RX turnaround.
-    static constexpr uint32_t UPLINK_RX_RESERVE_MS = 140;
+    // Air to keep clear ahead of the next expected downlink packet: its
+    // time-on-air plus this margin for cadence jitter and TX/RX turnaround.
+    //
+    // #150 bench root-cause (dwell-1 uplink misses): the reserve used to be a
+    // flat 140 ms — the SF8 downlink's ~82 ms plus margin baked into one
+    // number.  At SF9 the downlink is ~203 ms, so the flat reserve sanctioned
+    // uplink attempts that overlapped the head of the rocket's next TX; the
+    // resulting half-duplex collision blinded the BS to that packet, and at
+    // dwell-1 (channel change every packet) losing one packet breaks the
+    // hop-follow — the rest of the retry burst then fired onto stale
+    // channels (two full 8-retry cmd-17 bursts lost on the bench, ~50%
+    // heartbeat delivery).  serviceUplink now computes the reserve from the
+    // ACTUAL telemetry airtime at the live modulation and adds this margin.
+    static constexpr uint32_t UPLINK_RX_RESERVE_MARGIN_MS = 60;
     // No packet for this long => no downlink worth protecting; transmit freely.
     // Also the case where we most need to (silence recovery, rendezvous).
     static constexpr uint32_t UPLINK_LINK_STALE_MS = 2000;

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -117,6 +117,14 @@ static uint32_t lora_low_snr_drops = 0;
 // drifts from the BS default (forced to 0 at boot, see #136).
 static uint32_t lora_netid_mismatch_drops = 0;
 
+// #150 (Seam B finding): the counter is lifetime-cumulative, so the app's
+// mismatch banner keyed on "drops > 0" never cleared after the link healed.
+// Report drops over BLE only while they are RECENT — the banner then
+// self-clears shortly after a fix, and a reconnecting app doesn't
+// resurrect a stale warning.  The log/stats lines keep the lifetime count.
+static constexpr uint32_t NETID_DROP_REPORT_WINDOW_MS = 30000;
+static uint32_t lora_netid_last_drop_ms = 0;
+
 // Base station battery (MAX17205G fuel gauge via I2C)
 static float bs_voltage = NAN;
 static float bs_soc = NAN;
@@ -1516,7 +1524,11 @@ static void buildBLETelemetry(const LoRaDataSI& lora, float rssi, float snr,
     // with a healthy nid).
     out.hop_active      = hop_active_;
     out.hop_channel_idx = hop_idx_;
-    out.netid_drops     = lora_netid_mismatch_drops;
+    // Only surface nid drops while they're recent — see the counter's
+    // declaration for why (lifetime count kept for logs/stats).
+    out.netid_drops     = (lora_netid_mismatch_drops > 0 &&
+                           (millis() - lora_netid_last_drop_ms) < NETID_DROP_REPORT_WINDOW_MS)
+                          ? lora_netid_mismatch_drops : 0;
 
     // Base station battery (local measurement)
     out.bs_soc = bs_soc;
@@ -3869,6 +3881,7 @@ static void loop_bs()
                 // packet lands here and the flight log stays empty with no
                 // clue why.  Count it + a throttled warning so it's attributable.
                 lora_netid_mismatch_drops++;
+                lora_netid_last_drop_ms = millis();   // #150: recency for BLE reporting
                 if (lora_netid_mismatch_drops == 1 ||
                     lora_netid_mismatch_drops % 100 == 0)
                 {

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -313,13 +313,26 @@ static uint8_t  hop_idx_          = 0;
 static bool     hop_needs_retune_ = false;
 static uint32_t hop_last_rx_ms_   = 0;
 
-// Operator override (#106): suppress hopping in PRELAUNCH/INFLIGHT and stay
-// on lora_freq_mhz instead.  BS is the authority; the BLE handler for
-// cmd 17 updates this flag, persists to NVS, and uplinks the same byte to
-// the rocket via LORA_CMD_SET_HOP_DISABLED so both sides stay aligned.
-// Diagnostic / link-debugging mode only — fixed-frequency in flight is
-// not FHSS-compliant.
-static bool     lora_hop_disabled = false;
+// Link mode (#106 origin, user-facing since #150): suppress hopping and
+// stay on lora_freq_mhz.  BS is the authority; the BLE handler for cmd 17
+// (driven by the app's Fixed/Hopping picker) updates this flag, persists
+// to NVS, and uplinks the same byte to the rocket via
+// LORA_CMD_SET_HOP_DISABLED so both sides stay aligned —
+// serviceHopModeResync() re-pushes on evidence of a mismatch.
+// Initialized true (fixed mode, the default) so the window between boot
+// and the NVS load can never report hop-enabled.
+static bool     lora_hop_disabled = true;
+
+// #150: packets-per-channel dwell for the CURRENT modulation, derived
+// from real airtime so the FCC occupancy bound holds at every preset.
+// 0 means a single packet exceeds the budget => hopping is not permitted
+// at this (sf, bw): the cmd-17 enable is refused and the hop-follow path
+// stays inert.  Must match the rocket's computation — both call the same
+// shared function on the same cmd-10-synced values.
+static inline uint8_t currentHopDwell()
+{
+    return loraHopDwellForConfig(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
+}
 
 // ----------------------------------------------------------------------------
 // Channel-set state (#40 / #41 phase 3)
@@ -357,6 +370,7 @@ static void invalidateSkipMaskForBwChange();
 static void analyzeAndPushFromCachedScan();
 static void pushCurrentChannelSet();
 static void serviceMaskDriftRepush();
+static void serviceHopModeResync();
 
 // Auto-acquire + auto-scan state (#136).  Full definitions live just
 // before setup_bs(); the enum + state variable are declared here so
@@ -401,6 +415,25 @@ static uint32_t hop_session_started_ms     = 0;   // 0 = no active session
 static uint32_t hop_session_total_pkts     = 0;   // accepted while hop_active_
 static uint32_t hop_session_observed_loss  = 0;   // sum of observed gaps (#105)
 static uint32_t lora_total_observed_loss   = 0;   // lifetime, since boot
+
+// ----------------------------------------------------------------------------
+// Hop-mode resync (#150)
+// ----------------------------------------------------------------------------
+// The BS is the link-mode authority, but a rocket that rebooted before a
+// cmd-17 change persisted (or missed it entirely) can disagree.  The RX
+// path collects evidence and serviceHopModeResync() re-uplinks cmd 17
+// with the BS's mode.  Two directions, different bars:
+//   • BS hop-enabled, rocket announces NO_HOP in a hop state: legitimate
+//     during rendezvous visits / coordinated-scan pauses, so require
+//     HOP_MODE_RESYNC_STREAK consecutive frames before acting.
+//   • BS fixed, rocket announces a real channel idx: never legitimate —
+//     act on first evidence (cooldown still applies).
+static constexpr uint8_t  HOP_MODE_RESYNC_STREAK      = 6;
+static constexpr uint32_t HOP_MODE_RESYNC_COOLDOWN_MS = 10000;
+static uint8_t  hop_mode_mismatch_streak_  = 0;
+static bool     hop_mode_resync_pending    = false;
+static uint32_t hop_mode_resync_last_ms_   = 0;
+static uint32_t hop_mode_resync_count_     = 0;
 
 // Per-rocket tracker (replaces single last_decoded for multi-rocket support)
 static constexpr int MAX_TRACKED_ROCKETS = 4;
@@ -1451,6 +1484,13 @@ static void buildBLETelemetry(const LoRaDataSI& lora, float rssi, float snr,
     out.rssi = rssi;
     out.snr = snr;
 
+    // #150: hop-state + nid-drop surface (rides the droppable tier-3 tail
+    // of the telemetry JSON; both keys are omitted entirely in fixed mode
+    // with a healthy nid).
+    out.hop_active      = hop_active_;
+    out.hop_channel_idx = hop_idx_;
+    out.netid_drops     = lora_netid_mismatch_drops;
+
     // Base station battery (local measurement)
     out.bs_soc = bs_soc;
     out.bs_voltage = bs_voltage;
@@ -1618,7 +1658,7 @@ static void sendCurrentConfig()
              ",\"pmn\":%.1f,\"pmx\":%.1f"
              ",\"sen\":%s"
              ",\"lf\":%.1f,\"lsf\":%u,\"lbw\":%.0f,\"lcr\":%u,\"lpw\":%d"
-             ",\"lhd\":%s}",
+             ",\"lhd\":%s,\"lhdw\":%u}",
              (int)cfg_servo_bias1, (int)cfg_servo_hz,
              (int)cfg_servo_min, (int)cfg_servo_max,
              (double)cfg_pid_kp, (double)cfg_pid_ki, (double)cfg_pid_kd,
@@ -1626,7 +1666,10 @@ static void sendCurrentConfig()
              cfg_servo_enabled ? "true" : "false",
              (double)lora_freq_mhz, (unsigned)lora_sf,
              (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
-             lora_hop_disabled ? "true" : "false");
+             lora_hop_disabled ? "true" : "false",
+             // #150: airtime-derived hop dwell; 0 = hopping unavailable at
+             // this preset (the app greys the picker option).
+             (unsigned)currentHopDwell());
     if (n < 0 || (size_t)n >= sizeof(buf)) {
         ESP_LOGW(TAG, "[CFG] Config JSON truncated! (%d bytes, buf=%u)", n, (unsigned)sizeof(buf));
     }
@@ -2164,13 +2207,14 @@ static void recoveryPushRocketHome()
 
 static void serviceRecovery()
 {
-    // #136: with hopping disabled the whole recovery state machine is
-    // redundant.  Both ends are pinned to LORA_FACTORY_RENDEZVOUS at
-    // boot (and can't drift — no auto-acquire move, no app-driven cmd
-    // 10), so Phase A's reconfigure is a no-op and the post-Phase-A
-    // "push rocket home" cmd 10 just blasts redundant TX retries at
-    // a rocket that's already on the right channel.  Leave the
-    // state machine inert until #150 re-enables hopping.
+    // #136/#150: in fixed mode the recovery state machine is redundant —
+    // both ends are pinned to LORA_FACTORY_RENDEZVOUS at boot, so Phase
+    // A's reconfigure is a no-op and the post-Phase-A "push rocket home"
+    // cmd 10 just blasts redundant TX retries at a rocket that's already
+    // on the right channel.  Since #150 this gate is live policy, not a
+    // placeholder: recovery runs whenever the user selects hopping mode
+    // (where the two ends genuinely can lose each other), and stays
+    // suppressed in fixed mode.
     if (lora_hop_disabled)
     {
         if (recovery_state != RecoveryState::IDLE)
@@ -2669,10 +2713,41 @@ static void serviceMaskDriftRepush()
     pushCurrentChannelSet();
 }
 
+// Hop-mode resync (#150).  Consumes the evidence flag set by the hop RX
+// path (see the streak/direction rules at the state definitions) and
+// re-uplinks cmd 17 with the BS's current link mode so a rocket that
+// rebooted or missed the change converges back.  Same radio-idle gating
+// and cooldown pattern as serviceMaskDriftRepush.
+static void serviceHopModeResync()
+{
+    if (!hop_mode_resync_pending) return;
+    if (uplinkBusy())                          return;
+    if (lora_txn_state != LoRaTxnState::IDLE)  return;
+    if (recovery_state != RecoveryState::IDLE) return;
+    const uint32_t now = millis();
+    if (hop_mode_resync_last_ms_ != 0 &&
+        (now - hop_mode_resync_last_ms_) < HOP_MODE_RESYNC_COOLDOWN_MS)
+    {
+        // Cooldown active; clear so we don't spin.  Fresh evidence after
+        // the cooldown re-arms it.
+        hop_mode_resync_pending = false;
+        return;
+    }
+    hop_mode_resync_pending   = false;
+    hop_mode_mismatch_streak_ = 0;
+    hop_mode_resync_last_ms_  = now;
+    hop_mode_resync_count_++;
+    const uint8_t desired = lora_hop_disabled ? 1 : 0;
+    ESP_LOGW(TAG, "[HOP] Mode mismatch evidence — re-pushing cmd 17 (%s, count=%lu)",
+             lora_hop_disabled ? "disable" : "enable",
+             (unsigned long)hop_mode_resync_count_);
+    buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, &desired, 1);
+}
+
 // All passes done.  Ship results to BLE (preserving the existing
 // single-result protocol so the iOS app doesn't need to change), then
 // dispatch to either the auto-acquire single-channel picker (#136) or
-// the legacy skip-mask push (kept for the hopping path, currently gated
+// the skip-mask push for the hopping path (#150: user-selectable, gated
 // off by default).
 static void finalizeNoiseScan()
 {
@@ -2952,9 +3027,13 @@ static void autoAcquireOnScanFinalize()
 // back, and the user (rightly) flagged the BS as no longer "on a
 // single frequency".
 //
-// State machine now just waits for first RX and declares success.  The
-// scan helpers (autoAcquireOnScanFinalize, AUTO_ACQUIRE_SCAN_*) are kept
-// in source for when #150 re-enables the scan-and-move pathway.
+// State machine now just waits for first RX and declares success.
+// #150 decision (2026-07-15): the scan-and-move pathway stays retired
+// even with hopping re-enabled — hopping starts over the FULL channel
+// set (trivially satisfies the FCC floor) and the operator's manual
+// Frequency Scan pushes an optional skip-mask via cmd 15 instead.  The
+// scan helpers (autoAcquireOnScanFinalize, AUTO_ACQUIRE_SCAN_*) remain
+// in source only as dead code; delete them if they rot.
 static void serviceAutoAcquire()
 {
     if (auto_acquire_state == AutoAcquireState::DONE) return;
@@ -3309,6 +3388,7 @@ static void setup_bs()
         prefs.putFloat("bw",    config::LORA_BW_KHZ);
         prefs.putUChar("cr",    config::LORA_CR);
         prefs.putChar("txpwr",  config::LORA_TX_POWER_DBM);
+        prefs.putUChar("hopdis", 1);  // #150: fixed mode is the default
         ESP_LOGI(TAG, "[CFG] LoRa NVS empty -- wrote config.h defaults");
     }
     lora_freq_mhz = prefs.getFloat("freq", config::LORA_FREQ_MHZ);
@@ -3316,7 +3396,7 @@ static void setup_bs()
     lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
     lora_cr        = prefs.getUChar("cr",   config::LORA_CR);
     lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
-    lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106 fixed-frequency override
+    lora_hop_disabled = prefs.getUChar("hopdis", 1) != 0;  // #150: default fixed mode
     prefs.end();
     ESP_LOGI(TAG, "[CFG] LoRa NVS (cached): %.1f MHz SF%u BW%.0f CR%u %d dBm hop_disabled=%d",
              (double)lora_freq_mhz, (unsigned)lora_sf,
@@ -3326,18 +3406,18 @@ static void setup_bs()
     // Issue #136: every BS power cycle starts on the hardcoded rendezvous
     // frequency + preset, regardless of any NVS values left over from
     // prior sessions.  This guarantees that BS and rocket meet on a known
-    // channel before the BS scans + picks a quiet one.  cmd-10 commits
-    // still write through to NVS during a session for visibility and
-    // BLE-readback, but those values no longer drive boot config.
-    // Hopping is also gated off at boot — re-enable via cmd 17 if you're
-    // testing the hop state machine.  See the "Re-enable LoRa hopping"
-    // follow-up enhancement.
+    // channel.  cmd-10 commits still write through to NVS during a
+    // session for visibility and BLE-readback, but those values no longer
+    // drive boot config.
+    // #150: lora_hop_disabled is deliberately NOT in this override
+    // anymore — the link mode is user-selected (app Fixed/Hopping picker
+    // via BLE cmd 17) and honors NVS across reboots.  Schema v4 wiped any
+    // stale pre-#150 hopdis, and the default is 1 (fixed mode).
     lora_freq_mhz     = LORA_FACTORY_RENDEZVOUS_MHZ;
     lora_sf           = LORA_FACTORY_RENDEZVOUS_SF;
     lora_bw_khz       = LORA_FACTORY_RENDEZVOUS_BW_KHZ;
     lora_cr           = LORA_FACTORY_RENDEZVOUS_CR;
     lora_tx_power     = LORA_FACTORY_RENDEZVOUS_TX_DBM;
-    lora_hop_disabled = true;
     ESP_LOGI(TAG, "[CFG] LoRa boot (forced rendezvous): %.1f MHz SF%u BW%.0f CR%u %d dBm",
              (double)lora_freq_mhz, (unsigned)lora_sf,
              (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power);
@@ -3388,6 +3468,24 @@ static void setup_bs()
                  mac[2], mac[3], mac[4], mac[5]);
 
         prefs.begin("identity", false);
+
+        // #150: the identity namespace versions SEPARATELY from the lora
+        // namespace and MIGRATES instead of wiping — a wipe is what caused
+        // the #133-era regression (this BS came back nid=0 while the
+        // rocket kept nid=180 and the network-id filter silently dropped
+        // everything).  v1 just stamps the version; un/nid are unchanged.
+        // Future bumps must preserve `un` (user data) and may reset nid
+        // only if its stored layout actually changes.
+        {
+            const uint8_t stored_v = prefs.getUChar("schemv", 0);
+            if (stored_v != IDENTITY_NVS_SCHEMA_VERSION)
+            {
+                ESP_LOGW(TAG, "[CFG] Identity NVS schema %u -> %u (migrating, keys preserved)",
+                         (unsigned)stored_v, (unsigned)IDENTITY_NVS_SCHEMA_VERSION);
+                prefs.putUChar("schemv", IDENTITY_NVS_SCHEMA_VERSION);
+            }
+        }
+
         if (!prefs.isKey("un"))
         {
             char default_name[24];
@@ -3405,23 +3503,12 @@ static void setup_bs()
         network_id = prefs.getUChar("nid", config::DEFAULT_NETWORK_ID);
         prefs.end();
 
-        // #136: every boot also forces network_id back to the hardcoded
-        // default, mirroring the LoRa rendezvous override.  Without this,
-        // a BS and OC can quietly drift apart whenever one device's NVS
-        // is wiped (e.g., the LORA_NVS_SCHEMA_VERSION bump in #105 cleared
-        // the lora namespace on this BS but left the OC's `identity` nid
-        // alone, so OC stayed on nid=180 while the BS came back on nid=0
-        // — every beacon and telemetry packet from the rocket got dropped
-        // silently by the network_id filter).  Cmd 9 still lets a
-        // developer change network_id at runtime, but boot always
-        // re-resets, so devices can't drift across power cycles.
-        // Reintroduce per-network IDs alongside hopping in #150.
-        if (network_id != config::DEFAULT_NETWORK_ID)
-        {
-            ESP_LOGW(TAG, "[CFG] NVS nid=%u differs from default %u — forcing default",
-                     (unsigned)network_id, (unsigned)config::DEFAULT_NETWORK_ID);
-            network_id = config::DEFAULT_NETWORK_ID;
-        }
+        // #150: the #136 boot-time force of network_id back to default is
+        // gone.  Per-network IDs are user-set again (BLE cmd 41 / the
+        // network-name UI), survive reboot, and drift is now VISIBLE
+        // instead of silent: the RX filter counts nid-mismatch drops and
+        // surfaces them to the app ("nidd"), and identity NVS migrates
+        // rather than wipes.
 
         ESP_LOGI(TAG, "[CFG] Identity: uid=%s name=%s nid=%u",
                  unit_id_hex, unit_name, (unsigned)network_id);
@@ -3852,12 +3939,29 @@ static void loop_bs()
                 // the NO_HOP sentinel as the "not currently hopping"
                 // signal, but for the actual channel we consult seq.
                 //
-                // #106: when the operator has disabled hopping, ignore
-                // the rocket's hop entirely and stay on lora_freq_mhz.
-                if (!lora_hop_disabled && shouldHopInState(decoded.rocket_state))
+                // #150 direction B evidence: rocket announces a live hop
+                // channel while our link mode is fixed — never legitimate
+                // (either it rebooted with a stale hopdis=0 or missed our
+                // disable).  Queue a cmd-17 re-push immediately; the
+                // service applies the cooldown.
+                if (lora_hop_disabled &&
+                    decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
+                {
+                    hop_mode_resync_pending = true;
+                }
+
+                // #106/#150: when the link mode is fixed, ignore the
+                // rocket's hop entirely and stay on lora_freq_mhz.  Also
+                // stay put when the current modulation can't legally hop
+                // (currentHopDwell() == 0) — the cmd-17 refusal should
+                // make that unreachable, but the gate keeps a bad state
+                // from chasing a non-compliant schedule.
+                if (!lora_hop_disabled && currentHopDwell() > 0 &&
+                    shouldHopInState(decoded.rocket_state))
                 {
                     if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
                     {
+                        hop_mode_mismatch_streak_ = 0;
                         const uint8_t n = loraChannelCount(lora_bw_khz);
                         if (n > 0)
                         {
@@ -3881,7 +3985,7 @@ static void loop_bs()
                             // the rocket so the link stays up.
                             const uint8_t expected_next = loraHopChannelForSeq(
                                 (uint16_t)(decoded.seq + 1),
-                                LORA_HOP_DWELL_PACKETS, mask, n);
+                                currentHopDwell(), mask, n);
                             if (decoded.next_channel_idx != expected_next) {
                                 ESP_LOGW(TAG, "[HOP] seq=%u: rocket says next=%u, "
                                               "we'd compute next=%u (mask drift "
@@ -3913,17 +4017,31 @@ static void loop_bs()
                                 ESP_LOGI(TAG, "[HOP] Active: %u channels at BW=%.0f kHz "
                                               "dwell=%u, first hop -> idx=%u (%.3f MHz)",
                                          (unsigned)n, (double)lora_bw_khz,
-                                         (unsigned)LORA_HOP_DWELL_PACKETS,
+                                         (unsigned)currentHopDwell(),
                                          (unsigned)hop_idx_,
                                          (double)loraChannelMHz(lora_bw_khz, hop_idx_));
                                 char ev[96];
                                 snprintf(ev, sizeof(ev),
                                          "hop_active idx=%u nch=%u dwell=%u",
                                          (unsigned)hop_idx_, (unsigned)n,
-                                         (unsigned)LORA_HOP_DWELL_PACKETS);
+                                         (unsigned)currentHopDwell());
                                 logHopEvent(ev,
                                             loraChannelMHz(lora_bw_khz, hop_idx_));
                             }
+                        }
+                    }
+                    else
+                    {
+                        // #150 direction A evidence: rocket is in a hop
+                        // state but announces NO_HOP.  Legitimate during
+                        // rendezvous visits and coordinated-scan pauses,
+                        // so require a consecutive run before treating it
+                        // as a mode mismatch (e.g. rocket rebooted before
+                        // our enable was persisted).
+                        if (hop_mode_mismatch_streak_ < 255) hop_mode_mismatch_streak_++;
+                        if (hop_mode_mismatch_streak_ >= HOP_MODE_RESYNC_STREAK)
+                        {
+                            hop_mode_resync_pending = true;
                         }
                     }
                 }
@@ -4322,24 +4440,39 @@ static void loop_bs()
         if (payload_len >= 1)
         {
             const bool new_disabled = (payload[0] != 0);
-            if (new_disabled != lora_hop_disabled)
+            if (!new_disabled && currentHopDwell() == 0)
             {
-                lora_hop_disabled = new_disabled;
-                prefs.begin("lora", false);
-                prefs.putUChar("hopdis", lora_hop_disabled ? 1 : 0);
-                prefs.end();
-                if (lora_hop_disabled && hop_active_)
-                {
-                    // Drop hop tracking so the next radio service tick
-                    // returns us to lora_freq_mhz.
-                    hop_active_       = false;
-                    hop_needs_retune_ = true;
-                }
+                // #150: the current modulation can't fit one packet inside
+                // the FCC dwell budget — refuse the enable and re-send
+                // config so the app's picker snaps back.  The app also
+                // greys the option via "lhdw" == 0; this is the belt to
+                // that brace.
+                ESP_LOGW(TAG, "[BLE] Hop enable REFUSED: dwell=0 at SF%u/BW%.0f",
+                         (unsigned)lora_sf, (double)lora_bw_khz);
+                sendCurrentConfig();
             }
-            buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, payload, 1);
-            ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: %s",
-                     lora_hop_disabled ? "DISABLED (fixed freq)" : "ENABLED");
-            sendCurrentConfig();
+            else
+            {
+                if (new_disabled != lora_hop_disabled)
+                {
+                    lora_hop_disabled = new_disabled;
+                    prefs.begin("lora", false);
+                    prefs.putUChar("hopdis", lora_hop_disabled ? 1 : 0);
+                    prefs.end();
+                    if (lora_hop_disabled && hop_active_)
+                    {
+                        // Drop hop tracking so the next radio service tick
+                        // returns us to lora_freq_mhz.
+                        hop_active_       = false;
+                        hop_needs_retune_ = true;
+                    }
+                    hop_mode_mismatch_streak_ = 0;  // fresh mode, fresh evidence
+                }
+                buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, payload, 1);
+                ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: %s",
+                         lora_hop_disabled ? "DISABLED (fixed freq)" : "ENABLED");
+                sendCurrentConfig();
+            }
         }
     }
     else if (ble_cmd == BLE_BS_CMD_CONFIG_READBACK)
@@ -4514,6 +4647,11 @@ static void loop_bs()
     // the rocket's.  Cheap when no drift is pending; only acts when
     // the radio is otherwise idle.
     serviceMaskDriftRepush();
+
+    // Hop-mode resync (#150).  Re-pushes cmd 17 if frame evidence says
+    // the rocket's link mode disagrees with ours.  Same idle-only /
+    // cooldown discipline as the mask repush.
+    serviceHopModeResync();
 
     // Auto-acquire (#136): one-shot per power cycle.  Waits to hear the
     // rocket on rendezvous, runs a noise scan, picks the quietest

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1837,10 +1837,27 @@ static void serviceUplink()
     // the quiet stretch between the rocket's ~500 ms telemetry packets instead.
     // Transmitting right after the rocket's own TX is also when it is listening,
     // so this should help uplink delivery too.
+    // #150: while following a hop, never transmit with a retune still
+    // pending — the radio is on the channel of the packet we just decoded,
+    // which at dwell-1 the rocket has ALREADY left (it steps to its next
+    // channel immediately after its own TX).  One deferred pass lets the
+    // top-of-loop retune land the attempt on the channel the rocket is
+    // actually listening on.
+    if (hop_active_ && hop_needs_retune_)
+    {
+        return;
+    }
+
     bs_uplink_txwin::Params win;
     win.period_ms     = rx_cadence.periodMs();
     win.tx_airtime_ms = bs_uplink_txwin::timeOnAirMs(tx->len, lora_sf, lora_bw_khz, lora_cr);
-    win.rx_reserve_ms = config::UPLINK_RX_RESERVE_MS;
+    // #150: reserve = the REAL downlink airtime at the live modulation plus
+    // margin.  The old flat 140 ms was sized for SF8's ~82 ms downlink and
+    // under-reserved at higher SFs, sanctioning attempts that collided with
+    // the head of the next downlink (see config.h UPLINK_RX_RESERVE_MARGIN_MS).
+    win.rx_reserve_ms = loraTimeOnAirMs(SIZE_OF_LORA_DATA, lora_sf, lora_bw_khz,
+                                        lora_cr, LORA_TELEM_PREAMBLE_SYMS)
+                        + config::UPLINK_RX_RESERVE_MARGIN_MS;
     win.link_stale_ms = config::UPLINK_LINK_STALE_MS;
     win.max_defer_ms  = config::UPLINK_MAX_DEFER_MS;
 

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -2542,7 +2542,14 @@ static constexpr uint32_t COORD_SCAN_PAUSE_GRACE_MS  = 500;
 static constexpr uint32_t COORD_SCAN_RESUMING_MAX_MS = 5000;
 // Slack on top of the computed scan + cmd 15 retry budget so the rocket's
 // pause comfortably outlasts our work window.
-static constexpr uint32_t COORD_SCAN_PAUSE_SLACK_MS  = 2000;
+// #150 Seam B finding: the rocket's pause clock starts at cmd-16 RECEIPT,
+// but the BS only starts spending the budget once it has confirmed the
+// park (~2 s later: remaining cmd-16 retries + grace).  With 2 s of slack
+// the cmd-15 mask push landed exactly at the rocket's resume deadline and
+// collided with its resume bootstraps (half-duplex), costing ~46 s of
+// fallback healing after every mid-hop scan.  5 s absorbs the start
+// latency + the push train with margin; the rocket-side cap is 60 s.
+static constexpr uint32_t COORD_SCAN_PAUSE_SLACK_MS  = 5000;
 // "Recent enough" window for treating a non-hop_active_ rocket as still
 // in a hop state (#90).  A packet within this window showing PRELAUNCH
 // or INFLIGHT means the rocket is conceptually hopping (possibly

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -325,13 +325,15 @@ static bool     lora_hop_disabled = true;
 
 // #150: packets-per-channel dwell for the CURRENT modulation, derived
 // from real airtime so the FCC occupancy bound holds at every preset.
-// 0 means a single packet exceeds the budget => hopping is not permitted
-// at this (sf, bw): the cmd-17 enable is refused and the hop-follow path
-// stays inert.  Must match the rocket's computation — both call the same
-// shared function on the same cmd-10-synced values.
+// 0 means hopping is not permitted at this (sf, bw, cr): the cmd-17
+// enable is refused and the hop-follow path stays inert.  Uses the link
+// gate (not the raw config function): CR-only changes are unverifiable
+// over the air, so hopping is only offered at the factory CR — see
+// loraHopDwellForLink.  Must match the rocket's computation — both call
+// the same shared function.
 static inline uint8_t currentHopDwell()
 {
-    return loraHopDwellForConfig(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
+    return loraHopDwellForLink(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
 }
 
 // ----------------------------------------------------------------------------
@@ -350,6 +352,20 @@ static inline uint8_t currentHopDwell()
 static uint8_t skip_mask_[LORA_SKIP_MASK_MAX_BYTES] = {0};
 static uint8_t skip_mask_n_        = 0;        // 0 = no mask yet
 static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
+
+// #150: effective skip mask for the hop schedule = the scan mask (when
+// valid for the current BW) + the implicit home-channel skip — identical
+// derivation to the rocket's, so the expected-next sanity check compares
+// like with like.  `buf` must hold LORA_SKIP_MASK_MAX_BYTES.
+static const uint8_t* effectiveHopMask(uint8_t* buf, uint8_t n_channels)
+{
+    const bool mask_valid = (skip_mask_n_ == n_channels &&
+                              channel_set_bw_khz_ == lora_bw_khz);
+    if (mask_valid) memcpy(buf, skip_mask_, LORA_SKIP_MASK_MAX_BYTES);
+    else            memset(buf, 0, LORA_SKIP_MASK_MAX_BYTES);
+    (void)loraApplyHomeChannelSkip(buf, lora_bw_khz, lora_freq_mhz);
+    return buf;
+}
 
 // Mask-drift auto-recovery (#105 follow-up).  Set in the hop RX path
 // when the rocket's announced next_channel_idx disagrees with the
@@ -371,6 +387,7 @@ static void analyzeAndPushFromCachedScan();
 static void pushCurrentChannelSet();
 static void serviceMaskDriftRepush();
 static void serviceHopModeResync();
+static void serviceHopDisableDrain();
 
 // Auto-acquire + auto-scan state (#136).  Full definitions live just
 // before setup_bs(); the enum + state variable are declared here so
@@ -434,6 +451,16 @@ static uint8_t  hop_mode_mismatch_streak_  = 0;
 static bool     hop_mode_resync_pending    = false;
 static uint32_t hop_mode_resync_last_ms_   = 0;
 static uint32_t hop_mode_resync_count_     = 0;
+
+// #150 (review): graceful hop disable.  A cmd-17 disable taken while we
+// are FOLLOWING a hop must drain its uplink retries on the channel the
+// rocket is listening on BEFORE we stop following and retune away — the
+// naive order (flip, retune, then let serviceUplink fire) put at most one
+// blind retry on the hop channel and the rocket essentially never heard
+// the disable.  Non-zero deadline = drain in progress; commit happens in
+// serviceHopDisableDrain().
+static constexpr uint32_t HOP_DISABLE_DRAIN_MAX_MS = 1500;
+static uint32_t hop_disable_drain_deadline_ms = 0;
 
 // Per-rocket tracker (replaces single last_decoded for multi-rocket support)
 static constexpr int MAX_TRACKED_ROCKETS = 4;
@@ -2744,6 +2771,30 @@ static void serviceHopModeResync()
     buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, &desired, 1);
 }
 
+// #150 (review): completes a graceful hop disable — see the cmd-17 BLE
+// handler.  The uplink retries were queued while we kept following the
+// hop so they'd go out on the channel the rocket is listening on; once
+// they drain (or the deadline passes) commit the mode locally.
+static void serviceHopDisableDrain()
+{
+    if (hop_disable_drain_deadline_ms == 0) return;
+    if (uplinkBusy() &&
+        (int32_t)(millis() - hop_disable_drain_deadline_ms) < 0) return;
+    hop_disable_drain_deadline_ms = 0;
+    lora_hop_disabled = true;
+    prefs.begin("lora", false);
+    prefs.putUChar("hopdis", 1);
+    prefs.end();
+    if (hop_active_)
+    {
+        hop_active_       = false;
+        hop_needs_retune_ = true;
+    }
+    hop_mode_mismatch_streak_ = 0;
+    ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: drain complete — fixed mode");
+    sendCurrentConfig();
+}
+
 // All passes done.  Ship results to BLE (preserving the existing
 // single-result protocol so the iOS app doesn't need to change), then
 // dispatch to either the auto-acquire single-channel picker (#136) or
@@ -3473,14 +3524,33 @@ static void setup_bs()
         // namespace and MIGRATES instead of wiping — a wipe is what caused
         // the #133-era regression (this BS came back nid=0 while the
         // rocket kept nid=180 and the network-id filter silently dropped
-        // everything).  v1 just stamps the version; un/nid are unchanged.
-        // Future bumps must preserve `un` (user data) and may reset nid
-        // only if its stored layout actually changes.
+        // everything).
+        //
+        // v0 -> v1 resets nid to the compile-time default ONCE (review
+        // finding): the #136 boot-force this branch removes was RAM-only,
+        // so fielded devices still store whatever nid the #133 era left
+        // behind — masked, divergent, and unreachable for months.  Making
+        // those live would kill the link on the first post-flash boot
+        // with no over-the-air recovery (both directions are
+        // nid-filtered).  The pre-upgrade EFFECTIVE nid was always the
+        // default, so resetting to it is the behavior-preserving
+        // migration.  `un` (user data) is preserved.
         {
             const uint8_t stored_v = prefs.getUChar("schemv", 0);
             if (stored_v != IDENTITY_NVS_SCHEMA_VERSION)
             {
-                ESP_LOGW(TAG, "[CFG] Identity NVS schema %u -> %u (migrating, keys preserved)",
+                if (stored_v == 0)
+                {
+                    const uint8_t old_nid =
+                        prefs.getUChar("nid", config::DEFAULT_NETWORK_ID);
+                    if (old_nid != config::DEFAULT_NETWORK_ID)
+                    {
+                        ESP_LOGW(TAG, "[CFG] Identity migration: stale masked nid=%u reset to default %u",
+                                 (unsigned)old_nid, (unsigned)config::DEFAULT_NETWORK_ID);
+                        prefs.putUChar("nid", config::DEFAULT_NETWORK_ID);
+                    }
+                }
+                ESP_LOGW(TAG, "[CFG] Identity NVS schema %u -> %u (migrated)",
                          (unsigned)stored_v, (unsigned)IDENTITY_NVS_SCHEMA_VERSION);
                 prefs.putUChar("schemv", IDENTITY_NVS_SCHEMA_VERSION);
             }
@@ -3940,10 +4010,14 @@ static void loop_bs()
                 // signal, but for the actual channel we consult seq.
                 //
                 // #150 direction B evidence: rocket announces a live hop
-                // channel while our link mode is fixed — never legitimate
-                // (either it rebooted with a stale hopdis=0 or missed our
-                // disable).  Queue a cmd-17 re-push immediately; the
-                // service applies the cooldown.
+                // channel — or the off-schedule marker 0xFE — while our
+                // link mode is fixed.  Never legitimate (it rebooted with
+                // a stale hopdis=0 or missed our disable).  Queue a
+                // cmd-17 re-push immediately; the service applies the
+                // cooldown.  The 0xFE case is the valuable one: the
+                // rocket is parked on the shared rendezvous LISTENING for
+                // the full visit window, so the push queued off this very
+                // frame lands while it can still hear us.
                 if (lora_hop_disabled &&
                     decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
                 {
@@ -3959,16 +4033,26 @@ static void loop_bs()
                 if (!lora_hop_disabled && currentHopDwell() > 0 &&
                     shouldHopInState(decoded.rocket_state))
                 {
-                    if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
+                    if (decoded.next_channel_idx == LORA_NEXT_CH_HOP_OFFSCHEDULE)
+                    {
+                        // #150 (review): rocket is hopping but momentarily
+                        // off-schedule (rendezvous visit / scan pause) —
+                        // it is transmitting on the channel we just heard
+                        // it on and returns to the schedule on its own.
+                        // Hold position; 0xFE is a marker, not a channel
+                        // index.  A rebooted BS parked on the rendezvous
+                        // sees these frames and simply waits for the
+                        // rocket's post-visit bootstrap on lora_freq_mhz.
+                        hop_mode_mismatch_streak_ = 0;
+                    }
+                    else if (decoded.next_channel_idx != LORA_NEXT_CH_NO_HOP)
                     {
                         hop_mode_mismatch_streak_ = 0;
                         const uint8_t n = loraChannelCount(lora_bw_khz);
                         if (n > 0)
                         {
-                            const bool mask_valid = (skip_mask_n_ == n &&
-                                                      channel_set_bw_khz_ == lora_bw_khz);
-                            static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
-                            const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                            uint8_t mask_buf[LORA_SKIP_MASK_MAX_BYTES];
+                            const uint8_t* mask = effectiveHopMask(mask_buf, n);
                             // Compute next channel from seq+1 — what the
                             // rocket will be on for the *next* packet.
                             // Trust the rocket's announced next_channel_idx
@@ -4451,8 +4535,24 @@ static void loop_bs()
                          (unsigned)lora_sf, (double)lora_bw_khz);
                 sendCurrentConfig();
             }
+            else if (new_disabled && !lora_hop_disabled && hop_active_)
+            {
+                // #150 (review): we are FOLLOWING a hop — drain the
+                // disable retries on the channel the rocket is listening
+                // on before we stop following and retune away.  Keep
+                // tracking the hop while the retries run; the flag flip,
+                // NVS persist, retune, and config readback happen in
+                // serviceHopDisableDrain() once the queue empties (or the
+                // deadline passes).  No sendCurrentConfig() here: the app
+                // keeps its optimistic picker state and gets one clean
+                // readback when the mode actually commits (~1 s).
+                hop_disable_drain_deadline_ms = millis() + HOP_DISABLE_DRAIN_MAX_MS;
+                buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, payload, 1);
+                ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: draining retries on the hop channel first");
+            }
             else
             {
+                hop_disable_drain_deadline_ms = 0;  // an enable cancels a pending drain
                 if (new_disabled != lora_hop_disabled)
                 {
                     lora_hop_disabled = new_disabled;
@@ -4563,7 +4663,12 @@ static void loop_bs()
             memcpy(&step_khz,  payload + 8, 2);
             memcpy(&dwell_ms,  payload + 10, 2);
 
-            const bool need_coord = rocketLikelyHopping(
+            // #150 (review): in fixed mode the rocket cannot legitimately
+            // be hopping, and shouldHopInState(LANDED) is now true — a
+            // recently-heard landed rocket would otherwise force the
+            // coordinated-pause path (pointless cmd 16 + a RESUMING
+            // stall) where pre-#150 the scan ran directly.
+            const bool need_coord = !lora_hop_disabled && rocketLikelyHopping(
                 hop_active_, last_packet_ms, millis(),
                 lastSeenRocketState(), COORD_HOP_RECENT_MS);
 
@@ -4652,6 +4757,10 @@ static void loop_bs()
     // the rocket's link mode disagrees with ours.  Same idle-only /
     // cooldown discipline as the mask repush.
     serviceHopModeResync();
+
+    // Graceful hop-disable commit (#150 review): flips to fixed mode once
+    // the disable retries have drained on the hop channel.
+    serviceHopDisableDrain();
 
     // Auto-acquire (#136): one-shot per power cycle.  Waits to hear the
     // rocket on rendezvous, runs a noise scan, picks the quietest

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -2381,6 +2381,13 @@ static void serviceRecovery()
 // state-machine enums it depends on are in scope.)
 
 static constexpr uint32_t HEARTBEAT_INTERVAL_MS = 10000;  // every 10 s (#105)
+
+// #150 bench finding: a heartbeat TX can land exactly in the rocket's
+// post-enable bootstrap window and eat the handoff (the BS is deaf while
+// transmitting).  Hold heartbeats briefly after we send a cmd-17 ENABLE so
+// the bootstrap packets meet a listening receiver.
+static constexpr uint32_t HEARTBEAT_HOLD_AFTER_ENABLE_MS = 4000;
+static uint32_t heartbeat_hold_until_ms = 0;
 static constexpr uint32_t HEARTBEAT_RX_FRESH_MS = 5000;   // rocket "alive"
 static constexpr uint8_t  HEARTBEAT_RETRIES     = 2;
 static uint32_t last_heartbeat_tx_ms = 0;
@@ -2408,6 +2415,10 @@ static void serviceHeartbeat()
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (scan_passes_remaining_ != 0)           return;  // #136: don't TX mid-scan
     if (uplinkBusy())                          return;  // Don't compete with a real cmd
+    // #150: stay quiet through the rocket's post-enable bootstrap window
+    // so we can't be deaf (mid-TX) when the handoff packets arrive.
+    if (heartbeat_hold_until_ms != 0 &&
+        (int32_t)(millis() - heartbeat_hold_until_ms) < 0) return;
     // While hopping, only TX in the safe window right after a fresh
     // rocket RX — see HOP_BS_TX_SAFE_WINDOW_MS comment.  With slow-hop
     // dwell=4 (#105 follow-up) the rocket stays on a channel for 2 s,
@@ -2768,6 +2779,12 @@ static void serviceHopModeResync()
     ESP_LOGW(TAG, "[HOP] Mode mismatch evidence — re-pushing cmd 17 (%s, count=%lu)",
              lora_hop_disabled ? "disable" : "enable",
              (unsigned long)hop_mode_resync_count_);
+    if (!lora_hop_disabled)
+    {
+        // #150: same heartbeat hold as the BLE enable path — the resync
+        // enable also triggers a deferred bootstrap on the rocket.
+        heartbeat_hold_until_ms = millis() + HEARTBEAT_HOLD_AFTER_ENABLE_MS;
+    }
     buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, &desired, 1);
 }
 
@@ -4567,6 +4584,13 @@ static void loop_bs()
                         hop_needs_retune_ = true;
                     }
                     hop_mode_mismatch_streak_ = 0;  // fresh mode, fresh evidence
+                }
+                if (!new_disabled)
+                {
+                    // #150: hold heartbeats through the rocket's deferred
+                    // activation + bootstrap so we're listening when the
+                    // handoff packets arrive.
+                    heartbeat_hold_until_ms = millis() + HEARTBEAT_HOLD_AFTER_ENABLE_MS;
                 }
                 buildUplinkPacket(LORA_CMD_SET_HOP_DISABLED, payload, 1);
                 ESP_LOGI(TAG, "[BLE->UPLINK] Hop disable: %s",

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -4117,7 +4117,15 @@ static void loop_bs()
                             const uint8_t expected_next = loraHopChannelForSeq(
                                 (uint16_t)(decoded.seq + 1),
                                 currentHopDwell(), mask, n);
-                            if (decoded.next_channel_idx != expected_next) {
+                            // #150: bootstrap frames announce the schedule
+                            // ENTRY channel (seq + remaining bootstraps),
+                            // deliberately != f(seq+1) — so skip the drift
+                            // sanity check on the frame that STARTS a
+                            // follow session (it's a bootstrap whenever the
+                            // session is new) or a false "mask drift" warn
+                            // fires and queues a pointless cmd-15 re-push.
+                            if (hop_active_ &&
+                                decoded.next_channel_idx != expected_next) {
                                 ESP_LOGW(TAG, "[HOP] seq=%u: rocket says next=%u, "
                                               "we'd compute next=%u (mask drift "
                                               "— following rocket)",

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -594,13 +594,15 @@ static bool    hop_active_        = false;
 static uint8_t hop_idx_           = 0;
 static bool    hop_first_pkt_     = false;
 static bool    hop_needs_retune_  = false;
-// Operator override: when true, hopping is suppressed even in PRELAUNCH /
-// INFLIGHT and we stay on lora_freq_mhz for the whole flight (#106).  Set
-// by the BS via LORA_CMD_SET_HOP_DISABLED (cmd 17).  NVS-backed so the
+// Link mode (#106 origin, user-facing since #150): when true, hopping is
+// suppressed even in PRELAUNCH/INFLIGHT/LANDED and we stay on
+// lora_freq_mhz.  Set by the BS via LORA_CMD_SET_HOP_DISABLED (cmd 17),
+// driven by the app's Fixed/Hopping link-mode picker.  NVS-backed so the
 // setting survives reboot.  Both sides must agree; the BS keeps its own
-// copy and pushes changes here.  Diagnostic / link-debugging mode only —
-// using a fixed frequency in flight is not FHSS-compliant.
-static bool    lora_hop_disabled  = false;
+// copy, mirrors changes here, and re-pushes on evidence of a mismatch.
+// Initialized true (fixed mode, the default) so the window between boot
+// and the NVS load can never report hop-enabled.
+static bool    lora_hop_disabled  = true;
 
 // Hop-silence rendezvous fallback state (#40 / #41 phase 2b).
 // Definitions of HOP_FALLBACK_*_MS constants and the serviceHopFallback()
@@ -633,12 +635,23 @@ static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
 // alongside the other LoRa-stats vars.
 static bool lora_in_rx_mode = false;
 
+// #150: packets-per-channel dwell for the CURRENT modulation, derived from
+// real airtime so the FCC occupancy bound holds at every preset.  0 means a
+// single packet exceeds the budget => hopping is not permitted at this
+// (sf, bw) and every hop entry point below refuses to start.
+static inline uint8_t currentHopDwell()
+{
+    return loraHopDwellForConfig(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
+}
+
 static inline void updateHopFromState(RocketState s)
 {
-    // Operator override: in fixed-frequency mode (#106) we stay on
-    // lora_freq_mhz for every state.  Otherwise fall back to the
-    // shared per-state policy.
-    const bool want_active = !lora_hop_disabled && shouldHopInState(s);
+    // Fixed-frequency mode (#106/#150 link mode) stays on lora_freq_mhz
+    // for every state.  #150 also refuses to hop when the current
+    // modulation can't fit a dwell visit inside the FCC occupancy budget
+    // (currentHopDwell() == 0, e.g. BW125 @ SF9+).
+    const bool want_active = !lora_hop_disabled && currentHopDwell() > 0 &&
+                             shouldHopInState(s);
     if (want_active && !hop_active_)
     {
         // OFF → ON.  Bootstrap: the next TX still goes out on
@@ -796,12 +809,16 @@ static float max_speed_mps = 0.0f;
 
 static uint32_t lora_tx_ok = 0;
 static uint32_t lora_tx_fail = 0;
+// #150: uplinks dropped by the network-id filter.  Counted (and logged in
+// the periodic LoRa stats line) because the #133-era nid-drift regression
+// was invisible precisely because this drop path said nothing.
+static uint32_t lora_uplink_nid_drops = 0;
 static uint32_t last_lora_tx_ms = 0;
 
 // Free-running per-TX sequence counter (#105).  Stamped into LoRaData.seq
 // on every actual transmit so the BS can compute observed-loss rates and
 // the slow-hop seq-anchored channel schedule.  Widened to 16 bits in
-// proto v4 — see LORA_HOP_DWELL_PACKETS for why u8 was insufficient.
+// proto v4 — see loraHopDwellForConfig() for why u8 was insufficient.
 // Wraps mod 65536; resets to 0 on reboot.
 static uint16_t lora_tx_seq = 0;
 // lora_in_rx_mode forward-declared up with the hop state.
@@ -2756,7 +2773,7 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
             static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
             const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
             lora.next_channel_idx = loraHopChannelForSeq(
-                (uint16_t)(seq + 1), LORA_HOP_DWELL_PACKETS, mask, n);
+                (uint16_t)(seq + 1), currentHopDwell(), mask, n);
         }
     }
     else
@@ -2938,7 +2955,7 @@ static void serviceLoRa()
                 static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
                 const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
                 hop_idx_ = loraHopChannelForSeq(
-                    lora_tx_seq, LORA_HOP_DWELL_PACKETS, mask, n);
+                    lora_tx_seq, currentHopDwell(), mask, n);
             }
             hop_needs_retune_ = true;
         }
@@ -2967,6 +2984,14 @@ static void sendLoRaBeacon()
     // we don't change channel mid-flight anyway.  Logic shared with
     // tests via shouldBeaconInState() in RocketComputerTypes.h.
     if (!shouldBeaconInState(latest_rocket_state)) return;
+
+    // #150: no beacons while the hop schedule is running.  They would ride
+    // hop channels the BS already follows (it knows this rocket by then),
+    // and a beacon inside a dwell visit can blow the FCC occupancy budget
+    // (at SF10/BW250 a single beacon pushes the visit ~50% over — see the
+    // BeaconSuppressionDuringHopIsLoadBearing host test).  Rendezvous
+    // visits and scan pauses still beacon — that's their purpose.
+    if (hop_active_ && hop_fallback_state == HopFallbackState::NORMAL) return;
 
     const uint32_t now_ms = millis();
     if ((now_ms - last_beacon_ms) < 2000) return;
@@ -3110,6 +3135,9 @@ static void sendCurrentConfig()
     j += ",\"lcr\":"; j += itos(lora_cr);
     j += ",\"lpw\":"; j += itos(lora_tx_power);
     j += ",\"lhd\":"; j += lora_hop_disabled ? "true" : "false";  // #106
+    // #150: airtime-derived hop dwell for the current preset; 0 tells the
+    // app hopping is unavailable at this modulation (option greys out).
+    j += ",\"lhdw\":"; j += itos(currentHopDwell());
     j += "}";
     enqueueConfigReadback(j);   // #398 item 3: paced drain in loop_oc, no delay()
     ESP_LOGI("CFG", "Queued config readback (%u bytes)", (unsigned)j.length());
@@ -3409,7 +3437,19 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         // hopping off mid-PRELAUNCH or back on once the operator clears
         // the override.  Persist to NVS so the setting survives reboot.
         const bool new_disabled = (payload[0] != 0);
-        if (new_disabled != lora_hop_disabled)
+        if (!new_disabled && currentHopDwell() == 0)
+        {
+            // #150: this modulation can't fit one packet inside the FCC
+            // dwell budget — refuse the enable so we cannot be commanded
+            // into a non-compliant schedule.  The BS applies the same
+            // gate (and the app greys the option via "lhdw"==0), so
+            // reaching here means the two ends disagree on sf/bw; the
+            // cmd-10 config sync heals that, after which the enable can
+            // be retried.
+            ESP_LOGW("LORA", "UPLINK Hop enable REFUSED: dwell=0 at SF%u/BW%.0f",
+                     (unsigned)lora_sf, (double)lora_bw_khz);
+        }
+        else if (new_disabled != lora_hop_disabled)
         {
             lora_hop_disabled = new_disabled;
             prefs.begin("lora", false);
@@ -3671,6 +3711,10 @@ static void serviceLoRaUplink()
                     last_uplink_rx_ms = millis();
                     if (hop_active_) hop_session_uplink_count++;
                 }
+            }
+            else if (pkt_nid != network_id)
+            {
+                lora_uplink_nid_drops++;   // #150: no more silent nid drops
             }
         }
         // readPacket() internally re-enters RX mode after reading
@@ -4505,7 +4549,7 @@ static void printStats()
         {
             TR_LoRa_Comms::Stats ls = {};
             lora_comms.getStats(ls);
-            ESP_LOGI("LORA", "LoRa tx=%lu/%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu rxmode=%c",
+            ESP_LOGI("LORA", "LoRa tx=%lu/%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu nid_drop=%lu rxmode=%c",
                           (unsigned long)ls.tx_ok,
                           (unsigned long)ls.tx_fail,
                           (unsigned long)ls.rx_count,
@@ -4513,6 +4557,7 @@ static void printStats()
                           (unsigned long)lora_low_snr_drops,
                           (unsigned long)ls.isr_count,
                           (unsigned long)lora_uplink_rx_count,
+                          (unsigned long)lora_uplink_nid_drops,
                           ls.rx_mode ? 'Y' : 'N');
         }
 
@@ -4884,6 +4929,7 @@ void initPeripherals()
             prefs.putFloat("bw",    config::LORA_BW_KHZ);
             prefs.putUChar("cr",    config::LORA_CR);
             prefs.putChar("txpwr",  config::LORA_TX_POWER_DBM);
+            prefs.putUChar("hopdis", 1);  // #150: fixed mode is the default
             ESP_LOGI("CFG", "LoRa NVS empty -- wrote config.h defaults");
         }
         lora_freq_mhz = prefs.getFloat("freq", config::LORA_FREQ_MHZ);
@@ -4891,23 +4937,24 @@ void initPeripherals()
         lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
         lora_cr        = prefs.getUChar("cr",   config::LORA_CR);
         lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
-        lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106 fixed-frequency override
+        lora_hop_disabled = prefs.getUChar("hopdis", 1) != 0;  // #150: default fixed mode
 
         // Issue #136: every rocket boot starts on the hardcoded
-        // rendezvous frequency + preset, hopping off, regardless of
-        // any NVS values left from prior sessions.  The BS reaches
-        // here on rendezvous, scans, and uses the cmd-10 transactional
-        // flow to move us to the picked channel.  cmd-10's NVS write
-        // still happens during a session for visibility, but boot
-        // always re-resets here so the rendezvous is reliable.
-        // Hopping is gated behind cmd 17 (developer flag); see the
-        // "Re-enable LoRa hopping" follow-up enhancement.
+        // rendezvous frequency + preset regardless of any NVS values
+        // left from prior sessions.  The BS reaches here on rendezvous
+        // and uses the cmd-10 transactional flow to move us as needed.
+        // cmd-10's NVS write still happens during a session for
+        // visibility, but boot always re-resets here so the rendezvous
+        // is reliable.
+        // #150: lora_hop_disabled is deliberately NOT in this override
+        // anymore — the link mode is user-selected (app picker → BS →
+        // uplink cmd 17) and honors NVS across reboots.  Schema v4
+        // wiped any stale pre-#150 hopdis, and the default is 1 (fixed).
         lora_freq_mhz     = LORA_FACTORY_RENDEZVOUS_MHZ;
         lora_sf           = LORA_FACTORY_RENDEZVOUS_SF;
         lora_bw_khz       = LORA_FACTORY_RENDEZVOUS_BW_KHZ;
         lora_cr           = LORA_FACTORY_RENDEZVOUS_CR;
         lora_tx_power     = LORA_FACTORY_RENDEZVOUS_TX_DBM;
-        lora_hop_disabled = true;
 
         // Channel-set restore (#40 / #41 phase 3): skip-mask pushed by
         // the BS via cmd 15.  Skip-mask is keyed off the BW it was
@@ -5272,7 +5319,7 @@ static void setup_oc()
             lora_bw_khz    = prefs.getFloat("bw",   config::LORA_BW_KHZ);
             lora_cr        = prefs.getUChar("cr",    config::LORA_CR);
             lora_tx_power  = (int8_t)prefs.getChar("txpwr", config::LORA_TX_POWER_DBM);
-            lora_hop_disabled = prefs.getUChar("hopdis", 0) != 0;  // #106
+            lora_hop_disabled = prefs.getUChar("hopdis", 1) != 0;  // #150: default fixed mode
             ESP_LOGI("CFG", "NVS LoRa early load (cached): %.1f MHz SF%u BW%.0f CR%u %d dBm hop_disabled=%d",
                           (double)lora_freq_mhz, (unsigned)lora_sf,
                           (double)lora_bw_khz, (unsigned)lora_cr, (int)lora_tx_power,
@@ -5280,16 +5327,17 @@ static void setup_oc()
         }
         prefs.end();
 
-        // Issue #136: same boot-time override as the later peripheral
-        // init.  Done here too so any code between this early load and
-        // initPeripherals() (e.g., config-readback construction) sees
-        // the rendezvous values rather than stale NVS.
+        // Issue #136: same boot-time rendezvous override as the later
+        // peripheral init.  Done here too so any code between this early
+        // load and initPeripherals() (e.g., config-readback construction)
+        // sees the rendezvous values rather than stale NVS.  #150: the
+        // hopdis override is gone — link mode honors NVS (see the
+        // peripheral-init comment).
         lora_freq_mhz     = LORA_FACTORY_RENDEZVOUS_MHZ;
         lora_sf           = LORA_FACTORY_RENDEZVOUS_SF;
         lora_bw_khz       = LORA_FACTORY_RENDEZVOUS_BW_KHZ;
         lora_cr           = LORA_FACTORY_RENDEZVOUS_CR;
         lora_tx_power     = LORA_FACTORY_RENDEZVOUS_TX_DBM;
-        lora_hop_disabled = true;
 
         prefs.begin("servo", false);
         if (prefs.isKey("b1"))
@@ -5326,6 +5374,24 @@ static void setup_oc()
                  mac[2], mac[3], mac[4], mac[5]);
 
         prefs.begin("identity", false);
+
+        // #150: the identity namespace versions SEPARATELY from the lora
+        // namespace and MIGRATES instead of wiping — a wipe here is what
+        // caused the #133-era regression (BS came back nid=0, rocket kept
+        // nid=180, network-id filter silently dropped everything).  v1
+        // just stamps the version; un/nid/rid are unchanged.  Future
+        // bumps must preserve `un` (user data) and may reset nid/rid only
+        // if their stored layout actually changes.
+        {
+            const uint8_t stored_v = prefs.getUChar("schemv", 0);
+            if (stored_v != IDENTITY_NVS_SCHEMA_VERSION)
+            {
+                ESP_LOGW("CFG", "Identity NVS schema %u -> %u (migrating, keys preserved)",
+                         (unsigned)stored_v, (unsigned)IDENTITY_NVS_SCHEMA_VERSION);
+                prefs.putUChar("schemv", IDENTITY_NVS_SCHEMA_VERSION);
+            }
+        }
+
         if (!prefs.isKey("un"))
         {
             char default_name[24];
@@ -5344,19 +5410,12 @@ static void setup_oc()
         rocket_id  = prefs.getUChar("rid", config::DEFAULT_ROCKET_ID);
         prefs.end();
 
-        // #136: force network_id back to default on every boot, matching
-        // the LoRa rendezvous override.  Stops BS and OC from drifting
-        // apart when one side's NVS gets wiped (e.g., the lora-namespace
-        // clear on a schema bump) while the other keeps an old nid.
-        // Cmd 9 still works at runtime for developers; on next boot the
-        // device returns to the hardcoded default.  Per-network IDs come
-        // back in #150 alongside hopping.
-        if (network_id != config::DEFAULT_NETWORK_ID)
-        {
-            ESP_LOGW("CFG", "NVS nid=%u differs from default %u — forcing default",
-                     (unsigned)network_id, (unsigned)config::DEFAULT_NETWORK_ID);
-            network_id = config::DEFAULT_NETWORK_ID;
-        }
+        // #150: the #136 boot-time force of network_id back to default is
+        // gone.  Per-network IDs are user-set again (BLE cmd 41 / the
+        // network-name UI), survive reboot, and drift is now VISIBLE
+        // instead of silent: both ends count nid-mismatch drops (the BS
+        // surfaces its count to the app as "nidd") and identity NVS
+        // migrates rather than wipes.
 
         ESP_LOGI("CFG", "Identity early load: uid=%s name=%s nid=%u rid=%u",
                  unit_id_hex, unit_name, (unsigned)network_id, (unsigned)rocket_id);

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -636,12 +636,29 @@ static float   channel_set_bw_khz_ = 0.0f;     // BW the mask was built for
 static bool lora_in_rx_mode = false;
 
 // #150: packets-per-channel dwell for the CURRENT modulation, derived from
-// real airtime so the FCC occupancy bound holds at every preset.  0 means a
-// single packet exceeds the budget => hopping is not permitted at this
-// (sf, bw) and every hop entry point below refuses to start.
+// real airtime so the FCC occupancy bound holds at every preset.  0 means
+// hopping is not permitted at this (sf, bw, cr) and every hop entry point
+// below refuses to start.  Uses the link gate (not the raw config
+// function): CR-only changes are unverifiable over the air, so hopping is
+// only offered at the factory CR — see loraHopDwellForLink.
 static inline uint8_t currentHopDwell()
 {
-    return loraHopDwellForConfig(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
+    return loraHopDwellForLink(lora_sf, lora_bw_khz, SIZE_OF_LORA_DATA, lora_cr);
+}
+
+// #150: effective skip mask for the hop schedule = the cmd-15 noise mask
+// (when valid for the current BW) + the implicit home-channel skip
+// (loraApplyHomeChannelSkip — keeps transition packets on lora_freq_mhz
+// from stacking with a scheduled visit to the same frequency inside one
+// FCC window).  `buf` must hold LORA_SKIP_MASK_MAX_BYTES.
+static const uint8_t* effectiveHopMask(uint8_t* buf, uint8_t n_channels)
+{
+    const bool mask_valid = (skip_mask_n_ == n_channels &&
+                              channel_set_bw_khz_ == lora_bw_khz);
+    if (mask_valid) memcpy(buf, skip_mask_, LORA_SKIP_MASK_MAX_BYTES);
+    else            memset(buf, 0, LORA_SKIP_MASK_MAX_BYTES);
+    (void)loraApplyHomeChannelSkip(buf, lora_bw_khz, lora_freq_mhz);
+    return buf;
 }
 
 static inline void updateHopFromState(RocketState s)
@@ -2765,16 +2782,26 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
         }
         else
         {
-            // Skip-mask aware schedule.  When no valid mask is loaded
-            // (n_chan == 0 or BW mismatch) the empty mask makes
-            // loraHopChannelForSeq degenerate to (seq/dwell) % n.
-            const bool mask_valid = (skip_mask_n_ == n &&
-                                      channel_set_bw_khz_ == lora_bw_khz);
-            static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
-            const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+            // Skip-mask aware schedule (cmd-15 noise mask + the #150
+            // implicit home-channel skip).  With no valid stored mask the
+            // empty mask makes loraHopChannelForSeq degenerate to
+            // (seq/dwell) % n.
+            uint8_t mask_buf[LORA_SKIP_MASK_MAX_BYTES];
+            const uint8_t* mask = effectiveHopMask(mask_buf, n);
             lora.next_channel_idx = loraHopChannelForSeq(
                 (uint16_t)(seq + 1), currentHopDwell(), mask, n);
         }
+    }
+    else if (hop_active_)
+    {
+        // #150 (review): rendezvous visit / coordinated-scan pause — the
+        // hop session is live but this frame is off-schedule.  Tell the
+        // BS the truth (0xFE) instead of "not hopping" (0xFF): a
+        // fixed-mode BS gets immediate mode-mismatch evidence while we
+        // are parked HERE and listening — the one window where its
+        // cmd-17 push can land — and a lost BS parked on the rendezvous
+        // learns the session is still alive.
+        lora.next_channel_idx = LORA_NEXT_CH_HOP_OFFSCHEDULE;
     }
     else
     {
@@ -2950,10 +2977,8 @@ static void serviceLoRa()
             const uint8_t n = loraChannelCount(lora_bw_khz);
             if (n > 0)
             {
-                const bool mask_valid = (skip_mask_n_ == n &&
-                                          channel_set_bw_khz_ == lora_bw_khz);
-                static const uint8_t empty_mask[LORA_SKIP_MASK_MAX_BYTES] = {0};
-                const uint8_t* mask = mask_valid ? skip_mask_ : empty_mask;
+                uint8_t mask_buf[LORA_SKIP_MASK_MAX_BYTES];
+                const uint8_t* mask = effectiveHopMask(mask_buf, n);
                 hop_idx_ = loraHopChannelForSeq(
                     lora_tx_seq, currentHopDwell(), mask, n);
             }
@@ -5378,15 +5403,34 @@ static void setup_oc()
         // #150: the identity namespace versions SEPARATELY from the lora
         // namespace and MIGRATES instead of wiping — a wipe here is what
         // caused the #133-era regression (BS came back nid=0, rocket kept
-        // nid=180, network-id filter silently dropped everything).  v1
-        // just stamps the version; un/nid/rid are unchanged.  Future
-        // bumps must preserve `un` (user data) and may reset nid/rid only
-        // if their stored layout actually changes.
+        // nid=180, network-id filter silently dropped everything).
+        //
+        // v0 -> v1 resets nid to the compile-time default ONCE (review
+        // finding): the #136 boot-force this branch removes was RAM-only,
+        // so fielded devices still store whatever nid the #133 era left
+        // behind — values that have been masked, divergent, and
+        // unreachable for months.  Making them live would kill the link
+        // on the first post-flash boot with no over-the-air recovery
+        // (both directions are nid-filtered).  The pre-upgrade EFFECTIVE
+        // nid was always the default, so resetting to it is the
+        // behavior-preserving migration.  `un` (user data) and `rid`
+        // (never boot-forced) are preserved.
         {
             const uint8_t stored_v = prefs.getUChar("schemv", 0);
             if (stored_v != IDENTITY_NVS_SCHEMA_VERSION)
             {
-                ESP_LOGW("CFG", "Identity NVS schema %u -> %u (migrating, keys preserved)",
+                if (stored_v == 0)
+                {
+                    const uint8_t old_nid =
+                        prefs.getUChar("nid", config::DEFAULT_NETWORK_ID);
+                    if (old_nid != config::DEFAULT_NETWORK_ID)
+                    {
+                        ESP_LOGW("CFG", "Identity migration: stale masked nid=%u reset to default %u",
+                                 (unsigned)old_nid, (unsigned)config::DEFAULT_NETWORK_ID);
+                        prefs.putUChar("nid", config::DEFAULT_NETWORK_ID);
+                    }
+                }
+                ESP_LOGW("CFG", "Identity NVS schema %u -> %u (migrated)",
                          (unsigned)stored_v, (unsigned)IDENTITY_NVS_SCHEMA_VERSION);
                 prefs.putUChar("schemv", IDENTITY_NVS_SCHEMA_VERSION);
             }

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -576,11 +576,19 @@ static inline void updateFreqLockFromState(RocketState s)
 //                     currently tuned to (or, equivalently, the channel of
 //                     the packet most recently transmitted).  Meaningless
 //                     while inactive.
-// hop_first_pkt_    = true on the very first TX after activating: that
-//                     packet still goes out on the static lora_freq_mhz
-//                     channel with next_channel_idx = 0, so the BS sees
-//                     the transition and follows without needing time
-//                     sync.  Cleared after the packet is queued.
+// hop_bootstrap_left_ = remaining bootstrap packets to transmit on the
+//                     static lora_freq_mhz channel before entering the
+//                     schedule.  #150 bench finding: a SINGLE bootstrap
+//                     frame carried the whole BS handoff, and three
+//                     independent BS-deaf windows ate it on the bench
+//                     (its cmd-17 mirror-retry train, a heartbeat TX,
+//                     and a recovery reconfigure racing the transition).
+//                     Now every (re)bootstrap sends a full dwell-count
+//                     of packets — same per-visit occupancy as any
+//                     scheduled dwell, so the FCC math is unchanged —
+//                     each stamped with the SCHEDULE ENTRY channel so
+//                     any one of them lets the BS park where the rocket
+//                     will arrive.  0 = on-schedule (or inactive).
 // hop_needs_retune_ = a retune is owed (e.g. just transitioned, or just
 //                     finished a TX and need to step to the next channel).
 //                     Honoured at the top of serviceLoRa as soon as the
@@ -592,7 +600,7 @@ static inline void updateFreqLockFromState(RocketState s)
 // change so it can drop in without coordination.
 static bool    hop_active_        = false;
 static uint8_t hop_idx_           = 0;
-static bool    hop_first_pkt_     = false;
+static uint8_t hop_bootstrap_left_ = 0;
 static bool    hop_needs_retune_  = false;
 // Link mode (#106 origin, user-facing since #150): when true, hopping is
 // suppressed even in PRELAUNCH/INFLIGHT/LANDED and we stay on
@@ -603,6 +611,18 @@ static bool    hop_needs_retune_  = false;
 // Initialized true (fixed mode, the default) so the window between boot
 // and the NVS load can never report hop-enabled.
 static bool    lora_hop_disabled  = true;
+
+// #150 bench finding (2026-07-15): when the BS mirrors a cmd-17 ENABLE it
+// fires an 8 x 100 ms blind retry train and is deaf (half-duplex TX) for
+// most of that window.  Activating the hop immediately on first-retry
+// receipt made the bootstrap packet collide with retries 2-8: the BS
+// missed it and the link sat dark for ~60 s until the fallback visit
+// healed it.  Defer activation past the train so the bootstrap lands on
+// a listening BS.  0 = no deferred enable pending.  (A disable cancels
+// the defer; a state transition during the window may still activate
+// early via updateHopFromState — rare and self-healing.)
+static constexpr uint32_t HOP_ENABLE_DEFER_MS = 1500;
+static uint32_t hop_enable_apply_at_ms = 0;
 
 // Hop-silence rendezvous fallback state (#40 / #41 phase 2b).
 // Definitions of HOP_FALLBACK_*_MS constants and the serviceHopFallback()
@@ -671,19 +691,21 @@ static inline void updateHopFromState(RocketState s)
                              shouldHopInState(s);
     if (want_active && !hop_active_)
     {
-        // OFF → ON.  Bootstrap: the next TX still goes out on
-        // lora_freq_mhz with next_channel_idx = 0 so the BS sees the
-        // transition; we retune to channel 0 only after that packet is
-        // in the air.
+        // OFF → ON.  Bootstrap: a dwell-count of packets still go out on
+        // lora_freq_mhz, each announcing the schedule-entry channel, so
+        // the BS can catch ANY one of them and park where we'll arrive
+        // (see hop_bootstrap_left_).
         hop_active_              = true;
-        hop_first_pkt_           = true;
+        hop_bootstrap_left_      = currentHopDwell();
+        if (hop_bootstrap_left_ == 0) hop_bootstrap_left_ = 1;  // want_active guarantees dwell>0
         hop_idx_                 = 0;
         hop_needs_retune_        = true;  // ensure we're on lora_freq_mhz before TXing
         hop_active_entered_ms    = millis();
         hop_session_uplink_count = 0;
         hop_fallback_state       = HopFallbackState::NORMAL;
-        ESP_LOGI("OC", "[HOP] Active: bootstrap on %.2f MHz, then idx=0 "
+        ESP_LOGI("OC", "[HOP] Active: %u bootstrap pkt(s) on %.2f MHz, then schedule "
                        "(%u channels at BW=%.0f kHz)",
+                 (unsigned)hop_bootstrap_left_,
                  (double)lora_freq_mhz, (unsigned)loraChannelCount(lora_bw_khz),
                  (double)lora_bw_khz);
     }
@@ -710,20 +732,20 @@ static inline void updateHopFromState(RocketState s)
             hop_fallback_state = HopFallbackState::NORMAL;
             hop_pause_until_ms = 0;
         }
-        hop_active_       = false;
-        hop_first_pkt_    = false;
-        hop_needs_retune_ = true;
+        hop_active_         = false;
+        hop_bootstrap_left_ = 0;
+        hop_needs_retune_   = true;
         ESP_LOGI("OC", "[HOP] Inactive: returning to %.2f MHz", (double)lora_freq_mhz);
     }
 }
 
 // Frequency the radio should currently be tuned to, given the hop state.
-// First-packet bootstrap, PAUSED_FOR_SCAN (#90), and inactive all stay on
+// Bootstrap packets, PAUSED_FOR_SCAN (#90), and inactive all stay on
 // lora_freq_mhz; the active steady state uses the channel table for the
 // current BW.
 static inline float hopTargetFreqMHz()
 {
-    if (hop_active_ && !hop_first_pkt_ &&
+    if (hop_active_ && hop_bootstrap_left_ == 0 &&
         hop_fallback_state == HopFallbackState::NORMAL)
     {
         const float f = loraChannelMHz(lora_bw_khz, hop_idx_);
@@ -2786,10 +2808,19 @@ static bool buildLoRaPayload(uint8_t out_payload[SIZE_OF_LORA_DATA], uint16_t se
             // implicit home-channel skip).  With no valid stored mask the
             // empty mask makes loraHopChannelForSeq degenerate to
             // (seq/dwell) % n.
+            //
+            // Bootstrap packets (#150) all announce the SCHEDULE ENTRY
+            // channel — the channel of the first on-schedule packet,
+            // whose seq is this seq plus the remaining bootstrap count —
+            // so the BS can decode ANY one of them and park where we
+            // will arrive.  On-schedule packets announce seq+1 as always.
             uint8_t mask_buf[LORA_SKIP_MASK_MAX_BYTES];
             const uint8_t* mask = effectiveHopMask(mask_buf, n);
+            const uint16_t anchor_seq = (hop_bootstrap_left_ > 0)
+                ? (uint16_t)(seq + hop_bootstrap_left_)
+                : (uint16_t)(seq + 1);
             lora.next_channel_idx = loraHopChannelForSeq(
-                (uint16_t)(seq + 1), currentHopDwell(), mask, n);
+                anchor_seq, currentHopDwell(), mask, n);
         }
     }
     else if (hop_active_)
@@ -2963,12 +2994,13 @@ static void serviceLoRa()
         // the hop sequence.
         if (hop_active_ && hop_fallback_state == HopFallbackState::NORMAL)
         {
-            if (hop_first_pkt_)
+            if (hop_bootstrap_left_ > 0)
             {
-                // Bootstrap packet just went out on lora_freq_mhz.  Clear
-                // the first-packet flag; the next packet (seq just
-                // incremented) will go on its scheduled hop channel.
-                hop_first_pkt_ = false;
+                // A bootstrap packet just went out on lora_freq_mhz.
+                // Count it down; once it hits zero the retune below
+                // steps onto the schedule-entry channel every bootstrap
+                // frame announced.
+                hop_bootstrap_left_--;
             }
             // Recompute hop_idx_ from the just-incremented seq via the
             // seq-anchored schedule.  This MUST equal the next_channel_idx
@@ -3480,9 +3512,24 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
             prefs.begin("lora", false);
             prefs.putUChar("hopdis", lora_hop_disabled ? 1 : 0);
             prefs.end();
-            ESP_LOGI("LORA", "UPLINK Hop disable: %s — re-evaluating hop state",
-                     lora_hop_disabled ? "DISABLED (fixed freq)" : "ENABLED");
-            updateHopFromState(latest_rocket_state);
+            if (!lora_hop_disabled)
+            {
+                // #150 bench finding: don't activate while the BS is
+                // still blasting its cmd-17 mirror retries (it's deaf
+                // mid-TX and would miss our bootstrap, costing ~60 s of
+                // fallback healing).  The poll next to
+                // serviceHopFallback() applies the enable after the
+                // train finishes.
+                hop_enable_apply_at_ms = millis() + HOP_ENABLE_DEFER_MS;
+                ESP_LOGI("LORA", "UPLINK Hop disable: ENABLED — activating in %u ms (after BS retry train)",
+                         (unsigned)HOP_ENABLE_DEFER_MS);
+            }
+            else
+            {
+                hop_enable_apply_at_ms = 0;   // a disable cancels any pending enable
+                ESP_LOGI("LORA", "UPLINK Hop disable: DISABLED (fixed freq) — re-evaluating hop state");
+                updateHopFromState(latest_rocket_state);
+            }
         }
         else
         {
@@ -4036,7 +4083,8 @@ static void serviceHopFallback()
             (void)lora_comms.startReceive();
             lora_in_rx_mode = true;
 
-            hop_first_pkt_    = true;
+            hop_bootstrap_left_ = currentHopDwell();
+            if (hop_bootstrap_left_ == 0) hop_bootstrap_left_ = 1;
             hop_idx_          = 0;
             hop_needs_retune_ = false;  // already on lora_freq_mhz from reconfigure
             hop_fallback_state = HopFallbackState::NORMAL;
@@ -4045,7 +4093,8 @@ static void serviceHopFallback()
             // arrives during this pass either).
             hop_active_entered_ms = now;
             hop_session_uplink_count = 0;
-            ESP_LOGI("OC", "[HOP] Visit done — resuming hop with fresh bootstrap");
+            ESP_LOGI("OC", "[HOP] Visit done — resuming hop (%u bootstrap pkt(s))",
+                     (unsigned)hop_bootstrap_left_);
             break;
         }
         case HopFallbackState::PAUSED_FOR_SCAN:
@@ -4058,14 +4107,16 @@ static void serviceHopFallback()
             // both sides re-enter the table cleanly.  Use signed delta
             // to handle millis() wrap.
             if ((int32_t)(now - hop_pause_until_ms) < 0) return;
-            hop_first_pkt_           = true;
+            hop_bootstrap_left_      = currentHopDwell();
+            if (hop_bootstrap_left_ == 0) hop_bootstrap_left_ = 1;
             hop_idx_                 = 0;
             hop_needs_retune_        = false;  // already on lora_freq_mhz
             hop_active_entered_ms    = now;
             hop_session_uplink_count = 0;
             hop_fallback_state       = HopFallbackState::NORMAL;
             hop_pause_until_ms       = 0;
-            ESP_LOGI("OC", "[HOP] Pause done — resuming hop with fresh bootstrap");
+            ESP_LOGI("OC", "[HOP] Pause done — resuming hop (%u bootstrap pkt(s))",
+                     (unsigned)hop_bootstrap_left_);
             break;
         }
     }
@@ -5727,6 +5778,16 @@ static void loop_oc()
         // the rocket has been silent in READY for a long time, so the base
         // station's Phase-A recovery has a meeting point (issue #71).
         LOOP_STALL_INSTR("serviceRocketRendezvous", serviceRocketRendezvous());
+
+        // #150: deferred hop-enable (see the cmd-17 handler) — activate
+        // once the BS's mirror-retry train has finished so the bootstrap
+        // packet lands on a listening BS.
+        if (hop_enable_apply_at_ms != 0 &&
+            (int32_t)(millis() - hop_enable_apply_at_ms) >= 0)
+        {
+            hop_enable_apply_at_ms = 0;
+            updateHopFromState(latest_rocket_state);
+        }
 
         // Hop-silence rendezvous: same idea but gated for the hopping
         // case (#40 / #41 phase 2b).  Active only while hop_active_ and

--- a/tools/bench_ble_cmd.py
+++ b/tools/bench_ble_cmd.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Bench BLE command tool (#150) — drive TinkerRocket BLE commands from a Mac.
+
+The iOS app is the normal command path, but bench work sometimes needs a
+command the app has no UI for yet (the #150 hop toggle was the motivating
+case).  This connects to a device over CoreBluetooth (via bleak) and writes
+the COMMAND characteristic with exactly the bytes the app's
+sendRawCommand() would: [cmd_u8][payload...], write-with-response.
+
+Wire facts (TR_BLE_To_APP.h / BLEDevice.swift):
+  service    4fafc201-1fb5-459e-8fcc-c5c9c331914b
+  telemetry  beb5483e-36e1-4688-b7f5-ea07361b26a8   (notify: JSON)
+  command    cba1d466-344c-4be3-ab3f-189f80dd7518   (write)
+
+Examples:
+  python3 tools/bench_ble_cmd.py --scan
+  python3 tools/bench_ble_cmd.py --name TR-B --hop on --listen 6
+  python3 tools/bench_ble_cmd.py --name TR-B --hop off
+  python3 tools/bench_ble_cmd.py --name TR-B --lora 915.0 250 9 5 12
+  python3 tools/bench_ble_cmd.py --name TR-B --cmd 20 --listen 4   # config readback
+  # cmd 60 noise scan 902..928 MHz, 500 kHz step, 30 ms dwell
+  # payload = [start f32][stop f32][step_khz u16][dwell_ms u16], little-endian:
+  python3 tools/bench_ble_cmd.py --name TR-B --cmd 60 --payload 0080614400006844f4011e00
+
+Notes:
+  * The device supports a limited number of BLE centrals — if the iOS app
+    is connected to the same device, disconnect it first.
+  * --hop on sends cmd 17 payload 0x00 (payload is the hop_DISABLED flag).
+  * The firmware refuses a hop enable when the current modulation cannot
+    hop legally (config readback shows "lhdw":0) — watch --listen output.
+"""
+
+import argparse
+import asyncio
+import struct
+import sys
+
+from bleak import BleakClient, BleakScanner
+
+SERVICE_UUID   = "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
+TELEMETRY_UUID = "beb5483e-36e1-4688-b7f5-ea07361b26a8"
+COMMAND_UUID   = "cba1d466-344c-4be3-ab3f-189f80dd7518"
+
+SCAN_TIMEOUT_S = 8.0
+
+
+def build_payload(args) -> tuple[int, bytes]:
+    """Resolve the (cmd, payload) to send from the CLI sugar options."""
+    if args.hop is not None:
+        # cmd 17 payload byte = lora_hop_disabled (0 = hopping ON)
+        return 17, bytes([0x00 if args.hop == "on" else 0x01])
+    if args.lora is not None:
+        freq, bw, sf, cr, pwr = args.lora
+        # BS BLE cmd 10: [freq f32][bw f32][sf u8][cr u8][pwr i8], little-endian
+        return 10, struct.pack("<ffBBb", freq, bw, int(sf), int(cr), int(pwr))
+    if args.cmd is not None:
+        payload = bytes.fromhex(args.payload) if args.payload else b""
+        return args.cmd, payload
+    raise SystemExit("nothing to send: use --hop/--lora/--cmd (or --scan)")
+
+
+async def scan(name_filter: str | None):
+    print(f"Scanning {SCAN_TIMEOUT_S:.0f}s ...")
+    devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT_S)
+    hits = 0
+    for d in devices:
+        name = d.name or ""
+        if name_filter and name_filter.lower() not in name.lower():
+            continue
+        if not name_filter and not (name.startswith("TR-") or "Base" in name):
+            continue
+        print(f"  {d.address}  rssi={getattr(d, 'rssi', '?')}  {name}")
+        hits += 1
+    if hits == 0:
+        print("  no matching devices (is it powered? is the app connected to it?)")
+
+
+async def find_device(name_substr: str):
+    dev = await BleakScanner.find_device_by_filter(
+        lambda d, ad: name_substr.lower() in (d.name or "").lower(),
+        timeout=SCAN_TIMEOUT_S,
+    )
+    if dev is None:
+        raise SystemExit(
+            f"device matching '{name_substr}' not found — power it, and make "
+            f"sure the iOS app isn't holding its only BLE connection")
+    return dev
+
+
+async def run(args):
+    if args.scan:
+        await scan(args.name)
+        return
+
+    if not args.name:
+        raise SystemExit("--name <substring> required (e.g. --name TR-B)")
+
+    cmd, payload = build_payload(args)
+    dev = await find_device(args.name)
+    print(f"Connecting to {dev.name} ({dev.address}) ...")
+
+    async with BleakClient(dev) as client:
+        if args.listen > 0:
+            def on_notify(_h, data: bytearray):
+                try:
+                    print(f"  <- {data.decode('utf-8', 'replace')}")
+                except Exception:
+                    print(f"  <- {data.hex()}")
+            await client.start_notify(TELEMETRY_UUID, on_notify)
+
+        frame = bytes([cmd]) + payload
+        print(f"Writing cmd {cmd} payload={payload.hex() or '(none)'} "
+              f"[{frame.hex()}]")
+        await client.write_gatt_char(COMMAND_UUID, frame, response=True)
+        print("Write OK")
+
+        if args.listen > 0:
+            print(f"Listening {args.listen}s for notifications ...")
+            await asyncio.sleep(args.listen)
+            await client.stop_notify(TELEMETRY_UUID)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--scan", action="store_true",
+                   help="list nearby TinkerRocket devices and exit")
+    p.add_argument("--name", help="device name substring (e.g. TR-B, TR-R)")
+    p.add_argument("--cmd", type=int, help="raw BLE command id")
+    p.add_argument("--payload", default="", help="raw payload as hex string")
+    p.add_argument("--hop", choices=["on", "off"],
+                   help="cmd-17 sugar: link mode (on = hopping)")
+    p.add_argument("--lora", nargs=5, type=float, metavar=("MHZ", "BW", "SF", "CR", "DBM"),
+                   help="cmd-10 sugar: LoRa reconfigure (e.g. 915.0 250 9 5 12)")
+    p.add_argument("--listen", type=float, default=0.0,
+                   help="after writing, print telemetry-char notifications for N seconds")
+    args = p.parse_args()
+    try:
+        asyncio.run(run(args))
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_ble_cmd.py
+++ b/tools/bench_ble_cmd.py
@@ -41,7 +41,7 @@ SERVICE_UUID   = "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
 TELEMETRY_UUID = "beb5483e-36e1-4688-b7f5-ea07361b26a8"
 COMMAND_UUID   = "cba1d466-344c-4be3-ab3f-189f80dd7518"
 
-SCAN_TIMEOUT_S = 8.0
+SCAN_TIMEOUT_S = 15.0   # generous: a marginal-RSSI BS at 1 Hz advertising needs headroom
 
 
 def build_payload(args) -> tuple[int, bytes]:
@@ -92,12 +92,18 @@ async def run(args):
         await scan(args.name)
         return
 
-    if not args.name:
-        raise SystemExit("--name <substring> required (e.g. --name TR-B)")
+    if not args.name and not args.address:
+        raise SystemExit("--name <substring> or --address <uuid> required")
 
     cmd, payload = build_payload(args)
-    dev = await find_device(args.name)
-    print(f"Connecting to {dev.name} ({dev.address}) ...")
+    if args.address:
+        # Connect by cached identifier — on macOS this can reach a known
+        # peripheral whose advertisements are too weak to scan reliably.
+        dev = args.address
+        print(f"Connecting by address {args.address} ...")
+    else:
+        dev = await find_device(args.name)
+        print(f"Connecting to {dev.name} ({dev.address}) ...")
 
     async with BleakClient(dev) as client:
         if args.listen > 0:
@@ -126,6 +132,8 @@ def main():
     p.add_argument("--scan", action="store_true",
                    help="list nearby TinkerRocket devices and exit")
     p.add_argument("--name", help="device name substring (e.g. TR-B, TR-R)")
+    p.add_argument("--address", help="connect by CoreBluetooth peripheral UUID "
+                                     "(works at RSSI too weak for name scans)")
     p.add_argument("--cmd", type=int, help="raw BLE command id")
     p.add_argument("--payload", default="", help="raw payload as hex string")
     p.add_argument("--hop", choices=["on", "off"],


### PR DESCRIPTION
## Summary

Re-enables LoRa frequency hopping as a user-selectable link mode — closes #150.

The iOS app gets a **Link Mode** picker (Fixed Channel / Frequency Hopping); fixed mode remains the default and is byte-identical to #136 behavior. Hopping is the #133 seq-anchored design, re-enabled and hardened to be genuinely FCC 15.247-compliant, with the network-ID flow restored per the #150 checklist.

Full design record, worldwide regulatory survey, compliance math, and bench evidence: `docs/plans/150-fhss-reenable.md`.

## Key design points

- **Adaptive dwell** (`loraHopDwellForConfig`, budget 390 ms): packets-per-channel derived from real airtime so the FCC 0.4 s occupancy bound holds at every preset — SF8/BW250→3, SF10/BW250→1 (the +5 dB long-range rung), BW125@SF9+/SF11+→hopping refused (`lhdw:0`, GUI greys the option). CR gated to factory 4/5 (CR-only cmd-10 commits are unverifiable over the air).
- **LANDED hops** — 2 Hz telemetry continues after touchdown; a fixed channel would be 5× over the occupancy bound. Observed live on a sim flight.
- **`0xFE` off-schedule sentinel** — visit/pause frames announce "hopping, momentarily off-schedule" so a fixed or rebooted BS gets mode-resync evidence exactly when the rocket is parked and listening.
- **Dwell-count bootstrap** announcing the schedule-entry channel; graceful cmd-17 disable drain; 1.5 s deferred enable; heartbeat hold — each closes a bench-observed half-duplex collision on the mode handoff.
- **Network IDs are durable again**: identity NVS migrates (never wipes), with a one-time v0→v1 nid reset to default (the old boot-force was RAM-only, so fielded devices still stored divergent #133-era nids that would have silently killed the link on first post-flash boot). Drops are counted and user-visible (`nidd` + dashboard banner, recency-gated).
- **NVS schema v4** wipes stale pre-#150 `hopdis` developer flags; boot keeps the #136 rendezvous preset force but honors the persisted link mode.

## Verification

- **Host**: 588/588 gtests incl. a new FCC compliance suite (dwell table, `dwell×ToA ≤ 400 ms` invariant, revisit-vs-window bound, exact + u16-wrap channel-use uniformity, scan-handoff floor, home-channel skip). App: 181+ simulator tests.
- **Adversarial reviews**: 27-agent firmware review (9 confirmed findings, all fixed pre-bench) + 32-agent iOS review (12 confirmed, all fixed pre-commit).
- **Bench Seam A** (BS V2 + OC V7): 30-min SF8/dwell-3 soak — 3,596 packets, 0 loss, 0 CRC, 0 TX-wdog across ~1,200 retunes; dwell-1 sessions 0 loss; BS power-cycle self-recovery in ~70 s; drain/defer verified live.
- **Bench Seam B** (app-driven): mode toggles, mid-hop coordinated scan with FCC-floored mask push (65/69 active), NetID mismatch drill (live drop counter, per-device sync), full sim flight (2 packets lost at 99 m/s, LANDED-hopping observed).
- **Root-caused & fixed en route**: dwell-1 uplink bursts missing entirely (flat SF8-sized TX-window reserve → airtime-derived; toggles 40–75 s → 1–3 s, repro 3/3).

## Notes

- **Coordinated re-flash required**: BS and rocket must be flashed together (0xFE sentinel + dwell derivation changed) — same rule #133's shared constant already imposed. Mixed fleets unsupported.
- BW125/SF11-class max-range presets stay fixed-channel-only (a packet can't fit the dwell window); the SX1276 daughterboard path for true mid-packet FHSS is documented as future work.
- UART-modem pair (BS V3 + OC V8) bench deferred until the V8 radio respin returns.
- New bench tool: `tools/bench_ble_cmd.py` (drive any BLE command from a Mac; used for all Seam A testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
