### PR TITLE
docs: add the CERN-OHL-S v2 licence for hardware design files

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,10 +485,16 @@ v3.0 or later](LICENSE)** — firmware, the iOS app, the simulator, and the tool
 You may use, study, modify and redistribute it, and anything you distribute that
 builds on it must be released under the same terms with source available.
 
-**Hardware design files will be licensed under [CERN-OHL-S
-v2](https://cern-ohl.web.cern.ch/)** (strongly reciprocal) when they are added to
-this repository. A `hardware/LICENSE` will accompany them; until then, no hardware
-files are published here.
+**Hardware design files under [`hardware/`](hardware/) are licensed under the
+[CERN Open Hardware Licence v2 — Strongly Reciprocal](hardware/LICENSE)**
+(`CERN-OHL-S-2.0`). If you make or distribute a product based on these designs, or
+publish a modified version of them, you must make the complete design sources
+available under the same licence.
+
+CERN-OHL-S is to hardware roughly what the GPL is to software, which is why the two
+sit together here. They are separate licences covering separate files: the software
+licence does not reach the board files, and the hardware licence does not reach the
+firmware.
 
 Two exceptions to the above:
 

--- a/hardware/LICENSE
+++ b/hardware/LICENSE
@@ -1,0 +1,289 @@
+CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among
+hardware designers and to provide a legal tool which supports the
+freedom to use, study, modify, share and distribute hardware designs
+and products based on those designs. Version 2 of the CERN Open
+Hardware Licence comes in three variants: CERN-OHL-P (permissive); and
+two reciprocal licences: CERN-OHL-W (weakly reciprocal) and this
+licence, CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-S is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any
+Licensor or their designs nor does it imply any involvement by CERN in
+their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-S.
+
+  1.2 'Compatible Licence' means
+
+       a) any earlier version of the CERN Open Hardware licence, or
+
+       b) any version of the CERN-OHL-S, or
+
+       c) any licence which permits You to treat the Source to which
+          it applies as licensed under CERN-OHL-S provided that on
+          Conveyance of any such Source, or any associated Product You
+          treat the Source in question as being licensed under
+          CERN-OHL-S.
+
+  1.3 'Source' means information such as design materials or digital
+      code which can be applied to Make or test a Product or to
+      prepare a Product for use, Conveyance or sale, regardless of its
+      medium or how it is expressed. It may include Notices.
+
+  1.4 'Covered Source' means Source that is explicitly made available
+      under this Licence.
+
+  1.5 'Product' means any device, component, work or physical object,
+      whether in finished or intermediate form, arising from the use,
+      application or processing of Covered Source.
+
+  1.6 'Make' means to create or configure something, whether by
+      manufacture, assembly, compiling, loading or applying Covered
+      Source or another Product or otherwise.
+
+  1.7 'Available Component' means any part, sub-assembly, library or
+      code which:
+
+       a) is licensed to You as Complete Source under a Compatible
+          Licence; or
+
+       b) is available, at the time a Product or the Source containing
+          it is first Conveyed, to You and any other prospective
+          licensees
+
+            i) as a physical part with sufficient rights and
+               information (including any configuration and
+               programming files and information about its
+               characteristics and interfaces) to enable it either to
+               be Made itself, or to be sourced and used to Make the
+               Product; or
+           ii) as part of the normal distribution of a tool used to
+               design or Make the Product.
+
+  1.8 'Complete Source' means the set of all Source necessary to Make
+      a Product, in the preferred form for making modifications,
+      including necessary installation and interfacing information
+      both for the Product, and for any included Available Components.
+      If the format is proprietary, it must also be made available in
+      a format (if the proprietary tool can create it) which is
+      viewable with a tool available to potential licensees and
+      licensed under a licence approved by the Free Software
+      Foundation or the Open Source Initiative. Complete Source need
+      not include the Source of any Available Component, provided that
+      You include in the Complete Source sufficient information to
+      enable a recipient to Make or source and use the Available
+      Component to Make the Product.
+
+  1.9 'Source Location' means a location where a Licensor has placed
+      Covered Source, and which that Licensor reasonably believes will
+      remain easily accessible for at least three years for anyone to
+      obtain a digital copy.
+
+ 1.10 'Notice' means copyright, acknowledgement and trademark notices,
+      Source Location references, modification notices (subsection
+      3.3(b)) and all notices that refer to this Licence and to the
+      disclaimer of warranties that are included in the Covered
+      Source.
+
+ 1.11 'Licensee' or 'You' means any person exercising rights under
+      this Licence.
+
+ 1.12 'Licensor' means a natural or legal person who creates or
+      modifies Covered Source. A person may be a Licensee and a
+      Licensor at the same time.
+
+ 1.13 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying
+      of Covered Source and Products, and the Making of Products. By
+      exercising any right granted under this Licence, You irrevocably
+      accept these terms and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and
+      shall apply worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the
+      rights granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing,
+      or any other similar right.
+
+
+3 Copying, modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in
+      any medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices, provided that
+      You irrevocably undertake to make that modified Covered Source
+      available from a Source Location should You Convey a Product in
+      circumstances where the recipient does not otherwise receive a
+      copy of the modified Covered Source. In each case subsection 3.3
+      shall apply.
+
+      You may only delete Notices if they are no longer applicable to
+      the corresponding Covered Source as modified by You and You may
+      add additional Notices applicable to Your modifications.
+      Including Covered Source in a larger work is modifying the
+      Covered Source, and the larger work becomes modified Covered
+      Source.
+
+  3.3 You may Convey modified Covered Source (with the effect that You
+      shall also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2;
+
+       b) add a Notice to the modified Covered Source stating that You
+          have modified it, with the date and brief description of how
+          You have modified it;
+
+       c) add a Source Location Notice for the modified Covered Source
+          if You Convey in circumstances where the recipient does not
+          otherwise receive a copy of the modified Covered Source; and
+
+       d) license the modified Covered Source under the terms and
+          conditions of this Licence (or, as set out in subsection
+          8.3, a later version, if permitted by the licence of the
+          original Covered Source). Such modified Covered Source must
+          be licensed as a whole, but excluding Available Components
+          contained in it, which remain licensed under their own
+          applicable licences.
+
+
+4 Making and Conveying Products
+
+You may Make Products, and/or Convey them, provided that You either
+provide each recipient with a copy of the Complete Source or ensure
+that each recipient is notified of the Source Location of the Complete
+Source. That Complete Source is Covered Source, and You must
+accordingly satisfy Your obligations set out in subsection 3.3. If
+specified in a Notice, the Product must visibly and securely display
+the Source Location on it or its packaging or documentation in the
+manner specified in that Notice.
+
+
+5 Research and Development
+
+You may Convey Covered Source, modified Covered Source or Products to
+a legal entity carrying out development, testing or quality assurance
+work on Your behalf provided that the work is performed on terms which
+prevent the entity from both using the Source or Products for its own
+internal purposes and Conveying the Source or Products or any
+modifications to them to any person other than You. Any modifications
+made by the entity shall be deemed to be made by You pursuant to
+subsection 3.2.
+
+
+6 DISCLAIMER AND LIABILITY
+
+  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
+      are provided 'as is' and any express or implied warranties,
+      including, but not limited to, implied warranties of
+      merchantability, of satisfactory quality, non-infringement of
+      third party rights, and fitness for a particular purpose or use
+      are disclaimed in respect of any Source or Product to the
+      maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not
+      infringe any patent, copyright, trade secret or other
+      proprietary right. The entire risk as to the use, quality, and
+      performance of any Source or Product shall be with You and not
+      the Licensor. This disclaimer of warranty is an essential part
+      of this Licence and a condition for the grant of any rights
+      granted under this Licence.
+
+  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
+      the maximum extent permitted by law, have no liability for
+      direct, indirect, special, incidental, consequential, exemplary,
+      punitive or other damages of any character including, without
+      limitation, procurement of substitute goods or services, loss of
+      use, data or profits, or business interruption, however caused
+      and on any theory of contract, warranty, tort (including
+      negligence), product liability or otherwise, arising in any way
+      in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of
+      the possibility of such damages, and You shall hold the
+      Licensor(s) free and harmless from any liability, costs,
+      damages, fees and expenses, including claims by third parties,
+      in relation to such use.
+
+
+7 Patents
+
+  7.1 Subject to the terms and conditions of this Licence, each
+      Licensor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable (except as
+      stated in subsections 7.2 and 8.4) patent license to Make, have
+      Made, use, offer to sell, sell, import, and otherwise transfer
+      the Covered Source and Products, where such licence applies only
+      to those patent claims licensable by such Licensor that are
+      necessarily infringed by exercising rights under the Covered
+      Source as Conveyed by that Licensor.
+
+  7.2 If You institute patent litigation against any entity (including
+      a cross-claim or counterclaim in a lawsuit) alleging that the
+      Covered Source or a Product constitutes direct or contributory
+      patent infringement, or You seek any declaration that a patent
+      licensed to You under this Licence is invalid or unenforceable
+      then any rights granted to You under this Licence shall
+      terminate as of the date such process is initiated.
+
+
+8 General
+
+  8.1 If any provisions of this Licence are or subsequently become
+      invalid or unenforceable for any reason, the remaining
+      provisions shall remain effective.
+
+  8.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is
+      known, except where needed to comply with section 3, or where
+      the use is otherwise allowed by law. Any such permitted use
+      shall be factual and shall not be made so as to suggest any kind
+      of endorsement or implication of involvement by the Licensor or
+      its personnel.
+
+  8.3 CERN may publish updated versions and variants of this Licence
+      which it considers to be in the spirit of this version, but may
+      differ in detail to address new problems or concerns. New
+      versions will be published with a unique version number and a
+      variant identifier specifying the variant. If the Licensor has
+      specified that a given variant applies to the Covered Source
+      without specifying a version, You may treat that Covered Source
+      as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be
+      treated as being released under CERN-OHL-S. The Licensor may
+      also specify that the Covered Source is subject to a specific
+      version of the CERN-OHL or any later version in which case You
+      may apply this or any later version of CERN-OHL with the same
+      variant identifier published by CERN.
+
+  8.4 This Licence shall terminate with immediate effect if You fail
+      to comply with any of its terms and conditions.
+
+  8.5 However, if You cease all breaches of this Licence, then Your
+      Licence from any Licensor is reinstated unless such Licensor has
+      terminated this Licence by giving You, while You remain in
+      breach, a notice specifying the breach and requiring You to cure
+      it within 30 days, and You have failed to come into compliance
+      in all material respects by the end of the 30 day period. Should
+      You repeat the breach after receipt of a cure notice and
+      subsequent reinstatement, this Licence will terminate
+      immediately and permanently. Section 6 shall continue to apply
+      after any termination.
+
+  8.6 This Licence shall not be enforceable except by a Licensor
+      acting as such, and third party beneficiary rights are
+      specifically excluded.


