### PR TITLE
bench: HIL sim test — LANDED is terminal since #317, drop the stale READY wait

### DIFF
--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -23,7 +23,8 @@ simulated flight cycle.
    the flight computer via LoRa uplink
 5. The flight computer's `SensorCollectorSim` feeds synthetic GNSS / IMU /
    pressure to the state machine, driving:
-   `READY → PRELAUNCH → POWERED → COASTING → DESCENT → LANDED → READY`
+   `READY → PRELAUNCH → POWERED → COASTING → DESCENT → LANDED` (LANDED is
+   terminal — post_flight_lockout holds until reboot/power-cycle, #317)
 6. The rocket transmits real LoRa packets the whole time; the BS receives
    them and writes to SD
 7. After the cycle, downloads the newest `lora_*.csv` via BLE
@@ -98,9 +99,10 @@ log, and asserts on it.  Use this when you want to:
 6. Enter sim parameters and tap **Launch Sim**.  The app sends cmd 5
    (config) + cmd 6 (start) via the BS LoRa uplink.
 7. Watch the dashboard.  The rocket state field should sweep:
-   `READY → PRELAUNCH → INFLIGHT → LANDED → READY`.  Total ~30-60 s
-   depending on burn / descent parameters.
-8. After the state shows READY again, **wait ~5 s** for the BS to flush
+   `READY → PRELAUNCH → INFLIGHT → LANDED`.  Total ~30-60 s
+   depending on burn / descent parameters.  The rocket stays LANDED
+   until rebooted (#317) — that is the expected end state.
+8. After the state shows LANDED, **wait ~10 s** for the BS to flush
    the LANDED-close fsync to disk.  The BS will auto-open a *second*
    log file ("log B") for post-landing telemetry — that file stays
    open until 5 min of LoRa silence elapses
@@ -164,7 +166,7 @@ python3 tests/bench/test_lora_log_capture.py --help
 - `0`   — all assertions passed
 - `3`   — BLE scan found no base station
 - `4`   — connected but received no telemetry within 10 s
-- `5-8` — state-machine timeout (PRELAUNCH / INFLIGHT / LANDED / READY)
+- `5-7` — state-machine timeout (PRELAUNCH / INFLIGHT / LANDED)
 - `9`   — BS didn't respond to file-list request
 - `10`  — no `lora_*.csv` on the SD after the cycle
 - `11`  — newest log is suspiciously small

--- a/tests/bench/test_lora_log_capture.py
+++ b/tests/bench/test_lora_log_capture.py
@@ -7,7 +7,8 @@ Drives a simulated flight on real hardware end-to-end:
 
 The flight computer's SensorCollectorSim provides synthetic GNSS / IMU /
 pressure that drive the rocket state machine through READY → PRELAUNCH →
-INFLIGHT → LANDED → READY, while the rocket transmits real LoRa packets
+INFLIGHT → LANDED (terminal: post_flight_lockout holds until a reboot /
+power-cycle, #317), while the rocket transmits real LoRa packets
 on the operating frequency.  The BS receives them and writes lora_*.csv
 to the SD card.  After the cycle, the test downloads the newest LoRa log
 via BLE and asserts:
@@ -48,7 +49,7 @@ Usage:
 
     # iOS-driven mode: skip the sim drive, just verify the newest log on the
     # BS SD.  Workflow: drive the sim from the iOS Simulation view, wait for
-    # rocket to return to READY, disconnect iOS, then run this.
+    # LANDED (terminal since #317), disconnect iOS, then run this.
     python3 tests/bench/test_lora_log_capture.py --skip-sim
 
     # Verify a specific file (e.g. a recovered log from a past flight)
@@ -326,30 +327,34 @@ async def run_test(args) -> int:
                 COMMAND_CHAR_UUID, bytes([CMD_SIM_START]), response=True)
 
             # Watch the state machine.  Timeouts are conservative — even a 10 s
-            # burn + 30 s descent should comfortably hit READY again within 90 s.
+            # burn + 30 s descent should comfortably hit LANDED within 90 s.
             if not await wait_for_state(
                     cap, "PRELAUNCH",  20, "READY → PRELAUNCH"): return 5
             if not await wait_for_state(
                     cap, "INFLIGHT",   30, "PRELAUNCH → INFLIGHT"): return 6
             if not await wait_for_state(
                     cap, "LANDED",     90, "INFLIGHT → LANDED"): return 7
+            # LANDED is the TERMINAL state for a sim cycle: since #317 the
+            # flight computer latches post_flight_lockout until a reboot /
+            # power-cycle, so the rocket deliberately never returns to READY.
+            # (An earlier version of this test waited for LANDED → READY here
+            # — a pre-#317 leftover that timed out on every modern run while
+            # everything upstream passed.)
+            #
             # After landing, the BS closes log A on the LANDED transition
             # and immediately auto-opens log B for any post-landing packets
             # (intentional — captures recovery telemetry).  Log A is on
             # disk; log B will close on its own once 5 min of silence
             # elapses (LOG_SILENCE_TIMEOUT_MS, #137).
-            await asyncio.sleep(5.0)
-            if not await wait_for_state(
-                    cap, "READY",      30, "LANDED → READY (sim done)"): return 8
-
-            # Short grace so the LANDED-close fsync has finished and log A
-            # is visible in the BLE file listing.  We deliberately do NOT
+            #
+            # Grace so the LANDED-close fsync has finished and log A is
+            # visible in the BLE file listing.  We deliberately do NOT
             # wait for log B's 5-min silence-close — we want the assertion
             # to run against log A (the file with PRELAUNCH/INFLIGHT/LANDED
             # rows).  The newest-by-name pick below selects log B if it's
             # opened with a later timestamp, so we use --file to force log
             # A when running back-to-back tests.
-            await asyncio.sleep(5.0)
+            await asyncio.sleep(10.0)
 
         # ---- File list ----
         print("[ble]  requesting file list")


### PR DESCRIPTION
The #137 HIL test's final step waited for LANDED → READY, but since #317 LANDED latches `post_flight_lockout` until reboot/power-cycle — so every modern run timed out at the finish line with everything upstream green (bench 2026-07-17: `seen=[READY, PRELAUNCH, INFLIGHT, LANDED]`, then timeout).

- Treat LANDED as the terminal success state; fold the two settle sleeps into one 10 s grace for the BS's LANDED-close fsync.
- Renumber the exit-code table to 5–7; update the docstring + README state cycles to end at LANDED with the #317 explanation.
- Capture/download assertions untouched — they already accepted LANDED-terminal sequences.

**Verified on the bench** against the co-flashed OC+BS pair: the full scripted run now passes end-to-end (BS BLE → time-sync → sim config/start over LoRa uplink → full flight → 457-row capture downloaded, peak 201 m, worst in-flight gap 511 ms → `[pass]`), no timeouts, no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
