### PR TITLE
fix(app): #560 PyroTest abort paths must not blind-toggle an operator's pre-existing log

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift
@@ -310,7 +310,14 @@ struct PyroTestView: View {
     private func safeRocket() {
         ticker.stop()
         if cameraRecording {
-            device.sendToggleLogging()
+            // #560: cmd 23 is a TOGGLE — only stop logging if THIS test started
+            // it. Blind-toggling here stopped an operator's pre-existing session
+            // (the #385 failure mode, which was fixed on the recording-complete
+            // path but missed on the abort paths). Stop the camera regardless.
+            if startedLoggingForTest {
+                device.sendToggleLogging()
+                startedLoggingForTest = false
+            }
             camera.stopRecording()
             cameraRecording = false
         }
@@ -346,7 +353,13 @@ struct PyroTestView: View {
     private func cancelAll() {
         ticker.stop()
         if cameraRecording {
-            device.sendToggleLogging()
+            // #560: only stop logging if THIS test started it (see safeRocket) —
+            // otherwise navigating away / dismissing mid-test toggles off an
+            // operator's pre-existing log. Stop the camera regardless.
+            if startedLoggingForTest {
+                device.sendToggleLogging()
+                startedLoggingForTest = false
+            }
             camera.stopRecording()
             cameraRecording = false
         }


### PR DESCRIPTION
Closes #560

## The defect
Logging (cmd 23) is a **toggle**. #385 fixed the recording-*complete* path to only stop logging if the pyro test was the one that started it (`startedLoggingForTest`), but the two **abort** paths were missed:

- `safeRocket()` and `cancelAll()` both called `sendToggleLogging()` **unconditionally** whenever `cameraRecording` was true.

`cameraRecording` is set true unconditionally at T-5; `startedLoggingForTest` is set only when the rocket wasn't already logging. So if the operator was **already logging** (cmd 23), opened Pyro Test, and hit FIRE, then tapped SAFE / X / navigated away, the abort path toggled logging **off** and stopped their in-progress session — the #385 failure mode, re-opened on the abort paths.

It also fired on the normal completion-then-dismiss path: `cameraRecording` is never reset on normal completion, so `.onDisappear → cancelAll()` re-ran the block.

## The fix
Guard both abort paths exactly like the recording-complete path, and stop the camera separately:

```swift
if cameraRecording {
    if startedLoggingForTest {          // only stop what THIS test started
        device.sendToggleLogging()
        startedLoggingForTest = false
    }
    camera.stopRecording()              // stop camera regardless
    cameraRecording = false
}
```

Only ever stop what this test started; the operator's pre-existing log is left untouched.

## Verification
- Compile-verified: `xcodebuild` (iOS Simulator, Debug) → **BUILD SUCCEEDED**.
- No test added — matches #385's convention; these are SwiftUI `@State` view methods, not unit-testable without a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
