### PR TITLE
sim(#170): Dryden gust spectrum + config files that stop advertising dead keys

### DIFF
--- a/tinkerrocket-sim/config/launch_site.yaml
+++ b/tinkerrocket-sim/config/launch_site.yaml
@@ -1,13 +1,25 @@
 # Launch site configuration
+#
+# Read by rocketpy_passive._load_site_config, whose only caller is
+# scripts/run_passive_sim.py --site. The 6-DOF closed-loop sim does NOT read
+# this file at all.
 launch_site:
   latitude_deg: 38.0
   longitude_deg: -122.0
   elevation_m: 0.0
+  # NOT consumed: the RocketPy environment is set to "standard_atmosphere" and
+  # the 6-DOF engine uses the ISA model in physics/atmosphere.py. Kept as a
+  # record of the reference conditions both assume.
   ground_pressure_pa: 101325.0
   ground_temperature_k: 293.15   # 20 C
 
-# Wind model
-wind:
-  speed_mps: 0.0           # steady wind speed
-  direction_deg: 0.0       # wind FROM direction (0=North)
-  gust_sigma_mps: 0.0      # gust standard deviation
+# Wind and turbulence are NOT configured here — they never were. This file's
+# only reader consumes the launch_site: block above and always flies calm.
+# The 6-DOF sim takes both from SimConfig
+# (src/tinkerrocket_sim/simulation/closed_loop_sim.py):
+#     wind_speed / wind_direction_deg   steady wind
+#     gust_w20_mps / gust_vertical      Dryden turbulence (physics/dryden.py)
+#
+# A `wind:` block used to sit here with speed_mps, direction_deg and
+# gust_sigma_mps. Nothing had ever read any of the three, and gust_sigma_mps
+# advertised a turbulence model that did not exist until #170.

--- a/tinkerrocket-sim/config/sim_config.yaml
+++ b/tinkerrocket-sim/config/sim_config.yaml
@@ -1,15 +1,33 @@
 # TinkerRocket Simulation Configuration
-# Parameters not defined in the .ork file (fin tabs, sensors, control, inertia)
+#
+# SCOPE: this file is read by rocket.definition._apply_yaml_overrides, which
+# consumes exactly the three sections below (fin_tabs, mass_overrides,
+# aerodynamics) and applies them to a RocketDefinition. Its only caller is
+# scripts/run_passive_sim.py --config. Nothing else in the repo reads it.
+#
+# In particular the closed-loop sim does NOT read this file. Controller gains,
+# actuator limits, sensor models and simulation timing all come from SimConfig
+# (src/tinkerrocket_sim/simulation/closed_loop_sim.py) — see the reference
+# block at the bottom for where each of those actually lives.
 
 # Fin tab aerodynamic model (from CFD analysis)
 fin_tabs:
+  # STALE: this is the retired 57.4 mm design and the sign is POSITIVE. The
+  # current 67 mm CFD value is 5.34e-3, and the firmware roll controller needs
+  # it NEGATIVE in the sim body frame to be stabilizing — see
+  # simulation/scenarios.py:build_rollypolly_iii, which is the source of truth
+  # for the flown vehicle. Left as-is because changing it would change
+  # run_passive_sim.py --config results.
   Kt_ref: 4.20e-3         # N-m/deg at V_ref, per tab
   V_ref: 95.0             # m/s reference velocity
   n_tabs: 4               # number of fin tabs (all deflect identically)
   deflection_min: -20.0   # deg
   deflection_max: 20.0    # deg
 
-# Mass & inertia overrides (from CFD report component breakdown)
+# Mass & inertia overrides (from CFD report component breakdown).
+# .ork-derived. The measured RollyPolly III values used by the canonical
+# scenarios are in simulation/scenarios.py (I_roll 2.0e-3, I_transverse 0.10)
+# and differ from these by ~2.4x and ~5x.
 mass_overrides:
   I_roll_launch: 8.3e-4       # kg-m^2 (at launch, full propellant)
   I_roll_burnout: 8.237e-4    # kg-m^2 (at burnout)
@@ -18,66 +36,60 @@ mass_overrides:
 
 # Aerodynamic overrides
 aerodynamics:
+  # Reaches the RocketPy passive path only. The 6-DOF engine computes Cd from
+  # the Barrowman component buildup (physics/drag.compute_Cd) and ignores this.
   Cd: 0.5    # drag coefficient
 
-# PID roll controller
-control:
-  pid:
-    kp: 0.10
-    ki: 0.0
-    kd: 0.0
-    setpoint_dps: 0.0      # target roll rate (deg/s)
-    min_cmd_deg: -20.0
-    max_cmd_deg: 20.0
-  gain_schedule:
-    enabled: true
-    v_ref: 95.0            # m/s
-    v_min: 30.0            # m/s (floor)
-    max_scale: 3.0         # cap on gain multiplier
-  actuator:
-    servo_rate_hz: 50      # servo PWM update rate
-    rate_limit_dps: 500.0  # servo slew rate (deg/s)
 
-# Sensor specifications (matching ISM6HG256, BMP585, MMC5983MA, GNSS)
-sensors:
-  imu:
-    update_rate_hz: 1200
-    accel_noise_sigma: 0.05       # m/s^2
-    accel_bias_sigma: 0.01        # m/s^2
-    accel_bias_tau: 100.0         # s (Markov correlation time)
-    gyro_noise_sigma: 0.00175     # rad/s
-    gyro_bias_sigma: 0.00025      # rad/s
-    gyro_bias_tau: 50.0           # s
-    accel_low_range: 16.0         # g (±16g)
-    accel_high_range: 256.0       # g (±256g)
-    gyro_range: 4000.0            # deg/s
-    accel_low_lsb: 0.00488        # m/s^2 per LSB
-    accel_high_lsb: 0.0781        # m/s^2 per LSB
-    gyro_lsb: 0.122               # deg/s per LSB
-    mounting_rotation_z_deg: -45.0  # sensor frame rotation
-  barometer:
-    update_rate_hz: 500
-    pressure_noise_sigma: 5.0     # Pa
-    temperature_noise_sigma: 0.1  # K
-  magnetometer:
-    update_rate_hz: 1000
-    noise_sigma: 0.5              # uT per axis
-    mounting_rotation_z_deg: 180.0
-    # Earth field at ~38N (approximate)
-    earth_field_x_uT: 22.0       # North
-    earth_field_y_uT: 5.0        # East
-    earth_field_z_uT: 42.0       # Down
-  gnss:
-    update_rate_hz: 25
-    pos_noise_ne_m: 3.0           # horizontal position sigma
-    pos_noise_d_m: 6.0            # vertical position sigma
-    vel_noise_ne_mps: 0.5         # horizontal velocity sigma
-    vel_noise_d_mps: 1.0          # vertical velocity sigma
-
-# Simulation settings
-simulation:
-  physics_dt: 1.0e-4       # s (10 kHz)
-  control_dt: 8.333e-4     # s (1200 Hz, matches IMU)
-  duration: 30.0            # s total simulation time
-  launch_rail_length: 1.0   # m
-  launch_angle_deg: 85.0    # from horizontal (90 = vertical)
+# ============================================================================
+# NOT CONFIGURATION — hardware and tuning reference only.
+#
+# `control:`, `sensors:` and `simulation:` sections used to appear below as
+# real-looking YAML keys. Nothing has ever read any of them, and several were
+# actively misleading: control.pid.kp: 0.10 contradicted the flight-proven
+# tune (kp 0.02), sensors.imu.gyro_range: 4000 contradicted the deliberate
+# 100 dps clip in the sensor-degradation scenario, and simulation.physics_dt:
+# 1.0e-4 contradicted the 1e-3 every scenario actually runs at. Reading any of
+# them as live config would have silently broken those.
+#
+# The values are kept here as commented reference because the hardware specs
+# exist nowhere else in the repo. Where each concern is actually configured:
+#
+#   roll/guidance gains, actuator limits, sim timing, sensor rates
+#       -> SimConfig, simulation/closed_loop_sim.py
+#   the flight-proven roll tune shipped to firmware config.h
+#       -> scenarios.FLOWN_ROLL_GAINS, simulation/scenarios.py
+#   sensor noise and bias parameters
+#       -> the constructor defaults in sensors/*.py
+#
+# --- PID roll controller (superseded by SimConfig + FLOWN_ROLL_GAINS) -------
+#   pid:        kp 0.10, ki 0.0, kd 0.0, setpoint_dps 0.0
+#               min_cmd_deg -20.0, max_cmd_deg 20.0
+#   gain_sched: enabled true, v_ref 95.0, v_min 30.0, max_scale 3.0
+#   actuator:   servo_rate_hz 50, rate_limit_dps 500.0
+#               (the measured PTK 7308 slew is 923 deg/s — SimConfig default)
+#
+# --- Sensor hardware specs (ISM6HG256, BMP585, MMC5983MA, GNSS) ------------
+#   imu:  update_rate_hz 1200
+#         accel_noise_sigma 0.05 m/s^2, accel_bias_sigma 0.01, tau 100 s
+#         gyro_noise_sigma 0.00175 rad/s, gyro_bias_sigma 0.00025, tau 50 s
+#         accel_low_range 16 g, accel_high_range 256 g, gyro_range 4000 dps
+#         accel_low_lsb 0.00488 m/s^2, accel_high_lsb 0.0781, gyro_lsb 0.122
+#         mounting_rotation_z_deg -45.0
+#         NOTE the LSB values imply a quantization stage IMUModel does not
+#         have, and SimConfig.imu_mounting_rotation_deg is a FAULT-INJECTION
+#         knob (a misalignment the firmware constants do NOT undo), not a
+#         declaration of how the board is mounted — they are not the same
+#         thing, which is why -45.0 was never wired to it.
+#   baro: update_rate_hz 500, pressure_noise_sigma 5.0 Pa,
+#         temperature_noise_sigma 0.1 K
+#   mag:  update_rate_hz 1000, noise_sigma 0.5 uT, mounting_rotation_z_deg 180
+#         earth field at ~38N: x 22.0, y 5.0, z 42.0 uT (N/E/D)
+#         NOTE MagModel has no mounting-rotation parameter at all.
+#   gnss: update_rate_hz 25, pos_noise_ne_m 3.0, pos_noise_d_m 6.0,
+#         vel_noise_ne_mps 0.5, vel_noise_d_mps 1.0
+#
+# --- Simulation settings (superseded by SimConfig) -------------------------
+#   physics_dt 1.0e-4, control_dt 8.333e-4, duration 30.0,
+#   launch_rail_length 1.0 m, launch_angle_deg 85.0
+# ============================================================================

--- a/tinkerrocket-sim/scripts/run_closed_loop.py
+++ b/tinkerrocket-sim/scripts/run_closed_loop.py
@@ -75,6 +75,11 @@ SERVO_RATE_LIMIT = 923.0    # servo slew rate (deg/s)
 # --- Wind ---
 WIND_SPEED = 0.0            # m/s (0 = calm)
 WIND_DIRECTION = 0.0        # direction wind comes FROM in degrees (0=N, 90=E)
+# Dryden turbulence on top of the steady wind: the 20 ft reference wind that
+# sets the intensity. 0 = smooth air; ~7.7 light, ~15.4 moderate, ~23.2 severe.
+# Stresses pitch/yaw, AoA and dispersion — not the roll loop (a uniform gust
+# exerts no roll moment on a symmetric airframe).
+GUST_W20 = 0.0              # m/s (0 = no turbulence)
 
 # --- Simulation ---
 PAD_TIME = 2.0              # pre-launch pad warmup (s) for EKF convergence
@@ -659,6 +664,7 @@ if __name__ == "__main__":
         heading_deg=HEADING_DEG,
         wind_speed=WIND_SPEED,
         wind_direction_deg=WIND_DIRECTION,
+        gust_w20_mps=GUST_W20,
         imu_rate=IMU_RATE,
         baro_rate=BARO_RATE,
         mag_rate=MAG_RATE,
@@ -740,6 +746,8 @@ if __name__ == "__main__":
         print(f"  Guidance: OFF (roll-only)")
     if WIND_SPEED > 0:
         print(f"  Wind: {WIND_SPEED:.1f} m/s from {WIND_DIRECTION:.0f}°")
+    if GUST_W20 > 0:
+        print(f"  Turbulence: Dryden, W20={GUST_W20:.1f} m/s")
 
     # EKF mode summary
     ekf_flags = []

--- a/tinkerrocket-sim/scripts/sim_gui.py
+++ b/tinkerrocket-sim/scripts/sim_gui.py
@@ -246,7 +246,7 @@ class SimGUI:
         'roll_disturbance': 0.0,
         'gain_v_ref': 95.0, 'gain_v_min': 30.0, 'gain_max_scale': 3.0,
         'defl_min': -10.0, 'defl_max': 10.0, 'servo_rate': 500.0,
-        'wind_speed': 0.0, 'wind_dir': 0.0,
+        'wind_speed': 0.0, 'wind_dir': 0.0, 'gust_w20': 0.0,
         'pad_time': 2.0, 'duration': 16.0, 'physics_dt': 0.001,
         'launch_angle': 89.0, 'heading': 0.0,
         'imu_rate': 1200.0, 'baro_rate': 500.0,
@@ -420,6 +420,10 @@ class SimGUI:
                          self.DEFAULTS['wind_speed'], 0)
         self._make_entry(grp, "From (°):", 'wind_dir',
                          self.DEFAULTS['wind_dir'], 1)
