### PR TITLE
fc(#529): log EKF tick counter; replay derives rate + follows master apogee flag

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -57,7 +57,7 @@ MSG_EXPECTED_LEN = {
     MSG_ISM6HG256:        22,
     MSG_BMP585:           12,
     MSG_MMC5983MA:        16,
-    MSG_NON_SENSOR:       (42, 43, 44, 48),
+    MSG_NON_SENSOR:       (42, 43, 44, 48, 50),
     MSG_POWER:            10,
     MSG_START_LOGGING:    None,
     MSG_END_FLIGHT:       None,
@@ -72,6 +72,7 @@ FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'
 FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'
+FMT_NONSENSOR_50 = '<I hhhhh iii iii BB h B B I H'  # +uint16 ekf_ticks (#529)
 FMT_STATUS_QUERY = '<B H H hh B hhh'
 
 ROCKET_STATES = {
@@ -230,7 +231,9 @@ def parse_file(filepath):
                 # (centideg); the old layout's 4 Euler int16 are gone. Pick the
                 # FMT by length and derive Euler from the quaternion, mirroring
                 # plot_flight_data_mini.parse_binary_file.
-                if msg_len == 48:
+                if msg_len == 50:
+                    fields = struct.unpack(FMT_NONSENSOR_50, payload)
+                elif msg_len == 48:
                     fields = struct.unpack(FMT_NONSENSOR_48, payload)
                 elif msg_len == 44:
                     fields = struct.unpack(FMT_NONSENSOR_44, payload)

--- a/Data_Analysis/analyze_pyro_apogee.py
+++ b/Data_Analysis/analyze_pyro_apogee.py
@@ -18,6 +18,7 @@ MSG_NON_SENSOR = 0xA5
 # <I hhhhh iii iii BB h B B
 #  time_us(4), q0-q3+roll_cmd(5*2=10), e/n/u_pos(3*4=12), e/n/u_vel(3*4=12),
 #  flags(1), rocket_state(1), baro_alt_rate_dmps(2), pyro_status(1), apogee_flags(1) = 44
+FMT_NONSENSOR_50 = '<I hhhhh iii iii BB h B B I H'  # +uint16 ekf_ticks (#529)
 FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'  # +uint32 sensor_health (#303)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'
@@ -115,7 +116,11 @@ def parse(filepath):
         stats["frames"] += 1
 
         if msg_type == MSG_NON_SENSOR:
-            if msg_len == 48:
+            if msg_len == 50:
+                fields = struct.unpack(FMT_NONSENSOR_50, payload)
+                pyro_status = fields[15]
+                apogee_flags = fields[16]
+            elif msg_len == 48:
                 fields = struct.unpack(FMT_NONSENSOR_48, payload)
                 pyro_status = fields[15]
                 apogee_flags = fields[16]

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -132,11 +132,12 @@ FMT_NONSENSOR_42 = '<I hhhhh iii iii BB h'     # legacy (no pyro_status)
 FMT_NONSENSOR_43 = '<I hhhhh iii iii BB h B'  # +pyro_status byte (#34)
 FMT_NONSENSOR_44 = '<I hhhhh iii iii BB h B B'  # +apogee_flags byte (#142/#143)
 FMT_NONSENSOR_48 = '<I hhhhh iii iii BB h B B I'  # +uint32 sensor_health (#303)
+FMT_NONSENSOR_50 = '<I hhhhh iii iii BB h B B I H'  # +uint16 ekf_ticks (#529)
 # #296: lengths we know how to decode. An unrecognized NonSensor length means the
 # struct grew without updating this parser — warn loudly (once each) below instead
 # of silently dropping every record (the #227 failure shape). Add the new length
 # + a FMT_NONSENSOR_<len> when NonSensorData grows.
-NONSENSOR_KNOWN_LENS = (42, 43, 44, 48)
+NONSENSOR_KNOWN_LENS = (42, 43, 44, 48, 50)
 _warned_nonsensor_lens = set()
 # OutStatusQueryData: 16 bytes (v2) / 26 bytes (v3, +b2r orientation)
 FMT_STATUS_QUERY = '<B H H hh B hhh'
@@ -480,7 +481,16 @@ def parse_binary_file(filepath):
                 })
 
             elif msg_type == MSG_NON_SENSOR and msg_len in NONSENSOR_KNOWN_LENS:
-                if msg_len == 48:
+                # apogee_flags_b is None (not 0) when the log predates the
+                # apogee_flags byte — lets consumers distinguish "voted False"
+                # from "never recorded" (#529 replay gate fallback).
+                ekf_ticks = None
+                if msg_len == 50:
+                    fields = struct.unpack(FMT_NONSENSOR_50, payload)
+                    pyro_status = fields[15]
+                    apogee_flags_b = fields[16]
+                    ekf_ticks = fields[18]
+                elif msg_len == 48:
                     fields = struct.unpack(FMT_NONSENSOR_48, payload)
                     pyro_status = fields[15]
                     apogee_flags_b = fields[16]
@@ -491,10 +501,13 @@ def parse_binary_file(filepath):
                 elif msg_len == 43:
                     fields = struct.unpack(FMT_NONSENSOR_43, payload)
                     pyro_status = fields[15]
-                    apogee_flags_b = 0
+                    apogee_flags_b = None
                 else:
                     fields = struct.unpack(FMT_NONSENSOR_42, payload)
                     pyro_status = 0
+                    apogee_flags_b = None
+                has_apogee_flags = apogee_flags_b is not None
+                if apogee_flags_b is None:
                     apogee_flags_b = 0
                 q0 = fields[1] / 10000.0
                 q1 = fields[2] / 10000.0
@@ -561,13 +574,19 @@ def parse_binary_file(filepath):
                     "pyro1_armed":   bool(flags & NSF_PYRO_ARMED),
                     "pyro2_armed":   bool(flags & NSF_PYRO_ARMED),
                     # #142/#143: full apogee detector set + master vote.
-                    # Legacy 42/43-byte logs decode all three as False.
+                    # Legacy 42/43-byte logs decode all three as False and
+                    # has_apogee_flags as False (byte never recorded).
+                    "has_apogee_flags":   has_apogee_flags,
                     "gps_apogee":         bool(apogee_flags_b & NSF2_GPS_APOGEE),
                     "pitch_apogee":       bool(apogee_flags_b & NSF2_PITCH_APOGEE),
                     "apogee_flag":        bool(apogee_flags_b & NSF2_MASTER_APOGEE),
                     "reboot_recovery":    bool(apogee_flags_b & NSF2_REBOOT_RECOVERY),
                     "guidance_enabled":   bool(apogee_flags_b & NSF2_GUIDANCE_ENABLED),
                     "fc_imu_drop":        bool(apogee_flags_b & NSF2_FC_IMU_DROP),
+                    # #529: free-running EKF update-tick counter (uint16 wrap);
+                    # None on logs that predate the field.  The replay derives
+                    # the achieved EKF rate from this instead of a constant.
+                    "ekf_ticks":          ekf_ticks,
                 })
 
             elif msg_type == MSG_NON_SENSOR:

