### PR TITLE
Drift-Cast guidance-point upload: cmd 28 end-to-end with readback echo (#435)

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -52,7 +52,7 @@ MSG_NAMES = {
 }
 
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY: (16, 26),  # v2 / v3 (+b2r orientation)
+    MSG_OUT_STATUS_QUERY: (16, 26, 28, 41),  # v2 / v3 (+b2r) / v4 (+iis2mdc rot) / v5 (+guid target echo, #435)
     MSG_GNSS:             42,
     MSG_ISM6HG256:        22,
     MSG_BMP585:           12,

--- a/Data_Analysis/plot_flight_data_legacy.py
+++ b/Data_Analysis/plot_flight_data_legacy.py
@@ -79,7 +79,9 @@ MSG_NAMES = {
 
 # Expected payload sizes for validation
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY: 1,
+    # Legacy logs carried a 1-byte query; later firmware grew it (v2 16,
+    # v3 26, v4 28, v5 41 — #435).  Tuple-aware check below.
+    MSG_OUT_STATUS_QUERY: (1, 16, 26, 28, 41),
     MSG_GNSS:             42,
     MSG_ICM45686:         36,
     MSG_MS5611:           10,
@@ -225,7 +227,8 @@ def parse_binary_file(filepath):
         # Validate: known type with expected length
         if msg_type in MSG_EXPECTED_LEN:
             expected = MSG_EXPECTED_LEN[msg_type]
-            if msg_len != expected:
+            valid = expected if isinstance(expected, tuple) else (expected,)
+            if msg_len not in valid:
                 # Bad length — probably false sync, skip one byte
                 pos -= 1
                 continue

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -99,7 +99,7 @@ MSG_NAMES = {
 # Expected payload sizes for validation.  A tuple lists every valid size
 # (wire structs grow by appending version-gated fields).
 MSG_EXPECTED_LEN = {
-    MSG_OUT_STATUS_QUERY:  (16, 26),  # OutStatusQueryData v2 / v3 (+b2r orientation)
+    MSG_OUT_STATUS_QUERY:  (16, 26, 28, 41),  # OutStatusQueryData v2 / v3 (+b2r) / v4 (+iis2mdc rot) / v5 (+guid target echo, #435)
     MSG_GNSS:              42,
     MSG_ISM6HG256:         22,
     MSG_BMP585:            12,

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -141,6 +141,14 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var imuOrientationName: String = ""
     @Published var imuOrientationMode: IMUOrientationMode = .unknown
 
+    /// Live guidance-target echo (#435): FC-authoritative state of the
+    /// station-keep aim point ("guid_target" frames relayed by the OC).
+    /// nil until the first frame — which also means "pre-#435 firmware,
+    /// echo unsupported" (the OC only emits it for format_version >= 5
+    /// FCs). The Drift-Cast send button gates success on this; nothing
+    /// else should infer target state from a send having "gone through".
+    @Published var guidanceTargetEcho: GuidanceTargetEcho?
+
     /// Display name: unitName if set, otherwise connectedDeviceName
     var displayName: String {
         unitName.isEmpty ? connectedDeviceName : unitName
@@ -292,6 +300,11 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         // republishes IDLE on reconnect anyway.
         magCalStatus = nil
         sensorCalStatus = nil
+        // #435: the guidance-target echo is per-connection live state; the
+        // OC re-pushes it in the connect-time config readback, so a stale
+        // copy must not bridge sessions (it could "confirm" a send made
+        // over a new connection to a rebooted FC).
+        guidanceTargetEcho = nil
         // Power state is unknown again until the next session's first frame
         // (#377). Reconnects build a new BLEDevice anyway; this covers the
         // state-restoration path that reuses one.
@@ -1070,12 +1083,24 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         sendCommand(23)
     }
 
-    /// #376/#435: cmd 28 is NOT handled by any firmware — the OC dispatch
-    /// doesn't include it and the BS doesn't relay it, so this vanishes
-    /// silently. The Drift-Cast "Send to Unit" button that called this is
-    /// disabled until #435 implements the handler end-to-end. Do not wire
-    /// this to UI again without gating success on a firmware readback echo.
+    /// #435: Drift-Cast guidance aim point, BLE cmd 28 — handled end-to-end
+    /// since #435. The OC queues the 20-byte GuidancePointData to the FC,
+    /// which converts geodetic → pad-relative ENU and (when the state / law /
+    /// GNSS-ref / 100 m-radius gates all pass) retargets station-keep.
+    /// Sending proves NOTHING by itself: success is gated on the
+    /// "guid_target" readback echo (`guidanceTargetEcho`) — the FC bumps its
+    /// seq on every processed upload, accept or reject. DriftCastSendButton
+    /// owns the confirm/timeout state machine; keep any new caller behind
+    /// the same echo gate.
     func sendGuidancePoint(lat: Double, lon: Double, altitudeM: Float) {
+        sendRawCommand(28, payload: Self.guidancePointPayload(
+            lat: lat, lon: lon, altitudeM: altitudeM))
+    }
+
+    /// Wire payload for cmd 28: {lat f64, lon f64, alt f32} little-endian,
+    /// 20 bytes — byte-for-byte the firmware's GuidancePointData. Shared by
+    /// the direct and BS-relay paths.
+    static func guidancePointPayload(lat: Double, lon: Double, altitudeM: Float) -> Data {
         var payload = Data()
         var latVal = lat
         var lonVal = lon
@@ -1083,7 +1108,18 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         payload.append(Data(bytes: &latVal, count: 8))
         payload.append(Data(bytes: &lonVal, count: 8))
         payload.append(Data(bytes: &altVal, count: 4))
-        sendRawCommand(28, payload: payload)
+        return payload
+    }
+
+    /// #435 BS path: the same cmd-28 payload wrapped in relay cmd 50 for a
+    /// base-station link. Fire-and-forget: BS uplink has no rocket ACK
+    /// (#285) and the guid_target echo only rides the direct OC BLE link,
+    /// so a relayed point can NEVER be confirmed — callers must show a
+    /// permanent "sent, unconfirmed" state, never success.
+    func sendGuidancePointViaRelay(rid: UInt8, lat: Double, lon: Double, altitudeM: Float) {
+        sendRelayCommand(targetRocketID: rid, innerCommand: 28,
+                         innerPayload: Self.guidancePointPayload(
+                             lat: lat, lon: lon, altitudeM: altitudeM))
     }
 
     func requestConfig() {
@@ -1130,11 +1166,14 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     }
 
     /// Relay a command to a specific rocket via this base station.
-    /// Command 50: [target_rid:1][inner_cmd:1][inner_payload:0..18]
-    /// The base station unpacks this and queues a LoRa uplink.
+    /// Command 50: [target_rid:1][inner_cmd:1][inner_payload:0..33]
+    /// The base station unpacks this and queues a LoRa uplink. The inner
+    /// cap is bs_uplink_queue::kMaxPayload = 33 (#435 widened the stale 18
+    /// so the 20-byte cmd-28 guidance point fits; the OC's uplink RX buffer
+    /// further caps delivered payloads at 26 — keep inner payloads ≤26).
     func sendRelayCommand(targetRocketID: UInt8, innerCommand: UInt8, innerPayload: Data = Data()) {
         var payload = Data([targetRocketID, innerCommand])
-        payload.append(innerPayload.prefix(18))
+        payload.append(innerPayload.prefix(33))
         sendRawCommand(50, payload: payload)
     }
 
@@ -1682,6 +1721,21 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 rocketConfig = cfg
             }
             print("[CFG] IMU orientation: \(imuOrientationName) (\(imuOrientationMode.label))")
+            return
+        }
+
+        // Guidance-target echo: "type":"guid_target" (#435) — FC-authoritative
+        // aim-point state (OutStatusQueryData v5 tail), relayed by the OC on
+        // connect, on every processed cmd 28, and on any cmd-65 apply that
+        // changes it. Live state, not part of rocketConfig: the Drift-Cast
+        // send button gates its success on this echo, and the "Unit target"
+        // row tracks it (e.g. a connect-time profile push visibly wiping a
+        // previously sent Drift-Cast point back to "none / overhead").
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let echo = GuidanceTargetEcho(json: dict) {
+            guidanceTargetEcho = echo
+            print("[CFG] Guidance target: seq=\(echo.seq) st=\(echo.status) rc=\(echo.lastRc) " +
+                  String(format: "lat=%.6f lon=%.6f alt=%dm", echo.lat, echo.lon, echo.altM))
             return
         }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -147,3 +147,194 @@ struct RocketConfig {
     var pyro4TriggerMode: UInt8 = 0
     var pyro4TriggerValue: Float = 0.0
 }
+
+// MARK: - Guidance-target echo (#435)
+
+/// FC-authoritative guidance aim-point state, relayed by the OC as a small
+/// `{"type":"guid_target",...}` JSON frame (OutStatusQueryData v5 tail).
+/// Live state, NOT folded into `RocketConfig` — it changes with every
+/// processed cmd 28 / cmd-65 apply, and the Drift-Cast send button gates its
+/// success on it. `status` describes the CURRENT target; `lastRc` the result
+/// of the LAST processed cmd-28 upload. They are separate fields so a
+/// rejected upload does not erase the display of a still-active target.
+/// Absent entirely (nil on BLEDevice) on pre-#435 firmware.
+nonisolated struct GuidanceTargetEcho: Equatable {
+    // tgt_status values — mirror GUID_TGT_* in RocketComputerTypes.h.
+    static let statusNone = 0        // no aim point (overhead / cleared)
+    static let statusGeoActive = 1   // cmd-28 geodetic point active
+    static let statusEnActive = 2    // cmd-65 profile E/N point active
+
+    /// Bumps on EVERY processed cmd 28 (accept or reject) and on any cmd-65
+    /// apply that changes the echo content. The send flow captures a baseline
+    /// before sending and treats any advance as "the FC processed something".
+    let seq: Int
+    let status: Int   // GUID_TGT_*
+    let lastRc: Int   // GUID_RC_* (see GuidancePointRc)
+    /// Receipt-time geodetic point as the FC stored it, f32-rounded on the
+    /// wire (ulp ~0.4 m at mid-latitudes — verification precision, the FC
+    /// keeps the f64 originals for navigation).
+    let lat: Double
+    let lon: Double
+    let altM: Int     // stored/echoed only — station-keep ignores altitude
+
+    /// Parse the OC's compact readback frame. Defensive per the MTU-budget
+    /// rule (#282): every field individually optional.
+    init?(json dict: [String: Any]) {
+        guard dict["type"] as? String == "guid_target" else { return nil }
+        self.init(seq: dict["seq"] as? Int ?? 0,
+                  status: dict["st"] as? Int ?? 0,
+                  lastRc: dict["rc"] as? Int ?? 0,
+                  lat: (dict["lat"] as? Double) ?? 0,
+                  lon: (dict["lon"] as? Double) ?? 0,
+                  altM: dict["alt"] as? Int ?? 0)
+    }
+
+    init(seq: Int, status: Int, lastRc: Int, lat: Double, lon: Double, altM: Int) {
+        self.seq = seq
+        self.status = status
+        self.lastRc = lastRc
+        self.lat = lat
+        self.lon = lon
+        self.altM = altM
+    }
+
+    // Confirmation-match tolerances: the echo is f32-rounded (ulp ~4e-6 deg),
+    // leaving >4x margin under these. Lon is looser than lat because a
+    // degree of longitude shrinks with cos(lat) while the f32 ulp doesn't.
+    static let latMatchTolDeg = 2e-5   // ~2.2 m
+    static let lonMatchTolDeg = 3e-5   // ~2.6 m at mid-latitudes
+
+    /// Pure confirmation predicate for a cmd-28 upload (unit-tested).
+    /// `baselineSeq` is the echo seq captured immediately before sending.
+    ///
+    /// Attribution caveats (the reason `GuidanceSendFlow` exists):
+    /// - `baselineSeq < 0` means NO baseline — nothing can be attributed to
+    ///   the upload, so every frame is `.pending` (the flow adopts the first
+    ///   frame as its baseline instead of misreading it as a verdict).
+    /// - `tgt_seq` also bumps on echo-changing cmd-65 applies, which never
+    ///   write `tgt_last_rc` — so `rc == NONE` can never be a cmd-28 verdict
+    ///   (the FC writes a nonzero GUID_RC_* on every processed cmd 28) and
+    ///   maps to `.pending`, and a `.rejected`/`.mismatch` result may still
+    ///   be an interleaved cmd-65 frame rather than OUR verdict.  Only
+    ///   `.confirmed` is self-authenticating (fresh ACCEPTED + GEO_ACTIVE +
+    ///   coordinate match); the flow treats the failures as provisional.
+    func outcome(baselineSeq: Int, sentLat: Double, sentLon: Double) -> GuidanceSendOutcome {
+        if baselineSeq < 0 { return .pending }
+        if seq == baselineSeq { return .pending }
+        if lastRc == GuidancePointRc.none.rawValue { return .pending }
+        if lastRc != GuidancePointRc.accepted.rawValue { return .rejected(rc: lastRc) }
+        guard status == Self.statusGeoActive,
+              abs(lat - sentLat) < Self.latMatchTolDeg,
+              abs(lon - sentLon) < Self.lonMatchTolDeg else { return .mismatch }
+        return .confirmed
+    }
+}
+
+/// Result of matching a guidance-target echo against a just-sent point.
+nonisolated enum GuidanceSendOutcome: Equatable {
+    case pending             // seq hasn't advanced — FC hasn't processed it yet
+    case confirmed           // accepted, geodetic-active, coordinates match
+    case rejected(rc: Int)   // FC processed and refused (GUID_RC_* reason)
+    case mismatch            // FC accepted SOMETHING, but not our point
+}
+
+/// Pure verdict state machine for one cmd-28 send (#435, unit-tested).
+///
+/// Frame-attribution rules — each one closes a demonstrated false-verdict
+/// path in the naive "first seq advance is the answer" reading:
+/// - No baseline (`baselineSeq < 0`, e.g. send raced the connect-time
+///   readback): the FIRST frame — typically the OC's stale connect push of a
+///   PREVIOUS session's state — becomes the baseline, never a verdict.
+///   Previously it could paint a false green for an upload the FC rejected,
+///   or never even received.
+/// - `.confirmed` is self-authenticating (fresh ACCEPTED + GEO_ACTIVE +
+///   coordinate match after a real seq advance) and settles immediately.
+/// - `.rejected` / `.mismatch` frames are only PROVISIONAL: an interleaved
+///   cmd-65 apply (connect-time profile sync, settings self-apply) also bumps
+///   seq while carrying a STALE rc, so the true accept may still be one poll
+///   behind. The provisional reason settles as `.failed` only at timeout, and
+///   a later genuine `.confirmed` upgrades over it.
+/// Net effect: false green and false red are both closed; the worst case for
+/// a genuine rejection is that its reason displays at the timeout instead of
+/// instantly.
+nonisolated struct GuidanceSendFlow: Equatable {
+    enum Verdict: Equatable {
+        case waiting
+        case confirmed
+        case failed(String)
+    }
+
+    static let timeoutMessage =
+        "No confirmation from the rocket within 6 s. The firmware may predate #435, or the link dropped — the aim point is NOT confirmed."
+
+    private(set) var baselineSeq: Int
+    let sentLat: Double
+    let sentLon: Double
+    private(set) var provisionalFailure: String?
+    private(set) var verdict: Verdict = .waiting
+
+    init(baselineSeq: Int, sentLat: Double, sentLon: Double) {
+        self.baselineSeq = baselineSeq
+        self.sentLat = sentLat
+        self.sentLon = sentLon
+    }
+
+    mutating func onEcho(_ echo: GuidanceTargetEcho) {
+        guard verdict == .waiting else { return }
+        if baselineSeq < 0 {
+            // Unattributable — adopt as baseline (see rules above).
+            baselineSeq = echo.seq
+            return
+        }
+        switch echo.outcome(baselineSeq: baselineSeq, sentLat: sentLat, sentLon: sentLon) {
+        case .pending:
+            break
+        case .confirmed:
+            verdict = .confirmed
+        case .rejected(let rc):
+            provisionalFailure = GuidancePointRc.message(forRawValue: rc)
+        case .mismatch:
+            provisionalFailure =
+                "The rocket confirmed a different aim point than the one sent — resend, and check nothing else is pushing settings."
+        }
+    }
+
+    mutating func onTimeout() {
+        guard verdict == .waiting else { return }
+        verdict = .failed(provisionalFailure ?? Self.timeoutMessage)
+    }
+}
+
+/// FC cmd-28 result codes — mirror GUID_RC_* in RocketComputerTypes.h (#435).
+nonisolated enum GuidancePointRc: Int {
+    case none = 0
+    case accepted = 1
+    case rejectedRadius = 2
+    case rejectedState = 3
+    case rejectedLaw = 4
+    case rejectedNoRef = 5
+    case rejectedBadValue = 6
+
+    var message: String {
+        switch self {
+        case .none:
+            return "No upload has been processed."
+        case .accepted:
+            return "Aim point accepted."
+        case .rejectedRadius:
+            return "Aim point is more than 100 m from the launch reference — recompute closer to the pad."
+        case .rejectedState:
+            return "Rocket must be in READY or PRELAUNCH (and not post-flight)."
+        case .rejectedLaw:
+            return "Rocket guidance law is PN — set the profile's law to Station-Keep and push settings first."
+        case .rejectedNoRef:
+            return "Rocket has no GNSS reference yet — wait for pad fix averaging."
+        case .rejectedBadValue:
+            return "Rejected: invalid values."
+        }
+    }
+
+    static func message(forRawValue rc: Int) -> String {
+        GuidancePointRc(rawValue: rc)?.message ?? "Rejected (unknown code \(rc))."
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -23,7 +23,7 @@ enum MessageType: UInt8 {
     case h3lis331 = 0xA9   // Legacy-only high-G accelerometer (10B)
     case cameraStart = 0xAA
     case cameraStop = 0xAB
-    case flightSettings = 0xE1  // FlightSettingsData (188B v1 / 200B v2 / 208B v3) — runtime settings snapshot at launch (#165)
+    case flightSettings = 0xE1  // FlightSettingsData (188B v1 / 200B v2 / 208B v3 / 210B v5 / 219B v6) — runtime settings snapshot at launch (#165)
     case iis2mdc = 0xD1    // IIS2MDC magnetometer (new Mini PCB rev, 10B)
     case lora = 0xF1
 }
@@ -171,6 +171,16 @@ nonisolated struct FlightSettingsData {
     /// v5+: IMU logging rate (ISM6HG256 ODR, Hz) that actually flew.
     let ism6_update_rate_hz: UInt16?
 
+    /// v6+ (#435): the horizontal guidance aim point that actually FLEW —
+    /// pad-relative ENU meters, re-converted from the frozen GNSS reference
+    /// at launch (so it can differ slightly from the receipt-time echo).
+    /// `guid_tgt_src` is the GUID_TGT_* code: 0 none/overhead, 1 cmd-28
+    /// geodetic (Drift-Cast) point, 2 cmd-65 profile E/N point. nil on
+    /// pre-v6 frames.
+    let guid_tgt_e_m: Float?
+    let guid_tgt_n_m: Float?
+    let guid_tgt_src: UInt8?
+
     let b2r_code: UInt8?
     let b2r_mode: UInt8?            // 0 default, 1 manual, 2 auto-snap, 3 auto-exact
     let b2r_residual_deg: Float?    // auto-snap residual angle
@@ -303,6 +313,18 @@ nonisolated struct FlightSettingsData {
             ism6_update_rate_hz = data.readUInt16LE(at: &o)
         } else {
             ism6_update_rate_hz = nil
+        }
+
+        // v6 flown-guidance-target tail at fixed offset 210 (#435).
+        if version >= 6 && data.count >= 219 {
+            var o = 210
+            guid_tgt_e_m = data.readFloat32LE(at: &o)
+            guid_tgt_n_m = data.readFloat32LE(at: &o)
+            guid_tgt_src = data.readUInt8(at: &o)
+        } else {
+            guid_tgt_e_m = nil
+            guid_tgt_n_m = nil
+            guid_tgt_src = nil
         }
     }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift
@@ -1159,36 +1159,267 @@ struct DriftCastView: View {
 /// `@ObservedObject` device — while the parent DriftCastView runs device-free
 /// (#42).  Only rendered when a device is present.
 ///
-/// #376: DISABLED pending firmware support (#435). The button used to send
-/// BLE cmd 28 — which no firmware handles (the OC dispatch doesn't include it
-/// and the BS doesn't relay it) — and then unconditionally reported
-/// "Guidance point sent". An operator would wind-compensate the aim point,
-/// see success, and fly believing the target moved, while the rocket guided
-/// to the profile's overhead target. Until cmd 28 exists end-to-end, show the
-/// computed point with an honest "not supported yet" note instead of a
-/// dangerous no-op button.
+/// #435: cmd 28 is now handled end-to-end, and success here is gated on the
+/// FC's "guid_target" readback echo — NEVER on the send having gone through
+/// (#376 taught us an unacknowledged "sent!" is a lie the operator flies on).
+/// Direct rocket link: send (enabled only while connected AND after the FC's
+/// target echo arrived — the baseline that makes frames attributable), then
+/// wait up to 6 s. Verdicts come from the pure GuidanceSendFlow: ACCEPTED +
+/// GEO_ACTIVE + matching coordinates → green immediately; rejections and
+/// mismatches are PROVISIONAL (an interleaved cmd-65 apply also bumps seq
+/// with a stale rc) and settle at the timeout unless a genuine accept
+/// upgrades them; silence → timeout.
+/// Base-station link: relayed via cmd 50, but BS uplink is fire-and-retry
+/// with no rocket ACK (#285) and the echo only rides the direct OC link —
+/// so the BS path lands in a PERMANENT amber "sent, unconfirmed" state and
+/// must never show green.
 private struct DriftCastSendButton: View {
     @ObservedObject var device: BLEDevice
     let result: GuidanceResult
     let unitSystem: UnitSystem
 
+    private enum SendState: Equatable {
+        case idle
+        /// Waiting on the echo. The pure GuidanceSendFlow (BLETypes.swift,
+        /// unit-tested) owns ALL verdict attribution: baseline adoption,
+        /// interleaved-cmd-65 provisional failures, confirm upgrades.
+        case sending(GuidanceSendFlow)
+        case confirmed
+        case failed(String)
+        /// BS relay fired; delivery/acceptance unknowable (#285). Terminal.
+        case sentUnconfirmedBS
+    }
+
+    @State private var sendState: SendState = .idle
+    /// Invalidates in-flight timeout closures when a new send (or a result
+    /// recompute) supersedes them.
+    @State private var sendGeneration = 0
+
+    /// Identity of the computed point — a recompute resets the state machine
+    /// so a stale "accepted" can't hang next to a fresh, unsent point.
+    private var resultKey: String {
+        "\(result.guidanceLat),\(result.guidanceLon),\(result.apogeeFt)"
+    }
+
+    private var isSending: Bool {
+        if case .sending = sendState { return true }
+        return false
+    }
+
+    private var canSend: Bool {
+        // isConnected: sendRawCommand silently drops when disconnected, and a
+        // "sent" that never left the phone must not be able to turn green off
+        // a stale reconnect echo.
+        guard result.feasible, !isSending, device.isConnected else { return false }
+        if device.isBaseStation { return device.focusRocketID != nil }
+        // Direct link: require the FC's target echo before allowing a send —
+        // it IS the confirmation channel (pre-#435 firmware never sends it,
+        // and sending without a baseline invites stale-frame misattribution).
+        return device.guidanceTargetEcho != nil
+    }
+
     var body: some View {
         VStack(spacing: 6) {
-            Label("Send to Unit", systemImage: "antenna.radiowaves.left.and.right")
-                .fontWeight(.bold)
+            Button(action: send) {
+                HStack {
+                    if isSending { ProgressView().tint(.white) }
+                    Label(buttonTitle, systemImage: buttonIcon)
+                        .fontWeight(.bold)
+                }
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.gray)
-                .foregroundColor(.white.opacity(0.7))
+                .background(buttonColor)
+                .foregroundColor(.white)
                 .cornerRadius(10)
-            Label("Not supported by the rocket firmware yet (#435) — the unit always guides to the profile's target. Use the computed point manually.",
+            }
+            .disabled(!canSend)
+
+            statusCaption
+
+            if !result.feasible {
+                Label("Result is infeasible — recompute before sending.",
+                      systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if device.isBaseStation && device.focusRocketID == nil {
+                Label("Base station has no focused rocket — select one on the dashboard first.",
+                      systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if !device.isConnected {
+                Label("Not connected — reconnect before sending.",
+                      systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if !device.isBaseStation && device.guidanceTargetEcho == nil {
+                Label("Waiting for the rocket's target state — sending unlocks once it arrives (a firmware without the #435 echo cannot confirm an aim point).",
+                      systemImage: "hourglass")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Live FC-side target state (#435 decision 5): the connect-time
+            // profile push asserting its own target visibly wipes a
+            // previously sent Drift-Cast point right here.
+            if let echo = device.guidanceTargetEcho {
+                HStack {
+                    Text("Unit target")
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text(unitTargetLabel(echo))
+                        .fontWeight(.medium)
+                }
+                .font(.caption)
+            }
+
+            if device.rocketConfig?.guidanceEnabled == false {
+                Label("Rocket guidance is OFF — enable it or the aim point won't fly.",
+                      systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 20)
+        .onReceive(device.$guidanceTargetEcho) { echo in
+            handleEcho(echo)
+        }
+        .onChange(of: resultKey) { _ in
+            sendGeneration += 1
+            sendState = .idle
+        }
+    }
+
+    // MARK: State-dependent chrome
+
+    private var buttonTitle: String {
+        switch sendState {
+        case .idle, .failed:      return "Send to Unit"
+        case .sending:            return "Waiting for rocket…"
+        case .confirmed:          return "Accepted by rocket"
+        case .sentUnconfirmedBS:  return "Sent via radio — unconfirmed"
+        }
+    }
+
+    private var buttonIcon: String {
+        switch sendState {
+        case .idle, .failed, .sending: return "antenna.radiowaves.left.and.right"
+        case .confirmed:               return "checkmark.circle.fill"
+        case .sentUnconfirmedBS:       return "questionmark.circle"
+        }
+    }
+
+    private var buttonColor: Color {
+        if !canSend && !isSending && sendState != .confirmed
+            && sendState != .sentUnconfirmedBS { return .gray }
+        switch sendState {
+        case .idle, .failed:      return .red
+        case .sending:            return .gray
+        case .confirmed:          return .green
+        case .sentUnconfirmedBS:  return .orange
+        }
+    }
+
+    @ViewBuilder
+    private var statusCaption: some View {
+        switch sendState {
+        case .idle, .sending:
+            EmptyView()
+        case .confirmed:
+            // "Accepted", never "locked": the FC re-converts against the
+            // frozen GNSS reference at launch, and a later profile push can
+            // still overwrite the point (watch the Unit target row).
+            Label("Rocket accepted the aim point for station-keep. A settings push or reboot clears it — recheck the Unit target row before launch.",
+                  systemImage: "checkmark.circle")
+                .font(.caption)
+                .foregroundColor(.green)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .failed(let reason):
+            Label(reason, systemImage: "xmark.octagon")
+                .font(.caption)
+                .foregroundColor(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .sentUnconfirmedBS:
+            Label("Sent via base station — delivery and acceptance UNCONFIRMED (no acknowledgment over the radio link). Verify with a direct connection, or fly the profile target.",
                   systemImage: "exclamationmark.triangle")
                 .font(.caption)
                 .foregroundColor(.orange)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal)
-        .padding(.bottom, 20)
+    }
+
+    private func unitTargetLabel(_ echo: GuidanceTargetEcho) -> String {
+        switch echo.status {
+        case GuidanceTargetEcho.statusGeoActive:
+            return String(format: "%.6f, %.6f (%@)", echo.lat, echo.lon,
+                          UnitFormatter.altitude(Double(echo.altM), system: unitSystem))
+        case GuidanceTargetEcho.statusEnActive:
+            return "profile E/N point"
+        default:
+            return "none (overhead)"
+        }
+    }
+
+    // MARK: Actions
+
+    private func send() {
+        guard canSend else { return }
+        sendGeneration += 1
+        let generation = sendGeneration
+        let sentLat = result.guidanceLat
+        let sentLon = result.guidanceLon
+        let altM = Float(ftToM(result.apogeeFt))
+
+        if device.isBaseStation {
+            guard let rid = device.focusRocketID else { return }
+            device.sendGuidancePointViaRelay(rid: rid, lat: sentLat, lon: sentLon,
+                                             altitudeM: altM)
+            sendState = .sentUnconfirmedBS   // terminal — never green (#285)
+            return
+        }
+
+        // Direct rocket link: capture the baseline BEFORE sending. canSend
+        // guarantees an echo exists, so the baseline is real; the -1 branch
+        // stays as a defensive fallback the flow turns into baseline
+        // adoption, never a verdict.
+        let baseline = device.guidanceTargetEcho?.seq ?? -1
+        sendState = .sending(GuidanceSendFlow(baselineSeq: baseline,
+                                              sentLat: sentLat, sentLon: sentLon))
+        device.sendGuidancePoint(lat: sentLat, lon: sentLon, altitudeM: altM)
+
+        // 6 s budget: FC poll ~251 ms + status-query round trip + 20 ms JSON
+        // pace, surviving one dropped poll cycle. Also when a provisional
+        // rejection/mismatch was recorded (it may have been an interleaved
+        // cmd-65 frame, not our verdict) — it settles as the failure HERE
+        // unless a genuine accept upgraded the flow first.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+            guard sendGeneration == generation,
+                  case .sending(var flow) = sendState else { return }
+            flow.onTimeout()
+            applyVerdict(of: flow)
+        }
+    }
+
+    private func handleEcho(_ echo: GuidanceTargetEcho?) {
+        guard let echo, case .sending(var flow) = sendState else { return }
+        flow.onEcho(echo)
+        applyVerdict(of: flow)
+    }
+
+    private func applyVerdict(of flow: GuidanceSendFlow) {
+        switch flow.verdict {
+        case .waiting:
+            sendState = .sending(flow)   // keep the (possibly updated) flow
+        case .confirmed:
+            sendState = .confirmed
+        case .failed(let reason):
+            sendState = .failed(reason)
+        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketAppTests/GuidancePointEchoTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/GuidancePointEchoTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+@testable import TinkerRocketApp
+
+/// #435: Drift-Cast guidance-point upload confirmation.
+/// Covers (a) the "guid_target" JSON frame → GuidanceTargetEcho parse,
+/// (b) the pure confirm-match predicate the DriftCast send button gates
+/// green on, and (c) the FlightSettingsData v6 flown-target tail.
+final class GuidancePointEchoTests: XCTestCase {
+
+    // MARK: - (a) guid_target JSON parse
+
+    private func decode(_ json: String) -> GuidanceTargetEcho? {
+        guard let data = json.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return GuidanceTargetEcho(json: dict)
+    }
+
+    func testGuidTargetFrameParses() {
+        // Byte-for-byte the OC's sendGuidTarget frame shape.
+        let echo = decode(
+            #"{"type":"guid_target","seq":3,"st":1,"rc":1,"lat":38.123456,"lon":-122.123456,"alt":250}"#)
+        XCTAssertNotNil(echo)
+        XCTAssertEqual(echo?.seq, 3)
+        XCTAssertEqual(echo?.status, GuidanceTargetEcho.statusGeoActive)
+        XCTAssertEqual(echo?.lastRc, GuidancePointRc.accepted.rawValue)
+        XCTAssertEqual(echo!.lat, 38.123456, accuracy: 1e-9)
+        XCTAssertEqual(echo!.lon, -122.123456, accuracy: 1e-9)
+        XCTAssertEqual(echo?.altM, 250)
+    }
+
+    func testGuidTargetRejectsOtherFrameTypes() {
+        XCTAssertNil(decode(#"{"type":"imu_orient","mode":2}"#))
+        XCTAssertNil(decode(#"{"type":"config","ge":true}"#))
+    }
+
+    func testGuidTargetMissingFieldsDefaultDefensively() {
+        // MTU-budget rule (#282): parse must survive a trimmed frame.
+        let echo = decode(#"{"type":"guid_target","seq":1}"#)
+        XCTAssertNotNil(echo)
+        XCTAssertEqual(echo?.status, GuidanceTargetEcho.statusNone)
+        XCTAssertEqual(echo?.lastRc, GuidancePointRc.none.rawValue)
+        XCTAssertEqual(echo?.lat, 0)
+        XCTAssertEqual(echo?.altM, 0)
+    }
+
+    // MARK: - (b) confirm-match predicate
+
+    private let sentLat = 38.1234567
+    private let sentLon = -122.7654321
+
+    private func echo(seq: Int = 1, st: Int = 1, rc: Int = 1,
+                      lat: Double? = nil, lon: Double? = nil) -> GuidanceTargetEcho {
+        GuidanceTargetEcho(seq: seq, status: st, lastRc: rc,
+                           lat: lat ?? sentLat, lon: lon ?? sentLon, altM: 120)
+    }
+
+    func testOutcomePendingWhenSeqUnchanged() {
+        // A connect-time re-push of the SAME echo must not confirm anything.
+        let e = echo(seq: 5)
+        XCTAssertEqual(e.outcome(baselineSeq: 5, sentLat: sentLat, sentLon: sentLon), .pending)
+    }
+
+    func testOutcomeConfirmedExactMatch() {
+        let e = echo(seq: 6)
+        XCTAssertEqual(e.outcome(baselineSeq: 5, sentLat: sentLat, sentLon: sentLon), .confirmed)
+    }
+
+    func testOutcomeNeverSettlesWithoutABaseline() {
+        // Baseline -1 = no echo received before the send: NOTHING is
+        // attributable, so even a perfect-looking accepted/GEO/matching
+        // frame must stay pending — it is typically the OC's stale
+        // connect-time push of a PREVIOUS session's state (the false-green
+        // reconnect path; GuidanceSendFlow adopts it as the baseline).
+        let e = echo(seq: 0)
+        XCTAssertEqual(e.outcome(baselineSeq: -1, sentLat: sentLat, sentLon: sentLon), .pending)
+        // Same for a stale frame with a bigger seq and for the FC boot frame.
+        XCTAssertEqual(echo(seq: 4).outcome(baselineSeq: -1, sentLat: sentLat, sentLon: sentLon),
+                       .pending)
+        XCTAssertEqual(echo(seq: 0, st: 0, rc: 0).outcome(baselineSeq: -1,
+                                                          sentLat: sentLat, sentLon: sentLon),
+                       .pending)
+    }
+
+    func testOutcomeRcNoneIsNeverAVerdict() {
+        // The FC writes a nonzero GUID_RC_* on every processed cmd 28, and a
+        // cmd-65 apply bumps seq WITHOUT touching rc — so a seq-advanced
+        // frame with rc == NONE (e.g. the boot-state echo pushed at connect,
+        // or a config wipe before any upload) means "no cmd-28 result yet",
+        // NOT "rejected". Mapping it to .rejected showed a false
+        // "No upload has been processed" failure moments before the real
+        // accept arrived.
+        let boot = echo(seq: 0, st: 0, rc: GuidancePointRc.none.rawValue)
+        XCTAssertEqual(boot.outcome(baselineSeq: 5, sentLat: sentLat, sentLon: sentLon), .pending)
+        let wipe = echo(seq: 3, st: GuidanceTargetEcho.statusEnActive,
+                        rc: GuidancePointRc.none.rawValue)
+        XCTAssertEqual(wipe.outcome(baselineSeq: 2, sentLat: sentLat, sentLon: sentLon), .pending)
+    }
+
+    func testOutcomeConfirmedSurvivesF32Rounding() {
+        // The echo carries f32-rounded degrees (ulp ~4e-6 at these
+        // magnitudes) — the tolerances must absorb that loss.
+        let e = echo(seq: 2,
+                     lat: Double(Float(sentLat)),
+                     lon: Double(Float(sentLon)))
+        XCTAssertEqual(e.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon), .confirmed)
+    }
+
+    func testOutcomeRejectedMapsRc() {
+        for rc in [2, 3, 4, 5, 6] {
+            let e = echo(seq: 2, st: 0, rc: rc)
+            XCTAssertEqual(e.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon),
+                           .rejected(rc: rc), "rc=\(rc)")
+        }
+    }
+
+    func testOutcomeRejectionKeepsPreviousTargetVisible() {
+        // status/lastRc are separate fields exactly so a rejected upload can
+        // ride alongside a still-active previous target: st stays GEO_ACTIVE
+        // with the OLD coordinates, rc reports the failure. Rejection must
+        // win over the coordinate match.
+        let e = GuidanceTargetEcho(seq: 7, status: GuidanceTargetEcho.statusGeoActive,
+                                   lastRc: GuidancePointRc.rejectedRadius.rawValue,
+                                   lat: 38.0, lon: -122.0, altM: 100)
+        XCTAssertEqual(e.outcome(baselineSeq: 6, sentLat: sentLat, sentLon: sentLon),
+                       .rejected(rc: 2))
+    }
+
+    func testOutcomeMismatchOnDifferentCoordinates() {
+        let e = echo(seq: 2, lat: sentLat + 1e-3)   // ~110 m off
+        XCTAssertEqual(e.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon), .mismatch)
+    }
+
+    func testOutcomeMismatchJustOutsideTolerance() {
+        let eLat = echo(seq: 2, lat: sentLat + 2.1e-5)
+        XCTAssertEqual(eLat.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon), .mismatch)
+        let eLon = echo(seq: 2, lon: sentLon + 3.1e-5)
+        XCTAssertEqual(eLon.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon), .mismatch)
+    }
+
+    func testOutcomeMismatchWhenStatusNotGeoActive() {
+        // rc=ACCEPTED but the active target is not the geodetic point (a
+        // cmd-65 apply raced in between) — never green.
+        let e = echo(seq: 2, st: GuidanceTargetEcho.statusEnActive)
+        XCTAssertEqual(e.outcome(baselineSeq: 1, sentLat: sentLat, sentLon: sentLon), .mismatch)
+    }
+
+    // MARK: - (b2) GuidanceSendFlow — verdict attribution across frames
+
+    /// The stale frame the OC re-pushes at connect time: a PREVIOUS upload's
+    /// accepted state, coordinates identical to what the user re-sends.
+    private var staleConnectPush: GuidanceTargetEcho { echo(seq: 4) }
+
+    func testFlowReconnectStaleFrameCannotConfirm_RealVerdictWins() {
+        // Finding scenario A: reconnect cleared the echo, user re-sends the
+        // same point with baseline -1, the stale connect push (seq 4, rc
+        // ACCEPTED, GEO, matching coords) arrives first, then the FC's REAL
+        // verdict — a post-flight REJ_STATE. The old machine went green on
+        // the stale frame and swallowed the rejection.
+        var flow = GuidanceSendFlow(baselineSeq: -1, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(staleConnectPush)
+        XCTAssertEqual(flow.verdict, .waiting)          // adopted as baseline
+        XCTAssertEqual(flow.baselineSeq, 4)
+        flow.onEcho(echo(seq: 5, rc: GuidancePointRc.rejectedState.rawValue))
+        flow.onTimeout()
+        XCTAssertEqual(flow.verdict,
+                       .failed(GuidancePointRc.rejectedState.message))
+    }
+
+    func testFlowNothingSentNothingArrives_TimesOutInsteadOfGreen() {
+        // Finding scenario C shape: only the stale connect push ever arrives
+        // (e.g. the write never reached the rocket). Must end in the timeout
+        // failure, never confirmed.
+        var flow = GuidanceSendFlow(baselineSeq: -1, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(staleConnectPush)
+        flow.onTimeout()
+        XCTAssertEqual(flow.verdict, .failed(GuidanceSendFlow.timeoutMessage))
+    }
+
+    func testFlowInterleavedConfigWipeDoesNotSettle_AcceptUpgrades() {
+        // Finding scenario D: a cmd-65 apply queued ahead of cmd 28 wipes a
+        // previously active geo point — its frame bumps seq with a STALE
+        // rc=ACCEPTED, status EN, zeroed coords. The old machine latched a
+        // terminal mismatch failure and ignored the genuine accept one poll
+        // later.
+        var flow = GuidanceSendFlow(baselineSeq: 7, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(GuidanceTargetEcho(seq: 8, status: GuidanceTargetEcho.statusEnActive,
+                                       lastRc: GuidancePointRc.accepted.rawValue,
+                                       lat: 0, lon: 0, altM: 0))
+        XCTAssertEqual(flow.verdict, .waiting)          // provisional only
+        XCTAssertNotNil(flow.provisionalFailure)
+        flow.onEcho(echo(seq: 9))                       // the genuine accept
+        XCTAssertEqual(flow.verdict, .confirmed)
+    }
+
+    func testFlowInterleavedWipeWithRcNoneStaysPending() {
+        // Finding scenario D': no cmd-28 processed this boot, so the wipe
+        // frame carries rc = NONE — not even a provisional failure.
+        var flow = GuidanceSendFlow(baselineSeq: 2, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(GuidanceTargetEcho(seq: 3, status: GuidanceTargetEcho.statusNone,
+                                       lastRc: GuidancePointRc.none.rawValue,
+                                       lat: 0, lon: 0, altM: 0))
+        XCTAssertEqual(flow.verdict, .waiting)
+        XCTAssertNil(flow.provisionalFailure)
+        flow.onEcho(echo(seq: 4))
+        XCTAssertEqual(flow.verdict, .confirmed)
+    }
+
+    func testFlowGenuineRejectionSettlesAtTimeoutWithItsReason() {
+        // A real rejection is indistinguishable from an interleaved stale-rc
+        // frame at arrival time, so it settles at the timeout — with the
+        // rc-mapped reason, not the generic silence message.
+        var flow = GuidanceSendFlow(baselineSeq: 3, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(echo(seq: 4, st: 0, rc: GuidancePointRc.rejectedRadius.rawValue))
+        XCTAssertEqual(flow.verdict, .waiting)
+        flow.onTimeout()
+        XCTAssertEqual(flow.verdict,
+                       .failed(GuidancePointRc.rejectedRadius.message))
+    }
+
+    func testFlowDuplicateBaselineFrameStaysWaiting_ConfirmIsTerminal() {
+        var flow = GuidanceSendFlow(baselineSeq: 5, sentLat: sentLat, sentLon: sentLon)
+        flow.onEcho(echo(seq: 5))                       // re-push of baseline
+        XCTAssertEqual(flow.verdict, .waiting)
+        flow.onEcho(echo(seq: 6))
+        XCTAssertEqual(flow.verdict, .confirmed)
+        // Terminal: a later rejection frame or timeout can't un-confirm.
+        flow.onEcho(echo(seq: 7, st: 0, rc: GuidancePointRc.rejectedState.rawValue))
+        flow.onTimeout()
+        XCTAssertEqual(flow.verdict, .confirmed)
+    }
+
+    func testRcMessagesCoverAllCodes() {
+        for rc in 0...6 {
+            XCTAssertNotNil(GuidancePointRc(rawValue: rc), "rc=\(rc)")
+        }
+        // Unknown codes must still produce a readable failure string.
+        XCTAssertTrue(GuidancePointRc.message(forRawValue: 99).contains("99"))
+    }
+
+    // MARK: - (c) FlightSettingsData v6 tail
+
+    /// 219-byte v6 frame: version byte at offset 4, guidance-target tail
+    /// {f32 e, f32 n, u8 src} at fixed offset 210.
+    private func v6Frame(e: Float, n: Float, src: UInt8) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 219)
+        bytes[4] = 6   // version
+        withUnsafeBytes(of: e.bitPattern.littleEndian) { bytes.replaceSubrange(210..<214, with: $0) }
+        withUnsafeBytes(of: n.bitPattern.littleEndian) { bytes.replaceSubrange(214..<218, with: $0) }
+        bytes[218] = src
+        return Data(bytes)
+    }
+
+    func testFlightSettingsV6TailParses() throws {
+        let fs = try FlightSettingsData(from: v6Frame(e: 12.5, n: -9.25, src: 1))
+        XCTAssertEqual(fs.guid_tgt_e_m, 12.5)
+        XCTAssertEqual(fs.guid_tgt_n_m, -9.25)
+        XCTAssertEqual(fs.guid_tgt_src, 1)
+    }
+
+    func testFlightSettingsV5FrameParsesWithNilTail() throws {
+        // Pre-#435 (v5, 210 B) frames must keep parsing, tail nil.
+        var bytes = [UInt8](repeating: 0, count: 210)
+        bytes[4] = 5
+        let fs = try FlightSettingsData(from: Data(bytes))
+        XCTAssertNil(fs.guid_tgt_e_m)
+        XCTAssertNil(fs.guid_tgt_n_m)
+        XCTAssertNil(fs.guid_tgt_src)
+        XCTAssertEqual(fs.version, 5)
+    }
+
+    func testFlightSettingsV6VersionButShortFrameStaysNil() throws {
+        // Defensive: version claims v6 but the frame is truncated at 210 —
+        // don't read past the buffer, report the tail as absent.
+        var bytes = [UInt8](repeating: 0, count: 210)
+        bytes[4] = 6
+        let fs = try FlightSettingsData(from: Data(bytes))
+        XCTAssertNil(fs.guid_tgt_e_m)
+        XCTAssertNil(fs.guid_tgt_src)
+    }
+}

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include <cstring>
 #include <map>
 #include "RocketComputerTypes.h"
+#include "GuidancePointGate.h"
 
 // Verify packed struct sizes match the SIZE_OF_* constants.
 // These must stay in sync because the I2S framing, binary log parser,
@@ -891,7 +893,12 @@ TEST(LoraMinValidSnrDb, AcceptsGenuineBorderlinePackets) {
 // by the FC (flight_computer/main.cpp) at byte-exact offsets. Lock the layout
 // here so a struct edit can't silently desync the cross-language decode.
 TEST(RocketComputerTypes, FlightSettingsData_Layout) {
-    EXPECT_EQ(sizeof(FlightSettingsData), 210u);  // v2: +12 b2r orientation; v3: +8 fin cal; v5: +2 imu rate
+    // v2: +12 b2r orientation; v3: +8 fin cal; v5: +2 imu rate;
+    // v6: +9 flown guidance target (#435).
+    EXPECT_EQ(sizeof(FlightSettingsData), 219u);
+    // 219 <= MAX_PAYLOAD (224, FlightSnapshotData-bound) — the v6 tail was
+    // deliberately E/N+src, not lat/lon+E/N, to stay under this ceiling
+    // WITHOUT growing the I2S frame bound.
     EXPECT_LE(sizeof(FlightSettingsData), MAX_PAYLOAD);
 
     EXPECT_EQ(offsetof(FlightSettingsData, time_us),            0u);
@@ -938,6 +945,13 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
     EXPECT_EQ(offsetof(FlightSettingsData, fin_min_deg),       200u);
     EXPECT_EQ(offsetof(FlightSettingsData, fin_max_deg),       204u);
     EXPECT_EQ(offsetof(FlightSettingsData, ism6_update_rate_hz), 208u);
+
+    // v6 flown-guidance-target tail (#435) — appended after
+    // ism6_update_rate_hz (208 + 2 = 210) so v1-v5 parsers decode their
+    // prefix unchanged.
+    EXPECT_EQ(offsetof(FlightSettingsData, guid_tgt_e_m),      210u);
+    EXPECT_EQ(offsetof(FlightSettingsData, guid_tgt_n_m),      214u);
+    EXPECT_EQ(offsetof(FlightSettingsData, guid_tgt_src),      218u);
 }
 
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
@@ -949,6 +963,315 @@ TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
                             (1u << FlightSettingsData::F_SOUNDS) |
                             (1u << FlightSettingsData::F_GUIDANCE_STATION_KEEP));
     EXPECT_EQ(all, 0x7Fu);  // bits 0-6, no overlap
+}
+
+// ============================================================================
+// #435: Drift-Cast guidance point (BLE cmd 28)
+// ============================================================================
+// The 20-byte GuidancePointData must be byte-for-byte the payload the iOS app
+// builds in BLEDevice.sendGuidancePoint ({lat f64, lon f64, alt f32} LE) —
+// there is no version field, so the layout IS the contract.
+TEST(RocketComputerTypes, GuidancePointData_Layout) {
+    EXPECT_EQ(sizeof(GuidancePointData), 20u);
+    EXPECT_EQ(offsetof(GuidancePointData, lat_deg), 0u);
+    EXPECT_EQ(offsetof(GuidancePointData, lon_deg), 8u);
+    EXPECT_EQ(offsetof(GuidancePointData, alt_m),   16u);
+}
+
+// OutStatusQueryData v5 guidance-target echo tail: the authoritative
+// sizeof/offsetof static_asserts live in RocketComputerTypes.h itself (this
+// test target recompiles the header, so they fire in CI); pin the version
+// semantics here so a format bump can't ship without a conscious edit.
+TEST(RocketComputerTypes, OutStatusQuery_GuidTargetEcho_V5) {
+    EXPECT_EQ(sizeof(OutStatusQueryData), 41u);  // v5: +13 guidance-target echo (#435)
+}
+
+// The FC's cmd-28 acceptance gate (GuidancePointGate.h) as a pure function —
+// each reject path, the gate ORDER, and the radius boundary are pinned here
+// (MramDirtyPolicy precedent: policy-as-pure-function, host-tested).
+namespace {
+constexpr float kMaxR = 100.0f;  // config::GUIDANCE_MAX_AIM_RADIUS_M
+
+// All-pass baseline; individual tests break one input at a time.
+uint8_t gateWith(bool ready_or_prelaunch = true, bool lockout = false,
+                 uint8_t law = GUIDE_LAW_STATION_KEEP, bool have_ref = true,
+                 double lat = 38.0, double lon = -122.0, float alt = 250.0f,
+                 float r = 15.0f, float max_r = kMaxR) {
+    return guidancePointRc(ready_or_prelaunch, lockout, law, have_ref,
+                           lat, lon, alt, r, max_r);
+}
+}  // namespace
+
+TEST(GuidancePointGate, AcceptsBaseline) {
+    EXPECT_EQ(gateWith(), GUID_RC_ACCEPTED);
+}
+
+TEST(GuidancePointGate, RejectsWrongStateAndLockout) {
+    EXPECT_EQ(gateWith(/*ready_or_prelaunch=*/false), GUID_RC_REJ_STATE);
+    EXPECT_EQ(gateWith(true, /*lockout=*/true),       GUID_RC_REJ_STATE);
+    // Both wrong: still STATE (single code for the whole class).
+    EXPECT_EQ(gateWith(false, true),                  GUID_RC_REJ_STATE);
+}
+
+TEST(GuidancePointGate, RejectsBadValues) {
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       NAN, -122.0),                     GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, INFINITY),                  GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, NAN),               GUID_RC_REJ_BADVAL);
+    // alt has NO range bound, so isfinite is the ONLY check standing between
+    // an infinite altitude and (int16_t)lround(INFINITY) in the echo —
+    // infinities pass isnan-only mutants, hence pinned explicitly.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, INFINITY),          GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, -INFINITY),         GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       90.001, -122.0),                  GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       -90.001, -122.0),                 GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, 180.001),                   GUID_RC_REJ_BADVAL);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -180.001),                  GUID_RC_REJ_BADVAL);
+    // Boundary coordinates are valid.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       90.0, 180.0),                     GUID_RC_ACCEPTED);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       -90.0, -180.0),                   GUID_RC_ACCEPTED);
+}
+
+TEST(GuidancePointGate, RejectsPnLaw) {
+    // Accepting a point PN silently ignores would recreate the #376 lie.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_PN), GUID_RC_REJ_LAW);
+}
+
+TEST(GuidancePointGate, RejectsNoReference) {
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP,
+                       /*have_ref=*/false),        GUID_RC_REJ_NOREF);
+}
+
+TEST(GuidancePointGate, RadiusBoundary_RejectNeverClamp) {
+    // <= max accepts: the 100.0 m boundary point is valid.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, 250.0f, 100.0f),  GUID_RC_ACCEPTED);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, 250.0f, 100.01f), GUID_RC_REJ_RADIUS);
+    // A non-finite radius (garbage conversion) must reject, not accept.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, 250.0f, NAN),     GUID_RC_REJ_RADIUS);
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, 250.0f, INFINITY), GUID_RC_REJ_RADIUS);
+}
+
+TEST(GuidancePointGate, GateOrder_StateBeatsBadvalBeatsLawBeatsNorefBeatsRadius) {
+    // Everything wrong at once: STATE wins.
+    EXPECT_EQ(gateWith(false, true, GUIDE_LAW_PN, false,
+                       NAN, 999.0, NAN, 1e9f),            GUID_RC_REJ_STATE);
+    // State ok, rest wrong: BADVAL wins.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_PN, false,
+                       NAN, 999.0, NAN, 1e9f),            GUID_RC_REJ_BADVAL);
+    // Values ok too: LAW wins over NOREF and RADIUS.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_PN, false,
+                       38.0, -122.0, 250.0f, 1e9f),       GUID_RC_REJ_LAW);
+    // Law ok: NOREF wins over RADIUS (r is meaningless without a reference).
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, false,
+                       38.0, -122.0, 250.0f, 1e9f),       GUID_RC_REJ_NOREF);
+    // Only the radius left: RADIUS.
+    EXPECT_EQ(gateWith(true, false, GUIDE_LAW_STATION_KEEP, true,
+                       38.0, -122.0, 250.0f, 1e9f),       GUID_RC_REJ_RADIUS);
+}
+
+// ============================================================================
+// guidanceLlaToEnu (GuidancePointGate.h) — the ONLY conversion on the cmd-28
+// flight path (receipt + launch re-convert).  An E/N transpose is exactly
+// radius-invariant (r is symmetric in e/n) so no runtime gate can see it, and
+// a degrees-as-radians slip only fails at runtime via the 100 m gate — both
+// mutations must die HERE, pinned against hand-computed flat-earth geodesy.
+namespace {
+constexpr double kRefLatDeg = 38.0;
+constexpr double kRefLonDeg = -122.0;
+constexpr double kDeg2Rad   = 0.017453292519943295;
+constexpr double kRefLatRad = kRefLatDeg * kDeg2Rad;
+constexpr double kRefLonRad = kRefLonDeg * kDeg2Rad;
+// 1e-4 deg of latitude on the R=6378137 sphere:
+//   N = 1e-4 * pi/180 * 6378137 = 11.131949 m
+// and the same arc of longitude scales by cos(38 deg) = 0.788011:
+//   E = 11.131949 * cos(38 deg) = 8.772097 m
+constexpr double kArcPerLatTick = 11.131949;   // m per 1e-4 deg, ref_alt = 0
+constexpr double kArcPerLonTick = 8.772097;    // m per 1e-4 deg at 38N
+}  // namespace
+
+TEST(GuidanceLlaToEnu, NorthOffsetMapsToNOnly) {
+    float e = -1.0f, n = -1.0f;
+    guidanceLlaToEnu(kRefLatDeg + 1e-4, kRefLonDeg,
+                     kRefLatRad, kRefLonRad, 0.0, e, n);
+    EXPECT_NEAR(n, kArcPerLatTick, 2e-3);
+    EXPECT_NEAR(e, 0.0, 1e-6);
+}
+
+TEST(GuidanceLlaToEnu, EastOffsetMapsToEOnly_CosLatScaled) {
+    float e = -1.0f, n = -1.0f;
+    guidanceLlaToEnu(kRefLatDeg, kRefLonDeg + 1e-4,
+                     kRefLatRad, kRefLonRad, 0.0, e, n);
+    EXPECT_NEAR(e, kArcPerLonTick, 2e-3);   // cos(lat)-scaled — kills E/N swap
+    EXPECT_NEAR(n, 0.0, 1e-6);
+}
+
+TEST(GuidanceLlaToEnu, SignsFollowSouthAndWest) {
+    float e = 0.0f, n = 0.0f;
+    guidanceLlaToEnu(kRefLatDeg - 1e-4, kRefLonDeg - 1e-4,
+                     kRefLatRad, kRefLonRad, 0.0, e, n);
+    EXPECT_NEAR(n, -kArcPerLatTick, 2e-3);
+    EXPECT_NEAR(e, -kArcPerLonTick, 2e-3);
+}
+
+TEST(GuidanceLlaToEnu, RefPointIsOrigin) {
+    float e = 99.0f, n = 99.0f;
+    guidanceLlaToEnu(kRefLatDeg, kRefLonDeg, kRefLatRad, kRefLonRad, 250.0, e, n);
+    EXPECT_EQ(e, 0.0f);
+    EXPECT_EQ(n, 0.0f);
+}
+
+TEST(GuidanceLlaToEnu, RefAltitudeGrowsTheSphere) {
+    // The EKF formula scales by (R_EARTH + ref_alt): 1000 m of pad altitude
+    // stretches the arc by 1 + 1000/6378137 = 1.5678e-4.
+    float e = 0.0f, n = 0.0f;
+    guidanceLlaToEnu(kRefLatDeg + 1e-4, kRefLonDeg,
+                     kRefLatRad, kRefLonRad, 1000.0, e, n);
+    EXPECT_NEAR(n, kArcPerLatTick * (1.0 + 1000.0 / 6378137.0), 2e-3);
+}
+
+TEST(GuidanceLlaToEnu, RadiansContract_DegreesInputWouldExplode) {
+    // Passing DEGREES where the formula multiplies by the earth radius gives
+    // km-scale garbage; the pinned metre-scale values above already kill that
+    // mutant, but pin the magnitude bound explicitly too.
+    float e = 0.0f, n = 0.0f;
+    guidanceLlaToEnu(kRefLatDeg + 1e-4, kRefLonDeg + 1e-4,
+                     kRefLatRad, kRefLonRad, 0.0, e, n);
+    EXPECT_LT(std::hypot(e, n), 20.0f);
+}
+
+// ============================================================================
+// guidanceLaunchReconvert (GuidancePointGate.h) — the launch-time keep-vs-wipe
+// policy.  A comparison flip here silently flies overhead on every Drift-Cast
+// flight while the pre-flight echo stays green, so keep/wipe/boundary are
+// host-pinned like the receipt gate.
+TEST(GuidanceLaunchReconvert, KeepsInRangePoint) {
+    const auto lt = guidanceLaunchReconvert(kRefLatDeg + 1e-4, kRefLonDeg,
+                                            kRefLatRad, kRefLonRad, 0.0, 100.0f);
+    EXPECT_TRUE(lt.point_kept);
+    EXPECT_NEAR(lt.n_m, kArcPerLatTick, 2e-3);
+    EXPECT_NEAR(lt.e_m, 0.0, 1e-6);
+}
+
+TEST(GuidanceLaunchReconvert, WipesOutOfRangePointToOverhead) {
+    // ~1113 m north — e.g. a point accepted against a REAL pad reference,
+    // re-converted after a sim reset rebuilt a synthetic one.
+    const auto lt = guidanceLaunchReconvert(kRefLatDeg + 1e-2, kRefLonDeg,
+                                            kRefLatRad, kRefLonRad, 0.0, 100.0f);
+    EXPECT_FALSE(lt.point_kept);
+    EXPECT_EQ(lt.e_m, 0.0f);
+    EXPECT_EQ(lt.n_m, 0.0f);
+}
+
+TEST(GuidanceLaunchReconvert, BoundaryRadiusKeeps_RejectNeverClamp) {
+    // <= accepts: compute the exact converted radius, then use it as max_r.
+    float e = 0.0f, n = 0.0f;
+    guidanceLlaToEnu(kRefLatDeg + 1e-4, kRefLonDeg + 1e-4,
+                     kRefLatRad, kRefLonRad, 0.0, e, n);
+    const float r = std::sqrt(e * e + n * n);
+    EXPECT_TRUE(guidanceLaunchReconvert(kRefLatDeg + 1e-4, kRefLonDeg + 1e-4,
+                                        kRefLatRad, kRefLonRad, 0.0, r)
+                    .point_kept);
+    EXPECT_FALSE(guidanceLaunchReconvert(kRefLatDeg + 1e-4, kRefLonDeg + 1e-4,
+                                         kRefLatRad, kRefLonRad, 0.0,
+                                         r * 0.999f)
+                     .point_kept);
+}
+
+// ============================================================================
+// Guidance-target echo transitions (GuidancePointGate.h) — the cmd-28 handler
+// wiring rules: honor the gate verdict (a reject NEVER applies the point),
+// bump seq on rejects too, leave the still-active display unchanged on
+// reject, and supersede-bumps only on real content changes.
+namespace {
+OutStatusQueryData echoWithAcceptedPoint() {
+    OutStatusQueryData q{};
+    EXPECT_TRUE(guidancePointEchoApply(q, GUID_RC_ACCEPTED, 38.1, -122.2, 249.6f));
+    return q;
+}
+}  // namespace
+
+TEST(GuidTargetEchoApply, AcceptUpdatesDisplayAndSeqAndRc) {
+    const OutStatusQueryData q = echoWithAcceptedPoint();
+    EXPECT_EQ(q.tgt_status, GUID_TGT_GEO_ACTIVE);
+    EXPECT_FLOAT_EQ(q.tgt_lat_deg, 38.1f);
+    EXPECT_FLOAT_EQ(q.tgt_lon_deg, -122.2f);
+    EXPECT_EQ(q.tgt_alt_m, 250);   // rounded, not truncated
+    EXPECT_EQ(q.tgt_seq, 1);
+    EXPECT_EQ(q.tgt_last_rc, GUID_RC_ACCEPTED);
+}
+
+TEST(GuidTargetEchoApply, RejectBumpsSeqButNeverAppliesOrTouchesDisplay) {
+    for (uint8_t rc : {GUID_RC_REJ_RADIUS, GUID_RC_REJ_STATE, GUID_RC_REJ_LAW,
+                       GUID_RC_REJ_NOREF, GUID_RC_REJ_BADVAL}) {
+        OutStatusQueryData q = echoWithAcceptedPoint();
+        // Returns false -> the caller must NOT move the flight target (the
+        // inverted-#376 lie: app shows "rejected" while the target moved).
+        EXPECT_FALSE(guidancePointEchoApply(q, rc, 40.0, -100.0, 10.0f))
+            << "rc=" << (int)rc;
+        // Display = the still-active PREVIOUS point, seq/rc = the verdict.
+        EXPECT_EQ(q.tgt_status, GUID_TGT_GEO_ACTIVE);
+        EXPECT_FLOAT_EQ(q.tgt_lat_deg, 38.1f);
+        EXPECT_FLOAT_EQ(q.tgt_lon_deg, -122.2f);
+        EXPECT_EQ(q.tgt_alt_m, 250);
+        EXPECT_EQ(q.tgt_seq, 2);
+        EXPECT_EQ(q.tgt_last_rc, rc);
+    }
+}
+
+TEST(GuidTargetEchoSupersede, WipesDisplayBumpsSeqKeepsRc) {
+    OutStatusQueryData q = echoWithAcceptedPoint();
+    EXPECT_TRUE(guidanceTargetEchoSupersede(q, GUID_TGT_EN_ACTIVE));
+    EXPECT_EQ(q.tgt_status, GUID_TGT_EN_ACTIVE);
+    EXPECT_EQ(q.tgt_lat_deg, 0.0f);
+    EXPECT_EQ(q.tgt_lon_deg, 0.0f);
+    EXPECT_EQ(q.tgt_alt_m, 0);
+    EXPECT_EQ(q.tgt_seq, 2);
+    // rc is "result of the LAST processed cmd 28" — a supersede isn't one.
+    EXPECT_EQ(q.tgt_last_rc, GUID_RC_ACCEPTED);
+}
+
+TEST(GuidTargetEchoSupersede, NoOpDoesNotChurnSeq) {
+    // Connect-time profile push with no cmd-28 point in play: seq must NOT
+    // move, or every reconnect would shift the app's send baseline.
+    OutStatusQueryData q{};
+    q.tgt_status = GUID_TGT_NONE;
+    EXPECT_FALSE(guidanceTargetEchoSupersede(q, GUID_TGT_NONE));
+    EXPECT_EQ(q.tgt_seq, 0);
+    // Same status twice in a row after a real wipe: second one is a no-op.
+    OutStatusQueryData g = echoWithAcceptedPoint();
+    EXPECT_TRUE(guidanceTargetEchoSupersede(g, GUID_TGT_NONE));
+    EXPECT_FALSE(guidanceTargetEchoSupersede(g, GUID_TGT_NONE));
+    EXPECT_EQ(g.tgt_seq, 2);
+}
+
+TEST(GuidTargetEchoSupersede, StatusChangeAloneBumps) {
+    // Sim-reset / cmd-65 path where only the status differs (display already
+    // clear): the app still needs to SEE the transition.
+    OutStatusQueryData q{};
+    q.tgt_status = GUID_TGT_EN_ACTIVE;
+    EXPECT_TRUE(guidanceTargetEchoSupersede(q, GUID_TGT_NONE));
+    EXPECT_EQ(q.tgt_seq, 1);
+}
+
+TEST(GuidFlownTargetSrc, GeoWinsThenModeDecides) {
+    EXPECT_EQ(guidanceFlownTargetSrc(true,  GUIDE_TARGET_OVERHEAD), GUID_TGT_GEO_ACTIVE);
+    EXPECT_EQ(guidanceFlownTargetSrc(true,  GUIDE_TARGET_POINT),    GUID_TGT_GEO_ACTIVE);
+    EXPECT_EQ(guidanceFlownTargetSrc(false, GUIDE_TARGET_POINT),    GUID_TGT_EN_ACTIVE);
+    EXPECT_EQ(guidanceFlownTargetSrc(false, GUIDE_TARGET_OVERHEAD), GUID_TGT_NONE);
 }
 
 // ============================================================================
@@ -1034,6 +1357,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         MT(FIN_CONFIG_PENDING),       MT(FIN_CONFIG_MSG),
         // IMU logging rate config (BLE cmd 67).
         MT(IMU_RATE_CONFIG_PENDING),  MT(IMU_RATE_CONFIG_MSG),
+        // #435 Drift-Cast guidance point (BLE cmd 28).
+        MT(GUIDANCE_POINT_PENDING),   MT(GUIDANCE_POINT_MSG),
         // #402: FC->OC slave TX-ring desync recovery trigger.
         MT(I2C_TX_RESYNC),
     };
@@ -1057,7 +1382,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // -- the uniqueness check is only as strong as the list it walks.
     // 87 = 80 prior + guidance/fin config pair codes (were missing, #386 gap)
     //    + I2C_TX_RESYNC (#402) + IMU rate config pair (BLE cmd 67).
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 87u)
+    // 89 = 87 + Drift-Cast guidance point pair (#435, BLE cmd 28).
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 89u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/GuidancePointGate.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/GuidancePointGate.h
@@ -1,0 +1,180 @@
+#ifndef GUIDANCE_POINT_GATE_H
+#define GUIDANCE_POINT_GATE_H
+
+// #435: the cmd-28 (Drift-Cast guidance aim point) acceptance policy as a
+// PURE function, extracted from the FC handler so the gate ORDER and its
+// edge cases are host-testable (MramDirtyPolicy precedent).  The FC handler
+// computes the inputs (state, lockout, law, ref availability, the converted
+// pad-relative radius) and this function alone decides the GUID_RC_* result.
+//
+// Gate order is LOAD-BEARING and pinned by the host tests:
+//   state > badval > law > noref > radius
+// - state first: a point delivered in the wrong state must never leak a more
+//   specific (and more actionable-sounding) rejection reason.
+// - badval before law/noref: garbage coordinates are garbage regardless of
+//   configuration.
+// - law before noref: accepting a point that PN would silently ignore
+//   recreates the #376 lie, and that answer doesn't depend on GNSS.
+// - radius last: it is the only check that needs the conversion, which in
+//   turn needs the reference (noref already screened that).
+//
+// r_m is the caller-converted pad-relative horizontal distance; it is only
+// consulted once every earlier gate passed, so callers without a reference
+// may pass any value (conventionally 0).  Radius policy is REJECT-never-
+// clamp, <= max_r_m accepts (the 100.0 m boundary point is valid).
+//
+// guidance_enabled is deliberately NOT an input: cmd 32 (enable) may
+// legitimately arrive after the point, and "ge" is separately echoed.
+
+#include <cmath>
+#include <stdint.h>
+
+#include "RocketComputerTypes.h"
+
+inline uint8_t guidancePointRc(bool ready_or_prelaunch, bool lockout,
+                               uint8_t law, bool have_ref,
+                               double lat_deg, double lon_deg, float alt_m,
+                               float r_m, float max_r_m)
+{
+    if (!ready_or_prelaunch || lockout)
+    {
+        return GUID_RC_REJ_STATE;
+    }
+    if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg) ||
+        !std::isfinite(alt_m) ||
+        lat_deg < -90.0 || lat_deg > 90.0 ||
+        lon_deg < -180.0 || lon_deg > 180.0)
+    {
+        return GUID_RC_REJ_BADVAL;
+    }
+    if (law != GUIDE_LAW_STATION_KEEP)
+    {
+        return GUID_RC_REJ_LAW;
+    }
+    if (!have_ref)
+    {
+        return GUID_RC_REJ_NOREF;
+    }
+    if (!std::isfinite(r_m) || r_m > max_r_m)
+    {
+        return GUID_RC_REJ_RADIUS;
+    }
+    return GUID_RC_ACCEPTED;
+}
+
+// ---------------------------------------------------------------------------
+// WGS84 geodetic -> pad-relative flat-earth ENU (#435).  This is the ONLY
+// conversion the cmd-28 path uses (receipt + launch re-convert), extracted
+// pure so the axis convention and the radians contract are host-pinned
+// against known geodesy values — an E/N transpose or a degrees-as-radians
+// slip is radius-invariant, so no runtime gate can catch it.  Must agree
+// term-for-term with the EKF position path in FC main.cpp (loop_fc imu_pos
+// block) or the flown miss distance silently differs from the commanded one.
+// lat/lon in DEGREES; ref_lat/lon in RADIANS; ref_alt in metres.
+inline void guidanceLlaToEnu(double lat_deg, double lon_deg,
+                             double ref_lat_rad, double ref_lon_rad,
+                             double ref_alt_m,
+                             float& e_m, float& n_m)
+{
+    constexpr double R_EARTH  = 6378137.0;
+    constexpr double DEG2RAD  = 0.017453292519943295;  // pi/180
+    const double lat_rad = lat_deg * DEG2RAD;
+    const double lon_rad = lon_deg * DEG2RAD;
+    e_m = (float)((lon_rad - ref_lon_rad) * (R_EARTH + ref_alt_m) * cos(ref_lat_rad));
+    n_m = (float)((lat_rad - ref_lat_rad) * (R_EARTH + ref_alt_m));
+}
+
+// Launch-time re-check of an accepted Drift-Cast point against the just-
+// frozen reference (#435).  Same REJECT-never-clamp policy as the receipt
+// gate: keep the re-converted point iff its radius is finite and inside
+// max_r_m, otherwise fail SAFE to (0,0) overhead and drop the point
+// (point_kept=false -> caller clears guid_point_valid so the settings
+// snapshot + echo record what actually flies).  Extracted pure so the
+// keep-vs-wipe decision — a second acceptance policy — gets the same host
+// coverage as guidancePointRc().
+struct GuidanceLaunchTarget
+{
+    float e_m;
+    float n_m;
+    bool  point_kept;   // false = fail-safed to (0,0) overhead
+};
+
+inline GuidanceLaunchTarget guidanceLaunchReconvert(double lat_deg, double lon_deg,
+                                                    double ref_lat_rad,
+                                                    double ref_lon_rad,
+                                                    double ref_alt_m,
+                                                    float max_r_m)
+{
+    float e = 0.0f, n = 0.0f;
+    guidanceLlaToEnu(lat_deg, lon_deg, ref_lat_rad, ref_lon_rad, ref_alt_m, e, n);
+    const float r = sqrtf(e * e + n * n);
+    if (std::isfinite(r) && r <= max_r_m)
+    {
+        return { e, n, true };
+    }
+    return { 0.0f, 0.0f, false };
+}
+
+// ---------------------------------------------------------------------------
+// Guidance-target echo transitions (#435), pure over OutStatusQueryData so the
+// handler wiring rules are host-testable: the gate verdict must be honored
+// (a reject NEVER applies the point), seq bumps on EVERY processed cmd 28,
+// and a reject leaves the display fields (status/lat/lon/alt — the still-
+// active previous target) untouched.
+
+// Apply a processed cmd-28 result to the echo.  Returns true iff the point
+// was ACCEPTED — the caller applies it to the flight target ONLY then.
+inline bool guidancePointEchoApply(OutStatusQueryData& q, uint8_t rc,
+                                   double lat_deg, double lon_deg, float alt_m)
+{
+    const bool accepted = (rc == GUID_RC_ACCEPTED);
+    if (accepted)
+    {
+        q.tgt_status  = GUID_TGT_GEO_ACTIVE;
+        q.tgt_lat_deg = (float)lat_deg;
+        q.tgt_lon_deg = (float)lon_deg;
+        q.tgt_alt_m   = (int16_t)std::lround((double)alt_m);
+    }
+    // On reject: status/lat/lon/alt stay UNCHANGED — a still-active previous
+    // target keeps displaying; only seq/last_rc report the result (why the
+    // two are separate fields).
+    q.tgt_seq++;
+    q.tgt_last_rc = rc;
+    return accepted;
+}
+
+// A non-cmd-28 event superseded any geodetic point (cmd-65 apply, sim
+// start/stop reset, launch fail-safe): show new_status with cleared
+// coordinates.  Bumps seq ONLY when the echo content actually changed, so a
+// no-op connect-time profile push (no cmd-28 point in play) doesn't churn
+// the app's seq baseline.  Deliberately does NOT touch tgt_last_rc: rc is
+// the result of the last processed cmd 28, and this event isn't one.
+// Returns true when the echo changed.
+inline bool guidanceTargetEchoSupersede(OutStatusQueryData& q, uint8_t new_status)
+{
+    if (q.tgt_status == new_status &&
+        q.tgt_lat_deg == 0.0f && q.tgt_lon_deg == 0.0f && q.tgt_alt_m == 0)
+    {
+        return false;
+    }
+    q.tgt_status  = new_status;
+    q.tgt_lat_deg = 0.0f;
+    q.tgt_lon_deg = 0.0f;
+    q.tgt_alt_m   = 0;
+    q.tgt_seq++;
+    return true;
+}
+
+// Which target actually flies / is currently active (#435): a valid cmd-28
+// geodetic point wins, else the cmd-65 profile point when target_mode is
+// POINT, else overhead.  Shared by the FlightSettings v6 tail (flown src),
+// the boot echo init, and the cmd-65 supersede status.
+inline uint8_t guidanceFlownTargetSrc(bool geo_point_valid, uint8_t target_mode)
+{
+    return geo_point_valid
+               ? GUID_TGT_GEO_ACTIVE
+               : ((target_mode == GUIDE_TARGET_POINT) ? GUID_TGT_EN_ACTIVE
+                                                      : GUID_TGT_NONE);
+}
+
+#endif  // GUIDANCE_POINT_GATE_H

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -758,6 +758,7 @@ typedef struct __attribute__((packed))
                                   //   2 = has HG bias
                                   //   3 = has board→rocket orientation
                                   //   4 = has IIS2MDC rotation
+                                  //   5 = has guidance-target echo (#435)
     int16_t  hg_bias_x_cmss;     // high-g bias X, centi-m/s² (0.01 m/s² units)
     int16_t  hg_bias_y_cmss;     // high-g bias Y, centi-m/s²
     int16_t  hg_bias_z_cmss;     // high-g bias Z, centi-m/s²
@@ -776,9 +777,23 @@ typedef struct __attribute__((packed))
     // from the MMC5983MA's (mmc_rot_z_cdeg).  Consumers must apply THIS to
     // IIS2MDC data — using mmc_rot_z_cdeg gives a 180° (or worse) heading error.
     int16_t  iis2mdc_rot_z_cdeg; // centi-deg
+
+    // Guidance-target echo (format_version >= 5, #435).  f32 degrees: ulp is
+    // ~0.4 m at mid-latitudes — fine for the app's send-verify, NOT for
+    // navigation (the FC keeps the f64 originals).  tgt_status describes the
+    // CURRENT target; tgt_last_rc the result of the LAST processed cmd 28.
+    // They are separate fields so a rejected upload does not erase the
+    // display of a still-active previous target.
+    float   tgt_lat_deg;   // WGS84 (0 when no cmd-28 geodetic point)
+    float   tgt_lon_deg;
+    int16_t tgt_alt_m;     // stored/echoed only — station-keep ignores altitude
+    uint8_t tgt_seq;       // ++ on EVERY processed cmd 28 (accept or reject)
+                           // and on any cmd-65 apply that changes the echo
+    uint8_t tgt_status;    // GUID_TGT_*
+    uint8_t tgt_last_rc;   // GUID_RC_*
 } OutStatusQueryData;
-static_assert(sizeof(OutStatusQueryData) == 28,
-              "OutStatusQueryData must be 28 bytes");
+static_assert(sizeof(OutStatusQueryData) == 41,
+              "OutStatusQueryData must be 41 bytes");
 
 // ### Data Structures ###
 // Packed and unpacked data structures for each type ---
@@ -1896,6 +1911,13 @@ static constexpr uint8_t FIN_CONFIG_MSG          = 0xF3;  // 18-byte FinConfigDa
 // the 44100 Hz I2S link can carry (3840 ≈ 156 of 176 KB/s framed).
 static constexpr uint8_t IMU_RATE_CONFIG_PENDING = 0xF5;  // OC→FC: payload follows as IMU_RATE_CONFIG_MSG
 static constexpr uint8_t IMU_RATE_CONFIG_MSG     = 0xF6;  // 2-byte ImuRateConfigData
+// Drift-Cast guidance aim point (#435, BLE cmd 28): OC→FC two-phase like the
+// other config pairs.  Payload is byte-for-byte the app's 20-byte
+// {lat f64, lon f64, alt f32} LE frame (GuidancePointData).  0xF7-0xFD were
+// free — the contiguous config block ended at 0xF6; stay clear of 0xFE/0xFF
+// (LoRa-namespace sentinels, a separate code space, but don't tempt fate).
+static constexpr uint8_t GUIDANCE_POINT_PENDING  = 0xF7;  // OC→FC: payload follows as GUIDANCE_POINT_MSG
+static constexpr uint8_t GUIDANCE_POINT_MSG      = 0xF8;  // 20-byte GuidancePointData
 
 // #402: FC→OC over I2C, sent as a master WRITE (writes still work while the
 // slave TX ring is desynced by an aborted read).  On receipt the OC resets its
@@ -2035,6 +2057,20 @@ static constexpr uint8_t GUIDE_LAW_PN           = 0;  // proportional navigation
 static constexpr uint8_t GUIDE_LAW_STATION_KEEP = 1;  // overhead PD regulator (#335)
 static constexpr uint8_t GUIDE_LAW_MAX          = 1;  // highest defined law (validation bound)
 
+// Guidance-target echo codes (OutStatusQueryData v5 tgt_status / tgt_last_rc,
+// #435).  Shared FC/OC via this header; the app mirrors them as a Swift enum.
+static constexpr uint8_t GUID_TGT_NONE       = 0;  // no aim point (overhead / cleared)
+static constexpr uint8_t GUID_TGT_GEO_ACTIVE = 1;  // cmd-28 geodetic point active
+static constexpr uint8_t GUID_TGT_EN_ACTIVE  = 2;  // cmd-65 profile E/N point active
+// tgt_last_rc: result of the last processed cmd 28.
+static constexpr uint8_t GUID_RC_NONE       = 0;  // no cmd 28 processed since boot
+static constexpr uint8_t GUID_RC_ACCEPTED   = 1;
+static constexpr uint8_t GUID_RC_REJ_RADIUS = 2;  // converted point > GUIDANCE_MAX_AIM_RADIUS_M
+static constexpr uint8_t GUID_RC_REJ_STATE  = 3;  // not READY/PRELAUNCH, or post-flight lockout
+static constexpr uint8_t GUID_RC_REJ_LAW    = 4;  // law is PN — a point would be silently inert (#376)
+static constexpr uint8_t GUID_RC_REJ_NOREF  = 5;  // no GNSS launch-site reference yet
+static constexpr uint8_t GUID_RC_REJ_BADVAL = 6;  // non-finite / out-of-range lat/lon/alt
+
 // App-configurable guidance (PN and station-keep share this frame).
 // ENU metres are relative to the launch pad, matching the FC's imu_pos frame
 // (no conversion).
@@ -2075,6 +2111,19 @@ typedef struct __attribute__((packed))
                                 //   (mirrors TR_GuidancePN::Mode by value)
 } GuidanceConfigData;
 static_assert(sizeof(GuidanceConfigData) == 45, "GuidanceConfigData must be 45 bytes");
+
+// Drift-Cast guidance aim point (#435, BLE cmd 28).  Byte-for-byte the app
+// payload built by BLEDevice.sendGuidancePoint: {lat f64, lon f64, alt f32} LE.
+// The FC converts to pad-relative ENU at receipt (and re-converts when the
+// reference freezes at launch); it is held in RAM only — never NVS — so a
+// stale wind-compensated target can't self-apply on a later boot.
+typedef struct __attribute__((packed)) {
+    double lat_deg;   // WGS84
+    double lon_deg;
+    float  alt_m;     // profile apogee (m). Stored + echoed only — station-keep
+                      // does not consume a target altitude (see FC handler).
+} GuidancePointData;
+static_assert(sizeof(GuidancePointData) == 20, "GuidancePointData must be 20 bytes");
 
 // App-configurable fin→servo mix.  azimuth_deg[i] is the CONTROL azimuth of the fin
 // driven by servo i:
@@ -2190,7 +2239,8 @@ struct __attribute__((packed)) FlightSettingsData
     //  free flags bit, bit 6.  Layout is byte-identical, so VERSION stays 5 —
     //  bumping it would force a sweep of the Data_Analysis parsers, which
     //  hardcode message lengths, for a bit that older readers already ignore.)
-    static constexpr uint8_t VERSION = 5;
+    // v6: appended the flown guidance target (guid_tgt_* tail, #435).
+    static constexpr uint8_t VERSION = 6;
 
     // flags bit positions
     static constexpr uint8_t F_USE_ANGLE_CONTROL = 0;  // cascaded angle vs rate-only
@@ -2267,8 +2317,23 @@ struct __attribute__((packed)) FlightSettingsData
 
     // IMU logging rate that actually flew (v5+): the ISM6HG256 ODR in Hz.
     uint16_t ism6_update_rate_hz;
+
+    // Flown guidance target (v6+, #435).  ENU metres relative to the pad —
+    // the frame guidance actually flies.  A cmd-28 geodetic point is snapped
+    // here AFTER the launch-time re-conversion against the frozen reference,
+    // so these are the FLOWN values (the receipt-time geodetic original lives
+    // in the OutStatusQueryData echo + the app's record; serial log lines
+    // don't persist).  guid_tgt_src = GUID_TGT_* (0 = overhead/none,
+    // 1 = cmd-28 geodetic point, 2 = cmd-65 profile E/N point).  Kept to
+    // E/N + src (9 B, sizeof 219) deliberately: a lat/lon+E/N tail would
+    // cross MAX_PAYLOAD (224, FlightSnapshotData-bound) and force an I2S
+    // frame-size ripple across FC+OC.
+    float    guid_tgt_e_m;
+    float    guid_tgt_n_m;
+    uint8_t  guid_tgt_src;
 };
