### PR TITLE
docs: standby draw is ~1 mA; feature table for the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An open source hardware and software full featured flight computer with out of t
 
 | | |
 |---|---|
-| **High-rate logging** | IMU at a configurable 1, 2, or 4 kHz, written straight to onboard NAND |
+| **High-rate logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
 | **Remote power switch** | Built-in low-power 'WiFi' switch — no through-wall switch to drill for. ~1 mA standby, weeks on a 600 mAh pack |
 | **Four pyro channels** | Fully isolated, with continuity monitoring and configurable triggers |
 | **Camera control** | RunCam Split 4 and 'naked' GoPro Hero 10 Black — power and recording, remotely over LoRa |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # TinkerRocket
 
-An open source hardware and software full featured flight computer with out of the box functionality and room to tinker. The flight computer, base station, and companion iOS or Andriod app provide out of the box dual deploy and GNSS tracking with plenty of extra bells and whistles to support all your rocketry needs.
+An open source hardware and software full featured flight computer with out of the box functionality and room to tinker. The flight computer, base station, and companion iOS or Android app provide out of the box dual deploy and GNSS tracking with plenty of extra bells and whistles to support all your rocketry needs.
 
-high data rate logging (configurable 1,2, or 4 kHz), remote control power 'WiFi' switch with days of standby time, four fully isolated pyro channels, camera control for RunCam Split4 or 'naked' GoPro, servo control for active roll control or flight stabalization using proportional navigation, GNSS and LoRa modules on daughter boards for maximum flexibility with included long range LoRa and uBlox GNSS, voice call outs during flight.
+| | |
+|---|---|
+| **High-rate logging** | IMU at a configurable 1, 2, or 4 kHz, written straight to onboard NAND |
+| **Remote power switch** | Built-in low-power 'WiFi' switch — no through-wall switch to drill for. ~1 mA standby, weeks on a 600 mAh pack |
+| **Four pyro channels** | Fully isolated, with continuity monitoring and configurable triggers |
+| **Camera control** | RunCam Split 4 and 'naked' GoPro Hero 10 Black — power and recording, remotely over LoRa |
+| **Active control** | 1-4 servos for roll control, or flight stabilization under a proportional-navigation guidance law |
+| **Modular radios** | GNSS and LoRa on swappable daughter boards; ships with long-range LoRa and u-blox GNSS |
+| **Voice callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
 
 <!-- TODO: add a hero photo, then restore this:
 ![TinkerRocket](docs/images/rocket_hero.jpg) -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An open source hardware and software full featured flight computer with out of t
 | | |
 |---|---|
 | **High-rate logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
-| **Remote power switch** | Built-in low-power 'WiFi' switch — no through-wall switch to drill for. ~1 mA standby, weeks on a 600 mAh pack |
+| **Remote power switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
 | **Four pyro channels** | Fully isolated, with continuity monitoring and configurable triggers |
 | **Camera control** | RunCam Split 4 and 'naked' GoPro Hero 10 Black — power and recording, remotely over LoRa |
 | **Active control** | 1-4 servos for roll control, or flight stabilization under a proportional-navigation guidance law |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The system comprises three physical cooperating components:
 
 The onboard computer has both the ESP32-P4 main processor with two cores running at 400 MHz for sensor intake, flight processing, and controls. An ESP32-S3 serves as the WiFi/BlueTooth LE radio as well as high speed data logger and LoRa radio control. To support guidance and control functions, the onboard flight computer runs a 15-state Extended Kalman Filter fusing IMU, barometer, magnetometer, and GNSS data at up to 1000 Hz. Optional roll control or, a proportional navigation guidance law commands 1-4 fin-tab servos through cascaded PID controllers with velocity-based gain scheduling. There are four fully programmable pyro channels. There is also an interface to power and control an on board camera, with RunCam Split4 and GoPro Hero 10 Black support currently implemented.
 
-Remove the need for a dedicated through wall power switch using the built in low power 'WiFi' type switch. After plugging in a battery the unit draws only 10-15 mA, which gives you over 2.5 days of battery life on a typical 600 mAh battery. Power up the main processor using the app before leaving the pad over the BlueTooth connection and control powering up the camera remotely from the base station over LoRa to maximize battery life and reduce camera run time. Control recording remotely from the base station over LoRa as well.
+Remove the need for a dedicated through wall power switch using the built in low power 'WiFi' type switch. After plugging in a battery the unit draws only about 1 mA, which is over three weeks of standby on a typical 600 mAh battery. Power up the main processor using the app before leaving the pad over the BlueTooth connection and control powering up the camera remotely from the base station over LoRa to maximize battery life and reduce camera run time. Control recording remotely from the base station over LoRa as well.
 
 The base station relays data sent over LoRa from the flight computer to a nearby iOS device, giving the user a realtime view of telemetry data prior to launch, as well as telemetry and tracking data post launch. Use your phone's speakers to call out altitude, apogee, max speed, and descent rate during the flight and to locate the rocket via an arrow that points towards the rocket and/or a map view of where the rocket landed.
 