--- a/Data_Analysis/replay_flight_ekf.py
+++ b/Data_Analysis/replay_flight_ekf.py
@@ -54,11 +54,60 @@ PAD_HEADING_DEG = 0.0
 # Driving the EKF on a clock instead of a sample counter is right for both, and
 # stays right the next time the IMU ODR moves.
 #
-# CAVEAT: the loop rate is not recorded in the flight log, so this constant cannot
-# be derived from the file — it has to track the firmware. Logging the EKF rate
-# (or a tick counter) would remove the last hand-maintained number here; see #515.
-EKF_RATE_HZ = 490.0
-EKF_PERIOD_US = 1e6 / EKF_RATE_HZ
+# #529 retired the hand-maintained rate: the firmware logs a free-running EKF
+# update-tick counter (NonSensorData.ekf_ticks, uint16 wrap), and
+# derive_ekf_rate_hz() below recovers the ACHIEVED rate from it — per log, no
+# constant to track (a real collect measured 474 Hz against the 490 target).
+# This value remains only as the fallback for logs that predate the field.
+DEFAULT_EKF_RATE_HZ = 490.0
+
+
+def derive_ekf_rate_hz(records):
+    """Achieved EKF rate from the logged ekf_ticks counter (#529), or None.
+
+    NonSensorData.ekf_ticks is a free-running uint16 count of actual EKF update
+    ticks. Summing wrap-aware deltas over consecutive NonSensor records — and
+    trimming the frozen head/tail (the counter sits at 0 until the EKF
+    initializes, before the first good GNSS fix) — gives ticks/second as the
+    vehicle actually ran, robust to loop-rate and EKF_DECIMATION changes.
+
+    Returns None when the log predates the field (records carry ekf_ticks=None)
+    or carries too little tick motion to trust.
+    """
+    ns = records.get("NonSensor") or []
+    pts = [(r["time_us"], r["ekf_ticks"]) for r in ns
+           if r.get("ekf_ticks") is not None]
+    if len(pts) < 2:
+        return None
+
+    # Per consecutive pair: wrap-aware tick delta + wall time. A pair is
+    # discarded (contributing neither ticks nor time) when time runs backwards,
+    # spans a logging hole > 10 s, or the delta is implausibly large — a huge
+    # "delta" is really the counter resetting across an in-flight reboot.
+    pairs = []
+    for (t0, k0), (t1, k1) in zip(pts, pts[1:]):
+        dt_us = t1 - t0
+        d_ticks = (k1 - k0) & 0xFFFF
+        if dt_us <= 0 or dt_us > 10_000_000 or d_ticks > 4096:
+            continue
+        pairs.append((dt_us, d_ticks))
+
+    # Trim to the window where the counter is actually moving, so the pre-init
+    # frozen-at-0 stretch does not dilute the average. d == 0 pairs INSIDE the
+    # window stay — they are the legitimate beat between the ~500 Hz NonSensor
+    # cadence and the ~490 Hz EKF cadence, and dropping them would skew high.
+    active = [i for i, (_, d) in enumerate(pairs) if d > 0]
+    if not active:
+        return None
+    window = pairs[active[0]:active[-1] + 1]
+    ticks = sum(d for _, d in window)
+    dur_s = sum(dt for dt, _ in window) / 1e6
+    if ticks < 100 or dur_s <= 0:
+        return None                       # too little motion to trust
+    rate = ticks / dur_s
+    if not (50.0 <= rate <= 5000.0):
+        return None                       # implausible — refuse, use fallback
+    return rate
 
 # RocketState::INFLIGHT (TR_RocketComputerTypes/RocketComputerTypes.h).
 # INITIALIZATION=0, READY=1, PRELAUNCH=2, INFLIGHT=3, LANDED=4, MAG_CALIBRATION=5
