### PR TITLE
fc(#556): baro apogee backstop must survive a dead IMU (burnout gate + mach lockout)

### DIFF
--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -141,20 +141,66 @@ TEST_F(KinematicChecksTest, MaxAltitude_SpikeRejection) {
     EXPECT_LT(kc.max_altitude, 135.0f);
 }
 
-TEST_F(KinematicChecksTest, Apogee_GatedOnBurnout) {
-    // Force launch
+TEST_F(KinematicChecksTest, Apogee_VoteGatedOnBurnout) {
+    // The 4-test apogee VOTE is gated on burnout_detected.  With burnout never
+    // latched, a descent too shallow to trip the (burnout-independent, #556)
+    // baro backstop must NOT declare apogee.  The backstop's own dead-IMU path
+    // is covered by Apogee_DeadIMUInBoost_BaroBackstopStillFires below.
     for (int i = 0; i < 80; i++) {
         setMockMillis(i * 2);
         callFlight(float(i), 25.0f, 10.0f);
     }
     ASSERT_TRUE(kc.launch_flag);
 
-    // Now descending, but burnout NOT detected
+    // Genuine but shallow descent (~15 m) from the ~79 m launch peak, burnout
+    // NOT detected.  vel/pitch here would satisfy the vote had burnout latched.
     for (int i = 0; i < 50; i++) {
         setMockMillis(160 + i * 2);
-        callFlight(100.0f - i, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.2f, false);
+        callFlight(79.0f - i * 0.3f, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.2f, /*burnout*/false);
     }
-    EXPECT_FALSE(kc.apogee_flag); // gated on burnout
+    // Guard: confirm the descent stayed within APOGEE_BACKSTOP_DROP_M (30 m), so
+    // the assertion below tests the burnout gate — not an insufficient descent.
+    EXPECT_LT(kc.max_altitude - kc.alt_est, 30.0f);
+    EXPECT_FALSE(kc.apogee_flag) << "vote is burnout-gated; a sub-backstop descent must not fire";
+}
+
+TEST_F(KinematicChecksTest, Apogee_DeadIMUInBoost_BaroBackstopStillFires) {
+    // #556 regression: if the IMU dies during boost, burnout_detected never
+    // latches (it only latches from a fresh-IMU accel sample).  Before the fix
+    // the whole apogee block — including the baro-only Layer-2 backstop that is
+    // documented to survive a dead IMU — was nested under the burnout gate, so
+    // apogee was never declared and drogue/main never fired (ballistic).  This
+    // mirrors Apogee_EKFUnhealthy_BaroBackstopFires but with burnout==false
+    // (dead IMU) rather than a merely-unhealthy EKF: the backstop must still fire.
+    kc.launch_flag = true;
+
+    // Seed the baro KF at a 140 m apogee, then pin the running peak.  burnout is
+    // NEVER set (the IMU stopped producing fresh samples during boost).
+    for (int i = 0; i < 250; i++) {
+        setMockMillis(i * 2);
+        callFlight(140.0f, 9.81f, 0.0f, 0.0f, 0.0f, false, 1.0f, /*burnout*/false);
+    }
+    ASSERT_GT(kc.alt_est, 130.0f);
+    ASSERT_FALSE(kc.apogee_flag) << "no apogee at the top of coast";
+    kc.max_altitude = 140.0f;
+
+    // Descend ~0.5 m/call (inside the baro rate-gate), burnout still FALSE.  The
+    // backstop must stay silent until > 30 m below the peak, then latch apogee.
+    uint32_t t = 600;
+    float alt = 140.0f;
+    bool fired_too_high = false;
+    for (int i = 0; i < 160; i++, t += 2) {
+        alt -= 0.5f;
+        setMockMillis(t);
+        callFlight(alt, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f, /*burnout*/false);
+        if (kc.apogee_flag && (140.0f - kc.alt_est) < 28.0f) fired_too_high = true;
+    }
+    EXPECT_TRUE(kc.apogee_flag)
+        << "baro backstop must declare apogee without burnout (dead-IMU boost dropout, #556)";
+    EXPECT_TRUE(kc.apogee_backstop_flag)
+        << "Layer-2 backstop should be the firing path";
+    EXPECT_FALSE(fired_too_high)
+        << "backstop must not fire < 30 m below the peak";
 }
 
 TEST_F(KinematicChecksTest, Apogee_WithBurnout_DetectsApogee) {

--- a/tests_cpp/test_kinematic_checks.cpp
+++ b/tests_cpp/test_kinematic_checks.cpp
@@ -184,15 +184,21 @@ TEST_F(KinematicChecksTest, Apogee_DeadIMUInBoost_BaroBackstopStillFires) {
     ASSERT_FALSE(kc.apogee_flag) << "no apogee at the top of coast";
     kc.max_altitude = 140.0f;
 
-    // Descend ~0.5 m/call (inside the baro rate-gate), burnout still FALSE.  The
-    // backstop must stay silent until > 30 m below the peak, then latch apogee.
+    // Descend ~0.5 m/call (inside the baro rate-gate), burnout still FALSE AND
+    // baro_locked_out=TRUE.  This is the exact dead-IMU failure mode found on the
+    // bench (2026-07-21): a dead IMU freezes the EKF velocity, so the transonic
+    // mach lockout latches true and never releases (it clears only below
+    // BARO_MACH_LOCKOUT_OFF) — which vetoed the backstop and left the vehicle
+    // ballistic.  The backstop must NOT be gated on the lockout and must fire
+    // anyway.  Stays silent until > 30 m below the peak, then latches.
     uint32_t t = 600;
     float alt = 140.0f;
     bool fired_too_high = false;
     for (int i = 0; i < 160; i++, t += 2) {
         alt -= 0.5f;
         setMockMillis(t);
-        callFlight(alt, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f, /*burnout*/false);
+        callFlight(alt, 5.0f, -10.0f, 0.0f, 0.0f, false, -0.5f,
+                   /*burnout*/false, /*baro_lockout*/true);
         if (kc.apogee_flag && (140.0f - kc.alt_est) < 28.0f) fired_too_high = true;
     }
     EXPECT_TRUE(kc.apogee_flag)

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -587,35 +587,48 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
                 apogee_flag = true;
             }
         }
-
-        // --- Layer 2: baro-only descent backstop (#257) ---
-        // Last-resort net for the degraded case where the primary vote cannot
-        // reach quorum (e.g. an unhealthy EKF leaves < 2 healthy voters).  A
-        // healthy, mach-unlocked baro that has fallen >= APOGEE_BACKSTOP_DROP_M
-        // below the running peak while still descending is unambiguously past
-        // apogee — a condition unreachable during a normal boost, so there is
-        // no false-positive exposure.  alt_est / d_alt_est_ come from the
-        // baro-only KF, so this still works with a dead EKF (and dead IMU).
-        // Latches apogee_flag exactly like the vote, enabling the full
-        // drogue + main sequence; apogee_backstop_flag records that Layer 2
-        // (not the vote) was the path that fired, for post-flight diagnostics.
-        if (baro_healthy && !baro_locked_out &&
-            alt_est > 15.0f &&
-            alt_est <= max_altitude - APOGEE_BACKSTOP_DROP_M &&
-            d_alt_est_ < 0.0f)
-        {
-            if (backstop_descent_count_ < APOGEE_COUNT_MAX) backstop_descent_count_++;
-        }
-        else if (backstop_descent_count_ > 0)
-        {
-            backstop_descent_count_--;
-        }
-        if (backstop_descent_count_ >= APOGEE_COUNT_HI && !apogee_flag)
-        {
-            apogee_flag = true;
-            apogee_backstop_flag = true;
-        }
     } // end burnout gate
+
+    // --- Layer 2: baro-only descent backstop (#257; decoupled from burnout, #556) ---
+    // Last-resort net for the degraded case where the primary vote cannot
+    // reach quorum (e.g. an unhealthy EKF leaves < 2 healthy voters).  A
+    // healthy, mach-unlocked baro that has fallen >= APOGEE_BACKSTOP_DROP_M
+    // below the running peak while still descending is unambiguously past
+    // apogee — a condition unreachable during a normal boost, so there is
+    // no false-positive exposure.  alt_est / d_alt_est_ / max_altitude all
+    // come from the baro-only KF and are updated every call, so this works
+    // with a dead EKF *and* a dead IMU.
+    //
+    // #556: this block is deliberately OUTSIDE the burnout_detected gate above.
+    // burnout_detected only ever latches from a fresh-IMU accel sample
+    // (main.cpp burnoutDetectStep, gated on ism6_fresh).  If the IMU dies
+    // during boost before burnout latches, the gated vote never runs — and
+    // while this backstop was still nested inside that gate, apogee was never
+    // declared, so drogue/main never fired and the vehicle came in ballistic.
+    // The 30 m-below-peak + descending + APOGEE_COUNT_HI debounce is
+    // self-gating against any ascent/boost transient (including the burnout
+    // bay-pressure snap-back, which is <= ~16 m), so running it on launch_flag
+    // alone is safe and restores a real dead-IMU recovery path.  Latches
+    // apogee_flag exactly like the vote, enabling the full drogue + main
+    // sequence; apogee_backstop_flag records that Layer 2 (not the vote) was
+    // the path that fired, for post-flight diagnostics.
+    if (launch_flag &&
+        baro_healthy && !baro_locked_out &&
+        alt_est > 15.0f &&
+        alt_est <= max_altitude - APOGEE_BACKSTOP_DROP_M &&
+        d_alt_est_ < 0.0f)
+    {
+        if (backstop_descent_count_ < APOGEE_COUNT_MAX) backstop_descent_count_++;
+    }
+    else if (backstop_descent_count_ > 0)
+    {
+        backstop_descent_count_--;
+    }
+    if (backstop_descent_count_ >= APOGEE_COUNT_HI && !apogee_flag)
+    {
+        apogee_flag = true;
+        apogee_backstop_flag = true;
+    }
 
     // ### Apogee rising edge: reset landing sub-flag counters (#192) ###
     // The 1 Hz sub-detectors above accumulate evidence regardless of

--- a/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/TR_KinematicChecks.cpp
@@ -592,12 +592,12 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
     // --- Layer 2: baro-only descent backstop (#257; decoupled from burnout, #556) ---
     // Last-resort net for the degraded case where the primary vote cannot
     // reach quorum (e.g. an unhealthy EKF leaves < 2 healthy voters).  A
-    // healthy, mach-unlocked baro that has fallen >= APOGEE_BACKSTOP_DROP_M
-    // below the running peak while still descending is unambiguously past
-    // apogee — a condition unreachable during a normal boost, so there is
-    // no false-positive exposure.  alt_est / d_alt_est_ / max_altitude all
-    // come from the baro-only KF and are updated every call, so this works
-    // with a dead EKF *and* a dead IMU.
+    // healthy baro that has fallen >= APOGEE_BACKSTOP_DROP_M below the running
+    // peak while still descending is unambiguously past apogee — a condition
+    // unreachable during a normal boost, so there is no false-positive
+    // exposure.  alt_est / d_alt_est_ / max_altitude all come from the
+    // baro-only KF and are updated every call, so this works with a dead EKF
+    // *and* a dead IMU.
     //
     // #556: this block is deliberately OUTSIDE the burnout_detected gate above.
     // burnout_detected only ever latches from a fresh-IMU accel sample
@@ -605,15 +605,22 @@ void TR_KinematicChecks::kinematicChecks(float pressure_altitude,
     // during boost before burnout latches, the gated vote never runs — and
     // while this backstop was still nested inside that gate, apogee was never
     // declared, so drogue/main never fired and the vehicle came in ballistic.
-    // The 30 m-below-peak + descending + APOGEE_COUNT_HI debounce is
-    // self-gating against any ascent/boost transient (including the burnout
-    // bay-pressure snap-back, which is <= ~16 m), so running it on launch_flag
-    // alone is safe and restores a real dead-IMU recovery path.  Latches
-    // apogee_flag exactly like the vote, enabling the full drogue + main
-    // sequence; apogee_backstop_flag records that Layer 2 (not the vote) was
-    // the path that fired, for post-flight diagnostics.
+    //
+    // #556 (bench-found): the backstop must ALSO ignore baro_locked_out (the
+    // transonic mach lockout).  That lockout is driven by the EKF velocity,
+    // which a dead IMU freezes/corrupts — so it latches true and never releases
+    // (it clears only when speed < BARO_MACH_LOCKOUT_OFF), silently vetoing the
+    // very backstop meant to survive a dead IMU.  The vote's baro test (above)
+    // still honours the lockout; the backstop does not need it — the
+    // 30 m-below-peak + descending + APOGEE_COUNT_HI debounce is self-gating
+    // against any ascent / boost / transonic transient (a sustained 30 m drop
+    // below the running max cannot occur while climbing), so dropping the
+    // lockout gate here removes no real protection and restores the dead-IMU
+    // recovery path.  Latches apogee_flag exactly like the vote, enabling the
+    // full drogue + main sequence; apogee_backstop_flag records that Layer 2
+    // (not the vote) was the path that fired, for post-flight diagnostics.
     if (launch_flag &&
-        baro_healthy && !baro_locked_out &&
+        baro_healthy &&
         alt_est > 15.0f &&
         alt_est <= max_altitude - APOGEE_BACKSTOP_DROP_M &&
         d_alt_est_ < 0.0f)

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/CMakeLists.txt
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/CMakeLists.txt
@@ -1,2 +1,11 @@
 idf_component_register(SRCS "TR_Sensor_Collector_Sim.cpp" INCLUDE_DIRS "." REQUIRES TR_Compat TR_RocketComputerTypes TR_Sensor_Collector)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-reorder -Wno-format-truncation -Wno-format)
+
+# #556 bench validation: `idf.py -B build_deadimu -DTR_SIM_DEAD_IMU=1 build`
+# makes the sim stop delivering IMU samples from the boost->coast boundary on,
+# so burnout never latches and only the baro-only apogee backstop can fire.
+# Sim-only + compile-guarded; the default build never defines it.
+if(TR_SIM_DEAD_IMU)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_SIM_DEAD_IMU=1)
+    message(STATUS "TR_Sensor_Collector_Sim: DEAD-IMU sim mode ENABLED (#556 bench)")
+endif()

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -233,6 +233,27 @@ bool SensorCollectorSim::getISM6HG256Data(ISM6HG256Data& data_out)
     sim_time_s_ += clamped_dt;
 
     stepPhysics(clamped_dt);
