### PR TITLE
docs: draw the actuator arrow from the Flight Computer box

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flowchart TB
     APP["<b>iOS App</b><br/>Dashboard · Logs · Config"]
 
     SENSORS --> FC
-    CTRL --> OUT
+    FC --> OUT
     RAD -->|"LoRa 915 MHz · 2 Hz"| RX
     RAD -->|"BLE · Pad"| APP
     RX -->|"BLE · Flight"| APP


### PR DESCRIPTION
One-line diagram fix: `FC --> OUT` instead of `CTRL --> OUT`.

The edge started at `Flight Control` — a node two subgraph levels deep — so Mermaid routed it
out through the outer **Rocket Computer** boundary. It read as though the servos, pyro and
camera hung off the board as a whole rather than off the flight computer that drives them.

Originating the edge at the `FC` subgraph attaches it to that box's border instead. Nothing
moved; the actuator box stays outside the Rocket Computer box where it belongs.

Verified rendered before committing, and `CTRL` is still wired via `EKF --> CTRL` so no node
is orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)