@@ -322,6 +371,19 @@ def replay(binary_file, plot_dir=None, align_baro=True):
 
     check_ekf_version(binary_file)
 
+    # #529: EKF cadence — from the log itself when the firmware recorded its
+    # tick counter; the hand-maintained constant only as a legacy fallback.
+    ekf_rate_hz = derive_ekf_rate_hz(records)
+    if ekf_rate_hz is not None:
+        print(f"  EKF rate: {ekf_rate_hz:.1f} Hz (derived from the logged "
+              f"ekf_ticks counter)")
+    else:
+        ekf_rate_hz = DEFAULT_EKF_RATE_HZ
+        print(f"  EKF rate: {ekf_rate_hz:.0f} Hz (constant fallback — log "
+              f"predates the #529 ekf_ticks field; verify it matches the "
+              f"firmware that flew)")
+    ekf_period_us = 1e6 / ekf_rate_hz
+
     # Detect flight phases
     imu_times = get_array(records["ISM6HG256"], "time_us")
     t0_us = imu_times[0]
@@ -339,11 +401,17 @@ def replay(binary_file, plot_dir=None, align_baro=True):
     # ---- Initialize EKF ----
     ekf = GpsInsEKF()
     ekf_initialized = False
-    next_ekf_us = None          # firmware-rate EKF clock (see EKF_RATE_HZ)
+    next_ekf_us = None          # firmware-rate EKF clock (see ekf_rate_hz above)
     # Firmware flight state, tracked from the log (drives the AHRS accel gate).
     # Default to a non-INFLIGHT state so a log with no NonSensor records behaves
     # like the pad — AHRS on — rather than silently disabling the gravity update.
     log_rocket_state = ROCKET_STATE_INFLIGHT - 1
