### PR TITLE
fix(app): #564 iOS gyro converter gets the #369 sensitivity fix (CSV was ~12.8% low)

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -29,14 +29,20 @@ nonisolated class SensorConverter {
     private var iis2mdc_rot_z_rad: Double = 0.0
 
     init() {
-        // Calculate sensitivity values
-        // ISM6HG256 outputs 16-bit two's-complement samples:
-        //   value = raw * (full_scale / 32768)
+        // Calculate sensitivity values. Mirror the firmware converter
+        // (TR_Sensor_Data_Converter.cpp configureISM6HG256FullScale) exactly:
+        //   accel: the full ±32768 LSB span maps to the full scale, so
+        //          mg/LSB = FS[g] * 1000 / 32768.
+        //   gyro : ST gyros use a FIXED per-FS sensitivity, NOT FS/32768 —
+        //          8.75 mdps/LSB at ±250 dps, doubling each FS step (140 @
+        //          ±4000), i.e. mdps/LSB = FS[dps] * 0.035. The old FS/32768
+        //          form (122.07 @ ±4000) understated every CSV gyro value
+        //          ~12.8% — fixed in firmware by #369, here by #564.
         let denom: Double = 32768.0
 
         let low_mg_per_lsb = (lowGFullScale * 1000.0) / denom
         let high_mg_per_lsb = (highGFullScale * 1000.0) / denom
-        let gyro_mdps_per_lsb = (gyroFullScale * 1000.0) / denom
+        let gyro_mdps_per_lsb = gyroFullScale * 0.035
 
         // mg/LSB -> m/s² per LSB
         acc_low_ms2_per_lsb = (low_mg_per_lsb * 1e-3) * g_ms2

--- a/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/SensorConverterTests.swift
@@ -114,6 +114,28 @@ final class SensorConverterTests: XCTestCase {
         XCTAssertEqual(si.low_g_acc_x, expected, accuracy: 0.1)
     }
 
+    func testIMU_GyroSensitivity_MatchesFirmware369Fix() throws {
+        // #564: ST gyros use a FIXED per-FS sensitivity, NOT FS/32768. The
+        // ISM6HG256 datasheet gives 8.75 mdps/LSB at ±250 dps, doubling each
+        // FS step → 140 mdps/LSB at ±4000 (mdps/LSB = FS * 0.035). The
+        // firmware converter was fixed in #369 (TR_Sensor_Data_Converter.cpp);
+        // this pins the app converter to the same 0.14 dps/LSB so the two
+        // can't drift apart again. The stale FS/32768 form (122.07 mdps/LSB)
+        // understated every post-flight CSV gyro value by ~12.8%.
+        let raw = try makeISM6Data(gyro: (1000, -2000, 500))
+        let si = converter.convertISM6HG256(raw)
+
+        // Default zero rotation: raw maps straight through at 0.14 dps/LSB.
+        XCTAssertEqual(si.gyro_x,  140.0, accuracy: 1e-9)
+        XCTAssertEqual(si.gyro_y, -280.0, accuracy: 1e-9)
+        XCTAssertEqual(si.gyro_z,   70.0, accuracy: 1e-9)
+
+        // Guard the exact regression: FS/32768 would give 122.07 dps here.
+        let staleDps = 1000.0 * (4000.0 / 32768.0)
+        XCTAssertNotEqual(si.gyro_x, staleDps, accuracy: 0.01,
+                          "gyro scale regressed to the pre-#369 FS/32768 form")
+    }
+
     // MARK: - GNSS
 
     func testGNSS_LatLonAlt() throws {


### PR DESCRIPTION
Closes #564

## The defect
#369 fixed the firmware C++ converter: ST gyros use a **fixed per-FS sensitivity** (8.75 mdps/LSB at ±250 dps, doubling per FS step → **140 mdps/LSB at ±4000**), *not* FS/32768. The parallel Swift converter never got that fix — it still computed `4000*1000/32768 = 122.07` mdps/LSB.

Result: every `gyro_x/y/z` value in a post-flight CSV exported from a Mini/new-PCB (ISM6HG256) .bin was **~12.8% low** (122.07/140) — a real 1000 dps roll read as ~872 dps, silently biasing all roll-rate / roll-control tuning analysis done off CSVs. Accel/mag/baro/power scales matched the firmware; only the gyro formula diverged.

Blast radius is exactly the CSV path: `SensorConverter`'s sole consumer is `CSVGenerator`. Live BLE telemetry was never affected (pre-scaled JSON from the OC).

## The fix
`gyro_mdps_per_lsb = gyroFullScale * 0.035`, mirroring the firmware formula (`TR_Sensor_Data_Converter.cpp` `configureISM6HG256FullScale`), with the sensitivity table documented alongside so the next reader sees why gyro differs from accel.

## Test — red→green verified
New `testIMU_GyroSensitivity_MatchesFirmware369Fix` pins the app converter to **0.14 dps/LSB on all three axes** and additionally asserts the output is **not** the stale FS/32768 value, so the two converters can't silently drift apart again.

- **Red:** run against the unfixed converter → the new test **FAILS** (xcodebuild exit 65) while all 10 sibling `SensorConverterTests` pass.
- **Green:** with the fix → `** TEST SUCCEEDED **`, full `SensorConverterTests` suite green.

## Note on existing exports
CSVs already generated from ISM6 flights carry the ~12.8% understatement. Re-export from the .bin with the fixed app, or scale gyro columns by 140/122.07 ≈ **1.1469**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