+        # Dryden turbulence intensity, as the 20 ft reference wind.
+        # 0 = smooth; ~7.7 light, ~15.4 moderate, ~23.2 severe.
+        self._make_entry(grp, "Gust W20 (m/s):", 'gust_w20',
+                         self.DEFAULTS['gust_w20'], 2)
 
         # --- Disturbance ---
         grp = ttk.LabelFrame(parent, text="Disturbances", padding=5)
@@ -571,6 +575,7 @@ class SimGUI:
             servo_rate_limit=self._get_float('servo_rate', 500.0),
             wind_speed=self._get_float('wind_speed', 0.0),
             wind_direction_deg=self._get_float('wind_dir', 0.0),
+            gust_w20_mps=self._get_float('gust_w20', 0.0),
         )
 
     def _load_rocket(self):

--- a/tinkerrocket-sim/src/tinkerrocket_sim/physics/dryden.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/physics/dryden.py
@@ -1,0 +1,193 @@
+"""Dryden atmospheric turbulence (continuous gust spectrum) — issue #170.
+
+Generates a time-varying wind vector whose power spectral density matches the
+Dryden form of MIL-F-8785B / MIL-HDBK-1797, so the sim can exercise the
+guidance loop and the EKF against continuous buffeting rather than only the
+steady wind and the impulsive `roll_kick_dps` perturbation.
+
+WHAT THIS IS AND IS NOT A TEST OF
+    A *uniform* gust produces exactly ZERO roll moment on this symmetric
+    airframe: `sixdof.derivatives` zeroes the normal-force roll contribution,
+    and every other roll term depends on the wind only through the scalar
+    airspeed.  So this is a pitch/yaw, angle-of-attack, EKF-buffeting and
+    dispersion stressor — NOT a roll-loop stressor.  The roll loop is
+    disturbed by `roll_misalign_deg` (a V^2 fin-tab build misalignment) and
+    `roll_kick_dps` (an impulsive boost transient); those remain the right
+    tools for it.  The one coupling here is that the gust modulates airspeed,
+    which scales the V^2 misalignment torque by ~3% 1-sigma at light
+    turbulence.
+
+FRAME — earth (ENU), not body
+    The gust is generated directly in ENU and subtracted from the vehicle
+    velocity, matching how `SixDOF.derivatives` already consumes wind.  East
+    and North carry the horizontal (u/v) spectrum, Up carries the vertical (w)
+    spectrum, which is the earth-frame reading of the standard: the vertical
+    component has its own scale length (L_w = h) because the ground constrains
+    vertical eddies.  Generating in the body frame would be actively wrong
+    here — a constant body-frame gust becomes a *rotating* ENU gust as the
+    rocket rolls, injecting a fictitious disturbance perfectly correlated with
+    the very state the roll controller regulates, and the usual body triad is
+    singular for a vertical rocket (i.e. for all of boost).
+
+APPROXIMATION, stated rather than hidden
+    Strict MIL-F-8785 gives the longitudinal component a 1st-order spectrum
+    and the lateral a 2nd-order one.  Both horizontals here use the 1st-order
+    form.  Splitting them would tie the spectral shape to the arbitrary
+    East/North axes (the two are interchangeable with no mean wind), and
+    horizontal isotropy matters more for this vehicle than the exact
+    high-frequency rolloff of one component.  The vertical — the component
+    that feeds axial velocity and therefore apogee — uses the correct
+    2nd-order form.
+
+The filter gains are recomputed from the instantaneous airspeed and altitude
+on every step and stay INSIDE the recursion.  They are deliberately not
+factored out as a unit-variance filter scaled by sigma(t): that shortcut is
+only valid for constant V and L, and a rocket going 0 -> 110 m/s in under two
+seconds is the maximally invalid case for it (the defect NASA's LaSRS++ code
+review documents).
+"""
+import math
+
+import numpy as np
+
+_FT = 0.3048
+# Free-atmosphere scale length, 1750 ft.  Above ~2000 ft the standard drops
+# the ground-proximity dependence entirely.
+L_FREE_AIR_M = 1750.0 * _FT
+# Airspeed floor for the filter coefficients.  V appears only as V/L (an
+# inverse time constant), and V -> 0 on the pad and at apogee would divide by
+# zero.  Dynamic pressure at 5 m/s is ~0.2% of the flight maximum, so the
+# gust is aerodynamically irrelevant wherever this floor binds.
+V_FLOOR_MPS = 5.0
+# Altitude floor, 20 ft — W20's own reference height, below which the
+# low-altitude scale lengths (L_w = h) collapse to zero.
+H_FLOOR_M = 20.0 * _FT
+
+_INV_SQRT3 = 1.0 / math.sqrt(3.0)
+
+# Turbulence intensity presets, as the 20 ft reference wind W20 (m/s).
+# MIL-F-8785B defines light/moderate/severe at 15/30/45 kt.
+W20_LIGHT = 15.0 * 0.514444
+W20_MODERATE = 30.0 * 0.514444
+W20_SEVERE = 45.0 * 0.514444
+
+
+def dryden_scales(h_agl_m: float, w20_mps: float):
+    """Dryden scale lengths and intensities at altitude `h_agl_m`.
+
+    Returns (L_u, L_w, sigma_u, sigma_w) in metres and m/s.
+
+    Below 1000 ft this is the MIL-F-8785B low-altitude form verbatim (h in
+    feet)::
+
+        L_w = h                                  sigma_w = 0.1 * W20
+        L_u = h / (0.177 + 0.000823 h)**1.2      sigma_u = sigma_w / (...)**0.4
+
+    At exactly 1000 ft the denominator is 1, so both scale lengths meet at
+    1000 ft and both intensities meet at 0.1*W20 — the form is naturally
+    continuous there.  Above it the standard is undefined until 2000 ft
+    (MIL-F-8785C leaves an explicit gap), so the scale length is blended
+    linearly from its 1000 ft value to L_FREE_AIR_M across that gap and the
+    intensities are held.  A rocket transits this band in a few seconds; a
+    discontinuity there would read as a real disturbance rather than as a
+    modelling seam.
+    """
+    h = max(float(h_agl_m), H_FLOOR_M)
+    h_ft = h / _FT
+    sigma_w = 0.1 * w20_mps
+
+    if h_ft < 1000.0:
+        den = 0.177 + 0.000823 * h_ft
+        return h / den**1.2, h, sigma_w / den**0.4, sigma_w
+
+    blend = min((h_ft - 1000.0) / 1000.0, 1.0)
+    L_1000 = 1000.0 * _FT
+    L = L_1000 + blend * (L_FREE_AIR_M - L_1000)
+    return L, L, sigma_w, sigma_w
+
+
+class DrydenGust:
+    """Dryden gust generator producing an ENU wind-velocity vector.
+
+    Advance it once per physics step with the current airspeed and altitude;
+    the returned vector is meant to be added to the steady wind and passed to
+    `SixDOF.derivatives` / `step_rk4` as `wind_enu`.
+    """
+
+    def __init__(self, w20_mps: float, seed: int = None,
+                 vertical: bool = True,
+                 v_floor: float = V_FLOOR_MPS,
+                 h_floor: float = H_FLOOR_M):
+        if w20_mps <= 0.0:
+            raise ValueError("w20_mps must be > 0 (build no gust to disable)")
+        self.w20_mps = float(w20_mps)
+        self.vertical = bool(vertical)
+        self.v_floor = float(v_floor)
+        self.h_floor = float(h_floor)
+        self._rng = np.random.default_rng(seed)
+        # First-order (horizontal) states, and the 2nd-order vertical pair.
+        self._e = 0.0
+        self._n = 0.0
+        self._w_x = 0.0   # intermediate (1st stage of the vertical cascade)
+        self._w = 0.0
+
+    def reset(self, h_agl_m: float = 0.0, v_mps: float = 30.0,
+              burn_in_s: float = 60.0, burn_in_dt: float = 0.01):
+        """Zero the states, then burn in to the stationary distribution.
+
+        Starting from zero would bias the whole of boost: the horizontal time
+        constant L_u/V reaches several seconds against a ~10 s climb, and
+        early in flight V is small enough that the filter barely leaves the
+        origin.  The recursions are exact at any step size and the stationary
+        distribution does not depend on it, so the burn-in runs at a coarse
+        100 Hz — a few thousand cheap steps, not `physics_dt` ones.
+        """
+        self._e = self._n = self._w_x = self._w = 0.0
+        for _ in range(int(burn_in_s / burn_in_dt)):
+            self.step(burn_in_dt, v_mps, h_agl_m)
+
+    def step(self, dt: float, v_air_mps: float, h_agl_m: float) -> np.ndarray:
+        """Advance one step; return the gust velocity as an ENU (3,) array."""
+        V = max(float(v_air_mps), self.v_floor)
+        L_u, L_w, sigma_u, sigma_w = dryden_scales(h_agl_m, self.w20_mps)
+
+        # --- Horizontal: exact Ornstein-Uhlenbeck sampling -------------
+        # x[k] = a x[k-1] + sigma sqrt(1 - a^2) eta  is the exact transition
+        # of the 1st-order Dryden process, for any dt.
+        b = V * dt / L_u
+        a = math.exp(-b)
+        c = sigma_u * math.sqrt(-math.expm1(-2.0 * b))
+        self._e = a * self._e + c * self._rng.standard_normal()
+        self._n = a * self._n + c * self._rng.standard_normal()
+
+        # --- Vertical: 2nd-order Dryden as a ZOH stage feeding a lead-lag --
+        # Reproduces R_w(t) = sigma_w^2 e^(-Vt/L) (1 - Vt/2L), including the
+        # sign reversal past t = 2L/V that distinguishes the true 2nd-order
+        # spectrum from a 1st-order one (see tests/test_dryden.py).
+        # The vertical filter is advanced unconditionally — `vertical=False`
+        # suppresses the OUTPUT only.  Skipping the draw instead would shift
+        # every subsequent horizontal sample, so the flag would silently
+        # change the horizontal gust too.
+        bw = V * dt / L_w
+        aw = math.exp(-bw)
+        om = -math.expm1(-bw)
+        g1 = sigma_w * math.sqrt(3.0 * L_w / (V * dt))
+        x_prev = self._w_x
+        self._w_x = aw * x_prev + g1 * om * self._rng.standard_normal()
+        # Written as C2*(x - x_prev) + r*om*x_prev rather than the literal
+        # C2*x + C3*x_prev: the latter has C2 -> +1 and C3 -> -1 while
+        # their sum is ~1e-5 at our step sizes, and cancels away most of
+        # the mantissa.
+        C2 = _INV_SQRT3 + om * (1.0 - _INV_SQRT3) / bw
+        self._w = (aw * self._w + C2 * (self._w_x - x_prev)
+                   + _INV_SQRT3 * om * x_prev)
+
+        out = np.array([self._e, self._n,
+                        self._w if self.vertical else 0.0])
+        if not np.all(np.isfinite(out)):
+            # A NaN here would propagate into v_air_mag and silently switch
+            # off both the aero and the fin-torque gates in derivatives(),
+            # producing a force-free ballistic coast instead of an error.
+            raise FloatingPointError(
+                f"non-finite Dryden gust {out} at V={V}, h={h_agl_m}")
+        return out

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -445,7 +445,17 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
     # Latest IMU measurement and true specific force (for logging at log rate)
     latest_imu_meas = None
     latest_true_accel_body = None