+    # Master voted apogee_flag as logged (apogee_flags bit 2, #142/#143) —
+    # followed live, exactly like the firmware reads kinematics.apogee_flag.
+    log_apogee_master = False
+    log_has_master = False
+    # Fallback for pre-#143 logs (42/43-byte NonSensor): latched OR of the two
+    # voters that byte layout carried.
     log_apogee_latched = False
 
     # Track latest sensor data for EKF
@@ -425,6 +493,10 @@ def replay(binary_file, plot_dir=None, align_baro=True):
         elif etype == "nonsensor":
             # Track the firmware's own flight state — the AHRS gate reads it.
             log_rocket_state = rec["rocket_state"]
+            if rec.get("has_apogee_flags"):
+                # #529: the master voted apogee_flag is in the log — follow it.
+                log_apogee_master = rec["apogee_flag"]
+                log_has_master = True
             if rec["alt_apogee"] or rec["vel_apogee"]:
                 log_apogee_latched = True
 
@@ -584,12 +656,13 @@ def replay(binary_file, plot_dir=None, align_baro=True):
                 continue
 
             # Run the EKF on the firmware's CLOCK, not on every logged IMU sample
-            # (see EKF_RATE_HZ). The firmware feeds it the newest sample at ~490 Hz
-            # and never sees the rest, so this drops the intervening samples exactly
-            # as the flight loop does — imu_d here is already the latest one.
+            # (see ekf_rate_hz — logged since #529, constant fallback before). The
+            # firmware feeds it the newest sample at that cadence and never sees
+            # the rest, so this drops the intervening samples exactly as the
+            # flight loop does — imu_d here is already the latest one.
             if (next_ekf_us is not None) and (time_us < next_ekf_us):
                 continue
-            next_ekf_us = time_us + EKF_PERIOD_US
+            next_ekf_us = time_us + ekf_period_us
 
             # #514: AHRS accel gate — follow the LOGGED flight state.
             #
@@ -605,13 +678,14 @@ def replay(binary_file, plot_dir=None, align_baro=True):
             # flight_20260615_171305: a 70° divergence appearing right at launch,
             # on top of an otherwise <2° track.
             #
-            # rocket_state is logged exactly, so the first term is now exact.
-            # CAVEAT: kinematics.apogee_flag is a 4-voter quorum (vel / alt / gps
-            # / pitch) and only two of those voters reach the log, so post_apogee
-            # is reconstructed as a LATCHED OR of the two that do. It is the one
-            # term here that is still an approximation — logging the master flag
-            # (a spare NSF bit) would make this exact.
-            post_apogee = log_apogee_latched
+            # rocket_state is logged exactly, so the first term is exact. And
+            # since #529 the second is too: kinematics.apogee_flag — the 4-voter
+            # quorum (vel / alt / gps / pitch) — has been in the log all along
+            # (apogee_flags bit 2, #142/#143), so post_apogee follows the logged
+            # master directly. Only pre-#143 logs (42/43-byte NonSensor, no
+            # apogee_flags byte) fall back to the old approximation: a LATCHED OR
+            # of the two voters that layout carried.
+            post_apogee = log_apogee_master if log_has_master else log_apogee_latched
             use_ahrs_acc = (log_rocket_state != ROCKET_STATE_INFLIGHT) or post_apogee
 
             ekf.update_lla(use_ahrs_acc, imu_d, gnss_d, mag_d)
