### PR TITLE
app(#571): low-severity flight-readiness roundup — 2 fixes

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -191,7 +191,11 @@ class BLEFleet: NSObject, ObservableObject {
     private let maxReconnectAttempts = 8   // #291: was 3 (~7 s); raised for flight dropouts
     private var lastPeripheralIdentifier: UUID?
     private var userInitiatedDisconnect = false
-    private var reconnectingPeripheral: CBPeripheral?
+    // #571: ALL peripherals handed back by CoreBluetooth state restoration —
+    // a BS + direct-rocket session restores two, and keeping only .first
+    // silently lost the second (it never reappeared because the restored
+    // link's isConnected suppressed the scan trigger).
+    private var reconnectingPeripherals: [CBPeripheral] = []
 
     // Strong references to peripherals while a connection is in flight (#173).
     // CBCentralManager only retains peripherals weakly, so without our own
@@ -346,10 +350,14 @@ extension BLEFleet: CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager,
                        willRestoreState dict: [String: Any]) {
+        // #571: keep EVERY restored peripheral, not just .first — a two-device
+        // session (BS + direct rocket) restores both, and dropping one here
+        // lost it for the whole relaunched session.
         if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral],
-           let restored = peripherals.first {
-            print("[BLE] State restoration: holding reference to \(restored.name ?? "unknown")")
-            reconnectingPeripheral = restored
+           !peripherals.isEmpty {
+            print("[BLE] State restoration: holding \(peripherals.count) peripheral(s): "
+                  + peripherals.map { $0.name ?? "unknown" }.joined(separator: ", "))
+            reconnectingPeripherals = peripherals
         }
     }
 
@@ -357,8 +365,18 @@ extension BLEFleet: CBCentralManagerDelegate {
         switch central.state {
         case .poweredOn:
             statusMessage = "Bluetooth ready"
-            if let p = reconnectingPeripheral, p.state == .connected {
-                print("[BLE] Restored peripheral still connected — resuming")
+            // #571: resume every restored peripheral that is still connected.
+            var resumedAny = false
+            var anyNotConnected = false
+            for p in reconnectingPeripherals {
+                guard p.state == .connected else {
+                    // Restored but the link didn't survive — the scan below
+                    // picks it back up (this is the case the old single-slot
+                    // code silently lost for the second device).
+                    anyNotConnected = true
+                    continue
+                }
+                print("[BLE] Restored peripheral still connected — resuming \(p.name ?? "unknown")")
                 let device = BLEDevice(peripheral: p, name: p.name ?? "Restored")
                 // #290: mirror the didConnect path. Without the fleet backref,
                 // fleet?.recordRocketFix() no-ops, so lastValidRocketFix never
@@ -367,9 +385,15 @@ extension BLEFleet: CBCentralManagerDelegate {
                 adopt(device, peripheralID: p.identifier)
                 device.onConnect()
                 devices.append(device)
-                activeDeviceID = p.identifier
-                reconnectingPeripheral = nil
-            } else {
+                if activeDeviceID == nil { activeDeviceID = p.identifier }
+                resumedAny = true
+            }
+            reconnectingPeripherals = []
+            // Scan when anything is missing: nothing restored at all, or a
+            // restored link that didn't survive the relaunch. (When every
+            // restored link resumed, behave as before — no scan while
+            // connected.)
+            if !resumedAny || anyNotConnected {
                 startScanning()
             }
         case .poweredOff:

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -325,13 +325,19 @@ struct TelemetryData: Codable {
         voltage = try c.decodeIfPresent(Float.self, forKey: .voltage)
         latitude = try c.decodeIfPresent(Double.self, forKey: .latitude)
         longitude = try c.decodeIfPresent(Double.self, forKey: .longitude)
-        num_sats = try c.decodeIfPresent(Int.self, forKey: .num_sats) ?? 0
+        // #571: complete the #293 hardening — every integer key goes through
+        // flexInt. The stragglers below were still strict decodeIfPresent, so
+        // ONE field emitted as float/string (firmware-contract drift) threw in
+        // init(from:) and the caller's catch discarded the WHOLE frame — on a
+        // BS-relayed stream that made the rocket vanish from the dashboard
+        // instead of degrading one field.
+        num_sats = flexInt(.num_sats) ?? 0
         state = try c.decodeIfPresent(String.self, forKey: .state) ?? "UNKNOWN"
         active_file = try c.decodeIfPresent(String.self, forKey: .active_file) ?? ""
         rx_kbs = try c.decodeIfPresent(Float.self, forKey: .rx_kbs)
         wr_kbs = try c.decodeIfPresent(Float.self, forKey: .wr_kbs)
-        frames_rx = try c.decodeIfPresent(UInt32.self, forKey: .frames_rx) ?? 0
-        frames_drop = try c.decodeIfPresent(UInt32.self, forKey: .frames_drop) ?? 0
+        frames_rx = UInt32(clamping: flexInt(.frames_rx) ?? 0)      // #571
+        frames_drop = UInt32(clamping: flexInt(.frames_drop) ?? 0)  // #571
         max_alt_m = try c.decodeIfPresent(Float.self, forKey: .max_alt_m)
         max_speed_mps = try c.decodeIfPresent(Float.self, forKey: .max_speed_mps)
         pressure_alt = try c.decodeIfPresent(Float.self, forKey: .pressure_alt)
@@ -356,20 +362,20 @@ struct TelemetryData: Codable {
         q3 = try c.decodeIfPresent(Float.self, forKey: .q3)
         rssi = try c.decodeIfPresent(Float.self, forKey: .rssi)
         snr = try c.decodeIfPresent(Float.self, forKey: .snr)
-        hop_channel = try c.decodeIfPresent(Int.self, forKey: .hop_channel)
-        netid_drops = try c.decodeIfPresent(Int.self, forKey: .netid_drops)
+        hop_channel = flexInt(.hop_channel)                          // #571
+        netid_drops = flexInt(.netid_drops)                          // #571
         bs_soc = try c.decodeIfPresent(Float.self, forKey: .bs_soc)
         bs_voltage = try c.decodeIfPresent(Float.self, forKey: .bs_voltage)
         bs_current = try c.decodeIfPresent(Float.self, forKey: .bs_current)
-        bs_log_silence_remaining_s = try c.decodeIfPresent(UInt16.self, forKey: .bs_log_silence_remaining_s)
+        bs_log_silence_remaining_s = flexInt(.bs_log_silence_remaining_s).map { UInt16(clamping: $0) }  // #571
         imu_orient_packed = flexInt(.imu_orient_packed)   // #293: tolerant, like fs/ps
         flight_status_bits = flexInt(.flight_status_bits) ?? 0   // #293: tolerant
         pyro_status_bits = flexInt(.pyro_status_bits) ?? 0       // #293: tolerant
-        sensor_health = try c.decodeIfPresent(Int.self, forKey: .sensor_health) ?? 0
-        source_rocket_id = try c.decodeIfPresent(Int.self, forKey: .source_rocket_id)
+        sensor_health = flexInt(.sensor_health) ?? 0                 // #571
+        source_rocket_id = flexInt(.source_rocket_id)                // #571: rid is the demux key
         source_unit_name = try c.decodeIfPresent(String.self, forKey: .source_unit_name)
         // #95: missing "ds" → .live (older firmware doesn't emit it)
-        let dsRaw = try c.decodeIfPresent(Int.self, forKey: .data_status) ?? 0
+        let dsRaw = flexInt(.data_status) ?? 0                       // #571
         data_status = DataStatus(rawValue: dsRaw) ?? .live
         data_age_ms = UInt32(clamping: flexInt(.data_age_ms) ?? 0)   // #293: tolerant
         fields_trimmed = (flexInt(.fields_trimmed) ?? 0) != 0        // #282

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -37,6 +37,31 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(telemetry.state, "INFLIGHT")
     }
 
+    func testJSONDecode_IntFieldsTolerateFloatAndString() throws {
+        // #571: completes the #293 hardening — EVERY integer key must survive
+        // firmware-contract drift emitting it as a float or string. A strict
+        // decode threw inside init(from:) and the caller's catch discarded the
+        // WHOLE frame, so one off-type field (e.g. "rid" on a relayed frame)
+        // made the rocket vanish from the BS dashboard instead of degrading a
+        // single field.
+        let json = """
+        {"st":"INFLIGHT","nsat":7.0,"rid":"3","frx":"1000","fdr":2.0,
+         "hch":"5","nidd":4.0,"h":"9","slrm":"120","ds":1.0}
+        """.data(using: .utf8)!
+
+        let t = try JSONDecoder().decode(TelemetryData.self, from: json)
+        XCTAssertEqual(t.num_sats, 7)
+        XCTAssertEqual(t.source_rocket_id, 3, "rid is the multi-rocket demux key")
+        XCTAssertEqual(t.frames_rx, 1000)
+        XCTAssertEqual(t.frames_drop, 2)
+        XCTAssertEqual(t.hop_channel, 5)
+        XCTAssertEqual(t.netid_drops, 4)
+        XCTAssertEqual(t.sensor_health, 9)
+        XCTAssertEqual(t.bs_log_silence_remaining_s, 120)
+        XCTAssertEqual(t.data_status, .stale)
+        XCTAssertEqual(t.state, "INFLIGHT", "frame must decode as a whole")
+    }
+
     func testJSONDecode_HopStateKeys() throws {
         // #150: "hch" (current hop channel) and "nidd" (network-id
         // mismatch drops) ride the droppable tail of the telemetry JSON —


### PR DESCRIPTION
Closes #571

Batch of the two verified low-severity iOS-app findings from the 2026-07-20 pre-flight review roundup.

## 1. Complete the #293 telemetry-decode hardening
`flexInt` covered only `fs`/`ps`/`imo`/`age`/`tr`; **eight** integer keys were still strict `decodeIfPresent(Int/UInt)`: `nsat`, `frx`, `fdr`, `slrm`, `hch`, `nidd`, `h`, and `rid` (plus `ds`, converted for consistency). One field emitted as a float or string (firmware-contract drift) threw inside `init(from:)` and the caller's catch discarded the **whole frame** — on a BS-relayed stream, an off-type `rid` made the rocket vanish from the dashboard/roster instead of degrading one field. All integer keys now route through `flexInt`.

**Test:** `testJSONDecode_IntFieldsTolerateFloatAndString` feeds every one of those keys as a float or string and asserts the frame decodes whole with correct values. Red-by-construction against the old code (a strict `decodeIfPresent(Int)` on `"3"` throws `typeMismatch`, failing the entire decode); green with the fix — full `TelemetryDataTests` suite `** TEST SUCCEEDED **`.

## 2. BLE state restoration kept only one peripheral
`willRestoreState` held `peripherals.first` only, and the `poweredOn` branch either resumed that single peripheral **or** scanned — never both. A BS + direct-rocket session force-quit (or OS-terminated) mid-flight restored only one link on relaunch; the second never returned because the restored link's `isConnected` suppressed the scan trigger.

Now: `willRestoreState` holds **all** restored peripherals; `poweredOn` resumes every still-connected one (mirroring the #290 `adopt`/`onConnect` path; the first resumed becomes active if none is), and falls back to `startScanning()` when nothing was restored **or** any restored link didn't survive. A fully-resumed session behaves exactly as before — no scan while connected.

## Verification
- `xcodebuild test` (iOS Simulator) — `TelemetryDataTests` green including the new tolerance test; the build compiles the `BLEFleet` change.
- The restoration path itself is CoreBluetooth-delegate code with no unit harness (established convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
