### PR TITLE
docs: put the Rocket Computer's constituent parts on their own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The system comprises three physical cooperating components:
 
 | Component | Hardware | Role |
 |-----------|----------|------|
-| **Rocket Computer** ([Flight Computer](docs/architecture/flight-computer.md) & [Out Computer](docs/architecture/out-computer.md)) | ESP32-P4 & ESP32-S3 | Power switch, flight control, sensor fusion, data logging, LoRa transmitter, BLE ground link |
+| **Rocket Computer**<br/>([Flight Computer](docs/architecture/flight-computer.md) & [Out Computer](docs/architecture/out-computer.md)) | ESP32-P4 & ESP32-S3 | Power switch, flight control, sensor fusion, data logging, LoRa transmitter, BLE ground link |
 | **[Base Station](docs/architecture/base-station.md)** | ESP32-S3 | LoRa receiver, BLE ground link, LoRa data logging |
 | **[iOS App](docs/architecture/ios-app.md)** | iPhone/iPad | Real-time flight data dashboard, flight and LoRa data storage, rocket and downlink configuration |
 


### PR DESCRIPTION
Splits the first Overview row so the product name and the two computers inside it sit on separate lines:

```
| **Rocket Computer**<br/>([Flight Computer](...) & [Out Computer](...)) | ESP32-P4 & ESP32-S3 | ... |
```

That cell was the widest in the table by a good margin, squeezing the other two columns. The
split gives the row a clear hierarchy — what you buy on the first line, what's on it
underneath.

Uses `<br/>` because a Markdown table cell can't hold a literal newline; GitHub renders it
inside cells. Matches the `<br/>` style already used in the architecture pages' diagram
labels. Both links still resolve — `check_docs.py` confirms.

Worth eyeballing the rendered diff on this PR to confirm the break lands where you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)