### PR TITLE
fix(oc): create the SPI bus mutex unconditionally, not just with MRAM

### DIFF
--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.cpp
@@ -51,14 +51,6 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
         pinMode(cfg.mram_cs, OUTPUT);
         digitalWrite(cfg.mram_cs, HIGH);
 
-        // Create SPI bus mutex (both cores share the NAND/MRAM SPI bus)
-        spi_mutex_ = xSemaphoreCreateMutex();
-        if (!spi_mutex_)
-        {
-            if (cfg.debug) ESP_LOGE(TAG, "Failed to create SPI mutex");
-            return false;
-        }
-
         if (cfg.debug) ESP_LOGI(TAG, "MRAM ring: %lu bytes on CS pin %d",
                                       (unsigned long)ring_size_, cfg.mram_cs);
     }
@@ -77,6 +69,21 @@ bool TR_LogToFlash::begin(SPIClass& spi_in, const TR_LogToFlashConfig& cfg_in)
                                       (unsigned long)ring_size_, (unsigned long)esp_get_free_heap_size());
     }
     ring_prelaunch_cap_ = prelaunchCap();
+
+    // SPI bus mutex — created unconditionally.  It used to live inside the
+    // MRAM branch above, which left every NAND transaction unserialized
+    // whenever MRAM was absent: the flush task (Core 0) programs pages while
+    // the BLE download path reads them, and spiAcquire/spiRelease silently
+    // no-op on a null handle.  Nothing caught it because the RAM-ring branch
+    // has never been flown — but it becomes live the moment a board ships
+    // without the MRAM part.  Keeping it unconditional also keeps the #398
+    // spi_wait/spi_hold instrumentation meaningful on both paths.
+    spi_mutex_ = xSemaphoreCreateMutex();
+    if (!spi_mutex_)
+    {
+        if (cfg.debug) ESP_LOGE(TAG, "Failed to create SPI mutex");
+        return false;
+    }
 
     // Mutex to serialize ringPush callers and to block clearRing from
     // running concurrently with an in-flight push (#74). Unconditionally
@@ -744,7 +751,7 @@ bool TR_LogToFlash::isLoggingActive() const
 }
 
 // ============================================================================
-// SPI bus mutex (active when MRAM is enabled)
+// SPI bus mutex (always active — NAND alone needs it; see begin())
 // ============================================================================
 
 void TR_LogToFlash::spiAcquire()

--- a/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
+++ b/tinkerrocket-idf/components/TR_LogToFlash/TR_LogToFlash.h
@@ -496,7 +496,8 @@ private:
     // Pre-create log file support
     volatile bool prepare_file_requested_ = false;
 
-    // SPI bus mutex (active when MRAM is enabled — both cores share SPI bus)
+    // SPI bus mutex — always created.  Both cores share the bus even without
+    // MRAM (flush task programs NAND pages while the BLE download path reads).
     SemaphoreHandle_t spi_mutex_ = nullptr;
     void spiAcquire();
     void spiRelease();


### PR DESCRIPTION
## The bug

`spi_mutex_` was created inside the `cfg.mram_cs >= 0` branch of `TR_LogToFlash::begin()`. On a board without MRAM the handle stays null — and `spiAcquire()`/`spiRelease()` both `return` early on a null handle, silently:

```cpp
void TR_LogToFlash::spiAcquire()
{
    if (!spi_mutex_) return;   // <-- no serialization, no warning
```

So every NAND transaction runs unserialized. The flush task programs NAND pages on Core 0 while the BLE download path reads them — exactly the pair the mutex exists to separate.

## Why it has never bitten

The RAM-ring branch has never been flown. Every board to date has the MR25H10 fitted, so `mram_cs >= 0` and the mutex gets created.

It stops being theoretical the moment a board ships without U12 — which is the direction the BOM is heading. The MR25H10CDFR is **$10.53 at qty 100**, the single most expensive line item on the rocket computer (~12% of the $86.00 board), and the replacement path is in-package PSRAM on the SoC.

The comments were part of the problem: both the declaration and the definition said *"active when MRAM is enabled"*, which made the omission read as deliberate rather than as a gap. Both are corrected here.

## The change

Two files, +18/−10:

- `begin()`: mutex creation moved out of the MRAM branch to after the ring-backing selection, alongside the already-unconditional `push_mutex_`.
- Comments at the declaration and the definition updated.

**Behaviour-neutral for the MRAM path** — nothing between the old and the new creation point touches the SPI bus (the MRAM branch does `pinMode`/`digitalWrite` only). It also keeps the #398 `spi_wait`/`spi_hold` instrumentation meaningful without MRAM instead of reporting zeros.

## Verification

- esp32s3 firmware builds clean (V7 pin map, IDF v6.0).
- Host suite: **637/637 passed, 0 failed**.
- **Not bench-run**, deliberately: the fixed path is unreachable on hardware with the MRAM fitted. That is the point of the fix.

`begin()` is ESP-IDF code requiring FreeRTOS and SPI, so the host suite does not reach it — `tests_cpp` covers the extracted policy headers (`mram_dirty_policy.h`, `bad_block_scan_policy.h`). The build is the relevant gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)