### PR TITLE
fix(oc): #558 mid-download flash read error must fail the download, not present as complete

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6421,8 +6421,18 @@ static void loop_oc()
                 flash_us += (uint32_t)(micros() - t_flash);
                 if (!read_ok)
                 {
-                    ESP_LOGE("BLE", "File read error, aborting download");
-                    ble_app.sendFileChunk(bytes_sent, nullptr, 0, true, /*abort=*/true);
+                    // #558: funnel through the unified post-loop abort handler
+                    // instead of emitting an inline abort-EOF here. The inline
+                    // abort-EOF did NOT set send_failed, so the post-loop fell
+                    // through to a BARE EOF and the final redundant EOF also
+                    // carried abort=false — so if this one inline abort-EOF was
+                    // dropped on the link the app saw only bare EOFs and saved the
+                    // truncated flight as complete, defeating #526's redundant-
+                    // abort drop guard. Set the flag + break; the post-loop emits
+                    // the abort-EOF AND a matching redundant one.
+                    ESP_LOGE("BLE", "File read error at offset %lu, aborting download",
+                             (unsigned long)file_offset);
+                    send_failed = true;
                     break;
                 }
                 file_offset += flash_bytes_read;
@@ -6461,6 +6471,7 @@ static void loop_oc()
                             // #524: could not send even after full backpressure. Do
                             // NOT keep going — that would hand the app a file with a
                             // hole in it and call it a success.
+                            ESP_LOGE("BLE", "BLE send failed mid-transfer, aborting download");
                             send_failed = true;
                             break;
                         }
@@ -6488,8 +6499,11 @@ static void loop_oc()
             if (send_failed)
             {
                 // #526: EOF|ABORT, not a bare EOF. The app must REJECT the partial
-                // file, not save the truncated bytes and call it complete.
-                ESP_LOGE("BLE", "Download ABORTED after %lu bytes: BLE send failed",
+                // file, not save the truncated bytes and call it complete. #558:
+                // this branch now covers a flash read error as well as a BLE send
+                // failure, so the specific cause is logged at each break point
+                // rather than named here.
+                ESP_LOGE("BLE", "Download ABORTED after %lu bytes",
                          (unsigned long)bytes_sent);
                 ble_app.sendFileChunk(bytes_sent, nullptr, 0, true, /*abort=*/true);
             }


### PR DESCRIPTION
Closes #558

## The defect
When a BLE flight download hits a NAND ECC/read failure partway through, the OC's read-error branch sent an inline abort-EOF but **never set `send_failed`**. That leaves two holes downstream:

- the unified post-loop handler falls through to a **bare** EOF (`else if (ble_used > 0)` / `else`), and
- the redundant trailing EOF (`abort=send_failed`) carries `abort=false`.

So if the single inline abort-EOF is dropped on the link, the app sees only bare EOFs and `completeDownload()` (BLEDevice.swift) saves the truncated flight **as a complete file** — the exact dropped-abort case #526's redundant-abort guard was built to cover, which this branch (uniquely) failed to. Compounded by #315 auto-evict reclaiming the on-device original at the next arm → permanent silent loss of the flight tail, presented as success.

#527's commit message claimed it covered "all four give-up paths … AND the redundant trailing EOF", but the flash-read-error path was the one that only got `abort=true` on its inline call and never set `send_failed`, so its redundant EOF never actually aborted.

## The fix
In the read-error branch: drop the inline abort-EOF, set `send_failed = true; break;` — funnel through the unified post-loop handler (the issue's suggested fix). The read-error path now emits an abort-EOF **and** a matching redundant abort-EOF, identical to the existing `send_failed` path. A dropped notification can no longer resurrect the truncation.

Also keeps abort-path logging accurate now that the post-loop branch covers two causes: each break point logs its own reason (flash read error / BLE send failure); the post-loop message no longer hard-codes "BLE send failed".

## Scope / other paths
The other three give-up paths were already correct and are unchanged: INFLIGHT refusal (pre-loop, clears filename), chunk-size-0 (skips loop via `else`), and BLE send failure (`send_failed=true`). App-side terminal handling (`EOF|ABORT → failDownload()`) is unchanged.

## Verification
- Compile-verified: `idf.py build` (esp32s3) clean.
- No host test added — matches #527's convention; the loop lives in `loop_oc()` with hardware deps and isn't host-testable without a refactor.
- Bench caveat: exercising this path needs a genuine NAND read failure mid-download (bad/marginal block), hard to force on the bench — verified by code-path reasoning + compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
