### PR TITLE
bs(#570): low-severity flight-readiness roundup — 6 fixes

### DIFF
--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1676,6 +1676,16 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
 
     // ── Tier 1: recovery + dashboard-critical (never sacrificed) ──────────
 
+    // #570: source rocket id FIRST — it is the multi-rocket DEMUX KEY. The BS
+    // relays every rocket on one characteristic and the app attributes each
+    // frame by "rid"; it used to ride Tier 2, where a peak-payload frame
+    // (boost + GPS fix under a small MTU) could trim it and the app would
+    // book rocket B's telemetry to the selected rocket A. ~6 B, never
+    // droppable. (Direct FC/OC connections have no rid — omitted as before.)
+    if (data.source_rocket_id > 0) {
+        addInt("rid", data.source_rocket_id);
+    }
+
     // State
     addString("st", data.state);
 
@@ -1759,12 +1769,7 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("vol", data.voltage, 2);
 
     // ── Tier 2: attitude + IMU detail (dropped only under MTU pressure) ───
-
-    // Source rocket identity (numeric id; base station relay only).  The
-    // longer unit-name string ("run") is deferred to the droppable tail.
-    if (data.source_rocket_id > 0) {
-        addInt("rid", data.source_rocket_id);
-    }
+    // ("rid" moved to the head of Tier 1 — #570: it is the demux key.)
 
     // Roll command + quaternion — quat at 3 decimals gives ~0.06° angle
     // error in the derived Euler display, well under the dashboard's
@@ -1800,6 +1805,11 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     }
     if (data.netid_drops > 0) {
         addUint("nidd", data.netid_drops);
+    }
+    // #570: size-mismatch drops (mixed-flash SIZE_OF_LORA_DATA trap) — the
+    // sibling of "nidd". Zero bytes on a healthy link.
+    if (data.size_drops > 0) {
+        addUint("szd", data.size_drops);
     }
 
     // Base station

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.h
@@ -77,6 +77,10 @@ public:
         bool     hop_active = false;
         uint8_t  hop_channel_idx = 0;
         uint32_t netid_drops = 0;
+        // #570: CRC-valid packets dropped for a wrong length (mixed-flash
+        // SIZE_OF_LORA_DATA trap). BS-only, recency-windowed like netid_drops;
+        // 0 (the default) emits nothing on the wire.
+        uint32_t size_drops = 0;
 
         // Base station (only meaningful when connected via base station)
         float bs_soc;           // Base station battery SOC %

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -125,6 +125,15 @@ static uint32_t lora_netid_mismatch_drops = 0;
 static constexpr uint32_t NETID_DROP_REPORT_WINDOW_MS = 30000;
 static uint32_t lora_netid_last_drop_ms = 0;
 
+// #570: CRC-valid packets dropped because their length is neither a beacon
+// nor exactly SIZE_OF_LORA_DATA — the classic 65-vs-66 B mixed-flash trap
+// (rocket and BS built from commits with different LoRaData sizes drops 100%
+// of telemetry while the app just shows "Searching"). Mirrors the #329
+// netid-drop pattern: lifetime count for logs, recency-windowed "szd"
+// surface over BLE (same window as nidd).
+static uint32_t lora_size_mismatch_drops = 0;
+static uint32_t lora_size_last_drop_ms   = 0;
+
 // Base station battery (MAX17205G fuel gauge via I2C)
 static float bs_voltage = NAN;
 static float bs_soc = NAN;
