### PR TITLE
fc+app(#557): GNSS-absent degraded flight — bound bring-up, baro+IMU EKF init, guidance-off, degraded banner

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -193,6 +193,12 @@ struct TelemetryData: Codable {
     var gnssHealth: SensorHealth { shState(8) }
     var battHealth: SensorHealth { shState(10) }
     var storageHealth: SensorHealth { shState(20) }   // #281/#278: flight-log NAND — BAD = full/failing, won't record
+    // #557: GNSS-absent degraded flight (shift 22) — DISTINCT from gnssHealth
+    // (fix health, shift 8).  .bad = the FC initialized the EKF on the baro+IMU
+    // path because the module failed bring-up (dead/deaf UART), so there is no
+    // absolute position and guidance is off.  Rides sensor_health, so it reaches
+    // the app on both the direct-BLE and base-station-relay paths.
+    var gnssAbsentMode: Bool { shState(22) == .bad }
     func pyroHealth(channel: Int) -> SensorHealth {   // channel 1...4; .na = not configured
         guard (1...4).contains(channel) else { return .na }
         return shState(12 + (channel - 1) * 2)

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -613,6 +613,16 @@ struct ConnectedDashboardView: View {
                     .opacity(staleOpacity)
             }
 
+            // #557: the FC lost its GNSS module and is flying a baro+IMU-only
+            // degraded path — no absolute position/track, guidance off (recovery
+            // is unaffected).  Shown on the pad too, so the operator sees it
+            // before launching.  Rides sensor_health, so it appears on both the
+            // direct-BLE and base-station-relay links.
+            if showRocketViews && device.telemetry.gnssAbsentMode {
+                GnssAbsentBannerView()
+                    .opacity(staleOpacity)
+            }
+
             // #393: gate on the rocket's REPORTED sim state (fs bit 8) OR the
             // local launch latch.  The latch alone dies on BLE reconnect
             // (BLEDevice is recreated), which made the Stop-sim control vanish
@@ -1072,6 +1082,37 @@ struct SimModeBannerView: View {
         .frame(maxWidth: .infinity)
         .background(Color.orange.opacity(0.1))
         .cornerRadius(10)
+    }
+}
+
+// #557: GNSS-absent degraded-flight warning.  Passive/informational (no control
+// — it reflects a hardware condition the operator can't toggle), modeled on
+// SimModeBannerView.  Driven by the FC's SH_GNSS_ABSENT verdict in sensor_health.
+struct GnssAbsentBannerView: View {
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "location.slash.fill")
+                    .font(.title2)
+                Text("NO GNSS — DEGRADED FLIGHT")
+                    .font(.system(size: 20, weight: .bold, design: .monospaced))
+            }
+            .foregroundColor(.orange)
+            Text("Flying on baro + IMU only: no position or ground track, "
+                 + "landing prediction and guidance are off. Apogee, deployment "
+                 + "and landing detection are unaffected.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color.orange.opacity(0.12))
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.orange.opacity(0.5), lineWidth: 1)
+        )
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -169,6 +169,11 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(onlyGnss.pyroHealth(channel: 1), .na)
         // BAD encodes as 0b11 in-place (verifies the 2-bit mask).
         XCTAssertEqual(try decode(health: 3 << 4).ekfHealth, .bad)
+        // #557: GNSS-absent degraded-flight flag at shift 22 (SH_BAD = active),
+        // distinct from the gnss fix-health item at shift 8.
+        XCTAssertTrue(try decode(health: 3 << 22).gnssAbsentMode)
+        XCTAssertFalse(try decode(health: 1 << 8).gnssAbsentMode)   // fix health ≠ absent mode
+        XCTAssertFalse(try decode(health: 0).gnssAbsentMode)
     }
 
     /// Missing "h" (older firmware / BS self-frame) → no scorecard, unknown.

--- a/tests_cpp/test_lora_roundtrip.cpp
+++ b/tests_cpp/test_lora_roundtrip.cpp
@@ -166,6 +166,26 @@ TEST_F(LoRaRoundtripTest, VelocityAndBurnout_IndependentOfFlagsState) {
     EXPECT_NEAR(out.vel_u, -45.6f, 0.05f);
 }
 
