### PR TITLE
shared(#572): low-severity flight-readiness roundup — 8 fixes

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -61,7 +61,7 @@ MSG_EXPECTED_LEN = {
     MSG_POWER:            10,
     MSG_START_LOGGING:    None,
     MSG_END_FLIGHT:       None,
-    MSG_LORA:             49,
+    MSG_LORA:             65,   # sizeof(LoRaData) — #572: was a stale 49; sweep on struct-size changes (#227)
 }
 
 FMT_ISM6       = '<I hhh hhh hhh'

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -110,7 +110,7 @@ MSG_EXPECTED_LEN = {
     MSG_START_LOGGING:     None,  # variable / no payload
     MSG_END_FLIGHT:        None,
     MSG_LOG_BUFFER_STATS:  28,    # LogBufferStatsData
-    MSG_LORA:              49,
+    MSG_LORA:              65,  # sizeof(LoRaData) — #572: was a stale 49; sweep on struct-size changes (#227)
     MSG_GUIDANCE_TELEM:    (15, 19),  # legacy (mislabeled) / current (+fin cmds)
 }
 

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -886,17 +886,24 @@ bool TR_GNSSReceiverUBloxSerial::pollNewPVT(GNSSData &gnss_data)
 
 void TR_GNSSReceiverUBloxSerial::getGNSSData(GNSSData &gnss_data)
 {
+    // #572: every getter passes maxWait=0 explicitly. The SparkFun default is
+    // ~1.1 s: a getter whose cache bit is stale silently issues a BLOCKING
+    // getPVT(1100) — safe on the pollNewPVT path only because getPVT(0)==true
+    // just primed the whole cache, but a lethal footgun for any standalone
+    // caller (up to ~1.1 s PER FIELD). With 0 the contract is explicit:
+    // this function reads the already-parsed NAV-PVT and never touches the
+    // serial link. Must be called after a successful getPVT (pollNewPVT does).
     gnss_data.time_us = micros();
-    gnss_data.year = gnss.getYear();
-    gnss_data.month = gnss.getMonth();
-    gnss_data.day = gnss.getDay();
-    gnss_data.hour = gnss.getHour();
-    gnss_data.minute = gnss.getMinute();
-    gnss_data.second = gnss.getSecond();
-    gnss_data.milli_second = gnss.getMillisecond();
+    gnss_data.year = gnss.getYear(0);
+    gnss_data.month = gnss.getMonth(0);
+    gnss_data.day = gnss.getDay(0);
+    gnss_data.hour = gnss.getHour(0);
+    gnss_data.minute = gnss.getMinute(0);
+    gnss_data.second = gnss.getSecond(0);
+    gnss_data.milli_second = gnss.getMillisecond(0);
     // 0: No Fix, 1: Dead Reckoning, 2: 2D Fix, 3: 3D Fix,
     // 4:GNSS + Dead Reckoning, 5: Time Only
-    gnss_data.fix_mode = gnss.getFixType();
+    gnss_data.fix_mode = gnss.getFixType(0);
 
     // #562: fixType alone is not enough to trust a fix. u-blox marks a fix
     // INVALID without dropping fixType below 3 — by clearing gnssFixOK (fix
@@ -905,25 +912,25 @@ void TR_GNSSReceiverUBloxSerial::getGNSSData(GNSSData &gnss_data)
     // violation (>515 m/s or >18 km) — exactly the transonic / high-altitude
     // regime the apogee GPS voter and guidance/landing-prediction run in. Zero
     // fix_mode so every downstream `fix_mode >= 3` consumer treats it as "no
-    // fix" (same contract as the staleness gate below). maxWait=0 keeps this
-    // non-blocking: both flags come from the NAV-PVT that pollNewPVT already
-    // parsed this cycle. See open #491 (COCOM bench-test).
+    // fix". maxWait=0 keeps this non-blocking: both flags come from the
+    // NAV-PVT that pollNewPVT already parsed this cycle. See open #491
+    // (COCOM bench-test).
     if (!gnss.getGnssFixOk(0) || gnss.getInvalidLlh(0))
     {
         gnss_data.fix_mode = 0;
     }
 
-    gnss_data.num_sats = gnss.getSIV();
+    gnss_data.num_sats = gnss.getSIV(0);
 
     // SparkFun u-blox returns PDOP as scale 0.01. Convert to x10 for packed type.
-    const uint16_t pdop_x100 = gnss.getPDOP();
+    const uint16_t pdop_x100 = gnss.getPDOP(0);
     uint16_t pdop_x10_u16 = (uint16_t)((pdop_x100 + 5U) / 10U);
     if (pdop_x10_u16 > 255U) pdop_x10_u16 = 255U;
     gnss_data.pdop_x10 = (uint8_t)pdop_x10_u16;
 
     // Accuracy estimates are reported in mm. Convert to whole meters.
-    const uint32_t h_acc_mm = gnss.getHorizontalAccEst();
-    const uint32_t v_acc_mm = gnss.getVerticalAccEst();
+    const uint32_t h_acc_mm = gnss.getHorizontalAccEst(0);
+    const uint32_t v_acc_mm = gnss.getVerticalAccEst(0);
     uint32_t h_acc_m_u32 = (h_acc_mm + 500U) / 1000U;
     uint32_t v_acc_m_u32 = (v_acc_mm + 500U) / 1000U;
     if (h_acc_m_u32 > 255U) h_acc_m_u32 = 255U;
@@ -932,48 +939,25 @@ void TR_GNSSReceiverUBloxSerial::getGNSSData(GNSSData &gnss_data)
     gnss_data.v_acc_m = (uint8_t)v_acc_m_u32;
 
     // Velocity (ENU, mm/s)
-    gnss_data.vel_e_mmps = gnss.getNedEastVel();
-    gnss_data.vel_n_mmps = gnss.getNedNorthVel();
-    gnss_data.vel_u_mmps = -gnss.getNedDownVel();
+    gnss_data.vel_e_mmps = gnss.getNedEastVel(0);
+    gnss_data.vel_n_mmps = gnss.getNedNorthVel(0);
+    gnss_data.vel_u_mmps = -gnss.getNedDownVel(0);
 
     // Latitude and Longitude (deg*1e7)
-    gnss_data.lat_e7 = gnss.getLatitude();
-    gnss_data.lon_e7 = gnss.getLongitude();
+    gnss_data.lat_e7 = gnss.getLatitude(0);
+    gnss_data.lon_e7 = gnss.getLongitude(0);
 
     // Altitude relative to mean sea level (mm)
-    gnss_data.alt_mm = gnss.getAltitudeMSL();
+    gnss_data.alt_mm = gnss.getAltitudeMSL(0);
 
-    // --- Staleness detection ---
-    // If the GNSS second+millisecond are unchanged across consecutive reads,
-    // the SparkFun library is returning cached data (serial buffer overflow
-    // caused the UBX parser to lose frame sync).  After STALE_THRESHOLD
-    // consecutive unchanged readings, zero fix_mode so downstream consumers
-    // know the position is unreliable.
-    if (gnss_data.second == prev_second &&
-        gnss_data.milli_second == prev_milli_second)
-    {
-        if (stale_count < UINT16_MAX) stale_count++;
-
-        if (stale_count == STALE_THRESHOLD)
-        {
-            ESP_LOGW(TAG, "Data stale — no new PVT for 5 consecutive reads, zeroing fix_mode");
-        }
-    }
-    else
-    {
-        if (stale_count >= STALE_THRESHOLD)
-        {
-            ESP_LOGI(TAG, "Data resumed after %u stale reads",
-                          (unsigned)stale_count);
-        }
-        stale_count = 0;
-    }
-
-    prev_second = gnss_data.second;
-    prev_milli_second = gnss_data.milli_second;
-
-    if (stale_count >= STALE_THRESHOLD)
-    {
-        gnss_data.fix_mode = 0;  // signal "no fix" to consumers
-    }
+    // #572: the "staleness detection" that lived here was DEAD CODE — this
+    // function is only reached from pollNewPVT() after getPVT(0) returned
+    // true (a NEW NAV-PVT was fully parsed), so the second+millisecond
+    // "unchanged across consecutive reads" condition it counted could never
+    // occur on the live path; in the overflow/desync case it targeted,
+    // getPVT(0) returns false and this function is never called. Genuine
+    // GNSS silence is caught downstream by the collector/EKF time_us
+    // freshness gates (and #557's absent-module handling). Removed rather
+    // than relocated — a wall-clock silence detector here would duplicate
+    // the downstream gates.
 }

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.h
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.h
@@ -62,13 +62,10 @@ class TR_GNSSReceiverUBloxSerial
         // Helper: blocking read of one byte. Returns byte or -1 on timeout.
         int uartRead();
 
-        // Staleness detection: if GNSS second+millisecond are unchanged for
-        // STALE_THRESHOLD consecutive getGNSSData() calls, the serial link
-        // has likely lost sync and the library is returning cached data.
-        static constexpr uint16_t STALE_THRESHOLD = 5;  // ~500 ms at 10 Hz
-        uint8_t  prev_second      = 0xFF;   // impossible initial value
-        uint16_t prev_milli_second = 0xFFFF;
-        uint16_t stale_count       = 0;
+        // (#572: the old getGNSSData() staleness counter was removed — it was
+        // dead code, only reachable after getPVT(0) already proved a fresh
+        // frame. Liveness is owned by the downstream collector/EKF time_us
+        // freshness gates.)
 
         void enuToEcefVelocityAndPosition(float v_east,
                                           float v_north,

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.cpp
@@ -109,7 +109,8 @@ void GpsInsEKF::initCore(EkfIMUData imu_data,
     // the physical envelope, and start the health counters clean.
     gbias_gate_trips_ = 0;
     gbias_clip_count_ = 0;
-    gbias_gate_hold_until_us_ = 0;
+    gbias_gate_armed_   = false;   // #572: trip-time + armed flag (wrap-safe hold)
+    gbias_gate_trip_us_ = 0;
     wBias_rps_[0]=wMeas[0]; wBias_rps_[1]=wMeas[1]; wBias_rps_[2]=wMeas[2];
     clampGyroBias();
 

--- a/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
+++ b/tinkerrocket-idf/components/TR_GpsInsEKF/TR_GpsInsEKF.h
@@ -139,13 +139,20 @@ public:
     void getQuaternion(float (&r)[4]) const { r[0]=quat_BL_[0]; r[1]=quat_BL_[1]; r[2]=quat_BL_[2]; r[3]=quat_BL_[3]; }
 
     /// EKF health for downstream consumers (#257 apogee voter exclusion, #265
-    /// servo-stow gate).  v1 signal: the quaternion + velocity estimate are
-    /// finite AND stabilizeP() has not had to repair a non-finite covariance
-    /// within the last divergence-cooldown window.  Conservative — covariance-
-    /// magnitude thresholds are deferred until tuned against flight logs.
+    /// servo-stow gate).  v1 signal: the quaternion + velocity + position
+    /// estimates are finite AND stabilizeP() has not had to repair a
+    /// non-finite covariance within the last divergence-cooldown window.
+    /// #572: position was missing — a NaN reaching only pEst_D_rrm_ fed NaN
+    /// into guidance range/bearing and the landing estimate while isHealthy()
+    /// still said true, so the voter and servo gate kept trusting it.
+    /// Conservative — covariance-magnitude thresholds are deferred until
+    /// tuned against flight logs.  (Bias states are deliberately not checked:
+    /// a non-finite bias corrupts velocity/attitude within one predict step,
+    /// so these checks already catch it a tick later.)
     bool isHealthy() const {
         for (int i = 0; i < 4; ++i) if (!std::isfinite(quat_BL_[i]))      return false;
         for (int i = 0; i < 3; ++i) if (!std::isfinite(vEst_NED_mps_[i])) return false;
+        for (int i = 0; i < 3; ++i) if (!std::isfinite(pEst_D_rrm_[i]))   return false;  // #572
         return unhealthy_cooldown_ == 0;
     }
 
@@ -481,16 +488,31 @@ private:
     // consistent for a dwell, i.e. until the slew has finished. Sized to comfortably
     // outlast the accel update's attitude time constant.
     static constexpr uint32_t GBIAS_GATE_HOLD_US = 2000000u;   // 2 s
-    uint32_t gbias_gate_hold_until_us_ = 0;
+    // #572: store the TRIP time and compare elapsed, not an absolute
+    // "hold-until" deadline. The old `tPrev_us_ < hold_until` broke across
+    // the uint32 microsecond wrap (~71.6 min) twice over: a trip within 2 s
+    // of the wrap computed a small hold_until so the hold dropped instantly,
+    // and long after any trip the wrapped tPrev_us_ dipped BELOW the stale
+    // nonzero hold_until, spuriously re-holding the coupling cut. Elapsed
+    // arithmetic is wrap-safe, and the armed flag disarms on expiry so a
+    // stale trip time can't re-trigger 71 minutes later.
+    uint32_t gbias_gate_trip_us_ = 0;
+    bool     gbias_gate_armed_   = false;
 
     // True while the gyro-bias coupling is held cut (gate tripped recently).
-    inline bool gyroBiasGateHeld() const {
-        return gbias_gate_hold_until_us_ != 0 && tPrev_us_ < gbias_gate_hold_until_us_;
+    inline bool gyroBiasGateHeld() {
+        if (!gbias_gate_armed_) return false;
+        if ((uint32_t)(tPrev_us_ - gbias_gate_trip_us_) >= GBIAS_GATE_HOLD_US) {
+            gbias_gate_armed_ = false;   // expired — disarm so wrap can't re-hold
+            return false;
+        }
+        return true;
     }
     // Arm/refresh the hold and count the trip.
     inline void tripGyroBiasGate() {
         ++gbias_gate_trips_;
-        gbias_gate_hold_until_us_ = tPrev_us_ + GBIAS_GATE_HOLD_US;
+        gbias_gate_armed_   = true;
+        gbias_gate_trip_us_ = tPrev_us_;
     }
 
     // Hard physical bound on the gyro-bias state (rad/s). A backstop: no

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -2052,6 +2052,15 @@ typedef struct __attribute__((packed))
     float max_cmd;
 } PIDConfigData;
 static_assert(sizeof(PIDConfigData) == 20, "PIDConfigData must be 20 bytes");
+// #572: field-ORDER pin. This struct is homogeneous (same-typed fields), is
+// hand-packed byte-by-byte in the iOS app (BLEDevice.swift) and memcpy'd on
+// the FC — a same-size field reorder passes the sizeof assert and every gtest
+// while silently mismapping (e.g. the app's ki applied as kd: wrong gains
+// fly). The offsets ARE the wire ABI.
+static_assert(offsetof(PIDConfigData, kp) == 0 && offsetof(PIDConfigData, ki) == 4 &&
+              offsetof(PIDConfigData, kd) == 8 && offsetof(PIDConfigData, min_cmd) == 12 &&
+              offsetof(PIDConfigData, max_cmd) == 16,
+              "PIDConfigData field order is wire ABI (app hand-packs it)");
 
 // PN guidance target mode (which point the rocket steers toward).
 static constexpr uint8_t GUIDE_TARGET_OVERHEAD = 0;  // directly over the pad: (0,0,target_alt)
@@ -2159,12 +2168,20 @@ typedef struct __attribute__((packed))
     float descent_rate_mps;
 } SimConfigData;
 static_assert(sizeof(SimConfigData) == 16, "SimConfigData must be 16 bytes");
+// #572: field-order pin — see PIDConfigData.
+static_assert(offsetof(SimConfigData, mass_kg) == 0 && offsetof(SimConfigData, thrust_n) == 4 &&
+              offsetof(SimConfigData, burn_time_s) == 8 && offsetof(SimConfigData, descent_rate_mps) == 12,
+              "SimConfigData field order is wire ABI (app hand-packs it)");
 
 typedef struct __attribute__((packed))
 {
     int16_t angle_cdeg[4];  // Per-servo angle in centi-degrees (-2000 to +2000)
 } ServoTestAnglesData;
 static_assert(sizeof(ServoTestAnglesData) == 8, "ServoTestAnglesData must be 8 bytes");
+// #572: field-order pin — see PIDConfigData.
+static_assert(offsetof(ServoTestAnglesData, angle_cdeg) == 0 &&
+              sizeof(((ServoTestAnglesData*)nullptr)->angle_cdeg[0]) == 2,
+              "ServoTestAnglesData layout is wire ABI (app hand-packs it)");
 
 // --- Servo Replay Data ---
 // Replays recorded flight data through the control loop to observe servo response
@@ -2219,6 +2236,13 @@ typedef struct __attribute__((packed))
     float    integral_sep_threshold_dps;  // roll-rate PID integral-separation anti-windup threshold (deg/s); >=0 applies (0 disables), <0 keeps firmware default
 } RollControlConfigData;
 static_assert(sizeof(RollControlConfigData) == 16, "RollControlConfigData must be 16 bytes");
+// #572: field-order pin — see PIDConfigData.
+static_assert(offsetof(RollControlConfigData, use_angle_control) == 0 &&
+              offsetof(RollControlConfigData, roll_delay_ms) == 2 &&
+              offsetof(RollControlConfigData, kp_angle_rate_cap_dps) == 4 &&
+              offsetof(RollControlConfigData, kp_angle) == 8 &&
+              offsetof(RollControlConfigData, integral_sep_threshold_dps) == 12,
+              "RollControlConfigData field order is wire ABI (app hand-packs it)");
 
 // --- Flight settings snapshot (#165) ---
 // One-shot snapshot of the rocket's runtime settings, emitted FC→OC over I2S

--- a/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector/TR_Sensor_Collector.cpp
@@ -1112,12 +1112,20 @@ void SensorCollector::calibrateGyro(float rotation_z_deg)
     // --- Accel cross-calibration ---
     if (accel_count > 0)
     {
-        // ISM6HG256 sensitivity (must match SensorConverter config):
-        //   low-g  ±16g  → 16*1000/32768 mg/LSB → * 1e-3 * 9.80665 m/s²/LSB
-        //   high-g ±256g → 256*1000/32768 mg/LSB → * 1e-3 * 9.80665 m/s²/LSB
+        // ISM6HG256 sensitivity — #572: derived from the CONFIGURED full
+        // scales (the same ctor members Set_X_FullScale programs into the
+        // chip), NOT literals. The old hardcoded 16g/256g silently decoupled
+        // from a non-default FS: counts scaled with the wrong per-LSB put a
+        // ~1 g error into hg_bias, which setHighGBias() then subtracted from
+        // every boost sample (burnout detect, max-speed, launch fallback).
+        // Inert on the shipping build (FS is constexpr 16/256 in config.h) —
+        // this is the maintainability pin. Formula mirrors
+        // SensorConverter::configureISM6HG256FullScale (FS*1000/32768 mg/LSB).
         static constexpr float g_ms2 = 9.80665f;
-        static constexpr float lg_ms2_per_lsb = (16.0f * 1000.0f / 32768.0f) * 1e-3f * g_ms2;
-        static constexpr float hg_ms2_per_lsb = (256.0f * 1000.0f / 32768.0f) * 1e-3f * g_ms2;
+        const float lg_ms2_per_lsb =
+            ((float)ism6_low_g_fs_g_  * 1000.0f / 32768.0f) * 1e-3f * g_ms2;
+        const float hg_ms2_per_lsb =
+            ((float)ism6_high_g_fs_g_ * 1000.0f / 32768.0f) * 1e-3f * g_ms2;
 
         // Average raw → SI (sensor frame)
         const float avg_lg_x = ((float)sum_lg_x / accel_count) * lg_ms2_per_lsb;

--- a/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Data_Converter/TR_Sensor_Data_Converter.cpp
@@ -404,9 +404,14 @@ void SensorConverter::packLoRa(const LoRaDataSI& in, LoRaData& out)
     packed |= (state & 0x07u) << LORA_STATE_SHIFT; // b4..b6
     out.flags_state = packed;
 
-    // acceleration (×10), −400..400 → i16
+    // acceleration (×10) → i16. #572: clamp at the WIRE max (±3276.7, same
+    // bound as enc_gyro/enc_vel_dms), not the old ±400 m/s² (~40.8 g) which
+    // silently flat-topped telemetry/CSV traces on any boost above ~40 g even
+    // though the high-g accelerometer reads to 256 g (~2511 m/s² — inside the
+    // wire range, so the sensor ceiling is the real limit). Saturation only
+    // ever occurs above int16 capacity; no wire-format change.
     auto enc_acc = [](float a)->int16_t {
-        a = SensorConverter::clampf(a, -400.f, 400.f);
+        a = SensorConverter::clampf(a, -3276.7f, 3276.7f);
         return (int16_t)lroundf(a * 10.f);
     };
     out.acc_x_x10 = enc_acc(in.acc_x);


### PR DESCRIPTION
Closes #572

Batch of the eight verified low-severity shared-component findings from the 2026-07-20 pre-flight review roundup — the final issue of tracker #573.

## 1. GNSS staleness detector removed (dead code)
`getGNSSData()` is only reached after `getPVT(0)==true` proved a freshly parsed NAV-PVT, so its consecutive-unchanged-timestamp counter could never fire on the live path — and in the overflow/desync case it targeted, the function is never called at all. Liveness is owned by the downstream collector/EKF `time_us` freshness gates (+ #557 absent-module handling). Removed rather than relocated.

## 2. `getGNSSData()` getters pass `maxWait=0` explicitly
The SparkFun default is ~1.1 s: a standalone caller with a stale cache would silently **block ~1.1 s per field**. The explicit zero makes the read-the-parsed-frame contract real (and documented) instead of an accident of the `pollNewPVT` call order.

## 3. Collector high-G cross-cal derives from the configured full-scales
Per-LSB constants now come from `ism6_low/high_g_fs_g_` (the same members programmed into the chip), not hardcoded 16g/256g literals — a non-default FS would have put ~1 g of error into `hg_bias`, subtracted from every boost sample. Inert on the shipping build (FS is `constexpr`); a maintainability pin mirroring `SensorConverter`'s formula.

## 4. EKF `isHealthy()` checks position finiteness
A NaN reaching only `pEst_D_rrm_` fed NaN into guidance range/bearing and the landing estimate while the EKF still advertised healthy to the apogee voter and servo gate. (Bias states deliberately unchecked — a non-finite bias corrupts velocity/attitude within one predict step, already caught.)

## 5. EKF gyro-bias gate hold made wrap-safe — fixes TWO wrap bugs
The old absolute `hold_until` deadline broke across the uint32 µs wrap (~71.6 min) twice over: a trip within 2 s of the wrap dropped the hold instantly (the filed bug), **and** long after any trip the wrapped clock dipped below the stale nonzero deadline, spuriously re-holding the coupling cut every ~71.6 min. Now stores the trip **time**, compares elapsed (wrap-safe), and disarms on expiry.

## 6. LoRa `enc_acc` clamp ±400 → ±3276.7 m/s²
The wire max, uniform with `enc_gyro`/`enc_vel_dms`. The old bound silently flat-topped telemetry accel above ~40 g even though the high-g accelerometer reads to 256 g (~2511 m/s², inside the wire range — the sensor ceiling is now the real limit). No wire-format change.

## 7. Data_Analysis stale `MSG_LORA` length 49 → 65
`= sizeof(LoRaData)` in both current-format parsers — dead today (the OC never logs LoRaData) but it would have silently rejected every frame if that changed; annotated for the #227 struct-size sweep.

## 8. offsetof field-order pins for the four hand-packed config structs
`PIDConfigData`, `SimConfigData`, `ServoTestAnglesData`, `RollControlConfigData` are homogeneous and hand-packed byte-by-byte by the app — a same-size field reorder passed every sizeof assert and gtest while silently mismapping (the app's ki applied as kd: wrong gains fly, all tests green). The offsets are now compile-time wire ABI.

## Verification
- Host suites green: `test_rocket_computer_types` **111** (compiles the new pins), `test_ekf` **33**, `test_lora_roundtrip` **11**, `test_sensor_data_converter` **15**.
- `idf.py build` (esp32p4 FC — compiles every touched component) → Project build complete; CI matrix covers OC/BS/radio_board.
- Python parsers ast-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