-    latest_baro_alt = None
+    # Seeded rather than left None: the first log row is emitted on the same
+    # tick that initializes the EKF, and the baro is only sampled in the
+    # *other* branch of that if/elif, so no reading exists yet. Left as None
+    # the row omits the key entirely and pandas backfills NaN for it, poking a
+    # one-sample hole in the column that any numpy-side consumer inherits.
+    # The seed is the noiseless ISA inversion at the starting altitude —
+    # exactly what the sampler computes, minus the sensor noise it has not
+    # drawn yet — so it costs no RNG draw and shifts no baseline.
+    latest_baro_alt = 44330.0 * (
+        1.0 - (atm.pressure(state[2] + config.ref_alt_m) / 101325.0)
+        ** (1.0 / 5.255))
     latest_mach = 0.0
     latest_gnss_valid = True
     latest_baro_valid = True

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -30,6 +30,7 @@ from ..sensors.baro_model import BaroModel
 from ..sensors.mag_model import MagModel
 from ..sensors.gnss_model import GNSSModel
 from ..control.controller import RollController
+from ..physics.dryden import DrydenGust
 
 
 @dataclass
@@ -114,6 +115,20 @@ class SimConfig:
     # Wind (constant ENU, m/s)
     wind_speed: float = 0.0             # m/s
     wind_direction_deg: float = 0.0     # direction wind comes FROM (0=North, 90=East)