+
+#if defined(TR_SIM_DEAD_IMU) && TR_SIM_DEAD_IMU
+    // #556 bench validation: emulate an IMU that dies at burnout.  The flight
+    // physics are stepped above, so baro/GNSS keep flying the FULL trajectory
+    // (ascent -> apogee -> descent); but from the boost->coast boundary on we
+    // stop DELIVERING fresh IMU samples.  The main loop derives IMU freshness
+    // from this getter returning true, so ism6 goes stale, burnout_detected
+    // never latches, and the burnout-gated apogee vote never runs — leaving the
+    // baro-only Layer-2 backstop as the ONLY path to apogee.  That is exactly
+    // the dead-IMU condition #556 must survive.  The IMU stays live through
+    // PRELAUNCH/POWERED so launch still latches normally (launch detection
+    // requires acc_mag > 20).  Compile-guarded AND sim-only: it can never
+    // affect a real flight or a normal sim run.
+    if (phase_ >= SIM_COASTING)
+    {
+        static bool announced = false;
+        if (!announced) { announced = true; Serial.println("[SIM] DEAD-IMU: withholding IMU from coast (#556)"); }
+        return false;
+    }
+#endif
+
     encodeISM6(now_us, data_out);
     return true;
 }


### PR DESCRIPTION
Fixes the critical #556 finding: a **boost-phase IMU dropout disabled all apogee detection**, leaving the vehicle ballistic (no drogue/main, and — since landing is gated on apogee — no LANDED either).