+// #557: the GNSS-absent degraded-flight verdict rides the raw sensor_health
+// bitfield over LoRa to the base station (packLoRa copies it verbatim), so the
+// BS-relayed app session shows the degraded banner too.  Pin that the new slot
+// (bits 22-23) survives the round-trip and does not bleed into a neighbour.
+TEST_F(LoRaRoundtripTest, GnssAbsentHealthSlot_Roundtrip) {
+    LoRaDataSI in = makeNominal();
+    in.sensor_health = shSet(0u, SH_GNSS_ABSENT_SHIFT, SH_BAD);   // degraded active
+    in.sensor_health = shSet(in.sensor_health, SH_STORAGE_SHIFT, SH_OK);  // neighbour
+    in.sensor_health = shSet(in.sensor_health, SH_GNSS_SHIFT, SH_DEGRADED);
+
+    LoRaData packed{};
+    conv.packLoRa(in, packed);
+    LoRaDataSI out{};
+    conv.unpackLoRa(packed, out);
+
+    EXPECT_EQ(shGet(out.sensor_health, SH_GNSS_ABSENT_SHIFT), SH_BAD);
+    EXPECT_EQ(shGet(out.sensor_health, SH_STORAGE_SHIFT),     SH_OK);
+    EXPECT_EQ(shGet(out.sensor_health, SH_GNSS_SHIFT),        SH_DEGRADED);
+}
+
 // #390: orientation field semantics — the wire sentinels are load-bearing.
 // A pre-#390 frame (flags2 orientation bits zero-filled) must unpack as
 // "not reported", never as a confident "+X default"; auto-exact's no-code

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -64,6 +64,30 @@ TEST(RocketComputerTypes, StorageHealth_BitPosition) {
     EXPECT_EQ(shGet(f, SH_PYRO_SHIFT[3]), SH_OK);
 }
 
