### PR TITLE
ci: run docs checks on every push/PR, and check the prose too

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,53 +1,50 @@
 name: Docs
 
-# Guards the generated firmware section maps against drift.
+# Documentation checks. Two kinds:
 #
-# docs/architecture/generated/*-map.md is produced from the `// SECTION:` banners
-# in each firmware's main.cpp. A hand-maintained line-range table would be stale
-# the first time anyone inserted a function, and a stale navigation map is worse
-# than none -- it sends the reader to the wrong place with full confidence.
+#   1. Generated artifacts (section maps, protocol reference) must match the
+#      sources they were extracted from. Each generator re-runs with --check.
+#   2. Hand-written prose must agree with the source on the facts a machine can
+#      verify -- links resolve, the IDF version matches CI, the workflow list is
+#      complete, quoted struct sizes match the wire.
 #
-# So the map is generated and this job re-runs the generator and fails if the
-# committed output differs. Adding or moving a section means re-running
-# `python3 tools/gen_section_index.py` and committing the result.
+# DELIBERATELY NOT PATH-FILTERED. Every other workflow in this repo is, which
+# is correct for them -- there is no point compiling firmware for a README typo.
+# It is wrong here. Documentation drifts *because of* changes elsewhere: the
+# README's ESP-IDF version went stale when the toolchain moved, its struct sizes
+# went stale when a field was added, its workflow list went stale when workflows
+# were added. A path filter listing "everything that could invalidate the docs"
+# is the same unbounded list as "everything", and PR #594 -- a README-only
+# change -- ran no checks at all because nothing matched it.
+#
+# The whole job is ~15 s of pure-stdlib Python, so running it on every push and
+# every PR costs less than maintaining the filter would.
+#
+# This is also why the docs checks are NOT duplicated into the other six
+# workflows: one always-on job covers every change, and a check that lives in
+# one place cannot fall out of sync with copies of itself.
 
 on:
   push:
-    paths:
-      - 'tinkerrocket-idf/projects/flight_computer/main/main.cpp'
-      - 'tinkerrocket-idf/projects/out_computer/main/main.cpp'
-      - 'tinkerrocket-idf/projects/base_station/main/main.cpp'
-      - 'TinkerRocketApp/TinkerRocketApp/**/*.swift'
-      - 'docs/architecture/generated/**'
-      - 'tools/gen_section_index.py'
-      - 'tools/gen_protocol_reference.py'
-      - 'tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h'
-      - 'tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h'
-      - 'tests_cpp/test_rocket_computer_types.cpp'
-      - '.github/workflows/docs.yml'
   pull_request:
-    paths:
-      - 'tinkerrocket-idf/projects/flight_computer/main/main.cpp'
-      - 'tinkerrocket-idf/projects/out_computer/main/main.cpp'
-      - 'tinkerrocket-idf/projects/base_station/main/main.cpp'
-      - 'TinkerRocketApp/TinkerRocketApp/**/*.swift'
-      - 'docs/architecture/generated/**'
-      - 'tools/gen_section_index.py'
-      - 'tools/gen_protocol_reference.py'
-      - 'tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h'
-      - 'tinkerrocket-idf/components/TR_I2C_Interface/TR_I2C_Interface.h'
-      - 'tests_cpp/test_rocket_computer_types.cpp'
-      - '.github/workflows/docs.yml'
 
 jobs:
-  section-index:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # Pure stdlib (re, argparse, pathlib); ubuntu-latest ships python3.
+      # Every step below is pure stdlib (re, argparse, pathlib); ubuntu-latest
+      # ships python3, so there is nothing to install.
+
       - name: Check the generated section maps match the firmware sources
         run: python3 tools/gen_section_index.py --check
 
       - name: Check the protocol reference matches the wire definitions
         run: python3 tools/gen_protocol_reference.py --check
+
+      # Runs even if a generator check above failed, so one PR surfaces every
+      # documentation problem at once instead of one per push.
+      - name: Check the prose agrees with the source
+        if: '!cancelled()'
+        run: python3 tools/check_docs.py

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Seven GitHub Actions workflows run automatically, each path-filtered to what it 
 | **ios-tests.yml** | XCTest for `TinkerRocketApp/` |
 | **flight-report-tests.yml** | Flight-report tooling |
 | **wire-codes.yml** | Fails on duplicate BLE command numbers — the dispatch is a first-match chain, so a duplicate silently makes the later handler dead code |
