### PR TITLE
fix(gnss): #562 gate fix_mode on gnssFixOK / invalidLlh (COCOM + DOP/accuracy)

### DIFF
--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -897,6 +897,22 @@ void TR_GNSSReceiverUBloxSerial::getGNSSData(GNSSData &gnss_data)
     // 0: No Fix, 1: Dead Reckoning, 2: 2D Fix, 3: 3D Fix,
     // 4:GNSS + Dead Reckoning, 5: Time Only
     gnss_data.fix_mode = gnss.getFixType();
+
+    // #562: fixType alone is not enough to trust a fix. u-blox marks a fix
+    // INVALID without dropping fixType below 3 — by clearing gnssFixOK (fix
+    // outside the configured DOP/accuracy masks) or setting invalidLlh
+    // (lat/lon/height not valid). gnssFixOK is ALSO how it signals a COCOM
+    // violation (>515 m/s or >18 km) — exactly the transonic / high-altitude
+    // regime the apogee GPS voter and guidance/landing-prediction run in. Zero
+    // fix_mode so every downstream `fix_mode >= 3` consumer treats it as "no
+    // fix" (same contract as the staleness gate below). maxWait=0 keeps this
+    // non-blocking: both flags come from the NAV-PVT that pollNewPVT already
+    // parsed this cycle. See open #491 (COCOM bench-test).
+    if (!gnss.getGnssFixOk(0) || gnss.getInvalidLlh(0))
+    {
+        gnss_data.fix_mode = 0;
+    }
+
     gnss_data.num_sats = gnss.getSIV();
 
     // SparkFun u-blox returns PDOP as scale 0.01. Convert to x10 for packed type.


### PR DESCRIPTION
Closes #562

## The defect
The u-blox wrapper set `fix_mode = gnss.getFixType()` and trusted it. But u-blox marks a fix **invalid without dropping fixType below 3**:
- it clears **`gnssFixOK`** when the fix is outside the configured DOP/accuracy masks, and — critically — clears it to signal a **COCOM violation** (>515 m/s or >18 km);
- it sets **`invalidLlh`** when lat/lon/height are not valid.

A repo-wide grep confirmed neither `getGnssFixOk()` nor `getInvalidLlh()` was called anywhere in our code. So a COCOM-invalidated or accuracy-failing fix flowed downstream as a trusted 3D fix — into the apogee GPS voter and guidance / landing-prediction, at exactly the transonic / high-altitude regime where it matters. `num_sats`/`hAcc`/freshness gates don't reject a confident-but-invalid fix.

## The fix
In `getGNSSData()`, right where `fix_mode` is derived, zero it when the fix is flagged invalid — reusing the file's existing "zero `fix_mode` to signal unreliable" contract (the staleness detector does the same a few lines below):

```cpp
if (!gnss.getGnssFixOk(0) || gnss.getInvalidLlh(0))
    gnss_data.fix_mode = 0;
```

- **`maxWait=0`** keeps it non-blocking — both flags come from the NAV-PVT that `pollNewPVT` already parsed this cycle.
- Every FC consumer already gates on `fix_mode >= 3U` (`main.cpp` 3920 / 4231 / 6897), so zeroing rejects the fix everywhere it's used.
- **FC-scoped**: the wrapper is used only by the flight computer; no OC/BS impact.

This is the necessary **software gate**, not the complete COCOM cure — see open #491 (COCOM bench-test).

## Verification
- Compile-verified: `idf.py build` (esp32p4) → **Project build complete**.
- No test added — no host gtest exists on this wrapper (it wraps the vendor lib + serial); source-only, matching the component's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