### PR DESCRIPTION
Adds the hardware licence ahead of the board files, so `hardware/` declares its terms
from the first commit that populates it.

## What's here

- **`hardware/LICENSE`** — CERN Open Hardware Licence v2, Strongly Reciprocal
  (`CERN-OHL-S-2.0`), the SPDX license-list text.
- **README** — the License section moves from future tense to describing what is actually
  in the tree, and states that the two licences cover separate files: the software licence
  does not reach the board sources, and the hardware licence does not reach the firmware.

CERN-OHL-S is to hardware roughly what the GPL is to software, which is why it pairs with
the GPL-3.0 adopted in #597.

## Verification

The licence text was checked before committing, not assumed:

- title line is the **Strongly Reciprocal** variant (not W or P)
- all eight top-level sections present — Definitions, Applicability, Copying, Making and
  Conveying Products, Research and Development, Disclaimer and Liability, Patents, General
- ends correctly at 8.6

## No conflict with the incoming board files

`hardware/README.md` belongs to `hw/596-hardware-design-files`, so this PR deliberately
does not touch it — only `hardware/LICENSE` is added. A trial merge against that branch
completes with **no conflicts**, leaving `hardware/` with the LICENSE, that README, and all
six board directories.

The docs gate passes, and the link checker now verifies `hardware/LICENSE` resolves from
the README.

## Follow-up worth considering

`hardware/README.md` has no licensing section. Once the board files merge, a one-line
pointer to `LICENSE` there would help — that edit belongs on the hardware branch rather
than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