@@ -655,13 +729,13 @@ def replay(binary_file, plot_dir=None, align_baro=True):
 
     # Show the achieved EKF rate against the firmware's, so a rate mismatch is
     # visible rather than inferred — it is the single easiest way to make this
-    # tool silently wrong (see EKF_RATE_HZ).
+    # tool silently wrong (see derive_ekf_rate_hz / DEFAULT_EKF_RATE_HZ).
     span_s = (imu_times[-1] - imu_times[0]) / 1e6
     if span_s > 0:
         imu_hz = len(records["ISM6HG256"]) / span_s
         ekf_hz = n_imu / span_s
         print(f"  IMU logged at {imu_hz:.0f} Hz; EKF run at {ekf_hz:.0f} Hz "
-              f"(firmware target {EKF_RATE_HZ:.0f} Hz — the EKF sees "
+              f"(firmware {ekf_rate_hz:.0f} Hz — the EKF sees "
               f"1 in {imu_hz / max(ekf_hz, 1e-9):.1f} logged samples)")
 
     # ---- Convert to numpy ----
@@ -757,8 +831,8 @@ def replay(binary_file, plot_dir=None, align_baro=True):
                           "heading fusion, so a modern EKF cannot reproduce them.")
                     print("       • MATCHED → versions agree, so it's a real replay "
                           "gap: AHRS phase gate, GNSS velocity, EKF rate")
-                    print("                  (EKF_RATE_HZ), or units (EkfIMUData gyro "
-                          "is DEG/S, not rad/s).")
+                    print("                  (derive_ekf_rate_hz / fallback), or units "
+                          "(EkfIMUData gyro is DEG/S, not rad/s).")
     if fidelity is None:
         print("\n  ── Replay fidelity: no logged quaternion in this file "
               "(legacy log) — replay is UNVERIFIED ──")

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -570,6 +570,10 @@ nonisolated class CSVGenerator {
         columns.append("Pyro 4 Fired")
         columns.append("Reboot Recovery")
         columns.append("FC Guidance Enabled")
+        // #529: free-running EKF update-tick counter (uint16 wrap). Deltas of
+        // this against Time give the achieved EKF rate — the number the EKF
+        // replay tool needs. Blank on logs predating the 50-byte NonSensorData.
+        columns.append("EKF Ticks")
 
         return columns.joined(separator: ",") + "\n"
     }
@@ -678,6 +682,7 @@ nonisolated class CSVGenerator {
         values.append(nonSensor.map { $0.pyro4_fired ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.reboot_recovery ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.guidance_enabled ? "1" : "0" } ?? "")
+        values.append(nonSensor.flatMap { $0.ekf_ticks.map(String.init) } ?? "")
 
         return values.joined(separator: ",") + "\n"
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -402,7 +402,8 @@ nonisolated class SensorConverter {
             pyro3_fired: false,
             pyro4_fired: false,
             reboot_recovery: false,
-            guidance_enabled: false
+            guidance_enabled: false,
+            ekf_ticks: nil
         )
     }
 
@@ -511,7 +512,8 @@ nonisolated class SensorConverter {
             pyro3_fired:      (raw.pyro_status & PSF_CH3_FIRED) != 0,
             pyro4_fired:      (raw.pyro_status & PSF_CH4_FIRED) != 0,
             reboot_recovery:  reboot_recovery,
-            guidance_enabled: guidance_enabled
+            guidance_enabled: guidance_enabled,
+            ekf_ticks:        raw.ekf_ticks   // #529
         )
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -16,7 +16,7 @@ enum MessageType: UInt8 {
     case imu = 0xA2        // ISM6HG256 (Mini, 22B) or ICM45686 (Legacy, 36B)
     case baro = 0xA3       // BMP585 (Mini, 12B) or MS5611 (Legacy, 10B)
     case mag = 0xA4        // MMC5983MA (Mini, 16B) or LIS3MDL (Legacy, 10B)
-    case nonSensor = 0xA5  // Computed data (Mini 38/40B, Legacy 65B)
+    case nonSensor = 0xA5  // Computed data (Mini 43–50B by fw era, Legacy 65B)
     case power = 0xA6      // Battery
     case startLogging = 0xA7
     case endFlight = 0xA8
@@ -497,7 +497,7 @@ nonisolated struct IIS2MDCData {
     }
 }
 
