### PR TITLE
fc: shorten pyro fire pulse 500 -> 200 ms

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -130,7 +130,9 @@ struct config : board_pins
     // One shared arming FET feeds all four squib drivers. ARM is raised
     // only momentarily — for the PRELAUNCH continuity check and again
     // during a fire pulse — never latched in flight.
-    static constexpr uint32_t PYRO_FIRE_DURATION_MS    = 500;
+    // E-matches commit in <10 ms; 200 ms is ignition margin while bounding
+    // the I2t a shorted match can dump into the channel FET on 2S.
+    static constexpr uint32_t PYRO_FIRE_DURATION_MS    = 200;
     // Time between raising ARM and reading CONT / pulsing FIRE, giving
     // the upstream arming FET its turn-on settle margin.
     static constexpr uint32_t PYRO_ARM_SETTLE_MS       = 10;


### PR DESCRIPTION
## Summary
- `PYRO_FIRE_DURATION_MS` 500 → 200 ms. E-matches commit in well under 10 ms, so 200 ms keeps generous ignition margin while cutting the worst-case I²t a shorted match can dump into the low-side channel FET on the 2S rail by 2.5×.
- Sized alongside the channel-FET selection for the next PCB spin (TI CSD16323Q3, SON 3.3×3.3, guaranteed 7.2 mΩ max at Vgs = 3 V).
- Firmware-only constant used by the fire state machine in `main.cpp` — no BLE/app config mirror to keep in lockstep.

## Test
- `idf.py build` (ESP32-P4, IDF v6) clean.
- Not bench-fired; PRELAUNCH continuity and fire paths are unchanged apart from pulse length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)