### Root cause (two layers)
1. The Layer-2 baro-only apogee backstop — documented to survive a dead IMU — was nested inside the `if (launch_flag && burnout_detected)` gate. `burnout_detected` only latches from a fresh-IMU accel sample, so a dead IMU → no burnout → the whole apogee block (vote **and** backstop) never runs.
2. After decoupling it from the burnout gate, the backstop was *still* vetoed by `!baro_locked_out` (the transonic mach lockout). That lockout is driven by the EKF velocity, which a dead IMU freezes at ~260 m/s — exactly `BARO_MACH_LOCKOUT_ON`. It clears only below 240, so it latches true forever and blocks the backstop.

### Fix
- Move the baro backstop **out** of the burnout gate (`ea3be1c`).
- Drop the `!baro_locked_out` term from the backstop (`c0efb23`). The vote's baro test still honours the lockout; the backstop's `30 m below peak + descending + APOGEE_COUNT_HI` debounce is self-gating against any ascent/transonic transient, so it needs neither the burnout gate nor the lockout.
- Add a compile-guarded dead-IMU HIL sim mode (`f5169c5`, `-DTR_SIM_DEAD_IMU=1`) so this failure class stays bench-testable.

### Verification
- **Host:** `Apogee_DeadIMUInBoost_BaroBackstopStillFires` updated to model the real failure (`burnout=false` **and** `baro_locked_out=true`); fails on the pre-fix code, passes now. All 33 KinematicChecks tests green.
- **Bench (HIL, IMU withheld from coast):** console shows `mach_lock=1 ekf_spd=260` stuck the whole descent, then `[PYRO] Apogee detected … backstop=1` the instant altitude drops 30 m below the 1184 m peak — apogee fires despite the stuck lockout.

Closes #556

Follow-up (not in this PR): #574 — landing detection is likewise IMU/EKF-dependent and, on a dead IMU, only reaches LANDED via the 600 s timeout. Tracked under #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
