### PR TITLE
fix(bs): #565 bound uplink send() failures so a wedged radio can't jam the queue

### DIFF
--- a/tests_cpp/test_bs_uplink_queue.cpp
+++ b/tests_cpp/test_bs_uplink_queue.cpp
@@ -250,3 +250,34 @@ TEST(BsUplinkQueue, HeadIsNullAndPopIsSafeWhenEmpty) {
     EXPECT_EQ(q.size(), 0u);
     EXPECT_EQ(q.head(), nullptr);
 }
+
+// ---- #565: send-failure counter starts clean, even in a reused ring slot ----
+
+// serviceUplink pops the head after UPLINK_MAX_SEND_FAILURES consecutive
+// send() failures so a wedged radio can't jam the queue until reboot. The
+// counter lives in Entry, and ring slots are REUSED: if push() didn't reset
+// it, a new command landing in a slot whose previous occupant died of send
+// failures would inherit that count and be dropped prematurely — a healthy
+// command silently losing (up to all of) its failure budget.
+TEST(BsUplinkQueue, SendFailureCountStartsAtZeroInAReusedSlot) {
+    Queue q;
+    ASSERT_EQ(push(q, /*cmd=*/5), PushResult::Queued);
+    EXPECT_EQ(q.head()->send_failures, 0);  // fresh entry starts clean
+
+    // The command dies of send() failures, the way serviceUplink counts them.
+    q.head()->send_failures = 20;  // config::UPLINK_MAX_SEND_FAILURES
+    q.pop();
+    EXPECT_TRUE(q.empty());
+
+    // Cycle the ring so the SAME slot (index 0) is reused by a new command.
+    for (size_t i = 0; i < bs_uplink_queue::kDepth - 1; i++) {
+        ASSERT_EQ(push(q, (uint8_t)(10 + i)), PushResult::Queued);
+        q.pop();
+    }
+    ASSERT_EQ(push(q, /*cmd=*/6), PushResult::Queued);
+
+    ASSERT_NE(q.head(), nullptr);
+    EXPECT_EQ(q.head()->cmd(), 6);
+    EXPECT_EQ(q.head()->send_failures, 0)
+        << "reused slot inherited the previous occupant's send-failure count";
+}

--- a/tinkerrocket-idf/projects/base_station/main/bs_uplink_queue.h
+++ b/tinkerrocket-idf/projects/base_station/main/bs_uplink_queue.h
@@ -49,6 +49,12 @@ struct Entry
     uint8_t buf[kMaxPacket];
     size_t  len          = 0;
     uint8_t retries_left = 0;
+    // #565: consecutive send() FAILURES (startTransmit error — nothing went on
+    // air). Deliberately separate from retries_left, which counts blind
+    // TRANSMISSIONS and is the delivery mechanism: an SPI hiccup must not eat
+    // a command's delivery odds. serviceUplink pops the head when this hits
+    // UPLINK_MAX_SEND_FAILURES so a wedged radio can't jam the queue forever.
+    uint8_t send_failures = 0;
 
     uint8_t cmd() const { return buf[kCmdOffset]; }
 };
@@ -85,8 +91,9 @@ public:
         {
             memcpy(&e.buf[kHeaderBytes], payload, payload_len);
         }
-        e.len          = kHeaderBytes + payload_len;
-        e.retries_left = retries;
+        e.len           = kHeaderBytes + payload_len;
+        e.retries_left  = retries;
+        e.send_failures = 0;  // #565: slots are reused — never inherit a stale count
         count_++;
         return PushResult::Queued;
     }

--- a/tinkerrocket-idf/projects/base_station/main/config.h
+++ b/tinkerrocket-idf/projects/base_station/main/config.h
@@ -61,6 +61,12 @@ struct config : board_pins
     static constexpr uint8_t  UPLINK_SYNC_BYTE        = 0xCA;
     static constexpr uint8_t  UPLINK_RETRIES           = 8;     // TX attempts per command
     static constexpr uint32_t UPLINK_RETRY_INTERVAL_MS = 100;   // Delay between retries
+    // #565: consecutive send() FAILURES (startTransmit error, nothing on air)
+    // before the head command is dropped. Failed attempts are paced at
+    // UPLINK_RETRY_INTERVAL_MS, so a wedged radio holds each command at most
+    // ~2 s (20 x 100 ms) instead of jamming the queue until reboot. Generous
+    // enough that a transient SPI/radio hiccup never costs a command.
+    static constexpr uint8_t  UPLINK_MAX_SEND_FAILURES = 20;
 
     // --- Uplink TX window (#506) ---
     // The radio is half-duplex, so every uplink retry is a deaf window. At

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1994,6 +1994,7 @@ static void serviceUplink()
         uplink_tx_count++;
         uplink_tx_airtime_ms += win.tx_airtime_ms;
         tx->retries_left--;
