### PR TITLE
docs: add a CLA and contributor guide

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,148 @@
+# TinkerRocket Contributor License Agreement
+
+**Version 1.0**
+
+Thanks for wanting to contribute. This agreement covers the legal side of that, once,
+so neither of us has to think about it again.
+
+> **Maintainer note:** this document is a draft derived from the Apache Software
+> Foundation's Individual CLA, adapted to cover hardware design files as well as
+> software. It has **not** been reviewed by a lawyer. If Tinkerbug Robotics intends to
+> rely on the relicensing right in section 4 commercially, have counsel read it first.
+> Delete this note once that has happened.
+
+---
+
+## In plain language, before the legal text
+
+You keep the copyright in everything you contribute. You are not signing your work away.
+
+What you grant is a **licence** — permission for Tinkerbug Robotics to use your
+contribution, including the permission to release it under a different licence later.
+That last part is the reason this document exists. TinkerRocket is GPL-3.0 for software
+and CERN-OHL-S for hardware. If every contributor's work is locked to those licences,
+the project can never change them without tracking down every person who ever sent a
+patch. This agreement keeps that door open.
+
+You can still do anything you like with your own contribution elsewhere. Granting a
+licence is not exclusive.
+
+If you would rather not sign, that is a completely reasonable position, and you are
+still welcome to open issues, report bugs, and discuss designs.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution, or the legal entity
+authorising it. For an entity, the entity and all others that control it, are
+controlled by it, or are under common control with it are treated as one.
+
+**"Tinkerbug Robotics"**, **"we"**, and **"us"** mean the TinkerRocket project
+maintainers.
+
+**"Contribution"** means any work of authorship you intentionally submit to the project.
+This expressly includes **both**:
+
+- **software** — source code, firmware, application code, scripts, tests, build files,
+  configuration and documentation; and
+- **hardware design files** — schematics, PCB layouts, symbol and footprint libraries,
+  fabrication outputs, mechanical drawings, and bills of materials.
+
+"Submit" means any form of communication sent to us or our repositories — a pull
+request, an issue attachment, an email, or a message on a project discussion channel —
+except anything you conspicuously mark **"Not a Contribution"** in writing.
+
+## 2. Copyright licence
+
+You grant Tinkerbug Robotics and everyone who receives the project a perpetual,
+worldwide, non-exclusive, royalty-free, irrevocable copyright licence to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense, and
+distribute your Contribution and derivative works of it.
+
+## 3. Patent licence
+
+You grant Tinkerbug Robotics and everyone who receives the project a perpetual,
+worldwide, non-exclusive, royalty-free, irrevocable (except as stated below) patent
+licence to make, have made, use, offer to sell, sell, import, and otherwise transfer
+your Contribution, whether alone or combined with the project.
+
+This licence covers only those patent claims you can license that are necessarily
+infringed by your Contribution alone, or by the combination of your Contribution with
+the project it was submitted to.
+
+If you begin patent litigation against anyone alleging that the project or a
+Contribution in it constitutes direct or contributory patent infringement, every patent
+licence you were granted under this agreement terminates as of the date that litigation
+is filed.
+
+## 4. Relicensing
+
+You agree that Tinkerbug Robotics may license your Contribution under terms of its
+choosing, including licences that differ from the project's current ones, and including
+proprietary terms.
+
+This is the clause that lets the project change direction — adopt a different open
+source licence, or offer a commercial licence alongside the open one — without needing
+to contact every past contributor. It does not restrict what you may do with your own
+Contribution, and it does not withdraw the open source release of anything already
+published.
+
+## 5. What you are representing
+
+By signing, you confirm:
+
+1. **The work is yours.** Each Contribution is your original creation, or you have the
+   right to submit it under this agreement.
+2. **You have the authority.** If your employer has rights in work you create, you have
+   permission to make the Contribution, your employer has waived those rights, or your
+   employer has itself signed this agreement.
+3. **You will flag anything that is not yours.** See section 6.
+
+## 6. Third-party material
+
+If your Contribution includes work you did not write — a vendored library, a reference
+design, a footprint from a manufacturer, code adapted from elsewhere — you must say so
+clearly, identify its source and licence, and note any restriction that applies.
+
+Mark such material plainly in the Contribution itself, in the pull request description,
+or with a note reading **"Submitted on behalf of a third party: [name and licence]"**.
+
+TinkerRocket already vendors third-party components under their own terms; this section
+exists to make sure new ones stay identifiable rather than being silently absorbed.
+
+## 7. No obligations
+
+You are not expected to provide support for your Contribution. You may, but you are not
+required to.
+
+Except for the representations in section 5, your Contribution is provided **"AS IS"**,
+without warranties or conditions of any kind, express or implied, including any warranty
+of merchantability, fitness for a particular purpose, or non-infringement.
+
+Nothing here obliges us to merge, ship, or keep any Contribution.
+
+## 8. If something changes
+
+If any statement you made here becomes inaccurate — you learn you did not hold rights
+you thought you held, for example — tell us at the contact address in the repository as
+soon as you reasonably can.
+
+---
+
+## How to sign
+
+State the following in the first pull request you open, in a comment on it:
+
+```
+I have read the TinkerRocket CLA and I agree to it.
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use a real name and an address that reaches you. One signature covers all your future
+contributions; you do not repeat it per pull request.
+
+**Safety-critical reminder.** TinkerRocket fires pyrotechnic devices and flies at
+altitude. Contributions touching pyro, deployment, recovery, or flight-state logic get
+proportionally more scrutiny, and may be asked for bench evidence before merge. That is
+not distrust — it is that a mistake in those paths is not recoverable in flight.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to TinkerRocket
+
+Contributions are welcome — firmware, the iOS app, the simulator, hardware, or docs.
+This page covers what you need to know before your first pull request.
+
+## Before your first PR: the CLA
+
+TinkerRocket asks contributors to agree to a [Contributor License Agreement](CLA.md)
+once. You keep the copyright in your work; you grant us a licence to use it, including
+the right to relicense the project later.
+
+To sign, comment on your first pull request with:
+
+```
+I have read the TinkerRocket CLA and I agree to it.
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+One signature covers everything you contribute afterwards. If you would rather not
+sign, you are still very welcome to file issues, report flight anomalies, and discuss
+designs — that is genuinely useful and needs no agreement.
+
+## Getting set up
+
+| What | You need |
+|------|----------|
+| Firmware | [ESP-IDF v6.0](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/get-started/) — **every** project needs v6; CI builds on `espressif/idf:v6.0.1` |
+| iOS app | Xcode 16+ |
+| Simulator | Python 3.10+ |
+| Host tests | CMake 3.16+ |
+| Hardware | KiCad 10.0.3 |
+
+A plain, non-recursive clone is enough. The proportional-navigation guidance law is a
+private submodule; everything else builds and runs without it, against a header-only
+no-op stub. If you see `PN Guidance: NOT COMPILED IN (stub active)` at boot, that is
+expected and not a problem.
+
+## Making a change
+
+Branch, commit, open a PR — the same for hardware as for firmware.
+
+```bash
+git switch -c my-change
+# ... work ...
+git commit
+```
+
+Write commit messages that explain **why**, not just what. The existing history is a
+reasonable guide: most of the value in this repo's messages is the reasoning that would
+otherwise be lost.
+
+## What CI checks
+
+Seven workflows, each path-filtered to what it covers — except `docs.yml`, which runs on
+everything.
+
+| Workflow | Runs on |
+|----------|---------|
+| `cpp-tests.yml` | changes to components, `tests_cpp/`, integration tests |
+| `firmware-build.yml` | full ESP-IDF build of all four firmware projects |
+| `sim-tests.yml` | the simulator and the sources it binds to |
+| `ios-tests.yml` | the iOS app |
+| `flight-report-tests.yml` | flight-report tooling |
+| `wire-codes.yml` | duplicate BLE command numbers |
+| `docs.yml` | **every push and PR** — generated docs and prose consistency |
+
+Run the equivalents locally before pushing:
+
+```bash
+cmake -S tests_cpp -B tests_cpp/build -DCMAKE_BUILD_TYPE=Debug
+cmake --build tests_cpp/build -j$(nproc)
+ctest --test-dir tests_cpp/build --output-on-failure
+```
+
+```bash
+python3 tools/check_docs.py
+python3 tools/gen_section_index.py --check
+python3 tools/gen_protocol_reference.py --check
+```
+
+## Things that will trip you up
+
+These are real traps that have each cost someone a debugging session.
+
+### Adding a BLE command or message type
+
+The dispatch is a flat first-match `if (ble_cmd == N)` chain. Assign a number twice and
+the **second handler becomes dead code** — no compiler error, no failing test. That
+shipped once already.
+
+1. Pick an unused number *in that device's space* — check the
+   [protocol reference](docs/architecture/generated/protocol-reference.md), not memory.
+   The Out Computer and Base Station spaces are independent and may overlap.
+2. Put a comment on the branch. It becomes the description in the generated reference.
+3. For a new FC↔OC message type, add it to the registry in
+   `tests_cpp/test_rocket_computer_types.cpp` and bump the count — a code missing from
+   that registry is one nothing checks for collisions.
+4. If it carries a struct, add a `static_assert` on its size.
+5. Regenerate: `python3 tools/gen_protocol_reference.py`
+
+Note the gap no guard closes: **two branches can each take the same free number**, pass
+CI independently, and collide only at merge. If someone else is adding commands at the
+same time, agree on numbers first.
+
+### Editing documentation
+
+Some docs are generated and must not be hand-edited — anything under
+`docs/architecture/generated/`. Change the source, then re-run the generator. CI fails if
+a committed file disagrees with its source.
+
+Prose is checked too: links must resolve, the ESP-IDF version must match CI, the workflow
+list must be complete, and struct sizes quoted in the README must match the header.
+
+### Editing KiCad files
+
+**Never let git three-way-merge a board file.** `.kicad_pcb` and `.kicad_sch` are text, so
+git will merge them happily and produce a corrupt or subtly wrong board. See
+[`hardware/README.md`](hardware/README.md), which covers this and three other
+hardware-specific rules in detail.
+
+### Building the base station
+
+The build flag does not match the board number. Current hardware is **V5**, built as
+`TR_BS_BOARD=3`:
+
+```bash
+idf.py -B build_v3 -DTR_BS_BOARD=3 build
+```
+
+A plain `build/` defaults to board 2 — a superseded revision. Flashing it onto a V5 boots
+cleanly with the wrong pin map: no error, just peripherals that are not where the firmware
+expects.
+
+### `sdkconfig` overrides `sdkconfig.defaults`
+
+`sdkconfig` is generated and untracked, and it wins. Editing the defaults file does
+nothing while a stale `sdkconfig` sits beside it, and a symbol that no longer exists fails
+silently. When a config change appears to have no effect, delete `sdkconfig` and rebuild.
+
+## Safety-critical areas
+
+TinkerRocket fires pyrotechnic devices. Changes touching pyro, deployment, recovery, or
+flight-state logic get more scrutiny and may be asked for bench evidence before merge.
+That is not distrust — a mistake in those paths cannot be recovered in flight.
+
+If you are changing one of these, say what you tested and how in the PR description.
+
+## Understanding the system
+
+Each codebase has an architecture page covering its task model, data paths, state
+machines, and the decisions that are not visible from reading the code. Each ends with a
+**Gotchas** section of things that have cost bench time.
+
+- [Flight Computer](docs/architecture/flight-computer.md)
+- [Out Computer](docs/architecture/out-computer.md)
+- [Base Station](docs/architecture/base-station.md)
+- [iOS App](docs/architecture/ios-app.md)
+- [Protocols](docs/architecture/protocols.md)
+
+Start with the [index](docs/architecture/README.md).
+
+## Licensing
+
+Software contributions are licensed under GPL-3.0-or-later, hardware contributions under
+CERN-OHL-S v2. See [LICENSE](LICENSE), [hardware/LICENSE](hardware/LICENSE), and the
+License section of the [README](README.md#license).

--- a/README.md
+++ b/README.md
@@ -514,6 +514,9 @@ Two exceptions to the above:
 | **Vendored components** | Third-party code under `tinkerrocket-idf/components/` keeps its own license — RadioLib is MIT, `spi_nand_flash` is Apache-2.0. Both permit inclusion in a GPL-3.0 work; their own terms continue to govern those files. See the `LICENSE` / `license.txt` in each. |
 | **`TR_GuidancePN`** | The proportional-navigation guidance law is a separate private submodule and is **not** covered by this license. Everything else builds and runs without it (see [Guidance](#guidance-optional)), so the public tree is complete and buildable on its own. |
 
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for how to get set
+up and what to watch out for. Contributors are asked to agree to the [CLA](CLA.md) once.
+
 TinkerRocket controls pyrotechnic devices. As set out in sections 15 and 16 of the
 GPL, it comes with **no warranty of any kind** — you are responsible for the safe
 construction, testing, and operation of anything you build from it, and for

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -6,6 +6,11 @@ analysis behind what is and isn't tracked here.
 
 Built with **KiCad 10.0.3**.
 
+These design files are licensed under the [CERN Open Hardware Licence v2 — Strongly
+Reciprocal](LICENSE) (`CERN-OHL-S-2.0`), which is separate from the GPL covering the
+software. If you distribute a product based on them, or publish a modified design, the
+complete sources must be available under the same licence.
+
 ## Boards
 
 | Folder | Board | Firmware target |

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -67,8 +67,16 @@ MSG_PROSE = re.compile(r"`?(0[xX][0-9A-Fa-f]{2})`?\s*\([^)]*?(\d+)\s*B\)")
 
 
 def markdown_files():
-    """README plus the architecture pages. See the scope note above."""
-    files = [README]
+    """Root-level docs plus the architecture pages. See the scope note above.
+
+    CONTRIBUTING.md and CLA.md are included because they are the first thing a
+    new contributor reads -- a broken link there costs someone their first
+    half hour. hardware/README.md is included for the same reason.
+    """
+    files = [README,
+             REPO / "CONTRIBUTING.md",
+             REPO / "CLA.md",
+             REPO / "hardware/README.md"]
     if DOCS.is_dir():
         files += sorted(DOCS.rglob("*.md"))
     return [f for f in files if f.exists()]


### PR DESCRIPTION
Drafts the CLA and the contributor guide.

## `CLA.md`

A **licence grant**, not a copyright assignment — contributors keep their copyright and
grant permission to use the work, including permission to relicense it later. Derived from
the Apache ICLA, which is the standard template for exactly this.

Adapted in one important way: **"Contribution" explicitly covers hardware design files** —
schematics, layouts, symbol and footprint libraries, fab outputs, BOMs — not just software.
Most CLAs are software-only, and this repo now carries both.

Section 4 (relicensing) is the reason the document exists. Today Tinkerbug Robotics is the
sole copyright holder and can license its own code however it likes — which is what lets a
private guidance module sit alongside a GPL tree. The first merged outside contribution
ends that, and reversing it later means finding every contributor who ever sent a patch.

**The draft carries a visible maintainer note that it has not been reviewed by a lawyer.**
That note should be removed only once it has been. If you intend to rely on section 4
commercially, that review is worth doing.

## `CONTRIBUTING.md`

Written around what actually trips people up, rather than restating how to use git:

- **The `ble_cmd` dispatch is first-match** — a duplicate number silently turns the later
  handler into dead code. Includes the full add-a-command checklist, and names the gap no
  guard closes: two branches can each claim the same free number and collide only at merge.
- **Generated docs must not be hand-edited** — change the source, re-run the generator.
- **The base station's build flag doesn't match its board number** — V5 hardware builds as
  `TR_BS_BOARD=3`, and a plain `build/` boots cleanly with the wrong pin map.
- **`sdkconfig` overrides `sdkconfig.defaults`** and fails silently.
- **Never let git three-way-merge a KiCad board file** — links to `hardware/README.md`,
  which already covers this properly, rather than duplicating it.

It also states plainly that pyro, deployment, recovery and flight-state changes get more
scrutiny and may be asked for bench evidence — worth setting that expectation before
someone's first PR rather than during review.

## Also

- `hardware/README.md` gains the CERN-OHL-S pointer that was missing when the board files
  landed in #600.
- `check_docs.py` now link-checks `CONTRIBUTING.md`, `CLA.md` and `hardware/README.md`.
  These are the first files a new contributor opens, so a broken link there is the most
  expensive kind. Verified the widened check fails on a planted break.

## Not included

**CLA Assistant is not set up.** The signing flow in the doc is manual (a comment on the
first PR). Automating it means installing the [CLA Assistant](https://github.com/cla-assistant/cla-assistant)
GitHub app, which is a maintainer action — happy to walk through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
