### PR TITLE
fix(oc): #566 uninitialized flight log reports SH_BAD, not the benign SH_NA

### DIFF
--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -133,7 +133,17 @@ static bool flightlogWriteSink(void* ctx, const uint8_t* payload, size_t payload
 // it visible on the pre-launch go/no-go and the live downlink instead.
 static SensorHealthState ocStorageHealth()
 {
-    if (!flightlog.isInitialized()) return SH_NA;
+    // #566: an uninitialized flight log is the MOST severe storage state, not
+    // an inapplicable one. flightlog.begin() failing at boot (corrupt index /
+    // metadata read error) is deliberately non-fatal, so the OC runs — but
+    // flightlogWriteSink() then refuses every frame and the #271 drop path
+    // discards ALL flight data. Returning SH_NA here hid exactly the silent
+    // loss this fold-in exists to surface: the app hides the Storage row on
+    // NA and excludes it from the go/no-go, so the operator saw a green
+    // board. There is no logger-disabled OC build (begin() is unconditional),
+    // so NA is never legitimate once boot completes — report BAD and let the
+    // scorecard go red.
+    if (!flightlog.isInitialized()) return SH_BAD;
     TR_LogToFlashStats s = {};
     logger.getStats(s);
     const uint32_t free_blocks = flightlog.bitmap().countInState(tr_flightlog::BLOCK_FREE);
@@ -5190,7 +5200,12 @@ void initPeripherals()
         }
         else
         {
-            ESP_LOGE("FLIGHTLOG", "begin failed: %s",
+            // #566: deliberately non-fatal (BLE/downlink still run so the fault
+            // is reachable), but flight logging is DEAD this boot — every frame
+            // will be dropped. ocStorageHealth() reports SH_BAD for this state
+            // so the pre-launch scorecard goes red instead of grey N/A.
+            ESP_LOGE("FLIGHTLOG", "begin failed: %s — flight logging DEAD this "
+                     "boot (all frames will drop); storage health = BAD",
                      tr_flightlog::to_string(st));
         }
     }


### PR DESCRIPTION
Closes #566

## The defect
`flightlog.begin()` failing at boot (corrupt flight index / NAND metadata read error) is deliberately non-fatal — the OC keeps running so BLE and the downlink stay reachable. But in that state `flightlogWriteSink()` refuses every frame and the #271 drop path discards **all flight data** — and `ocStorageHealth()` reported the condition as **`SH_NA`**, the "not applicable / ignore" state.

The app hides the Storage row on `.na` and excludes it from the go/no-go verdict entirely (`TelemetryData.swift` `flightReadiness`), so the operator saw a green board, got a go, flew — and every logged frame was silently dropped. That's the exact silent-loss failure the #281/#278 health fold-in was added to surface. The inversion: an initialized-but-full card correctly showed `SH_BAD`, while the strictly worse never-came-up state showed benign N/A.

## The fix
`!flightlog.isInitialized()` → **`SH_BAD`**.

Verified before changing: there is **no logger-disabled OC build** — the `begin()` block is unconditional (and a `logger.begin()` failure aborts init before it), so `SH_NA` is never a legitimate storage state once boot completes. App-side, `.bad` is a hard fault → scorecard red / `.notReady` — the wanted operator-side gate.

Also upgraded the boot-path `ESP_LOGE` to state the consequence ("flight logging DEAD this boot (all frames will drop); storage health = BAD").

**Deliberately not included:** the issue's optional firmware-side hard pre-arm blocker on `begin()` failure — the red go/no-go verdict *is* the operator gate; refusing arm outright is a larger behavior change than this severity fix.

## Verification
- Compile-verified: `idf.py build` (esp32s3) → Project build complete.
- No host test: `ocStorageHealth()` is a static fn over firmware globals (same convention as prior OC fixes); the app-side mapping it feeds is already test-covered (`naStor→ready`, `full→notReady` in TelemetryDataTests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
