### PR TITLE
fix(app): CSV header names must not contain commas — #514 exports load shifted

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -526,13 +526,20 @@ nonisolated class CSVGenerator {
         // Roll/Pitch/Yaw is NOT a valid Euler triple and cannot be combined into an
         // orientation. Anything needing the actual attitude must use q0..q3.
         // Blank for legacy logs, whose wire format carried no quaternion.
+        //
+        // Column names must never contain a comma: this writer does not quote
+        // fields, and the readers (CSVParser here, pandas/awk in Data_Analysis)
+        // split rows blind. The original #514 names carried commas, so the
+        // header row had three more tokens than every data row and every
+        // column after "Quat q3" loaded shifted (exports 2026-07-14…07-16;
+        // CSVParser.repairSplitHeaderNames rescues those files on read).
         columns.append("Quat q0")
         columns.append("Quat q1")
         columns.append("Quat q2")
         columns.append("Quat q3")
-        columns.append("Roll (deg, body-Z azimuth)")
-        columns.append("Pitch (deg, ZYX Euler)")
-        columns.append("Yaw (deg, ZYX Euler)")
+        columns.append("Roll (deg; body-Z azimuth)")
+        columns.append("Pitch (deg; ZYX Euler)")
+        columns.append("Yaw (deg; ZYX Euler)")
         columns.append("Roll Command (deg)")
         columns.append("Position East (m)")
         columns.append("Position North (m)")

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
@@ -32,12 +32,14 @@ struct FlightCSVData {
         ]),
         // #514: the quaternion is the only reconstructable attitude — Roll is the
         // body-Z azimuth while Pitch/Yaw are ZYX-Euler, so those three are NOT a
-        // valid Euler triple. The old unqualified names are kept so CSVs exported
-        // before #514 still group correctly.
+        // valid Euler triple. Two name generations appear in the wild: the
+        // current semicolon names (the #514 comma names broke naive readers and
+        // were re-released with semicolons; repairSplitHeaderNames folds the
+        // 7/14–7/16 comma exports into this form) and the pre-#514 plain names.
         ("Rotation", [
             "Gyro X (deg/s)", "Gyro Y (deg/s)", "Gyro Z (deg/s)",
             "Quat q0", "Quat q1", "Quat q2", "Quat q3",
-            "Roll (deg, body-Z azimuth)", "Pitch (deg, ZYX Euler)", "Yaw (deg, ZYX Euler)",
+            "Roll (deg; body-Z azimuth)", "Pitch (deg; ZYX Euler)", "Yaw (deg; ZYX Euler)",
             "Roll (deg)", "Pitch (deg)", "Yaw (deg)",           // pre-#514 exports
             "Roll Command (deg)"
         ]),