@@ -1624,6 +1633,11 @@ static void buildBLETelemetry(const LoRaDataSI& lora, float rssi, float snr,
     out.netid_drops     = (lora_netid_mismatch_drops > 0 &&
                            (millis() - lora_netid_last_drop_ms) < NETID_DROP_REPORT_WINDOW_MS)
                           ? lora_netid_mismatch_drops : 0;
+    // #570: same recency treatment for size-mismatch drops ("szd") — the
+    // mixed-flash trap the netid surface doesn't catch.
+    out.size_drops      = (lora_size_mismatch_drops > 0 &&
+                           (millis() - lora_size_last_drop_ms) < NETID_DROP_REPORT_WINDOW_MS)
+                          ? lora_size_mismatch_drops : 0;
 
     // Base station battery (local measurement)
     out.bs_soc = bs_soc;
@@ -1811,7 +1825,11 @@ static void sendCurrentConfig()
     ble_app.sendConfigJSON(j);
     ESP_LOGI(TAG, "[CFG] Sent config readback to app");
 
-    delay(50);
+    // #570: the fixed delay(50) that used to sit here was legacy pre-#524
+    // pacing. It parked the single bs_loop task for 50 ms per config command
+    // (no RX decode, no uplink retries, no heartbeat, no CSV flush) — a
+    // connect-time burst chained several of those. notify_data now applies
+    // MTU-aware backpressure itself, so back-to-back sends are safe.
 
     // Message 2: device identity ("config_identity" type)
     const esp_app_desc_t* app_desc = esp_app_get_description();
@@ -2671,6 +2689,19 @@ static constexpr uint32_t COORD_SCAN_PAUSE_GRACE_MS  = 500;
 // If the rocket never resumes hopping after we push cmd 15, give up so
 // the normal silence/recovery machinery can take over.
 static constexpr uint32_t COORD_SCAN_RESUMING_MAX_MS = 5000;
+// #570: SCANNING-state budget — the driver scan's own worst case at the
+// stored params (steps × (dwell + 250 ms/step of loop-pacing margin) + 5 s
+// slack, matching the #567 in-driver backstop sizing), so a healthy slow
+// scan can never trip it. Guards the coordinated-scan machine against a
+// scan that finishes with nothing pushable (see the SCANNING case).
+static uint32_t coordScanScanningBudgetMs()
+{
+    if (coord_scan_step_khz_ == 0) return 30000u;  // defensive; startScan rejects 0
+    const uint32_t steps = (uint32_t)(((coord_scan_stop_mhz_ - coord_scan_start_mhz_) * 1000.0f)
+                                      / (float)coord_scan_step_khz_) + 1u;
+    return steps * (uint32_t)(coord_scan_dwell_ms_ + 250u) + 5000u;
+}
+
 // Slack on top of the computed scan + cmd 15 retry budget so the rocket's
 // pause comfortably outlasts our work window.
 // #150 Seam B finding: the rocket's pause clock starts at cmd-16 RECEIPT,
@@ -3114,6 +3145,23 @@ static void serviceCoordinatedScan()
             {
                 coord_scan_state_    = CoordScanState::PUSHING_CHSET;
                 coord_scan_phase_ms_ = now;
+            }
+            // #570: this state had NO timeout — the only exit needed BOTH a
+            // valid scan AND a queued cmd 15. A zero-sample pass (quiet /
+            // wedged radio: analyzeAndPushFromCachedScan early-returns, no
+            // cmd 15) or a RejectedFull cmd 15 left it stuck in SCANNING
+            // forever, which suppresses the hop-silence fallback and rejects
+            // every future scan until reboot. Budget = the driver scan's own
+            // worst case (steps × (dwell+250 ms) + 5 s, the #567 sizing) so
+            // it can never fire on a healthy slow scan; on expiry drop to
+            // IDLE and let the normal recovery machinery take over.
+            else if ((now - coord_scan_phase_ms_) > coordScanScanningBudgetMs())
+            {
+                ESP_LOGW(TAG, "[CHSET] Coord scan: no pushable result within "
+                              "%lu ms (empty scan or cmd-15 not queued) — "
+                              "abandoning to normal recovery",
+                         (unsigned long)coordScanScanningBudgetMs());
+                coord_scan_state_ = CoordScanState::IDLE;
             }
             break;
         }
@@ -4004,7 +4052,8 @@ static void loop_bs()
                 }
             }
         }
