### PR TITLE
fix(lora): keep BS heartbeats alive in flight while hopping — ends the ~33 s session-teardown loop

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -2439,7 +2439,16 @@ static inline bool inHopSafeWindow()
 
 static void serviceHeartbeat()
 {
-    if (freq_locked_for_flight)                return;  // No heartbeats in flight
+    // The flight freq-lock freezes radio PARAMETERS mid-flight (#106); a
+    // zero-payload broadcast heartbeat changes none, and while hopping the
+    // heartbeats are load-bearing: without them the rocket hears no uplink,
+    // its rendezvous fallback fires every 30 s (HOP_FALLBACK_TRIGGER_
+    // INITIAL_MS), and each 3 s visit trips our own 3 s silence teardown —
+    // ~8 packets lost per ~33 s, ~5% flight loss (2026-07-16 bench, three
+    // sim flights; loss <0.2% in every non-flight state). Fixed-channel
+    // flights keep the old behavior: no hop fallback to feed, and staying
+    // RX-only in flight costs nothing.
+    if (freq_locked_for_flight && !hop_active_) return;  // fixed-channel flight only
     if (lora_txn_state != LoRaTxnState::IDLE)  return;  // Don't interfere with txn
     if (recovery_state != RecoveryState::IDLE) return;  // Recovery owns the radio
     if (scan_passes_remaining_ != 0)           return;  // #136: don't TX mid-scan

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4035,9 +4035,13 @@ static void serviceRocketRendezvous()
 // This mirrors slow_rendezvous (#71) but with hop-aware triggers:
 //   • Reference time is the most recent LoRa uplink during the
 //     current hop session (or hop entry, if no uplink heard yet).
-//     Heartbeats from the BS — newly safe-window-scheduled in this
-//     phase — bump last_uplink_rx_ms every 30 s in nominal operation,
-//     so this trigger fires only when comms have actually broken.
+//     Heartbeats from the BS — safe-window-scheduled, every 10 s
+//     (HEARTBEAT_INTERVAL_MS) — bump last_uplink_rx_ms in nominal
+//     operation, so this trigger fires only when comms have actually
+//     broken.  NOTE the BS must keep heartbeating IN FLIGHT for this
+//     to hold: gating heartbeats on freq_locked_for_flight starved
+//     this timer and tore the session down every ~33 s (2026-07-16
+//     bench; fixed BS-side in serviceHeartbeat).
 //   • Visit is a single short window (no on/off oscillation), then we
 //     re-bootstrap hopping with a fresh transition packet on
 //     lora_freq_mhz so the BS sees a clean re-entry.


### PR DESCRIPTION
## Problem

Every hopping (#150) flight lost ~5-10% of telemetry in a deterministic pattern (identical 58-pkt / 32.64 s session signature across three sim flights, byte-level RF pristine, 0 CRC fails). Root cause chain, established with BS console + LoRa logs + 74 min of control soaks:

1. Launch latches `freq_locked_for_flight` (#106 — freeze radio *parameters* mid-flight).
2. `serviceHeartbeat()`'s first gate suppressed **all** heartbeats under that lock — zero uplinks queued in INFLIGHT (TX scheduler exonerated: deferred counter flat).
3. The OC hears no uplink for 30 s → correctly visits rendezvous for 3.0 s → trips the BS's 3.0 s silence teardown → ~8 packets lost per ~33 s cycle, all flight.

The same function's own comment documents that hopping without heartbeats tears down every 30 s — the #106 gate and the #150 design contradicted each other. Control data: LANDED soak 44 min / 5,250 pkts / 0 lost; PRELAUNCH soak 30 min / 3,562 pkts / 0 lost; the loop fires **only** when heartbeats stop.

## Change

Heartbeats now flow in flight **while hopping** (`freq_locked_for_flight && !hop_active_`); fixed-channel flights keep the old RX-only behavior. A zero-payload broadcast heartbeat changes no radio parameters, so the #106 lock's purpose is intact. Deliberately **not** touched: visit (3 s) == BS silence threshold (3 s) — that equality is the post-visit resync path, not a bug. Also corrects the stale OC comment (heartbeats are every 10 s, not 30 s).

## Validation (bench, 2026-07-16, same 1,183 m sim profile before/after)

| | before | after |
|---|---|---|
| in-flight teardowns | 3 | **0** |
| INFLIGHT telemetry | 4 fragments, 16 lost | **one 137.6 s session, 0 lost** |
| flight-window loss | 32 pkts (~10%) | 8 pkts (all in the pre-launch sim-start stall — separate bench-only artifact) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)