### PR TITLE
fc(#568): low-severity flight-readiness roundup — 6 fixes

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -397,12 +397,14 @@ struct config : board_pins
     static constexpr float GUIDANCE_MAX_AIM_RADIUS_M = 100.0f;
 
     // ### Burnout Detection ###
-    // Consecutive samples of negative body-X accel required to latch
-    // burnout_detected. The IMU runs at ~1 kHz so 50 samples ≈ 50 ms of
-    // sustained deceleration — long enough to filter vibration / sensor
-    // noise / wind gusts that briefly drop body_ax below zero during
-    // boost, short enough to catch real motor cutoff within one PN coast
-    // delay tick. See issue #197.
+    // Consecutive FLIGHT-LOOP TICKS of negative body-X accel required to
+    // latch burnout_detected. #568: counted per burnoutDetectStep() call —
+    // once per loop_fc() pass (~1 kHz), NOT per IMU sample (the IMU logs at
+    // up to 3840 Hz; the loop consumes the freshest sample each tick). At
+    // ~1 kHz loop rate 50 ticks ≈ 50 ms of sustained deceleration — long
+    // enough to filter vibration / sensor noise / wind gusts that briefly
+    // drop body_ax below zero during boost, short enough to catch real
+    // motor cutoff within one PN coast delay tick. See issue #197.
     static constexpr uint16_t BURNOUT_NEG_HYSTERESIS = 50;
 
     // ### Ground Test ###

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1331,13 +1331,23 @@ static volatile uint32_t fc_ota_rx_cb_count = 0;  // I2S RX cb ticks; teardown s
 
 static inline IRAM_ATTR void fcOtaRingPush(uint8_t b)
 {
-    fc_ota_ring[fc_ota_head] = b;
-    fc_ota_head = (fc_ota_head + 1) % FC_OTA_RING;
-    if (fc_ota_head == fc_ota_tail)
+    // #568: drop the NEWEST byte on overflow — the ISR must NEVER write
+    // fc_ota_tail. The old drop-oldest advanced tail from ISR context while
+    // fcOtaRingPop's non-atomic RMW ran in the parser task; the ISR preempting
+    // mid-pop (parser reads tail, ISR advances it, parser writes back stale+1)
+    // tore the index and corrupted fcOtaRingLen/framing. Same ISR-touches-tail
+    // hazard the OC eliminated in #383 (see OC rxPush) — with the ISR owning
+    // only head and the parser owning only tail this is a true SPSC ring.
+    // Dropping newest is safe here: chunks are CRC-framed and offset-ordered,
+    // so a lost byte costs one chunk resend, same as drop-oldest did.
+    const size_t next = (fc_ota_head + 1) % FC_OTA_RING;
+    if (next == fc_ota_tail)
     {
         fc_ota_ring_ovf = fc_ota_ring_ovf + 1;           // (-Wvolatile: avoid ++)
-        fc_ota_tail = (fc_ota_tail + 1) % FC_OTA_RING;   // drop oldest
+        return;                                          // ring full: drop newest
     }
+    fc_ota_ring[fc_ota_head] = b;
+    fc_ota_head = next;
 }
 static inline size_t  fcOtaRingLen()         { return (fc_ota_head + FC_OTA_RING - fc_ota_tail) % FC_OTA_RING; }
 static inline uint8_t fcOtaRingPeek(size_t i){ return fc_ota_ring[(fc_ota_tail + i) % FC_OTA_RING]; }
@@ -2235,9 +2245,18 @@ static inline void serviceCameraStart(uint32_t now_ms)
 
     if (camera_start_phase == CameraStartPhase::Probing)
     {
-        const bool alive = runCamProbeOnce();
+        // #568: each probe blocks up to RUNCAM_PROBE_READ_MS (60 ms) on the
+        // camera UART — fine on the pad, but if the operator starts the
+        // camera and launches inside the probe window (~8 s), those stalls
+        // would land in early boost. The flight loop must never wait on a
+        // camera in flight: on launch detect, skip the blocking probe and
+        // start recording blind immediately (fire-and-forget START_RECORDING
+        // — blind beats both a stalled boost loop and a camera that never
+        // records).
+        const bool in_flight = (rocket_state == INFLIGHT);
+        const bool alive = in_flight ? false : runCamProbeOnce();
         const bool deadline = (int32_t)(now_ms - camera_probe_deadline_ms) >= 0;
-        if (!alive && !deadline)
+        if (!alive && !deadline && !in_flight)
         {
             camera_start_due_ms = now_ms + config::RUNCAM_PROBE_INTERVAL_MS;
             return;  // keep polling
@@ -2247,6 +2266,9 @@ static inline void serviceCameraStart(uint32_t now_ms)
                      (unsigned long)(now_ms - camera_start_power_ms), runcam_features,
                      (runcam_features & RUNCAM_FEAT_START_RECORDING)
                          ? "" : " — START_RECORDING not advertised!");
+        else if (in_flight)
+            ESP_LOGW(TAG, "RunCam: launch during boot probe — starting blind NOW "
+                          "(no blocking UART reads in boost)");
         else
             ESP_LOGW(TAG, "RunCam: no GET_DEVICE_INFO reply in %lu ms — recording "
                           "blind (check RX wire to FC pin %d and the camera's "
@@ -2610,6 +2632,15 @@ static void setup_fc()
     pn_min_speed      = prefs.getFloat("gms", config::PN_MIN_SPEED_MPS);
     pn_coast_delay_ms = prefs.getUShort("gcd", config::PN_COAST_DELAY_MS);
     pn_target_mode    = prefs.getUChar("gtm", config::PN_TARGET_MODE);
+    // #568: whitelist the NVS-loaded mode exactly like the command path does
+    // (and like pn_guidance_law below) — a corrupt / forward-version record
+    // must not flow into guidance unchecked.
+    if (pn_target_mode != GUIDE_TARGET_OVERHEAD &&
+        pn_target_mode != GUIDE_TARGET_POINT) {
+        ESP_LOGW(TAG, "[GUID CFG] stored target mode %u unknown — falling back "
+                      "to OVERHEAD", (unsigned)pn_target_mode);
+        pn_target_mode = GUIDE_TARGET_OVERHEAD;
+    }
     pn_target_e       = prefs.getFloat("gte", config::PN_TARGET_E_M);
     pn_target_n       = prefs.getFloat("gtn", config::PN_TARGET_N_M);
     pn_target_alt     = prefs.getFloat("gta", config::PN_TARGET_ALT_M);
@@ -6360,6 +6391,10 @@ static void loop_fc()
                         // would jerk the fins when roll control activates.
                         servo_control.stowControl();
                         servo_control.resetPID();
+                        // #568: defensive — can't be true here on a normal flight
+                        // (guidance only sets it after roll_delay elapses), but a
+                        // stowed vehicle must never report guidance active.
+                        guidance_active = false;
                     }
                     else if (ism6_fresh)   // #259: stale IMU -> neutral-hold branch below
                     {
@@ -6508,6 +6543,19 @@ static void loop_fc()
                         else
                         {
                             // --- Roll-only mode (powered flight or guidance disabled) ---
+                            // #568: guidance→roll-only handback. While guiding,
+                            // roll was nulled by roll_rate_pid_standalone +
+                            // setServoAngles, so servo_control's INTERNAL PID
+                            // never ran and its integrator froze at its
+                            // pre-guidance value (#268 syncs gains, not state).
+                            // Reset it once on the falling edge — guidance_active
+                            // still holds last tick's value here — so the
+                            // resuming controller doesn't apply the stale
+                            // integral as a step on the fins.
+                            if (guidance_active)
+                            {
+                                servo_control.resetPID();
+                            }
                             guidance_active = false;
 
                             // Decide per-segment whether to track angle or null rate.
@@ -6566,6 +6614,12 @@ static void loop_fc()
                         // resumes clean if the IMU recovers.
                         servo_control.stowControl();
                         servo_control.resetPID();
+                        // #568: without this, guidance_active latched true across
+                        // an IMU dropout during guided coast — NSF_GUIDANCE kept
+                        // asserting and GuidanceTelemData kept streaming stale
+                        // accel commands while the fins were actually stowed.
+                        // Telemetry/log fidelity only; mirrors the roll-only path.
+                        guidance_active = false;
                     }
                 }
                 const bool landing_conditions =


### PR DESCRIPTION
Closes #568

Batch of the six verified low-severity FC findings from the 2026-07-20 pre-flight review roundup — each independent and low-risk, landed as one PR per the #385 roundup precedent.

## 1. Guidance→roll-only PID handback (stale integrator)
While guiding, roll is nulled by `roll_rate_pid_standalone` + `setServoAngles`, so `servo_control`'s internal PID never runs and its integrator freezes at its pre-guidance value (#268 syncs gains, not state). On the falling edge — the roll-only branch, where `guidance_active` still holds last tick's value — `resetPID()` once, so the resuming controller doesn't apply the stale integral as a fin step. (Latent this campaign: guidance defaults off.)

## 2. `guidance_active` stale-latch on mid-flight IMU dropout
The IMU-stale stow branch stowed fins and reset the PID but never cleared `guidance_active` — `NSF_GUIDANCE` kept asserting and `GuidanceTelemData` streamed stale accel commands while the fins were actually stowed. Cleared there (telemetry/log fidelity only), plus defensively in the roll-delay/reboot stow.

## 3. `BURNOUT_NEG_HYSTERESIS` comment (doc only)
It counts **flight-loop ticks** (~1 kHz `loop_fc` pass), not IMU samples (the IMU logs at up to 3840 Hz; the loop consumes the freshest sample per tick). The old comment could mislead a future re-tune. Logic unchanged.

## 4. `pn_target_mode` NVS whitelist
The boot NVS load is now validated exactly like the command path (and like `pn_guidance_law` right below it) — a corrupt or forward-version record falls back to `GUIDE_TARGET_OVERHEAD` with a warn instead of flowing into guidance unchecked.

## 5. RunCam boot probe vs. launch
Each probe blocks up to 60 ms on the camera UART inside a ~8 s window after CAMERA_START — an operator starting the camera and launching inside it put those stalls in early boost. On `INFLIGHT`, probing stops and `START_RECORDING` goes out blind immediately (fire-and-forget): no camera waits in boost, and the camera still records.

## 6. FC OTA image ring ISR/tail race
`fcOtaRingPush` runs in ISR context and, on overflow, advanced `fc_ota_tail` (drop-oldest) — racing the parser task's non-atomic `fcOtaRingPop` RMW. An ISR preempting mid-pop tore the index and corrupted `fcOtaRingLen`/framing (inflated `crc_fail`/`gap`, forced resends or an aborted OTA — never a bad flash; offset-ordered writes + image SHA hold). Now drops the **newest** byte on overflow so the ISR never writes tail — a true SPSC ring, mirroring the OC's #383 fix. A dropped byte costs one CRC-framed chunk resend, same as drop-oldest did.

## Verification
- Compile-verified: `idf.py build` (esp32p4) → Project build complete.
- No host tests: items are firmware-loop/ISR logic in `main.cpp` (same convention as prior FC fixes); item 3 is a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
