### PR TITLE
docs: CLA is reviewed — drop the draft caveat, answer the corporate case

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -5,11 +5,9 @@
 Thanks for wanting to contribute. This agreement covers the legal side of that, once,
 so neither of us has to think about it again.
 
-> **Maintainer note:** this document is a draft derived from the Apache Software
-> Foundation's Individual CLA, adapted to cover hardware design files as well as
-> software. It has **not** been reviewed by a lawyer. If Tinkerbug Robotics intends to
-> rely on the relicensing right in section 4 commercially, have counsel read it first.
-> Delete this note once that has happened.
+It is derived from the Apache Software Foundation's Individual CLA — so if you have
+signed one of those, this will look familiar — extended to cover hardware design files
+as well as software, since this project publishes both.
 
 ---
 
@@ -141,6 +139,12 @@ Signed-off-by: Your Name <your.email@example.com>
 
 Use a real name and an address that reaches you. One signature covers all your future
 contributions; you do not repeat it per pull request.
+
+**Contributing on behalf of a company?** There is no separate corporate agreement — this
+is the only one. Someone authorised to bind the company signs this same document, naming
+the company, and it then covers contributions made by its people. If your employer holds
+rights in what you write and has not signed, get their permission before contributing —
+see "You have the authority" in section 5.
 
 **Safety-critical reminder.** TinkerRocket fires pyrotechnic devices and flies at
 altitude. Contributions touching pyro, deployment, recovery, or flight-state logic get


### PR DESCRIPTION
Legal review is complete, and no separate corporate CLA is being adopted.

## Draft caveat removed

The `Maintainer note` block saying the CLA had not been reviewed by a lawyer is gone.

What replaces it is the part of that note a **contributor** actually benefits from: the
agreement derives from the Apache ICLA, so anyone who has signed one before will recognise
it, extended to cover hardware design files since this project publishes both.

## The corporate case, answered in one place

Deciding against a separate corporate CLA leaves a predictable question — *where is your
CCLA?* — so `How to sign` now answers it:

> **Contributing on behalf of a company?** There is no separate corporate agreement — this
> is the only one. Someone authorised to bind the company signs this same document, naming
> the company, and it then covers contributions made by its people.

The text already supported this: `"You"` is defined as "the individual who submits a
Contribution, **or the legal entity authorising it**", and the authority representation in
section 5 already contemplates "your employer has itself signed this agreement". This
surfaces it where someone will look instead of leaving it to be inferred from the
definitions.

Also replaced a `section 5.2` cross-reference with the item's actual heading, since
section 5's items are numbered `1./2./3.` in the text and "5.2" would send a reader
hunting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)