+// #557: the GNSS-absent degraded-flight slot rides sensor_health to the app on
+// both the direct-BLE and LoRa/BS-relay paths.  Pin its slot clear of every
+// existing item (esp. the neighbouring SH_STORAGE at 20 and the real SH_GNSS
+// fix-health at 8) so the degraded-mode banner can never alias another verdict.
+TEST(RocketComputerTypes, GnssAbsent_BitPosition) {
+    EXPECT_EQ(SH_GNSS_ABSENT_SHIFT, 22u);
+    for (uint8_t other : {SH_BARO_SHIFT, SH_IMU_SHIFT, SH_EKF_SHIFT, SH_MAG_SHIFT,
+                          SH_GNSS_SHIFT, SH_BATT_SHIFT, SH_STORAGE_SHIFT,
+                          SH_PYRO_SHIFT[0], SH_PYRO_SHIFT[1], SH_PYRO_SHIFT[2],
+                          SH_PYRO_SHIFT[3]}) {
+        EXPECT_NE(SH_GNSS_ABSENT_SHIFT, other);   // clear of every other field
+    }
+    // Slot fits inside the 32-bit field.
+    EXPECT_LT(SH_GNSS_ABSENT_SHIFT + 2u, 32u);
+    uint32_t f = shSet(0u, SH_GNSS_ABSENT_SHIFT, SH_BAD);  // degraded mode active
+    EXPECT_EQ(shGet(f, SH_GNSS_ABSENT_SHIFT), SH_BAD);
+    // Neighbouring SH_STORAGE (shift 20) and the real SH_GNSS (shift 8) don't bleed.
+    f = shSet(f, SH_STORAGE_SHIFT, SH_OK);
+    f = shSet(f, SH_GNSS_SHIFT,    SH_DEGRADED);
+    EXPECT_EQ(shGet(f, SH_GNSS_ABSENT_SHIFT), SH_BAD);
+    EXPECT_EQ(shGet(f, SH_STORAGE_SHIFT),     SH_OK);
+    EXPECT_EQ(shGet(f, SH_GNSS_SHIFT),        SH_DEGRADED);
+}
+
 TEST(RocketComputerTypes, NSF_FlagBits_NoOverlap) {
     // bits 0-6 used; bit 7 reserved post per-fire-arming refactor.
     uint8_t all = NSF_ALT_LANDED | NSF_ALT_APOGEE | NSF_VEL_APOGEE |

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -76,6 +76,22 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
     uint8_t active_rx = GNSS_RX;
     uint8_t active_tx = GNSS_TX;
 
+    // Bring-up deadline (#557).  A dead or deaf-UART module used to hang begin()
+    // forever in the retry loops below — delay() feeds the WDT, so the FC sat
+    // silently on the pad with no telemetry and no flight.  One full baud sweep
+    // (6 bauds x 2 orientations, each with a ~1.5 s begin() timeout) is ~27 s, so
+    // the budget must cover at least one complete sweep; 35 s leaves margin for
+    // the pre-sweep bootstrap/orientation probes.  On expiry begin() returns
+    // false and the collector continues in a GNSS-absent degraded mode.  The
+    // loops still run one full attempt first (the deadline is only checked before
+    // a *retry*), so a live-but-slow module is never cut off mid-sweep.  Compared
+    // wrap-safe; boot-time millis() never wraps, but keep the idiom consistent.
+    const uint32_t kBeginTimeoutMs   = 35000U;
+    const uint32_t begin_deadline_ms = millis() + kBeginTimeoutMs;
+    auto beginExpired = [&]() -> bool {
+        return (int32_t)(millis() - begin_deadline_ms) >= 0;
+    };
+
     if (safeboot_n_pin >= 0)
     {
         pinMode((uint8_t)safeboot_n_pin, OUTPUT);
@@ -264,6 +280,17 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
     while ((connected_baud == 0U) && !scanAndConnect(connected_baud))
     {
         scan_attempt++;
+        // #557: give up after the deadline rather than spinning forever on a
+        // dead/deaf-UART module.  scanAndConnect() above already ran one full
+        // sweep this iteration, so a live-but-slow module always gets at least
+        // one complete attempt before we can bail here.
+        if (beginExpired())
+        {
+            ESP_LOGE(TAG, "GNSS bring-up: no response after %lu ms (%u sweeps); "
+                          "continuing without GNSS", (unsigned long)kBeginTimeoutMs,
+                     scan_attempt);
+            return false;
+        }
         ESP_LOGW(TAG, "No response on known bauds, retrying...");
         if ((scan_attempt % 2U) == 0U)
         {
@@ -323,6 +350,12 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 
             while (!scanAndConnect(connected_baud))
             {
+                if (beginExpired())
+                {
+                    ESP_LOGE(TAG, "GNSS baud recovery timed out after %lu ms; "
+                                  "continuing without GNSS", (unsigned long)kBeginTimeoutMs);
+                    return false;
+                }
                 delay(500);
             }
 
@@ -564,6 +597,12 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 
         while (!scanAndConnect(connected_baud))
         {
+            if (beginExpired())
+            {
+                ESP_LOGE(TAG, "GNSS config recovery timed out after %lu ms; "
+                              "continuing without GNSS", (unsigned long)kBeginTimeoutMs);
+                return false;
+            }
             delay(500);
         }
 

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -150,6 +150,13 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
         const size_t n = sizeof(probe_bauds) / sizeof(probe_bauds[0]);
         for (size_t i = 0; i < n; i++)
         {
+            // #557: bail mid-sweep on the bring-up deadline.  A removed module
+            // whose UART floats reads noise, so hasSerialActivity() trips and
+            // each baud runs a double begin() (~5 s) — a full 12-baud sweep is
+            // ~60 s.  Checking the deadline only *between* whole sweeps let a
+            // dead/noisy module spin ~100 s (bench 2026-07-21); a per-baud check
+            // bounds bring-up to roughly the deadline + one baud probe.
+            if (beginExpired()) return false;
             const uint32_t baud = probe_bauds[i];
             ESP_LOGI(TAG, "Trying %lu baud (RX=%d, TX=%d)",
                      (unsigned long)baud, rx_pin, tx_pin);

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1364,7 +1364,15 @@ static constexpr uint8_t SH_PYRO_SHIFT[4] = { 12, 14, 16, 18 };
 // battery.  BAD = a full or write-failing NAND that will NOT record the flight
 // — the silent failure mode that lost the 2026-06-25 guided flight.
 static constexpr uint8_t SH_STORAGE_SHIFT = 20;
-// bits 22-31 reserved
+// #557: GNSS-absent degraded flight mode.  DISTINCT from SH_GNSS (shift 8,
+// which reports fix health): this reports that the FC committed to the
+// baro+IMU-only EKF path because the module failed bring-up (dead/deaf UART),
+// so there is no absolute position, guidance is forced off, and roll control is
+// rate-null only.  Encoded SH_BAD = degraded mode active, SH_NA = normal.  Rides
+// the existing sensor_health carrier to the app on BOTH the direct-BLE and
+// LoRa/BS-relay paths (BLE JSON key "h") — no new wire field needed.
+static constexpr uint8_t SH_GNSS_ABSENT_SHIFT = 22;
+// bits 24-31 reserved
 static inline uint32_t shSet(uint32_t field, uint8_t shift, SensorHealthState st) {
     return (field & ~(uint32_t)(0x3u << shift)) | ((uint32_t)st << shift);
 }

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -499,10 +499,21 @@ void SensorCollector::begin(uint8_t imu_execution_core)
                                  GNSS_RESET_N,
                                  GNSS_SAFEBOOT_N))
         {
-            ESP_LOGE(SC_TAG, "GNSS initialization failed, stopping.");
-            while (1) { delay_ms(1000); }
+            // #557: a dead or deaf-UART module used to hang boot here forever
+            // (while(1)), leaving the FC silent on the pad.  begin() now returns
+            // false on a bring-up-deadline expiry; continue in a GNSS-absent
+            // degraded mode instead.  gnss_online_ stays false so the poll task
+            // idles and getGNSSData() reports no fix; the flight computer sees
+            // isGnssOnline()==false and initializes the EKF from baro+IMU.  No
+            // flight-critical function needs GNSS (baro-backstop apogee, baro
+            // deploy, accel/baro launch, baro/gyro/accel landing).
+            gnss_online_ = false;
+            ESP_LOGE(SC_TAG, "GNSS init failed — continuing in GNSS-absent mode");
         }
-        ESP_LOGI(SC_TAG, "GNSS found and initialized");
+        else
+        {
+            ESP_LOGI(SC_TAG, "GNSS found and initialized");
+        }
     }
 
     // TODO Calibrate low and high g accel
@@ -845,7 +856,9 @@ void SensorCollector::pollGNSSdata(void* parameter)
     {
         vTaskDelay(xPollInterval);
 
-        if (!self->use_gnss) continue;
+        // #557: skip polling when GNSS is disabled (build config) or the module
+        // failed bring-up (dead/deaf UART) — no serial traffic to parse.
+        if (!self->use_gnss || !self->gnss_online_) continue;
 
         const uint32_t gnss_t0 = time_us();
 

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.h
@@ -138,6 +138,12 @@ public:
     // vs. MMC software offset.)
     bool isIIS2MDCActive() const { return iis2mdc_active; }
 
+    // #557: true iff GNSS is enabled in the build AND the module came up at
+    // boot.  False after a dead/deaf-UART bring-up failure — the flight
+    // computer reads this to enter GNSS-absent mode (baro+IMU EKF init,
+    // guidance forced off).  Always false when use_gnss is compiled out.
+    bool isGnssOnline() const { return use_gnss && gnss_online_; }
+
     // Program IIS2MDC OFFSET_X/Y/Z hard-iron registers.  Returns false if
     // the IIS2MDC isn't active or the I2C write failed.  Issue #96.
     bool setIIS2MDCHardIronOffset(int16_t cx, int16_t cy, int16_t cz);
@@ -184,6 +190,11 @@ private:
     bool use_iis2mdc;
     bool use_gnss;
     bool use_ism6hg256;
+
+    // #557: runtime GNSS liveness.  Starts true; cleared in begin() if the
+    // module fails bring-up (dead/deaf UART).  Gates the GNSS poll task and is
+    // exposed via isGnssOnline() so the FC can enter GNSS-absent mode.
+    bool gnss_online_ = true;
 
     // Set true after IIS2MDC is detected and configured at boot. When true,
     // the legacy MMC5983MA SPI path is skipped.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -277,6 +277,25 @@ static uint32_t valid_gnss_start_millis = 0;
 static uint32_t landed_candidate_start_millis = 0;
 static bool landed_candidate_active = false;  // #297: explicit flag (0 collided with now_ms==0)
 static bool gnss_started = false;
+
+// #557 GNSS-absent degraded flight.  A dead/deaf-UART module makes the GNSS
+// bring-up fail; the FC then flies without GNSS instead of hanging.
+//   gnss_absent_mode   — latched once at boot from the collector: the module
+//                        failed bring-up.  Makes the baro+IMU-only EKF init
+//                        ELIGIBLE (no fix will ever arrive).
+//   gnss_absent_flight — set true when the EKF was actually initialized on the
+//                        degraded path this session.  Drives the SH_GNSS_ABSENT
+//                        telemetry flag and the launch-time guidance force-off.
+//                        Reset per sim run so a sim re-evaluates on the normal path.
+//   gnss_absent_dwell_ms — earliest millis() a degraded init may fire.  A short
+//                        settle after boot / sim-reset so an injected sim GNSS
+//                        fix (arrives ~100 ms) reaches the normal init path
+//                        before the degraded fallback can commit.  A real dead
+//                        module never gets a fix, so it degrades right after.
+static constexpr uint32_t GNSS_ABSENT_INIT_DWELL_MS = 5000U;
+static bool     gnss_absent_mode    = false;
+static bool     gnss_absent_flight  = false;
+static uint32_t gnss_absent_dwell_ms = 0;
 static bool ground_pressure_found = false;
 static bool out_ready = false;
 static uint32_t out_ready_request_time_ms = 0;
@@ -2806,6 +2825,19 @@ static void setup_fc()
     // Initialize sensor collector (including sensors) and start polling tasks
     ESP_LOGI(TAG, "Sensor collector init...");
     sensor_collector.begin(config::SENSOR_CORE);
+
+    // #557: latch GNSS-absent mode.  isGnssOnline() is false when GNSS is built
+    // in but the module failed bring-up (dead/deaf UART).  The FC then flies a
+    // baro+IMU-only degraded path instead of hanging on the pad.  begin() blocks
+    // until the ~35 s bring-up deadline in that case, so millis() is already
+    // well past zero here.
+    gnss_absent_mode     = config::USE_GNSS && !sensor_collector_hw.isGnssOnline();
+    gnss_absent_dwell_ms = millis() + GNSS_ABSENT_INIT_DWELL_MS;
+    if (gnss_absent_mode)
+    {
+        ESP_LOGW(TAG, "[GNSS] Module absent (bring-up failed) — GNSS-absent "
+                      "degraded mode: baro+IMU EKF init, guidance forced off");
+    }
     sensor_converter.configureISM6HG256FullScale(
         static_cast<ISM6LowGFullScale>(config::ISM6_LOW_G_FS_G),
         static_cast<ISM6HighGFullScale>(config::ISM6_HIGH_G_FS_G),
@@ -3233,6 +3265,11 @@ static void resetFlightStateForSim(const char* edge)
     last_gnss_fix_ms     = 0xFFFF;
     gnss_started = false;
     have_gnss_si = false;
+    // #557: a sim injects synthetic GNSS, so re-evaluate the degraded path from
+    // scratch — clear the degraded-flight latch and restart the settle so the
+    // sim's ~100 ms first fix reaches the normal init path before any fallback.
+    gnss_absent_flight   = false;
+    gnss_absent_dwell_ms = millis() + GNSS_ABSENT_INIT_DWELL_MS;
     guidance.reset();
     control_mixer.reset();
     roll_rate_pid_standalone.reset();
@@ -3286,6 +3323,14 @@ static void enterInflight(uint32_t now_ms, const char* from_state)
             ESP_LOGW(TAG, "[GUIDANCE] Auto-disabled — EKF not initialized");
             guidance_enabled = false;
         }
+    }
+    // #557: in a GNSS-absent degraded flight the EKF *is* initialized (baro+IMU),
+    // so the gate above does not fire — but there is no absolute position frame,
+    // so PN/station-keep guidance must not steer.  Force it off here (roll
+    // control is untouched; coast_guidance_active also self-gates on have_ref_pos).
+    if (gnss_absent_flight && guidance_enabled) {
+        ESP_LOGW(TAG, "[GUIDANCE] Auto-disabled — GNSS-absent degraded flight");
+        guidance_enabled = false;
     }
     // Freeze the ENU reference position at launch
     if (!ref_pos_frozen && have_ref_pos) {
@@ -3965,7 +4010,35 @@ static void loop_fc()
                 // and can also set kinematics flags we'd rather not pick up)
                 // can't trigger an init.  EKF init resumes naturally after
                 // the cal session ends and rocket_state returns to READY.
-                if (have_ref_pos && gnss_gate3_init) {
+                // #557: degraded init — when the GNSS module is absent (dead/
+                // deaf UART) initialize the EKF from baro + IMU only, so attitude
+                // + vertical velocity (hence the velocity/pitch apogee voters and
+                // roll control) still work.  Gated on initGyroN >= 8 (well-averaged
+                // stationary gyro-bias seed, same readiness the normal path needs),
+                // on never having seen a fix (!gnss_started — defers to the normal
+                // path if a real/sim fix ever arrives), and on a short settle so an
+                // injected sim fix wins first.
+                const bool normal_init = have_ref_pos && gnss_gate3_init;
+                const bool degraded_init =
+                    !normal_init && gnss_absent_mode && !gnss_started &&
+                    (initGyroN >= 8) &&
+                    ((int32_t)(millis() - gnss_absent_dwell_ms) >= 0);
+                if (normal_init || degraded_init) {
+                    if (degraded_init) {
+                        // Pad-relative seed: lat/lon 0 (equator — regular, no
+                        // geodetic singularity), alt from baro (pressure_altitude_m
+                        // is height above the pad), zero velocity, and a stale GNSS
+                        // time so the EKF never runs a GNSS measurement update
+                        // against this fake origin.  Baro then bounds the vertical
+                        // channel and accel+mag bound attitude.
+                        ekf_gnss.time_us   = 0;
+                        ekf_gnss.lat_rad   = 0.0;
+                        ekf_gnss.lon_rad   = 0.0;
+                        ekf_gnss.alt_m     = pressure_altitude_m;
+                        ekf_gnss.vel_n_mps = 0.0f;
+                        ekf_gnss.vel_e_mps = 0.0f;
+                        ekf_gnss.vel_d_mps = 0.0f;
+                    }
                     // #297: seed wBias off the recent-window gyro average rather
                     // than the single live sample (see the ring above).
                     if (initGyroN >= 8)
@@ -4031,6 +4104,18 @@ static void loop_fc()
                                       gnss_latest_si.month, gnss_latest_si.day);
                     }
                     ekf_initialized = true;
+                    if (degraded_init) {
+                        // #557: mark the session degraded so the SH_GNSS_ABSENT
+                        // telemetry flag and the launch-time guidance force-off
+                        // (enterInflight) fire.  Guidance also physically can't
+                        // engage without a position frame — have_ref_pos stays
+                        // false, so coast_guidance_active is false regardless.
+                        // Roll control is unaffected (raw-gyro rate-null path).
+                        gnss_absent_flight = true;
+                        ESP_LOGW(TAG, "[EKF] GNSS-absent degraded init: baro+IMU "
+                                      "only, position pad-relative, guidance off "
+                                      "(roll control unaffected)");
+                    }
                 }
             }
             else if (run_ekf_this_tick)
@@ -6338,6 +6423,7 @@ static void loop_fc()
                         const bool coast_guidance_active =
                             guidance_enabled &&
                             ekf_initialized &&
+                            have_ref_pos &&       // #557: no GNSS-anchored position frame → no steering
                             ekf_ctrl_healthy &&   // #265: don't fly guidance on a diverged EKF
                             !guidance_tilt_inhibited &&  // tilt-limit safety latch
                             (speed > pn_min_speed) &&
@@ -6827,6 +6913,15 @@ static void loop_fc()
                 }
                 sh = shSet(sh, SH_PYRO_SHIFT[i], pst);
             }