-// Non-Sensor Data (43 bytes)
+// Non-Sensor Data (43/44/48/50-byte layouts, oldest → newest)
 // Wire layout mirrors C++ NonSensorData in RocketComputerTypes.h — bump the
 // size guard + add the matching field here whenever a byte is appended.
 nonisolated struct NonSensorData {
@@ -547,10 +547,17 @@ nonisolated struct NonSensorData {
     // Older logs (43-byte struct) decode this field as 0.
     let apogee_flags: UInt8
 
+    // #529 (50-byte layout): free-running count of EKF update ticks, uint16
+    // wrap.  The EKF replay tool derives the achieved EKF rate from deltas of
+    // this counter, so it must survive into the CSV export.  nil on logs that
+    // predate the field — 0 is a real value (EKF not yet initialized).
+    let ekf_ticks: UInt16?
+
     init(from data: Data) throws {
-        // Accept both legacy 43-byte logs (pre #142/#143) and the current
-        // 44-byte layout.  apogee_flags reads as 0 on legacy logs, which
-        // matches the historical "we never recorded these bits" behavior.
+        // Accept every layout since 43 bytes (pre-#142/#143 legacy) — 44
+        // (+apogee_flags), 48 (+sensor_health), 50 (+ekf_ticks, #529).
+        // apogee_flags reads as 0 on legacy logs, which matches the
+        // historical "we never recorded these bits" behavior.
         guard data.count >= 43 else {
             throw ParseError.invalidSize(expected: 43, got: data.count)
         }
@@ -582,6 +589,15 @@ nonisolated struct NonSensorData {
         pyro_status = data.readUInt8(at: &offset)
 
         apogee_flags = has_apogee_flags ? data.readUInt8(at: &offset) : 0
+
+        // #529: ekf_ticks sits AFTER sensor_health (#303, 4 bytes, offset 44),
+        // which the app has never surfaced — skip over it.
+        if data.count >= 50 {
+            offset += 4  // sensor_health
+            ekf_ticks = data.readUInt16LE(at: &offset)
+        } else {
+            ekf_ticks = nil
+        }
     }
 }
 
@@ -864,6 +880,11 @@ nonisolated struct NonSensorDataSI {
     let pyro4_fired: Bool
     let reboot_recovery: Bool
     let guidance_enabled: Bool
+
+    // #529: free-running EKF update-tick counter (uint16 wrap), carried through
+    // verbatim for the CSV so the achieved EKF rate is recoverable from an app
+    // export.  nil on logs that predate the 50-byte layout.
+    let ekf_ticks: UInt16?
 }
 
 // MARK: - Parsing Errors

--- a/TinkerRocketApp/TinkerRocketAppTests/SensorTypesTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/SensorTypesTests.swift
@@ -64,4 +64,21 @@ final class SensorTypesTests: XCTestCase {
         XCTAssertNotNil(raw)
         XCTAssertEqual(raw?.apogee_flags, 0)
     }
+
+    func testNonSensorData_Size50_EkfTicksDecodes() throws {
+        // #529: 50-byte layout appends uint16 ekf_ticks after the uint32
+        // sensor_health (#303, offset 44, never surfaced by the app).
+        var bytes = [UInt8](repeating: 0, count: 50)
+        bytes[48] = 0x34  // little-endian 0x1234 = 4660
+        bytes[49] = 0x12
+        let raw = try NonSensorData(from: Data(bytes))
+        XCTAssertEqual(raw.ekf_ticks, 0x1234)
+    }
+
+    func testNonSensorData_PreEkfTicksLayoutsDecodeNil() throws {
+        // 44- and 48-byte layouts predate ekf_ticks: decode nil (not 0 —
+        // 0 is a real counter value, meaning "EKF not yet initialized").
+        XCTAssertNil(try NonSensorData(from: Data(count: 44)).ekf_ticks)
+        XCTAssertNil(try NonSensorData(from: Data(count: 48)).ekf_ticks)
+    }
 }

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -25,7 +25,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(ISM6HG256Data),  22u);
     EXPECT_EQ(sizeof(MMC5983MAData),  16u);
     EXPECT_EQ(sizeof(POWERData),      10u);