-static_assert(sizeof(FlightSettingsData) == 210, "FlightSettingsData layout check");
+static_assert(sizeof(FlightSettingsData) == 219,
+              "FlightSettingsData layout check (v6: flown guidance target, #435)");
 
 // --- Log Buffer Stats Data (OC self-emitted, ~1 Hz while logging) -----------
 // Snapshot of the OC's ring-buffer health written into the flight log so the
@@ -2490,7 +2555,7 @@ static_assert(offsetof(NonSensorData, apogee_flags) == 43, "NonSensorData.apogee
 static_assert(offsetof(NonSensorData, sensor_health) == 44, "NonSensorData.sensor_health moved");
 static_assert(offsetof(NonSensorData, ekf_ticks) == 48, "NonSensorData.ekf_ticks moved");
 
-static_assert(sizeof(OutStatusQueryData) == 28, "OutStatusQueryData wire size");
+static_assert(sizeof(OutStatusQueryData) == 41, "OutStatusQueryData wire size");
 static_assert(offsetof(OutStatusQueryData, ism6_low_g_fs_g) == 0, "OutStatusQueryData.ism6_low_g_fs_g moved");
 static_assert(offsetof(OutStatusQueryData, ism6_high_g_fs_g) == 1, "OutStatusQueryData.ism6_high_g_fs_g moved");
 static_assert(offsetof(OutStatusQueryData, ism6_gyro_fs_dps) == 3, "OutStatusQueryData.ism6_gyro_fs_dps moved");
@@ -2504,6 +2569,13 @@ static_assert(offsetof(OutStatusQueryData, b2r_code) == 16, "OutStatusQueryData.
 static_assert(offsetof(OutStatusQueryData, b2r_mode) == 17, "OutStatusQueryData.b2r_mode moved");
 static_assert(offsetof(OutStatusQueryData, b2r_q) == 18, "OutStatusQueryData.b2r_q moved");
 static_assert(offsetof(OutStatusQueryData, iis2mdc_rot_z_cdeg) == 26, "OutStatusQueryData.iis2mdc_rot_z_cdeg moved");
+// v5 guidance-target echo tail (#435).
+static_assert(offsetof(OutStatusQueryData, tgt_lat_deg) == 28, "OutStatusQueryData.tgt_lat_deg moved");
+static_assert(offsetof(OutStatusQueryData, tgt_lon_deg) == 32, "OutStatusQueryData.tgt_lon_deg moved");
+static_assert(offsetof(OutStatusQueryData, tgt_alt_m)   == 36, "OutStatusQueryData.tgt_alt_m moved");
+static_assert(offsetof(OutStatusQueryData, tgt_seq)     == 38, "OutStatusQueryData.tgt_seq moved");
+static_assert(offsetof(OutStatusQueryData, tgt_status)  == 39, "OutStatusQueryData.tgt_status moved");
+static_assert(offsetof(OutStatusQueryData, tgt_last_rc) == 40, "OutStatusQueryData.tgt_last_rc moved");
 
 static_assert(sizeof(ServoConfigData) == 22, "ServoConfigData wire size");
 static_assert(offsetof(ServoConfigData, bias_us) == 0, "ServoConfigData.bias_us moved");

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -4880,7 +4880,9 @@ static void loop_bs()
     else if (ble_cmd == BLE_BS_CMD_RELAY_TO_ROCKET)
     {
         // Relay command to a specific rocket via LoRa uplink
-        // Payload: [target_rid:1][inner_cmd:1][inner_payload:0..18]
+        // Payload: [target_rid:1][inner_cmd:1][inner_payload:0..33 (bs_uplink_queue::kMaxPayload)]
+        // (was documented as 0..18 — stale; the queue accepts 33, and #435's
+        // cmd-28 guidance point needs a 20-byte inner payload.)
         const uint8_t* payload = ble_app.getCommandPayload();
         const size_t plen = ble_app.getCommandPayloadLength();
         if (plen >= 2)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -20,6 +20,7 @@
 #include <TR_GuidancePN.h>
 #include <TR_ControlMixer.h>
 #include <RocketComputerTypes.h>
+#include <GuidancePointGate.h>    // #435: pure cmd-28 acceptance gate (host-tested)
 #include <TR_OTA_Receiver.h>      // FC-side OTA relay receiver (#8 Phase 4)
 #include <TR_OTA_Backend_esp.h>
 #include <esp_system.h>           // esp_restart after a verified relayed OTA
@@ -390,6 +391,24 @@ static float    pn_target_alt     = config::PN_TARGET_ALT_M;
 static float    pn_kp_pos         = config::PN_KP_POS_PER_S2;
 static float    pn_kd_vel         = config::PN_KD_VEL_PER_S;
 static uint8_t  pn_guidance_law   = config::GUIDANCE_LAW_DEFAULT;  // GUIDE_LAW_*
+// Drift-Cast geodetic aim point (#435, BLE cmd 28).  RAM ONLY — deliberately
+// never persisted to NVS: a stale wind-compensated target self-applying on a
+// later boot is the hazard; Drift-Cast targets are per-flight ephemeral (the
+// NVS gte/gtn/gta keys stay owned exclusively by cmd 65).  The echo state
+// lives directly in out_status_query_data.tgt_* (single writer: loop_fc), so
+// every OUT_STATUS_QUERY poll carries it for free.
+static bool   guid_point_valid   = false;
+static double guid_point_lat_deg = 0.0;
+static double guid_point_lon_deg = 0.0;
+static float  guid_point_alt_m   = 0.0f;
+// Shadow of the cmd-65/NVS-OWNED aim point.  pn_target_e/n temporarily
+// diverge from these while a Drift-Cast (cmd-28) point is active; every
+// path that drops the cmd-28 point outside a flight (cmd-65 reject-keep-
+// previous, sim start/stop reset) reverts pn_target_e/n to these — NEVER
+// leaving the wind-compensated conversion behind where the unconditional
+// cmd-65 NVS persist (or a sim run) could adopt it as a profile point.
+static float  pn_profile_target_e = config::PN_TARGET_E_M;
+static float  pn_profile_target_n = config::PN_TARGET_N_M;
 // Last commanded pre-mix fin deflections from guidance, carried from the
 // guidance compute block to the ~10 Hz GuidanceTelemData emit. Only meaningful
 // while guidance_active (the only condition under which they are logged).
@@ -1601,6 +1620,23 @@ static void applyGuidanceConfig()
     guidance.setHorizontalTarget(pn_target_e, pn_target_n);   // inert in MODE_PN
 }
 
+// #435: convert a WGS84 geodetic point to pad-relative ENU.  The math is the
+// pure host-tested guidanceLlaToEnu() in GuidancePointGate.h (pinned against
+// known geodesy values — it must agree with the EKF position path in
+// loop_fc's imu_pos block or the flown miss distance silently differs from
+// the commanded one); this wrapper only binds the launch-site reference
+// statics.  Inputs in degrees; ref_* are radians.  Returns false (and leaves
+// e/n untouched) when no launch-site reference exists yet.
+static bool guidanceLlaToEnu(double lat_deg, double lon_deg, float& e, float& n)
+{
+    if (!have_ref_pos)
+    {
+        return false;
+    }
+    guidanceLlaToEnu(lat_deg, lon_deg, ref_lat_rad, ref_lon_rad, ref_alt_m, e, n);
+    return true;
+}
+
 // Build a snapshot of the active roll-control / IMU settings (#165).  Reads
 // the live PID gains from servo_control (these can be NVS- or BLE-overridden),
 // the runtime override globals, the config:: defaults for the compile-time-only
@@ -1676,6 +1712,13 @@ static void buildFlightSettings(FlightSettingsData& s)
     for (int i = 0; i < 4; ++i) {
         s.b2r_q[i] = (int16_t)lroundf(b2r_active_quat[i] * ORIENT_QUAT_WIRE_SCALE);
     }
+
+    // Flown guidance target (v6+, #435).  Emitted at launch+0/100/200 ms —
+    // AFTER enterInflight()'s re-conversion — so a cmd-28 point lands here
+    // with the flown E/N values.  src records where the point came from.
+    s.guid_tgt_e_m = pn_target_e;
+    s.guid_tgt_n_m = pn_target_n;
+    s.guid_tgt_src = guidanceFlownTargetSrc(guid_point_valid, pn_target_mode);
 }
 
 static void sendFlightSettings()
@@ -2551,6 +2594,10 @@ static void setup_fc()
     pn_target_e       = prefs.getFloat("gte", config::PN_TARGET_E_M);
     pn_target_n       = prefs.getFloat("gtn", config::PN_TARGET_N_M);
     pn_target_alt     = prefs.getFloat("gta", config::PN_TARGET_ALT_M);
+    // The NVS record IS the profile-owned aim point — seed the shadows the
+    // cmd-65 reject path / sim reset revert to (see pn_profile_target_*).
+    pn_profile_target_e = pn_target_e;
+    pn_profile_target_n = pn_target_n;
     pn_kp_pos       = prefs.getFloat("gkp", config::PN_KP_POS_PER_S2);
     pn_kd_vel       = prefs.getFloat("gkd", config::PN_KD_VEL_PER_S);
     pn_guidance_law = prefs.getUChar("glw", config::GUIDANCE_LAW_DEFAULT);
@@ -2805,7 +2852,16 @@ static void setup_fc()
     // v3: adds board→rocket orientation (b2r_* fields, filled by
     // applyBoardToRocketOrientation above and on any runtime change).
     // v4: adds per-chip iis2mdc_rot_z_cdeg (#204).
-    out_status_query_data.format_version = 4;
+    // v5: adds the guidance-target echo (#435).
+    out_status_query_data.format_version = 5;
+    // Guidance-target echo boot state (#435): no cmd 28 processed yet; the
+    // current target is whatever cmd 65 left in NVS (restored above).
+    out_status_query_data.tgt_seq     = 0;
+    out_status_query_data.tgt_last_rc = GUID_RC_NONE;
+    out_status_query_data.tgt_status  = guidanceFlownTargetSrc(false, pn_target_mode);
+    out_status_query_data.tgt_lat_deg = 0.0f;
+    out_status_query_data.tgt_lon_deg = 0.0f;
+    out_status_query_data.tgt_alt_m   = 0;
 
     // NOTE: Do NOT drain the slave TX buffer here.  With the new
     // i2c_slave driver, reading when the slave has no TX data queued
@@ -3187,6 +3243,25 @@ static void resetFlightStateForSim(const char* edge)
     reboot_recovery = false;
     reboot_recovery_telem = false;
     clearFlightSnapshot();
+    // #435: a sim start/stop is the sim's equivalent of a reboot, and a real
+    // reboot drops the (RAM-only) Drift-Cast point.  The ref just discarded
+    // above is also the frame the point's receipt-time conversion used — the
+    // sim's synthetic GNSS rebuilds a DIFFERENT reference, so keeping the
+    // point would either fly a bogus E/N or hit the enterInflight fail-safe
+    // while the echo kept asserting GEO_ACTIVE.  Drop it, revert the target
+    // to the profile-owned point, and refresh the echo so the app SEES the
+    // drop (supersede bumps tgt_seq -> the OC's change-detect republishes).
+    if (guid_point_valid) {
+        guid_point_valid = false;
+        pn_target_e = pn_profile_target_e;
+        pn_target_n = pn_profile_target_n;
+        applyGuidanceConfig();   // re-runs the radius gate + setHorizontalTarget
+        ESP_LOGW(TAG, "[GUID PT] sim %s dropped the Drift-Cast point — "
+                      "target reverted to profile (%.1f,%.1f)",
+                 edge, (double)pn_target_e, (double)pn_target_n);
+    }
+    (void)guidanceTargetEchoSupersede(
+        out_status_query_data, guidanceFlownTargetSrc(false, pn_target_mode));
     ESP_LOGI(TAG, "[STATE] Sim %s -> READY", edge);
 }
 