@@ -114,6 +116,36 @@ enum CSVParserError: Error, LocalizedError {
 
 class CSVParser {
 
+    /// Apps built 2026-07-14…07-16 (#514, pre-fix) emitted three column names
+    /// containing literal commas without quoting, so the header row carried
+    /// three more comma-separated tokens than every data row and all columns
+    /// after "Quat q3" loaded shifted. Re-join those known token pairs into
+    /// the current comma-free names so existing exports parse correctly.
+    /// (The writer no longer puts commas in column names — see CSVGenerator.)
+    private nonisolated static let splitHeaderRepairs: [String: (second: String, joined: String)] = [
+        "Roll (deg": ("body-Z azimuth)", "Roll (deg; body-Z azimuth)"),
+        "Pitch (deg": ("ZYX Euler)", "Pitch (deg; ZYX Euler)"),
+        "Yaw (deg": ("ZYX Euler)", "Yaw (deg; ZYX Euler)"),
+    ]
+
+    nonisolated static func repairSplitHeaderNames(_ headers: [String]) -> [String] {
+        var repaired: [String] = []
+        repaired.reserveCapacity(headers.count)
+        var i = 0
+        while i < headers.count {
+            if i + 1 < headers.count,
+               let fix = splitHeaderRepairs[headers[i]],
+               headers[i + 1] == fix.second {
+                repaired.append(fix.joined)
+                i += 2
+            } else {
+                repaired.append(headers[i])
+                i += 1
+            }
+        }
+        return repaired
+    }
+
     /// Parse a CSV file into columnar FlightCSVData.
     /// Call from a background Task for large files.
     nonisolated static func parse(url: URL) throws -> FlightCSVData {
@@ -125,7 +157,8 @@ class CSVParser {
         }
 
         let headerLine = lines[0]
-        let headers = headerLine.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+        let rawHeaders = headerLine.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+        let headers = repairSplitHeaderNames(rawHeaders)
         let columnCount = headers.count
 
         guard columnCount > 0 else {

--- a/TinkerRocketApp/TinkerRocketAppTests/CSVParserTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/CSVParserTests.swift
@@ -47,4 +47,34 @@ final class CSVParserTests: XCTestCase {
         XCTAssertEqual(data.columns["c0"], [0.0, 0.0])
         XCTAssertEqual(data.columns["c35"]?.count, 2)        // all columns aligned
     }
+
+    /// Exports from 2026-07-14…07-16 app builds have unquoted commas in the
+    /// three #514 attitude names, so the header row carries three more tokens
+    /// than every data row and all later columns load shifted. The parser must
+    /// re-join those tokens into the current semicolon names so the values
+    /// land under the right columns.
+    func testParse_SplitAttitudeHeaderNames_AreRepairedAndAligned() throws {
+        let header = "Quat q3,Roll (deg, body-Z azimuth),Pitch (deg, ZYX Euler),"
+                   + "Yaw (deg, ZYX Euler),Roll Command (deg),Position Up (m)"
+        let data = try parse("\(header)\n0.5,10,20,30,0.04,407.2\n")
+        XCTAssertEqual(data.headers, [
+            "Quat q3",
+            "Roll (deg; body-Z azimuth)", "Pitch (deg; ZYX Euler)", "Yaw (deg; ZYX Euler)",
+            "Roll Command (deg)", "Position Up (m)",
+        ])
+        XCTAssertEqual(data.columns["Quat q3"], [0.5])
+        XCTAssertEqual(data.columns["Roll (deg; body-Z azimuth)"], [10.0])
+        XCTAssertEqual(data.columns["Roll Command (deg)"], [0.04])
+        XCTAssertEqual(data.columns["Position Up (m)"], [407.2])   // not shifted
+    }
+
+    /// Headers without the broken comma names pass through untouched — a
+    /// lone "Roll (deg)" (pre-#514) or the current semicolon names must not
+    /// trigger the repair.
+    func testParse_CurrentAndLegacyHeaders_NotRewritten() throws {
+        let data = try parse("Roll (deg; body-Z azimuth),Roll (deg),Yaw (deg)\n1,2,3\n")
+        XCTAssertEqual(data.headers,
+                       ["Roll (deg; body-Z azimuth)", "Roll (deg)", "Yaw (deg)"])
+        XCTAssertEqual(data.columns["Roll (deg)"], [2.0])
+    }
 }


### PR DESCRIPTION
## Problem

The #514 attitude column names (`Roll (deg, body-Z azimuth)` etc., PR #516) were emitted **unquoted**, so every flight CSV exported since 2026-07-14 has a header row with three more comma-separated tokens than each data row. Every column after `Quat q3` loads under the wrong name in every naive reader (the app's own CSVParser, pandas in Data_Analysis): launch flag reads "never", EKF up-position shows max *speed*, apogee votes land under the wrong detectors, and the last three columns read NaN. Diagnosed by decoding the raw .bin at the frame level and matching every "corrupt" CSV value to its true field. Bins were never wrong.

## Change

- **CSVGenerator**: semicolon names (`Roll (deg; body-Z azimuth)` …) + a documented no-comma rule for column names.
- **CSVParser**: re-joins the known split token pairs on read, so the two days of already-exported files load correctly; grouping list updated.
- **CSVParserTests**: repair + no-false-positive coverage (5/5 pass on simulator).

Exports from 7/14–7/16 builds can also simply be re-downloaded after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)