### PR TITLE
docs: drop the legacy-board sensor note

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ Two references are generated from source and re-checked in CI, so they cannot dr
 | **u-blox M10** | GNSS | UART 115200 | 18 Hz | GPS/GLONASS/Galileo/BeiDou |
 | **INA230** | Power monitor | I2C | 10 Hz | Voltage, current, SOC |
 
-Rates above are the configured rates on a V8 board. Earlier boards carry an MMC5983MA
-magnetometer (200 Hz) instead of the IIS2MDC; the board header selects which is used.
-
 **IMU logging rate is settable from the app** — nominally 1 kHz, 2 kHz, or 4 kHz, which
 land on the sensor's own output rates of 960, 1920 (default), and 3840 Hz. The rate
 cannot be changed in flight.


### PR DESCRIPTION
Removes the caveat under the Sensors table:

> ~~Rates above are the configured rates on a V8 board. Earlier boards carry an MMC5983MA
> magnetometer (200 Hz) instead of the IIS2MDC; the board header selects which is used.~~

Production won't carry the earlier boards, so the table doesn't need to hedge against a
magnetometer shipping hardware doesn't populate. The rates are just the rates.

**Scoped to this one note.** The firmware still selects between MMC5983MA and IIS2MDC by
board header, so the architecture pages — which document what the code does rather than what
ships — are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)