@@ -3217,6 +3292,49 @@ static void enterInflight(uint32_t now_ms, const char* from_state)
         ref_pos_frozen = true;
         ESP_LOGI(TAG, "[EKF] Ref pos frozen (launch): n=%lu",
                       (unsigned long)ref_pos_count);
+    }
+    // #435: re-convert the Drift-Cast geodetic aim point against the just-
+    // frozen reference — the receipt-time conversion used the then-current
+    // running pad average, which keeps drifting (normally centimetres) until
+    // the freeze.  Runs BEFORE the first sendFlightSettings emit below
+    // (launch+0/100/200 ms) so the logged FlightSettings carries the FLOWN
+    // E/N.  If have_ref_pos is false here (READY degraded launch), the
+    // receipt-time conversion could never have happened (NOREF gate) and
+    // resetFlightStateForSim() clears the point whenever it discards the
+    // reference — so guid_point_valid is false and the guard is consistent.
+    if (guid_point_valid && have_ref_pos) {
+        // Keep-vs-wipe policy is the pure host-tested guidanceLaunchReconvert()
+        // (GuidancePointGate.h) — same conversion + REJECT-never-clamp radius
+        // rule as the receipt gate.
+        const GuidanceLaunchTarget lt = guidanceLaunchReconvert(
+            guid_point_lat_deg, guid_point_lon_deg,
+            ref_lat_rad, ref_lon_rad, ref_alt_m,
+            config::GUIDANCE_MAX_AIM_RADIUS_M);
+        if (lt.point_kept) {
+            ESP_LOGI(TAG, "[GUID PT] launch re-convert: E=%.2f N=%.2f (was %.2f,%.2f)",
+                     (double)lt.e_m, (double)lt.n_m,
+                     (double)pn_target_e, (double)pn_target_n);
+            pn_target_e = lt.e_m;
+            pn_target_n = lt.n_m;
+        } else {
+            // Should be unreachable (accepted at receipt, pad average moves
+            // centimetres) — but a boundary point + drift could cross the
+            // gate.  Fail SAFE to overhead rather than fly an out-of-policy
+            // point; drop guid_point_valid so the settings snapshot records
+            // what actually flies, and refresh the echo so the app's Unit
+            // target row stops asserting a point that no longer flies (the
+            // OC only sees it after landing — the FC skips polls INFLIGHT —
+            // but the post-flight state must not lie).
+            ESP_LOGW(TAG, "[GUID PT] launch re-convert exceeds %.0f m — "
+                          "forcing (0,0) overhead",
+                     (double)config::GUIDANCE_MAX_AIM_RADIUS_M);
+            pn_target_e = 0.0f;
+            pn_target_n = 0.0f;
+            guid_point_valid = false;
+            (void)guidanceTargetEchoSupersede(out_status_query_data,
+                                              GUID_TGT_NONE);
+        }
+        guidance.setHorizontalTarget(pn_target_e, pn_target_n);
     }
     // #297: do NOT re-capture ground pressure here.  launch_flag
     // lags real liftoff, so bmp_latest_si is already a few m up and
