### PR TITLE
sim: document cmd-5 grams wire unit, warn on implausible mass_kg

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/SimulationView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SimulationView.swift
@@ -152,6 +152,8 @@ struct SimulationView: View {
         }
 
         // Pack 4 floats as little-endian bytes: [mass_g:4][thrust_n:4][burn_s:4][descent_rate_mps:4]
+        // Wire mass is GRAMS: the OC relay divides by 1000 into SimConfigData.mass_kg
+        // (firmware-internal struct is kg — do not "fix" this to pack kg).
         var payload = Data()
         var m = massG
         var t = thrustN

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -2160,6 +2160,11 @@ typedef struct __attribute__((packed))
 } FinConfigData;
 static_assert(sizeof(FinConfigData) == 18, "FinConfigData must be 18 bytes");
 
+// UNIT TRAP: this struct is the OC→FC I2C frame and the sim's internal config —
+// mass in KILOGRAMS.  The BLE cmd-5 payload the app sends has the same field
+// order but its first float is mass in GRAMS; the OC relay handlers (BLE and
+// LoRa uplink, out_computer main.cpp) divide by 1000 when building this struct.
+// Never memcpy a raw cmd-5 payload into SimConfigData.
 typedef struct __attribute__((packed))
 {
     float mass_kg;
@@ -2171,7 +2176,8 @@ static_assert(sizeof(SimConfigData) == 16, "SimConfigData must be 16 bytes");
 // #572: field-order pin — see PIDConfigData.
 static_assert(offsetof(SimConfigData, mass_kg) == 0 && offsetof(SimConfigData, thrust_n) == 4 &&
               offsetof(SimConfigData, burn_time_s) == 8 && offsetof(SimConfigData, descent_rate_mps) == 12,
-              "SimConfigData field order is wire ABI (app hand-packs it)");
+              "SimConfigData field order matches the cmd-5 BLE payload (app hand-packs it), "
+              "but the BLE mass field is grams — OC converts (see unit trap above)");
 
 typedef struct __attribute__((packed))
 {

--- a/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
+++ b/tinkerrocket-idf/components/TR_Sensor_Collector_Sim/TR_Sensor_Collector_Sim.cpp
@@ -94,6 +94,14 @@ void SensorCollectorSim::configureSim(const SimConfigData& cfg)
 {
     cfg_ = cfg;
     configured_ = true;
+    // mass_kg outside any plausible vehicle (>50 kg / <10 g) almost certainly
+    // means a raw cmd-5 BLE payload (grams) reached us without the OC's /1000
+    // conversion — the sim will sit on the pad (or go ballistic) silently.
+    if (cfg_.mass_kg > 50.0f || cfg_.mass_kg < 0.010f)
+    {
+        ESP_LOGE("SIM", "Implausible mass_kg=%.4f — grams sent where kg expected? "
+                 "(BLE cmd-5 mass is grams; OC converts)", (double)cfg_.mass_kg);
+    }
     ESP_LOGI("SIM", "Config: mass=%.3fkg thrust=%.1fN burn=%.1fs descent=%.1fm/s",
              (double)cfg_.mass_kg, (double)cfg_.thrust_n,
              (double)cfg_.burn_time_s, (double)cfg_.descent_rate_mps);


### PR DESCRIPTION
## Summary

Investigation of a suspected 1000× sim-mass bug (flagged during the Android golden-fixture work) found **no live defect** — this PR lands the documentation and hardening that prevent the trap from recurring.

The BLE cmd-5 payload carries mass in **grams by design**; both OC relay handlers (BLE + LoRa uplink) divide by 1000 into `SimConfigData.mass_kg` before forwarding to the FC over I2C. The FC has no raw cmd-5 parser. The 2026-07-16 HIL log confirms end-to-end correctness: app default 500 g → 0.5 kg → exactly 80 m/s² boost accel with the default 40 N motor, burn 1.5 s and descent 10 m/s matching the app-entered values.

The trap: `SimConfigData`'s static_assert message called the struct "wire ABI", which misled the Android fixture work into labeling the BLE mass field kg (fixed separately on the Android branch).

## Changes

- `RocketComputerTypes.h`: unit-trap comment on `SimConfigData` (it is the OC→FC I2C frame in kg, not the BLE wire) + corrected static_assert message — field ORDER matches the BLE payload, the mass unit does not
- `TR_Sensor_Collector_Sim.cpp`: `ESP_LOGE` in `configureSim()` when `mass_kg` lands outside 10 g–50 kg — catches any future path that skips the OC's /1000 conversion (the failure mode is otherwise a sim that silently sits on the pad or goes ballistic)
- `SimulationView.swift`: comment noting the grams wire unit is intentional — do not "fix" the app to pack kg (that would double-divide)

## Testing

- Host gtest suite: 637/637 pass
- Firmware change is a log line only; not bench-flown

🤖 Generated with [Claude Code](https://claude.com/claude-code)