+
+    # Dryden atmospheric turbulence (physics/dryden.py), added on top of the
+    # steady wind above and independent of it — a gust may be flown with zero
+    # mean wind. gust_w20_mps is the wind speed at the 20 ft reference height,
+    # which sets the turbulence intensity: ~7.7 light, ~15.4 moderate, ~23.2
+    # severe (W20_LIGHT / W20_MODERATE / W20_SEVERE). 0 = off, and with it off
+    # no filter is built and the wind vector is exactly what it was before the
+    # gust model existed. gust_vertical=False drops the Up component, which is
+    # the one that perturbs axial velocity and so moves apogee.
+    # NOTE: a uniform gust exerts NO roll moment on this symmetric airframe —
+    # it stresses pitch/yaw, AoA, the EKF and dispersion, not the roll loop.
+    # Use roll_misalign_deg / roll_kick_dps for roll disturbances.
+    gust_w20_mps: float = 0.0
+    gust_vertical: bool = True
 
     # Launch site (for GNSS)
     ref_lat_deg: float = 38.0
@@ -250,13 +265,16 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
     # Wind vector in ENU
     # wind_direction_deg is where wind comes FROM (meteorological convention)
     # so wind blows TOWARD the opposite direction
-    wind_enu = None
+    wind_steady_enu = None
     if config.wind_speed > 0:
         wind_from_rad = math.radians(config.wind_direction_deg)
         # Wind FROM north (0°) → blows south → negative North → negative ENU-y
         wind_east = -config.wind_speed * math.sin(wind_from_rad)
         wind_north = -config.wind_speed * math.cos(wind_from_rad)
-        wind_enu = np.array([wind_east, wind_north, 0.0])
+        wind_steady_enu = np.array([wind_east, wind_north, 0.0])
+    # With the gust off this is never rebound, so wind_enu keeps its None
+    # sentinel and every downstream consumer behaves exactly as before.
+    wind_enu = wind_steady_enu
 
     # Initialize sensors
     def _seed(i):
@@ -282,6 +300,15 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         ref_alt_m=config.ref_alt_m,
         seed=_seed(3),
     )
