### PR TITLE
app(#191): Recovery settings section + DriftCast profile-seeded descent fields

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -553,6 +553,14 @@ struct DriftCastView: View {
     var device: BLEDevice?
     @Environment(\.dismiss) var dismiss
 
+    /// Active rocket profile (#191).  When a profile is selected, the descent
+    /// fields (drogue/main rate, main deploy) mirror it — seeded on open,
+    /// valid edits written back — so drift-cast and the live landing
+    /// predictor share one per-airframe source of truth.  With no active
+    /// profile the @AppStorage globals below stand alone (pre-#191 behavior).
+    /// Injected at the app root, so it survives the sheet boundary.
+    @EnvironmentObject var profileStore: RocketProfileStore
+
     // Display units (#160).  DriftCast is feet/knots-native (winds-aloft
     // convention); only the result readouts respect this toggle — the wind
     // profile table and ft/fps inputs stay as-is.
@@ -677,7 +685,10 @@ struct DriftCastView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .onAppear { locationManager.startUpdates() }
+            .onAppear {
+                locationManager.startUpdates()
+                seedFromActiveProfile()
+            }
             .onDisappear { locationManager.stopUpdates() }
             // Seed the launch/landing points from the first GPS fix, but only
             // while they're still blank — never clobber a value the user typed
@@ -687,6 +698,13 @@ struct DriftCastView: View {
                 didAutoSeed = true
                 applyCurrentLocation(coord)
             }
+            // #191: valid descent-field edits flow back into the active
+            // profile.  Fires per keystroke, so unparseable / non-positive
+            // mid-edit strings are skipped; the same-value guard inside
+            // swallows the echo from seedFromActiveProfile().
+            .onChange(of: drogueRate) { writeBackToProfile(\.drogueRateFps, $0) }
+            .onChange(of: mainRate) { writeBackToProfile(\.mainRateFps, $0) }
+            .onChange(of: mainDeploy) { writeBackToProfile(\.mainDeployAltAglFt, $0) }
             .sheet(isPresented: $showOfflineMaps) {
                 OfflineMapsView(suggestedCenter: mapRegion.center)
             }
@@ -796,6 +814,12 @@ struct DriftCastView: View {
                 paramRow(label: "Drogue rate", value: $drogueRate, unit: "fps")
                 paramRow(label: "Main rate", value: $mainRate, unit: "fps")
                 paramRow(label: "Main deploy", value: $mainDeploy, unit: "ft")
+                if let name = profileStore.activeProfile?.name {
+                    Text("Descent rates & main deploy come from \u{201C}\(name)\u{201D} \u{2014} edits save back to that rocket's profile.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
                 paramRow(label: "Max steering", value: $maxSteering, unit: "°")
 
                 DatePicker("Launch time",
@@ -1015,6 +1039,38 @@ struct DriftCastView: View {
             center: coord,
             span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
         )
+    }
+
+    // MARK: - Profile sync (#191)
+
+    /// Mirror the active profile's recovery fields into the editable strings.
+    /// Unconditional overwrite (unlike the GPS auto-seed): the profile is the
+    /// per-airframe source of truth, and any stale @AppStorage value it
+    /// replaces here is exactly the cross-rocket bleed #191 removes.
+    private func seedFromActiveProfile() {
+        guard let p = profileStore.activeProfile else { return }
+        drogueRate = formatFieldValue(p.drogueRateFps)
+        mainRate = formatFieldValue(p.mainRateFps)
+        mainDeploy = formatFieldValue(p.mainDeployAltAglFt)
+    }
+
+    /// Persist a parsed-valid descent-field edit into the active profile.
+    /// Runs on every keystroke, so it must be tolerant: unparseable or
+    /// non-positive mid-edit strings are ignored, and writing the value the
+    /// profile already holds is suppressed (blocks the seeding echo and
+    /// pointless updatedAt bumps / disk writes).
+    private func writeBackToProfile(_ kp: WritableKeyPath<RocketProfile, Double>,
+                                    _ s: String) {
+        guard let id = profileStore.activeId,
+              let v = Double(s), v > 0,
+              profileStore.activeProfile?[keyPath: kp] != v else { return }
+        profileStore.update(id) { $0[keyPath: kp] = v }
+    }
+
+    /// Double → editable string, matching the stored value exactly so the
+    /// seed → onChange → write-back round trip compares equal ("60" not "60.0").
+    private func formatFieldValue(_ v: Double) -> String {
+        v == v.rounded() ? String(Int(v)) : String(v)
     }
 
     private func compute() {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -61,6 +61,14 @@ struct SettingsView: View {
     // Pyro trigger values edited as strings (seconds or meters by mode).
     @State private var sPyroValue: [String] = ["", "", "", ""]
 
+    // Recovery descent profile edited as strings (#191).  App-only fields:
+    // consumed by the live landing predictor and Drift Cast, never sent to
+    // the flight computer.
+    @State private var sDrogueRate = ""
+    @State private var sMainRate = ""
+    @State private var sMainDeployAlt = ""
+    @State private var sDragK = ""
+
     // Drives the full-screen pyro test-fire cover.  (The per-channel continuity
     // readout state lives in the PyroChannelTestControls child view.)
     @State private var pyroTestChannel: Int?
@@ -143,6 +151,7 @@ struct SettingsView: View {
         case guidTargetAlt, guidNavGain, guidMaxAccel, guidAccelToFin, guidMaxFin, guidMinSpeed
         case wpTime(Int), wpAngle(Int)
         case pyroValue(Int)   // ch index 0..3
+        case drogueRate, mainRate, mainDeployAlt, dragK
     }
 
     /// Fin-angle range implied by the pulse + travel fields as they are being
@@ -170,7 +179,7 @@ struct SettingsView: View {
         .font(.subheadline)
     }
 
-    private enum EditGroup { case servo, pid, rollControl, guidance, rollWaypoints, pyro }
+    private enum EditGroup { case servo, pid, rollControl, guidance, rollWaypoints, pyro, recovery }
 
     private func group(of field: EditField?) -> EditGroup? {
         switch field {
@@ -180,6 +189,7 @@ struct SettingsView: View {
         case .guidTargetAlt, .guidNavGain, .guidMaxAccel, .guidAccelToFin, .guidMaxFin, .guidMinSpeed: return .guidance
         case .wpTime, .wpAngle: return .rollWaypoints
         case .pyroValue: return .pyro
+        case .drogueRate, .mainRate, .mainDeployAlt, .dragK: return .recovery
         case nil: return nil
         }
     }
@@ -192,6 +202,7 @@ struct SettingsView: View {
         case .guidance: applyGuidanceConfig()
         case .rollWaypoints: applyRollProfile()
         case .pyro: applyPyroConfig()
+        case .recovery: applyRecoveryConfig()
         }
     }
 
@@ -534,6 +545,26 @@ struct SettingsView: View {
         pyroChannelSection(4)
         Section {
             Text("Single shared arm FET arms momentarily for each fire pulse. Test continuity and test-fire from the rocket dashboard before flight.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+        recoverySection
+    }
+
+    // Recovery descent profile (#191).  These fields live only in the app
+    // profile (landing-prediction + drift-cast inputs) and are never sent to
+    // the rocket — hence no "Sent" badge and no BLE push on apply.  The
+    // static header also keeps this section free of telemetry-driven
+    // re-renders next to a focused TextField (#361).
+    @ViewBuilder
+    private var recoverySection: some View {
+        Section(header: Text("Recovery")) {
+            stringRow("Drogue Rate", text: $sDrogueRate, field: .drogueRate, unit: "fps", decimal: true)
+            stringRow("Main Rate", text: $sMainRate, field: .mainRate, unit: "fps", decimal: true)
+            stringRow("Main Deploy", text: $sMainDeployAlt, field: .mainDeployAlt, unit: "ft", decimal: true)
+            Text("Descent profile for the live landing prediction and Drift Cast: drogue rate above the main-deploy altitude (AGL), main rate below it. Stored per rocket in the app \u{2014} not sent to the flight computer.")
+                .font(.caption).foregroundColor(.secondary)
+            stringRow("Drag k", text: $sDragK, field: .dragK, unit: "1/m", decimal: true)
+            Text("Quadratic drag coefficient for the coast-to-apogee ballistic prediction (a = \u{2212}k\u{00B7}|v|\u{00B7}v). \u{2248}0.0005 for typical 54\u{2013}65 mm airframes; 0 = gravity-only.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -1130,6 +1161,10 @@ struct SettingsView: View {
         rollWaypoints = p.rollWaypoints.map {
             (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg))
         }
+        sDrogueRate = formatInt(p.drogueRateFps)
+        sMainRate = formatInt(p.mainRateFps)
+        sMainDeployAlt = formatInt(p.mainDeployAltAglFt)
+        sDragK = formatDecimal(p.ballisticDragK)
         reloadPyroValueStrings()
     }
 
@@ -1283,6 +1318,24 @@ struct SettingsView: View {
             }
         }
         showApplied($pyroApplied)
+    }
+
+    // Recovery fields are app-only (#191): "apply" is just parse + persist —
+    // no BLE push, no "Sent" badge.  Non-positive rates/altitudes are
+    // rejected: simulateDescent degrades a rate ≤ 0.1 fps to a one-point
+    // track, which the live predictor would render as "lands where it is".
+    // Drag k legitimately accepts 0 (= gravity-only ballistic).
+    private func applyRecoveryConfig() {
+        let dr = parseDouble(sDrogueRate, fallback: profile.drogueRateFps)
+        let mr = parseDouble(sMainRate, fallback: profile.mainRateFps)
+        let md = parseDouble(sMainDeployAlt, fallback: profile.mainDeployAltAglFt)
+        let k = parseDouble(sDragK, fallback: profile.ballisticDragK)
+        updateProfile {
+            if dr > 0 { $0.drogueRateFps = dr }
+            if mr > 0 { $0.mainRateFps = mr }
+            if md > 0 { $0.mainDeployAltAglFt = md }
+            if k >= 0 { $0.ballisticDragK = k }
+        }
     }
 
     private func applyPIDConfig() {


### PR DESCRIPTION
Items 3+4 of #191 (items 1+2 landed in #545). App-only — no firmware, no wire changes.

**Item 3 — Recovery section in rocket Settings**: per-profile Drogue Rate (fps), Main Rate (fps), Main Deploy (ft AGL), Drag K. Fields drive the app's DriftCast/landing-prediction math, not the rocket — deliberately no "Sent" badge and no BLE push; edits self-apply on focus loss (#144), static header so a focused TextField can't freeze under telemetry (#361).

**Item 4 — DriftCastView profile wiring**: descent fields seed from and write back to the active rocket profile; the old global `dc_*` @AppStorage values remain only as the no-profile fallback. Visible default change: profile main rate defaults to 12 fps (old global default was 18). Profile export needed no work (profiles JSON-encode whole).

Validated on-device 2026-07-18: Recovery section renders + round-trips edits, DriftCast mirrors and writes back to the active profile, no-profile fallback intact. Full app unit suite green on the merged tree (includes a merge of main through `18bf051`).

Refs #191 — the coded items are now complete; the issue holds for the real-flight test of the ascent prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