@@ -5529,8 +5647,18 @@ static void loop_fc()
                             pn_target_e = g.target_e_m;
                             pn_target_n = g.target_n_m;
                         } else {
+                            // "Keep the previous point" means the previous
+                            // PROFILE point (the shadows) — NOT the live
+                            // pn_target_e/n, which may hold a Drift-Cast
+                            // (cmd-28) conversion that the unconditional NVS
+                            // persist below would otherwise adopt as a
+                            // profile point and self-apply on the next boot
+                            // (the exact hazard the cmd-28 RAM-only rule
+                            // exists to exclude).
+                            pn_target_e = pn_profile_target_e;
+                            pn_target_n = pn_profile_target_n;
                             ESP_LOGW(TAG, "[GUID CFG] aim point (%.1f,%.1f) r=%.1f m REJECTED "
-                                          "(limit %.0f m) — keeping (%.1f,%.1f)",
+                                          "(limit %.0f m) — keeping profile (%.1f,%.1f)",
                                           (double)g.target_e_m, (double)g.target_n_m, (double)r,
                                           (double)config::GUIDANCE_MAX_AIM_RADIUS_M,
                                           (double)pn_target_e, (double)pn_target_n);
@@ -5541,8 +5669,24 @@ static void loop_fc()
                         pn_target_e = 0.0f;
                         pn_target_n = 0.0f;
                     }
