### PR TITLE
app(#150): hop-armed badge says "starts when pad-ready", not the wire-state name

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -705,8 +705,13 @@ struct DeviceChipBar: View {
 // #150: the three honest hop states the tile can report.  Derived from the
 // mode readback (lhd), the live-following signal (hch — only present while
 // the BS is actually walking the schedule), and the rocket state:
-//   armed    = mode on, rocket in READY/INIT — hopping starts at PRELAUNCH
-//              by design, nothing is wrong (this wait is usually GPS)
+//   armed    = mode on, rocket in READY/INIT — hopping starts at wire-state
+//              PRELAUNCH by design, nothing is wrong (this wait is usually
+//              GPS).  The label says "pad-ready" rather than "PRELAUNCH":
+//              #382 renders wire READY as "PRELAUNCH" on screen too, so
+//              naming the wire state here read as a contradiction ("in
+//              PRELAUNCH, starts at PRELAUNCH, not hopping") while the
+//              rocket was still acquiring GNSS.
 //   engaging = mode on, rocket in a hop state, schedule not followed yet —
 //              the handoff is in flight (normally 1-3 s; a missed bootstrap
 //              self-heals within ~60 s)
@@ -780,7 +785,7 @@ struct RocketStateView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.orange)
             case .armed:
-                Label("Hopping armed — starts at PRELAUNCH", systemImage: "dot.radiowaves.left.and.right")
+                Label("Hopping armed — starts when pad-ready", systemImage: "dot.radiowaves.left.and.right")
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.secondary)
             case nil:


### PR DESCRIPTION
## Problem

Pre-GNSS the dashboard read **"PRELAUNCH … Hopping armed — starts at PRELAUNCH"** while not hopping. #382 deliberately renders wire `READY` as "PRELAUNCH" on screen (with the "Acquiring GNSS" badge carrying the distinction), so the #150 hop badge naming the wire state became a self-contradiction.

## Change

Display-only: the armed badge now reads **"Hopping armed — starts when pad-ready"**, matching the pad-readiness badge right above it — the two visibly resolve together when GNSS acquires. The firmware gate (hop from wire `PRELAUNCH` = OC link + GNSS held 3 s) is unchanged, and the comment above `HopBadge` records why the label avoids the wire-state name.

Bench-checked on 2026-07-16: badge shows the new text through the GNSS-acquisition wait, hop engages at pad-ready as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)