+        tx->send_failures = 0;  // #565: the radio works again — count CONSECUTIVE failures
         uplink_last_tx_ms = now;
         // #285: "blind" + "unconfirmed" so the log is not mistaken for an ACK.
         ESP_LOGI(TAG, "[UPLINK] blind TX cmd=%u, %u attempt(s) left (unconfirmed, no ACK)",
@@ -2001,7 +2002,33 @@ static void serviceUplink()
     }
     else
     {
-        ESP_LOGW(TAG, "[UPLINK] send() failed, will retry");
+        // #565: a failed send() put NOTHING on air (startTransmit error;
+        // tx_ongoing_ is never set on this path, so the TX watchdog can't
+        // recover it either). This branch used to log-and-return without
+        // bounding anything: retries_left never decremented, so a radio whose
+        // startTransmit fails persistently wedged the head command — and with
+        // it the entire queue — until reboot, RejectedFull-dropping every
+        // later command. Count consecutive failures (NOT retries_left: a
+        // transient hiccup must not eat the blind delivery budget), pace them
+        // like retries via uplink_last_tx_ms (this also stops the old
+        // busy-retry-every-pass spin), and at the cap drop the command LOUDLY
+        // so the queue stays live for the ones behind it.
+        tx->send_failures++;
+        uplink_last_tx_ms = now;
+        if (tx->send_failures >= config::UPLINK_MAX_SEND_FAILURES)
+        {
+            ESP_LOGE(TAG, "[UPLINK] cmd=%u DROPPED after %u consecutive send() "
+                          "failures (radio TX fault) — command was NEVER transmitted",
+                     (unsigned)tx->cmd(), (unsigned)tx->send_failures);
+            uplink_q.pop();             // unwedge: next command gets its chance
+            uplink_defer_start_ms = 0;  // #506: don't carry this command's defer clock over
+        }
+        else
+        {
+            ESP_LOGW(TAG, "[UPLINK] cmd=%u send() failed (%u/%u), will retry",
+                     (unsigned)tx->cmd(), (unsigned)tx->send_failures,
+                     (unsigned)config::UPLINK_MAX_SEND_FAILURES);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #565

## The defect
`serviceUplink()` only pops the head command when `retries_left` reaches 0, and `retries_left` is decremented **only on a successful** `lora_comms.send()`. The send()-failed branch logged "will retry" and returned — no attempt counter, no pacing, no bound of any kind.

`send()` returns false permanently when the radio's `startTransmit()` keeps erroring (SPI glitch / bad radio state), and on that path `tx_ongoing_` is never set — so the TX watchdog (gated on `tx_ongoing_`) can never recover it either. Net effect: the head command never pops, the retry gate stays open (busy-retry every loop pass), the queue fills to depth 8, and every subsequent command is RejectedFull-dropped. **Total, permanent loss of uplink command capability to every rocket, recoverable only by rebooting the BS**, with nothing louder than a repeating WARN.

## The fix
Mirrors the retries-exhausted pop path:

- **`Entry.send_failures`** counts *consecutive* failed `send()` attempts. Deliberately separate from `retries_left`: the retry budget is the blind delivery mechanism (the rocket sends no ACK), and a transient SPI hiccup must not eat a command's delivery odds. A successful send resets it; `push()` zeroes it so a reused ring slot never inherits the previous occupant's count.
- **Failed attempts are paced** via `uplink_last_tx_ms` at `UPLINK_RETRY_INTERVAL_MS` (100 ms) — also replacing the old busy-retry-every-pass spin.
- **At `UPLINK_MAX_SEND_FAILURES` (20, ≈2 s per command)** the head is dropped with a loud `ESP_LOGE` naming the cmd and stating it was NEVER transmitted, and the queue moves on. `uplink_defer_start_ms` is cleared on this pop (#506), same as the retries-exhausted path.

A wedged radio now drains a full queue in ~16 s of loud per-command errors instead of jamming forever.

**Deliberately out of scope:** radio re-init (standby + reconfigure) after a failure run — that's recovery machinery beyond the queue-liveness bug; the bound already converts a silent permanent wedge into loud bounded failures.

## Verification
- New host test `BsUplinkQueue.SendFailureCountStartsAtZeroInAReusedSlot` pins the `push()` reset in the exact ring-reuse scenario (slot whose occupant died of send failures gets reused by a fresh command).
- **Mutation-verified:** removing the reset line makes the test fail with the inherited-count message; restored, the suite is 14/14 green.
- Compile-verified: `idf.py build` (esp32) → Project build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