+                    // pn_target_e/n are now profile-owned again in every
+                    // branch — refresh the shadows in lockstep.
+                    pn_profile_target_e = pn_target_e;
+                    pn_profile_target_n = pn_target_n;
                     // Law first, aim point second — see applyGuidanceConfig().
                     applyGuidanceConfig();
+                    // #435: every applied cmd-65 guidance config supersedes a
+                    // Drift-Cast geodetic point (pn_target_e/n were just
+                    // overwritten above).  Refresh the echo so the app SEES
+                    // the wipe — e.g. the connect-time profile push asserting
+                    // OVERHEAD over a previously-sent Drift-Cast point.  Bump
+                    // tgt_seq ONLY when the echo content actually changed,
+                    // so a no-op connect-time push (no cmd-28 point in play)
+                    // doesn't churn the app's seq baseline.
+                    guid_point_valid = false;
+                    (void)guidanceTargetEchoSupersede(
+                        out_status_query_data,
+                        guidanceFlownTargetSrc(false, pn_target_mode));
                     ESP_LOGI(TAG, "[GUID CFG] en=%s law=%s N=%.1f maxA=%.0f a2f=%.1f maxFin=%.0f "
                                   "minV=%.0f mode=%u alt=%.0f kp=%.2f kd=%.2f aim=(%.1f,%.1f)",
                                   guidance_enabled ? "ON" : "OFF",
@@ -5581,6 +5725,80 @@ static void loop_fc()
                                   "If the FC is healthy this is an OUT-OF-DATE APP: guidance "
                                   "config was NOT applied and the previous config still flies.",
                                   (unsigned)cfg_len, (unsigned)sizeof(GuidanceConfigData));
