### PR TITLE
oc(log): #511 skip trusted-map bad-block boot scan; #510 flush-iteration ledger

### DIFF
--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -517,6 +517,21 @@ target_include_directories(test_mram_dirty_policy PRIVATE
 target_link_libraries(test_mram_dirty_policy GTest::gtest_main)
 gtest_discover_tests(test_mram_dirty_policy)
 
+# ---------- test_bad_block_scan_policy (#511) ----------
+# Host-side test for the boot bad-block-scan gate: the full 2048-block scan
+# (~2.7 s of the cmd-8 Power-On stall) runs only until one scan has completed
+# for the current chip — recorded by the NVS "scanned" marker written strictly
+# AFTER the scan (the "chip" key is written BEFORE it and must not be trusted).
+# A dead RDID bus skips the scan so 2048 failing reads can't poison the map.
+# bad_block_scan_policy.h is pure, so the test just adds the component dir.
+add_executable(test_bad_block_scan_policy test_bad_block_scan_policy.cpp)
+target_include_directories(test_bad_block_scan_policy PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_LogToFlash
+)
+target_link_libraries(test_bad_block_scan_policy GTest::gtest_main)
+gtest_discover_tests(test_bad_block_scan_policy)
+
 # ---------- test_sim_pad_align (#508) ----------
 # Header-only pure math (no ESP/Arduino deps), so there is no component .cpp to
 # compile — the alignment solve was extracted out of SensorCollectorSim precisely

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -532,6 +532,20 @@ target_include_directories(test_bad_block_scan_policy PRIVATE
 target_link_libraries(test_bad_block_scan_policy GTest::gtest_main)
 gtest_discover_tests(test_bad_block_scan_policy)
 
+# ---------- test_flush_iter_ledger (#510) ----------
+# Host-side test for the flush-task per-iteration accounting: section sums,
+# clamped unaccounted/drain-other arithmetic, and the WARN/INFO classification
+# (a long iteration the section timers explain — arm-time erase, activation
+# ring drain — logs INFO; a genuine blind spot stays WARN with a breakdown).
+# flush_iter_ledger.h is pure arithmetic, so the test just adds the dir.
+add_executable(test_flush_iter_ledger test_flush_iter_ledger.cpp)
+target_include_directories(test_flush_iter_ledger PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_LogToFlash
+)
+target_link_libraries(test_flush_iter_ledger GTest::gtest_main)
+gtest_discover_tests(test_flush_iter_ledger)
+
 # ---------- test_sim_pad_align (#508) ----------
 # Header-only pure math (no ESP/Arduino deps), so there is no component .cpp to
 # compile — the alignment solve was extracted out of SensorCollectorSim precisely

--- a/tests_cpp/test_bad_block_scan_policy.cpp
+++ b/tests_cpp/test_bad_block_scan_policy.cpp
@@ -1,0 +1,83 @@
+// #511: BadBlockScanPolicy — the boot-time full bad-block scan (2048 blocks,
+// ~2.7 s of the cmd-8 Power-On stall) must run only until one scan has
+// completed for the current chip. The gate keys on the NVS "scanned" marker,
+// written strictly AFTER scanBadBlocksAtBoot() — NOT on the "chip" key, which
+// nandInit() writes BEFORE the scan (it exists for chip-swap map wipes), so
+// "chip matches" never proves a scan completed. A dead RDID bus (0x0000 /
+// 0xFFFF) must skip the scan outright: 2048 failing reads would mark every
+// block bad and poison the persisted map. These tests pin the decision table.
+
+#include <gtest/gtest.h>
+
+#include "bad_block_scan_policy.h"
+
+using Verdict = BadBlockScanPolicy::Verdict;
+
+// Factory-fresh device: no NVS namespace, so no map blob and no marker.
+TEST(BadBlockScanPolicy, FirstBoot_NoNamespace_Scans)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(
+                  /*dead_bus=*/false, /*map_blob_valid=*/false,
+                  /*scanned_chip_id=*/0, /*current_chip_id=*/0xCD53),
+              Verdict::Scan);
+}
+
+// First boot after the #511 firmware update: the map blob and "chip" key
+// exist from earlier firmware, but the "scanned" marker was never written.
+// One more full scan runs, then the marker gates it off forever.
+TEST(BadBlockScanPolicy, PostOta_MapPresentNoMarker_ScansOnce)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(false, true, 0, 0xCD53),
+              Verdict::Scan);
+}
+
+// Steady state: marker matches the live chip — skip the 2.7 s walk.
+TEST(BadBlockScanPolicy, NormalBoot_TrustedMap_Skips)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(false, true, 0xCD53, 0xCD53),
+              Verdict::SkipTrustedMap);
+}
+
+// NAND replaced: nandInit() wipes the map, but the stale marker still names
+// the old chip, so the new chip gets its mandatory factory-marker scan.
+TEST(BadBlockScanPolicy, ChipSwapped_Rescans)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(false, true, 0xAAAA, 0xCD53),
+              Verdict::Scan);
+}
+
+// Truncated/corrupt NVS blob: the in-RAM map was zeroed, so the marker alone
+// (even matching) must not be trusted — rescan to rebuild factory knowledge.
+TEST(BadBlockScanPolicy, CorruptBlob_MarkerMatches_StillScans)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(false, false, 0xCD53, 0xCD53),
+              Verdict::Scan);
+}
+
+// Power cut mid-scan: the marker is written only after a completed scan, so
+// the next boot sees it absent (0) and rescans. Same inputs as PostOta.
+TEST(BadBlockScanPolicy, MidScanPowerLoss_MarkerAbsent_Rescans)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(false, true, 0, 0xCD53),
+              Verdict::Scan);
+}
+
+// Dead bus, RDID all-zero. Trap pinned here: scanned==0 (never written) would
+// arithmetically "match" chip==0x0000 — dead_bus must win before that compare.
+TEST(BadBlockScanPolicy, DeadBus0000_SkipsEvenWithZeroMarker)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(true, true, 0, 0x0000),
+              Verdict::SkipDeadBus);
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(true, false, 0, 0x0000),
+              Verdict::SkipDeadBus);
+}
+
+// Dead bus, RDID all-ones — including a previously-healthy map for a real
+// chip. Never scan (would mark all 2048 blocks bad and poison that map).
+TEST(BadBlockScanPolicy, DeadBusFFFF_SkipsRegardlessOfMap)
+{
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(true, true, 0xFFFF, 0xFFFF),
+              Verdict::SkipDeadBus);
+    EXPECT_EQ(BadBlockScanPolicy::bootScanVerdict(true, true, 0xCD53, 0xFFFF),
+              Verdict::SkipDeadBus);
+}

