### PR TITLE
docs: drop the architecture-photo TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Finally, manage the flight data intuitively by uploading from the flight compute
 
 ## Architecture
 
-<!-- TODO: add a system photo/diagram, then restore this:
-![Architecture](docs/images/architecture.jpg) -->
-
 ```mermaid
 flowchart TB
     subgraph SENSORS["Sensors"]


### PR DESCRIPTION
Removes the `<!-- TODO: add a system photo/diagram -->` placeholder that sat directly above
the Mermaid diagram. The diagram does that job now, so the comment was asking for something
already delivered.

The other two image TODOs stay — the hero photo and the app screenshot still have nothing
standing in for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)