### PR TITLE
app: My Devices screen (device names + network IDs in one place); drop the BLE scanner name filter

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -67,19 +67,35 @@ final class ActiveRocketSyncer: ObservableObject {
     private var magCalReadPending = false
     private var sensorCalReadPending = false
 
+    /// Which role the current attach ran under.  A renamed device can
+    /// mis-parse its type from the BLE name until config_identity lands
+    /// (e.g. a rocket called "SUBSONIC" reads as a base station via the
+    /// legacy substring check), so the role at attach time isn't final —
+    /// see the re-evaluation in attach().
+    private var attachedAsBaseStation = false
+
     // MARK: - Lifecycle
 
     func attach(device: BLEDevice, store: RocketProfileStore) {
-        // Idempotent for the same device+store pair (#375): the dashboard now
+        // Idempotent for the same device+store pair (#375): the dashboard
         // re-attaches on every device-list / active-device change, and a
         // redundant call must not tear down subscriptions or reset a .synced
         // state back through the pipeline. A NEW device object (reconnects
         // create one) intentionally falls through to a full re-attach.
-        if device === self.device && store === self.store { return }
+        //
+        // Exception: if the device's ROLE changed since we attached (the
+        // config_identity readback corrected a name-based mis-parse), fall
+        // through and re-attach under the right role — otherwise a rocket
+        // first mis-read as a base station keeps profile sync silently
+        // disabled for the whole session (the #375 failure mode, back
+        // through a different door).
+        if device === self.device && store === self.store
+            && attachedAsBaseStation == device.isBaseStation { return }
 
         detach()
         self.device = device
         self.store = store
+        attachedAsBaseStation = device.isBaseStation
 
         guard !device.isBaseStation else {
             // Base station is a read-only display of the active rocket; it
@@ -130,6 +146,7 @@ final class ActiveRocketSyncer: ObservableObject {
         cancellables.removeAll()
         device = nil
         store = nil
+        attachedAsBaseStation = false
         magCalReadPending = false
         sensorCalReadPending = false
         syncState = .idle

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1551,6 +1551,13 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
             }
             if let fw = dict["fw"] as? String { firmwareVersion = fw }
             print("[CFG] Identity: uid=\(unitID) name=\(unitName) nid=\(networkID) rid=\(rocketID) type=\(deviceType.rawValue) fw=\(firmwareVersion)")
+            // Fold the readback into the known-device registry and let it
+            // push any edits queued while this device was offline.  The
+            // firmware echoes a fresh config_identity after each identity-set
+            // command, so pushed values confirm through this same path.
+            fleet?.knownDevices.deviceDidReportIdentity(
+                unitID: unitID, name: unitName, deviceType: deviceType,
+                networkID: networkID, rocketID: rocketID, pusher: self)
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -1044,7 +1044,9 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     // MARK: - Identity commands
 
     func sendSetUnitName(_ name: String) {
-        guard let data = name.prefix(20).data(using: .utf8) else { return }
+        // Byte clamp, not char clamp: the firmware rejects plen > 20 outright
+        // (no write, no echo), and 20 chars of multibyte UTF-8 can exceed it.
+        guard let data = name.utf8Clamped(maxBytes: 20).data(using: .utf8) else { return }
         sendRawCommand(40, payload: data)
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -37,6 +37,19 @@ class BLEFleet: NSObject, ObservableObject {
     /// Currently connected devices (for now, max 1 — multi-connect in PR #4).
     @Published var devices: [BLEDevice] = []
 
+    /// Registry of every device ever provisioned/seen, keyed by hardware
+    /// unitID.  Lives on the fleet (not a view) because BLEDevice feeds it
+    /// on every config_identity readback — including for non-active devices.
+    let knownDevices = KnownDeviceStore()
+
+    /// The live BLEDevice for a hardware unitID, if that device is currently
+    /// connected AND has completed its identity readback.  Used by the
+    /// device manager to decide push-now vs queue-for-next-connect.
+    func connectedDevice(unitID: String) -> BLEDevice? {
+        guard !unitID.isEmpty else { return nil }
+        return devices.first { $0.unitID == unitID }
+    }
+
     /// Which device the dashboard is currently showing.
     @Published var activeDeviceID: UUID?
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -193,6 +193,26 @@ class BLEFleet: NSObject, ObservableObject {
         devices.first { $0.peripheral?.identifier == peripheral.identifier }
     }
 
+    /// Seed a just-created BLEDevice's type from what we already know,
+    /// BEFORE the config_identity readback arrives.  Registry knowledge
+    /// wins over BLEDevice.init's name parse (mirrors DiscoveredDevice's
+    /// precedence): the firmware advertises the raw user-set name, so a
+    /// renamed device either parses .unknown or — worse — mis-parses via
+    /// the legacy substring check (a rocket called "SUBSONIC" reads as a
+    /// base station), and a wrong role at connect latches the profile
+    /// syncer (#375).  Prefers the scan-time DiscoveredDevice identity:
+    /// peripheral.name is iOS-cached and can be nil/stale after a
+    /// re-flash, while the scan response carried the real name.  The
+    /// readback's "dt" still overrides everything ~1 s later.
+    private func seedTypeFromRegistry(_ device: BLEDevice, peripheral: CBPeripheral) {
+        let discovered = discoveredDevices.first { $0.id == peripheral.identifier }
+        let advertisedName = discovered?.name ?? device.connectedDeviceName
+        if let known = discovered?.knownType
+            ?? knownDevices.deviceType(forAdvertisedName: advertisedName) {
+            device.deviceType = known
+        }
+    }
+
     // MARK: - Last-valid rocket fix cache (#140)
 
     /// Called by BLEDevice on every telemetry packet.  Updates the
@@ -237,6 +257,7 @@ extension BLEFleet: CBCentralManagerDelegate {
                 // populates and the map marker / direction arrow / landing anchor
                 // stay blank for the whole restored session.
                 device.fleet = self
+                seedTypeFromRegistry(device, peripheral: p)
                 device.onConnect()
                 devices.append(device)
                 activeDeviceID = p.identifier
@@ -271,8 +292,12 @@ extension BLEFleet: CBCentralManagerDelegate {
         let name = advertisedName ?? peripheral.name ?? "Unknown"
         print("Discovered: \(name) RSSI: \(RSSI)")
 
-        // Only list Tinker devices (legacy "TinkerRocket"/"TinkerBaseStation" + new "TR-R-"/"TR-B-")
-        guard name.hasPrefix("TR-") || name.contains("Tinker") else { return }
+        // No name filter here: the scan is already service-UUID-filtered
+        // (scanForPeripherals(withServices:)), so anything delivered to this
+        // callback IS a TinkerRocket board.  The old belt-and-suspenders
+        // TR-*/Tinker name guard silently dropped every device renamed
+        // through My Devices — the firmware advertises the raw user-set
+        // unit name; only factory defaults carry the TR-R-/TR-B- prefix.
 
         if let idx = discoveredDevices.firstIndex(where: { $0.id == peripheral.identifier }) {
             discoveredDevices[idx].rssi = RSSI.intValue
@@ -281,7 +306,11 @@ extension BLEFleet: CBCentralManagerDelegate {
                 id: peripheral.identifier,
                 peripheral: peripheral,
                 name: name,
-                rssi: RSSI.intValue
+                rssi: RSSI.intValue,
+                // Renames happen through this app, so a renamed device's
+                // advertised name matches its registry record — recover the
+                // type the name prefix no longer carries.
+                knownType: knownDevices.deviceType(forAdvertisedName: name)
             )
             discoveredDevices.append(device)
         }
@@ -298,6 +327,7 @@ extension BLEFleet: CBCentralManagerDelegate {
 
         let device = BLEDevice(peripheral: peripheral, name: name)
         device.fleet = self
+        seedTypeFromRegistry(device, peripheral: peripheral)
         device.onConnect()
         devices.append(device)
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -75,12 +75,28 @@ struct DiscoveredDevice: Identifiable {
     let name: String
     var rssi: Int
 
+    /// Type recovered from the known-device registry at discovery time
+    /// (matched by advertised name).  nil when the device isn't in the
+    /// registry — e.g. a fresh app install, or a board renamed on another
+    /// phone.
+    var knownType: BLEDeviceType? = nil
+
+    /// Registry hint first; the TR-R-/TR-B- name heuristic only works for
+    /// factory-default names (the firmware advertises the raw unit name).
+    var deviceType: BLEDeviceType {
+        knownType ?? BLEDeviceType.from(name: name)
+    }
+
     var isBaseStation: Bool {
-        name.hasPrefix("TR-B-") || name.contains("Base") || name.contains("BS")
+        deviceType == .baseStation
     }
 
     var typeLabel: String {
-        isBaseStation ? "Base Station" : "Rocket"
+        switch deviceType {
+        case .rocket: return "Rocket"
+        case .baseStation: return "Base Station"
+        case .unknown: return "TinkerRocket device"
+        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
@@ -30,6 +30,18 @@ extension BLEDevice: DeviceIdentityPusher {}
 
 extension BLEDeviceType: Codable {}
 
+extension String {
+    /// Longest prefix that fits `maxBytes` of UTF-8 without splitting a
+    /// Character.  The firmware identity handlers hard-reject longer
+    /// payloads (plen > 20) with no write and no readback echo, so a
+    /// character-count clamp is not enough for multibyte names.
+    func utf8Clamped(maxBytes: Int) -> String {
+        var s = self
+        while s.utf8.count > maxBytes { s.removeLast() }
+        return s
+    }
+}
+
 /// One physical device as last seen over BLE, plus queued offline edits.
 struct KnownDevice: Identifiable, Codable, Equatable {
     let unitID: String              // immutable hardware id — the key
@@ -135,28 +147,32 @@ final class KnownDeviceStore: ObservableObject {
             rec.rocketID = rocketID
             rec.lastSeen = Date()
 
-            if let pendingName = rec.pendingName {
-                rec.pendingName = nil
-                if pendingName != name {
-                    rec.name = pendingName
-                    pusher?.sendSetUnitName(pendingName)
-                }
-            }
-            if let pendingNid = rec.pendingNetworkID {
-                rec.pendingNetworkID = nil
-                if pendingNid != networkID {
-                    rec.networkID = pendingNid
-                    pusher?.sendSetNetworkID(pendingNid)
-                }
-            }
-            if let pendingRid = rec.pendingRocketID {
-                rec.pendingRocketID = nil
-                if pendingRid != rocketID {
-                    rec.rocketID = pendingRid
-                    pusher?.sendSetRocketID(pendingRid)
-                }
-            }
+            applyPending(&rec, readback: name,
+                         current: \.name, pending: \.pendingName,
+                         push: pusher.map { p in { p.sendSetUnitName($0) } })
+            applyPending(&rec, readback: networkID,
+                         current: \.networkID, pending: \.pendingNetworkID,
+                         push: pusher.map { p in { p.sendSetNetworkID($0) } })
+            applyPending(&rec, readback: rocketID,
+                         current: \.rocketID, pending: \.pendingRocketID,
+                         push: pusher.map { p in { p.sendSetRocketID($0) } })
         }
+    }
+
+    /// Apply one queued offline edit against a fresh readback.  The queue is
+    /// cleared BEFORE pushing so the firmware's echo readback runs this as a
+    /// plain upsert — no re-push loop even if the device rejects or clamps
+    /// the value.  A queued value the device already has is just dropped.
+    private func applyPending<V: Equatable>(_ rec: inout KnownDevice,
+                                            readback: V,
+                                            current: WritableKeyPath<KnownDevice, V>,
+                                            pending: WritableKeyPath<KnownDevice, V?>,
+                                            push: ((V) -> Void)?) {
+        guard let queued = rec[keyPath: pending] else { return }
+        rec[keyPath: pending] = nil
+        guard queued != readback else { return }
+        rec[keyPath: current] = queued
+        push?(queued)
     }
 
     /// Called by the provisioning sheet on Save/Skip so the device stops
@@ -170,43 +186,43 @@ final class KnownDeviceStore: ObservableObject {
 
     /// Rename.  With a live pusher the new name is sent immediately and the
     /// record updated optimistically (the firmware's readback echo confirms);
-    /// offline it's queued for the next connect.
+    /// offline it's queued for the next connect.  Clamped to the firmware's
+    /// 20-byte payload limit so the device can never silently reject it.
     func setName(_ newName: String, for unitID: String, pusher: DeviceIdentityPusher?) {
-        let trimmed = String(newName.trimmingCharacters(in: .whitespacesAndNewlines).prefix(20))
-        guard !trimmed.isEmpty, !unitID.isEmpty else { return }
-        withRecord(unitID) { rec in
-            if let pusher {
-                pusher.sendSetUnitName(trimmed)
-                rec.name = trimmed
-                rec.pendingName = nil
-            } else {
-                rec.pendingName = trimmed == rec.name ? nil : trimmed
-            }
-        }
+        let clamped = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+            .utf8Clamped(maxBytes: 20)
+        guard !clamped.isEmpty, !unitID.isEmpty else { return }
+        applyEdit(clamped, for: unitID, current: \.name, pending: \.pendingName,
+                  push: pusher.map { p in { p.sendSetUnitName($0) } })
     }
 
     func setNetworkID(_ nid: UInt8, for unitID: String, pusher: DeviceIdentityPusher?) {
         guard nid > 0, !unitID.isEmpty else { return }   // 0 is the unset sentinel (#150)
-        withRecord(unitID) { rec in
-            if let pusher {
-                pusher.sendSetNetworkID(nid)
-                rec.networkID = nid
-                rec.pendingNetworkID = nil
-            } else {
-                rec.pendingNetworkID = nid == rec.networkID ? nil : nid
-            }
-        }
+        applyEdit(nid, for: unitID, current: \.networkID, pending: \.pendingNetworkID,
+                  push: pusher.map { p in { p.sendSetNetworkID($0) } })
     }
 
     func setRocketID(_ rid: UInt8, for unitID: String, pusher: DeviceIdentityPusher?) {
         guard (1...254).contains(rid), !unitID.isEmpty else { return }  // firmware rejects 0/255
+        applyEdit(rid, for: unitID, current: \.rocketID, pending: \.pendingRocketID,
+                  push: pusher.map { p in { p.sendSetRocketID($0) } })
+    }
+
+    /// Shared push-now-vs-queue tail for the setters above.  Connected:
+    /// push + optimistic record update + clear any stale queue.  Offline:
+    /// queue the target, where queueing the device's current value just
+    /// clears the queue (a changed-my-mind no-op).
+    private func applyEdit<V: Equatable>(_ value: V, for unitID: String,
+                                         current: WritableKeyPath<KnownDevice, V>,
+                                         pending: WritableKeyPath<KnownDevice, V?>,
+                                         push: ((V) -> Void)?) {
         withRecord(unitID) { rec in
-            if let pusher {
-                pusher.sendSetRocketID(rid)
-                rec.rocketID = rid
-                rec.pendingRocketID = nil
+            if let push {
+                push(value)
+                rec[keyPath: current] = value
+                rec[keyPath: pending] = nil
             } else {
-                rec.pendingRocketID = rid == rec.rocketID ? nil : rid
+                rec[keyPath: pending] = value == rec[keyPath: current] ? nil : value
             }
         }
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
@@ -123,6 +123,18 @@ final class KnownDeviceStore: ObservableObject {
         return device(for: unitID)?.provisioned ?? false
     }
 
+    /// Best-effort device type for a scan result, matched by advertised
+    /// name.  The firmware advertises the raw unit name, and renames happen
+    /// through this app, so a renamed device's adv name equals its record's
+    /// name.  nil when there's no single unambiguous match (unknown name,
+    /// or two records sharing one).
+    func deviceType(forAdvertisedName name: String) -> BLEDeviceType? {
+        guard !name.isEmpty else { return nil }
+        let matches = devices.filter { $0.name == name && $0.deviceType != .unknown }
+        guard matches.count == 1 else { return nil }
+        return matches[0].deviceType
+    }
+
     // MARK: - Readback intake
 
     /// Fold a config_identity readback into the registry, then push any

--- a/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift
@@ -1,0 +1,297 @@
+//
+//  KnownDeviceStore.swift
+//  TinkerRocketApp
+//
+//  App-side registry of every physical device (rocket / base station) the
+//  app has ever completed an identity readback with, keyed by the immutable
+//  hardware unitID.  Backs the "My Devices" management screen: names and
+//  network IDs live ON the device (identity NVS, #150), so this registry is
+//  a cache of the last readback plus a queue of edits made while the device
+//  was offline.  Pending edits are pushed on the next config_identity
+//  readback; the firmware echoes a fresh readback after every identity-set
+//  command (cmds 40/41/42), which folds device truth back into the record.
+//
+//  Subsumes the legacy "knownDeviceIDs" UserDefaults array that only gated
+//  the first-connect provisioning sheet — migrated once, then removed.
+//
+
+import Foundation
+import Combine
+
+/// The three identity pushes + nothing else, so the store can be unit-tested
+/// with a spy instead of a live CBPeripheral (same seam as TelemetryAnnouncer).
+protocol DeviceIdentityPusher: AnyObject {
+    func sendSetUnitName(_ name: String)
+    func sendSetNetworkID(_ nid: UInt8)
+    func sendSetRocketID(_ rid: UInt8)
+}
+
+extension BLEDevice: DeviceIdentityPusher {}
+
+extension BLEDeviceType: Codable {}
+
+/// One physical device as last seen over BLE, plus queued offline edits.
+struct KnownDevice: Identifiable, Codable, Equatable {
+    let unitID: String              // immutable hardware id — the key
+    var name: String = ""           // device's own unit_name at last readback
+    var deviceType: BLEDeviceType = .unknown
+    var networkID: UInt8 = 0        // last readback nid (0 = factory/unset)
+    var rocketID: UInt8 = 0         // rockets only; 0 = unset
+    var provisioned: Bool = false   // user finished (or skipped) first-connect setup
+    var lastSeen: Date?
+
+    // Edits queued while the device was offline; cleared when pushed.
+    var pendingName: String?
+    var pendingNetworkID: UInt8?
+    var pendingRocketID: UInt8?
+
+    var id: String { unitID }
+
+    var hasPendingChanges: Bool {
+        pendingName != nil || pendingNetworkID != nil || pendingRocketID != nil
+    }
+
+    // Target state for display: what the device will be once pending applies.
+    var effectiveName: String { pendingName ?? name }
+    var effectiveNetworkID: UInt8 { pendingNetworkID ?? networkID }
+    var effectiveRocketID: UInt8 { pendingRocketID ?? rocketID }
+
+    init(unitID: String) {
+        self.unitID = unitID
+    }
+
+    // Tolerate additive schema changes: decode field-by-field with defaults
+    // so a registry written by a newer build never bricks an older one.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        unitID = try c.decode(String.self, forKey: .unitID)
+        name = try c.decodeIfPresent(String.self, forKey: .name) ?? ""
+        deviceType = (try? c.decodeIfPresent(BLEDeviceType.self, forKey: .deviceType)) ?? .unknown
+        networkID = try c.decodeIfPresent(UInt8.self, forKey: .networkID) ?? 0
+        rocketID = try c.decodeIfPresent(UInt8.self, forKey: .rocketID) ?? 0
+        provisioned = try c.decodeIfPresent(Bool.self, forKey: .provisioned) ?? false
+        lastSeen = try c.decodeIfPresent(Date.self, forKey: .lastSeen)
+        pendingName = try c.decodeIfPresent(String.self, forKey: .pendingName)
+        pendingNetworkID = try c.decodeIfPresent(UInt8.self, forKey: .pendingNetworkID)
+        pendingRocketID = try c.decodeIfPresent(UInt8.self, forKey: .pendingRocketID)
+    }
+}
+
+final class KnownDeviceStore: ObservableObject {
+    // Workaround for swiftlang/swift#87316: with SWIFT_DEFAULT_ACTOR_ISOLATION
+    // = MainActor, the implicit isolated deinit routes through the runtime's
+    // back-deploy shim, which aborts when the object is deallocated inside a
+    // synchronous XCTest.  No deinit-time logic here, so the hop is free to skip.
+    nonisolated deinit {}
+
+    /// Rockets first, then base stations, each sorted by display name.
+    @Published private(set) var devices: [KnownDevice] = []
+
+    private let defaults: UserDefaults
+
+    private static let storeKey = "knownDevices.v1"
+    private static let legacyKnownIDsKey = "knownDeviceIDs"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        load()
+        migrateLegacyIfNeeded()
+    }
+
+    // MARK: - Lookup
+
+    func device(for unitID: String) -> KnownDevice? {
+        devices.first { $0.unitID == unitID }
+    }
+
+    /// Gates the first-connect provisioning sheet.  Empty unitID reads as
+    /// provisioned so the sheet never pops before the identity readback.
+    func isProvisioned(_ unitID: String) -> Bool {
+        guard !unitID.isEmpty else { return true }
+        return device(for: unitID)?.provisioned ?? false
+    }
+
+    // MARK: - Readback intake
+
+    /// Fold a config_identity readback into the registry, then push any
+    /// pending offline edits.  Pending fields are cleared at push time
+    /// (fire-and-forget): the firmware echoes a fresh readback after each
+    /// identity-set command, so the record converges on device truth, and
+    /// clearing first makes the echo pass a plain upsert — no re-push loop
+    /// even if the firmware rejects or clamps a value.
+    func deviceDidReportIdentity(unitID: String,
+                                 name: String,
+                                 deviceType: BLEDeviceType,
+                                 networkID: UInt8,
+                                 rocketID: UInt8,
+                                 pusher: DeviceIdentityPusher?) {
+        guard !unitID.isEmpty else { return }
+        withRecord(unitID) { rec in
+            rec.name = name
+            // Keep a previously learned type if this readback doesn't know it
+            // (pre-"dt" firmware) — a device never changes species.
+            if deviceType != .unknown { rec.deviceType = deviceType }
+            rec.networkID = networkID
+            rec.rocketID = rocketID
+            rec.lastSeen = Date()
+
+            if let pendingName = rec.pendingName {
+                rec.pendingName = nil
+                if pendingName != name {
+                    rec.name = pendingName
+                    pusher?.sendSetUnitName(pendingName)
+                }
+            }
+            if let pendingNid = rec.pendingNetworkID {
+                rec.pendingNetworkID = nil
+                if pendingNid != networkID {
+                    rec.networkID = pendingNid
+                    pusher?.sendSetNetworkID(pendingNid)
+                }
+            }
+            if let pendingRid = rec.pendingRocketID {
+                rec.pendingRocketID = nil
+                if pendingRid != rocketID {
+                    rec.rocketID = pendingRid
+                    pusher?.sendSetRocketID(pendingRid)
+                }
+            }
+        }
+    }
+
+    /// Called by the provisioning sheet on Save/Skip so the device stops
+    /// re-prompting.  Creates the record if the readback hasn't yet.
+    func markProvisioned(_ unitID: String) {
+        guard !unitID.isEmpty else { return }
+        withRecord(unitID) { $0.provisioned = true }
+    }
+
+    // MARK: - Edits (push now when connected, queue when offline)
+
+    /// Rename.  With a live pusher the new name is sent immediately and the
+    /// record updated optimistically (the firmware's readback echo confirms);
+    /// offline it's queued for the next connect.
+    func setName(_ newName: String, for unitID: String, pusher: DeviceIdentityPusher?) {
+        let trimmed = String(newName.trimmingCharacters(in: .whitespacesAndNewlines).prefix(20))
+        guard !trimmed.isEmpty, !unitID.isEmpty else { return }
+        withRecord(unitID) { rec in
+            if let pusher {
+                pusher.sendSetUnitName(trimmed)
+                rec.name = trimmed
+                rec.pendingName = nil
+            } else {
+                rec.pendingName = trimmed == rec.name ? nil : trimmed
+            }
+        }
+    }
+
+    func setNetworkID(_ nid: UInt8, for unitID: String, pusher: DeviceIdentityPusher?) {
+        guard nid > 0, !unitID.isEmpty else { return }   // 0 is the unset sentinel (#150)
+        withRecord(unitID) { rec in
+            if let pusher {
+                pusher.sendSetNetworkID(nid)
+                rec.networkID = nid
+                rec.pendingNetworkID = nil
+            } else {
+                rec.pendingNetworkID = nid == rec.networkID ? nil : nid
+            }
+        }
+    }
+
+    func setRocketID(_ rid: UInt8, for unitID: String, pusher: DeviceIdentityPusher?) {
+        guard (1...254).contains(rid), !unitID.isEmpty else { return }  // firmware rejects 0/255
+        withRecord(unitID) { rec in
+            if let pusher {
+                pusher.sendSetRocketID(rid)
+                rec.rocketID = rid
+                rec.pendingRocketID = nil
+            } else {
+                rec.pendingRocketID = rid == rec.rocketID ? nil : rid
+            }
+        }
+    }
+
+    /// Drop all queued offline edits without touching the device.
+    func clearPending(for unitID: String) {
+        guard device(for: unitID)?.hasPendingChanges == true else { return }
+        withRecord(unitID) { rec in
+            rec.pendingName = nil
+            rec.pendingNetworkID = nil
+            rec.pendingRocketID = nil
+        }
+    }
+
+    /// Drop the record entirely.  The device is treated as brand new on its
+    /// next connect (provisioning sheet pops again).
+    func forget(_ unitID: String) {
+        devices.removeAll { $0.unitID == unitID }
+        persist()
+    }
+
+    // MARK: - Record plumbing
+
+    /// Get-or-create the record, mutate it, then sort + persist + publish.
+    private func withRecord(_ unitID: String, _ mutate: (inout KnownDevice) -> Void) {
+        var rec = device(for: unitID) ?? KnownDevice(unitID: unitID)
+        mutate(&rec)
+        devices.removeAll { $0.unitID == unitID }
+        devices.append(rec)
+        sortDevices()
+        persist()
+    }
+
+    private func sortDevices() {
+        func rank(_ t: BLEDeviceType) -> Int {
+            switch t {
+            case .rocket: return 0
+            case .baseStation: return 1
+            case .unknown: return 2
+            }
+        }
+        devices.sort {
+            if rank($0.deviceType) != rank($1.deviceType) {
+                return rank($0.deviceType) < rank($1.deviceType)
+            }
+            let n0 = $0.effectiveName, n1 = $1.effectiveName
+            if n0.localizedCaseInsensitiveCompare(n1) != .orderedSame {
+                return n0.localizedCaseInsensitiveCompare(n1) == .orderedAscending
+            }
+            return $0.unitID < $1.unitID
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = defaults.data(forKey: Self.storeKey),
+              let decoded = try? JSONDecoder().decode([KnownDevice].self, from: data)
+        else { return }
+        devices = decoded
+        sortDevices()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(devices) else { return }
+        defaults.set(data, forKey: Self.storeKey)
+    }
+
+    /// One-time fold of the legacy provisioning-gate array ("knownDeviceIDs",
+    /// bare unitIDs) into real records.  Names/types arrive on each device's
+    /// next readback.  The legacy key is deleted afterwards so a forgotten
+    /// device can't be resurrected by re-migration.
+    private func migrateLegacyIfNeeded() {
+        guard let legacy = defaults.stringArray(forKey: Self.legacyKnownIDsKey) else { return }
+        for unitID in legacy where !unitID.isEmpty {
+            if let idx = devices.firstIndex(where: { $0.unitID == unitID }) {
+                devices[idx].provisioned = true
+            } else {
+                var rec = KnownDevice(unitID: unitID)
+                rec.provisioned = true
+                devices.append(rec)
+            }
+        }
+        sortDevices()
+        persist()
+        defaults.removeObject(forKey: Self.legacyKnownIDsKey)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/ActiveRocketHeader.swift
@@ -30,11 +30,9 @@ struct ActiveRocketHeader: View {
     private var card: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                Image("RocketIcon")
-                    .resizable().renderingMode(.template)
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 20)
-                    .foregroundColor(.accentColor)
+                // Always the rocket glyph (this header is about the active
+                // rocket profile), accent-tinted to read as tappable.
+                DeviceTypeIcon(type: .rocket, size: 20, tint: .custom(.accentColor))
                 Text(store.activeProfile?.name ?? "No rocket selected")
                     .font(.headline)
                     .foregroundColor(.primary)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -244,6 +244,13 @@ struct DashboardView: View {
         .onChange(of: fleet.activeDeviceID) { _ in
             attachActiveDevice()
         }
+        // A renamed device can mis-parse its role from the BLE name until
+        // config_identity lands; the syncer re-evaluates on a role flip
+        // (attachedAsBaseStation), but only if attach is called again —
+        // this edge is what calls it.
+        .onChange(of: fleet.activeDevice?.deviceType) { _ in
+            attachActiveDevice()
+        }
         .sheet(item: $activeSheet) { sheet in
             Group {
                 switch sheet {
@@ -366,7 +373,8 @@ struct ConnectedDashboardView: View {
                 isConnected: true,
                 isScanning: fleet.isScanning,
                 statusMessage: fleet.statusMessage,
-                connectedDeviceName: device.displayName
+                connectedDeviceName: device.displayName,
+                connectedDeviceType: device.deviceType
             )
         }
 
@@ -596,6 +604,17 @@ struct ConnectionStatusView: View {
     let isScanning: Bool
     let statusMessage: String
     var connectedDeviceName: String = ""
+    // Resolved role, not a name-substring guess: renamed devices carry no
+    // type hint in the name, and a rocket called "SUBSONIC" contains "BS".
+    var connectedDeviceType: BLEDeviceType = .unknown
+
+    private var roleLabel: String {
+        switch connectedDeviceType {
+        case .rocket: return "Rocket"
+        case .baseStation: return "Base Station"
+        case .unknown: return "TinkerRocket device"
+        }
+    }
 
     var body: some View {
         HStack {
@@ -606,7 +625,7 @@ struct ConnectionStatusView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(connectedDeviceName)
                         .font(.headline)
-                    Text((connectedDeviceName.contains("Base") || connectedDeviceName.contains("BS")) ? "Base Station" : "Rocket")
+                    Text(roleLabel)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -644,7 +663,7 @@ struct DeviceChipBar: View {
                         HStack(spacing: 6) {
                             // .inherit: the chip's own foregroundColor
                             // (white when active, primary otherwise) tints it.
-                            DeviceTypeIcon(type: device.isBaseStation ? .baseStation : .rocket,
+                            DeviceTypeIcon(type: device.deviceType,
                                            size: 14, symbolFont: .caption, tint: .inherit)
                             Text(device.displayName)
                                 .font(.caption)
@@ -1513,8 +1532,10 @@ struct DevicePickerView: View {
                     if !alreadyConnected { fleet.connect(to: device) }
                 }) {
                     HStack {
-                        DeviceTypeIcon(type: device.isBaseStation ? .baseStation : .rocket,
-                                       symbolFont: .title2)
+                        // Resolved type: registry hint for renamed devices,
+                        // name prefix for factory defaults, honest question
+                        // mark when neither knows.
+                        DeviceTypeIcon(type: device.deviceType, symbolFont: .title2)
                             .frame(width: 36)
 
                         VStack(alignment: .leading, spacing: 2) {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -89,6 +89,21 @@ struct DashboardView: View {
                             .cornerRadius(10)
                         }
 
+                        // One place to rename any known rocket/base station and
+                        // manage network IDs — including while they're offline
+                        // (edits queue and apply on the next connect).
+                        NavigationLink(destination: DeviceManagerView(fleet: fleet)) {
+                            HStack {
+                                Image(systemName: "list.bullet.rectangle")
+                                Text("My Devices")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.indigo)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                        }
+
                         Button {
                             activeSheet = .driftCast
                         } label: {
@@ -264,7 +279,7 @@ struct DashboardView: View {
         }
         .sheet(isPresented: $showProvisioning) {
             if let device = fleet.activeDevice {
-                DeviceProvisioningSheet(device: device)
+                DeviceProvisioningSheet(device: device, store: fleet.knownDevices)
             }
         }
         .sheet(isPresented: Binding(
@@ -293,7 +308,7 @@ struct DashboardView: View {
             // When config_identity readback populates the unitID,
             // show provisioning sheet if this is a new device.
             guard let id = newID, !id.isEmpty,
-                  !DeviceProvisioningSheet.isDeviceKnown(id),
+                  !fleet.knownDevices.isProvisioned(id),
                   !showProvisioning else { return }
             showProvisioning = true
         }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -642,16 +642,10 @@ struct DeviceChipBar: View {
                         fleet.activeDeviceID = device.peripheral?.identifier
                     } label: {
                         HStack(spacing: 6) {
-                            if device.isBaseStation {
-                                Image(systemName: "antenna.radiowaves.left.and.right")
-                                    .font(.caption)
-                            } else {
-                                Image("RocketIcon")
-                                    .resizable()
-                                    .renderingMode(.template)
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(height: 14)
-                            }
+                            // .inherit: the chip's own foregroundColor
+                            // (white when active, primary otherwise) tints it.
+                            DeviceTypeIcon(type: device.isBaseStation ? .baseStation : .rocket,
+                                           size: 14, symbolFont: .caption, tint: .inherit)
                             Text(device.displayName)
                                 .font(.caption)
                                 .fontWeight(.medium)
@@ -675,11 +669,7 @@ struct DeviceChipBar: View {
                 // Remote rockets (seen via base station)
                 ForEach(fleet.remoteRockets) { remote in
                     HStack(spacing: 6) {
-                        Image("RocketIcon")
-                            .resizable()
-                            .renderingMode(.template)
-                            .aspectRatio(contentMode: .fit)
-                            .frame(height: 14)
+                        DeviceTypeIcon(type: .rocket, size: 14, tint: .inherit)
                         Text(remote.displayName)
                             .font(.caption)
                             .fontWeight(.medium)
@@ -1523,20 +1513,9 @@ struct DevicePickerView: View {
                     if !alreadyConnected { fleet.connect(to: device) }
                 }) {
                     HStack {
-                        Group {
-                            if device.isBaseStation {
-                                Image(systemName: "antenna.radiowaves.left.and.right")
-                                    .font(.title2)
-                            } else {
-                                Image("RocketIcon")
-                                    .resizable()
-                                    .renderingMode(.template)
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(height: 24)
-                            }
-                        }
-                        .foregroundColor(device.isBaseStation ? .orange : .blue)
-                        .frame(width: 36)
+                        DeviceTypeIcon(type: device.isBaseStation ? .baseStation : .rocket,
+                                       symbolFont: .title2)
+                            .frame(width: 36)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(device.name)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
@@ -119,7 +119,8 @@ struct DeviceManagerView: View {
             let n = mismatchedDevices.count
             return "\(n) device\(n == 1 ? " is" : "s are") on a different network ID and can't hear the others. Moving them pushes connected devices right away and queues the rest for their next connect."
         }
-        return "Devices only hear each other on the same network ID. Edits to offline devices are queued and apply automatically the next time each one connects."
+        return NetworkCopy.sameNetworkExplainer
+            + " Edits to offline devices are queued and apply automatically the next time each one connects."
     }
 
     // MARK: - Devices
@@ -151,6 +152,7 @@ struct DeviceManagerView: View {
         let mismatch = networkID > 0 && rec.effectiveNetworkID != appNid
         return HStack(spacing: 12) {
             DeviceTypeIcon(type: rec.deviceType)
+                .frame(width: 32)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(rec.effectiveName.isEmpty ? "Unnamed" : rec.effectiveName)
@@ -203,34 +205,6 @@ struct DeviceManagerView: View {
     }
 }
 
-/// Rocket / base-station / unknown glyph, sized for a list row.
-private struct DeviceTypeIcon: View {
-    let type: BLEDeviceType
-
-    var body: some View {
-        Group {
-            switch type {
-            case .baseStation:
-                Image(systemName: "antenna.radiowaves.left.and.right")
-                    .font(.title3)
-                    .foregroundColor(.orange)
-            case .rocket:
-                Image("RocketIcon")
-                    .resizable()
-                    .renderingMode(.template)
-                    .aspectRatio(contentMode: .fit)
-                    .frame(height: 24)
-                    .foregroundColor(.blue)
-            case .unknown:
-                Image(systemName: "questionmark.circle")
-                    .font(.title3)
-                    .foregroundColor(.secondary)
-            }
-        }
-        .frame(width: 32)
-    }
-}
-
 // MARK: - Detail / editor
 
 struct KnownDeviceDetailView: View {
@@ -280,6 +254,7 @@ struct KnownDeviceDetailView: View {
                     : Text("")) {
                 HStack(spacing: 12) {
                     DeviceTypeIcon(type: rec.deviceType)
+                        .frame(width: 32)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(rec.effectiveName.isEmpty ? "Unnamed" : rec.effectiveName)
                             .font(.headline)
@@ -437,10 +412,10 @@ struct KnownDeviceDetailView: View {
 
     private func networkSectionFooter(_ rec: KnownDevice, mismatch: Bool, connected: Bool) -> String {
         if mismatch {
-            return connected
-                ? "This device is on a different network ID than the app expects — it can't hear your other devices. Tap to sync it now."
-                : "This device is on a different network ID than the app expects. Syncing queues the change for its next connect."
+            return NetworkCopy.deviceMismatchWarning + (connected
+                ? " Tap to sync it now."
+                : " Syncing queues the change for its next connect.")
         }
-        return "Devices only hear each other on the same network ID."
+        return NetworkCopy.sameNetworkExplainer
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
@@ -1,0 +1,430 @@
+//
+//  DeviceManagerView.swift
+//  TinkerRocketApp
+//
+//  "My Devices" — one place to see and manage every provisioned rocket and
+//  base station: rename them, fix rocket IDs, and keep the whole fleet on
+//  the app's network ID.  Reachable from the first screen, with or without
+//  anything connected: edits to offline devices queue in the registry and
+//  are pushed automatically on that device's next connect.
+//
+
+import SwiftUI
+
+struct DeviceManagerView: View {
+    @ObservedObject var fleet: BLEFleet
+    @ObservedObject var store: KnownDeviceStore
+
+    init(fleet: BLEFleet) {
+        _fleet = ObservedObject(initialValue: fleet)
+        _store = ObservedObject(initialValue: fleet.knownDevices)
+    }
+
+    // #150: network identity (app side; onboarding writes these).
+    @AppStorage("networkName") private var networkName: String = ""
+    @AppStorage("networkID") private var networkID: Int = 0
+
+    @State private var editingNetworkName = false
+    @State private var networkNameInput = ""
+
+    private var appNid: UInt8 { UInt8(clamping: networkID) }
+
+    /// Devices whose target network ID differs from the app's.
+    private var mismatchedDevices: [KnownDevice] {
+        guard networkID > 0 else { return [] }
+        return store.devices.filter { $0.effectiveNetworkID != appNid }
+    }
+
+    var body: some View {
+        List {
+            networkSection
+            devicesSection
+        }
+        .navigationTitle("My Devices")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Network
+
+    private var networkSection: some View {
+        Section(header: Text("Network"), footer: Text(networkFooter)) {
+            if editingNetworkName {
+                TextField("Network name", text: $networkNameInput)
+                    .autocapitalization(.words)
+                    .onSubmit(commitNetworkName)
+                // Live wire-ID preview, same as onboarding — the ID is what
+                // actually goes over the air.
+                if !trimmedNetworkInput.isEmpty {
+                    Text("Network ID: \(networkIdForName(trimmedNetworkInput))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Button("Cancel") { editingNetworkName = false }
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Button("Save") { commitNetworkName() }
+                        .fontWeight(.semibold)
+                        .disabled(trimmedNetworkInput.isEmpty)
+                }
+            } else {
+                HStack {
+                    Text(networkName.isEmpty ? "Not set" : networkName)
+                    Spacer()
+                    Text("ID: \(networkID)")
+                        .foregroundColor(.secondary)
+                        .font(.system(.body, design: .monospaced))
+                }
+                Button {
+                    networkNameInput = networkName
+                    editingNetworkName = true
+                } label: {
+                    Label("Change network name…", systemImage: "pencil")
+                }
+            }
+
+            if !mismatchedDevices.isEmpty {
+                Button {
+                    syncAllToAppNetwork()
+                } label: {
+                    Label("Move all devices to ID \(networkID)",
+                          systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+        }
+    }
+
+    private var trimmedNetworkInput: String {
+        networkNameInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func commitNetworkName() {
+        let trimmed = trimmedNetworkInput
+        guard !trimmed.isEmpty else { return }
+        networkName = trimmed
+        networkID = Int(networkIdForName(trimmed))   // #150: never 0
+        editingNetworkName = false
+    }
+
+    private func syncAllToAppNetwork() {
+        guard networkID > 0 else { return }
+        for rec in mismatchedDevices {
+            store.setNetworkID(appNid, for: rec.unitID,
+                               pusher: fleet.connectedDevice(unitID: rec.unitID))
+        }
+    }
+
+    private var networkFooter: String {
+        if !mismatchedDevices.isEmpty {
+            let n = mismatchedDevices.count
+            return "\(n) device\(n == 1 ? " is" : "s are") on a different network ID and can't hear the others. Moving them pushes connected devices right away and queues the rest for their next connect."
+        }
+        return "Devices only hear each other on the same network ID. Edits to offline devices are queued and apply automatically the next time each one connects."
+    }
+
+    // MARK: - Devices
+
+    private var devicesSection: some View {
+        Section(header: Text("Devices")) {
+            if store.devices.isEmpty {
+                Text("No devices yet. Scan and connect to a rocket or base station and it will appear here.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            ForEach(store.devices) { rec in
+                NavigationLink {
+                    KnownDeviceDetailView(unitID: rec.unitID, fleet: fleet)
+                } label: {
+                    deviceRow(rec)
+                }
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) { store.forget(rec.unitID) } label: {
+                        Label("Forget", systemImage: "trash")
+                    }
+                }
+            }
+        }
+    }
+
+    private func deviceRow(_ rec: KnownDevice) -> some View {
+        let connected = fleet.connectedDevice(unitID: rec.unitID) != nil
+        let mismatch = networkID > 0 && rec.effectiveNetworkID != appNid
+        return HStack(spacing: 12) {
+            DeviceTypeIcon(type: rec.deviceType)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(rec.effectiveName.isEmpty ? "Unnamed" : rec.effectiveName)
+                    .fontWeight(.medium)
+                    .foregroundColor(rec.effectiveName.isEmpty ? .secondary : .primary)
+                Text(subtitle(rec))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                HStack(spacing: 6) {
+                    if connected {
+                        Circle().fill(Color.green).frame(width: 8, height: 8)
+                    }
+                    if mismatch {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                    }
+                    Text("ID \(rec.effectiveNetworkID)")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(mismatch ? .orange : .secondary)
+                }
+                if rec.hasPendingChanges {
+                    Label("queued", systemImage: "clock")
+                        .font(.caption2)
+                        .foregroundColor(.blue)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func subtitle(_ rec: KnownDevice) -> String {
+        var parts: [String] = []
+        switch rec.deviceType {
+        case .rocket:
+            parts.append("Rocket")
+            if rec.effectiveRocketID > 0 { parts.append("R\(rec.effectiveRocketID)") }
+        case .baseStation:
+            parts.append("Base Station")
+        case .unknown:
+            parts.append("Unknown type")
+        }
+        parts.append(rec.unitID)
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// Rocket / base-station / unknown glyph, sized for a list row.
+private struct DeviceTypeIcon: View {
+    let type: BLEDeviceType
+
+    var body: some View {
+        Group {
+            switch type {
+            case .baseStation:
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.title3)
+                    .foregroundColor(.orange)
+            case .rocket:
+                Image("RocketIcon")
+                    .resizable()
+                    .renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 24)
+                    .foregroundColor(.blue)
+            case .unknown:
+                Image(systemName: "questionmark.circle")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(width: 32)
+    }
+}
+
+// MARK: - Detail / editor
+
+struct KnownDeviceDetailView: View {
+    let unitID: String
+    @ObservedObject var fleet: BLEFleet
+    @ObservedObject var store: KnownDeviceStore
+    @Environment(\.dismiss) private var dismiss
+
+    init(unitID: String, fleet: BLEFleet) {
+        self.unitID = unitID
+        _fleet = ObservedObject(initialValue: fleet)
+        _store = ObservedObject(initialValue: fleet.knownDevices)
+    }
+
+    @AppStorage("networkName") private var networkName: String = ""
+    @AppStorage("networkID") private var networkID: Int = 0
+
+    @State private var showRename = false
+    @State private var renameText = ""
+    @State private var showForgetConfirm = false
+
+    /// Live BLE handle when this device is currently connected — nil means
+    /// edits queue for the next connect.
+    private var live: BLEDevice? { fleet.connectedDevice(unitID: unitID) }
+
+    var body: some View {
+        Group {
+            if let rec = store.device(for: unitID) {
+                detail(rec)
+            } else {
+                // Forgotten while open — nothing left to show.
+                Text("Device removed.")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .navigationTitle(store.device(for: unitID)?.effectiveName ?? "Device")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func detail(_ rec: KnownDevice) -> some View {
+        let connected = live != nil
+        let mismatch = networkID > 0 && rec.effectiveNetworkID != appNid
+
+        return List {
+            Section(footer: rec.pendingName != nil
+                    ? Text("Rename to \u{201C}\(rec.pendingName!)\u{201D} is queued — it applies the next time this device connects.")
+                    : Text("")) {
+                HStack(spacing: 12) {
+                    DeviceTypeIcon(type: rec.deviceType)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(rec.effectiveName.isEmpty ? "Unnamed" : rec.effectiveName)
+                            .font(.headline)
+                            .foregroundColor(rec.effectiveName.isEmpty ? .secondary : .primary)
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(connected ? Color.green : Color(.systemGray4))
+                                .frame(width: 8, height: 8)
+                            Text(connected ? "Connected" : "Not connected")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Spacer()
+                }
+                Button {
+                    renameText = rec.effectiveName
+                    showRename = true
+                } label: {
+                    Label("Rename…", systemImage: "pencil")
+                }
+            }
+
+            if rec.deviceType != .baseStation {
+                rocketIDSection(rec, connected: connected)
+            }
+
+            networkSection(rec, mismatch: mismatch, connected: connected)
+
+            Section(header: Text("Info")) {
+                HStack {
+                    Text("Hardware ID")
+                    Spacer()
+                    Text(rec.unitID)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+                if let seen = rec.lastSeen {
+                    HStack {
+                        Text("Last seen")
+                        Spacer()
+                        if connected {
+                            Text("Now").foregroundColor(.secondary)
+                        } else {
+                            Text(seen, style: .relative)
+                                .foregroundColor(.secondary)
+                            Text("ago").foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+
+            if rec.hasPendingChanges {
+                Section(footer: Text("Queued changes are pushed automatically the next time this device connects.")) {
+                    Button {
+                        store.clearPending(for: unitID)
+                    } label: {
+                        Label("Cancel queued changes", systemImage: "clock.badge.xmark")
+                    }
+                }
+            }
+
+            Section(footer: Text("The device itself keeps its name and IDs — forgetting only removes it from this app, and it will be treated as new the next time it connects.")) {
+                Button(role: .destructive) {
+                    showForgetConfirm = true
+                } label: {
+                    Label("Forget This Device", systemImage: "trash")
+                }
+            }
+        }
+        .alert("Rename Device", isPresented: $showRename) {
+            TextField("Name (max 20 chars)", text: $renameText)
+            Button("Cancel", role: .cancel) {}
+            Button("Save") {
+                store.setName(renameText, for: unitID, pusher: live)
+            }
+        } message: {
+            Text(connected
+                 ? "The new name is sent to the device now."
+                 : "The device is offline — the new name applies on its next connect.")
+        }
+        .confirmationDialog("Forget \u{201C}\(rec.effectiveName.isEmpty ? rec.unitID : rec.effectiveName)\u{201D}?",
+                            isPresented: $showForgetConfirm, titleVisibility: .visible) {
+            Button("Forget Device", role: .destructive) {
+                store.forget(unitID)
+                dismiss()
+            }
+        }
+    }
+
+    private var appNid: UInt8 { UInt8(clamping: networkID) }
+
+    private func rocketIDSection(_ rec: KnownDevice, connected: Bool) -> some View {
+        Section(header: Text("Rocket ID"),
+                footer: Text(connected
+                             ? "Unique ID within your network (1–254). Each rocket needs a different ID."
+                             : "Unique ID within your network (1–254). Changes apply on the next connect.")) {
+            Stepper("ID: \(displayRocketID(rec))\(rec.pendingRocketID != nil ? "  (queued)" : "")",
+                    value: Binding(
+                        get: { Int(displayRocketID(rec)) },
+                        set: { store.setRocketID(UInt8(clamping: $0), for: unitID, pusher: live) }
+                    ), in: 1...254)
+        }
+    }
+
+    private func displayRocketID(_ rec: KnownDevice) -> UInt8 {
+        rec.effectiveRocketID == 0 ? 1 : rec.effectiveRocketID
+    }
+
+    private func networkSection(_ rec: KnownDevice, mismatch: Bool, connected: Bool) -> some View {
+        Section(header: Text("Network"), footer: Text(networkSectionFooter(rec, mismatch: mismatch, connected: connected))) {
+            HStack {
+                Text("App network")
+                Spacer()
+                Text(networkName.isEmpty ? "Not set" : networkName)
+                    .foregroundColor(.secondary)
+                Text("ID: \(networkID)")
+                    .foregroundColor(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text("This device")
+                Spacer()
+                if mismatch {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                }
+                Text("ID: \(rec.effectiveNetworkID)\(rec.pendingNetworkID != nil ? "  (queued)" : "")")
+                    .foregroundColor(mismatch ? .orange : .secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            if mismatch && networkID > 0 {
+                Button("Set to \u{201C}\(networkName)\u{201D} (ID \(networkID))") {
+                    store.setNetworkID(appNid, for: unitID, pusher: live)
+                }
+            }
+        }
+    }
+
+    private func networkSectionFooter(_ rec: KnownDevice, mismatch: Bool, connected: Bool) -> String {
+        if mismatch {
+            return connected
+                ? "This device is on a different network ID than the app expects — it can't hear your other devices. Tap to sync it now."
+                : "This device is on a different network ID than the app expects. Syncing queues the change for its next connect."
+        }
+        return "Devices only hear each other on the same network ID."
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift
@@ -303,7 +303,10 @@ struct KnownDeviceDetailView: View {
                 }
             }
 
-            if rec.deviceType != .baseStation {
+            // Positively-identified rockets only: a legacy-migrated record is
+            // .unknown until its next readback and may really be a base
+            // station, which has no rocket ID to edit.
+            if rec.deviceType == .rocket {
                 rocketIDSection(rec, connected: connected)
             }
 
@@ -377,16 +380,29 @@ struct KnownDeviceDetailView: View {
                 footer: Text(connected
                              ? "Unique ID within your network (1–254). Each rocket needs a different ID."
                              : "Unique ID within your network (1–254). Changes apply on the next connect.")) {
-            Stepper("ID: \(displayRocketID(rec))\(rec.pendingRocketID != nil ? "  (queued)" : "")",
-                    value: Binding(
-                        get: { Int(displayRocketID(rec)) },
-                        set: { store.setRocketID(UInt8(clamping: $0), for: unitID, pusher: live) }
-                    ), in: 1...254)
+            Stepper {
+                Text(rocketIDLabel(rec))
+            } onIncrement: {
+                bumpRocketID(rec, by: +1)
+            } onDecrement: {
+                bumpRocketID(rec, by: -1)
+            }
         }
     }
 
-    private func displayRocketID(_ rec: KnownDevice) -> UInt8 {
-        rec.effectiveRocketID == 0 ? 1 : rec.effectiveRocketID
+    private func rocketIDLabel(_ rec: KnownDevice) -> String {
+        guard rec.effectiveRocketID > 0 else { return "ID: not set" }
+        return "ID: \(rec.effectiveRocketID)\(rec.pendingRocketID != nil ? "  (queued)" : "")"
+    }
+
+    /// Unset (0) becomes 1 on the first tap in either direction — a
+    /// value-bound Stepper pinned at its minimum could display 1 but never
+    /// actually assign it.  Thereafter steps clamp to the firmware's 1–254.
+    private func bumpRocketID(_ rec: KnownDevice, by delta: Int) {
+        let current = Int(rec.effectiveRocketID)
+        let next = current == 0 ? 1 : min(254, max(1, current + delta))
+        guard next != current else { return }
+        store.setRocketID(UInt8(next), for: unitID, pusher: live)
     }
 
     private func networkSection(_ rec: KnownDevice, mismatch: Bool, connected: Bool) -> some View {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct DeviceProvisioningSheet: View {
     @ObservedObject var device: BLEDevice
+    @ObservedObject var store: KnownDeviceStore
     @Environment(\.dismiss) var dismiss
 
     @State private var nameInput: String = ""
@@ -115,45 +116,28 @@ struct DeviceProvisioningSheet: View {
         let trimmed = nameInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        // Send name to device
-        device.sendSetUnitName(trimmed)
+        // All edits go through the known-device registry, which pushes to the
+        // connected device and keeps the "My Devices" record in sync.
+
+        store.setName(trimmed, for: device.unitID, pusher: device)
 
         // #150: push the network ID (cmd 41) — the firmware persists it in
         // identity NVS across reboots now, so the push is durable.  The
         // Settings Network section verifies via the device's readback.
         if networkID > 0 {
-            device.sendSetNetworkID(UInt8(clamping: networkID))
+            store.setNetworkID(UInt8(clamping: networkID), for: device.unitID, pusher: device)
         }
 
-        // Send rocket ID (rockets only)
         if !device.isBaseStation {
-            device.sendSetRocketID(UInt8(rocketIDInput))
+            store.setRocketID(UInt8(rocketIDInput), for: device.unitID, pusher: device)
         }
 
-        // Mark as known
-        markDeviceKnown(device.unitID)
+        store.markProvisioned(device.unitID)
         dismiss()
     }
 
     private func skipAndDismiss() {
-        markDeviceKnown(device.unitID)
+        store.markProvisioned(device.unitID)
         dismiss()
-    }
-
-    // MARK: - Known devices persistence
-
-    static func isDeviceKnown(_ unitID: String) -> Bool {
-        guard !unitID.isEmpty else { return true }  // Don't prompt for empty IDs
-        let known = UserDefaults.standard.stringArray(forKey: "knownDeviceIDs") ?? []
-        return known.contains(unitID)
-    }
-
-    private func markDeviceKnown(_ unitID: String) {
-        guard !unitID.isEmpty else { return }
-        var known = UserDefaults.standard.stringArray(forKey: "knownDeviceIDs") ?? []
-        if !known.contains(unitID) {
-            known.append(unitID)
-            UserDefaults.standard.set(known, forKey: "knownDeviceIDs")
-        }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
@@ -45,9 +45,10 @@ struct DeviceProvisioningSheet: View {
                     TextField("Name (max 20 chars)", text: $nameInput)
                         .autocapitalization(.words)
                         .onChange(of: nameInput) { newValue in
-                            if newValue.count > 20 {
-                                nameInput = String(newValue.prefix(20))
-                            }
+                            // Firmware limit is 20 UTF-8 BYTES (multibyte
+                            // names hit it before 20 chars).
+                            let clamped = newValue.utf8Clamped(maxBytes: 20)
+                            if clamped != newValue { nameInput = clamped }
                         }
                 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceProvisioningSheet.swift
@@ -64,7 +64,8 @@ struct DeviceProvisioningSheet: View {
                 // guards against the #133-era silent drift).
                 if networkID > 0 {
                     Section(header: Text("Network"),
-                            footer: Text("All your devices are set to this network. Devices only hear each other on the same network ID.")) {
+                            footer: Text("All your devices are set to this network. "
+                                         + NetworkCopy.sameNetworkExplainer)) {
                         HStack {
                             Text(networkName.isEmpty ? "Not set" : networkName)
                             Spacer()

--- a/TinkerRocketApp/TinkerRocketApp/Views/DeviceTypeIcon.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DeviceTypeIcon.swift
@@ -1,0 +1,78 @@
+//
+//  DeviceTypeIcon.swift
+//  TinkerRocketApp
+//
+//  Shared vocabulary for device-list UI: the rocket / base-station glyph
+//  every device row renders, and the network-ID copy that Settings and
+//  My Devices must state identically.  Extracted from four near-identical
+//  view-local copies so the screens can't drift apart.
+//
+
+import SwiftUI
+
+/// Rocket / base-station / unknown glyph for a device row.
+///
+/// Sites differ on three axes, so each is a parameter with the common-case
+/// default: `size` bounds the rocket asset (square, aspect-fit), `symbolFont`
+/// sizes the SF-symbol types (semantic fonts so Dynamic Type keeps working),
+/// and `tint` picks fixed standard colors (blue rocket / orange antenna /
+/// secondary unknown), the environment color (DeviceChipBar chips flip
+/// white/primary with selection), or an explicit color.
+struct DeviceTypeIcon: View {
+    enum Tint {
+        case standard
+        case inherit
+        case custom(Color)
+    }
+
+    let type: BLEDeviceType
+    var size: CGFloat = 24
+    var symbolFont: Font = .title3
+    var tint: Tint = .standard
+
+    var body: some View {
+        switch type {
+        case .rocket:
+            tinted(standard: .blue) {
+                Image("RocketIcon")
+                    .resizable()
+                    .renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: size, height: size)
+            }
+        case .baseStation:
+            tinted(standard: .orange) {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(symbolFont)
+            }
+        case .unknown:
+            tinted(standard: .secondary) {
+                Image(systemName: "questionmark.circle")
+                    .font(symbolFont)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tinted<V: View>(standard: Color, _ content: () -> V) -> some View {
+        switch tint {
+        case .standard: content().foregroundColor(standard)
+        case .inherit: content()
+        case .custom(let color): content().foregroundColor(color)
+        }
+    }
+}
+
+/// Network-ID copy shared between SettingsView and the My Devices screens —
+/// the same condition must be described in the same words everywhere (#150:
+/// mismatched wording is how the nid drift stayed undebuggable).
+enum NetworkCopy {
+    /// The baseline explainer under every network section.
+    static let sameNetworkExplainer =
+        "Devices only hear each other on the same network ID."
+
+    /// A specific device is on the wrong network ID.  Sites append their own
+    /// call to action ("Tap to sync it now.", queueing details, …).
+    static let deviceMismatchWarning =
+        "This device is on a different network ID than the app expects — it can't hear your other devices."
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FlightLogsView.swift
@@ -148,21 +148,8 @@ struct FlightLogRow: View {
     var body: some View {
         HStack(spacing: 12) {
             // Type icon
-            Group {
-                if flight.type == .rocket {
-                    Image("RocketIcon")
-                        .resizable()
-                        .renderingMode(.template)
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.blue)
-                } else {
-                    Image(systemName: "antenna.radiowaves.left.and.right")
-                        .font(.title3)
-                        .foregroundColor(.orange)
-                }
-            }
-            .frame(width: 32)
+            DeviceTypeIcon(type: flight.type == .rocket ? .rocket : .baseStation)
+                .frame(width: 32)
 
             // Title and subtitle
             VStack(alignment: .leading, spacing: 4) {

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -1448,9 +1448,11 @@ struct SettingsView: View {
 
     private var networkFooter: String {
         if deviceNidMismatch {
-            return "This device is on a different network ID than the app expects — it can't hear your other devices. Tap to sync it (a rising NetID Drops count on the dashboard is the same problem seen from the other side)."
+            return NetworkCopy.deviceMismatchWarning
+                + " Tap to sync it (a rising NetID Drops count on the dashboard is the same problem seen from the other side)."
         }
-        return "Devices only hear each other on the same network ID. Set during onboarding; pushed to each device when provisioned."
+        return NetworkCopy.sameNetworkExplainer
+            + " Set during onboarding; pushed to each device when provisioned."
     }
 
     // #150: hopping is unavailable when the firmware reports dwell 0 for

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -354,7 +354,15 @@ struct SettingsView: View {
             }
             if deviceNidMismatch {
                 Button("Set device to \"\(appNetworkName)\" (ID \(appNetworkID))") {
-                    device.sendSetNetworkID(UInt8(clamping: appNetworkID))
+                    // Route through the known-device registry (the single
+                    // writer for identity edits) so the My Devices record
+                    // updates immediately, not only via the readback echo.
+                    if let store = device.fleet?.knownDevices {
+                        store.setNetworkID(UInt8(clamping: appNetworkID),
+                                           for: device.unitID, pusher: device)
+                    } else {
+                        device.sendSetNetworkID(UInt8(clamping: appNetworkID))
+                    }
                 }
                 .disabled(!device.isConnected)
             }

--- a/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerLifecycleTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/ActiveRocketSyncerLifecycleTests.swift
@@ -82,4 +82,44 @@ final class ActiveRocketSyncerLifecycleTests: XCTestCase {
         syncer.detach()
         XCTAssertEqual(syncer.syncState, .idle)
     }
+
+    // MARK: - Role flip after a late config_identity (renamed devices)
+
+    func testRoleFlipToRocket_ReattachesInsteadOfStayingLatched() {
+        // A rocket renamed "SUBSONIC" parses as .baseStation via the legacy
+        // "BS" substring check, so the first attach idles it.  When the
+        // config_identity readback corrects the type, a re-attach for the
+        // SAME device object must break through the idempotence guard —
+        // otherwise profile sync stays silently dead all session (#375's
+        // failure mode through a different door).
+        let syncer = ActiveRocketSyncer()
+        let store = makeStore()
+        let device = BLEDevice(peripheral: nil, name: "SUBSONIC")
+        device.isConnected = true
+        device.deviceType = .baseStation   // as the name parse / a stale seed left it
+
+        syncer.attach(device: device, store: store)
+        XCTAssertEqual(syncer.syncState, .idle)
+
+        device.deviceType = .rocket        // config_identity "dt" correction
+        syncer.attach(device: device, store: store)
+        XCTAssertEqual(syncer.syncState, .awaitingSync,
+                       "role correction must re-run the rocket attach path")
+    }
+
+    func testRoleFlipToBaseStation_DropsRocketSubscriptions() {
+        // Mirror image: a base station mis-seeded as a rocket must fall back
+        // to the read-only .idle role once the readback says "B".
+        let syncer = ActiveRocketSyncer()
+        let store = makeStore()
+        let device = makeRocket()
+
+        syncer.attach(device: device, store: store)
+        XCTAssertEqual(syncer.syncState, .awaitingSync)
+
+        device.deviceType = .baseStation
+        syncer.attach(device: device, store: store)
+        XCTAssertEqual(syncer.syncState, .idle,
+                       "a corrected base station must not keep a rocket sync pipeline")
+    }
 }

--- a/TinkerRocketApp/TinkerRocketAppTests/DeviceTypeFromNameTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/DeviceTypeFromNameTests.swift
@@ -1,0 +1,34 @@
+//
+//  DeviceTypeFromNameTests.swift
+//  TinkerRocketAppTests
+//
+//  Pins the BLE-name → device-type heuristic.  Only factory-default names
+//  carry the TR-R-/TR-B- prefix — a device renamed through My Devices
+//  advertises its raw name and MUST come back .unknown here (the scan path
+//  then recovers the type from the known-device registry).  The front-page
+//  scanner must never filter on this: the scan is service-UUID-gated, and
+//  the old TR-*/Tinker name guard made renamed devices invisible.
+//
+
+import XCTest
+@testable import TinkerRocketApp
+
+final class DeviceTypeFromNameTests: XCTestCase {
+
+    func testFactoryDefaultPrefixes() {
+        XCTAssertEqual(BLEDeviceType.from(name: "TR-R-1a2b"), .rocket)
+        XCTAssertEqual(BLEDeviceType.from(name: "TR-B-3c4d"), .baseStation)
+    }
+
+    func testLegacyNames() {
+        XCTAssertEqual(BLEDeviceType.from(name: "TinkerRocket"), .rocket)
+        XCTAssertEqual(BLEDeviceType.from(name: "TinkerBaseStation"), .baseStation)
+    }
+
+    func testRenamedDevicesAreUnknownNotMistyped() {
+        // Raw user names carry no type information — the heuristic must
+        // say so rather than guess, so the registry hint can take over.
+        XCTAssertEqual(BLEDeviceType.from(name: "Atlas"), .unknown)
+        XCTAssertEqual(BLEDeviceType.from(name: "RollyPolly III"), .unknown)
+    }
+}

--- a/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
@@ -322,6 +322,34 @@ final class KnownDeviceStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.isProvisioned("a1b2c3d4"))
     }
 
+    // MARK: - Scan-time type recovery (renamed devices lose the TR- prefix)
+
+    func testDeviceTypeForAdvertisedName() {
+        // The firmware advertises the raw unit name, so a device renamed to
+        // "Atlas" no longer carries the TR-R- prefix the name heuristic
+        // needs — the registry is the only thing that still knows its type.
+        let store = makeStore()
+        report(store, unitID: "r1", name: "Atlas", type: .rocket)
+        report(store, unitID: "bs1", name: "Pad Station", type: .baseStation)
+
+        XCTAssertEqual(store.deviceType(forAdvertisedName: "Atlas"), .rocket)
+        XCTAssertEqual(store.deviceType(forAdvertisedName: "Pad Station"), .baseStation)
+        XCTAssertNil(store.deviceType(forAdvertisedName: "TR-R-1a2b"))  // not in registry
+        XCTAssertNil(store.deviceType(forAdvertisedName: ""))
+    }
+
+    func testDeviceTypeForAdvertisedName_AmbiguousOrUnknownGivesNil() {
+        let store = makeStore()
+        // Two devices sharing a name: no unambiguous answer.
+        report(store, unitID: "r1", name: "Atlas", type: .rocket)
+        report(store, unitID: "bs1", name: "Atlas", type: .baseStation)
+        XCTAssertNil(store.deviceType(forAdvertisedName: "Atlas"))
+
+        // A record whose own type is unknown can't type a scan result.
+        report(store, unitID: "x1", name: "Mystery", type: .unknown)
+        XCTAssertNil(store.deviceType(forAdvertisedName: "Mystery"))
+    }
+
     // MARK: - Ordering
 
     func testRocketsSortBeforeBaseStations() {

--- a/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
@@ -162,12 +162,19 @@ final class KnownDeviceStoreTests: XCTestCase {
         XCTAssertEqual(store.device(for: "a1b2c3d4")?.name, "Atlas")
     }
 
-    func testNameClampedTo20Chars() {
+    func testNameClampedTo20Bytes() {
         let store = makeStore()
         report(store)
         let spy = PusherSpy()
         store.setName(String(repeating: "x", count: 30), for: "a1b2c3d4", pusher: spy)
         XCTAssertEqual(spy.names, [String(repeating: "x", count: 20)])
+
+        // The firmware limit is 20 UTF-8 BYTES, not characters — it rejects
+        // longer payloads silently (no write, no echo), so the clamp must
+        // count bytes and never split a character.  🚀 is 4 bytes.
+        store.setName(String(repeating: "🚀", count: 10), for: "a1b2c3d4", pusher: spy)
+        XCTAssertEqual(spy.names.last, String(repeating: "🚀", count: 5))
+        XCTAssertLessThanOrEqual(spy.names.last!.utf8.count, 20)
     }
 
     // MARK: - Offline edits (queue, then apply on next readback)

--- a/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/KnownDeviceStoreTests.swift
@@ -1,0 +1,329 @@
+//
+//  KnownDeviceStoreTests.swift
+//  TinkerRocketAppTests
+//
+//  Registry semantics for the "My Devices" screen: readback upsert, the
+//  offline pending-edit queue and its push-on-next-connect behavior, the
+//  provisioning gate, and the legacy knownDeviceIDs migration.
+//
+
+import XCTest
+@testable import TinkerRocketApp
+
+/// Records pushes instead of writing to a CBPeripheral.
+private final class PusherSpy: DeviceIdentityPusher {
+    var names: [String] = []
+    var nids: [UInt8] = []
+    var rids: [UInt8] = []
+    func sendSetUnitName(_ name: String) { names.append(name) }
+    func sendSetNetworkID(_ nid: UInt8) { nids.append(nid) }
+    func sendSetRocketID(_ rid: UInt8) { rids.append(rid) }
+}
+
+final class KnownDeviceStoreTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "KnownDeviceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeStore() -> KnownDeviceStore {
+        KnownDeviceStore(defaults: defaults)
+    }
+
+    /// Simulate a config_identity readback for a rocket.
+    private func report(_ store: KnownDeviceStore, unitID: String = "a1b2c3d4",
+                        name: String = "Atlas", type: BLEDeviceType = .rocket,
+                        nid: UInt8 = 42, rid: UInt8 = 3,
+                        pusher: DeviceIdentityPusher? = nil) {
+        store.deviceDidReportIdentity(unitID: unitID, name: name, deviceType: type,
+                                      networkID: nid, rocketID: rid, pusher: pusher)
+    }
+
+    // MARK: - Readback intake
+
+    func testReadbackCreatesUnprovisionedRecord() {
+        let store = makeStore()
+        report(store)
+
+        let rec = try! XCTUnwrap(store.device(for: "a1b2c3d4"))
+        XCTAssertEqual(rec.name, "Atlas")
+        XCTAssertEqual(rec.deviceType, .rocket)
+        XCTAssertEqual(rec.networkID, 42)
+        XCTAssertEqual(rec.rocketID, 3)
+        XCTAssertNotNil(rec.lastSeen)
+        // A readback alone must NOT mark the device provisioned — that would
+        // stop the first-connect sheet from ever appearing.
+        XCTAssertFalse(rec.provisioned)
+        XCTAssertFalse(store.isProvisioned("a1b2c3d4"))
+    }
+
+    func testReadbackRefreshesExistingRecord() {
+        let store = makeStore()
+        report(store, name: "Atlas", nid: 42)
+        report(store, name: "Renamed On Other Phone", nid: 77)
+
+        let rec = store.device(for: "a1b2c3d4")
+        XCTAssertEqual(store.devices.count, 1)
+        XCTAssertEqual(rec?.name, "Renamed On Other Phone")
+        XCTAssertEqual(rec?.networkID, 77)
+    }
+
+    func testEmptyUnitIDIsIgnored() {
+        let store = makeStore()
+        report(store, unitID: "")
+        XCTAssertTrue(store.devices.isEmpty)
+        // Empty id reads as provisioned so the sheet can't pop pre-readback.
+        XCTAssertTrue(store.isProvisioned(""))
+    }
+
+    func testUnknownTypeReadbackKeepsLearnedType() {
+        // A device never changes species — a readback without "dt" (pre-dt
+        // firmware) must not downgrade a learned type to unknown.
+        let store = makeStore()
+        report(store, type: .rocket)
+        report(store, type: .unknown)
+        XCTAssertEqual(store.device(for: "a1b2c3d4")?.deviceType, .rocket)
+    }
+
+    // MARK: - Provisioning gate
+
+    func testMarkProvisioned() {
+        let store = makeStore()
+        report(store)
+        store.markProvisioned("a1b2c3d4")
+        XCTAssertTrue(store.isProvisioned("a1b2c3d4"))
+        // Survives a reload.
+        XCTAssertTrue(makeStore().isProvisioned("a1b2c3d4"))
+    }
+
+    func testForgetRemovesAndReprompts() {
+        let store = makeStore()
+        report(store)
+        store.markProvisioned("a1b2c3d4")
+        store.forget("a1b2c3d4")
+        XCTAssertNil(store.device(for: "a1b2c3d4"))
+        // Next connect treats it as brand new.
+        XCTAssertFalse(store.isProvisioned("a1b2c3d4"))
+        XCTAssertFalse(makeStore().isProvisioned("a1b2c3d4"))
+    }
+
+    // MARK: - Connected edits (push immediately)
+
+    func testConnectedRenamePushesAndUpdates() {
+        let store = makeStore()
+        report(store)
+        let spy = PusherSpy()
+
+        store.setName("  Ares 2  ", for: "a1b2c3d4", pusher: spy)
+
+        XCTAssertEqual(spy.names, ["Ares 2"])   // trimmed
+        let rec = store.device(for: "a1b2c3d4")
+        XCTAssertEqual(rec?.name, "Ares 2")
+        XCTAssertNil(rec?.pendingName)
+    }
+
+    func testConnectedNetworkAndRocketIDPush() {
+        let store = makeStore()
+        report(store)
+        let spy = PusherSpy()
+
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: spy)
+        store.setRocketID(7, for: "a1b2c3d4", pusher: spy)
+
+        XCTAssertEqual(spy.nids, [99])
+        XCTAssertEqual(spy.rids, [7])
+        let rec = store.device(for: "a1b2c3d4")
+        XCTAssertEqual(rec?.networkID, 99)
+        XCTAssertEqual(rec?.rocketID, 7)
+        XCTAssertFalse(rec?.hasPendingChanges ?? true)
+    }
+
+    func testInvalidValuesRejected() {
+        let store = makeStore()
+        report(store)
+        let spy = PusherSpy()
+
+        store.setName("   ", for: "a1b2c3d4", pusher: spy)
+        store.setNetworkID(0, for: "a1b2c3d4", pusher: spy)   // 0 = unset sentinel
+        store.setRocketID(0, for: "a1b2c3d4", pusher: spy)    // firmware rejects
+        store.setRocketID(255, for: "a1b2c3d4", pusher: spy)  // firmware rejects
+
+        XCTAssertTrue(spy.names.isEmpty)
+        XCTAssertTrue(spy.nids.isEmpty)
+        XCTAssertTrue(spy.rids.isEmpty)
+        XCTAssertEqual(store.device(for: "a1b2c3d4")?.name, "Atlas")
+    }
+
+    func testNameClampedTo20Chars() {
+        let store = makeStore()
+        report(store)
+        let spy = PusherSpy()
+        store.setName(String(repeating: "x", count: 30), for: "a1b2c3d4", pusher: spy)
+        XCTAssertEqual(spy.names, [String(repeating: "x", count: 20)])
+    }
+
+    // MARK: - Offline edits (queue, then apply on next readback)
+
+    func testOfflineEditsQueueAsPending() {
+        let store = makeStore()
+        report(store)
+
+        store.setName("Ares 2", for: "a1b2c3d4", pusher: nil)
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+        store.setRocketID(7, for: "a1b2c3d4", pusher: nil)
+
+        let rec = try! XCTUnwrap(store.device(for: "a1b2c3d4"))
+        // Current values untouched; targets queued.
+        XCTAssertEqual(rec.name, "Atlas")
+        XCTAssertEqual(rec.pendingName, "Ares 2")
+        XCTAssertEqual(rec.pendingNetworkID, 99)
+        XCTAssertEqual(rec.pendingRocketID, 7)
+        XCTAssertTrue(rec.hasPendingChanges)
+        // Display prefers the target state.
+        XCTAssertEqual(rec.effectiveName, "Ares 2")
+        XCTAssertEqual(rec.effectiveNetworkID, 99)
+        XCTAssertEqual(rec.effectiveRocketID, 7)
+    }
+
+    func testClearPendingDropsQueueOnly() {
+        let store = makeStore()
+        report(store)
+        store.setName("Ares 2", for: "a1b2c3d4", pusher: nil)
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+
+        store.clearPending(for: "a1b2c3d4")
+
+        let rec = try! XCTUnwrap(store.device(for: "a1b2c3d4"))
+        XCTAssertFalse(rec.hasPendingChanges)
+        XCTAssertEqual(rec.name, "Atlas")       // current values untouched
+        XCTAssertEqual(rec.networkID, 42)
+    }
+
+    func testOfflineEditMatchingCurrentClearsPending() {
+        let store = makeStore()
+        report(store, name: "Atlas", nid: 42)
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+        // User changes their mind back to the device's actual value.
+        store.setNetworkID(42, for: "a1b2c3d4", pusher: nil)
+        XCTAssertFalse(store.device(for: "a1b2c3d4")?.hasPendingChanges ?? true)
+    }
+
+    func testPendingAppliedOnNextReadback() {
+        let store = makeStore()
+        report(store)
+        store.setName("Ares 2", for: "a1b2c3d4", pusher: nil)
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+
+        // Device reconnects and reports its (old) identity.
+        let spy = PusherSpy()
+        report(store, name: "Atlas", nid: 42, pusher: spy)
+
+        XCTAssertEqual(spy.names, ["Ares 2"])
+        XCTAssertEqual(spy.nids, [99])
+        XCTAssertTrue(spy.rids.isEmpty)   // nothing queued for rid
+        let rec = try! XCTUnwrap(store.device(for: "a1b2c3d4"))
+        XCTAssertFalse(rec.hasPendingChanges)
+        XCTAssertEqual(rec.name, "Ares 2")       // optimistic until the echo
+        XCTAssertEqual(rec.networkID, 99)
+    }
+
+    func testPendingMatchingReadbackClearsWithoutPush() {
+        // The device already has the queued value (e.g. set from another
+        // phone) — don't push a redundant write, just clear the queue.
+        let store = makeStore()
+        report(store, nid: 42)
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+
+        let spy = PusherSpy()
+        report(store, nid: 99, pusher: spy)
+
+        XCTAssertTrue(spy.nids.isEmpty)
+        let rec = try! XCTUnwrap(store.device(for: "a1b2c3d4"))
+        XCTAssertFalse(rec.hasPendingChanges)
+        XCTAssertEqual(rec.networkID, 99)
+    }
+
+    func testEchoReadbackAfterPushIsPlainUpsert() {
+        // After a pending push, the firmware echoes config_identity with the
+        // new values.  Pending was cleared at push time, so the echo must not
+        // re-push (no loop) and must land the confirmed values.
+        let store = makeStore()
+        report(store)
+        store.setName("Ares 2", for: "a1b2c3d4", pusher: nil)
+
+        let spy = PusherSpy()
+        report(store, name: "Atlas", pusher: spy)          // reconnect → push
+        report(store, name: "Ares 2", pusher: spy)         // firmware echo
+
+        XCTAssertEqual(spy.names, ["Ares 2"])              // exactly one push
+        XCTAssertEqual(store.device(for: "a1b2c3d4")?.name, "Ares 2")
+    }
+
+    // MARK: - Persistence + migration
+
+    func testPersistenceRoundTrip() {
+        let store = makeStore()
+        report(store)
+        store.markProvisioned("a1b2c3d4")
+        store.setNetworkID(99, for: "a1b2c3d4", pusher: nil)
+
+        let reloaded = makeStore()
+        let rec = try! XCTUnwrap(reloaded.device(for: "a1b2c3d4"))
+        XCTAssertEqual(rec.name, "Atlas")
+        XCTAssertEqual(rec.deviceType, .rocket)
+        XCTAssertTrue(rec.provisioned)
+        XCTAssertEqual(rec.pendingNetworkID, 99)   // queue survives relaunch
+    }
+
+    func testLegacyKnownDeviceIDsMigration() {
+        defaults.set(["aaaa1111", "bbbb2222"], forKey: "knownDeviceIDs")
+
+        let store = makeStore()
+
+        // Legacy-known devices must not re-trigger the provisioning sheet.
+        XCTAssertTrue(store.isProvisioned("aaaa1111"))
+        XCTAssertTrue(store.isProvisioned("bbbb2222"))
+        // Names/types are unknown until the next readback.
+        XCTAssertEqual(store.device(for: "aaaa1111")?.name, "")
+        // Source key is consumed so forget() can't be undone by re-migration.
+        XCTAssertNil(defaults.stringArray(forKey: "knownDeviceIDs"))
+
+        store.forget("aaaa1111")
+        XCTAssertFalse(makeStore().isProvisioned("aaaa1111"))
+    }
+
+    func testMigrationMergesWithExistingRecords() {
+        // Migration must not clobber a record that already exists (e.g. the
+        // readback landed before the legacy array was folded in).
+        let store = makeStore()
+        report(store)
+        defaults.set(["a1b2c3d4"], forKey: "knownDeviceIDs")
+
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.devices.count, 1)
+        XCTAssertEqual(reloaded.device(for: "a1b2c3d4")?.name, "Atlas")
+        // The legacy array only ever held provisioned devices — merging must
+        // carry that over to the surviving record.
+        XCTAssertTrue(reloaded.isProvisioned("a1b2c3d4"))
+    }
+
+    // MARK: - Ordering
+
+    func testRocketsSortBeforeBaseStations() {
+        let store = makeStore()
+        report(store, unitID: "bs1", name: "Pad Station", type: .baseStation)
+        report(store, unitID: "r2", name: "Zephyr", type: .rocket)
+        report(store, unitID: "r1", name: "Atlas", type: .rocket)
+
+        XCTAssertEqual(store.devices.map { $0.name },
+                       ["Atlas", "Zephyr", "Pad Station"])
+    }
+}

--- a/tools/bench_ble_cmd.py
+++ b/tools/bench_ble_cmd.py
@@ -61,15 +61,21 @@ def build_payload(args) -> tuple[int, bytes]:
 
 async def scan(name_filter: str | None):
     print(f"Scanning {SCAN_TIMEOUT_S:.0f}s ...")
-    devices = await BleakScanner.discover(timeout=SCAN_TIMEOUT_S)
+    found = await BleakScanner.discover(timeout=SCAN_TIMEOUT_S, return_adv=True)
     hits = 0
-    for d in devices:
+    for d, ad in found.values():
         name = d.name or ""
-        if name_filter and name_filter.lower() not in name.lower():
+        # Renamed devices advertise the raw user-set unit name (no TR-
+        # prefix), so a name gate hides them — the service UUID is the
+        # real membership test (same bug/fix as the app's scanner).
+        advertises_service = SERVICE_UUID.lower() in [u.lower() for u in (ad.service_uuids or [])]
+        if name_filter:
+            if name_filter.lower() not in name.lower():
+                continue
+        elif not (advertises_service or name.startswith("TR-") or "Base" in name):
             continue
-        if not name_filter and not (name.startswith("TR-") or "Base" in name):
-            continue
-        print(f"  {d.address}  rssi={getattr(d, 'rssi', '?')}  {name}")
+        tag = "svc" if advertises_service else "   "
+        print(f"  {d.address}  rssi={ad.rssi}  {tag}  {name}")
         hits += 1
     if hits == 0:
         print("  no matching devices (is it powered? is the app connected to it?)")


### PR DESCRIPTION
## My Devices: manage device names + network IDs in one place

New **My Devices** screen, reachable from the first screen, backed by a persistent
`KnownDeviceStore` registry keyed by hardware unitID and fed by every
`config_identity` readback.

- List every rocket/base station ever provisioned: type, rocket ID, network ID
  with mismatch badges, connected dot, queued marker.
- Per-device editor: rename, rocket ID, sync-to-app-network, forget (device
  re-provisions as new).
- Edits to **offline** devices queue on the record and push automatically on the
  next connect; the firmware's identity echo after cmds 40/41/42 converges the
  registry back to device truth (queue cleared at push time — no re-push loops).
- App network name/ID editable here too, with the live fnv1a8 wire-ID preview and
  a one-tap "move all devices" sync that queues offline units.
- Provisioning sheet + dashboard gate now run through the store; the legacy
  `knownDeviceIDs` array migrates once and is deleted.

## Renamed devices vanished from the scanner (found in field use)

The firmware advertises the **raw user-set unit name** (boot + cmd 40) — only
factory defaults carry the `TR-R-`/`TR-B-` prefix — and the front page's scan
callback dropped anything not named `TR-*`/`*Tinker*`. Renaming a board made it
invisible to the app, across reboots.

- Name filter removed: the scan is already gated on the TinkerRocket service
  UUID, so the name was never load-bearing for discovery.
- Type inference is registry-first (`deviceType(forAdvertisedName:)`,
  ambiguity → nil), then the `TR-` prefix parse, with `config_identity` final.
- The legacy substring trap ("SUBSONIC" contains "BS" → mis-parsed as a base
  station) could latch `ActiveRocketSyncer` idle for a whole session; attach now
  re-evaluates on role flips, with a `deviceType` onChange edge in the dashboard.
- `ConnectionStatusView` role label + chip/picker icons use resolved types, not
  name substrings. `bench_ble_cmd --scan` had the same name-gate bug; now
  service-UUID-based.

## Cleanups

- Shared `DeviceTypeIcon` (was 5 near-identical view-local copies) with
  standard/inherit/custom tint modes; shared `NetworkCopy` strings so Settings
  and My Devices describe network mismatches identically.
- Name clamp counts 20 UTF-8 **bytes** (the firmware payload limit), not chars —
  multibyte names were silently rejected; also fixed in `sendSetUnitName`.
- Rocket-ID stepper: unset (0) no longer renders a fake "ID: 1" it can't assign;
  editor gated to positively-identified rockets.

## Validation

- 26 new unit tests (registry semantics, pending queue/echo, migration, name
  clamp, type lookup, syncer role-flip both directions); full suite green.
- Multi-agent adversarial review (find→verify) + a 3-lens verification workflow
  on the scanner fix; firmware advertising path audited clean.
- Bench-verified on real boards over BLE: friendly-named rocket + BS both
  advertise the service UUID; cmd-40 rename round-trip ("SUBSONIC" → restore)
  echoed identity and stayed discoverable. Confirmed working in the app on
  hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