+
+    # Dryden turbulence. Seed index 4 — 0..3 are taken by the sensor models
+    # above, and sharing one would both correlate the gust with sensor noise
+    # and shift the existing scenarios' noise streams.
+    gust = None
+    if config.gust_w20_mps > 0.0:
+        gust = DrydenGust(config.gust_w20_mps, seed=_seed(4),
+                          vertical=config.gust_vertical)
+        gust.reset(h_agl_m=0.0, v_mps=30.0)
 
     # Initialize controller
     controller = RollController(
@@ -436,6 +463,21 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
         speed = np.linalg.norm(vel)
 
         in_pad_phase = (t < 0.0)
+
+        # Advance the gust before anything reads the wind this step, so the
+        # IMU derivative, the logged row and the RK4 step all see the same
+        # value at the same t. (Unlike the roll kick at the bottom of the
+        # loop, which deliberately applies after t advances.)
+        #
+        # Held off during the pad phase: wind is inert there anyway (IMU accel
+        # is forced to zero and the physics step is skipped), and integrating
+        # through it would make the gust at t=0 depend on pad_time, coupling
+        # two knobs that are currently independent. reset()'s burn-in already
+        # starts the filter stationary.
+        if gust is not None and not in_pad_phase:
+            gust_enu = gust.step(config.physics_dt, float(speed), float(alt))
+            wind_enu = (gust_enu if wind_steady_enu is None
+                        else wind_steady_enu + gust_enu)
 
         # Termination conditions (only during flight, not pad phase)
         if not in_pad_phase:

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/rocketpy_passive.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/rocketpy_passive.py
@@ -135,7 +135,10 @@ def _load_site_config(config_path: Optional[str | Path]) -> dict:
     if not cfg:
         return defaults
 
-    site = cfg.get("launch_site", {})
+    # `or {}` rather than a .get default: a present-but-null block
+    # (`launch_site:` with its body commented out) parses to None, and the
+    # .get default only applies when the KEY is absent.
+    site = cfg.get("launch_site") or {}
     for key in defaults:
         if key not in site:
             site[key] = defaults[key]

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/rocketpy_passive.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/rocketpy_passive.py
@@ -130,6 +130,11 @@ def _load_site_config(config_path: Optional[str | Path]) -> dict:
     with open(path) as f:
         cfg = yaml.safe_load(f)
 
+    # safe_load returns None for an empty or comment-only file — matches the
+    # guard _apply_yaml_overrides already has.
+    if not cfg:
+        return defaults
+
     site = cfg.get("launch_site", {})
     for key in defaults:
         if key not in site:

--- a/tinkerrocket-sim/tests/test_config_yaml.py
+++ b/tinkerrocket-sim/tests/test_config_yaml.py
@@ -1,0 +1,101 @@
+"""The checked-in YAML config must not advertise keys nothing reads (#170).
+
+Both config files had accumulated whole sections of real-looking keys that no
+code path consumed — sensor specs, controller gains, simulation timing, and a
+`gust_sigma_mps` that promised a turbulence model the sim did not have. Several
+contradicted the values actually in force, so anyone who trusted the file was
+misled rather than merely ignored.
+
+These tests pin the invariant: every key present is a key some reader consumes.
+Adding a new section without a reader fails here.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tinkerrocket_sim.rocket.definition import from_yaml
+from tinkerrocket_sim.simulation.rocketpy_passive import _load_site_config
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+SIM_CONFIG = CONFIG_DIR / "sim_config.yaml"
+LAUNCH_SITE = CONFIG_DIR / "launch_site.yaml"
+
+# The sections rocket.definition._apply_yaml_overrides actually reads.
+CONSUMED_SIM_SECTIONS = {"fin_tabs", "mass_overrides", "aerodynamics"}
+# rocketpy_passive._load_site_config reads only this one.
+CONSUMED_SITE_SECTIONS = {"launch_site"}
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def test_config_files_parse():
+    assert _load(SIM_CONFIG) is not None
+    assert _load(LAUNCH_SITE) is not None
+
+
+def test_sim_config_has_no_unread_sections():
+    """A section here with no reader is a promise the code does not keep."""
+    assert set(_load(SIM_CONFIG)) == CONSUMED_SIM_SECTIONS
+
+
+def test_launch_site_has_no_unread_sections():
+    assert set(_load(LAUNCH_SITE)) == CONSUMED_SITE_SECTIONS
+
+
+def _all_keys(node):
+    """Every mapping key anywhere in a parsed YAML tree."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield k
+            yield from _all_keys(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _all_keys(v)
+
+
+@pytest.mark.parametrize("path", [SIM_CONFIG, LAUNCH_SITE])
+def test_no_wind_or_gust_keys_masquerading_as_config(path):
+    """gust_sigma_mps sat in launch_site.yaml unread for the life of the sim.
+    Wind and turbulence are configured on SimConfig (wind_speed,
+    gust_w20_mps), never in these files. Checked against the parsed tree —
+    prose pointing readers at the real knobs is fine."""
+    keys = list(_all_keys(_load(path)))
+    assert not [k for k in keys if "gust" in k or "wind" in k]
+
+
+def test_sim_config_values_reach_the_rocket_definition():
+    """The sections we kept must genuinely round-trip, not just parse."""
+    cfg = _load(SIM_CONFIG)
+    rd = from_yaml(SIM_CONFIG)
+    assert rd.fin_tabs.Kt_ref == cfg["fin_tabs"]["Kt_ref"]
+    assert rd.fin_tabs.n_tabs == cfg["fin_tabs"]["n_tabs"]
+    assert rd.I_roll_launch == cfg["mass_overrides"]["I_roll_launch"]
+    assert rd.Cd == cfg["aerodynamics"]["Cd"]
+
+
+def test_launch_site_values_reach_the_environment():
+    cfg = _load(LAUNCH_SITE)["launch_site"]
+    site = _load_site_config(LAUNCH_SITE)
+    for key in ("latitude_deg", "longitude_deg", "elevation_m"):
+        assert site[key] == cfg[key]
+
+
+def test_site_loader_survives_an_empty_file(tmp_path):
+    """yaml.safe_load returns None for an empty or comment-only file, which
+    used to reach .get() and raise. Deleting a top-level block is exactly the
+    edit that makes this reachable."""
+    for content in ("", "# only a comment\n"):
+        p = tmp_path / "site.yaml"
+        p.write_text(content)
+        site = _load_site_config(p)
+        assert site["latitude_deg"] == 38.0
+        assert site["elevation_m"] == 0.0
+
+
+def test_site_loader_handles_a_missing_file(tmp_path):
+    site = _load_site_config(tmp_path / "does_not_exist.yaml")
+    assert site["latitude_deg"] == 38.0

--- a/tinkerrocket-sim/tests/test_config_yaml.py
+++ b/tinkerrocket-sim/tests/test_config_yaml.py
@@ -67,33 +67,97 @@ def test_no_wind_or_gust_keys_masquerading_as_config(path):
     assert not [k for k in keys if "gust" in k or "wind" in k]
 
 
-def test_sim_config_values_reach_the_rocket_definition():
-    """The sections we kept must genuinely round-trip, not just parse."""
+def _perturb(node):
+    """Copy a parsed YAML tree with every numeric leaf changed."""
+    if isinstance(node, dict):
+        return {k: _perturb(v) for k, v in node.items()}
+    if isinstance(node, bool):
+        return not node
+    if isinstance(node, (int, float)):
+        return node * 3.0 + 1.0
+    return node
+
+
+def _fingerprint(obj, depth=0):
+    """Flatten an object's scalar attributes so two of them can be diffed."""
+    if depth > 3 or not hasattr(obj, "__dict__"):
+        return {}
+    out = {}
+    for name, value in vars(obj).items():
+        if isinstance(value, (int, float, str, bool)) or value is None:
+            out[name] = value
+        else:
+            for sub, sv in _fingerprint(value, depth + 1).items():
+                out[f"{name}.{sub}"] = sv
+    return out
+
+
+@pytest.mark.parametrize("section", sorted(CONSUMED_SIM_SECTIONS))
+def test_every_sim_config_section_actually_reaches_the_rocket(section, tmp_path):
+    """Behavioral, not declarative: perturb one section's values and require
+    the RocketDefinition to change.
+
+    Asserting `rd.Cd == cfg["aerodynamics"]["Cd"]` would NOT do this — the
+    checked-in values happen to equal the dataclass defaults, so that
+    assertion passes even with the reader deleted. Perturbing proves a reader
+    exists and applies the value, so deleting one fails here.
+    """
     cfg = _load(SIM_CONFIG)
-    rd = from_yaml(SIM_CONFIG)
-    assert rd.fin_tabs.Kt_ref == cfg["fin_tabs"]["Kt_ref"]
-    assert rd.fin_tabs.n_tabs == cfg["fin_tabs"]["n_tabs"]
-    assert rd.I_roll_launch == cfg["mass_overrides"]["I_roll_launch"]
-    assert rd.Cd == cfg["aerodynamics"]["Cd"]
+    perturbed = dict(cfg)
+    perturbed[section] = _perturb(cfg[section])
+
+    path = tmp_path / "perturbed.yaml"
+    path.write_text(yaml.safe_dump(perturbed))
+
+    base = _fingerprint(from_yaml(SIM_CONFIG))
+    after = _fingerprint(from_yaml(path))
+    changed = [k for k in base if base[k] != after.get(k)]
+    assert changed, (
+        f"perturbing the '{section}' section changed nothing in the "
+        f"RocketDefinition — it has no live reader"
+    )
 
 
-def test_launch_site_values_reach_the_environment():
-    cfg = _load(LAUNCH_SITE)["launch_site"]
-    site = _load_site_config(LAUNCH_SITE)
+def test_launch_site_values_reach_the_environment(tmp_path):
+    """Same reasoning: use values that differ from the loader's defaults, so
+    the assertion fails if the file is ignored."""
+    path = tmp_path / "site.yaml"
+    path.write_text(yaml.safe_dump({"launch_site": {
+        "latitude_deg": 12.5, "longitude_deg": -77.25, "elevation_m": 1234.0,
+    }}))
+    site = _load_site_config(path)
+    assert site["latitude_deg"] == 12.5
+    assert site["longitude_deg"] == -77.25
+    assert site["elevation_m"] == 1234.0
+
+    # ...and the checked-in file still parses into that same shape.
+    real = _load_site_config(LAUNCH_SITE)
     for key in ("latitude_deg", "longitude_deg", "elevation_m"):
-        assert site[key] == cfg[key]
+        assert real[key] == _load(LAUNCH_SITE)["launch_site"][key]
 
 
-def test_site_loader_survives_an_empty_file(tmp_path):
-    """yaml.safe_load returns None for an empty or comment-only file, which
-    used to reach .get() and raise. Deleting a top-level block is exactly the
-    edit that makes this reachable."""
-    for content in ("", "# only a comment\n"):
-        p = tmp_path / "site.yaml"
-        p.write_text(content)
-        site = _load_site_config(p)
-        assert site["latitude_deg"] == 38.0
-        assert site["elevation_m"] == 0.0
+@pytest.mark.parametrize("content", [
+    "",                                          # empty file
+    "# only a comment\n",                        # comment-only -> safe_load None
+    "launch_site:\n",                            # key present, body null
+    "launch_site:\n  # latitude_deg: 38.0\n",    # body commented out
+    "other_section:\n  a: 1\n",                  # key absent entirely
+])
+def test_site_loader_falls_back_to_defaults(content, tmp_path):
+    """Every degenerate shape must fall back, not raise.
+
+    Two distinct traps here: safe_load returns None for an empty file, and a
+    present-but-null block parses to {'launch_site': None} — where a .get()
+    default does NOT apply, because the key exists. Commenting out the body
+    while leaving the key is the natural editing accident, and this file now
+    carries a long prose comment under that key.
+    """
+    p = tmp_path / "site.yaml"
+    p.write_text(content)
+    site = _load_site_config(p)
+    assert site["latitude_deg"] == 38.0
+    assert site["longitude_deg"] == -122.0
+    assert site["elevation_m"] == 0.0
 
 
 def test_site_loader_handles_a_missing_file(tmp_path):

--- a/tinkerrocket-sim/tests/test_dryden.py
+++ b/tinkerrocket-sim/tests/test_dryden.py
@@ -12,11 +12,14 @@ the estimate low by roughly 2*tau/T.
 import math
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from tinkerrocket_sim.physics.dryden import (
     DrydenGust, dryden_scales, L_FREE_AIR_M, W20_MODERATE, H_FLOOR_M,
 )
+from tinkerrocket_sim.simulation.closed_loop_sim import SimConfig, run_closed_loop
+from tinkerrocket_sim.simulation.scenarios import build_rollypolly_iii
 
 _FT = 0.3048
 
@@ -200,3 +203,58 @@ def test_reset_burn_in_leaves_filter_stationary():
 def test_zero_intensity_rejected():
     with pytest.raises(ValueError):
         DrydenGust(0.0)
+
+
+# --- integration with the closed-loop sim ----------------------------------
+
+def _short_flight(**overrides):
+    cfg = dict(pad_time=0.0, duration=6.0, physics_dt=1e-3,
+               launch_angle_deg=85.0, control_enabled=False,
+               guidance_enabled=False, enable_mag_updates=False,
+               pad_heading_deg=0.0, sensor_seed=0)
+    cfg.update(overrides)
+    return run_closed_loop(build_rollypolly_iii(), SimConfig(**cfg))
+
+
+def test_gust_off_leaves_the_sim_bit_for_bit_unchanged():
+    """The knob defaults off, and off must mean the gust model is not merely
+    quiet but absent — otherwise every existing scenario baseline moves."""
+    a = _short_flight()
+    b = _short_flight(gust_w20_mps=0.0, gust_vertical=False)
+    pd.testing.assert_frame_equal(a.df, b.df)
+
+
+def _n_nonfinite(result):
+    """Count non-finite cells. Stated differentially against a calm run rather
+    than as an absolute zero: baro_alt is already NaN in the first logged row
+    of every flight, gust or not (the row precedes the first baro sample)."""
+    num = result.df.select_dtypes('number').to_numpy(dtype=float)
+    return int((~np.isfinite(num)).sum())
+
+
+def test_gust_perturbs_angle_of_attack():
+    """The gust has to actually reach the aerodynamics. AoA is the signal it
+    drives (a uniform gust exerts no roll moment on a symmetric airframe)."""
+    calm = _short_flight()
+    windy = _short_flight(gust_w20_mps=W20_MODERATE)
+    assert windy.df['alpha_deg'].max() > calm.df['alpha_deg'].max()
+    assert _n_nonfinite(windy) == _n_nonfinite(calm)
+    # Still a plausible flight, not a force-free coast from a poisoned wind.
+    assert 0.5 * calm.apogee_m < windy.apogee_m < 1.5 * calm.apogee_m
+
+
+def test_gust_is_reproducible_and_seed_dependent():
+    a = _short_flight(gust_w20_mps=W20_MODERATE, sensor_seed=3)
+    b = _short_flight(gust_w20_mps=W20_MODERATE, sensor_seed=3)
+    c = _short_flight(gust_w20_mps=W20_MODERATE, sensor_seed=4)
+    pd.testing.assert_frame_equal(a.df, b.df)
+    assert a.df['alpha_deg'].max() != c.df['alpha_deg'].max()
+
+
+def test_gust_composes_with_steady_wind():
+    """Steady wind and gust are independent knobs that add."""
+    steady = _short_flight(wind_speed=5.0, wind_direction_deg=90.0)
+    both = _short_flight(wind_speed=5.0, wind_direction_deg=90.0,
+                         gust_w20_mps=W20_MODERATE)
+    assert both.df['alpha_deg'].max() != steady.df['alpha_deg'].max()
+    assert _n_nonfinite(both) == _n_nonfinite(steady)

--- a/tinkerrocket-sim/tests/test_dryden.py
+++ b/tinkerrocket-sim/tests/test_dryden.py
@@ -258,9 +258,11 @@ def test_gust_off_leaves_the_sim_bit_for_bit_unchanged():
 
 
 def _n_nonfinite(result):
-    """Count non-finite cells. Stated differentially against a calm run rather
-    than as an absolute zero: baro_alt is already NaN in the first logged row
-    of every flight, gust or not (the row precedes the first baro sample)."""
+    """Count non-finite cells. A poisoned wind vector propagates into
+    v_air_mag, which silently switches off both the aero and fin-torque gates
+    rather than raising, so this is the check that the gust reached the
+    physics intact. (This was a differential count against a calm run until
+    the row-0 baro_alt hole was fixed; see tests/test_log_columns.py.)"""
     num = result.df.select_dtypes('number').to_numpy(dtype=float)
     return int((~np.isfinite(num)).sum())
 
@@ -271,7 +273,8 @@ def test_gust_perturbs_angle_of_attack():
     calm = _short_flight()
     windy = _short_flight(gust_w20_mps=W20_MODERATE)
     assert windy.df['alpha_deg'].max() > calm.df['alpha_deg'].max()
-    assert _n_nonfinite(windy) == _n_nonfinite(calm)
+    assert _n_nonfinite(calm) == 0
+    assert _n_nonfinite(windy) == 0
     # Still a plausible flight, not a force-free coast from a poisoned wind.
     assert 0.5 * calm.apogee_m < windy.apogee_m < 1.5 * calm.apogee_m
 
@@ -290,4 +293,4 @@ def test_gust_composes_with_steady_wind():
     both = _short_flight(wind_speed=5.0, wind_direction_deg=90.0,
                          gust_w20_mps=W20_MODERATE)
     assert both.df['alpha_deg'].max() != steady.df['alpha_deg'].max()
-    assert _n_nonfinite(both) == _n_nonfinite(steady)
+    assert _n_nonfinite(both) == 0

--- a/tinkerrocket-sim/tests/test_dryden.py
+++ b/tinkerrocket-sim/tests/test_dryden.py
@@ -205,6 +205,39 @@ def test_zero_intensity_rejected():
         DrydenGust(0.0)
 
 
+def test_gust_is_continuous_across_an_altitude_change():
+    """The gain must stay INSIDE the recursion, not be hoisted out as a
+    unit-variance filter scaled by sigma(h) at the output.
+
+    sigma_u varies with altitude below 1000 ft, so a hoisted gain rescales the
+    whole carried state the instant h changes — the gust velocity teleports.
+    Physically it must decay toward the new intensity at the filter's own rate.
+
+    Taking the altitude step with a very short dt makes this a wide-margin
+    check rather than a statistical one: the only change the true filter can
+    make in that step is the noise it injects, of order sigma*sqrt(2*V*dt/L)
+    (~0.1% here), whereas a hoisted gain jumps by the full sigma ratio (~46%).
+    The 2% threshold sits about 20x above the former and 20x below the latter.
+
+    This is the one invariant the module docstring singles out as its reason
+    for existing, and it is invisible to every constant-altitude test: with h
+    fixed, hoisting the gain is mathematically exact.
+    """
+    h_low, h_high, v = H_FLOOR_M, 900.0 * _FT, 90.0
+    sigma_low = dryden_scales(h_low, W20_MODERATE)[2]
+    sigma_high = dryden_scales(h_high, W20_MODERATE)[2]
+    assert sigma_low > 1.8 * sigma_high      # the altitudes really do differ
+
+    g = DrydenGust(W20_MODERATE, seed=17)
+    for _ in range(4000):                     # build up state at low altitude
+        before = g.step(1e-2, v, h_low)
+    after = g.step(1e-6, v, h_high)           # same instant, new altitude
+
+    assert abs(before[0]) > 0.5 * sigma_low   # there is real state to rescale
+    assert after[0] == pytest.approx(before[0], rel=0.02)
+    assert after[1] == pytest.approx(before[1], rel=0.02)
+
+
 # --- integration with the closed-loop sim ----------------------------------
 
 def _short_flight(**overrides):

--- a/tinkerrocket-sim/tests/test_dryden.py
+++ b/tinkerrocket-sim/tests/test_dryden.py
@@ -1,0 +1,202 @@
+"""Dryden gust model tests (#170).
+
+The statistical tests drive the filter at a FIXED airspeed and altitude and at
+a coarse dt: the recursions are exact at any step size, so a 100 Hz record
+gives the same statistics as a 10 kHz one for a thousandth of the runtime.
+dt-independence is asserted separately rather than assumed.
+
+Variances use mean(x**2), not np.var: the process mean is known to be zero,
+and subtracting the *sample* mean of a strongly autocorrelated record biases
+the estimate low by roughly 2*tau/T.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from tinkerrocket_sim.physics.dryden import (
+    DrydenGust, dryden_scales, L_FREE_AIR_M, W20_MODERATE, H_FLOOR_M,
+)
+
+_FT = 0.3048
+
+
+def _record(w20, v, h, dt, n, seed, vertical=True):
+    """Drive the gust at constant V and h; return an (n, 3) ENU record."""
+    g = DrydenGust(w20, seed=seed, vertical=vertical)
+    return np.array([g.step(dt, v, h) for _ in range(n)])
+
+
+def _acf(x, lag):
+    return float(np.mean(x[:-lag] * x[lag:]) / np.mean(x * x))
+
+
+# --- scale lengths / intensities ------------------------------------------
+
+def test_low_altitude_form_matches_mil_f_8785b():
+    """Spot-check the published low-altitude formulas at 20 ft."""
+    h = 20.0 * _FT
+    L_u, L_w, s_u, s_w = dryden_scales(h, 15.4)
+    den = 0.177 + 0.000823 * 20.0
+    assert L_w == pytest.approx(h)                      # L_w = h
+    assert L_u == pytest.approx(h / den**1.2)
+    assert s_w == pytest.approx(0.1 * 15.4)
+    assert s_u == pytest.approx(s_w / den**0.4)
+    assert s_u > s_w                                    # horizontal is stronger near the ground
+
+
+def test_scales_continuous_at_1000ft():
+    """The low-altitude form and the blend must meet without a kink — a step
+    here would read as a real disturbance during the transit."""
+    below = dryden_scales((1000.0 - 1e-3) * _FT, 15.4)
+    above = dryden_scales((1000.0 + 1e-3) * _FT, 15.4)
+    for b, a in zip(below, above):
+        assert b == pytest.approx(a, abs=1e-3)
+    # and both scale lengths have converged to h = 1000 ft there
+    assert below[0] == pytest.approx(below[1], abs=1e-3)
+    assert below[2] == pytest.approx(below[3], abs=1e-6)
+
+
+def test_scales_reach_free_air_above_2000ft():
+    L_u, L_w, s_u, s_w = dryden_scales(2500.0 * _FT, 15.4)
+    assert L_u == pytest.approx(L_FREE_AIR_M)
+    assert L_w == pytest.approx(L_FREE_AIR_M)
+    assert s_u == pytest.approx(0.1 * 15.4)
+
+
+def test_altitude_floor_applied():
+    """Below the 20 ft floor, L_w = h would collapse to zero."""
+    assert dryden_scales(0.0, 15.4) == dryden_scales(H_FLOOR_M, 15.4)
+
+
+# --- filter statistics -----------------------------------------------------
+
+def test_horizontal_variance():
+    v, h, w20 = 90.0, 300.0, W20_MODERATE
+    _, _, sigma_u, _ = dryden_scales(h, w20)
+    rec = _record(w20, v, h, 1e-2, 400_000, 1)
+    for axis in (0, 1):
+        assert math.sqrt(np.mean(rec[:, axis] ** 2)) == pytest.approx(sigma_u, rel=0.05)
+
+
+def test_vertical_variance():
+    v, h, w20 = 90.0, 300.0, W20_MODERATE
+    _, _, _, sigma_w = dryden_scales(h, w20)
+    rec = _record(w20, v, h, 1e-2, 400_000, 2)
+    assert math.sqrt(np.mean(rec[:, 2] ** 2)) == pytest.approx(sigma_w, rel=0.05)
+
+
+def test_horizontal_autocorrelation_is_first_order():
+    """R_u(L/V) = 1/e for the 1st-order (exponential) spectrum."""
+    v, h, w20 = 90.0, 300.0, W20_MODERATE
+    L_u, _, _, _ = dryden_scales(h, w20)
+    dt = 1e-2
+    rec = _record(w20, v, h, dt, 600_000, 3)
+    lag = int(round((L_u / v) / dt))
+    assert _acf(rec[:, 0], lag) == pytest.approx(1.0 / math.e, abs=0.02)
+
+
+_ACF_V, _ACF_H, _ACF_DT = 90.0, 60.0, 1e-2
+
+
+@pytest.fixture(scope="module")
+def vertical_record():
+    """One long vertical record, shared by the autocorrelation tests — it is
+    the most expensive thing in this file and both tests want the same run."""
+    return _record(W20_MODERATE, _ACF_V, _ACF_H, _ACF_DT, 1_500_000, 4)[:, 2]
+
+
+def test_vertical_autocorrelation_matches_dryden(vertical_record):
+    """R_w(t) = e^(-Vt/L) (1 - Vt/2L) — the shape that distinguishes the true
+    2nd-order vertical spectrum from an accidentally 1st-order one."""
+    _, L_w, _, _ = dryden_scales(_ACF_H, W20_MODERATE)
+    for mult in (0.5, 1.0, 1.5):
+        lag = int(round(mult * (L_w / _ACF_V) / _ACF_DT))
+        t = lag * _ACF_DT
+        want = math.exp(-_ACF_V * t / L_w) * (1.0 - _ACF_V * t / (2.0 * L_w))
+        assert _acf(vertical_record, lag) == pytest.approx(want, abs=0.03)
+
+
+def test_vertical_autocorrelation_reverses_sign(vertical_record):
+    """The 2nd-order spectrum crosses zero at t = 2L/V and goes negative
+    beyond it; a 1st-order filter never does."""
+    _, L_w, _, _ = dryden_scales(_ACF_H, W20_MODERATE)
+    lag_of = lambda m: int(round(m * (L_w / _ACF_V) / _ACF_DT))
+    assert abs(_acf(vertical_record, lag_of(2.0))) < 0.03
+    assert _acf(vertical_record, lag_of(3.0)) < 0.0
+
+
+def test_variance_independent_of_timestep():
+    """Catches a missing sqrt(dt) normalization, which would scale RMS by
+    sqrt(10) per decade and is otherwise invisible."""
+    v, h, w20 = 90.0, 300.0, W20_MODERATE
+    _, _, sigma_u, _ = dryden_scales(h, w20)
+    rms = []
+    for dt, n in ((1e-2, 400_000), (1e-3, 1_000_000)):
+        rec = _record(w20, v, h, dt, n, 6)
+        rms.append(math.sqrt(np.mean(rec[:, 0] ** 2)))
+    assert rms[0] == pytest.approx(rms[1], rel=0.10)
+    assert rms[0] == pytest.approx(sigma_u, rel=0.10)
+
+
+def test_components_are_independent():
+    """A shared RNG draw across axes would show up as correlation.
+
+    Run near the ground, where the scale lengths (and so the correlation
+    times) are shortest: the useful sample count is T/(2*tau), not the raw
+    step count.  At h = 20 ft and V = 90 the slowest component has
+    tau = L_u/V ~ 0.5 s, so a 3000 s record carries ~3000 effective samples
+    and the sampling std of the correlation is ~0.018.  0.08 is ~4 sigma.
+    """
+    rec = _record(W20_MODERATE, 90.0, H_FLOOR_M, 1e-2, 300_000, 7)
+    c = np.corrcoef(rec.T)
+    for i in range(3):
+        for j in range(i + 1, 3):
+            assert abs(c[i, j]) < 0.08
+
+
+def test_intensity_scales_linearly():
+    a = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 100_000, 8)
+    b = _record(2.0 * W20_MODERATE, 90.0, 300.0, 1e-2, 100_000, 8)
+    assert np.allclose(b, 2.0 * a, rtol=1e-9)
+
+
+# --- guards and API --------------------------------------------------------
+
+def test_finite_at_zero_airspeed_and_altitude():
+    """V -> 0 (pad, apogee) and h -> 0 (off the rail) are both real states in
+    this flight profile and both are singular without the floors."""
+    rec = _record(W20_MODERATE, 0.0, 0.0, 1e-3, 2000, 9)
+    assert np.all(np.isfinite(rec))
+
+
+def test_deterministic_for_a_given_seed():
+    a = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 500, 10)
+    b = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 500, 10)
+    c = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 500, 11)
+    assert np.array_equal(a, b)
+    assert not np.array_equal(a, c)
+
+
+def test_vertical_flag_zeroes_up_without_disturbing_horizontals():
+    on = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 500, 12, vertical=True)
+    off = _record(W20_MODERATE, 90.0, 300.0, 1e-2, 500, 12, vertical=False)
+    assert np.all(off[:, 2] == 0.0)
+    assert np.array_equal(on[:, :2], off[:, :2])
+
+
+def test_reset_burn_in_leaves_filter_stationary():
+    """After the burn-in the state should already be a typical sample, not
+    parked near zero."""
+    _, _, sigma_u, _ = dryden_scales(300.0, W20_MODERATE)
+    finals = []
+    for seed in range(60):
+        g = DrydenGust(W20_MODERATE, seed=seed)
+        g.reset(h_agl_m=300.0, v_mps=90.0)
+        finals.append(g.step(1e-2, 90.0, 300.0)[0])
+    assert math.sqrt(np.mean(np.square(finals))) == pytest.approx(sigma_u, rel=0.35)
+
+
+def test_zero_intensity_rejected():
+    with pytest.raises(ValueError):
+        DrydenGust(0.0)

--- a/tinkerrocket-sim/tests/test_log_columns.py
+++ b/tinkerrocket-sim/tests/test_log_columns.py
@@ -1,0 +1,70 @@
+"""The logged DataFrame must not carry unintended holes.
+
+Log rows are built as dicts and only get a key when the corresponding
+`latest_*` value exists, so a field that is still None when the first row is
+emitted is simply absent from that dict — and pandas silently backfills NaN
+for it when the frame is assembled. The gap is invisible to pandas-side
+aggregation (mean/min skip NaN) but poisons anything that goes through
+.to_numpy(), which is how the Data_Analysis-style consumers read these frames.
+
+`baro_alt` had exactly this hole in row 0 of every run: the first log row is
+emitted on the same tick that initializes the EKF, and the barometer is
+sampled in the other branch of that if/elif, so no reading existed yet.
+"""
+import numpy as np
+import pytest
+
+from tinkerrocket_sim.simulation.closed_loop_sim import SimConfig, run_closed_loop
+from tinkerrocket_sim.simulation.scenarios import build_rollypolly_iii
+
+# roll_target_deg / current_roll_deg are legitimately absent before the roll
+# controller engages (explicitly set back to None while rate-nulling), so
+# their NaN region is meaningful "not applicable", not an initialization hole.
+INTENTIONALLY_SPARSE = {"roll_target_deg", "current_roll_deg"}
+
+
+def _flight(**overrides):
+    cfg = dict(pad_time=0.0, duration=3.0, physics_dt=1e-3,
+               control_enabled=False, guidance_enabled=False,
+               enable_mag_updates=False, pad_heading_deg=0.0, sensor_seed=0)
+    cfg.update(overrides)
+    return run_closed_loop(build_rollypolly_iii(), SimConfig(**cfg)).df
+
+
+def _holes(df):
+    num = df.select_dtypes("number")
+    out = {}
+    for col in num.columns:
+        if col in INTENTIONALLY_SPARSE:
+            continue
+        n = int((~np.isfinite(num[col].to_numpy(dtype=float))).sum())
+        if n:
+            out[col] = n
+    return out
+
+
+@pytest.mark.parametrize("overrides", [
+    {},
+    {"pad_time": 2.0},
+    {"enable_baro_updates": False},
+    {"ref_alt_m": 500.0},
+    {"control_enabled": True},
+])
+def test_logged_frame_has_no_non_finite_cells(overrides):
+    assert _holes(_flight(**overrides)) == {}
+
+
+def test_baro_alt_is_populated_from_the_very_first_row():
+    """Row 0 used to be NaN in every single run."""
+    df = _flight()
+    assert np.isfinite(df["baro_alt"].iloc[0])
+
+
+def test_baro_alt_seed_matches_the_starting_altitude():
+    """The pre-first-sample seed is the noiseless ISA inversion, so it must sit
+    at the launch altitude and agree with the samples that follow it."""
+    df = _flight(ref_alt_m=500.0)
+    assert df["baro_alt"].iloc[0] == pytest.approx(500.0, abs=1e-6)
+    # ...and the real samples scatter tightly around it, i.e. the seed is on
+    # the same scale as the sensor rather than an arbitrary placeholder.
+    assert df["baro_alt"].iloc[1:20].mean() == pytest.approx(500.0, abs=0.5)


### PR DESCRIPTION
Closes #170.

The last two open items on #170: a real gust spectrum, and config files that stop advertising keys nothing reads. Plus one incidental logging fix found on the way.

Item 2 from that issue — calibrating roll scenario (c) against a real logged flight — is **not** here. It needs a plant re-fit against a fresh flight rather than keyboard work, so it is split out as #549.

---

## 1. Dryden gust spectrum

`launch_site.yaml` has declared `gust_sigma_mps` since the sim was written and nothing ever read it — "gust" appeared exactly once in the whole repo. This adds the model behind it.

New `physics/dryden.py` generates an ENU gust with the Dryden PSD: first-order Ornstein-Uhlenbeck for the two horizontals, the true second-order cascade for the vertical. `SimConfig.gust_w20_mps` (0 = off) and `gust_vertical`, plumbed through `run_closed_loop.py` and the GUI.

Choices worth reviewing:

- **Scale lengths use the MIL-F-8785B low-altitude form verbatim** below 1000 ft, then blend linearly to the free-atmosphere value across the 1000–2000 ft band the standard leaves undefined. A 600 m apogee sits inside that gap for the top half of every flight, and a kink there would read as a real disturbance rather than a modelling seam.
- **Filter gains are recomputed each step and stay inside the recursion**, not factored out as a unit-variance filter scaled by σ(t). That shortcut is only valid at constant V and L, and a rocket going 0→110 m/s in under two seconds is the maximally invalid case for it.
- **ENU, not body frame.** A constant body-frame gust becomes a *rotating* ENU gust as the rocket rolls, injecting a fictitious disturbance perfectly correlated with the state the roll controller regulates — and the usual body triad is singular for a vertical rocket, i.e. for all of boost.
- Guards for V→0 (pad, apogee) and L_w = h → 0 (off the rail). Both are singular and both are real states here.

Validated as monotonic in intensity:

| W20 | apogee | max AoA | drift at apogee |
|---|---|---|---|
| calm | 358.6 m | 5.4° | 64.9 m |
| light | 350.8 m | 11.7° | 96.3 m |
| moderate | 336.9 m | 22.2° | 127.1 m |
| severe | 318.2 m | 31.2° | 153.5 m |

**Scope note:** a uniform gust exerts **zero roll moment** on this symmetric airframe. This is a pitch/yaw, AoA, EKF-buffeting and dispersion stressor — not a roll-loop stressor. `roll_misalign_deg` and `roll_kick_dps` remain the tools for that. Stated in the module docstring so the result is not later read as a null.

## 2. YAML that stops lying

`_apply_yaml_overrides` reads exactly `fin_tabs` / `mass_overrides` / `aerodynamics`; `_load_site_config` reads exactly `launch_site`. The entire `control:`, `sensors:`, `simulation:` and `wind:` blocks were decoration.

Worse than unused — several **contradicted** the values actually in force:

| dead key | said | actually in force |
|---|---|---|
| `control.pid.kp` | 0.10 | 0.02, the tune shipped to firmware `config.h` |
| `sensors.imu.gyro_range` | 4000 | 100 dps, the deliberate clip scenario (d) depends on |
| `simulation.physics_dt` | 1.0e-4 | 1e-3, what every scenario runs at |

So *wiring them up* — the obvious reading of "make the config honest" — would have silently broken all three. Deleted instead, with values preserved as clearly-marked reference since the sensor hardware specs exist nowhere else.

**`sensors.imu.mounting_rotation_z_deg` was deliberately not wired**, and should not be. `SimConfig.imu_mounting_rotation_deg` is a *fault-injection* knob — a misalignment the firmware constants do **not** undo. The YAML key reads as a description of how the board is physically mounted. Connecting them would model an uncompensated 45° error and wreck the EKF. Now noted in the file so it does not get "fixed" later.

Also fixes a latent crash that deleting a top-level block makes reachable: `_load_site_config` called `.get()` on `yaml.safe_load`'s result, which is `None` for an empty file — and `cfg.get("launch_site", {})` still returns `None` for a present-but-null block, where the `.get` default does not apply.

## 3. Incidental: row-0 `baro_alt` hole

Every run produced a NaN `baro_alt` in the first logged row. The first log row is emitted on the same tick that initializes the EKF, and the baro is sampled in the other branch of that `if/elif`, so no reading exists yet; the row omits the key and pandas backfills NaN.

Seeded with the noiseless ISA inversion at the starting altitude rather than by taking a real early sample — the latter would consume a baro RNG draw and shift every downstream sample. Verified: scenarios (b), (c) and (d) are **bit-identical** pre/post fix on max roll rate, max AoA, apogee, max fin deflection, and the sum of every real baro sample.

Audited the other logged `latest_*` fields for the same hole; `baro_alt` was the only one. `roll_target_deg` / `current_roll_deg` do have a large NaN region, but that one is by design — both are explicitly set back to `None` while rate-nulling, so it means "no angle target", not "uninitialized".

---

## Verification

**88 → 132 tests passing.** Existing behavior is preserved byte-for-byte: `test_gust_off_leaves_the_sim_bit_for_bit_unchanged` asserts frame equality between the default config and an explicitly-zeroed one, and all 88 pre-existing tests pass untouched.

An adversarial review raised 20 findings; 4 survived refutation and are fixed in `f1324bc`. The significant one is worth calling out:

> **Hoisting the filter gain out of the recursion — the exact defect `dryden.py`'s docstring names as its reason for existing — passed all 118 tests.** Every statistical test held V and h constant, and with h fixed that hoist is mathematically *exact*. The closed-loop tests do vary altitude but asserted only inequalities that a 7% intensity error survives.

Constant-parameter tests cannot test a time-varying-parameter invariant. `test_gust_is_continuous_across_an_altitude_change` now closes it deterministically in 0.3 s, verified to pass the real implementation and fail a mutated copy.

The other three were the same class of problem in the YAML tests — they compared against hardcoded constants and against values that happened to equal the dataclass defaults, so deleting a *reader* left them green. Both are now behavioral (perturb a section, require the object to change), verified by deleting the `aerodynamics` reader in a scratch copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
