### PR TITLE
fix(app): #561 servo bias default 0 (was 85) to match firmware config.h

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -101,7 +101,7 @@ struct DiscoveredDevice: Identifiable {
 }
 
 struct RocketConfig {
-    var servoBias1: Int16 = 85
+    var servoBias1: Int16 = 0   // #561: match RocketProfile/config.h (was 85 → ~10° servo-1 trim)
     var servoHz: Int16 = 333
     // #407: match RocketProfile (the source of truth) and config.h
     // SERVO_MIN_US/MAX_US = 1000/2000. The old 1250/1750 disagreed with the

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -134,7 +134,13 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     var imuRateHz: UInt16 = 1920
 
     // MARK: Servo
-    var servoBias1: Int16 = 85
+    // #561: default 0 (neutral) to match config.h SERVO_BIAS_N and biases 2-4.
+    // The old 85 (~10° on the ±60° / 1000-2000µs fin cal) baked a servo-1 trim
+    // into every freshly-created profile and — since the app pushes the whole
+    // profile on connect — overrode the FC's 0. Per-airframe mechanical trim is
+    // dialed in per-profile in the iOS UI and persists with the profile; the
+    // generic default must not carry one.
+    var servoBias1: Int16 = 0
     var servoBias2: Int16 = 0
     var servoBias3: Int16 = 0
     var servoBias4: Int16 = 0


### PR DESCRIPTION
Closes #561

## The defect
`RocketProfile.servoBias1` (and its mirror `BLETypes.RocketConfig.servoBias1`) defaulted to **85** while firmware `config.h SERVO_BIAS_1 = 0`, and biases 2-4 were 0 on both sides. The app is the source of truth and pushes the whole profile to the FC on connect (`ActiveRocketSyncer`), so every **freshly-created** profile overrode the FC's 0 with an 85 µs servo-1 bias — ~10° on the 1000/2000 µs ↔ ±60° fin cal — biasing control neutral and eating command authority on a roll-controlled / guided flight.

It also contradicted the file's own header comment that defaults mirror the firmware factory defaults. The 85 dates back to the original profiles feature (#132) with no rationale; found independently by two review agents.

## The fix
Set the generic default to **0** in both app structs, matching `config.h` and biases 2-4:
- `RocketProfile.servoBias1` (`RocketProfile.swift`)
- `RocketConfig.servoBias1` (`BLETypes.swift`)

**User-confirmed intent:** biases default to 0 for a new rocket; per-airframe mechanical trim is entered in the iOS UI and persists with the profile (already in place — not touched here).

## Scope note
This changes only the **default** for newly-created profiles. Existing **saved** profiles that persisted the old 85 keep it (that's data, not a default) — by decision, no migration is added; zero servo-1 bias in-app on any affected airframe.

## Verification
- Compile-verified: `xcodebuild` (iOS Simulator, Debug) → **BUILD SUCCEEDED**.
- No test added — a numeric default; no host-testable logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