+                }
+            }
+            else if (out_pending_command == GUIDANCE_POINT_PENDING)
+            {
+                // Drift-Cast guidance aim point (#435, BLE cmd 28): 20-byte
+                // geodetic GuidancePointData.  Accept/reject policy is the
+                // pure guidancePointRc() gate (host-tested, GuidancePointGate.h);
+                // the result rides back to the app in the OUT_STATUS_QUERY
+                // echo (tgt_* fields) every poll.  RAM only — never NVS.
+                delay_ms(1);
+                uint8_t cfg_payload[sizeof(GuidancePointData)];
+                size_t  cfg_len = 0;
+                if (readConfigFrame(GUIDANCE_POINT_MSG, sizeof(GuidancePointData),
+                                    cfg_payload, sizeof(cfg_payload), cfg_len)
+                    && cfg_len >= sizeof(GuidancePointData))
+                {
+                    GuidancePointData gp;
+                    memcpy(&gp, cfg_payload, sizeof(gp));
+                    // Convert at receipt (running pad average; re-converted at
+                    // the launch freeze in enterInflight()).  With no reference
+                    // the gate rejects NOREF before ever consulting r.
+                    float e = 0.0f, n = 0.0f;
+                    const bool converted = guidanceLlaToEnu(gp.lat_deg, gp.lon_deg, e, n);
+                    const float r = converted ? sqrtf(e * e + n * n) : 0.0f;
+                    const bool ready_or_prelaunch =
+                        (rocket_state == READY || rocket_state == PRELAUNCH);
+                    // State gate note: the FC skips I2C polls during INFLIGHT,
+                    // so a cmd 28 queued just before launch is delivered after
+                    // landing — LANDED (+ post_flight_lockout) refuses it here.
+                    const uint8_t rc = guidancePointRc(
+                        ready_or_prelaunch, post_flight_lockout, pn_guidance_law,
+                        have_ref_pos, gp.lat_deg, gp.lon_deg, gp.alt_m, r,
+                        config::GUIDANCE_MAX_AIM_RADIUS_M);
+                    // Echo transition + "apply iff ACCEPTED" are the pure
+                    // host-tested guidancePointEchoApply() (GuidancePointGate.h):
+                    // seq bumps on EVERY processed cmd 28, a reject leaves the
+                    // display fields (still-active previous target) unchanged,
+                    // and the flight target updates ONLY on its true return.
+                    if (guidancePointEchoApply(out_status_query_data, rc,
+                                               gp.lat_deg, gp.lon_deg, gp.alt_m))
+                    {
+                        guid_point_valid   = true;
+                        guid_point_lat_deg = gp.lat_deg;
+                        guid_point_lon_deg = gp.lon_deg;
+                        guid_point_alt_m   = gp.alt_m;
+                        // RAM only — deliberately NO prefs.put of gte/gtn/gta
+                        // (a stale wind-compensated target self-applying on the
+                        // next boot is the hazard).  pn_target_mode/pn_target_alt
+                        // untouched: alt is stored + echoed only.  The profile
+                        // shadows (pn_profile_target_*) are NOT touched either —
+                        // they keep the cmd-65/NVS-owned point for the revert
+                        // paths.
+                        pn_target_e = e;
+                        pn_target_n = n;
+                        // Law-first ordering + belt-and-braces radius gate both
+                        // re-run inside; idempotent.
+                        applyGuidanceConfig();
+                    }
+                    ESP_LOGI(TAG, "[GUID PT] RX lat=%.7f lon=%.7f alt=%.1f -> "
+                                  "E=%.2f N=%.2f r=%.2f (ref n=%lu frozen=%d) "
+                                  "rc=%u seq=%u",
+                             gp.lat_deg, gp.lon_deg, (double)gp.alt_m,
+                             (double)e, (double)n, (double)r,
+                             (unsigned long)ref_pos_count, (int)ref_pos_frozen,
+                             (unsigned)rc,
+                             (unsigned)out_status_query_data.tgt_seq);
+                }
+                else
+                {
+                    // Mirror the #534 skew diagnostic: echo the lengths so a
+                    // short frame is diagnosable from the log.
+                    ESP_LOGW(TAG, "[GUID PT] readConfigFrame FAILED — got %u bytes, "
+                                  "need %u. Guidance point NOT applied.",
+                                  (unsigned)cfg_len, (unsigned)sizeof(GuidancePointData));
                 }
             }
             else if (out_pending_command == FIN_CONFIG_PENDING)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -895,6 +895,16 @@ static volatile bool imu_orient_dirty    = false;
 static uint8_t       imu_orient_pub_code = 0xFF;   // last published (0xFF = never)
 static uint8_t       imu_orient_pub_mode = 0xFF;
 
