### PR TITLE
hardware: correct and add board names on silkscreen

### DIFF
--- a/hardware/base-station/base-station.kicad_pcb
+++ b/hardware/base-station/base-station.kicad_pcb
@@ -29003,7 +29003,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "TinkerRocket\nBase Station V4"
+	(gr_text "TinkerRocket\nBase Station V5"
 		(at 74.54 123.61 90)
 		(layer "F.SilkS")
 		(uuid "1f5c02ba-8316-4aba-ba92-7cd7a5b67c77")

--- a/hardware/gnss-px1105r-18mm-highpower-ext-ant/gnss-px1105r-18mm-highpower-ext-ant.kicad_pcb
+++ b/hardware/gnss-px1105r-18mm-highpower-ext-ant/gnss-px1105r-18mm-highpower-ext-ant.kicad_pcb
@@ -5895,7 +5895,7 @@
 		(layer "Edge.Cuts")
 		(uuid "40be5c3a-df4d-446e-bd89-81edb56e4189")
 	)
-	(gr_text "TinkerRocket\nLoRa Board\nV2"
+	(gr_text "TinkerRocket\nGNSS PX1105R\nV1"
 		(at 47.21 35 0)
 		(layer "F.SilkS")
 		(uuid "e47dfeb4-d4cc-4673-be80-55d4d8223489")

--- a/hardware/gnss-sam10m8-18mm-hv/gnss-sam10m8-18mm-hv.kicad_pcb
+++ b/hardware/gnss-sam10m8-18mm-hv/gnss-sam10m8-18mm-hv.kicad_pcb
@@ -6992,6 +6992,19 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "TinkerRocket\nGNSS SAM-M10Q\nV2"
+		(at 53.15 43.29 0)
+		(layer "B.SilkS")
+		(uuid "aeb8bc6d-37d4-42df-85ef-fd672e324ff2")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify mirror)
+		)
+	)
 	(segment
 		(start 62.61 43.43)
 		(end 62.37 43.67)

--- a/hardware/servo-adapter/servo-adapter.kicad_pcb
+++ b/hardware/servo-adapter/servo-adapter.kicad_pcb
@@ -2350,6 +2350,19 @@
 			(justify left bottom)
 		)
 	)
+	(gr_text "TinkerRocket\nServo Adapter"
+		(at 84.6 78 0)
+		(layer "B.SilkS")
+		(uuid "67e1ce0b-c400-4306-85fb-78e8b6c731d5")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+			(justify mirror)
+		)
+	)
 	(segment
 		(start 83.79 81.17)
 		(end 83.79 77.82)


### PR DESCRIPTION
A bare board's silkscreen is how it identifies itself on the bench. That matters more now that #596 took the revision out of the folder name — silkscreen and git tags are what's left to tell one physical board from another.

Two of the six boards were naming themselves wrong, and two weren't naming themselves at all. Both problems were found by opening the imported boards in KiCad after #600.

## Corrected

| Board | Was | Now |
|---|---|---|
| `base-station` | `TinkerRocket / Base Station V4` | `TinkerRocket / Base Station V5` |
| `gnss-px1105r-18mm-highpower-ext-ant` | `TinkerRocket / LoRa Board V2` | `TinkerRocket / GNSS PX1105R / V1` |

The PX1105R board was announcing itself as a completely different product — same folder-cloning that left five orphan Full-board sub-sheets in the LoRa project (see #600).

## Added

Neither of these carried a board name at all:

| Board | Text | Layer |
|---|---|---|
| `gnss-sam10m8-18mm-hv` | `TinkerRocket / GNSS SAM-M10Q / V2` | `B.SilkS` |
| `servo-adapter` | `TinkerRocket / Servo Adapter` | `B.SilkS` |

Back-layer text is mirrored, so it does not trip `nonmirrored_text_on_back_layer`.

**The added text is placed provisionally and needs nudging by hand.** Both boards are dense and the front had no clear space; the back was the better of the two, but the text still lands over some pads. This is deliberate — placement is a judgement call better made in the editor than computed.

## DRC

Measured against a baseline captured **before** any edit, so the boards' pre-existing violations don't muddy the result:

| Board | Before | After | New |
|---|---|---|---|
| `base-station` | 44 | 44 | none |
| `gnss-px1105r` | 4 | 4 | none |
| `gnss-sam10m8` | 4 | 8 | 4 — `silk_over_copper` ×3, `silk_overlap` ×1 |
| `servo-adapter` | 15 | 17 | 2 — `silk_over_copper`, pads 3/4 of `J1` |

**The two corrections are clean.** Every new violation belongs to the added text overlapping pads and clears when it is repositioned. Placing the SAM board's name on the front cost 7 new violations; the back cost 4, which is why it went there.

Each board's diff is the text change and nothing else — two one-line edits, two 13-line additions. No copper, no footprints, no connectivity touched.

## Note for reviewers

I wrote a free-space finder to place the added text automatically and validated it against `gnss-px1105r`, which demonstrably fits a 3-line name on an identical outline. It reported "no free area" there too, so its verdict that these boards have no room was wrong and I stopped trusting it. The boards are genuinely dense, but not as dense as that tool claimed — hand-placement is the right call, not a hard constraint.

## Unrelated, but found while doing this

Not addressed here; worth their own issues:

- **`base-station` baseline DRC has 44 violations, including 3 `shorting_items` and 3 `clearance`.** A different severity class from silkscreen cosmetics, on a board that flies.
- **`base-station` has a board/schematic sync gap** — the PCB carries a net `Net-(U12-CV)` that no longer exists in the schematic. Every schematic net is on the board; the board has this one extra, i.e. copper left behind after a net was removed without re-syncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