-| **docs.yml** | Fails if a generated section map or the protocol reference disagrees with its source |
+| **docs.yml** | Fails if a generated section map or the protocol reference disagrees with its source, or if the prose contradicts it — broken links, a stale ESP-IDF version, a missing workflow, a wrong struct size. The only workflow with **no path filter**: it runs on every push and PR, because docs drift as a side effect of changes anywhere |
 
 ## Communication Protocols
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -58,6 +58,33 @@ sources that define it, and CI re-checks it.
 python3 tools/gen_protocol_reference.py
 ```
 
+## What CI enforces
+
+The `Docs` workflow runs on **every** push and pull request — it is the only
+workflow here without a path filter, because documentation goes stale as a side
+effect of changes anywhere, and a filter listing everything that could invalidate
+a doc is the same list as "everything".
+
+It checks two things:
+
+| | |
+|---|---|
+| **Generated artifacts** | `gen_section_index.py --check` and `gen_protocol_reference.py --check` — the committed maps and protocol tables must match the sources they were extracted from |
+| **Prose** | [`tools/check_docs.py`](../../tools/check_docs.py) — links resolve, the ESP-IDF version matches the one CI builds with, the workflow list is complete, and struct sizes quoted in the README match the header's `static_assert`s |
+
+Every prose check exists because that exact mistake was found in the README on
+2026-07-24: three image tags pointing at files that were never added, an ESP-IDF
+version two majors behind, a CI list naming four of seven workflows, and two
+wire sizes that had been wrong since the structs grew.
+
+What CI cannot check is whether the prose is still *true* — that a described
+mechanism still works the way the page says. Nothing catches that but reading it,
+so when you change how something works, read its page.
+
+```bash
+python3 tools/check_docs.py
+```
+
 ## Conventions
 
 - **Audience is layered.** The body of each page assumes general embedded and rocketry

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Documentation consistency checks for prose that CI can actually verify.
+
+The generated artifacts (section maps, protocol reference) already cannot drift
+-- their generators run with --check in CI. This covers the other half: the
+hand-written prose, where drift is silent and reads as authoritative.
+
+Every check here corresponds to a defect found by hand in the 2026-07-24 README
+audit. None of them is hypothetical:
+
+  * links       3 image tags pointed at files that do not exist, so they
+                rendered as broken icons at the top of a public README
+  * idf         README said "ESP-IDF v5.x" long after every project moved to v6
+  * workflows   README said "Three GitHub Actions workflows", listed four, and
+                seven existed
+  * struct      README's message table said NonSensor was 43 B (it is 50) and
+                LoRa telemetry 59 B (it is 65)
+
+What this deliberately does NOT check: anything requiring judgement about
+whether prose is still *true*. A checker that guesses produces false failures,
+and a CI check people learn to ignore is worse than no check.
+
+Scope note: docs/plans/ is excluded. Those are design plans written before the
+work and explicitly not kept in sync afterwards (see docs/plans/README.md), so
+their stale links are correct history, not defects.
+
+Usage:
+    python3 tools/check_docs.py           # report and exit 1 on any problem
+    python3 tools/check_docs.py --quiet   # only print problems
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+README = REPO / "README.md"
+DOCS = REPO / "docs/architecture"
+WORKFLOWS = REPO / ".github/workflows"
+FW_BUILD = WORKFLOWS / "firmware-build.yml"
+TYPES_H = REPO / "tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h"
+
+# README message-type row -> the struct whose static_assert defines its size.
+# There is no mechanical link from a wire code to its struct, so this mapping is
+# explicit. A row with no entry is REPORTED rather than skipped, so a new row
+# cannot quietly opt out of the check.
+CODE_TO_STRUCT = {
+    0xA1: "GNSSData",
+    0xA2: "ISM6HG256Data",
+    0xA3: "BMP585Data",
+    0xA4: "MMC5983MAData",
+    0xA5: "NonSensorData",
+    0xA6: "POWERData",
+    0xD1: "IIS2MDCData",
+    0xF1: "LoRaData",
+}
+
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)
+LINK = re.compile(r"!?\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+SIZE_ASSERT = re.compile(r"static_assert\(\s*sizeof\((\w+)\)\s*==\s*(\d+)")
+# | 0xA5 | NonSensor (EKF) | 50 B | 500 Hz |
+MSG_ROW = re.compile(r"^\|\s*(0[xX][0-9A-Fa-f]{2})\s*\|([^|]*)\|\s*(\d+)\s*B\s*\|")
+# A code + size mentioned in running prose, e.g. "`0xA4` (MMC5983MA, 16 B)"
+MSG_PROSE = re.compile(r"`?(0[xX][0-9A-Fa-f]{2})`?\s*\([^)]*?(\d+)\s*B\)")
+
+
+def markdown_files():
+    """README plus the architecture pages. See the scope note above."""
+    files = [README]
+    if DOCS.is_dir():
+        files += sorted(DOCS.rglob("*.md"))
+    return [f for f in files if f.exists()]
+
+
+def check_links():
+    """Every relative link and image target must resolve on disk."""
+    problems = []
+    for md in markdown_files():
+        # Commented-out blocks are not rendered, so they are not broken links.
+        text = HTML_COMMENT.sub("", md.read_text())
+        for label, target in LINK.findall(text):
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            # Strip an #anchor and a trailing :line (a repo-wide convention for
+            # pointing at a specific line of source).
+            path = re.sub(r":\d+(-\d+)?$", "", target.split("#")[0])
+            if not path:
+                continue
+            if not (md.parent / path).exists():
+                rel = md.relative_to(REPO)
+                problems.append(f"{rel}: [{label}]({target}) -> no such file")
+    return problems
+
+
+def check_idf_version():
+    """The IDF version the README tells you to install must be the one CI uses."""
+    if not FW_BUILD.exists():
+        return [f"{FW_BUILD.relative_to(REPO)} missing; cannot verify the IDF version"]
+    m = re.search(r"espressif/idf:(v[\d.]+)", FW_BUILD.read_text())
+    if not m:
+        return [f"no 'container: espressif/idf:vX.Y.Z' in "
+                f"{FW_BUILD.relative_to(REPO)}; update this checker"]
+    version = m.group(1)                      # e.g. v6.0.1
+    major_minor = ".".join(version.lstrip("v").split(".")[:2])   # 6.0
+    text = README.read_text()
+    if version in text:
+        return []
+    if re.search(rf"ESP-IDF v{re.escape(major_minor)}\b", text):
+        return []
+    return [f"README does not mention ESP-IDF {version} (or v{major_minor}), "
+            f"but firmware-build.yml builds on espressif/idf:{version}"]
+
+
+def check_workflows():
+    """The README's CI list must name every workflow, and no phantom ones."""
+    problems = []
+    on_disk = {p.name for p in sorted(WORKFLOWS.glob("*.yml"))}
+    text = README.read_text()
+    cited = set(re.findall(r"[\w-]+\.yml", text))
+
+    for name in sorted(on_disk - cited):
+        problems.append(f"README does not mention .github/workflows/{name} — "
+                        f"add it to the CI table or the list is misleading")
+    for name in sorted(cited - on_disk):
+        problems.append(f"README mentions {name}, which does not exist in "
+                        f".github/workflows/")
+    return problems
+
+
+def check_struct_sizes():
+    """Byte sizes quoted in the README must match the header's static_asserts."""
+    if not TYPES_H.exists():
+        return [f"{TYPES_H.relative_to(REPO)} missing; cannot verify struct sizes"]
+    sizes = {name: int(n) for name, n in SIZE_ASSERT.findall(TYPES_H.read_text())}
+    problems = []
+    text = README.read_text()
+
+    claims = []                                   # (code, claimed_bytes, where)
+    for line in text.splitlines():
+        m = MSG_ROW.match(line)
+        if m:
+            claims.append((int(m.group(1), 16), int(m.group(3)), line.strip()))
+    for m in MSG_PROSE.finditer(text):
+        claims.append((int(m.group(1), 16), int(m.group(2)), m.group(0)))
+
+    for code, claimed, where in claims:
+        struct = CODE_TO_STRUCT.get(code)
+        if struct is None:
+            problems.append(f"README quotes a size for message 0x{code:02X} but "
+                            f"CODE_TO_STRUCT in this checker has no entry for it")
+            continue
+        actual = sizes.get(struct)
+        if actual is None:
+            problems.append(f"no static_assert(sizeof({struct})) in the header, "
+                            f"so 0x{code:02X} cannot be verified")
+        elif actual != claimed:
+            problems.append(f"README says message 0x{code:02X} is {claimed} B, but "
+                            f"sizeof({struct}) == {actual}  [{where}]")
+    return problems
+
+
+CHECKS = [
+    ("links resolve", check_links),
+    ("ESP-IDF version matches CI", check_idf_version),
+    ("CI workflow list is complete", check_workflows),
+    ("quoted struct sizes match the wire", check_struct_sizes),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--quiet", action="store_true",
+                    help="print only failures")
+    args = ap.parse_args()
+
+    if not README.exists():
+        print(f"ERROR: {README} not found", file=sys.stderr)
+        return 1
+
+    failed = 0
+    for label, fn in CHECKS:
+        problems = fn()
+        if problems:
+            failed += len(problems)
+            print(f"  X  {label}")
+            for p in problems:
+                print(f"       {p}")
+        elif not args.quiet:
+            print(f"  ok {label}")
+
+    if failed:
+        print(f"\n{failed} documentation problem(s). These are mechanical "
+              f"mismatches between the docs and the source, not style opinions "
+              f"-- each one means a reader would be misled.", file=sys.stderr)
+        return 1
+    if not args.quiet:
+        print("\nDocumentation consistent with source.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes documentation problems fail CI instead of being found by reading.

## 1. `docs.yml` loses its path filter

Every other workflow keeps its filter — there is no point compiling firmware for a README
typo. But a filter is the wrong tool for docs, because **docs go stale as a side effect of
changes elsewhere**: the ESP-IDF version went stale when the toolchain moved, struct sizes
when a field was added, the workflow list when workflows were added. A filter listing
everything that could invalidate a doc is the same list as "everything".

The concrete failure: **PR #594 was README-only and ran no checks at all.**

The job is ~15 s of pure-stdlib Python, so always-on costs less than maintaining the
filter. It is also why the checks are **not** duplicated into the other six workflows —
one always-on job covers every change, and a check that lives in one place cannot fall
out of sync with copies of itself.

## 2. `tools/check_docs.py` — checking the prose

The generators already make the *generated* artifacts undriftable. This covers the
hand-written half. Four checks, each one a defect found by hand in yesterday's audit
rather than a hypothetical:

| Check | The defect it would have caught |
|---|---|
| links resolve | 3 image tags pointing at files that never existed — broken icons at the top of a public README |
| ESP-IDF version | README said v5.x; every project had moved to v6 |
| workflow list | README said "Three", listed four, seven existed |
| struct sizes | NonSensor quoted at 43 B (is 50), LoRa at 59 B (is 65) |

**Validated by replaying the pre-audit README through it** — 9 problems caught, across all
four classes:

```
X  links resolve
     README.md: [TinkerRocket](docs/images/rocket_hero.jpg) -> no such file
     ... 2 more
X  ESP-IDF version matches CI
     README does not mention ESP-IDF v6.0.1 (or v6.0), but firmware-build.yml
     builds on espressif/idf:v6.0.1
X  CI workflow list is complete
     README does not mention .github/workflows/docs.yml ...
     ... 2 more
X  quoted struct sizes match the wire
     README says message 0xA5 is 43 B, but sizeof(NonSensorData) == 50
     README says message 0xF1 is 59 B, but sizeof(LoRaData) == 65
```

The reverse directions are covered too — a README citing a workflow that does not exist, a
workflow added without being documented, and a new message row with no struct mapping
(**reported**, not silently skipped, so a row cannot quietly opt out).

## What this deliberately does not do

- **No judgement calls.** Nothing here guesses whether prose is still *true*. A checker
  that guesses produces false failures, and a check people learn to ignore is worse than
  no check. Yesterday's audit also found a wrong BLE-naming claim and two missing wire
  fields — those needed reading, and still will.
- **`docs/plans/` is excluded.** Those are pre-work design plans, explicitly not kept in
  sync afterwards, so their stale links are correct history rather than defects.
- **No "you changed code but not docs" nag.** It cannot distinguish a change that needs a
  doc update from one that does not, so it would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)