### PR TITLE
oc(#541): USB-enum light-sleep grace, 32k-crystal second chance, fast-adv window

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -181,6 +181,8 @@ void TR_BLE_To_APP::on_ble_hs_sync()
 
     if (s_instance_)
     {
+        // #541: boot counts as a "someone may be trying to connect" moment.
+        s_instance_->armFastAdvWindow();
         s_instance_->startAdvertising();
     }
 }
@@ -284,8 +286,14 @@ int TR_BLE_To_APP::gap_event_cb(struct ble_gap_event* event, void* arg)
         break;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        // Advertising ended (e.g. timeout); restart it
-        self->startAdvertising();
+        // Advertising ended. With the #541 fast window this fires at the fast
+        // phase's duration expiry — startAdvertising() then picks the slow
+        // 1000 ms phase (deadline passed). Skip while connected: we advertise
+        // for ONE central; re-advertising mid-connection would invite a second.
+        if (!self->device_connected_)
+        {
+            self->startAdvertising();
+        }
         break;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
@@ -526,7 +534,9 @@ void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
     conn_param_attempts_ = 0;
     ESP_LOGW(BLE_TAG, "Device DISCONNECTED, reason=%d", reason);
 
-    // Restart advertising so new devices can connect
+    // Restart advertising so new devices can connect. Disconnect re-opens the
+    // fast window (#541): reconnects are the common case right here.
+    armFastAdvWindow();
     startAdvertising();
     ESP_LOGI(BLE_TAG, "Advertising restarted");
 }
@@ -845,15 +855,47 @@ void TR_BLE_To_APP::registerGattServices()
 // Advertising
 // ============================================================================
 
+void TR_BLE_To_APP::armFastAdvWindow()
+{
+    // #541: (re)open the fast-advertising window. Called at host sync (boot)
+    // and on disconnect — the two moments a central is likely to be trying to
+    // find us. startAdvertising() picks the phase from this deadline.
+    fast_adv_until_ms_ = (uint32_t)millis() + kFastAdvWindowMs;
+}
+
 void TR_BLE_To_APP::startAdvertising()
 {
     struct ble_gap_adv_params adv_params = {};
     adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;  // Undirected connectable
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;  // General discoverable
 
-    // Advertising interval: 1000 ms (in 0.625 ms units = 1600)
-    adv_params.itvl_min = 0x0640;   // 1000 ms
-    adv_params.itvl_max = 0x0640;   // 1000 ms
+    // #541: two-phase advertising. A fixed 1000 ms interval made discovery
+    // and connection latency poor on every central — each connect attempt
+    // waits for an adv event, so a 1 s interval adds up to a second before
+    // the CONNECT_IND can even be sent (and made this Mac's duty-cycled
+    // scanner miss the boards in a large fraction of scan windows). Advertise
+    // FAST (152.5 ms, an Apple-recommended value) for the first
+    // kFastAdvWindowMs after boot and after every disconnect — exactly when
+    // someone is trying to connect — then drop back to the 1000 ms power
+    // interval for the long idle wait. The fast phase uses NimBLE's duration
+    // so BLE_GAP_EVENT_ADV_COMPLETE hands us the phase transition for free.
+    const uint32_t now_ms = (uint32_t)millis();
+    const bool fast = (fast_adv_until_ms_ != 0) &&
+                      ((int32_t)(fast_adv_until_ms_ - now_ms) > 0);
+    int32_t duration_ms = BLE_HS_FOREVER;
+    if (fast)
+    {
+        adv_params.itvl_min = 0x00F4;   // 244 * 0.625 ms = 152.5 ms
+        adv_params.itvl_max = 0x00F4;
+        duration_ms = (int32_t)(fast_adv_until_ms_ - now_ms);
+        if (duration_ms < 100) duration_ms = 100;
+    }
+    else
+    {
+        // Advertising interval: 1000 ms (in 0.625 ms units = 1600)
+        adv_params.itvl_min = 0x0640;   // 1000 ms
+        adv_params.itvl_max = 0x0640;   // 1000 ms
+    }
 
     // Build advertising data: flags + complete 128-bit service UUID
     struct ble_hs_adv_fields fields = {};
@@ -888,11 +930,16 @@ void TR_BLE_To_APP::startAdvertising()
         ESP_LOGW(BLE_TAG, "ble_gap_adv_rsp_set_fields failed, rc=%d", rc);
     }
 