--- a/tests_cpp/test_flush_iter_ledger.cpp
+++ b/tests_cpp/test_flush_iter_ledger.cpp
@@ -1,0 +1,110 @@
+// #510: FlushIterLedger — per-iteration accounting for the OC log-flush task.
+// The 7/14 bench flight's 588 ms activation "STALL" was 98% invisible because
+// every existing accumulator is a per-op MAXIMUM; the activation iteration
+// drains the whole ~97 KB prelaunch ring as ~24 sub-threshold page writes.
+// These tests pin the ledger arithmetic and the WARN/INFO classification:
+// a long iteration the section timers explain is LongAccounted (INFO, e.g.
+// the designed arm-time 80-block erase), while a genuine blind spot stays
+// LongUnaccounted (WARN).
+
+#include <gtest/gtest.h>
+
+#include "flush_iter_ledger.h"
+
+using Verdict = FlushIterLedger::Verdict;
+
+static constexpr uint32_t THRESH = 100'000;  // mirrors STALL_THRESHOLD_US
+
+TEST(FlushIterLedger, DefaultsAndResetZeroEverything)
+{
+    FlushIterLedger l;
+    EXPECT_EQ(l.accountedUs(), 0u);
+    EXPECT_EQ(l.drain_pages, 0u);
+
+    l.staging_us = 1; l.open_us = 2; l.hook_us = 3; l.activate_us = 4;
+    l.drain_us = 5; l.endflight_us = 6;
+    l.drain_pages = 7; l.drain_bytes = 8; l.pop_us = 9; l.write_us = 10;
+    l.reset();
+    EXPECT_EQ(l.accountedUs(), 0u);
+    EXPECT_EQ(l.drain_pages, 0u);
+    EXPECT_EQ(l.drain_bytes, 0u);
+    EXPECT_EQ(l.pop_us, 0u);
+    EXPECT_EQ(l.write_us, 0u);
+}
+
+TEST(FlushIterLedger, AccountedSumsTheSixSections_NotSubDetails)
+{
+    FlushIterLedger l;
+    l.staging_us = 10; l.open_us = 20; l.hook_us = 30;
+    l.activate_us = 40; l.drain_us = 50; l.endflight_us = 60;
+    l.pop_us = 1000; l.write_us = 2000;  // sub-details of drain, not added
+    EXPECT_EQ(l.accountedUs(), 210u);
+}
+
+TEST(FlushIterLedger, UnaccountedClampsAtZero)
+{
+    FlushIterLedger l;
+    l.drain_us = 500;
+    EXPECT_EQ(l.unaccountedUs(1000), 500u);
+    // Section brackets can sum a hair past the iteration bracket (extra
+    // esp_timer reads between them) — must clamp, not wrap.
+    EXPECT_EQ(l.unaccountedUs(499), 0u);
+}
+
+TEST(FlushIterLedger, DrainOtherIsolatesNonPopWriteTime_AndClamps)
+{
+    FlushIterLedger l;
+    l.drain_us = 581'000; l.pop_us = 210'000; l.write_us = 350'000;
+    EXPECT_EQ(l.drainOtherUs(), 21'000u);  // FL prints / loop overhead
+
+    // End-of-flight iterations book pops under endflight_us, so drain_us
+    // can be smaller than the sub-details — clamp to 0, don't wrap.
+    FlushIterLedger e;
+    e.endflight_us = 400'000; e.pop_us = 150'000; e.write_us = 200'000;
+    EXPECT_EQ(e.drainOtherUs(), 0u);
+}
+
+TEST(FlushIterLedger, ClassifyQuietAtOrUnderThreshold)
+{
+    EXPECT_EQ(FlushIterLedger::classify(THRESH, 0, THRESH), Verdict::Quiet);
+    EXPECT_EQ(FlushIterLedger::classify(THRESH - 1, 0, THRESH), Verdict::Quiet);
+    // Matches the pre-#510 trigger: strictly-greater fires.
+    EXPECT_NE(FlushIterLedger::classify(THRESH + 1, 0, THRESH), Verdict::Quiet);
+}
+
+// The real 7/14 case as it SHOULD read with the ledger in place: 588 ms
+// iteration, ~583 ms of it in activate+drain sections → INFO, not WARN.
+TEST(FlushIterLedger, Bench588ms_MostlyAccounted_IsInfo)
+{
+    EXPECT_EQ(FlushIterLedger::classify(588'005, 583'000, THRESH),
+              Verdict::LongAccounted);
+}
+
+// The same case as it read on 7/14 (only ~11 ms instrumented): a genuine
+// blind spot → stays WARN.
+TEST(FlushIterLedger, Bench588ms_AsReported11msAccounted_IsWarn)
+{
+    EXPECT_EQ(FlushIterLedger::classify(588'005, 11'000, THRESH),
+              Verdict::LongUnaccounted);
+}
+
+// The designed 342 ms arm-time erase, fully booked under hook_us → INFO
+// (#510 item 3: the designed cost must stop reading as a fault).
+TEST(FlushIterLedger, ArmErase342ms_FullyAccounted_IsInfo)
+{
+    EXPECT_EQ(FlushIterLedger::classify(342'099, 342'000, THRESH),
+              Verdict::LongAccounted);
+}
+
+TEST(FlushIterLedger, ClassifyBoundary_UnaccountedExactlyThresholdIsInfo)
+{
+    // unacc == threshold → still LongAccounted (WARN needs strictly greater,
+    // mirroring the iteration trigger).
+    EXPECT_EQ(FlushIterLedger::classify(300'000, 200'000, THRESH),
+              Verdict::LongAccounted);
+    EXPECT_EQ(FlushIterLedger::classify(300'001, 200'000, THRESH),
+              Verdict::LongUnaccounted);
+    // accounted > iter (clamp path) → unacc 0 → INFO.
+    EXPECT_EQ(FlushIterLedger::classify(300'000, 300'500, THRESH),
+              Verdict::LongAccounted);
+}

--- a/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
+++ b/tinkerrocket-idf/components/TR_FlightLog/TR_FlightLog.cpp
@@ -54,6 +54,16 @@ inline uint32_t monotonic_ms() {
 #endif
 }
 
+// Monotonic microseconds for the #510 lock-wait metric. Host builds have no
+// clock, so waits measure 0 and the metric is inert — same as monotonic_ms().
+inline int64_t monotonic_us() {
+#ifdef ESP_PLATFORM
+    return esp_timer_get_time();
+#else
+    return 0;
+#endif
+}
+
 }  // namespace
 
 Status TR_FlightLog::begin(TR_NandBackend& nand, const Config& cfg,
@@ -502,7 +512,13 @@ bool TR_FlightLog::extendActiveRange() {
 }
 
 Status TR_FlightLog::writeFrame(const uint8_t* payload, size_t payload_len) {
+    // #510: time the lock acquire — the flush task's per-page wait behind a
+    // concurrent listFlights/readFlightPage (#388) is otherwise invisible.
+    const int64_t lk_t0 = monotonic_us();
     FlightLogLockGuard guard(mutex_);
+    const uint32_t lk_dt = static_cast<uint32_t>(monotonic_us() - lk_t0);
+    if (lk_dt > wf_lock_wait_max_us_) wf_lock_wait_max_us_ = lk_dt;
+    wf_lock_wait_sum_us_ = wf_lock_wait_sum_us_ + lk_dt;
     if (!initialized_)   return Status::NotInitialized;
     if (!flight_active_) return Status::Error;
     if (payload == nullptr && payload_len != 0) return Status::OutOfRange;

--- a/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
+++ b/tinkerrocket-idf/components/TR_FlightLog/include/TR_FlightLog.h
@@ -102,6 +102,16 @@ public:
     uint32_t  autoEvictedCount()      const { return auto_evicted_count_; }
     uint32_t  lastEvictedFlightId()   const { return last_evicted_flight_id_; }
 
+    // #510 (#388 contention): wall time writeFrame spent BLOCKED acquiring
+    // mutex_, per stats window — the flush task's per-page waits behind a
+    // concurrent BLE listFlights/readFlightPage are otherwise folded
+    // invisibly into the logger's write timing. Max single wait + window sum;
+    // reset alongside the logger's resetIntervalTimings(). On host builds the
+    // clock is inert (0), matching monotonic_ms().
+    uint32_t  writeLockWaitMaxUs() const { return wf_lock_wait_max_us_; }
+    uint32_t  writeLockWaitSumUs() const { return wf_lock_wait_sum_us_; }
+    void      resetLockWaitStats()       { wf_lock_wait_max_us_ = 0; wf_lock_wait_sum_us_ = 0; }
+
     // Pre-launch: pick + erase a free contiguous range. May stall ~770 ms.
     // Writes the assigned flight_id to `flight_id_out` on success.
     //
@@ -201,6 +211,12 @@ private:
     // volatile flag above, so the high-priority I2S task can never block on a
     // ~770 ms prepareFlight erase that holds the lock.
     FlightLogMutex mutex_;
+
+    // #510: writeFrame's mutex_-acquire wall time (see writeLockWaitMaxUs).
+    // Written only by the flush task, read cross-task for the stats print —
+    // same unsynchronized-diagnostics convention as the logger's spi peaks.
+    volatile uint32_t wf_lock_wait_max_us_ = 0;
+    volatile uint32_t wf_lock_wait_sum_us_ = 0;
 
     // Lock-held implementations, called by the public wrappers and by the two
     // internal call chains (servicePendingPrepareFlight -> prepareFlightLocked,

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -123,10 +123,37 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
 
     // Boot-time non-destructive bad-block scan (#47): walks every not-yet-
     // known-bad block and probes for read errors + factory bad markers.
-    // Findings get markBlockBad'd; we persist right away so a reboot during
-    // the scan doesn't lose the discoveries.
-    scanBadBlocksAtBoot();
-    persistBadBlocksIfDirty();
+    // #511: the full 2048-block walk costs ~2.7 s of the cmd-8 Power-On
+    // stall, so it now runs only until one scan has completed for this chip
+    // (NVS "scanned" marker, written strictly after the scan). Runtime
+    // discovery (markBlockBad on read/prog/erase failures) keeps the map
+    // current afterwards. A dead RDID bus skips the scan entirely — probing
+    // 2048 failing reads would mark every block bad and poison the map.
+    switch (BadBlockScanPolicy::bootScanVerdict(nand_dead_bus_,
+                                                bad_block_map_blob_ok_,
+                                                bad_block_scanned_chip_,
+                                                current_chip_id_))
+    {
+        case BadBlockScanPolicy::Verdict::Scan:
+            scanBadBlocksAtBoot();
+            // Persist right away so a reboot during the rest of begin()
+            // doesn't lose the discoveries. The marker goes last: a power
+            // cut between the two just rescans next boot.
+            persistBadBlocksIfDirty();
+            markBootScanComplete();
+            break;
+        case BadBlockScanPolicy::Verdict::SkipTrustedMap:
+            if (cfg.debug) ESP_LOGI(TAG, "Bad-block boot scan skipped: map trusted (chip 0x%04X, %lu known bad)",
+                                          (unsigned)current_chip_id_,
+                                          (unsigned long)countBadBlocks());
+            break;
+        case BadBlockScanPolicy::Verdict::SkipDeadBus:
+            // Not debug-gated — a dead NAND bus is serious, and the mount
+            // below will fail with less obvious symptoms.
+            ESP_LOGE(TAG, "NAND RDID dead bus (0x%04X) — skipping bad-block scan",
+                          (unsigned)current_chip_id_);
+            break;
+    }
 
     // Allocate LittleFS buffers on heap to avoid stack overflow
     lfs_read_buffer = (uint8_t*)malloc(NAND_PAGE_SIZE);
@@ -1404,6 +1431,10 @@ bool TR_LogToFlash::nandInit()
     // rest of begin() surface the real error.
     const uint16_t current_chip_id = (uint16_t)(((uint16_t)mid << 8) | (uint16_t)did);
     const bool dead_bus = (current_chip_id == 0x0000) || (current_chip_id == 0xFFFF);
+    // #511: stash both for the boot-scan gate in begin() — the gate must not
+    // read bad_block_chip_id_, which the wipe below rewrites pre-scan.
+    current_chip_id_ = current_chip_id;
+    nand_dead_bus_ = dead_bus;
     if (!dead_bus && current_chip_id != bad_block_chip_id_)
     {
         if (cfg.debug)
@@ -2027,18 +2058,25 @@ void TR_LogToFlash::loadBadBlocksFromNVS()
         // First boot, namespace doesn't exist yet — nothing to load.
         memset(bad_block_bitmap_, 0, sizeof(bad_block_bitmap_));
         bad_block_chip_id_ = 0;
+        bad_block_scanned_chip_ = 0;
+        bad_block_map_blob_ok_ = false;
         bad_block_bitmap_dirty_ = false;
         if (cfg.debug) ESP_LOGI(TAG, "Bad-block NVS namespace not found, starting clean");
         return;
     }
     const size_t got = prefs.getBytes("map", bad_block_bitmap_, sizeof(bad_block_bitmap_));
     bad_block_chip_id_ = prefs.getUShort("chip", 0);
+    bad_block_scanned_chip_ = prefs.getUShort("scanned", 0);  // #511: written only post-scan
     prefs.end();
-    if (got != sizeof(bad_block_bitmap_))
+    bad_block_map_blob_ok_ = (got == sizeof(bad_block_bitmap_));
+    bad_block_bitmap_dirty_ = false;
+    if (!bad_block_map_blob_ok_)
     {
         memset(bad_block_bitmap_, 0, sizeof(bad_block_bitmap_));
+        // Self-repair: mark dirty so the forced rescan's persist rewrites the
+        // truncated/corrupt blob instead of leaving it short forever.
+        bad_block_bitmap_dirty_ = true;
     }
-    bad_block_bitmap_dirty_ = false;
     const uint32_t n_bad = countBadBlocks();
     if (cfg.debug) ESP_LOGI(TAG, "Loaded bad-block map: %lu known-bad blocks (saved chip=0x%04X)",
                                   (unsigned long)n_bad, (unsigned)bad_block_chip_id_);
@@ -2060,6 +2098,22 @@ void TR_LogToFlash::persistBadBlocksIfDirty()
     if (cfg.debug) ESP_LOGI(TAG, "Persisted bad-block map (%lu bad, chip=0x%04X)",
                                   (unsigned long)countBadBlocks(),
                                   (unsigned)bad_block_chip_id_);
+}
+
+void TR_LogToFlash::markBootScanComplete()
+{
+    Preferences prefs;
+    if (!prefs.begin("bblk", false))  // read-write
+    {
+        // Not fatal: the marker stays stale and the next boot rescans.
+        if (cfg.debug) ESP_LOGW(TAG, "Bad-block NVS open failed; boot scan will re-run next boot");
+        return;
+    }
+    prefs.putUShort("scanned", current_chip_id_);
+    prefs.end();
+    bad_block_scanned_chip_ = current_chip_id_;
+    if (cfg.debug) ESP_LOGI(TAG, "Bad-block boot scan complete for chip 0x%04X — future boots skip it",
+                                  (unsigned)current_chip_id_);
 }
 
 uint32_t TR_LogToFlash::scanBadBlocksAtBoot()

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -486,6 +486,10 @@ void TR_LogToFlash::getStats(TR_LogToFlashStats& out) const
     out.flush_iter_max_us = flush_iter_max_us_;
     out.spi_wait_max_us = spi_wait_max_us_;   // #398
     out.spi_hold_max_us = spi_hold_max_us_;   // #398
+    out.drain_pages = drain_pages_win_;       // #510
+    out.drain_bytes = drain_bytes_win_;       // #510
+    out.pop_sum_us = pop_us_win_;             // #510
+    out.write_sum_us = write_us_win_;         // #510
     out.syncs_performed = syncs_performed_;
 
     out.known_bad_blocks = countBadBlocks();
@@ -504,6 +508,10 @@ void TR_LogToFlash::resetIntervalTimings()
     flush_iter_max_us_ = 0;
     spi_wait_max_us_ = 0;   // #398
     spi_hold_max_us_ = 0;   // #398
+    drain_pages_win_ = 0;   // #510
+    drain_bytes_win_ = 0;   // #510
+    pop_us_win_ = 0;        // #510
+    write_us_win_ = 0;      // #510
 }
 
 void TR_LogToFlash::getRecoveryInfo(TR_LogToFlashRecoveryInfo& out) const
