### PR TITLE
Wire station-keep guidance into the FC + library aim point (#534, unblocks #435)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift
@@ -208,7 +208,9 @@ final class ActiveRocketSyncer: ObservableObject {
                                   minSpeed: profile.pnMinSpeed, coastDelayMs: profile.pnCoastDelayMs,
                                   targetMode: profile.pnTargetMode,
                                   targetE: profile.pnTargetE, targetN: profile.pnTargetN,
-                                  targetAlt: profile.pnTargetAltM)
+                                  targetAlt: profile.pnTargetAltM,
+                                  kpPos: profile.pnKpPos, kdVel: profile.pnKdVel,
+                                  guidanceLaw: profile.pnGuidanceLaw)
         device.sendFinConfig(ringMode: profile.finRingMode,
                              servoAtSlot: profile.finServoAtSlot,
                              reverse: profile.finReverse,

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -842,11 +842,21 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendRawCommand(32, payload: Data([enabled ? 0x01 : 0x00]))
     }
 
-    /// Full PN guidance config (GuidanceConfigData = 36 bytes, cmd 65). Floats
-    /// LE in struct order, then coast_delay(u16), enable(u8), target_mode(u8).
+    /// Full guidance config (GuidanceConfigData = 45 bytes, cmd 65).  v1 floats LE
+    /// in struct order, then coast_delay(u16), enable(u8), target_mode(u8); #534
+    /// appended kp_pos(f32), kd_vel(f32), guidance_law(u8).  THE FIRST 36 BYTES
+    /// ARE FROZEN — the FC parses by offset, so append only, never insert.
+    ///
+    /// Both laws' parameters are sent unconditionally, every time, regardless of
+    /// which law is selected or which fields the UI is showing: the FC keeps the
+    /// unused law fully configured so switching laws never flies an untuned one.
+    ///
+    /// A 45-byte-era FC REJECTS a 36-byte frame outright (length check) and logs
+    /// it, so app and firmware must ship in lockstep.
     func sendGuidanceConfig(enabled: Bool, navGain: Float, maxAccel: Float, accelToFin: Float,
                             maxFinDeg: Float, minSpeed: Float, coastDelayMs: UInt16,
-                            targetMode: UInt8, targetE: Float, targetN: Float, targetAlt: Float) {
+                            targetMode: UInt8, targetE: Float, targetN: Float, targetAlt: Float,
+                            kpPos: Float, kdVel: Float, guidanceLaw: UInt8) {
         var payload = Data()
         var ng = navGain, ma = maxAccel, a2f = accelToFin, mf = maxFinDeg, ms = minSpeed
         var te = targetE, tn = targetN, ta = targetAlt
@@ -861,7 +871,15 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         var cd = coastDelayMs; payload.append(Data(bytes: &cd, count: 2))
         payload.append(enabled ? 0x01 : 0x00)
         payload.append(targetMode)
-        sendRawCommand(65, payload: payload)   // GuidanceConfigData = 36 bytes
+        // --- appended #534 (offsets 36/40/44) ---
+        var kp = kpPos, kd = kdVel
+        payload.append(Data(bytes: &kp, count: 4))
+        payload.append(Data(bytes: &kd, count: 4))
+        payload.append(guidanceLaw)
+        #if DEBUG
+        assert(payload.count == 45, "GuidanceConfigData must be 45 bytes, built \(payload.count)")
+        #endif
+        sendRawCommand(65, payload: payload)   // GuidanceConfigData = 45 bytes
         if var cfg = rocketConfig { cfg.guidanceEnabled = enabled; rocketConfig = cfg }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -112,6 +112,15 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var pnTargetMode: UInt8 = 0         // GUIDE_TARGET_OVERHEAD (Phase 1: locked)
     var pnTargetE: Float = 0
     var pnTargetN: Float = 0
+    // Station-keep PD gains + law selector (#534). Defaults MUST equal config.h
+    // (PN_KP_POS_PER_S2 / PN_KD_VEL_PER_S / GUIDANCE_LAW_DEFAULT) — the profile is
+    // pushed on connect and overrides the FC, so a mismatch silently re-tunes
+    // guidance. The gains are PROVISIONAL (seeded from the sim's guidance
+    // scenario, pending the #534 acceptance A/B); keep them in lockstep with
+    // config.h and tinkerrocket-sim scenarios.py.
+    var pnKpPos: Float = 0.8            // config::PN_KP_POS_PER_S2
+    var pnKdVel: Float = 1.5            // config::PN_KD_VEL_PER_S
+    var pnGuidanceLaw: UInt8 = 0        // config::GUIDANCE_LAW_DEFAULT (0 = PN, 1 = station-keep)
     var cameraType: UInt8 = 2          // 0=None, 1=GoPro, 2=RunCam
     /// IMU mounting orientation: 0xFF = auto (pad-gravity detect), 0..23 =
     /// manual board→rocket code. Manual fixes the roll clocking the control
@@ -304,6 +313,9 @@ extension RocketProfile {
         pnTargetMode = try c.decodeIfPresent(UInt8.self, forKey: .pnTargetMode) ?? defaults.pnTargetMode
         pnTargetE = try c.decodeIfPresent(Float.self, forKey: .pnTargetE) ?? defaults.pnTargetE
         pnTargetN = try c.decodeIfPresent(Float.self, forKey: .pnTargetN) ?? defaults.pnTargetN
+        pnKpPos = try c.decodeIfPresent(Float.self, forKey: .pnKpPos) ?? defaults.pnKpPos
+        pnKdVel = try c.decodeIfPresent(Float.self, forKey: .pnKdVel) ?? defaults.pnKdVel
+        pnGuidanceLaw = try c.decodeIfPresent(UInt8.self, forKey: .pnGuidanceLaw) ?? defaults.pnGuidanceLaw
         cameraType = try c.decodeIfPresent(UInt8.self, forKey: .cameraType) ?? defaults.cameraType
         imuOrientSetting = try c.decodeIfPresent(UInt8.self, forKey: .imuOrientSetting) ?? defaults.imuOrientSetting
         imuRateHz = try c.decodeIfPresent(UInt16.self, forKey: .imuRateHz) ?? defaults.imuRateHz

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -54,6 +54,8 @@ struct SettingsView: View {
     @State private var sPnAccelToFin = ""
     @State private var sPnMaxFin = ""
     @State private var sPnMinSpeed = ""
+    @State private var sPnKpPos = ""
+    @State private var sPnKdVel = ""
 
     // Roll waypoints edited as strings; committed to the profile on change.
     @State private var rollWaypoints: [(time: String, angle: String)] = []
@@ -149,6 +151,7 @@ struct SettingsView: View {
         case kpAngle
         case integralSep
         case guidTargetAlt, guidNavGain, guidMaxAccel, guidAccelToFin, guidMaxFin, guidMinSpeed
+        case guidKpPos, guidKdVel
         case wpTime(Int), wpAngle(Int)
         case pyroValue(Int)   // ch index 0..3
         case drogueRate, mainRate, mainDeployAlt, dragK
@@ -186,7 +189,8 @@ struct SettingsView: View {
         case .bias1, .bias2, .bias3, .bias4, .servoHz, .servoMin, .servoMax, .finTravel: return .servo
         case .pidKp, .pidKi, .pidKd, .pidMin, .pidMax: return .pid
         case .rollDelay, .rateCap, .kpAngle, .integralSep: return .rollControl
-        case .guidTargetAlt, .guidNavGain, .guidMaxAccel, .guidAccelToFin, .guidMaxFin, .guidMinSpeed: return .guidance
+        case .guidTargetAlt, .guidNavGain, .guidMaxAccel, .guidAccelToFin, .guidMaxFin, .guidMinSpeed,
+             .guidKpPos, .guidKdVel: return .guidance
         case .wpTime, .wpAngle: return .rollWaypoints
         case .pyroValue: return .pyro
         case .drogueRate, .mainRate, .mainDeployAlt, .dragK: return .recovery
@@ -921,13 +925,40 @@ struct SettingsView: View {
         }
     }
 
+    // The section body is split into three @ViewBuilder pieces purely to stay
+    // under SwiftUI's 10-subview ViewBuilder limit now that the law picker and
+    // the per-law field set live here.
     private var guidanceSection: some View {
-        Section(header: configHeader("PN Guidance", applied: guidanceApplied)) {
+        Section(header: configHeader("Guidance", applied: guidanceApplied)) {
+            guidanceIntroCopy
+            guidanceLawFields
+            guidanceSharedFields
+        }
+    }
+
+    @ViewBuilder private var guidanceIntroCopy: some View {
+        Group {
             Text("Roll axis is rate-nulled (held at zero spin) \u{2014} the roll profile is not followed in Guidance mode.")
                 .font(.caption).foregroundColor(.secondary)
-            Text("Proportional-navigation steering toward the target. Engages at the Activation Delay after launch (shared with roll control), not after burnout. Phase 1 target: directly over the launch pad (overhead).")
+            Text("Engages at the Activation Delay after launch (shared with roll control), not after burnout.")
                 .font(.caption).foregroundColor(.secondary)
 
+            Picker("Guidance Law", selection: guidanceLawBinding) {
+                Text("Proportional Nav").tag(UInt8(0))
+                Text("Station-Keep").tag(UInt8(1))
+            }
+            .pickerStyle(.segmented)
+            Text("Station-keep is a PD regulator that flies straight up over the aim point \u{2014} no closest-approach singularity. PN steers toward a target altitude and is the legacy law.")
+                .font(.caption).foregroundColor(.secondary)
+            Text("Aim point is currently the pad (overhead); wind-compensated aim points arrive with Drift-Cast.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    /// Per-law tuning. The other law's values stay in the profile and keep
+    /// going out on the wire, so switching laws never zeroes its tune.
+    @ViewBuilder private var guidanceLawFields: some View {
+        if profile.pnGuidanceLaw == 0 {
             HStack {
                 Text("Target Altitude")
                 Spacer()
@@ -946,6 +977,31 @@ struct SettingsView: View {
                     .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
                     .focused($focusedField, equals: .guidNavGain)
             }
+        } else {
+            HStack {
+                Text("Pos Gain (kp)")
+                Spacer()
+                TextField("0.8", text: $sPnKpPos)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidKpPos)
+                Text("1/s\u{00B2}").foregroundColor(.secondary)
+            }
+            HStack {
+                Text("Vel Gain (kd)")
+                Spacer()
+                TextField("1.5", text: $sPnKdVel)
+                    .keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)
+                    .focused($focusedField, equals: .guidKdVel)
+                Text("1/s").foregroundColor(.secondary)
+            }
+            Text("Lateral accel = \u{2212}kp\u{00D7}offset \u{2212} kd\u{00D7}velocity. Both must be in (0, 10]; the rocket rejects anything outside and keeps its previous tune.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+    }
+
+    /// Shared by both laws.
+    @ViewBuilder private var guidanceSharedFields: some View {
+        Group {
             HStack {
                 Text("Max Accel")
                 Spacer()
@@ -985,9 +1041,11 @@ struct SettingsView: View {
                     .focused($focusedField, equals: .rollDelay)
                 Text("ms").foregroundColor(.secondary)
             }
-            Text("Milliseconds after launch before control activates \u{2014} roll-rate-null and PN guidance both engage at this delay, keeping fins neutral through initial boost.")
+            Text("Milliseconds after launch before control activates \u{2014} roll-rate-null and guidance both engage at this delay, keeping fins neutral through initial boost.")
                 .font(.caption).foregroundColor(.secondary)
-            Text("Nav gain = PN aggressiveness (3\u{2013}5). Min speed gates guidance off below useful fin authority. Stored in the rocket profile.")
+            Text(profile.pnGuidanceLaw == 0
+                 ? "Nav gain = PN aggressiveness (3\u{2013}5). Min speed gates guidance off below useful fin authority. Stored in the rocket profile."
+                 : "Min speed gates guidance off below useful fin authority. Stored in the rocket profile.")
                 .font(.caption).foregroundColor(.secondary)
         }
     }
@@ -1120,6 +1178,18 @@ struct SettingsView: View {
             })
     }
 
+    /// Guidance law: 0 = proportional navigation, 1 = station-keep.  Applies on
+    /// change (#144) — no Apply button.  Both laws' parameters ride in every
+    /// frame, so flipping the picker never drops the other law's tune.
+    private var guidanceLawBinding: Binding<UInt8> {
+        Binding(
+            get: { profile.pnGuidanceLaw },
+            set: { newValue in
+                updateProfile { $0.pnGuidanceLaw = newValue }
+                applyGuidanceConfig()
+            })
+    }
+
     // Pyro enable / mode apply immediately (like toggles); the trigger value
     // commits on focus loss via the .pyro EditGroup.
     private func pyroEnabledBinding(_ ch: Int) -> Binding<Bool> {
@@ -1168,6 +1238,8 @@ struct SettingsView: View {
         sPnAccelToFin = formatDecimal(Double(p.pnAccelToFin))
         sPnMaxFin = formatDecimal(Double(p.pnMaxFinDeg))
         sPnMinSpeed = formatDecimal(Double(p.pnMinSpeed))
+        sPnKpPos = formatDecimal(Double(p.pnKpPos))
+        sPnKdVel = formatDecimal(Double(p.pnKdVel))
         rollWaypoints = p.rollWaypoints.map {
             (time: trimFloat($0.timeSeconds), angle: trimFloat($0.angleDeg))
         }
@@ -1401,10 +1473,16 @@ struct SettingsView: View {
         let minSpeed   = max(0, Float(sPnMinSpeed)   ?? profile.pnMinSpeed)
         let coastDelay = profile.pnCoastDelayMs  // inert in FW; guidance activation = rollDelayMs (Activation Delay)
         let targetAlt  = max(0, Float(sPnTargetAlt)  ?? profile.pnTargetAltM)
+        // Station-keep gains (#534).  Same floor-of-0 idiom as the rest — note
+        // Float("nan") survives it; the FC's (0, 10] gates are the real guard and
+        // they log on rejection.  Both laws' values are sent every time.
+        let kpPos      = max(0, Float(sPnKpPos)      ?? profile.pnKpPos)
+        let kdVel      = max(0, Float(sPnKdVel)      ?? profile.pnKdVel)
         updateProfile {
             $0.pnNavGain = navGain; $0.pnMaxAccel = maxAccel; $0.pnAccelToFin = accelToFin
             $0.pnMaxFinDeg = maxFin; $0.pnMinSpeed = minSpeed; $0.pnCoastDelayMs = coastDelay
             $0.pnTargetAltM = targetAlt
+            $0.pnKpPos = kpPos; $0.pnKdVel = kdVel
         }
         if device.isConnected {
             device.sendGuidanceConfig(enabled: profile.guidanceEnabled,
@@ -1412,7 +1490,9 @@ struct SettingsView: View {
                                       maxFinDeg: maxFin, minSpeed: minSpeed, coastDelayMs: coastDelay,
                                       targetMode: profile.pnTargetMode,
                                       targetE: profile.pnTargetE, targetN: profile.pnTargetN,
-                                      targetAlt: targetAlt)
+                                      targetAlt: targetAlt,
+                                      kpPos: kpPos, kdVel: kdVel,
+                                      guidanceLaw: profile.pnGuidanceLaw)
         }
         showApplied($guidanceApplied)
     }

--- a/docs/plans/534-station-keep-sim-ab.md
+++ b/docs/plans/534-station-keep-sim-ab.md
@@ -1,0 +1,144 @@
+# #534 sim A/B: station-keep vs PN on the canonical guided scenario
+
+**Verdict: the #534 acceptance criterion passes.** Station-keep ≤ PN apogee drift on
+every discriminating seed/condition pair (35/35; 52/52 including the null wind8/latched pairs), with zero singularity behavior in
+70 station-keep runs, and it holds that edge under the three off-nominal stress legs
+(heading bias, GNSS denial, gust latch lottery). Gains **kp=0.8 / kd=1.5 confirmed**.
+Recommended: keep `GUIDANCE_LAW_DEFAULT = PN` until a first guided flight validates
+either law in the air, then flip config.h + app RocketProfile in lockstep.
+
+- Runner (regenerates all 144 runs deterministically):
+  `tinkerrocket-sim/scripts/ab534_pn_vs_station_keep.py`
+- Regression pin: `tinkerrocket-sim/tests/test_scenarios.py::test_scenario_a2_station_keep_beats_pn_no_cpa`
+- Plant: scenario (a) — RollyPolly III / G80T, 85° launch, apogee ~360 m,
+  guidance active ~2.6 s → apogee ~8.5 s, PN target_alt 600 m (above apogee).
+- All numbers were independently re-derived by a second pass over the raw JSONL;
+  the analyst/verifier discrepancies were presentation errors only.
+
+## Metric definitions (two traps, hit and corrected)
+
+- **Effective apogee drift** = `final_horiz_offset_m` (offset at the last *guided*
+  row) when guidance ran to near apogee; `max_horiz_offset_m` when tilt-latched
+  early or unguided. The raw "final" for a latched run is the offset at *latch
+  time* (~0.4 m at t≈2.7 s), not apogee — treating it as drift silently flatters
+  latched runs.
+- **`max_tilt_coast_deg`** covers the whole post-burnout window *including* after
+  the benign speed-gate quit near apogee, so values above the 20° coast latch can
+  coexist with `cause=speed_gate`. The latch itself samples EKF tilt only while
+  guidance is active.
+
+## Core A/B — effective apogee drift, median [min–max] over 5 seeds
+
+| cond | PN (m) | SK (m) | unguided (m) | SK/PN | SK≤PN per seed |
+|---|---|---|---|---|---|
+| calm  | 13.8 [12.4–15.9] | **3.0** [0.3–3.5] | 64.9 | **0.21** | 5/5 |
+| wind4 | 34.8 [34.2–35.4] | **21.4** [20.4–21.8] | 105.0 | **0.61** | 5/5 |
+| wind8 | 189.7 | 188.9 | 189.8 | 1.00 | 5/5 (null — see below) |
+| gust  | 32.1 [21.4–141.8] | **17.6** [2.9–140.0] | 100.4 | **0.55** | 5/5 |
+
+- **wind8 is a null condition.** 8 m/s weathercocks the vehicle past the 20° coast
+  tilt latch essentially at guidance activation (`guided_frac` 0.009, both laws,
+  every seed, every gain cell). All wind8 rows fly the same ballistic arc; the
+  column carries **zero law or gain information**. It is an envelope statement:
+  at 8 m/s this airframe's guidance is decided by the tilt latch, not the law.
+- Gust is bimodal: 3/5 seeds fly guided to apogee (SK wins big), 2/5 latch both
+  laws right after burnout (wash, ≈ unguided).
+- **Apogee cost: none.** Both laws land within ~1 m of each other and 0.1–11 m
+  *above* the unguided same-seed flight (straighter flight). No seed anywhere has
+  either law worse than unguided.
+- SK actively re-centers (calm: out to ~7.8 m, back to 0.3–3.5 m at apogee);
+  PN only retards outward drift (max ≈ final).
+
+## Singularity probe — the reason station-keep exists
+
+PN with its target set *below* apogee (reachable — exactly what a Drift-Cast/#435
+offset target would create for PN, and why the aim point is station-keep-only):
+
+| case | cause | quit time | guided window lost | late accel (m/s²) | max LOS |
+|---|---|---|---|---|---|
+| PN, target 200 m | **CPA** | 3.0 s / 8.5 s | **94 %** | **20.0 (clamp-pinned)** | 90° |
+| PN, target 300 m | **CPA** | 5.0 s / 8.5 s | **59 %** | **20.0 (clamp-pinned)** | 91° |
+| SK, same configs | speed gate | — | none | 2.7 | 1.1° |
+
+The full signature: LOS sweeps 90° (overhead pass), commands pin the accel clamp
+(19–32× the calm PN baseline of 0.6–1.1 m/s²), ~90 % fin saturation, then the
+sticky `v_cl ≤ 0` quit throws away the rest of the coast. The two SK rows are
+**bit-identical** to the calm SK baseline — station-keep provably ignores
+`target_alt` for its law, and across all 70 SK runs in the study
+`cause=cpa` occurred **zero** times (the library hard-codes `cpa_reached_=false`).
+PN with the standard 600 m (unreachable) target never CPA'd either — keep it that
+way; PN must never be pointed at a reachable target.
+
+## Gain grid — kp × kd, calm, seed 7 (wind8 arm void per above)
+
+| kp\kd | 0.75 | 1.5 | 3.0 |
+|---|---|---|---|
+| 0.4 | 5.0 m, tilt 13.6° | 4.2 m, 9.9° | 5.0 m, 6.4° |
+| 0.8 | 1.3 m, **21.7°** | **0.32 m, 15.0°** ← | 2.3 m, 10.0° |
+| 1.6 | 5.0 m, **25.9°** | 3.6 m, 18.2° | 1.1 m, 11.8° |
+
+Best cell per kp row is the one nearest critical damping (ζ = kd/2√kp);
+underdamped cells (ζ ≤ 0.42) drive coast tilt past the 20° latch threshold.
+**kp=0.8 / kd=1.5 (ζ=0.84) confirmed**: drift-minimal, on the efficient frontier,
+~5° of tilt margin, late accel 2.7 m/s² (no blow-up — no 1/range term in the law).
+Corroborated across the 5-seed calm A/B at the same gains (0.3–3.5 m). Grid was
+calm/seed-7 only in its discriminating leg — if gains are revisited, rerun under
+wind4/gust, never wind8.
+
+## Stress legs (run after the completeness critique; all closed in SK's favor)
+
+**Heading bias** (`inject_heading_bias_deg`; the real vehicle's dominant estimator
+defect — heading is uncorrected all flight, and the IIS2MDC needs hard-iron cal):
+
+| bias | PN calm | SK calm | PN wind4 | SK wind4 |
+|---|---|---|---|---|
+| 10° | 15.1 | **0.6** | — | — |
+| 20° | 15.2 | **1.1** | 35.4 | **20.5** |
+| 45° | 15.8 | **2.5** | 35.5 (tilt-latched) | **21.1** |
+| 90° | 17.2 | **5.6** | — | — |
+
+SK's position feedback degrades gracefully: even a 90° rotation of the commanded
+accel still spirals the error down. SK never lost its win at any bias.
+
+**GNSS denial** (`enable_gnss_updates=False`, EKF coasts on IMU): SK 3.9–4.3 m vs
+PN 12.7–15.8 m vs unguided 64.9 m (2 seeds). SK does *not* chase a diverging
+estimate off the pad on this flight duration.
+
+**Gust latch lottery** (20 fresh seeds × both laws): latches PN 13 / SK 10;
+**SK-only latches: 0**, PN-only: 3, both: 10. On the 7 both-guided seeds SK ≤ PN
+7/7 (medians 7.2 vs 24.2 m). The "one SK-only latch inverts a flight" concern does
+not materialize — PN is the more latch-prone law (it tilts more because it corrects
+less).
+
+## Costs and caveats — what station-keep pays
+
+- **Control effort is the price.** Calm: 3× PN's fin saturation (32 % vs 11 %) and
+  coast tilt 14–19° vs 3–4°. Wind4: fins pinned 97–99 % of the guided window with
+  late accel 16–17 m/s² (authority-limited proportional command, not divergence —
+  LOS stays ≤ 10°, no quit, no oscillation, no integrator in the law).
+- **Tilt margin is thin in calm+gust**: SK works 1.3–5° from the 20° coast latch
+  (one gust seed crossed 20° *after* the speed gate). The lottery leg shows this
+  never actually latches SK where PN survives, but the margin should be watched in
+  flight logs (`GuidanceTelemData` + the tilt-latch log line).
+- **"Drift" here is apogee offset.** Descent wind drift (~100 m scale per
+  #191/#552) dominates the landing point; SK buys 3–20 m at apogee. State the
+  benefit in those terms — this is about controlled, singularity-free guidance
+  (and the #435 aim point), not about moving the landing site.
+- Sim-only evidence; single airframe/motor (the fleet *is* this airframe today).
+  Real-flight unknowns (servo behavior at altitude, real GNSS in boost per #249,
+  real heading error statistics) motivate the flight gate below.
+
+## Recommendation
+
+1. **Acceptance criterion: met.** SK ≤ PN on 35/35 discriminating pairs (52/52 overall); no
+   singularity behavior in any of 70 SK runs; gains 0.8/1.5 confirmed.
+2. **Do not flip `GUIDANCE_LAW_DEFAULT` yet.** Keep PN as the boot default until a
+   first guided flight (either law) validates the guidance stack in the air —
+   consistent with project precedent (#262 mach lockout, #552). The law is
+   BLE/NVS-selectable per flight, so the default costs nothing operationally.
+3. Fly the first guided flight with station-keep selected via the app (it is the
+   safer law by construction and now by simulation), watch coast tilt vs the 20°
+   latch and fin saturation in the log.
+4. Wind ≥ 8 m/s: don't fly guided — the tilt latch decides the flight, not the law.
+5. #435 (Drift-Cast aim point) remains station-keep-only. Never point PN at a
+   reachable target — the probe above is what happens.

--- a/tests_cpp/test_guidance_pn.cpp
+++ b/tests_cpp/test_guidance_pn.cpp
@@ -128,3 +128,384 @@ TEST_F(GuidancePNTest, Configure_UpdatesParams) {
     bool active = guid.update(pos_enu, vel_ned, DT);
     EXPECT_FALSE(active);
 }
+
+// MODE_PN must DELIBERATELY ignore the horizontal aim point: its r < 1 early
+// return latches the sticky cpa_reached_, which the FC uses to kill guidance
+// for the rest of the flight.  An overhead target above apogee is never
+// reached; a REACHABLE offset target would be, turning a rare failure into the
+// nominal case.  Pinned by replaying an identical scenario on two objects that
+// differ only in whether a (large, asymmetric) aim point was pushed.
+TEST_F(GuidancePNTest, ModePN_IgnoresHorizontalTarget) {
+    TR_GuidancePN targeted;
+    targeted.configure(3.0f, 20.0f, TARGET_ALT);
+    ASSERT_TRUE(targeted.setHorizontalTarget(500.0f, -350.0f));
+
+    float pos_enu[3] = {50.0f, -20.0f, 300.0f};
+    float vel_ned[3] = {12.0f, -8.0f, -50.0f};
+
+    guid.update(pos_enu, vel_ned, DT);
+    targeted.update(pos_enu, vel_ned, DT);
+
+    EXPECT_FLOAT_EQ(targeted.getAccelEastCmd(),  guid.getAccelEastCmd());
+    EXPECT_FLOAT_EQ(targeted.getAccelNorthCmd(), guid.getAccelNorthCmd());
+    EXPECT_FLOAT_EQ(targeted.getAccelUpCmd(),    guid.getAccelUpCmd());
+    EXPECT_FLOAT_EQ(targeted.getRange(),         guid.getRange());
+    EXPECT_FLOAT_EQ(targeted.getLosAngleDeg(),   guid.getLosAngleDeg());
+    // In MODE_PN tracking error IS the pad-relative offset.
+    EXPECT_FLOAT_EQ(targeted.getTargetOffset(), targeted.getLateralOffset());
+}
+
+// ─────────────────────── MODE_STATION_KEEP (#435 / #534) ───────────────────
+// Station-keep had ZERO coverage before this file's #435 work: the
+// GuidancePNTest fixture above configures MODE_PN, so all 9 tests exercised
+// the legacy law only.
+
+class GuidanceStationKeepTest : public ::testing::Test {
+protected:
+    TR_GuidancePN guid;
+    // Gains chosen so the hand-computed commands below stay UNDER the clamp;
+    // the clamp gets its own dedicated test.
+    static constexpr float KP  = 0.1f;
+    static constexpr float KD  = 0.5f;
+    static constexpr float AMAX = 20.0f;
+    static constexpr float DT  = 0.002f;
+
+    void SetUp() override {
+        guid.configureStationKeep(KP, KD, AMAX);
+    }
+};
+
+// Regression guard: with the aim point at its (0,0) default, the law must
+// reduce algebraically to the pre-#435 form.  Hand-computed with the ORIGINAL
+// gains, so a change to either term shows up as a numeric mismatch.
+TEST_F(GuidanceStationKeepTest, DefaultTarget_ReproducesLegacyLaw) {
+    guid.configureStationKeep(0.5f, 1.5f, 20.0f);
+
+    float pos_enu[3] = {60.0f, -25.0f, 300.0f};
+    float vel_ned[3] = {12.0f, -8.0f, -40.0f};   // vN=12, vE=-8, vD=-40
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // a_e = -0.5*60   - 1.5*(-8) = -30  + 12 = -18
+    // a_n = -0.5*(-25)- 1.5*(12) =  12.5- 18 =  -5.5
+    EXPECT_NEAR(guid.getAccelEastCmd(),  -18.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(),  -5.5f, 1e-4f);
+    EXPECT_FLOAT_EQ(guid.getAccelUpCmd(), 0.0f);
+    // No aim point set => tracking error == pad offset.
+    EXPECT_FLOAT_EQ(guid.getTargetOffset(), guid.getLateralOffset());
+    EXPECT_FALSE(guid.isCpaReached());
+}
+
+TEST_F(GuidanceStationKeepTest, OnTarget_ZeroVelocity_CommandsZero) {
+    ASSERT_TRUE(guid.setHorizontalTarget(120.0f, -80.0f));
+
+    float pos_enu[3] = {120.0f, -80.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};     // purely vertical
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    EXPECT_NEAR(guid.getAccelEastCmd(),  0.0f, 1e-5f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), 0.0f, 1e-5f);
+    EXPECT_NEAR(guid.getTargetOffset(),  0.0f, 1e-3f);
+}
+
+// DISCRIMINATING sign test, EAST axis.  The vehicle sits BETWEEN the pad and
+// the aim point, so a pad-seeking law and an aim-point-seeking law command
+// OPPOSITE directions.  A test with the vehicle outside the target would pass
+// under both laws and prove nothing.
+TEST_F(GuidanceStationKeepTest, EastOfPad_ShortOfTarget_CommandsEast) {
+    ASSERT_TRUE(guid.setHorizontalTarget(80.0f, 0.0f));
+
+    float pos_enu[3] = {60.0f, 0.0f, 300.0f};    // between pad and aim point
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // err_E = 60 - 80 = -20 -> a_e = -0.1*(-20) = +2.0 (EAST, toward target).
+    // A pad-seeking law would give -0.1*60 = -6.0 (WEST).
+    EXPECT_GT(guid.getAccelEastCmd(), 0.0f);
+    EXPECT_NEAR(guid.getAccelEastCmd(), 2.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), 0.0f, 1e-5f);
+}
+
+// Same discrimination on the NORTH axis, independently — a sign error on one
+// axis alone must not hide behind the other.
+TEST_F(GuidanceStationKeepTest, NorthOfPad_ShortOfTarget_CommandsNorth) {
+    ASSERT_TRUE(guid.setHorizontalTarget(0.0f, 75.0f));
+
+    float pos_enu[3] = {0.0f, 45.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // err_N = 45 - 75 = -30 -> a_n = +3.0 (NORTH).  Pad-seeking: -4.5 (SOUTH).
+    EXPECT_GT(guid.getAccelNorthCmd(), 0.0f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), 3.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelEastCmd(), 0.0f, 1e-5f);
+}
+
+// Every quantity asymmetric (|E| != |N|, opposite signs, distinct magnitudes)
+// so an E/N swap anywhere in the position path cannot pass by symmetry.
+TEST_F(GuidanceStationKeepTest, AsymmetricTarget_DetectsEastNorthSwap) {
+    ASSERT_TRUE(guid.setHorizontalTarget(40.0f, -15.0f));
+
+    float pos_enu[3] = {10.0f, 25.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // err_E = 10 - 40  = -30 -> a_e = +3.0
+    // err_N = 25 -(-15)= +40 -> a_n = -4.0
+    EXPECT_NEAR(guid.getAccelEastCmd(),   3.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), -4.0f, 1e-4f);
+    // Magnitudes differ, so a swap flips both the values AND the sign pattern.
+    EXPECT_NEAR(guid.getTargetOffset(), std::sqrt(30.0f*30.0f + 40.0f*40.0f),
+                1e-3f);
+}
+
+// The damping term is the only consumer of velocity, and update() takes pos in
+// ENU but vel in NED — a live footgun.  Park the vehicle exactly on the aim
+// point so the position term vanishes and the command IS the velocity term.
+TEST_F(GuidanceStationKeepTest, VelocityTerm_UsesNedToEnuConversion) {
+    ASSERT_TRUE(guid.setHorizontalTarget(30.0f, -60.0f));
+
+    float pos_enu[3] = {30.0f, -60.0f, 300.0f};  // on target: position term = 0
+    float vel_ned[3] = {7.0f, -3.0f, 11.0f};     // vN=7, vE=-3, vD=+11 (falling)
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // a_e = -KD * vel_e = -0.5*(-3) = +1.5   (a swap would give -3.5)
+    // a_n = -KD * vel_n = -0.5*( 7) = -3.5   (a swap would give +1.5)
+    EXPECT_NEAR(guid.getAccelEastCmd(),   1.5f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), -3.5f, 1e-4f);
+    // vD must not leak into the lateral command; vertical stays ballistic.
+    EXPECT_FLOAT_EQ(guid.getAccelUpCmd(), 0.0f);
+    // v_cl is plain vertical speed in station-keep: ENU up = -NED down.
+    EXPECT_NEAR(guid.getClosingVelocity(), -11.0f, 1e-4f);
+}
+
+// There is no integrator anywhere in the law, so an arbitrarily distant FINITE
+// target must simply saturate the fins — no windup, no instability.  This is
+// why the library deliberately does not range-limit the aim point.
+TEST_F(GuidanceStationKeepTest, DistantTarget_ClampsToMaxAccel) {
+    ASSERT_TRUE(guid.setHorizontalTarget(100000.0f, -70000.0f));
+
+    float pos_enu[3] = {5.0f, -2.0f, 300.0f};
+    float vel_ned[3] = {3.0f, -4.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    const float a_mag = std::sqrt(
+        guid.getAccelEastCmd()  * guid.getAccelEastCmd() +
+        guid.getAccelNorthCmd() * guid.getAccelNorthCmd());
+    EXPECT_NEAR(a_mag, AMAX, 1e-3f);
+    // Saturated, but still pointing at the aim point (NE quadrant is +E,-N).
+    EXPECT_GT(guid.getAccelEastCmd(),  0.0f);
+    EXPECT_LT(guid.getAccelNorthCmd(), 0.0f);
+}
+
+// LOG-INTEGRITY INVARIANT.  getLateralOffset() feeds the logged, int16-cm,
+// saturating GuidanceTelemData::lateral_offset_cm and is read as pad-relative
+// by three Data_Analysis decoders — it must stay pad-relative for ALL targets.
+// Aim-point-relative error goes to the NEW getTargetOffset() instead.
+TEST_F(GuidanceStationKeepTest, LateralOffsetStaysPadRelative_TargetOffsetIsError) {
+    ASSERT_TRUE(guid.setHorizontalTarget(90.0f, -120.0f));
+
+    float pos_enu[3] = {90.0f, -120.0f, 300.0f};  // exactly ON the aim point
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // Tracking error is zero...
+    EXPECT_NEAR(guid.getTargetOffset(), 0.0f, 1e-3f);
+    // ...while the PAD-relative offset is the full 150 m. These must NOT be
+    // the same number, or the logged field has silently changed meaning.
+    EXPECT_NEAR(guid.getLateralOffset(), 150.0f, 1e-2f);
+}
+
+// getRange() is allowed to be aim-point-relative: it is on no wire struct and
+// the FC never calls it.
+TEST_F(GuidanceStationKeepTest, Range_IsAimPointRelative) {
+    guid.configureStationKeep(KP, KD, AMAX);
+    guid.configure(3.0f, AMAX, 600.0f);            // set target_alt via PN cfg
+    guid.configureStationKeep(KP, KD, AMAX);       // back to station-keep
+    ASSERT_TRUE(guid.setHorizontalTarget(30.0f, -40.0f));
+
+    float pos_enu[3] = {0.0f, 0.0f, 100.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // err = (-30, +40), dh = 600 - 100 = 500 -> sqrt(900+1600+250000)
+    const float expected = std::sqrt(30.0f*30.0f + 40.0f*40.0f + 500.0f*500.0f);
+    EXPECT_NEAR(guid.getRange(), expected, 0.1f);
+}
+
+// SOLE LOG CHANNEL for station-keep tracking error.  getLateralOffset() is
+// frozen pad-relative and getTargetOffset() is on no wire struct, so
+// los_angle_cdeg (main.cpp:6521) is the ONLY field through which regulation
+// error reaches the log — and |pos - target| is NOT reconstructible post-hoc
+// from the logged |pos| magnitude plus a known target vector.  A regression to
+// atan2f(lateral_offset_m_, dh) is therefore undetectable after the flight.
+// Both legs are non-zero AND unequal so the pad-relative mutant gives a
+// different number rather than coincidentally matching.
+TEST_F(GuidanceStationKeepTest, LosAngle_IsAimPointRelative) {
+    ASSERT_TRUE(guid.setHorizontalTarget(30.0f, -40.0f));
+
+    float pos_enu[3] = {60.0f, 80.0f, 100.0f};   // pad offset 100 m ...
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    // err = (60-30, 80-(-40)) = (30, 120) -> target_offset = sqrt(15300)
+    const float target_off = std::sqrt(30.0f*30.0f + 120.0f*120.0f);
+    const float dh         = 600.0f - 100.0f;    // default target_alt_m_
+    ASSERT_NEAR(guid.getTargetOffset(), target_off, 1e-2f);
+    // ... which must NOT equal the pad-relative offset, or this test is blind.
+    ASSERT_NEAR(guid.getLateralOffset(), 100.0f, 1e-2f);
+
+    const float expected = std::atan2(target_off, dh) * 180.0f / (float)M_PI;
+    EXPECT_NEAR(guid.getLosAngleDeg(), expected, 1e-3f);
+
+    // Explicitly pin that it is NOT the pad-relative angle (~11.31 deg).
+    const float pad_relative = std::atan2(100.0f, dh) * 180.0f / (float)M_PI;
+    EXPECT_GT(std::fabs(guid.getLosAngleDeg() - pad_relative), 1.0f);
+}
+
+// #435 CORE CONTRACT.  TR_GuidancePN.h:71-72 keeps the aim point out of
+// configure*() precisely because Drift-Cast RE-PUSHES it as the wind forecast
+// updates.  Every other test sets a valid target exactly once per object, and
+// NonFiniteTarget_RejectedAndPreviousKept only exercises REJECTED follow-ups —
+// so a write-once-latching setter would fly the stalest forecast for the whole
+// flight with a fully green suite.  This is the only assertion that a second
+// VALID push takes effect.
+TEST_F(GuidanceStationKeepTest, SecondValidTarget_ReplacesFirst) {
+    ASSERT_TRUE(guid.setHorizontalTarget(50.0f, 0.0f));
+    ASSERT_FLOAT_EQ(guid.getTargetEast(),  50.0f);
+    ASSERT_FLOAT_EQ(guid.getTargetNorth(),  0.0f);
+
+    // Forecast update: a new aim point in a different quadrant.
+    ASSERT_TRUE(guid.setHorizontalTarget(-120.0f, 90.0f));
+    EXPECT_FLOAT_EQ(guid.getTargetEast(),  -120.0f);
+    EXPECT_FLOAT_EQ(guid.getTargetNorth(),   90.0f);
+
+    // Sitting on the SECOND aim point must command nothing.  Under a latching
+    // setter the vehicle is 210 m west / 90 m north of the stale (50,0) target
+    // and the law commands hard back toward it.
+    float pos_enu[3] = {-120.0f, 90.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    EXPECT_NEAR(guid.getTargetOffset(),  0.0f, 1e-3f);
+    EXPECT_NEAR(guid.getAccelEastCmd(),  0.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), 0.0f, 1e-4f);
+
+    // And the frozen pad-relative field still reports the true displacement.
+    EXPECT_NEAR(guid.getLateralOffset(),
+                std::sqrt(120.0f*120.0f + 90.0f*90.0f), 1e-2f);
+}
+
+TEST_F(GuidanceStationKeepTest, GetMode_TracksLastConfigureCall) {
+    EXPECT_EQ(guid.getMode(), TR_GuidancePN::MODE_STATION_KEEP);
+
+    guid.configure(3.0f, 20.0f, 600.0f);
+    EXPECT_EQ(guid.getMode(), TR_GuidancePN::MODE_PN);
+
+    guid.configureStationKeep(KP, KD, AMAX);
+    EXPECT_EQ(guid.getMode(), TR_GuidancePN::MODE_STATION_KEEP);
+
+    // A fresh object defaults to the legacy law.
+    TR_GuidancePN fresh;
+    EXPECT_EQ(fresh.getMode(), TR_GuidancePN::MODE_PN);
+}
+
+// MERGE BLOCKER.  The FC calls reset() from enterInflight() — AT LAUNCH, after
+// both configure sites, with no re-configure anywhere on the launch path.  A
+// reset() that cleared the aim point would zero it for the entire flight and
+// #435 would fly overhead every time while passing every pre-launch bench
+// check.  The pre-existing Reset_ClearsAll test cannot catch this: it never
+// re-runs update() afterwards.
+TEST_F(GuidanceStationKeepTest, StationKeep_TargetSurvivesReset) {
+    ASSERT_TRUE(guid.setHorizontalTarget(50.0f, -35.0f));
+
+    guid.reset();
+
+    // Configuration survived...
+    EXPECT_FLOAT_EQ(guid.getTargetEast(),   50.0f);
+    EXPECT_FLOAT_EQ(guid.getTargetNorth(), -35.0f);
+    EXPECT_EQ(guid.getMode(), TR_GuidancePN::MODE_STATION_KEEP);
+    // ...but the per-update output was cleared.
+    EXPECT_FLOAT_EQ(guid.getTargetOffset(), 0.0f);
+
+    // The decisive check: sitting on the aim point after a reset must command
+    // nothing.  A cleared target would command the vehicle back to the pad.
+    float pos_enu[3] = {50.0f, -35.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, -45.0f};
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    EXPECT_NEAR(guid.getTargetOffset(),  0.0f, 1e-3f);
+    EXPECT_NEAR(guid.getAccelEastCmd(),  0.0f, 1e-4f);
+    EXPECT_NEAR(guid.getAccelNorthCmd(), 0.0f, 1e-4f);
+}
+
+// setHorizontalTarget() and configure*() touch disjoint members, so either
+// ordering must work.  Pinned because the FC's #435 wiring is free to pick.
+TEST_F(GuidanceStationKeepTest, TargetBeforeConfigure_EquivalentToAfter) {
+    TR_GuidancePN before, after;
+
+    before.setHorizontalTarget(70.0f, -45.0f);
+    before.configureStationKeep(KP, KD, AMAX);
+
+    after.configureStationKeep(KP, KD, AMAX);
+    after.setHorizontalTarget(70.0f, -45.0f);
+
+    float pos_enu[3] = {15.0f, 20.0f, 300.0f};
+    float vel_ned[3] = {6.0f, -9.0f, -45.0f};
+    before.update(pos_enu, vel_ned, DT);
+    after.update(pos_enu, vel_ned, DT);
+
+    EXPECT_FLOAT_EQ(before.getAccelEastCmd(),  after.getAccelEastCmd());
+    EXPECT_FLOAT_EQ(before.getAccelNorthCmd(), after.getAccelNorthCmd());
+    EXPECT_FLOAT_EQ(before.getTargetOffset(),  after.getTargetOffset());
+}
+
+// The finiteness guard is load-bearing: the magnitude clamp tests
+// `a_mag > max_accel_mps2_`, which is FALSE for NaN, so a NaN aim point would
+// flow UNCLAMPED into the fin command.
+TEST_F(GuidanceStationKeepTest, NonFiniteTarget_RejectedAndPreviousKept) {
+    ASSERT_TRUE(guid.setHorizontalTarget(25.0f, -18.0f));
+
+    EXPECT_FALSE(guid.setHorizontalTarget(NAN, -18.0f));
+    EXPECT_FALSE(guid.setHorizontalTarget(25.0f, NAN));
+    EXPECT_FALSE(guid.setHorizontalTarget(INFINITY, -18.0f));
+    EXPECT_FALSE(guid.setHorizontalTarget(25.0f, -INFINITY));
+
+    // Previous aim point intact.
+    EXPECT_FLOAT_EQ(guid.getTargetEast(),   25.0f);
+    EXPECT_FLOAT_EQ(guid.getTargetNorth(), -18.0f);
+
+    float pos_enu[3] = {5.0f, -3.0f, 300.0f};
+    float vel_ned[3] = {2.0f, -1.0f, -45.0f};
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    EXPECT_TRUE(std::isfinite(guid.getAccelEastCmd()));
+    EXPECT_TRUE(std::isfinite(guid.getAccelNorthCmd()));
+    EXPECT_TRUE(std::isfinite(guid.getTargetOffset()));
+}
+
+// Station-keep has no CPA singularity, so it never latches the sticky flag the
+// FC uses to disable guidance.  Flagged in the ruling as a #534 hazard: wiring
+// station-keep leaves that shutdown path permanently open, and #534 owes a
+// replacement deactivation criterion before any flight.
+TEST_F(GuidanceStationKeepTest, NeverLatchesCpa_EvenWhileDescending) {
+    ASSERT_TRUE(guid.setHorizontalTarget(40.0f, -20.0f));
+
+    float pos_enu[3] = {10.0f, 5.0f, 300.0f};
+    float vel_ned[3] = {0.0f, 0.0f, 30.0f};      // vD > 0 => descending
+
+    EXPECT_TRUE(guid.update(pos_enu, vel_ned, DT));
+
+    EXPECT_LT(guid.getClosingVelocity(), 0.0f);  // receding
+    EXPECT_FALSE(guid.isCpaReached());           // ...but no latch
+    EXPECT_TRUE(guid.isActive());
+}

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -120,8 +120,13 @@ TEST(RocketComputerTypes, PyroConfigData_FourChannelLayout) {
 }
 
 TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
-    // 8 floats (32) + u16 coast_delay (2) + 2 u8 (2) = 36, naturally aligned (no pad).
-    EXPECT_EQ(sizeof(GuidanceConfigData), 36u);
+    // v1 prefix: 8 floats (32) + u16 coast_delay (2) + 2 u8 (2) = 36.
+    // #534 appended: 2 floats (8) + u8 guidance_law (1) = 45.
+    // The append deliberately breaks the "floats first" ordering so that the
+    // offsets 0..35 below stay FROZEN — that is what lets a 36-byte-era peer
+    // parse a 45-byte frame's prefix instead of misparsing it.  Do not
+    // "tidy" this by moving kp/kd up with the other floats.
+    EXPECT_EQ(sizeof(GuidanceConfigData), 45u);
     EXPECT_EQ(offsetof(GuidanceConfigData, nav_gain),         0u);
     EXPECT_EQ(offsetof(GuidanceConfigData, max_accel_mps2),   4u);
     EXPECT_EQ(offsetof(GuidanceConfigData, accel_to_fin_deg), 8u);
@@ -133,6 +138,22 @@ TEST(RocketComputerTypes, GuidanceConfigData_Layout) {
     EXPECT_EQ(offsetof(GuidanceConfigData, coast_delay_ms),   32u);
     EXPECT_EQ(offsetof(GuidanceConfigData, enable),           34u);
     EXPECT_EQ(offsetof(GuidanceConfigData, target_mode),      35u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, kp_pos_per_s2),    36u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, kd_vel_per_s),     40u);
+    EXPECT_EQ(offsetof(GuidanceConfigData, guidance_law),     44u);
+    // The 45-byte frame must still fit the OC->FC combined-read window:
+    // framed = 4 (sync/hdr) + 1 (type) + 1 (len) + 45 + 2 (crc) = 53, staged
+    // after a 10-byte status response inside FC_COMBINED_READ_SIZE (96).
+    EXPECT_LE(10u + 4u + 1u + 1u + sizeof(GuidanceConfigData) + 2u, 96u);
+}
+
+TEST(RocketComputerTypes, GuidanceLawCodes_MatchGuidanceLibrary) {
+    // Wire codes mirror TR_GuidancePN::Mode by value.  The library is not
+    // linked into the host test build, so this pins the wire side only; the
+    // FC pins the pair with a static_assert at each configure site.
+    EXPECT_EQ(GUIDE_LAW_PN,           0u);
+    EXPECT_EQ(GUIDE_LAW_STATION_KEEP, 1u);
+    EXPECT_EQ(GUIDE_LAW_MAX,          GUIDE_LAW_STATION_KEEP);
 }
 
 TEST(RocketComputerTypes, GuidanceTelemData_Layout) {
@@ -925,8 +946,9 @@ TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
                             (1u << FlightSettingsData::F_GUIDANCE) |
                             (1u << FlightSettingsData::F_SERVO_ENABLED) |
                             (1u << FlightSettingsData::F_FW_DIRTY) |
-                            (1u << FlightSettingsData::F_SOUNDS));
-    EXPECT_EQ(all, 0x3Fu);  // bits 0-5, no overlap
+                            (1u << FlightSettingsData::F_SOUNDS) |
+                            (1u << FlightSettingsData::F_GUIDANCE_STATION_KEEP));
+    EXPECT_EQ(all, 0x7Fu);  // bits 0-6, no overlap
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_GuidancePN_Stub/TR_GuidancePN.h
+++ b/tinkerrocket-idf/components/TR_GuidancePN_Stub/TR_GuidancePN.h
@@ -32,9 +32,26 @@ class TR_GuidancePN {
 public:
     TR_GuidancePN() = default;
 
+    /// Mirrors the real class's guidance law selection.  MODE_STATION_KEEP is
+    /// declared so #534's flight-computer call sites compile on public builds;
+    /// getMode() below always reports MODE_PN because nothing ever runs.
+    enum Mode : uint8_t { MODE_PN = 0, MODE_STATION_KEEP = 1 };
+
     void configure(float /*nav_gain*/,
                    float /*max_accel_mps2*/,
                    float /*target_alt_m*/) {}
+
+    void configureStationKeep(float /*kp_pos_per_s2*/,
+                              float /*kd_vel_per_s*/,
+                              float /*max_accel_mps2*/) {}
+
+    /// Accepts and discards the Drift-Cast (#435) horizontal aim point.
+    /// Returns true — the real class returns false only for non-finite input,
+    /// and a public build has no guidance to protect.
+    bool setHorizontalTarget(float /*target_e_m*/,
+                             float /*target_n_m*/) { return true; }
+
+    Mode getMode() const { return MODE_PN; }
 
     bool update(const float /*pos_enu*/[3],
                 const float /*vel_ned*/[3],
@@ -47,6 +64,9 @@ public:
     float getClosingVelocity() const { return 0.0f; }
     float getRange()           const { return 0.0f; }
     float getLateralOffset()   const { return 0.0f; }
+    float getTargetEast()      const { return 0.0f; }
+    float getTargetNorth()     const { return 0.0f; }
+    float getTargetOffset()    const { return 0.0f; }
     bool  isActive()           const { return false; }
     bool  isCpaReached()       const { return false; }
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1887,7 +1887,7 @@ static constexpr uint8_t FC_IDENTITY         = 0xEC;
 static constexpr uint8_t ORIENT_CONFIG_PENDING = 0xED;  // OC→FC: payload follows as ORIENT_CONFIG_MSG
 static constexpr uint8_t ORIENT_CONFIG_MSG     = 0xEE;  // 1-byte ImuOrientConfigData
 static constexpr uint8_t GUIDANCE_CONFIG_PENDING = 0xEF;  // OC→FC: payload follows as GUIDANCE_CONFIG_MSG
-static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 36-byte GuidanceConfigData
+static constexpr uint8_t GUIDANCE_CONFIG_MSG     = 0xF0;  // 45-byte GuidanceConfigData
 static constexpr uint8_t FIN_CONFIG_PENDING      = 0xF2;  // OC→FC: payload follows as FIN_CONFIG_MSG
 static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 18-byte FinConfigData
 // IMU logging rate (user setting, BLE cmd 67): the ISM6HG256 ODR the FC
@@ -2027,24 +2027,54 @@ static_assert(sizeof(PIDConfigData) == 20, "PIDConfigData must be 20 bytes");
 static constexpr uint8_t GUIDE_TARGET_OVERHEAD = 0;  // directly over the pad: (0,0,target_alt)
 static constexpr uint8_t GUIDE_TARGET_POINT    = 1;  // configured point: (target_e,target_n,target_alt)
 
-// App-configurable PN guidance.  Floats first so every field is naturally aligned
-// inside the packed struct (no internal padding) -> sizeof == 36.  ENU meters are
-// relative to the launch pad, matching the FC's imu_pos frame (no conversion).
+// Guidance law selector.  Values MIRROR TR_GuidancePN::Mode by value; the two
+// are pinned together by the FC's static_asserts at the configure sites.  The
+// wire type is declared here so the OC/app/tests never include the guidance
+// library (the OC EXCLUDE_COMPONENTS it entirely).
+static constexpr uint8_t GUIDE_LAW_PN           = 0;  // proportional navigation (legacy)
+static constexpr uint8_t GUIDE_LAW_STATION_KEEP = 1;  // overhead PD regulator (#335)
+static constexpr uint8_t GUIDE_LAW_MAX          = 1;  // highest defined law (validation bound)
+
+// App-configurable guidance (PN and station-keep share this frame).
+// ENU metres are relative to the launch pad, matching the FC's imu_pos frame
+// (no conversion).
+//
+// LAYOUT NOTE (#534): the first 36 bytes are FROZEN and the v1 "floats first,
+// naturally aligned" ordering is DELIBERATELY BROKEN past offset 35 — the
+// station-keep fields are APPENDED after the two u8s rather than inserted with
+// the other floats.  Rationale: the FC accepts any frame with
+// cfg_len >= sizeof(GuidanceConfigData) (flight_computer/main.cpp), so an
+// append leaves a 36-byte-era FC reading a 45-byte app frame correctly (it
+// parses the prefix and ignores the tail), whereas inserting floats mid-struct
+// would make it silently MISPARSE every field after the insertion point.
+// Silent misparse of nav_gain/max_accel is a flight-safety hazard; a truncated
+// tail is not.  kp_pos_per_s2/kd_vel_per_s land at offsets 36/40 — both are
+// 4-byte aligned by luck of 36 % 4 == 0, so the packed struct still has no
+// internal padding and sizeof == 45 exactly.
+//
+// Compatibility is ONE-DIRECTIONAL and accepted: a 45-byte-era FC rejects a
+// 36-byte app frame outright (length check) and logs it loudly.  The app must
+// ship in lockstep.
 typedef struct __attribute__((packed))
 {
-    float    nav_gain;          // PN navigation constant N (3-5)
-    float    max_accel_mps2;    // lateral accel command clamp (m/s^2)
-    float    accel_to_fin_deg;  // accel (m/s^2) -> fin (deg) scale
+    float    nav_gain;          // MODE_PN: navigation constant N (3-5)
+    float    max_accel_mps2;    // lateral accel command clamp (m/s^2), BOTH laws
+    float    accel_to_fin_deg;  // accel (m/s^2) -> fin (deg) scale (FC-side, both laws)
     float    max_fin_deg;       // per-fin deflection clamp in guided mode (deg)
     float    min_speed_mps;     // airspeed gate below which guidance is inactive
     float    target_e_m;        // POINT: East rel. pad (m); OVERHEAD: ignored (0)
     float    target_n_m;        // POINT: North rel. pad (m); OVERHEAD: ignored (0)
-    float    target_alt_m;      // target altitude above pad (m), both modes
-    uint16_t coast_delay_ms;    // delay after burnout before guidance engages (ms)
+    float    target_alt_m;      // MODE_PN: target altitude above pad (m)
+    uint16_t coast_delay_ms;    // delay after burnout before guidance engages (ms; inert)
     uint8_t  enable;            // 0/1 runtime guidance master enable
     uint8_t  target_mode;       // GUIDE_TARGET_OVERHEAD / _POINT
+    // --- appended #534 (v2 of this frame) ---
+    float    kp_pos_per_s2;     // MODE_STATION_KEEP: position gain (1/s^2)
+    float    kd_vel_per_s;      // MODE_STATION_KEEP: velocity gain (1/s)
+    uint8_t  guidance_law;      // GUIDE_LAW_PN / GUIDE_LAW_STATION_KEEP
+                                //   (mirrors TR_GuidancePN::Mode by value)
 } GuidanceConfigData;
-static_assert(sizeof(GuidanceConfigData) == 36, "GuidanceConfigData must be 36 bytes");
+static_assert(sizeof(GuidanceConfigData) == 45, "GuidanceConfigData must be 45 bytes");
 
 // App-configurable fin→servo mix.  azimuth_deg[i] is the CONTROL azimuth of the fin
 // driven by servo i:
@@ -2156,6 +2186,10 @@ struct __attribute__((packed)) FlightSettingsData
     //     (Pre-v4 firmware stepped to the NEXT waypoint's angle and honored
     //     per-waypoint null_rate modes — analysis must branch on this.)
     // v5: appended ism6_update_rate_hz (user-configurable IMU logging rate).
+    // (no version bump for #534: F_GUIDANCE_STATION_KEEP claims a previously
+    //  free flags bit, bit 6.  Layout is byte-identical, so VERSION stays 5 —
+    //  bumping it would force a sweep of the Data_Analysis parsers, which
+    //  hardcode message lengths, for a bit that older readers already ignore.)
     static constexpr uint8_t VERSION = 5;
 
     // flags bit positions
@@ -2165,6 +2199,8 @@ struct __attribute__((packed)) FlightSettingsData
     static constexpr uint8_t F_SERVO_ENABLED     = 3;  // servo/roll control enabled at all
     static constexpr uint8_t F_FW_DIRTY          = 4;  // build had uncommitted changes
     static constexpr uint8_t F_SOUNDS            = 5;  // piezo sounds enabled
+    static constexpr uint8_t F_GUIDANCE_STATION_KEEP = 6;  // guidance law: 1 = station-keep, 0 = PN
+                                                           // (meaningful only when F_GUIDANCE set)
 
     uint32_t time_us;            // micros() at snapshot
     uint8_t  version;            // = VERSION

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -352,6 +352,50 @@ struct config : board_pins
     static constexpr float   PN_TARGET_E_M  = 0.0f;
     static constexpr float   PN_TARGET_N_M  = 0.0f;
 
+    // --- Guidance law selection (#534) ---------------------------------
+    // Which law the FC configures at boot.  GUIDE_LAW_PN (0) preserves every
+    // flight flown to date; GUIDE_LAW_STATION_KEEP (1) is the PD regulator
+    // from #335 (no 1/range singularity, degrades gracefully).  Overridden at
+    // runtime by NVS "glw" and by the app's GuidanceConfigData push, so this
+    // is only the factory default.  FLIPPING THIS TO 1 IS A ONE-LINE CHANGE
+    // AND IS DELIBERATELY DEFERRED to #534's acceptance sim A/B — do not flip
+    // it until the sim run says station-keep beats PN on this airframe.
+    static constexpr uint8_t GUIDANCE_LAW_DEFAULT = 0;  // GUIDE_LAW_PN
+
+    // Station-keep PD gains: a_lat = -kp*offset - kd*vel (ENU horizontal).
+    // Seeded from the 6-DOF sim's guidance scenario, NOT from the library
+    // constructor (which is 0.5 / 1.5) and NOT from the closed_loop_sim
+    // dataclass defaults (0.5 / 1.0) — the scenario is the only one of the
+    // three that has actually been flown in the sim:
+    //   tinkerrocket-sim/src/tinkerrocket_sim/simulation/scenarios.py:164-165
+    //     pn_kp_pos=0.8, pn_kd_vel=1.5
+    // Damping check at these values: wn = sqrt(kp) = 0.89 rad/s,
+    // zeta = kd / (2*sqrt(kp)) = 0.84 — slightly under critical, ~7 s natural
+    // period, which is long compared to a ~15 s coast.  PROVISIONAL: final
+    // gains are pending the #534 acceptance sim A/B (PN vs station-keep on the
+    // same scenario); keep these in lockstep with scenarios.py and with
+    // RocketProfile.swift's pnKpPos/pnKdVel defaults.
+    static constexpr float PN_KP_POS_PER_S2 = 0.8f;
+    static constexpr float PN_KD_VEL_PER_S  = 1.5f;
+
+    // Max horizontal aim-point radius from the pad (m), station-keep only.
+    // The FC owns magnitude policy — TR_GuidancePN.h explicitly refuses to
+    // range-limit the aim point because a silent library clamp would make the
+    // FLOWN target disagree with the uploaded and logged one.
+    //
+    // Why 100 m: the PD term alone saturates long before that.  At
+    // kp = 0.8 /s^2 an offset of 25 m commands 0.8*25 = 20 m/s^2, i.e. the
+    // ENTIRE PN_MAX_ACCEL_MPS2 budget, and this airframe cannot deliver even
+    // that — the 67 mm fin tabs give near-negligible pitch/yaw authority on a
+    // G80 (surface size is the lever, not stability margin).  Past ~25 m the
+    // law is a saturated open-loop lean, so the limit is not a control bound
+    // but a SANITY bound: 4x the saturation radius leaves ample room for a
+    // real Drift-Cast (#435) wind offset (a ~600 m apogee flight drifts tens
+    // of metres) while making a unit error, a garbage float, or a latitude
+    // accidentally sent as metres impossible to fly.
+    // REJECT, never clamp — see the handler.
+    static constexpr float GUIDANCE_MAX_AIM_RADIUS_M = 100.0f;
+
     // ### Burnout Detection ###
     // Consecutive samples of negative body-X accel required to latch
     // burnout_detected. The IMU runs at ~1 kHz so 50 samples ≈ 50 ms of

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -374,8 +374,9 @@ static TR_ControlMixer control_mixer;
 static TR_PID roll_rate_pid_standalone(config::KP, config::KI, config::KD,
                                        config::MAX_CMD, config::MIN_CMD);
 static bool guidance_enabled = config::GUIDANCE_ENABLED;
-// Runtime-tunable PN guidance params (seeded from config::, overridden by NVS / the
-// app's GuidanceConfigData push). Phase 1 uses OVERHEAD (target_e/n forced 0).
+// Runtime-tunable guidance params (seeded from config::, overridden by NVS /
+// the app's GuidanceConfigData push).  pn_target_e/n are the station-keep aim
+// point; MODE_PN ignores them by library contract.
 static float    pn_nav_gain       = config::PN_NAV_GAIN;
 static float    pn_max_accel      = config::PN_MAX_ACCEL_MPS2;
 static float    pn_accel_to_fin   = config::PN_ACCEL_TO_FIN_DEG;
@@ -386,6 +387,9 @@ static uint8_t  pn_target_mode    = config::PN_TARGET_MODE;
 static float    pn_target_e       = config::PN_TARGET_E_M;
 static float    pn_target_n       = config::PN_TARGET_N_M;
 static float    pn_target_alt     = config::PN_TARGET_ALT_M;
+static float    pn_kp_pos         = config::PN_KP_POS_PER_S2;
+static float    pn_kd_vel         = config::PN_KD_VEL_PER_S;
+static uint8_t  pn_guidance_law   = config::GUIDANCE_LAW_DEFAULT;  // GUIDE_LAW_*
 // Last commanded pre-mix fin deflections from guidance, carried from the
 // guidance compute block to the ~10 Hz GuidanceTelemData emit. Only meaningful
 // while guidance_active (the only condition under which they are logged).
@@ -1562,6 +1566,41 @@ static void handleOrientationEstimate(const float up_rocket[3])
     }
 }
 
+// Push the guidance law, its gains and the horizontal aim point into the
+// guidance object.  ORDER IS LOAD-BEARING: configure()/configureStationKeep()
+// set mode_, and TR_GuidancePN consumes the aim point in MODE_STATION_KEEP
+// ONLY — setting the aim point before the law would leave it inert on a
+// PN->station-keep switch.  Law first, aim point second, always.
+static void applyGuidanceConfig()
+{
+    static_assert((uint8_t)TR_GuidancePN::MODE_PN           == GUIDE_LAW_PN,
+                  "GUIDE_LAW_PN must mirror TR_GuidancePN::MODE_PN");
+    static_assert((uint8_t)TR_GuidancePN::MODE_STATION_KEEP == GUIDE_LAW_STATION_KEEP,
+                  "GUIDE_LAW_STATION_KEEP must mirror TR_GuidancePN::MODE_STATION_KEEP");
+
+    if (pn_guidance_law == GUIDE_LAW_STATION_KEEP) {
+        guidance.configureStationKeep(pn_kp_pos, pn_kd_vel, pn_max_accel);
+    } else {
+        // OVERHEAD PN: target = (0,0,pn_target_alt); the 3-arg form pins
+        // horizontal at (0,0) and ignores the aim point set below.
+        guidance.configure(pn_nav_gain, pn_max_accel, pn_target_alt);
+    }
+
+    // Belt-and-braces magnitude gate.  The wire handler already rejects an
+    // over-radius aim point, so the only way to arrive here out of range is a
+    // corrupt / stale NVS record; fail SAFE to the pad rather than fly it.
+    const float r = sqrtf(pn_target_e * pn_target_e + pn_target_n * pn_target_n);
+    if (!std::isfinite(r) || r > config::GUIDANCE_MAX_AIM_RADIUS_M) {
+        ESP_LOGW(TAG, "[GUID CFG] stored aim point (%.1f,%.1f) r=%.1f m exceeds %.0f m "
+                      "limit — forcing (0,0) overhead",
+                      (double)pn_target_e, (double)pn_target_n, (double)r,
+                      (double)config::GUIDANCE_MAX_AIM_RADIUS_M);
+        pn_target_e = 0.0f;
+        pn_target_n = 0.0f;
+    }
+    guidance.setHorizontalTarget(pn_target_e, pn_target_n);   // inert in MODE_PN
+}
+
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
 // the live PID gains from servo_control (these can be NVS- or BLE-overridden),
 // the runtime override globals, the config:: defaults for the compile-time-only
@@ -1580,6 +1619,8 @@ static void buildFlightSettings(FlightSettingsData& s)
     if (servo_enabled)      flags |= (uint8_t)(1u << FlightSettingsData::F_SERVO_ENABLED);
     if (FW_GIT_DIRTY)       flags |= (uint8_t)(1u << FlightSettingsData::F_FW_DIRTY);
     if (enable_sounds)      flags |= (uint8_t)(1u << FlightSettingsData::F_SOUNDS);
+    if (pn_guidance_law == GUIDE_LAW_STATION_KEEP)
+                            flags |= (uint8_t)(1u << FlightSettingsData::F_GUIDANCE_STATION_KEEP);
     s.flags = flags;
     s.roll_delay_ms = roll_delay_ms;
 
@@ -2510,6 +2551,14 @@ static void setup_fc()
     pn_target_e       = prefs.getFloat("gte", config::PN_TARGET_E_M);
     pn_target_n       = prefs.getFloat("gtn", config::PN_TARGET_N_M);
     pn_target_alt     = prefs.getFloat("gta", config::PN_TARGET_ALT_M);
+    pn_kp_pos       = prefs.getFloat("gkp", config::PN_KP_POS_PER_S2);
+    pn_kd_vel       = prefs.getFloat("gkd", config::PN_KD_VEL_PER_S);
+    pn_guidance_law = prefs.getUChar("glw", config::GUIDANCE_LAW_DEFAULT);
+    if (pn_guidance_law > GUIDE_LAW_MAX) {          // corrupt/forward NVS record
+        ESP_LOGW(TAG, "[GUID CFG] stored law %u unknown — falling back to PN",
+                      (unsigned)pn_guidance_law);
+        pn_guidance_law = GUIDE_LAW_PN;
+    }
     // Fin→servo layout (servo azimuth + reverse), shared by every mix site.
     float fin_az[4] = {
         prefs.getFloat("fa0", config::FIN_AZIMUTH_0_DEG),
@@ -2528,14 +2577,23 @@ static void setup_fc()
                   use_angle_control ? "ON" : "OFF", (unsigned)roll_delay_ms,
                   (double)kp_angle_rate_cap_dps);
 #if TR_GUIDANCE_AVAILABLE
-    ESP_LOGI(TAG, "PN Guidance: %s (compiled in)", guidance_enabled ? "ON" : "OFF");
+    ESP_LOGI(TAG, "Guidance: %s  law=%s (compiled in)",
+                  guidance_enabled ? "ON" : "OFF",
+                  pn_guidance_law == GUIDE_LAW_STATION_KEEP ? "STATION_KEEP" : "PN");
+    if (pn_guidance_law == GUIDE_LAW_STATION_KEEP) {
+        ESP_LOGI(TAG, "  station-keep: kp=%.2f /s^2 kd=%.2f /s maxA=%.0f m/s^2 aim=(%.1f,%.1f) m",
+                      (double)pn_kp_pos, (double)pn_kd_vel, (double)pn_max_accel,
+                      (double)pn_target_e, (double)pn_target_n);
+    } else {
+        ESP_LOGI(TAG, "  PN: N=%.1f maxA=%.0f m/s^2 alt=%.0f m (aim point ignored by this law)",
+                      (double)pn_nav_gain, (double)pn_max_accel, (double)pn_target_alt);
+    }
 #else
-    ESP_LOGW(TAG, "PN Guidance: NOT COMPILED IN (TR_GuidancePN submodule not initialized — stub active)");
+    ESP_LOGW(TAG, "Guidance: NOT COMPILED IN (TR_GuidancePN submodule not initialized — stub active)");
 #endif
 
-    // Configure guidance and control mixer
-    // OVERHEAD: target = (0,0,pn_target_alt); the 3-arg form keeps horizontal at (0,0).
-    guidance.configure(pn_nav_gain, pn_max_accel, pn_target_alt);
+    // Configure guidance and control mixer (law + gains + aim point).
+    applyGuidanceConfig();
     control_mixer.configure(config::PN_PITCH_KP, config::PN_PITCH_KI, config::PN_PITCH_KD,
                             config::PN_YAW_KP,   config::PN_YAW_KI,   config::PN_YAW_KD,
                             config::PN_MAX_FIN_DEG,
@@ -5435,16 +5493,65 @@ static void loop_fc()
                     if (g.min_speed_mps   >= 0.0f && g.min_speed_mps   <= 200.0f)  pn_min_speed    = g.min_speed_mps;
                     if (g.target_alt_m     > 0.0f)                                 pn_target_alt   = g.target_alt_m;
                     pn_coast_delay_ms = g.coast_delay_ms;
-                    pn_target_mode    = g.target_mode;
-                    // OVERHEAD forces horizontal (0,0) so a stale POINT push can't pollute it.
-                    pn_target_e = (g.target_mode == GUIDE_TARGET_POINT) ? g.target_e_m : 0.0f;
-                    pn_target_n = (g.target_mode == GUIDE_TARGET_POINT) ? g.target_n_m : 0.0f;
-                    // Phase 1: OVERHEAD via the 3-arg form (horizontal stays 0,0).
-                    guidance.configure(pn_nav_gain, pn_max_accel, pn_target_alt);
-                    ESP_LOGI(TAG, "[GUID CFG] en=%s N=%.1f maxA=%.0f a2f=%.1f maxFin=%.0f minV=%.0f mode=%u alt=%.0f",
-                                  guidance_enabled ? "ON" : "OFF", (double)pn_nav_gain,
-                                  (double)pn_max_accel, (double)pn_accel_to_fin, (double)pn_max_fin_deg,
-                                  (double)pn_min_speed, (unsigned)pn_target_mode, (double)pn_target_alt);
+                    // Station-keep PD gains (#534).  Same convention as above:
+                    // positive/sane overrides, out-of-range keeps the prior value.
+                    // Upper bounds are saturation bounds, not stability bounds —
+                    // at kp = 10 /s^2 a 2 m offset already commands the whole
+                    // 20 m/s^2 accel budget, and kd = 10 /s is zeta ~ 5.6 at the
+                    // default kp (hopelessly overdamped).  Anything past these is
+                    // a typo, not a tune.  kd == 0 is REJECTED on purpose: an
+                    // undamped PD regulator oscillates.
+                    if (g.kp_pos_per_s2 > 0.0f && g.kp_pos_per_s2 <= 10.0f) pn_kp_pos = g.kp_pos_per_s2;
+                    else ESP_LOGW(TAG, "[GUID CFG] kp %.3f out of (0,10] — keeping %.3f",
+                                       (double)g.kp_pos_per_s2, (double)pn_kp_pos);
+                    if (g.kd_vel_per_s  > 0.0f && g.kd_vel_per_s  <= 10.0f) pn_kd_vel = g.kd_vel_per_s;
+                    else ESP_LOGW(TAG, "[GUID CFG] kd %.3f out of (0,10] — keeping %.3f",
+                                       (double)g.kd_vel_per_s, (double)pn_kd_vel);
+                    // Law: an UNKNOWN value must never select an undefined law.
+                    // Whitelist, keep the previous law on anything else.
+                    if (g.guidance_law <= GUIDE_LAW_MAX) pn_guidance_law = g.guidance_law;
+                    else ESP_LOGW(TAG, "[GUID CFG] law %u unknown — keeping %u",
+                                       (unsigned)g.guidance_law, (unsigned)pn_guidance_law);
+                    // Target mode is now branched on, so whitelist it too
+                    // (previously stored raw).
+                    if (g.target_mode == GUIDE_TARGET_OVERHEAD ||
+                        g.target_mode == GUIDE_TARGET_POINT)   pn_target_mode = g.target_mode;
+                    else ESP_LOGW(TAG, "[GUID CFG] target_mode %u unknown — keeping %u",
+                                       (unsigned)g.target_mode, (unsigned)pn_target_mode);
+                    // Aim point.  The FC — not the library — owns magnitude
+                    // policy (TR_GuidancePN.h).  REJECT and keep the previous
+                    // point; do NOT clamp, so the flown aim point always equals
+                    // the uploaded and logged one.
+                    if (pn_target_mode == GUIDE_TARGET_POINT) {
+                        const float r = sqrtf(g.target_e_m * g.target_e_m +
+                                              g.target_n_m * g.target_n_m);
+                        if (std::isfinite(r) && r <= config::GUIDANCE_MAX_AIM_RADIUS_M) {
+                            pn_target_e = g.target_e_m;
+                            pn_target_n = g.target_n_m;
+                        } else {
+                            ESP_LOGW(TAG, "[GUID CFG] aim point (%.1f,%.1f) r=%.1f m REJECTED "
+                                          "(limit %.0f m) — keeping (%.1f,%.1f)",
+                                          (double)g.target_e_m, (double)g.target_n_m, (double)r,
+                                          (double)config::GUIDANCE_MAX_AIM_RADIUS_M,
+                                          (double)pn_target_e, (double)pn_target_n);
+                        }
+                    } else {
+                        // OVERHEAD forces horizontal (0,0) so a stale POINT push
+                        // can't pollute it.
+                        pn_target_e = 0.0f;
+                        pn_target_n = 0.0f;
+                    }
+                    // Law first, aim point second — see applyGuidanceConfig().
+                    applyGuidanceConfig();
+                    ESP_LOGI(TAG, "[GUID CFG] en=%s law=%s N=%.1f maxA=%.0f a2f=%.1f maxFin=%.0f "
+                                  "minV=%.0f mode=%u alt=%.0f kp=%.2f kd=%.2f aim=(%.1f,%.1f)",
+                                  guidance_enabled ? "ON" : "OFF",
+                                  pn_guidance_law == GUIDE_LAW_STATION_KEEP ? "STATION_KEEP" : "PN",
+                                  (double)pn_nav_gain, (double)pn_max_accel, (double)pn_accel_to_fin,
+                                  (double)pn_max_fin_deg, (double)pn_min_speed,
+                                  (unsigned)pn_target_mode, (double)pn_target_alt,
+                                  (double)pn_kp_pos, (double)pn_kd_vel,
+                                  (double)pn_target_e, (double)pn_target_n);
                     prefs.begin("servo", false);
                     prefs.putBool("guid_en", guidance_enabled);
                     prefs.putFloat("gng", pn_nav_gain);
@@ -5457,12 +5564,23 @@ static void loop_fc()
                     prefs.putFloat("gte", pn_target_e);
                     prefs.putFloat("gtn", pn_target_n);
                     prefs.putFloat("gta", pn_target_alt);
+                    prefs.putFloat("gkp", pn_kp_pos);
+                    prefs.putFloat("gkd", pn_kd_vel);
+                    prefs.putUChar("glw", pn_guidance_law);
                     prefs.end();
                     ESP_LOGI(TAG, "[GUID CFG] Saved to NVS");
                 }
                 else
                 {
-                    ESP_LOGW(TAG, "[GUID CFG] readConfigFrame failed");
+                    // #534: this is now ALSO the "app is older than the
+                    // firmware" path — a 36-byte-era app frame fails the
+                    // cfg_len >= sizeof(GuidanceConfigData) gate.  Echo the
+                    // lengths so a version skew is diagnosable from the log
+                    // instead of looking like an I2C fault.
+                    ESP_LOGW(TAG, "[GUID CFG] readConfigFrame FAILED — got %u bytes, need %u. "
+                                  "If the FC is healthy this is an OUT-OF-DATE APP: guidance "
+                                  "config was NOT applied and the previous config still flies.",
+                                  (unsigned)cfg_len, (unsigned)sizeof(GuidanceConfigData));
                 }
             }
             else if (out_pending_command == FIN_CONFIG_PENDING)

--- a/tinkerrocket-sim/cpp/guidance/guidance_bindings.cpp
+++ b/tinkerrocket-sim/cpp/guidance/guidance_bindings.cpp
@@ -33,5 +33,14 @@ PYBIND11_MODULE(_guidance, m) {
         .def("get_lateral_offset", &TR_GuidancePN::getLateralOffset)
         .def("is_active", &TR_GuidancePN::isActive)
         .def("is_cpa_reached", &TR_GuidancePN::isCpaReached)
+        // #435 Drift-Cast horizontal aim point.  A separate named setter, not
+        // extra args on configure_station_keep: C++ default arguments are
+        // invisible through &TR_GuidancePN::configureStationKeep, so widening
+        // that arity would break the py::arg annotations above at COMPILE time.
+        .def("set_horizontal_target", &TR_GuidancePN::setHorizontalTarget,
+             py::arg("target_e_m"), py::arg("target_n_m"))
+        .def("get_target_east", &TR_GuidancePN::getTargetEast)
+        .def("get_target_north", &TR_GuidancePN::getTargetNorth)
+        .def("get_target_offset", &TR_GuidancePN::getTargetOffset)
         .def("reset", &TR_GuidancePN::reset);
 }

--- a/tinkerrocket-sim/scripts/ab534_pn_vs_station_keep.py
+++ b/tinkerrocket-sim/scripts/ab534_pn_vs_station_keep.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""#534 acceptance study: PN vs station-keep A/B on the canonical guided
+scenario (scenario (a), RollyPolly III / G80T).
+
+Regenerates the full 144-run matrix deterministically (every run is seeded;
+no other RNG) and emits one JSON object per run as JSONL:
+
+    python3 scripts/ab534_pn_vs_station_keep.py            # full matrix -> stdout
+    python3 scripts/ab534_pn_vs_station_keep.py --legs core gains  # subset
+
+Results and conclusions: docs/plans/534-station-keep-sim-ab.md (repo root).
+
+Matrix legs (case_id prefixes):
+  core  ab_*        2 laws + unguided x 5 seeds x {calm, wind4, wind8, gust}
+  gains gain_*      station-keep kp x kd 3x3 grid, calm + wind8, seed 7
+  sing  sing_*      PN target_alt BELOW apogee (reachable -> CPA) vs SK, same cfg
+  ang   ang_*       80/88 deg launch angle, both laws
+  hdg   hdg*_*      EKF heading bias 10-90 deg (the known real-vehicle defect)
+  gnss  gnssdeny_*  GNSS updates disabled in flight (EKF coasts on IMU)
+  lotto lotto_*     gust latch lottery: 20 seeds, both laws, count tilt latches
+
+Metric notes (learned the hard way; see the report):
+  - final_horiz_offset_m from metrics.summarize_guidance is the offset at the
+    LAST GUIDED row.  For tilt-latched runs that is the offset at latch time,
+    not apogee.  Use eff_drift (below) for apogee drift.
+  - max_tilt_coast_deg covers the whole post-burnout window INCLUDING after the
+    benign speed-gate quit near apogee, so values above the 20 deg coast latch
+    can coexist with deactivation_cause == speed_gate (the latch only samples
+    while guidance is active, on the EKF quaternion).
+  - wind8 is a null condition: 8 m/s weathercocks past the coast tilt latch at
+    guidance activation for BOTH laws; all wind8 rows fly the same ballistic
+    arc and carry no law or gain information.
+"""
+import argparse
+import dataclasses
+import json
+import sys
+import os
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from tinkerrocket_sim.simulation.closed_loop_sim import run_closed_loop
+from tinkerrocket_sim.simulation import scenarios as S
+from tinkerrocket_sim.simulation import metrics as M
+
+FIN_LIMIT = 20.0  # pn_max_fin_deg in the canonical config
+
+CONDS = {
+    "calm":  {},
+    "wind4": {"wind_speed": 4.0, "wind_direction_deg": 270.0},
+    "wind8": {"wind_speed": 8.0, "wind_direction_deg": 45.0},
+    "gust":  {"wind_speed": 4.0, "wind_direction_deg": 270.0, "gust_w20_mps": 6.0},
+}
+SEEDS = [7, 11, 23, 42, 101]
+
+
+def build_matrix(legs):
+    cases = []
+    if "core" in legs:
+        for law in ("pn", "station_keep", "unguided"):
+            for seed in SEEDS:
+                for cname, cond in CONDS.items():
+                    cases.append({"case_id": f"ab_{law}_{cname}_s{seed}", "law": law,
+                                  "sensor_seed": seed, **cond})
+    if "gains" in legs:
+        for kp in (0.4, 0.8, 1.6):
+            for kd in (0.75, 1.5, 3.0):
+                for cname in ("calm", "wind8"):
+                    cases.append({"case_id": f"gain_kp{kp}_kd{kd}_{cname}",
+                                  "law": "station_keep", "sensor_seed": 7,
+                                  "pn_kp_pos": kp, "pn_kd_vel": kd, **CONDS[cname]})
+    if "sing" in legs:
+        for alt in (200.0, 300.0):
+            for law in ("pn", "station_keep"):
+                cases.append({"case_id": f"sing_{law}_alt{int(alt)}", "law": law,
+                              "sensor_seed": 7, "pn_target_alt_m": alt})
+    if "ang" in legs:
+        for ang in (80.0, 88.0):
+            for law in ("pn", "station_keep"):
+                cases.append({"case_id": f"ang_{law}_{int(ang)}", "law": law,
+                              "sensor_seed": 7, "launch_angle_deg": ang})
+    if "hdg" in legs:
+        for bias in (10.0, 20.0, 45.0, 90.0):
+            for law in ("pn", "station_keep"):
+                cases.append({"case_id": f"hdg_{law}_b{int(bias)}", "law": law,
+                              "sensor_seed": 7, "inject_heading_bias_deg": bias})
+        for bias in (20.0, 45.0):
+            for law in ("pn", "station_keep"):
+                cases.append({"case_id": f"hdgw_{law}_b{int(bias)}", "law": law,
+                              "sensor_seed": 7, "inject_heading_bias_deg": bias,
+                              **CONDS["wind4"]})
+    if "gnss" in legs:
+        for law in ("pn", "station_keep", "unguided"):
+            for seed in (7, 42):
+                cases.append({"case_id": f"gnssdeny_{law}_s{seed}", "law": law,
+                              "sensor_seed": seed, "enable_gnss_updates": False})
+    if "lotto" in legs:
+        for seed in range(201, 221):
+            for law in ("pn", "station_keep"):
+                cases.append({"case_id": f"lotto_{law}_s{seed}", "law": law,
+                              "sensor_seed": seed, **CONDS["gust"]})
+    return cases
+
+
+def eff_drift(row):
+    """Apogee drift: final guided offset when guidance ran to (near) apogee,
+    max offset when latched early or unguided (ballistic growth is monotone)."""
+    f = row["final_horiz_offset_m"]
+    if row["guided_frac"] > 0.1 and f == f:
+        return f
+    return row["max_horiz_offset_m"]
+
+
+def run_case(case):
+    cfg = S.guidance_coast_config()
+    law = case.get("law", "pn")
+    over = {k: v for k, v in case.items() if k not in ("law", "case_id")}
+    if law == "unguided":
+        over["guidance_enabled"] = False
+    else:
+        over["guidance_mode"] = law
+    cfg = dataclasses.replace(cfg, **over)
+
+    t0 = time.time()
+    df = run_closed_loop(S.build_rollypolly_iii(), cfg).df
+    wall = time.time() - t0
+
+    apogee_idx = int(df["altitude"].idxmax())
+    df = df.iloc[: apogee_idx + 1].reset_index(drop=True)
+
+    out = dict(case)
+    out["wall_s"] = round(wall, 1)
+    out["apogee_m"] = float(df["altitude"].max())
+    out["apogee_time_s"] = float(df["time"].iloc[-1])
+    out.update(M.summarize_guidance(df))
+
+    guided = (df[df.get("guidance_active", False) == True]
+              if "guidance_active" in df else df.iloc[0:0])
+    out["guided_frac"] = float(len(guided) / len(df)) if len(df) else 0.0
+    out["max_los_angle_deg"] = (
+        float(guided["pn_los_angle"].abs().max())
+        if len(guided) and "pn_los_angle" in guided else float("nan"))
+
+    # Deactivation cause from the LAST guided row:
+    #   pn_v_cl <= 0          -> CPA latch (PN's sticky singularity-path quit)
+    #   speed <= min gate     -> speed gate (benign, expected near apogee)
+    #   else                  -> tilt latch
+    cause = "never_active"
+    cpa_time = float("nan")
+    if len(guided):
+        last = guided.iloc[-1]
+        last_idx = guided.index[-1]
+        min_speed = case.get("pn_min_speed_mps", 10.0)
+        if last_idx >= len(df) - 2:
+            cause = "none"
+        elif "pn_v_cl" in guided and float(last["pn_v_cl"]) <= 0.0:
+            cause = "cpa"
+            cpa_time = float(last["time"])
+        elif float(last["speed"]) <= min_speed + 0.5:
+            cause = "speed_gate"
+        else:
+            cause = "tilt_latch"
+    out["deactivation_cause"] = cause
+    out["cpa_reached"] = cause == "cpa"
+    out["cpa_time_s"] = cpa_time
+
+    # Tilt from the TRUTH quaternion (same nose_up formula as the sim's latch;
+    # never the Euler triple).  Covers the whole window incl. post-quit.
+    if "true_q0_ned" in df:
+        q0 = df["true_q0_ned"].to_numpy(); q1 = df["true_q1_ned"].to_numpy()
+        q2 = df["true_q2_ned"].to_numpy(); q3 = df["true_q3_ned"].to_numpy()
+        nose_up = np.clip(-2.0 * (q1 * q3 - q0 * q2), -1.0, 1.0)
+        tilt = np.degrees(np.arccos(nose_up))
+        out["max_tilt_deg"] = float(tilt.max())
+        if "burnout_detected" in df and df["burnout_detected"].any():
+            out["max_tilt_coast_deg"] = float(
+                tilt[df["burnout_detected"].to_numpy(bool)].max())
+        else:
+            out["max_tilt_coast_deg"] = float("nan")
+    else:
+        out["max_tilt_deg"] = float("nan")
+        out["max_tilt_coast_deg"] = float("nan")
+
+    fin_cols = [c for c in ("fin1_cmd", "fin2_cmd", "fin3_cmd", "fin4_cmd")
+                if c in df.columns]
+    if fin_cols and len(guided):
+        fins = guided[fin_cols].to_numpy()
+        pinned = (np.abs(fins) >= FIN_LIMIT - 1e-3).any(axis=1)
+        out["fin_saturation_pct"] = float(100.0 * pinned.mean())
+        out["peak_fin_deg"] = float(np.abs(fins).max())
+    else:
+        out["fin_saturation_pct"] = float("nan")
+        out["peak_fin_deg"] = float("nan")
+
+    # Singularity blow-up probe: max |a_cmd| over the last 1.5 s guided.
+    acc_cols = [c for c in ("pn_a_e", "pn_a_n", "pn_a_u") if c in df.columns]
+    if acc_cols and len(guided):
+        t_last = float(guided["time"].iloc[-1])
+        late = guided[guided["time"] > t_last - 1.5]
+        out["late_max_accel_mps2"] = (
+            float(np.linalg.norm(late[acc_cols].to_numpy(), axis=1).max())
+            if len(late) else float("nan"))
+    else:
+        out["late_max_accel_mps2"] = float("nan")
+
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--legs", nargs="+",
+                    default=["core", "gains", "sing", "ang", "hdg", "gnss", "lotto"],
+                    choices=["core", "gains", "sing", "ang", "hdg", "gnss", "lotto"])
+    args = ap.parse_args()
+    for case in build_matrix(args.legs):
+        try:
+            print(json.dumps(run_case(case)), flush=True)
+        except Exception as e:
+            print(json.dumps({**case, "error": repr(e)}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tinkerrocket-sim/tests/test_scenarios.py
+++ b/tinkerrocket-sim/tests/test_scenarios.py
@@ -115,3 +115,46 @@ def test_scenario_a_guidance_cpa_improvement():
     final_g = float(np.hypot(df_g['x'].iloc[-1], df_g['y'].iloc[-1]))
     final_u = float(np.hypot(df_u['x'].iloc[-1], df_u['y'].iloc[-1]))
     assert final_g < 0.6 * final_u
+
+
+# --- (a2) station-keep A/B: #534 acceptance pin -------------------------------
+
+def test_scenario_a2_station_keep_beats_pn_no_cpa():
+    """#534 acceptance: station-keep <= PN drift on the canonical guided
+    scenario, with no CPA (singularity-path) quit.  Invariants, not constants:
+    the full 144-run study lives in docs/plans/534-station-keep-sim-ab.md and
+    scripts/ab534_pn_vs_station_keep.py regenerates it."""
+    pytest.importorskip(
+        "tinkerrocket_sim._guidance",
+        reason="TR_GuidancePN submodule not initialized — _guidance extension "
+               "not built. Enable: git submodule update --init "
+               "tinkerrocket-idf/components/TR_GuidancePN",
+    )
+    cfg = S.guidance_coast_config()
+    df_pn = _run_to_apogee(cfg)
+    df_sk = _run_to_apogee(dataclasses.replace(cfg, guidance_mode='station_keep'))
+
+    assert 300.0 < df_sk['altitude'].max() < 420.0
+
+    # Both laws guided for the bulk of coast (neither latched out).
+    assert (df_sk['guidance_active'] == True).mean() > 0.5
+    assert (df_pn['guidance_active'] == True).mean() > 0.5
+
+    # Station-keep must not do worse than PN on apogee drift (the #534
+    # criterion), and must in fact materially beat it on this scenario
+    # (study: 3.0 m median vs 13.8 m over 5 seeds; margin below is generous).
+    final_sk = float(np.hypot(df_sk['x'].iloc[-1], df_sk['y'].iloc[-1]))
+    final_pn = float(np.hypot(df_pn['x'].iloc[-1], df_pn['y'].iloc[-1]))
+    assert final_sk <= final_pn
+    assert final_sk < 0.6 * final_pn
+
+    # No singularity behavior: station-keep never rides the closing-velocity
+    # CPA path (the library hard-codes cpa_reached_ False in this law), so its
+    # guided window must run to the low-speed gate near apogee, and its late
+    # accel commands stay far from the 20 m/s^2 clamp that a 1/range blow-up
+    # pins (study: PN with a reachable target pins 20.0; SK shows ~2.7).
+    guided_sk = df_sk[df_sk['guidance_active'] == True]
+    late = guided_sk[guided_sk['time'] > guided_sk['time'].iloc[-1] - 1.5]
+    late_a = np.hypot(late['pn_a_e'], late['pn_a_n']).max()
+    assert late_a < 10.0
+    assert float(guided_sk['speed'].iloc[-1]) < 12.0  # exited via the speed gate


### PR DESCRIPTION
Wires the station-keep guidance law into the flight computer end-to-end and validates it with a 144-run sim A/B. Also lands the library-side horizontal aim point that #435 (Drift-Cast) was blocked on — the wire fields `target_e_m`/`target_n_m` existed for some time but dead-ended before reaching the guidance object, because neither law had an aim-point API.

Closes #534.

## The three commits

**1. Library + stub + bindings + tests (`facb578`, submodule pin → [TR_GuidancePN #2](https://github.com/Tinkerbug-Robotics/TR_GuidancePN/pull/2))**
- `setHorizontalTarget(e, n)` in TR_GuidancePN, consumed by `MODE_STATION_KEEP` **only** — pointing PN at a reachable target makes its CPA latch the nominal exit (see the singularity probe below). Aim point survives `reset()`; NaN rejected (it passes the accel clamp otherwise); no library-side magnitude limit — that policy belongs to the FC.
- `getLateralOffset()` frozen pad-relative (it is the logged `lateral_offset_cm`); new `getTargetOffset()` carries the tracking error. `getLosAngleDeg()`'s fork on the aim point is documented — log the aim point alongside it before flying a non-zero target.
- Stub brought to full symbol parity (it had been missing `configureStationKeep`/`getMode`/`Mode` since #335 — the `TR_GUIDANCE_AVAILABLE=0` build would have broken the moment the FC called either).
- gtest 9 → 26; station-keep previously had **zero** coverage. New assertions mutation-verified (E/N swap, sign flip, target ignored, velocity-instead-of-position, write-once latch, pad-relative los — each killed by exactly one test).

**2. FC wiring + app (`dc5d388`)**
- `GuidanceConfigData` 36 → 45 B **by append** (kp@36, kd@40, law@44): the FC accepts `cfg_len >= sizeof`, so an old FC parses a new frame's prefix correctly, while inserting mid-struct would silently misparse `nav_gain`/`max_accel`. New FC rejects an old 36 B frame loudly (logs got/need + out-of-date-app hint).
- `applyGuidanceConfig()` at both configure sites: law first, aim point second (order is load-bearing); law byte whitelisted at wire + NVS entry; `static_assert`s pin the wire codes to `TR_GuidancePN::Mode`.
- Aim point: FC-owned limit `GUIDANCE_MAX_AIM_RADIUS_M = 100 m`, **reject never clamp** — flown target always equals uploaded and logged. At kp=0.8 a 25 m offset already saturates the full accel budget, so 100 m is a sanity bound against unit errors.
- Active law logged as `FlightSettingsData` flags bit 6 (`F_GUIDANCE_STATION_KEEP`); struct stays 210 B, VERSION stays 5. Boot banner states the active law + parameters.
- App: `pnKpPos`/`pnKdVel`/`pnGuidanceLaw` in RocketProfile (defaults == config.h), segmented law picker applying on change, per-law field sets; both laws' params ride every frame so switching never flies an untuned law. Old saved profiles decode via `decodeIfPresent`.
- OC unchanged (sizeof-driven relay). Guidance config stays BLE-only — 45 B exceeds the 32 B LoRa uplink buffer, so the "BS relay cmd 28" bullet in #435 is not achievable as written.

**3. Sim A/B (`f3978e8`) — acceptance criterion met**
- 144 deterministic runs: core A/B (2 laws + unguided × 5 seeds × calm/wind4/wind8/gust), 3×3 gain grid, reachable-target singularity probe, launch-angle sweep, plus three stress legs (EKF heading bias 10–90°, GNSS denial, 20-seed gust latch lottery).
- **SK ≤ PN apogee drift on 35/35 discriminating pairs** (52/52 overall); medians calm 3.0 vs 13.8 m, wind4 21.4 vs 34.8, gust 17.6 vs 32.1. **Zero CPA behavior in 70 SK runs.** No apogee cost for either law.
- Singularity probe: PN with target below apogee quits via CPA at 3–5 s of an 8.5 s flight, accel pinned at the 20 m/s² clamp, LOS through 90°. SK at identical settings: bit-identical to its calm baseline.
- Gains **kp=0.8 / kd=1.5 confirmed** (drift-minimal cell, ζ=0.84, ~5° coast-tilt margin).
- Stress legs all favor SK: graceful to 90° heading bias; unbothered by GNSS denial; zero SK-only tilt latches in 20 gust seeds (PN is the more latch-prone law).
- Two operational findings: **wind8 is a null condition** (both laws tilt-latch at guidance activation — don't fly guided ≥ 8 m/s), and SK pays in control effort (97–99% fin saturation in wind4) with a thin coast-tilt margin worth watching in flight logs.
- Report: `docs/plans/534-station-keep-sim-ab.md`. Regenerator: `tinkerrocket-sim/scripts/ab534_pn_vs_station_keep.py`. Permanent pin: `test_scenario_a2_station_keep_beats_pn_no_cpa` (invariant-based, 11 s).

## Deliberately NOT in this PR

- **`GUIDANCE_LAW_DEFAULT` stays PN.** Per project precedent, the flip waits for a first guided flight (fly it with station-keep selected via the app — the law is BLE/NVS-selectable per flight, so the default costs nothing). Flip = one line in config.h + one in RocketProfile, in lockstep.
- cmd 28 (the Drift-Cast phone→rocket upload path for #435) — the library API this PR lands is its blocker; the OC/FC handler and app readback-echo gate are follow-up work.

## Verification

- gtest **634/634** (includes the new 45 B layout offsets, law-code pins, flag-bit overlap, and 17 new guidance tests)
- FC firmware builds on IDF v6 (ESP32-P4)
- iOS app builds headless (Xcode 26.6); no telemetry reads added near focused TextFields; settings apply on change
- FC guidance logic compile-checked against the stub header (`TR_GUIDANCE_AVAILABLE=0` parity)
- Sim `_guidance` extension rebuilt; python guidance suite 9/9 + the new scenario pin

⚠️ Merge order: [TR_GuidancePN #2](https://github.com/Tinkerbug-Robotics/TR_GuidancePN/pull/2) must be merged **with a merge commit, not squash** (the submodule pin here records `f884b26`); CI's token-gated submodule checkout needs that SHA reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