+
+            // #557: GNSS-absent degraded-flight verdict (distinct from the fix
+            // health at SH_GNSS above).  SH_BAD = the FC initialized the EKF on
+            // the baro+IMU-only path because the module failed bring-up; guidance
+            // is off and there is no absolute position.  Rides sensor_health to
+            // the app on BOTH the direct-BLE and LoRa/BS-relay paths so the
+            // degraded banner shows regardless of transport.
+            sh = shSet(sh, SH_GNSS_ABSENT_SHIFT,
+                       gnss_absent_flight ? SH_BAD : SH_NA);
 
             // Battery bits (12-13) left N/A — the OC fills them from POWERData.
             non_sensor_data.sensor_health = sh;


### PR DESCRIPTION
Closes #557

## Problem

A dead or deaf-UART GNSS module hung the FC boot **forever**: `TR_GNSSReceiverUBloxSerial::begin()` spun in three unbounded retry loops (`delay()` feeds the WDT, so the FC sat silent on the pad with no telemetry and no flight), and the collector's `while(1)` hung init if `begin()` ever returned false. This is a documented real hardware failure mode (the deaf-UART GNSS board).

## Why blocking was wrong — and the scope

Investigation confirmed **no safety-of-flight function needs GNSS**: launch (accel+baro), apogee (baro-only Layer-2 backstop — works even with a dead EKF+IMU), deployment (baro altitude), and landing (baro/gyro/accel voters) all have GPS-free paths, and #382 already promotes READY→INFLIGHT degraded. The only load-bearing coupling was **EKF initialization** (gated on a 3D fix).