@@ -2305,7 +2313,8 @@ void TR_LogToFlash::flushRingToNand()
             break;
         }
 
-        // Issue #74 diagnostic: for the first 20 drains after activateLogging,
+        // Issue #74 diagnostic: for the first 4 drains after activateLogging
+        // (flush_log_remaining_ is armed to 4; the FL numbering starts at 16),
         // peek the first 8 bytes at rb_tail and log with pointer state.
         // `AA 55 AA 55 <type> <len>` = real frame; all-zero = post-clearRing
         // zeroed MRAM; anything else = stale prelaunch data being re-exposed.
@@ -2324,7 +2333,15 @@ void TR_LogToFlash::flushRingToNand()
             flush_log_remaining_--;
         }
 
+        // #510: MRAM-pop wall time. Deliberately excludes the FL print above —
+        // console cost must land in the ledger's drain-other bucket, not here.
+        const int64_t _p0 = esp_timer_get_time();
         const uint32_t popped = ringPop(page_buf + page_buf_idx, chunk);
+        {
+            const uint32_t _pdt = (uint32_t)(esp_timer_get_time() - _p0);
+            iter_ledger_.pop_us += _pdt;
+            pop_us_win_ += _pdt;
+        }
         if (popped == 0)
         {
             break;
@@ -2344,6 +2361,8 @@ void TR_LogToFlash::flushRingToNand()
                 ok = cfg.write_sink(cfg.write_sink_ctx, page_buf, chunk_target);
                 const uint32_t _dt = (uint32_t)(esp_timer_get_time() - _t0);
                 if (_dt > write_max_us_) write_max_us_ = _dt;
+                iter_ledger_.write_us += _dt;   // #510
+                write_us_win_ += _dt;
                 if (_dt > (uint32_t)STALL_THRESHOLD_US)
                 {
                     ESP_LOGW(TAG, "STALL: write_sink took %lu us", (unsigned long)_dt);
@@ -2359,6 +2378,8 @@ void TR_LogToFlash::flushRingToNand()
                 lfs_ssize_t written = lfs_file_write(&lfs, &file, page_buf, NAND_PAGE_SIZE);
                 const uint32_t _dt = (uint32_t)(esp_timer_get_time() - _t0);
                 if (_dt > write_max_us_) write_max_us_ = _dt;
+                iter_ledger_.write_us += _dt;   // #510
+                write_us_win_ += _dt;
                 if (_dt > (uint32_t)STALL_THRESHOLD_US)
                 {
                     ESP_LOGW(TAG, "STALL: lfs_file_write took %lu us "
@@ -2390,6 +2411,10 @@ void TR_LogToFlash::flushRingToNand()
             nand_bytes_written += chunk_target;
             nand_prog_ops++;
             page_buf_idx = 0;
+            iter_ledger_.drain_pages++;              // #510
+            iter_ledger_.drain_bytes += chunk_target;
+            drain_pages_win_++;
+            drain_bytes_win_ += chunk_target;
 
             // Periodic LFS sync — only meaningful when LFS is the destination.
             // TR_FlightLog pages are self-describing (PageHeader + CRC32), so
@@ -2431,11 +2456,17 @@ void TR_LogToFlash::flushTaskLoop()
     while (!flush_task_stop_)
     {
         const int64_t iter_t0 = esp_timer_get_time();
+        // #510: per-iteration section accounting — see flush_iter_ledger.h.
+        iter_ledger_.reset();
 
         // Push any staged frames that have waited past the age bound, so
         // trickle-rate traffic still reaches the (brownout-durable) MRAM
         // ring promptly even when staging never fills.
-        flushStagingIfStale(STAGING_MAX_AGE_US);
+        {
+            const int64_t _s0 = esp_timer_get_time();
+            flushStagingIfStale(STAGING_MAX_AGE_US);
+            iter_ledger_.staging_us = (uint32_t)(esp_timer_get_time() - _s0);
+        }
 
         // Handle deferred pre-create request (from PRELAUNCH state).
         // #365: consume the request ONLY after observing it set.  The old
@@ -2447,7 +2478,9 @@ void TR_LogToFlash::flushTaskLoop()
         {
             if (!file_open && !logging_active)
             {
+                const int64_t _o0 = esp_timer_get_time();
                 openLogSession();   // Creates file on NAND (slow, but we're not in a hurry yet)
+                iter_ledger_.open_us += (uint32_t)(esp_timer_get_time() - _o0);
                 // #417: pre-create must NOT dirty the marker — the session isn't
                 // active yet. activateLogging() sets it at launch/manual-start.
                 dirty_policy_.onPreCreate();
@@ -2464,7 +2497,9 @@ void TR_LogToFlash::flushTaskLoop()
         // ring on Core 1 while this hook runs.
         if (cfg.flush_task_hook != nullptr)
         {
+            const int64_t _h0 = esp_timer_get_time();
             cfg.flush_task_hook(cfg.flush_task_hook_ctx);
+            iter_ledger_.hook_us = (uint32_t)(esp_timer_get_time() - _h0);
         }
 
         // Handle deferred start-logging request (launch detected).
@@ -2479,12 +2514,14 @@ void TR_LogToFlash::flushTaskLoop()
         {
             if (!logging_active)
             {
+                const int64_t _a0 = esp_timer_get_time();
                 if (!file_open)
                 {
                     // File not pre-created — create now (legacy path)
                     openLogSession();
                 }
                 activateLogging();  // Fast — flips flags + markDirty (#417), no NAND I/O
+                iter_ledger_.activate_us = (uint32_t)(esp_timer_get_time() - _a0);
             }
             // else: already logging — duplicate request; consume it.
             start_logging_requested = false;
@@ -2499,6 +2536,7 @@ void TR_LogToFlash::flushTaskLoop()
         // so the drain loop will terminate quickly.
         if (end_flight_requested && logging_active && file_open)
         {
+            const int64_t _e0 = esp_timer_get_time();
             uint32_t t0 = millis();
 
             // The last <=STAGING_SIZE of accepted frames may still sit in RAM
@@ -2538,6 +2576,7 @@ void TR_LogToFlash::flushTaskLoop()
                      (unsigned long)(t1 - t0),
                      (unsigned long)(t2 - t1),
                      (unsigned long)(t2 - t0));
+            iter_ledger_.endflight_us = (uint32_t)(esp_timer_get_time() - _e0);
         }
 
         // Normal flush: write ring buffer data to NAND.
@@ -2551,19 +2590,53 @@ void TR_LogToFlash::flushTaskLoop()
 
             if (avail > 0)
             {
+                const int64_t _d0 = esp_timer_get_time();
                 flushRingToNand();
+                iter_ledger_.drain_us = (uint32_t)(esp_timer_get_time() - _d0);
                 vTaskDelay(1);  // 1ms yield — enough for WDT, no BLE contention
             }
         }
 
         // Iteration wall time — peaks indicate the flush loop itself
         // blocked for a long time (not just a single LFS op).
+        // #510: classify against the section ledger. A long iteration the
+        // sections explain (arm-time erase in hook, activation ring drain)
+        // is designed work → INFO; only a genuine blind spot stays WARN,
+        // and both name where the time went.
         {
             uint32_t iter_dt = (uint32_t)(esp_timer_get_time() - iter_t0);
             if (iter_dt > flush_iter_max_us_) flush_iter_max_us_ = iter_dt;
-            if (iter_dt > (uint32_t)STALL_THRESHOLD_US) {
-                ESP_LOGW(TAG, "STALL: flushTaskLoop iteration took %lu us",
-                         (unsigned long)iter_dt);
+            const FlushIterLedger::Verdict v = FlushIterLedger::classify(
+                iter_dt, iter_ledger_.accountedUs(), (uint32_t)STALL_THRESHOLD_US);
+            if (v != FlushIterLedger::Verdict::Quiet)
+            {
+                const FlushIterLedger& L = iter_ledger_;
+                if (v == FlushIterLedger::Verdict::LongUnaccounted)
+                {
+                    ESP_LOGW(TAG, "STALL: flush iter %lu us, unaccounted %lu us "
+                                  "(staging=%lu open=%lu hook=%lu act=%lu drain=%lu "
+                                  "[pg=%lu pop=%lu wr=%lu oth=%lu] end=%lu)",
+                             (unsigned long)iter_dt,
+                             (unsigned long)L.unaccountedUs(iter_dt),
+                             (unsigned long)L.staging_us, (unsigned long)L.open_us,
+                             (unsigned long)L.hook_us, (unsigned long)L.activate_us,
+                             (unsigned long)L.drain_us, (unsigned long)L.drain_pages,
+                             (unsigned long)L.pop_us, (unsigned long)L.write_us,
+                             (unsigned long)L.drainOtherUs(), (unsigned long)L.endflight_us);
+                }
+                else
+                {
+                    ESP_LOGI(TAG, "Long flush iteration (accounted): %lu us "
+                                  "(staging=%lu open=%lu hook=%lu act=%lu drain=%lu "
+                                  "[pg=%lu pop=%lu wr=%lu oth=%lu] end=%lu unacc=%lu)",
+                             (unsigned long)iter_dt,
+                             (unsigned long)L.staging_us, (unsigned long)L.open_us,
+                             (unsigned long)L.hook_us, (unsigned long)L.activate_us,
+                             (unsigned long)L.drain_us, (unsigned long)L.drain_pages,
+                             (unsigned long)L.pop_us, (unsigned long)L.write_us,
+                             (unsigned long)L.drainOtherUs(), (unsigned long)L.endflight_us,
+                             (unsigned long)L.unaccountedUs(iter_dt));
+                }
             }
         }
 

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -5,6 +5,7 @@
 #include <RocketComputerTypes.h>
 #include "lfs.h"
 #include "mram_dirty_policy.h"
+#include "bad_block_scan_policy.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
@@ -401,10 +402,24 @@ private:
     // bitmap is wiped — see nandInit().
     uint16_t bad_block_chip_id_ = 0;
 
+    // #511 boot-scan gate inputs. current_chip_id_/nand_dead_bus_ are set by
+    // nandInit()'s RDID read; the other two are captured by
+    // loadBadBlocksFromNVS() BEFORE nandInit() can rewrite bad_block_chip_id_
+    // (the "chip" key is written pre-scan and must not be trusted as a
+    // scan-completed signal — see bad_block_scan_policy.h).
+    uint16_t current_chip_id_ = 0;
+    bool     nand_dead_bus_ = false;
+    bool     bad_block_map_blob_ok_ = false;   // NVS "map" present, exact size
+    uint16_t bad_block_scanned_chip_ = 0;      // NVS "scanned" (0 = never)
+
     bool isBlockBad(uint32_t block) const;
     void markBlockBad(uint32_t block);
     void loadBadBlocksFromNVS();
     void persistBadBlocksIfDirty();
+    /// #511: record (NVS "bblk"/"scanned") that a boot scan completed for the
+    /// current chip. Written strictly AFTER scanBadBlocksAtBoot() so a power
+    /// cut mid-scan leaves the marker stale and the next boot rescans.
+    void markBootScanComplete();
     uint32_t countBadBlocks() const;
     /// Boot-time non-destructive bad-block scan: for every block not yet in
     /// the persistent map, PAGEREAD page 0 to catch NAND-reported read

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -6,6 +6,7 @@
 #include "lfs.h"
 #include "mram_dirty_policy.h"
 #include "bad_block_scan_policy.h"
+#include "flush_iter_ledger.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
@@ -106,6 +107,13 @@ struct TR_LogToFlashStats
     // multi-second parser_max stalls.
     uint32_t spi_wait_max_us = 0;      // max time blocked acquiring spi_mutex_
     uint32_t spi_hold_max_us = 0;      // max single spi_mutex_ hold
+    // #510: per-report-window SUMS complementing the maxima above — a burst
+    // of sub-threshold ops (e.g. the activation ring drain's ~24 page
+    // writes) is invisible to a max but shows up here.
+    uint32_t drain_pages = 0;          // pages shipped to NAND this window
+    uint32_t drain_bytes = 0;          // ring bytes drained this window
+    uint32_t pop_sum_us = 0;           // summed MRAM ringPop wall time
+    uint32_t write_sum_us = 0;         // summed write_sink/lfs_file_write time
     uint32_t syncs_performed = 0;      // cumulative lfs_file_sync calls since begin()
 
     // Persistent bad-block avoidance (#47): once a NAND block is known bad,
@@ -376,6 +384,16 @@ private:
     volatile uint32_t spi_hold_max_us_ = 0;
     int64_t  spi_hold_start_us_ = 0;
     uint32_t syncs_performed_ = 0;
+
+    // #510: per-iteration section ledger (reset at the top of every
+    // flushTaskLoop pass) + per-report-window SUMS (reset alongside the
+    // maxima above). The maxima hide a burst of sub-threshold ops — the
+    // 7/14 activation drain (~24 page writes, 588 ms total) read as 11 ms.
+    FlushIterLedger iter_ledger_;
+    uint32_t drain_pages_win_ = 0;
+    uint32_t drain_bytes_win_ = 0;
+    uint32_t pop_us_win_ = 0;
+    uint32_t write_us_win_ = 0;
 
     // Cumulative LFS-callback op counters (#47 follow-up).  Used to break
     // down *what* a slow lfs_file_write actually did — lots of reads with

--- a/tinkerrocket-idf/components/TR_LogToFlash/bad_block_scan_policy.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/bad_block_scan_policy.h
@@ -1,0 +1,58 @@
+#ifndef BAD_BLOCK_SCAN_POLICY_H
+#define BAD_BLOCK_SCAN_POLICY_H
+
+#include <stdint.h>
+
+// #511: gate for the boot-time full bad-block scan.
+//
+// scanBadBlocksAtBoot() probes all 2048 NAND blocks (3 reads each) and costs
+// ~2.7 s — over half of the 5.05 s cmd-8 Power-On stall that leaves the OC
+// deaf to BLE/LoRa. Factory bad-block markers only need to be harvested ONCE
+// per physical chip: after that the persisted map plus runtime discovery
+// (markBlockBad on read/program/erase failures, persisted at session close)
+// keep the map current without ever re-walking the chip.
+//
+// Two traps this policy encodes:
+//
+// 1. The NVS "chip" key is written by nandInit() BEFORE the scan runs (it
+//    exists to wipe a stale map on chip replacement), so "chip matches" does
+//    NOT mean "a scan ever completed". The gate therefore keys on a separate
+//    "scanned" marker (scanned_chip_id) written strictly AFTER
+//    scanBadBlocksAtBoot() returns — a power cut mid-scan leaves it stale and
+//    the next boot rescans.
+//
+// 2. A dead SPI bus (RDID reads 0x0000/0xFFFF) must skip the scan outright:
+//    probing 2048 blocks over a dead bus fails every read, marks EVERY block
+//    bad, and poisons the persisted map for the real chip. (Before #511 this
+//    was a live failure mode.) dead_bus also swallows the 0x0000 chip id, so
+//    the scanned_chip_id==0 "no marker yet" sentinel can never falsely match.
+//
+// Pure decision logic (no NVS/SPI), host-tested in
+// test_bad_block_scan_policy.cpp — same pattern as MramDirtyPolicy (#417).
+class BadBlockScanPolicy
+{
+public:
+    enum class Verdict : uint8_t
+    {
+        Scan,            // walk the chip (first boot, chip swap, or untrusted map)
+        SkipTrustedMap,  // persisted map already reflects a completed scan of this chip
+        SkipDeadBus,     // RDID dead bus — scanning would poison the map
+    };
+
+    // dead_bus:         RDID returned 0x0000 or 0xFFFF (see nandInit()).
+    // map_blob_valid:   NVS "map" blob was present with the exact bitmap size.
+    // scanned_chip_id:  NVS "scanned" marker (0 = never written).
+    // current_chip_id:  RDID (MID << 8) | DID read this boot.
+    static Verdict bootScanVerdict(bool dead_bus,
+                                   bool map_blob_valid,
+                                   uint16_t scanned_chip_id,
+                                   uint16_t current_chip_id)
+    {
+        if (dead_bus)                            return Verdict::SkipDeadBus;
+        if (!map_blob_valid)                     return Verdict::Scan;
+        if (scanned_chip_id != current_chip_id)  return Verdict::Scan;
+        return Verdict::SkipTrustedMap;
+    }
+};
+
+#endif  // BAD_BLOCK_SCAN_POLICY_H

--- a/tinkerrocket-idf/components/TR_LogToFlash/flush_iter_ledger.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/flush_iter_ledger.h
@@ -1,0 +1,95 @@
+#ifndef FLUSH_ITER_LEDGER_H
+#define FLUSH_ITER_LEDGER_H
+
+#include <stdint.h>
+
+// #510: per-iteration accounting for flushTaskLoop.
+//
+// The 2026-07-14 bench flight logged a 588 ms flush-task "STALL" at logging
+// activation of which only ~11 ms was visible to the existing instrumentation
+// — because every accumulator (write_max_us_ etc.) is a per-op MAXIMUM. The
+// activation iteration drains the whole ~97 KB prelaunch ring in one pass:
+// ~24 pages of MRAM ringPop + NAND program, each individually well under the
+// 100 ms per-op stall threshold, so hundreds of ms of legitimate work simply
+// vanished from the breakdown. In exactly that window the ring has only ~0.5 s
+// of overflow headroom, so a *genuine* blocker there must be attributable.
+//
+// This ledger sums wall time per iteration SECTION (staging / pre-create open
+// / hook / activate / drain / end-of-flight), plus sub-details accumulated
+// inside flushRingToNand (pages, bytes, MRAM-pop time, write time). classify()
+// then splits long iterations into:
+//   LongAccounted   — the section timers explain the time: designed work such
+//                     as the arm-time 80-block erase (hook) or the activation
+//                     ring drain. Logged INFO, not WARN (#510 item 3).
+//   LongUnaccounted — a real blind spot remains. Logged WARN with the
+//                     breakdown, naming where the time did NOT go.
+//
+// Pure arithmetic (no clock, no FreeRTOS) — host-tested in
+// test_flush_iter_ledger.cpp, same pattern as MramDirtyPolicy (#417).
+struct FlushIterLedger
+{
+    // Section wall-times (µs), one bracket per flushTaskLoop section.
+    uint32_t staging_us   = 0;  // flushStagingIfStale
+    uint32_t open_us      = 0;  // PRELAUNCH pre-create openLogSession
+    uint32_t hook_us      = 0;  // flush_task_hook (arm-time prepareFlight: auto-evict + 80-block erase)
+    uint32_t activate_us  = 0;  // start_logging_requested block (activateLogging)
+    uint32_t drain_us     = 0;  // normal-flush flushRingToNand call
+    uint32_t endflight_us = 0;  // end_flight_requested drain + rename + close
+
+    // Sub-details accumulated inside flushRingToNand, under whichever section
+    // invoked it (drain_us normally, endflight_us during the final drain).
+    // They explain section time and are NOT added to accountedUs().
+    uint32_t drain_pages = 0;   // pages shipped to NAND
+    uint32_t drain_bytes = 0;   // ring bytes drained into those pages
+    uint32_t pop_us      = 0;   // MRAM ringPeekAt/ringPop wall time
+    uint32_t write_us    = 0;   // write_sink / lfs_file_write wall time
+
+    void reset() { *this = FlushIterLedger{}; }
+
+    // Sum of the section timers — everything the iteration is KNOWN to have
+    // spent. iter_wall - accountedUs() is the remaining blind spot.
+    uint32_t accountedUs() const
+    {
+        return staging_us + open_us + hook_us + activate_us + drain_us
+             + endflight_us;
+    }
+
+    // Clamped at 0: section brackets sit inside the iteration bracket, but
+    // the extra esp_timer reads can make the sum land a hair over.
+    uint32_t unaccountedUs(uint32_t iter_us) const
+    {
+        const uint32_t acc = accountedUs();
+        return (iter_us > acc) ? (iter_us - acc) : 0;
+    }
+
+    // Drain-section time not explained by MRAM pops or writes — isolates the
+    // FL diagnostic prints / loop overhead (the console-backpressure suspect).
+    // Meaningful when drain_us dominates; clamped at 0 otherwise (e.g. an
+    // end-of-flight iteration books its pops under endflight_us instead).
+    uint32_t drainOtherUs() const
+    {
+        const uint32_t sub = pop_us + write_us;
+        return (drain_us > sub) ? (drain_us - sub) : 0;
+    }
+
+    enum class Verdict : uint8_t
+    {
+        Quiet,            // iteration at/under the stall threshold — no print
+        LongAccounted,    // long, but the section timers explain it (INFO)
+        LongUnaccounted,  // long with a real blind spot remaining (WARN)
+    };
+
+    // Thresholding matches the pre-#510 stall check: a print fires only when
+    // iter_us exceeds threshold_us, and it stays a WARN only when the
+    // unaccounted share alone would also exceed it.
+    static Verdict classify(uint32_t iter_us, uint32_t accounted_us,
+                            uint32_t threshold_us)
+    {
+        if (iter_us <= threshold_us) return Verdict::Quiet;
+        const uint32_t unacc = (iter_us > accounted_us) ? (iter_us - accounted_us) : 0;
+        return (unacc <= threshold_us) ? Verdict::LongAccounted
+                                       : Verdict::LongUnaccounted;
+    }
+};
+
+#endif  // FLUSH_ITER_LEDGER_H

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4714,7 +4714,8 @@ static void printStats()
              "write=%lu sync=%lu erase=%lu open=%lu close=%lu "
              "activate=%lu clr_ring=%lu iter=%lu us  syncs=%lu erases=%lu ring_peak=%lu "
              "bad_blocks=%lu skips=%lu  "
-             "rx_ovf=%lu rx_peak=%lu parser_max=%lu spiw=%lu spih=%lu us",
+             "rx_ovf=%lu rx_peak=%lu parser_max=%lu spiw=%lu spih=%lu us  "
+             "dpg=%lu dby=%lu pop=%lu wsum=%lu us",
              (unsigned long)s.write_max_us,
              (unsigned long)s.sync_max_us,
              (unsigned long)s.erase_max_us,
@@ -4732,7 +4733,11 @@ static void printStats()
              (unsigned long)cur_rx_peak,
              (unsigned long)cur_parser,
              (unsigned long)s.spi_wait_max_us,   // #398: parser starvation source
-             (unsigned long)s.spi_hold_max_us);  // #398
+             (unsigned long)s.spi_hold_max_us,   // #398
+             (unsigned long)s.drain_pages,       // #510: window SUMS — a burst of
+             (unsigned long)s.drain_bytes,       //   sub-threshold page writes is
+             (unsigned long)s.pop_sum_us,        //   invisible to the maxima above
+             (unsigned long)s.write_sum_us);     // #510
     logger.resetIntervalTimings();
 
     // #398: per-task CPU deltas over this same interval — pins the core-1 hog

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4715,7 +4715,7 @@ static void printStats()
              "activate=%lu clr_ring=%lu iter=%lu us  syncs=%lu erases=%lu ring_peak=%lu "
              "bad_blocks=%lu skips=%lu  "
              "rx_ovf=%lu rx_peak=%lu parser_max=%lu spiw=%lu spih=%lu us  "
-             "dpg=%lu dby=%lu pop=%lu wsum=%lu us",
+             "dpg=%lu dby=%lu pop=%lu wsum=%lu m388=%lu/%lu us",
              (unsigned long)s.write_max_us,
              (unsigned long)s.sync_max_us,
              (unsigned long)s.erase_max_us,
@@ -4737,8 +4737,11 @@ static void printStats()
              (unsigned long)s.drain_pages,       // #510: window SUMS — a burst of
              (unsigned long)s.drain_bytes,       //   sub-threshold page writes is
              (unsigned long)s.pop_sum_us,        //   invisible to the maxima above
-             (unsigned long)s.write_sum_us);     // #510
+             (unsigned long)s.write_sum_us,      // #510
+             (unsigned long)flightlog.writeLockWaitMaxUs(),   // #510: #388 max/sum —
+             (unsigned long)flightlog.writeLockWaitSumUs());  //   mutex share of wsum
     logger.resetIntervalTimings();
+    flightlog.resetLockWaitStats();  // #510: same window as the logger sums
 
     // #398: per-task CPU deltas over this same interval — pins the core-1 hog
     // that co-stalls loop_oc during the launch-activation window. Uses `dt`


### PR DESCRIPTION
Both issues come from the 2026-07-14 OC bench flight (`flight_20260714_101624`) and live in the same subsystem, so they land together: #511 is a behavior fix, #510 is the instrumentation that closes the flush-task blind spot (its final disposition needs the next bench run).

## #511 — skip the boot bad-block scan once a trusted map exists

`scanBadBlocksAtBoot()` walked all 2048 blocks (3 reads each, **2740 ms**) on every cmd-8 Power-On — over half of the 5.05 s `loop_oc` stall — even right after loading a persisted map for the same chip.

- New pure policy `BadBlockScanPolicy::bootScanVerdict()` gates the scan on an NVS **"scanned"** marker written strictly **after** a completed scan. The existing `"chip"` key is written by `nandInit()` **before** the scan (chip-swap wipe) and deliberately not trusted — a mid-scan power cut rescans next boot.
- Corrupt/short `"map"` blob ⇒ forced rescan + self-repairing persist.
- **Dead-bus fix in passing:** RDID 0x0000/0xFFFF used to run the scan anyway, fail all 2048 reads, mark every block bad, and poison the persisted map. It now skips with an always-on `ESP_LOGE`.
- Post-OTA each unit pays one final full scan (marker absent), then skips forever. Runtime discovery (`markBlockBad` on read/prog/erase failures, persisted at session close) keeps the map current; chip swap still forces a scan.
- App-facing storage stats are untouched (they come from TR_FlightLog's `BlockStateBitmap`, not this map).

**Expected:** Power-On stall 5.05 s → ~2.3 s on every boot after the first.

Fixes #511

## #510 — flush-iteration ledger: the 588 ms activation "stall" gets attributed

The 588 ms flush-task stall at logging activation was 98 % invisible because every accumulator is a per-op **maximum**: the activation iteration drains the whole ~97 KB prelaunch ring as ~24 page writes, each under the 100 ms per-op threshold. Core 0 showed 93 % idle because `nandWaitReady` yields a tick per busy-poll.

- `FlushIterLedger` (pure, host-tested) books each iteration section — staging / pre-create open / hook / activate / drain / end-of-flight — plus drain sub-details (pages, bytes, MRAM-pop sum, write sum).
- The bare `STALL:` WARN becomes a classified breakdown: **LongAccounted** (designed work: arm-time 80-block erase, activation drain) demotes to INFO (#510 item 3); **LongUnaccounted** stays WARN and names where the time did *not* go (#510 item 1).
- `LOG TIMING` gains window sums `dpg/dby/pop/wsum` plus `m388=<max>/<sum>` — writeFrame's #388 mutex-acquire wait, so `wsum` splits into NAND time vs contention with BLE `listFlights`/`readFlightPage`.
- No drain behavior change (drain-until-empty stays). #510 item 2 (shrink cost vs more ring headroom) is a post-bench decision once the ledger reports real numbers.

Refs #510 (left open pending bench attribution + the item-2 headroom decision).

## Verification

- Host: **605/605** gtests pass, including 17 new (`test_bad_block_scan_policy` × 8, `test_flush_iter_ledger` × 9); `test_tr_flightlog_core` stays green via an off-target-inert `monotonic_us()`.
- OC firmware (`out_computer`, ESP32-S3, IDF v6.0) builds clean at every commit.

## Bench checklist (hardware)

1. **#511:** flash → Power-On #1 runs one full scan (`Bad-block boot scan: 2048 blocks…` then `Bad-block boot scan complete for chip 0xCD53`); power-off (OC resets) → Power-On #2 logs `Bad-block boot scan skipped: map trusted (chip 0xCD53, 0 known bad)` and the `LOOP_STALL` drops ~5.05 s → ~2.3 s. Flights still list/download; app storage bar unchanged.
2. **#510:** bench logging session — arm now logs INFO `Long flush iteration (accounted): … hook=342xxx …` instead of a bare WARN; activation logs the INFO breakdown with `act+drain ≈ iter`, `pg≈24`, pop/wr/oth split; `LOG TIMING` shows `dpg/dby/pop/wsum/m388`; `rx_ovf=0`.
3. Post-bench: paste the activation breakdown into #510 and decide item 2 (headroom lever), then close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