-    rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, nullptr, BLE_HS_FOREVER,
+    rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, nullptr, duration_ms,
                            &adv_params, gap_event_cb, this);
     if (rc != 0 && rc != BLE_HS_EALREADY)
     {
         ESP_LOGE(BLE_TAG, "ble_gap_adv_start failed, rc=%d", rc);
+    }
+    else if (fast)
+    {
+        ESP_LOGI(BLE_TAG, "Advertising FAST (152.5 ms interval) for %ld ms, "
+                          "then 1000 ms", (long)duration_ms);
     }
     else
     {

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -501,8 +501,16 @@ private:
     void onConnParamsUpdated(uint16_t conn_handle, int status);
     void onCommandWrite(const uint8_t* data, size_t length);
 
-    // Start/restart BLE advertising
+    // Start/restart BLE advertising. Two-phase since #541: FAST (152.5 ms
+    // interval) for kFastAdvWindowMs after boot and after every disconnect —
+    // the moments a central is actually trying to find us — then the 1000 ms
+    // power interval for the long idle wait. A fixed 1 s interval made every
+    // central's discovery/connect slow (each connect attempt waits for an adv
+    // event) and made duty-cycled scanners (macOS) miss the boards outright.
     void startAdvertising();
+    void armFastAdvWindow();
+    static constexpr uint32_t kFastAdvWindowMs = 30000;
+    uint32_t fast_adv_until_ms_ = 0;   // 0 = window never armed (slow phase)
 
     // Register GATT services with the NimBLE host
     void registerGattServices();

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -14,6 +14,9 @@
 #include <esp_ota_ops.h>          // esp_ota_mark_app_valid_cancel_rollback (#8)
 #include <esp_partition.h>        // esp_ota_get_running_partition for rollback gate (#8)
 #include "soc/rtc_cntl_reg.h"  // Brownout detector control
+#include "soc/rtc.h"            // #541: rtc_clk_* for the 32k-crystal second chance
+#include "esp_private/esp_clk.h"  // #541: esp_clk_slowclk_cal_set after a late 32k start
+#include <esp_timer.h>          // #541: boot USB-enumeration light-sleep grace timer
 #include "freertos/queue.h"
 #include "freertos/semphr.h"    // oc_i2s_mutex for the Phase 4 Layer 3 I2S flip
 #include "host/ble_gap.h"       // ble_gap_update_params
@@ -1076,6 +1079,139 @@ static void readINA230Power()
 //  These optimisations are active in the ESP-IDF build (tinkerrocket-idf)
 //  which has proper sdkconfig support.
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// #541: light-sleep grace so USB enumeration can finish.
+//
+// Light sleep is held off by exactly two locks: the BT controller's (only when
+// its LP clock fell back to main XTAL) and the USJ driver's
+// USJ_NO_AUTO_LS_ON_CONNECTION lock — which is only taken once a USB
+// connection is DETECTED. Right after a chip reset, host re-enumeration takes
+// ~1 s; on a 32k-crystal boot (BT lock absent) nothing holds sleep off during
+// that window, and losing the race wedges the USJ so the host never sees the
+// port again until a physical re-plug (bench 2026-07-17: 2 transient + 3
+// re-plug-required incidents in one day, all immediately after resets; the BS,
+// which runs no light sleep, has never dropped once).
+//
+// Hold ESP_PM_NO_LIGHT_SLEEP for the first kBootUsjGraceMs after light sleep
+// is enabled, then release. On battery (no host) this delays the first
+// possible sleep by 10 s once per boot — irrelevant to flight power.
+// ---------------------------------------------------------------------------
+#if defined(CONFIG_PM_ENABLE)
+static esp_pm_lock_handle_t s_boot_usj_grace_lock = nullptr;
+static esp_timer_handle_t   s_boot_usj_grace_timer = nullptr;
+static bool                 s_boot_usj_grace_held = false;
+static constexpr uint32_t   kBootUsjGraceMs = 10000;
+
+static void bootUsjGraceExpired(void*)
+{
+    if (s_boot_usj_grace_held)
+    {
+        s_boot_usj_grace_held = false;
+        esp_pm_lock_release(s_boot_usj_grace_lock);
+        ESP_LOGI("PWR", "USB-enumeration grace over — light sleep unblocked");
+    }
+}
+
+static void holdBootUsjGrace()
+{
+    if (s_boot_usj_grace_lock == nullptr &&
+        esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "usj_boot_grace",
+                           &s_boot_usj_grace_lock) != ESP_OK)
+    {
+        return;  // lock unavailable — no grace, same behavior as before #541
+    }
+    if (s_boot_usj_grace_timer == nullptr)
+    {
+        const esp_timer_create_args_t args = {
+            .callback = bootUsjGraceExpired,
+            .arg = nullptr,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "usj_grace",
+            .skip_unhandled_events = true,
+        };
+        if (esp_timer_create(&args, &s_boot_usj_grace_timer) != ESP_OK)
+        {
+            return;
+        }
+    }
+    if (!s_boot_usj_grace_held)
+    {
+        s_boot_usj_grace_held = true;
+        esp_pm_lock_acquire(s_boot_usj_grace_lock);
+    }
+    esp_timer_stop(s_boot_usj_grace_timer);
+    esp_timer_start_once(s_boot_usj_grace_timer,
+                         (uint64_t)kBootUsjGraceMs * 1000ULL);
+    ESP_LOGI("PWR", "Light sleep held %lu ms for USB enumeration (#541)",
+             (unsigned long)kBootUsjGraceMs);
+}
+#endif  // CONFIG_PM_ENABLE
+
+// ---------------------------------------------------------------------------
+// #541: second chance for the 32.768 kHz crystal, BEFORE BT init.
+//
+// IDF's boot-time selection gives the crystal exactly RTC_XTAL_CAL_RETRY(=1)+1
+// calibration attempts of ~92 ms each (RTC_CLK_CAL_CYCLES=3000) before
+// silently falling back to the internal 150 kHz RC — and the BT controller
+// then picks main XTAL as its LP clock, quietly reverting the whole #519
+// power win ("light sleep will not be able to apply"). Bench data (#541):
+// this board's crystal starts 7/7 COLD but intermittently fails WARM, and a
+// warm tuning-fork crystal can need hundreds of ms — more than IDF's window.
+//
+// The knobs that don't work: ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES is a
+// STUB on S3 (rtc_clk_32k_bootstrap() ignores its argument), and the retry
+// count is a hardcoded #define in IDF's clk.c. So: if the slow clock fell
+// back, re-enable the crystal here and give it up to 2 s of extra attempts.
+// On success, adopt it (source switch + fresh calibration) so BT and light
+// sleep still get the crystal; on failure, say so LOUDLY — before this, the
+// only tell was one easily-missed BT_INIT info line.
+// ---------------------------------------------------------------------------
+static void retry32kCrystal()
+{
+#if defined(CONFIG_RTC_CLK_SRC_EXT_CRYS)
+    if (rtc_clk_slow_src_get() == SOC_RTC_SLOW_CLK_SRC_XTAL32K)
+    {
+        return;  // crystal came up during boot — nothing to do
+    }
+    ESP_LOGW("PWR", "32k crystal failed at boot (RTC fell back to internal RC) "
+                    "— retrying up to 2 s before BT init (#541)");
+    rtc_clk_32k_enable(true);
+    uint32_t cal = 0;
+    int attempts = 0;
+    const int64_t deadline_us = esp_timer_get_time() + 2000000;
+    while (esp_timer_get_time() < deadline_us)
+    {
+        attempts++;
+        // Times out (returns 0) in ~100 ms if the crystal isn't oscillating.
+        cal = rtc_clk_cal(CLK_CAL_32K_XTAL, CONFIG_RTC_CLK_CAL_CYCLES);
+        if (cal != 0) break;
+    }
+    if (cal != 0)
+    {
+        rtc_clk_slow_src_set(SOC_RTC_SLOW_CLK_SRC_XTAL32K);
+        // Recalibrate against the now-selected source and publish the period
+        // so RTC timekeeping stays consistent (same pair of calls IDF's own
+        // select_rtc_slow_clk() makes).
+        const uint32_t slow_cal =
+            rtc_clk_cal(CLK_CAL_RTC_SLOW, CONFIG_RTC_CLK_CAL_CYCLES);
+        if (slow_cal != 0)
+        {
+            esp_clk_slowclk_cal_set(slow_cal);
+        }
+        ESP_LOGI("PWR", "32k crystal recovered on attempt %d — RTC and BT LP "
+                        "clock will use the crystal after all (#541)", attempts);
+    }
+    else
+    {
+        rtc_clk_32k_enable(false);
+        ESP_LOGE("PWR", "32k CRYSTAL DID NOT START after +2 s of retries "
+                        "(#541 warm-start failure?) — BT LP clock falls back "
+                        "to main XTAL; #519 light sleep is INERT this boot. "
+                        "Hardware check (drive/load caps) indicated.");
+    }
+#endif  // CONFIG_RTC_CLK_SRC_EXT_CRYS
+}
+
 static void enterLowPowerMode()
 {
 #if defined(CONFIG_PM_ENABLE)
@@ -1111,6 +1247,11 @@ static void enterLowPowerMode()
                         "(held off while USB is connected)");
     else
         ESP_LOGE("PWR", "esp_pm_configure failed: %s", esp_err_to_name(pm_err));