@@ -349,7 +349,7 @@ from a specific run rather than current targets. Where a figure disagrees with t
 | GNSS rate | 18 Hz | 34 Hz |
 | I2S frame drops | 0 | 0 |
 | Max IMU gap | < 10 ms | 9.4 ms |
-| Standby power | -- | 12 mA |
+| Standby power | -- | ~1 mA |
 | Active power | -- | 130 mA |
 
 ## iOS App

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An open source hardware and software full featured flight computer with out of t
 | **High-rate logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
 | **Remote power switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
 | **Four pyro channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
-| **Camera control** | RunCam Split 4 and 'naked' GoPro Hero 10 Black — power and recording, remotely over LoRa |
+| **Camera control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
 | **Active control** | 1-4 servos for roll control, or flight stabilization under a proportional-navigation guidance law |
 | **Modular radios** | GNSS and LoRa on swappable daughter boards; ships with long-range LoRa and u-blox GNSS |
 | **Voice callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ An open source hardware and software full featured flight computer with out of t
 
 | | |
 |---|---|
-| **High-rate logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
-| **Remote power switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
-| **Four pyro channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
-| **Camera control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
-| **Active control** | 1-4 servos for roll control, or flight stabilization under a proportional-navigation guidance law |
-| **Modular radios** | GNSS and LoRa on swappable daughter boards; ships with long-range LoRa and u-blox GNSS |
-| **Voice callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
+| **High-Rate Logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
+| **Remote Power Switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
+| **Four Pyro Channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
+| **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
+| **Active Control** | One to four servos for roll control or flight stabilization |
+| **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 1 W 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART |
+| **Modular GNSS** | GNSS on a swappable daughter board. Ships with a u-blox SAM-M10Q module with ~20 Hz updates and multiple constellation support. Swap for another GNSS module, or position the shipped module in an optional location in your avionics bay |
+| **Voice Callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
 
 <!-- TODO: add a hero photo, then restore this:
 ![TinkerRocket](docs/images/rocket_hero.jpg) -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An open source hardware and software full featured flight computer with out of t
 |---|---|
 | **High-rate logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
 | **Remote power switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
-| **Four pyro channels** | Fully isolated, with continuity monitoring and configurable triggers |
+| **Four pyro channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
 | **Camera control** | RunCam Split 4 and 'naked' GoPro Hero 10 Black — power and recording, remotely over LoRa |
 | **Active control** | 1-4 servos for roll control, or flight stabilization under a proportional-navigation guidance law |
 | **Modular radios** | GNSS and LoRa on swappable daughter boards; ships with long-range LoRa and u-blox GNSS |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An open source hardware and software full featured flight computer with out of t
 | | |
 |---|---|
 | **High-Rate Logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
-| **Remote Power Switch** | Built-in low power wireless switch to completely disable pyro channels and allow you to install the computer days ahead of a flight while still having plenty of power to fly. Power it up on the pad using the phone app over BlueTooth |
+| **Remote Power Switch** | Use the built-in wireless switch to disable pyro channels and install the computer days ahead of a flight. Power it up on the pad using the phone app over BlueTooth |
 | **Four Pyro Channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
 | **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
 | **Active Control** | One to four servos for roll control or flight stabilization |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ An open source hardware and software full featured flight computer with out of t
 | **Four Pyro Channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
 | **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
 | **Active Control** | One to four servos for roll control or flight stabilization |
-| **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 1 W 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART |
-| **Modular GNSS** | GNSS on a swappable daughter board. Ships with a u-blox SAM-M10Q module with ~20 Hz updates and multiple constellation support. Swap for another GNSS module, or position the shipped module in an optional location in your avionics bay |
+| **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 22 dBm 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART |
+| **Modular GNSS** | GNSS on a swappable daughter board. Ships with a u-blox SAM-M10Q module with 18 Hz updates and multiple constellation support. Swap for another GNSS module, or position the shipped module in an optional location in your avionics bay |
 | **Voice Callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
 
 <!-- TODO: add a hero photo, then restore this:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An open source hardware and software full featured flight computer with out of t
 | **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
 | **Active Control** | One to four servos for roll control or flight stabilization |
 | **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 22 dBm 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART |
-| **Modular GNSS** | GNSS on a swappable daughter board. Ships with a u-blox SAM-M10Q module with 18 Hz updates and multiple constellation support. Swap for another GNSS module, or position the shipped module in an optional location in your avionics bay |
+| **Modular GNSS** | Swappable GNSS daughter board. Start with the u-blox SAM-M10Q module with 18 Hz updates and multiple constellation support. Swap for another GNSS module to meet specific flight requirements |
 | **Voice Callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
 
 <!-- TODO: add a hero photo, then restore this:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ An open source hardware and software full featured flight computer with out of t
 
 | | |
 |---|---|
-| **High-Rate Logging** | Full sensor suite data logging at configurable rates up to 4 kHz |
-| **Remote Power Switch** | Use the built-in wireless switch to disable pyro channels and install the computer days ahead of a flight. Power it up on the pad using the phone app over BlueTooth |
-| **Four Pyro Channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers |
-| **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, starting or stopping recording from the app or over LoRa just before take off. Monitor current usage in the app to ensure everything is recording before you launch |
-| **Active Control** | One to four servos for roll control or flight stabilization |
-| **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 22 dBm 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART |
-| **Modular GNSS** | Swappable GNSS daughter board. Start with the u-blox SAM-M10Q module with 18 Hz updates and multiple constellation support. Swap for another GNSS module to meet specific flight requirements |
-| **Voice Callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight |
+| **High-Rate Logging** | Full sensor suite data logging at configurable rates up to 4 kHz. |
+| **Remote Power Switch** | Use the built-in wireless switch to disable pyro channels and install the computer days ahead of a flight. Power it up on the pad using the phone app over BlueTooth. |
+| **Four Pyro Channels** | Fully isolated (low and high switched), with continuity monitoring and app configurable triggers. |
+| **Camera Control** | Control a RunCam Split 4 or 'naked' GoPro, start or stop recording from the flight line before take off. Monitor current usage in the app to ensure everything is recording before you launch. |
+| **Active Control** | One to four servos for roll control or flight stabilization. |
+| **Modular Radio** | Swappable daughter board for the LoRa radio, shipping with a 22 dBm 900 MHz radio supporting flights up to 30,000 ft. Swap it out for an even higher power radio that communicates over UART. |
+| **Modular GNSS** | Swappable GNSS daughter board. Start with the u-blox SAM-M10Q module with 18 Hz updates and multiple constellation support. Swap for another GNSS module to meet specific flight requirements. |
+| **Voice Callouts** | Altitude, apogee, max speed and descent rate spoken aloud during the flight. |
 
 <!-- TODO: add a hero photo, then restore this:
 ![TinkerRocket](docs/images/rocket_hero.jpg) -->

--- a/docs/architecture/out-computer.md
+++ b/docs/architecture/out-computer.md
@@ -61,7 +61,7 @@ stateDiagram-v2
 
 In the **idle** state only BLE is running. Peripheral init is deferred entirely —
 NAND, MRAM, LoRa and I2S are not even initialized — so the board sits at roughly a
-milliamp and a pack lasts days on the pad. The app can still connect, read config,
+milliamp and a pack lasts weeks on the pad. The app can still connect, read config,
 and download previous flights in this state.
 
 In the **active** state the rail is closed, the FC boots, and the OC starts doing all


### PR DESCRIPTION
Corrects the headline power claim and the battery-life figure that followed from it.

The 10-15 mA number predates #519, which took the out computer's rail-off idle from 22 mA to roughly **1 mA**. That made the battery-life claim wrong by an order of magnitude: at 1 mA a 600 mAh pack lasts about **25 days**, not "over 2.5 days".

| Where | Was | Now |
|---|---|---|
| Overview prose | 10-15 mA, over 2.5 days | **~1 mA, over three weeks** |
| Performance table | 12 mA | **~1 mA** |
| Out Computer page | "a pack lasts days on the pad" | **weeks** |

Stated as "over three weeks" rather than 25 days so the claim still holds for a pack that will not deliver its full rated capacity.

The Out Computer architecture page already had this right — it described the idle link as ~1 mA against 7 mA for the fast link. Only the README carried the pre-#519 figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)