+// FC's guidance-target echo (#435), mirrored from the v5 status query and
+// re-published as a compact "guid_target" JSON frame whenever it changes —
+// the app's cmd-28 send confirmation is gated on seeing this echo advance.
+// 0xFF sentinels = never published (tgt_seq starts at 0 on the FC, so the
+// first real query always looks changed and pushes an initial frame).
+static volatile bool guid_target_dirty   = false;
+static uint8_t       guid_tgt_pub_seq    = 0xFF;
+static uint8_t       guid_tgt_pub_status = 0xFF;
+static uint8_t       guid_tgt_pub_rc     = 0xFF;
+
 static inline bool nsFlagSet(uint8_t flags, uint8_t mask)
 {
     return (flags & mask) != 0U;
@@ -2150,6 +2160,8 @@ static bool isKnownMessageType(uint8_t type)
         case ROLL_CTRL_CONFIG_MSG:
         case GUIDANCE_CONFIG_PENDING:
         case GUIDANCE_CONFIG_MSG:
+        case GUIDANCE_POINT_PENDING:  // Drift-Cast aim point (#435) — OC→FC only,
+        case GUIDANCE_POINT_MSG:      // listed like the guidance-config pair
         case FIN_CONFIG_PENDING:
         case FIN_CONFIG_MSG:
         case GUIDANCE_ENABLE:
@@ -2396,6 +2408,19 @@ static void processFrame(const uint8_t* frame, size_t frame_len,
                         ESP_LOGI("CFG", "Re-staged MANUAL IMU orientation %u to FC",
                                  (unsigned)cfg_imu_orient);
                     }
+                }
+            }
+            // Guidance-target echo (#435, format v5+): surface changes to the
+            // app.  seq alone would suffice for cmd-28 results (it bumps on
+            // every processed upload); status/rc are compared too as belt-and-
+            // braces against a missed frame.
+            if (last_query_cfg.format_version >= 5)
+            {
+                if (last_query_cfg.tgt_seq     != guid_tgt_pub_seq ||
+                    last_query_cfg.tgt_status  != guid_tgt_pub_status ||
+                    last_query_cfg.tgt_last_rc != guid_tgt_pub_rc)
+                {
+                    guid_target_dirty = true;
                 }
             }
         }
@@ -3334,6 +3359,38 @@ static void sendImuOrientation()
              (unsigned)last_query_cfg.b2r_mode);
 }
 