+
+    // #541: give USB enumeration a sleep-free window (see holdBootUsjGrace).
+    // Re-armed on every low-power entry — a rail-off transition can coincide
+    // with a fresh host attach on the bench, same race.
+    holdBootUsjGrace();
 
     // BLE TX power reduction handled by NimBLE config in sdkconfig
 #else
@@ -5620,6 +5761,10 @@ static void setup_oc()
     // 30 ms and thrown away most of the power saving. Take ownership instead of
     // relying on who gets there first.
     ble_app.setAutoConnParams(false);
+
+    // #541: must run BEFORE ble_app.begin() — the BT controller samples the
+    // RTC slow-clock source once at init to choose its low-power clock.
+    retry32kCrystal();
 
     // Only BLE starts at boot — everything else is behind PWR_PIN
     if (!ble_app.begin())

--- a/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/out_computer/sdkconfig.defaults
@@ -124,9 +124,14 @@ CONFIG_BT_CTRL_LPCLK_SEL_EXT_32K_XTAL=y
 CONFIG_ESP_XT_WDT=y
 CONFIG_ESP_XT_WDT_BACKUP_CLK_ENABLE=y
 
-# NOTE if the bench boot log says "32.768kHz XTAL not detected": the first knob to
-# try is CONFIG_ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES (default 0 on S3), which
-# kicks the crystal with a 32 kHz square wave to help it start.
+# NOTE if the bench boot log says "32.768kHz XTAL not detected": do NOT reach for
+# CONFIG_ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES — on the S3 that knob is a STUB
+# (rtc_clk_32k_bootstrap() ignores its argument; the kick-start only exists on
+# classic ESP32). IDF gives the crystal exactly 2 × ~92 ms calibration attempts
+# (RTC_XTAL_CAL_RETRY is a hardcoded #define in clk.c), which a warm marginal
+# crystal can miss. The real remediation is retry32kCrystal() in main.cpp (#541):
+# an app-level second chance of up to 2 s before BT init, with a LOUD failure log.
+# Persistent failures indicate hardware (crystal drive / load caps) — see #541.
 
 # (#519) The other half of the reason light sleep was off. enterLowPowerMode()'s
 # comment cited "USB-Serial-JTAG incompatible" — which is true, the USJ peripheral