Chosen scope (per maintainer): unblock boot **and** let the EKF initialize from baro+IMU when GNSS is absent, so attitude + vertical velocity — and thus the velocity/pitch apogee voters and roll control — survive. Absolute position is lost (acceptable). Two hard constraints: **guidance stays off** (roll control kept), and the **iOS GUI clearly shows** the degraded state.

## What changed

- **Bring-up (`TR_GNSSReceiverUBlox_Serial`)**: a ~35 s deadline bounds all three retry loops, checked **per baud** so a noisy floating UART can't drag it out. On expiry `begin()` returns false.
- **Collector (`TR_Sensor_Collector`)**: `while(1)` → clear `gnss_online_` and continue to the polling task; new `isGnssOnline()`; GNSS poll task idles when offline.
- **FC (`flight_computer/main.cpp`)**: latch `gnss_absent_mode` at boot; degraded EKF init seeds pad-relative (lat/lon 0 = equator, alt = baro, zero velocity, stale GNSS time so no GNSS update fires on the fake origin), reusing the existing gyro-avg bias + accel/heading attitude + config declination fallback. Guidance forced off (`have_ref_pos` added to `coast_guidance_active` + `enterInflight` clears `guidance_enabled`); roll untouched. A `!gnss_started` guard + 5 s settle keep HIL/indoor **sim** on the normal path (the sim injects GNSS).
- **Wire + app**: new `SH_GNSS_ABSENT` slot in `sensor_health` (bit 22) — rides to the app on **both** the direct-BLE and LoRa/BS-relay paths with no new wire field (OC `shSet` / BS relay preserve the bit). iOS decodes it and shows a full-width "NO GNSS — DEGRADED FLIGHT" banner (on the pad too).

## Verification

- **Host gtests: 634/634** (incl. new `SH_GNSS_ABSENT` no-overlap + LoRa-roundtrip tests).
- **Builds**: `idf.py build` for flight_computer, out_computer, base_station; iOS `xcodebuild test` (`TelemetryDataTests`).
- **Bench (2026-07-21, real FC P4 with GNSS removed; OC/BS flashed)**: boot bails at **39.4 s** (`GNSS config recovery timed out … continuing without GNSS`) instead of hanging, collector continues, EKF baro+IMU inits at 44.5 s (config declination `0.00°`), guidance forced off, then loop steady **~980 Hz** with a healthy/converged EKF and no crash. Normal path (GNSS connected) confirmed unchanged. iOS degraded banner confirmed by the maintainer.
  - The bench caught a bug fixed in the last commit: the deadline was originally checked only *between* full baud sweeps, so a noisy floating UART took ~100 s to bail — now checked per baud.

Not bench-tested (no path to): apogee/deploy *in* degraded mode (the firmware sim injects GNSS, so a true no-GNSS ascent can't be sim-tested — host gtests + the now-available EKF voters cover it; a real GNSS-less flight is the ultimate check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