-    EXPECT_EQ(sizeof(NonSensorData),  48u);  // #303: +uint32 sensor_health (4 B)
+    EXPECT_EQ(sizeof(NonSensorData),  50u);  // #529: +uint16 ekf_ticks (2 B)
     EXPECT_EQ(sizeof(LoRaData),       66u);  // #303: +uint32 sensor_health (4 B)
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1308,10 +1308,18 @@ typedef struct __attribute__((packed))
     // before relay (both OC-owned — the FC reads neither).
     uint32_t sensor_health;
 
+    // Free-running count of EKF update ticks (#529), wraps at 2^16.  Frozen at
+    // 0 until the EKF initializes (first good GNSS fix).  The loop rate is not
+    // otherwise recoverable from a flight log, so the EKF replay derives the
+    // achieved EKF rate from deltas of this counter against time_us instead of
+    // hand-maintaining an EKF_RATE_HZ constant that silently goes stale when
+    // the loop rate or EKF_DECIMATION moves.
+    uint16_t ekf_ticks;
+
 } NonSensorData;
 
-static_assert(sizeof(NonSensorData) == 48,
-              "NonSensorData must be 48 bytes");
+static_assert(sizeof(NonSensorData) == 50,
+              "NonSensorData must be 50 bytes");
 
 // ── Sensor health scorecard (#303) ──────────────────────────────────────────
 // 2 bits per item packed into NonSensorData.sensor_health (FC→OC) and
@@ -2381,7 +2389,7 @@ static_assert(offsetof(GNSSData, vel_u_mmps) == 36, "GNSSData.vel_u_mmps moved")
 static_assert(offsetof(GNSSData, h_acc_m) == 40, "GNSSData.h_acc_m moved");
 static_assert(offsetof(GNSSData, v_acc_m) == 41, "GNSSData.v_acc_m moved");
 
-static_assert(sizeof(NonSensorData) == 48, "NonSensorData wire size");
+static_assert(sizeof(NonSensorData) == 50, "NonSensorData wire size");
 static_assert(offsetof(NonSensorData, time_us) == 0, "NonSensorData.time_us moved");
 static_assert(offsetof(NonSensorData, q0) == 4, "NonSensorData.q0 moved");
 static_assert(offsetof(NonSensorData, q1) == 6, "NonSensorData.q1 moved");
@@ -2400,6 +2408,7 @@ static_assert(offsetof(NonSensorData, baro_alt_rate_dmps) == 40, "NonSensorData.
 static_assert(offsetof(NonSensorData, pyro_status) == 42, "NonSensorData.pyro_status moved");
 static_assert(offsetof(NonSensorData, apogee_flags) == 43, "NonSensorData.apogee_flags moved");
 static_assert(offsetof(NonSensorData, sensor_health) == 44, "NonSensorData.sensor_health moved");
+static_assert(offsetof(NonSensorData, ekf_ticks) == 48, "NonSensorData.ekf_ticks moved");
 
 static_assert(sizeof(OutStatusQueryData) == 28, "OutStatusQueryData wire size");
 static_assert(offsetof(OutStatusQueryData, ism6_low_g_fs_g) == 0, "OutStatusQueryData.ism6_low_g_fs_g moved");

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -225,6 +225,10 @@ static uint32_t lt_ekf_max_us = 0;
 static uint32_t lt_ekf_count = 0;
 static uint32_t lt_loop_count = 0;
 static uint32_t lt_loop_max_us __attribute__((unused)) = 0;
+// Free-running EKF update-tick counter (#529) — unlike the lt_* diagnostics
+// above it is never reset.  Published as NonSensorData.ekf_ticks (uint16 wrap)
+// so the flight log records the achieved EKF cadence for the replay tool.
+static uint32_t ekf_tick_counter = 0;
 
 // --- Converted SI values (latest sample of each sensor) ---
 static ISM6HG256DataSI ism6_latest_si = {};
@@ -3934,6 +3938,7 @@ static void loop_fc()
                 const uint32_t ekf_us = time_us() - ekf_t0;
                 lt_ekf_total_us += ekf_us;
                 lt_ekf_count++;
+                ekf_tick_counter++;
                 if (ekf_us > lt_ekf_max_us) lt_ekf_max_us = ekf_us;
             }
 