+// Publish the FC's guidance-target echo (#435) as its own compact config
+// message.  This is the app's cmd-28 send confirmation: DriftCast captures
+// the seq baseline before sending and confirms on seq-advance + rc + a
+// lat/lon tolerance match.  Kept tiny per the fc_identity/imu_orient
+// pattern — sendConfigJSON silently drops frames over MTU-3, so this must
+// NEVER be folded into the big "config" frame.  6-decimal degrees keep the
+// f32 echo's full precision (~0.11 m/digit at the equator).
+static void sendGuidTarget()
+{
+    if (last_query_cfg.format_version < 5) return;  // pre-#435 FC — the app
+                                                    // treats absence as
+                                                    // unsupported firmware
+    char buf[144];
+    snprintf(buf, sizeof(buf),
+             "{\"type\":\"guid_target\",\"seq\":%u,\"st\":%u,\"rc\":%u,"
+             "\"lat\":%.6f,\"lon\":%.6f,\"alt\":%d}",
+             (unsigned)last_query_cfg.tgt_seq,
+             (unsigned)last_query_cfg.tgt_status,
+             (unsigned)last_query_cfg.tgt_last_rc,
+             (double)last_query_cfg.tgt_lat_deg,
+             (double)last_query_cfg.tgt_lon_deg,
+             (int)last_query_cfg.tgt_alt_m);
+    enqueueConfigReadback(String(buf));   // #398 item 3: paced drain
+    guid_tgt_pub_seq    = last_query_cfg.tgt_seq;
+    guid_tgt_pub_status = last_query_cfg.tgt_status;
+    guid_tgt_pub_rc     = last_query_cfg.tgt_last_rc;
+    ESP_LOGI("CFG", "Queued guid_target (seq=%u st=%u rc=%u)",
+             (unsigned)last_query_cfg.tgt_seq,
+             (unsigned)last_query_cfg.tgt_status,
+             (unsigned)last_query_cfg.tgt_last_rc);
+}
+
 static void sendCurrentConfig()
 {
     // Split config into two smaller JSON messages to stay within MTU limits.
@@ -3409,10 +3466,12 @@ static void sendCurrentConfig()
     ESP_LOGI("CFG", "Queued identity readback (%u bytes)", (unsigned)id_json.length());
 
     // Also push the relayed FC firmware version as its own small message (#8),
-    // then the FC's board→rocket mounting orientation (pre-arm display). Both
+    // then the FC's board→rocket mounting orientation (pre-arm display), then
+    // the guidance-target echo (#435 — covers connect AND cmd 20).  All
     // enqueue too, so the whole readback drains from loop_oc without blocking.
     sendFcIdentity();
     sendImuOrientation();
+    sendGuidTarget();
 }
 
 // Cache servo config to NVS (mirrors what FlightComputer stores)
@@ -3495,7 +3554,11 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
     // state change that never happened, and the stale command fired on the
     // ground after landing. Refuse honestly instead (per design decision);
     // the operator re-sends after landing if still wanted.
-    if ((cmd == 1 || cmd == 23) && latest_rocket_state == INFLIGHT)
+    // cmd 28 (#435) joins the list: a guidance point queued mid-flight would
+    // be delivered after landing and refused by the FC's state gate — but the
+    // LoRa path has no echo (#285, blind fire-and-retry), so refusing here is
+    // the only honest answer.
+    if ((cmd == 1 || cmd == 23 || cmd == 28) && latest_rocket_state == INFLIGHT)
     {
         uplink_inflight_refusals++;
         ESP_LOGW("LORA", "UPLINK cmd=%u refused: rocket INFLIGHT (undeliverable"
@@ -3566,6 +3629,18 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
         // Servo test stop
         setPendingCommand(SERVO_TEST_STOP);
         ESP_LOGI("LORA", "UPLINK Servo test stop");
+    }
+    else if (cmd == 28 && payload_len >= sizeof(GuidancePointData))
+    {
+        // Drift-Cast guidance point (#435) relayed via base station (BS cmd
+        // 50 wrap).  Frame math: uplink [0xCA][nid][rid][ch][cmd][len] + 20 B
+        // payload = 26 B, exactly inside the 32-byte RX buffer — this is why
+        // cmd 28 is uplink-viable where the 45-byte GuidanceConfigData is not
+        // (#383 note above).  NO acceptance feedback reaches the BS/app over
+        // LoRa; operators must verify by direct connection before flight.
+        setPendingCommandWithConfig(GUIDANCE_POINT_PENDING, GUIDANCE_POINT_MSG,
+                                    payload, sizeof(GuidancePointData));
+        ESP_LOGI("LORA", "UPLINK Guidance point queued");
     }
     else if (cmd == 5 && payload_len >= 12)
     {
@@ -6107,6 +6182,16 @@ static void loop_oc()
         sendImuOrientation();
     }
 
+    // Same pattern for the guidance-target echo (#435): the FC bumps tgt_seq
+    // on every processed cmd 28 (and on echo-changing cmd-65 applies), the
+    // status-query ingest flags the change, and this pushes the fresh
+    // "guid_target" frame the app's send confirmation is waiting on.
+    if (guid_target_dirty && ble_app.isConnected() && ble_app.isReadyForNotify())
+    {
+        guid_target_dirty = false;
+        sendGuidTarget();
+    }
+
     // Service the BLE library's poll-style work — currently just the OTA
     // deferred-restart watchdog. handleOtaFinish() sets the boot partition and
     // schedules esp_restart() ~500 ms out, but the reboot only fires from here.
@@ -6818,6 +6903,28 @@ static void loop_oc()
             // Roll profile clear (no payload)
             setPendingCommand(ROLL_PROFILE_CLEAR);
             ESP_LOGI("BLE", "Roll profile CLEAR -> FlightComputer");
+        }
+        else if (ble_cmd == 28)
+        {
+            // Drift-Cast guidance point (#435): relay the 20-byte
+            // GuidancePointData {lat f64, lon f64, alt f32} LE to the FC.
+            // No OC-side INFLIGHT gate here: the FC's state gate is
+            // authoritative and its rejection is VISIBLE to the app via the
+            // guid_target echo (unlike the LoRa path, which refuses INFLIGHT
+            // below because it has no echo).
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t plen = ble_app.getCommandPayloadLength();
+            if (plen >= sizeof(GuidancePointData))
+            {
+                setPendingCommandWithConfig(GUIDANCE_POINT_PENDING, GUIDANCE_POINT_MSG,
+                                            payload, sizeof(GuidancePointData));
+                ESP_LOGI("BLE", "Guidance point queued for RocketComputer");
+            }
+            else
+            {
+                ESP_LOGW("BLE", "Guidance point payload too short (%u < %u)",
+                              (unsigned)plen, (unsigned)sizeof(GuidancePointData));
+            }
         }
         else if (ble_cmd == 29)
         {

--- a/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
+++ b/tinkerrocket-sim/src/tinkerrocket_sim/simulation/closed_loop_sim.py
@@ -181,6 +181,12 @@ class SimConfig:
     pn_blend_radius_m: float = 5.0
     pn_kp_pos: float = 0.5
     pn_kd_vel: float = 1.0
+    # Station-keep horizontal aim point, ENU meters relative to the pad (#435;
+    # mirrors the FC's cmd-28 GuidancePointData after its LLA->ENU conversion).
+    # (0,0) = overhead.  Consumed only in STATION_KEEP; inert in MODE_PN,
+    # exactly like the firmware.
+    pn_target_e_m: float = 0.0
+    pn_target_n_m: float = 0.0
 
     # Pitch/yaw outer loop angle P gains
     pn_kp_pitch_angle: float = 4.0
@@ -365,6 +371,10 @@ def run_closed_loop(rocket_def, config: SimConfig = None) -> SimResult:
             guidance.configure(
                 config.pn_nav_gain, config.pn_max_accel_mps2,
                 config.pn_target_alt_m)  # OVERHEAD: aim straight up over the pad
+        # Horizontal aim point AFTER the law config, mirroring the FC's
+        # applyGuidanceConfig() ordering (law first — configure* resets the
+        # target; #435).  Inert in MODE_PN, exactly like the firmware.
+        guidance.set_horizontal_target(config.pn_target_e_m, config.pn_target_n_m)
 
         control_mixer = ControlMixer()
         control_mixer.configure(

--- a/tinkerrocket-sim/tests/test_scenarios.py
+++ b/tinkerrocket-sim/tests/test_scenarios.py
@@ -158,3 +158,50 @@ def test_scenario_a2_station_keep_beats_pn_no_cpa():
     late_a = np.hypot(late['pn_a_e'], late['pn_a_n']).max()
     assert late_a < 10.0
     assert float(guided_sk['speed'].iloc[-1]) < 12.0  # exited via the speed gate
+
+
+# --- (a3) station-keep with an OFFSET aim point: #435 SIL pin ------------------
+
+def test_scenario_a3_station_keep_offset_target():
+    """#435 SIL: station-keep converges toward a commanded off-pad aim point
+    (the sim-side twin of BLE cmd 28 -> LLA->ENU -> setHorizontalTarget).
+    This is the mutation of a2's fixed-(0,0)-target assumption: a regression
+    that ignores the target and converges on the pad fails the toward-target
+    invariants below.  Invariants, not constants."""
+    pytest.importorskip(
+        "tinkerrocket_sim._guidance",
+        reason="TR_GuidancePN submodule not initialized — _guidance extension "
+               "not built. Enable: git submodule update --init "
+               "tinkerrocket-idf/components/TR_GuidancePN",
+    )
+    # r = 15 m: inside the FC's 100 m aim-radius gate, large vs a2's ~3 m
+    # overhead residual, well inside the vehicle's coast authority.
+    target_e, target_n = 12.0, -9.0
+    cfg = S.guidance_coast_config()
+    df = _run_to_apogee(dataclasses.replace(
+        cfg, guidance_mode='station_keep',
+        pn_target_e_m=target_e, pn_target_n_m=target_n))
+
+    # Same flight sanity as a2.
+    assert 300.0 < df['altitude'].max() < 420.0
+    assert (df['guidance_active'] == True).mean() > 0.5
+
+    # Load-bearing pair: it converged toward the POINT, not the pad.
+    dist_to_target = float(np.hypot(df['x'].iloc[-1] - target_e,
+                                    df['y'].iloc[-1] - target_n))
+    dist_to_pad = float(np.hypot(df['x'].iloc[-1], df['y'].iloc[-1]))
+    assert dist_to_target < 7.5           # 0.5*r (a2 overhead residual ~3 m)
+    assert dist_to_target < dist_to_pad   # demonstrably steered off-vertical
+
+    # Redundant magnitude bracket on the pad-relative offset (~= r = 15 m).
+    assert 7.5 < dist_to_pad < 22.5
+
+    # No CPA/singularity path (a2 pattern): late guided accel stays far from
+    # the clamp and the guided window runs to low speed near apogee (observed:
+    # coast tilt latch at 20 deg fires at ~10 m/s — an offset target demands
+    # more tilt as speed drops; that is a low-speed exit, NOT an early
+    # CPA/singularity quit, which the speed bound below would catch).
+    guided = df[df['guidance_active'] == True]
+    late = guided[guided['time'] > guided['time'].iloc[-1] - 1.5]
+    assert np.hypot(late['pn_a_e'], late['pn_a_n']).max() < 10.0
+    assert float(guided['speed'].iloc[-1]) < 12.0


### PR DESCRIPTION
Implements the Drift-Cast guidance-point upload end-to-end: app → BLE cmd 28 → OC (direct BLE **and** LoRa-relayed via the base station) → I2C → FC → `guidance.setHorizontalTarget()`, plus the firmware readback echo the app has required since #376, and the SIL validation run. Every bullet in the issue is delivered.

Closes #435.

## The path

- **Wire**: `GUIDANCE_POINT_PENDING/MSG = 0xF7/0xF8`; `GuidancePointData` `{lat f64, lon f64, alt f32}` static_asserted at 20 B — byte-for-byte the payload `sendGuidancePoint` has built since #376.
- **FC**: the point is stored **geodetic and RAM-only** (never NVS — a stale wind-compensated target self-applying on a later boot is the hazard; `gte/gtn` stay owned by cmd 65). Converted at receipt against the running pad average, **re-converted in `enterInflight()`** against the just-frozen reference — before the first FlightSettings emit, so the log carries the *flown* E/N. Accept/reject policy is a pure host-tested gate (`GuidancePointGate.h`): state > badval > law > noref > radius, reject-never-clamp at `GUIDANCE_MAX_AIM_RADIUS_M`. **Rejects when the law is PN** — accepting a point PN silently ignores would recreate the #376 lie.
- **Echo (new, FC→OC→app)**: `OutStatusQueryData` v5 (28 → 41 B) gains `tgt_{lat,lon,alt,seq,status,last_rc}`; the OC change-detects and publishes a compact `{"type":"guid_target"}` frame (its own frame — the big config JSON silently drops over MTU). The app's `GuidanceSendFlow` verdict machine confirms only on a fresh ACCEPTED + GEO_ACTIVE + coordinate match; no-baseline frames are adopted as baseline (never verdicts) and interleaved cmd-65 frames leave rejections provisional until timeout — false green *and* false red are closed. 23 unit tests.
- **Supersede rules**: any applied cmd-65 clears the geodetic point and refreshes the echo (otherwise the launch re-conversion would resurrect a target the connect-time profile push had wiped); same on sim start/stop. The cmd-65 reject-keep-previous path reverts to profile shadows so a Drift-Cast conversion can never leak into the unconditional NVS persist.
- **LoRa/BS**: the 20 B body → 26 B uplink frame fits the OC's 32 B `rx_buf` — this is why cmd 28 is uplink-viable where the 45 B `GuidanceConfigData` never was (#383). The BS needs **zero new code**: the generic relay (cmd 50) carries it. The LoRa path refuses INFLIGHT (it has no echo, so refusing is the only honest answer); BS-relayed sends display honestly-unconfirmed in the app (no LoRa ACK, #285).
- **Logging**: `FlightSettingsData` v6 appends the flown target (`guid_tgt_e/n/src`, 210 → 219 B, under the 224 B I2S bound); the `Data_Analysis` parsers are tuple-aware for both struct growths; the app parses the v6 tail with nil-tolerant fallback for old logs.
- **SIL**: sim gains `pn_target_e_m/pn_target_n_m` → `set_horizontal_target`; scenario a3 flies station-keep to an asymmetric off-pad point and pins *toward-target* convergence (target-relative error < r/2 and closer-to-target-than-pad), no CPA, bounded late accel.

## Review

Adversarially reviewed across five lenses (wire agreement hop-by-hop, geodetic conversion, flight-state safety, echo integrity, test quality): 11 findings filed, 10 confirmed, all repaired — including an NVS leak via cmd-65's keep-previous path, the sim-re-arm stale-echo case, and three app false-verdict paths. The conversion, gate, launch-reconvert, and echo transitions are all host-pinned with mutation-verified tests (E/N transpose, degrees-as-radians, dropped re-convert, seq-not-bumped, and reject-still-applies all caught by exactly the tests meant to catch them).

## Verification

- gtest **658/658** (was 634)
- FC (ESP32-P4) + OC (ESP32-S3) build on IDF v6
- iOS app builds headless; **23/23** unit tests
- Sim suite **136/136** including the new SIL pin
- LLA→ENU hand-verified against a computed 300 m N / 200 m E geodesy case

## Not in this PR

- Bench validation (real cmd 28 + echo round-trip on hardware) — next step before flight use.
- The #534 first-guided-flight gate still applies; `GUIDANCE_LAW_DEFAULT` remains PN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