-        // --- Telemetry packet: SIZE_OF_LORA_DATA (73) bytes ---
+        // --- Telemetry packet: exactly SIZE_OF_LORA_DATA bytes ---
+        // (#570: no literal here — a stale "(73)" outlived two frame diets.)
         else if (rx_len == SIZE_OF_LORA_DATA)
         {
             // Decode the telemetry packet
@@ -4035,7 +4084,17 @@ static void loop_bs()
                 // #506: learn the downlink cadence from the TELEMETRY stream only.
                 // Beacons are sporadic (~2 s) and would corrupt the estimate; this
                 // is the steady ~500 ms stream whose gaps the uplink aims for.
-                rx_cadence.onPacket(last_packet_ms);
+                // #570: and ONLY from the FOCUSED rocket — with two rockets up,
+                // feeding every packet drove the learned period toward the
+                // inter-rocket spacing (~100-400 ms) instead of the true
+                // per-rocket ~500 ms, collapsing the #506 TX window until
+                // mayStartTx stopped gating and uplinks fired blind over
+                // downlinks. (No focus yet → isFocusedRocket is true for all,
+                // so single-rocket learning is unchanged.)
+                if (isFocusedRocket(decoded.rocket_id))
+                {
+                    rx_cadence.onPacket(last_packet_ms);
+                }
 
                 // Route to per-rocket tracker
                 int slot = findOrAllocRocket(decoded.rocket_id);
@@ -4388,8 +4447,17 @@ static void loop_bs()
         }
         else
         {
-            ESP_LOGW(TAG, "[RX] Unexpected packet size: %u (expected %u or beacon)",
-                     (unsigned)rx_len, (unsigned)SIZE_OF_LORA_DATA);
+            // #570: count + surface (was a bare WARN — a mixed-flash size
+            // mismatch dropped 100% of telemetry with no counter and nothing
+            // over BLE; the netid path got this treatment in #329, this
+            // didn't).
+            lora_size_mismatch_drops++;
+            lora_size_last_drop_ms = millis();
+            ESP_LOGW(TAG, "[RX] Unexpected packet size: %u (expected %u or beacon) "
+                          "— %lu dropped; mixed-firmware flash? (SIZE_OF_LORA_DATA "
+                          "differs between rocket and BS builds)",
+                     (unsigned)rx_len, (unsigned)SIZE_OF_LORA_DATA,
+                     (unsigned long)lora_size_mismatch_drops);
         }
     }
 


### PR DESCRIPTION
Closes #570

Batch of the six verified low-severity BS findings from the 2026-07-20 pre-flight review roundup — one PR per the roundup precedent.

## 1. `rx_cadence` learned from all rockets, defeating the #506 TX window
With two rockets up (~2 Hz each), feeding every net-id-matched packet drove the learned period toward the inter-rocket spacing (~100–400 ms) instead of the true per-rocket ~500 ms; once `period < reserve + airtime`, `mayStartTx` stopped gating and uplinks fired blind over downlinks. Cadence now learns **only from the focused rocket** (`isFocusedRocket`); with no focus latched every rocket qualifies, so single-rocket learning is unchanged.

## 2. Coordinated scan could stall permanently in SCANNING
The only exit required `scan_results_valid_ && uplinkBusy()`. An empty pass (quiet/wedged radio → `analyzeAndPushFromCachedScan` early-returns, no cmd 15) or a RejectedFull cmd 15 stuck the machine in SCANNING forever — suppressing the hop-silence fallback and rejecting all future scans until reboot. Added a wall-clock budget (steps × (dwell + 250 ms) + 5 s — the #567 in-driver backstop sizing, so a healthy slow scan can never trip it) that drops to IDLE for normal recovery.

## 3. `sendCurrentConfig()` parked the loop 50 ms per config command
The `delay(50)` between the config and identity JSON frames was legacy pre-#524 pacing; a connect-time burst chained several. `notify_data` now applies MTU-aware backpressure itself, so the fixed sleep is gone — RX decode, uplink retries, heartbeats, and CSV flush keep running.

## 4. `rid` was MTU-droppable — multi-rocket demux could lose attribution
`rid` is the demux key for the BS's single relay characteristic, but it rode Tier 2: a peak-payload frame (boost + GPS fix under a small MTU) could trim it, and the app would attribute rocket B's telemetry to the selected rocket A. Promoted to the **head of Tier 1** (~6 B, never droppable). Position-independent for the app's JSON parser — no app change needed; direct FC/OC frames (no rid) are byte-identical.

## 5. Size-mismatch drops: counted + surfaced (the 65-vs-66 B mixed-flash trap)
A CRC-valid packet with the wrong length hit a bare `ESP_LOGW` — if rocket and BS are flashed from commits with different `SIZE_OF_LORA_DATA`, 100% of telemetry silently drops and the app just shows "Searching". Now mirrors the #329 netid pattern: `lora_size_mismatch_drops` lifetime counter, recency-windowed **`"szd"`** BLE key (sibling of `nidd`, zero bytes on a healthy link), and a WARN that names the mixed-firmware hypothesis outright. App-side display can adopt `szd` later; the signal is now on the wire.

## 6. Stale "(73)" size comment
Replaced the literal with the symbol itself — it had outlived two frame diets (actual size 65 B) and would mislead a buffer-size audit.

## Verification
- Compile-verified: `idf.py build` (esp32 BS — includes the shared TR_BLE_To_APP change) → Project build complete; CI matrix covers OC/FC/radio_board.
- No host tests: BS loop/state-machine logic and JSON field ordering (established convention; the JSON tier system has no host harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