@@ -6293,6 +6298,8 @@ static void loop_fc()
 
         // Publish non-sensor summary (SI -> packed) for downstream logging/telem.
         non_sensor_data.time_us = logic_now_us;
+        // #529: achieved-EKF-cadence witness; stays 0 until the EKF initializes.
+        non_sensor_data.ekf_ticks = (uint16_t)ekf_tick_counter;
         if (ekf_initialized) {
             float imu_quat[4];
             ekf.getQuaternion(imu_quat);


### PR DESCRIPTION
Closes #529.

Retires the EKF replay tool's last two hand-set approximations (deferred from #515):

**1. EKF rate — logged, not hand-maintained.** NonSensorData grows 48→50 B with a free-running uint16 `ekf_ticks` counter (increments only on actual EKF update ticks, frozen at 0 pre-init). `derive_ekf_rate_hz()` recovers the achieved rate from wrap-aware deltas — trims the frozen pre-init head, skips reboot resets — and `EKF_RATE_HZ = 490` is demoted to a fallback for logs that predate the field.

**2. Master `apogee_flag` — followed, not reconstructed.** Investigation showed the 4-voter master vote has been logged since #142/#143 (`apogee_flags` bit 2) — the issue's "only two voters reach the log" premise was stale. The replay now follows the logged master directly in the AHRS accel gate; the latched-OR reconstruction remains only for pre-#143 (42/43 B) logs via the parser's new `has_apogee_flags` key.

**Lockstep updates:** `plot_flight_data_mini` (+`ekf_ticks`/`has_apogee_flags` keys), `analyze_pyro_apogee` (was skipping 50 B records), `analyze_launch_detection` (framing table would have rejected 50 B frames, then its else-branch unpack would crash), and the iOS app (SensorTypes parse skipping the never-surfaced `sensor_health`, SI struct, converter, "EKF Ticks" CSV column, +2 unit tests).

**Validation** (including the first real powered flight, `flight_20260716_163643.bin`, 407 m / 99 m/s):
- Powered-flight replay **PASSES**: mean 0.50°, p95 1.58°, max 6.14° vs the firmware's own logged quaternion through boost/coast/apogee — the boost-window check #515 deferred to this issue.
- Synthetic 50 B log end-to-end: 437.012 Hz recovered vs 437.0 truth through a uint16 wrap, a mid-log counter reset, and a 2 s pre-init head; legacy logs correctly fall back.
- Legacy 6/15 log: byte-identical behavior to its documented baseline (19.62° FAIL, version UNKNOWN — correct, pre-#243 EKF).
- FC (P4) and OC (S3) builds pass; targeted app suites (SensorTypes/SensorConverter/MessageParser/CSVParser) pass.

**Deploy note:** OC guards NON_SENSOR_MSG with `payload_len >= sizeof`, so new-FC + old-OC keeps working (48 B prefix read), but a rebuilt OC requires the FC flashed first or together — co-flash FC+OC as usual. Flight-pending: the first collect on this firmware should print "EKF rate: NNN Hz (derived from the logged ekf_ticks counter)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