### PR DESCRIPTION
Closes #541

Three fixes from the #541 bench investigation (full evidence trail on the issue):

1. **USB-enumeration light-sleep grace** (`holdBootUsjGrace()`, OC): hold `ESP_PM_NO_LIGHT_SLEEP` for 10 s on every low-power entry. After a chip reset, host re-enumeration takes ~1 s; on 32k-crystal boots nothing held light sleep off during that window, and losing the race wedged the USJ until a physical re-plug (5 incidents in one bench day; the BS, with no light sleep, never dropped). **Validated: 10/10 reset cycles, zero drops/wedges** (baseline: 2 drops + 1 wedge in 7).

2. **32k-crystal second chance** (`retry32kCrystal()`, OC, pre-BT-init): if the RTC slow clock fell back to internal RC, re-enable the crystal and retry up to 2 s; adopt on success so the #519 power win survives a slow warm start; LOUD error on failure. Corrects the #523 note in sdkconfig.defaults: `ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES` is a stub on S3 and IDF's retry count is a hardcoded `#define`. Cold boots: 15/15 clean crystal picks (retry dormant, as designed). Warm-boot results in the final issue comment.

3. **Two-phase advertising** (`TR_BLE_To_APP`, shared OC+BS): FAST 152.5 ms for 30 s after boot and after every disconnect, then the 1000 ms power interval (NimBLE adv duration + existing ADV_COMPLETE restart, now guarded while connected). The fixed 1 s interval made every central's discovery slow and duty-cycled scanners (macOS) miss the boards outright. **Validated: 3/3 scan hits in the fast window at −44 dBm; slow phase intact (~30% scan odds, advertising alive through minute 6).** Also the discovery-side lever for #542.

OC + BS build clean; both flashed and validated on the bench 2026-07-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
