### PR TITLE
fc+docs: confirm the servo GPIO map and document the expansion connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,48 @@ One of the twelve GPIO channels is ADC-capable. None of them are servo-dedicated
 can drive servos, carry communication, or read external sensors — so the four used for fin
 tabs are a choice rather than a fixed allocation.
 
+#### Expansion connector
+
+All twelve channels come out on one 16-pin Molex 878321620. Odd pins are on one row, even
+pins on the other, with pin 1 at the keyed end:
+
+| | | | | | | | | |
+|---|---|---|---|---|---|---|---|---|
+| **odd** | `1`<br/>RTN | `3`<br/>**EXP_01** | `5`<br/>**EXP_03** | `7`<br/>EXP_05 | `9`<br/>EXP_12 | `11`<br/>EXP_10 | `13`<br/>EXP_08 | `15`<br/>VBATT |
+| **even** | `2`<br/>RTN | `4`<br/>**EXP_02** | `6`<br/>**EXP_04** | `8`<br/>EXP_06 | `10`<br/>EXP_11 | `12`<br/>EXP_09 | `14`<br/>EXP_07 | `16`<br/>VBATT |
+
+**Servos 1-4 default to pins 3, 4, 5 and 6** — nets `EXP_01`–`EXP_04`. With the return on
+pins 1-2 and VBATT on 15-16, a three-wire servo lead reaches signal, power and ground
+without leaving the connector.
+
+Two things that will catch you out:
+
+- **The numbering reverses at pin 9.** Pins 3-8 run `EXP_01`→`EXP_06` ascending; pins 9-14
+  run `EXP_12`→`EXP_07` descending. Pin 9 is `EXP_12`, not `EXP_07`.
+- **Pins 1-2 are a switched return, not a ground.** They go through a MOSFET whose source
+  is on GND, so the firmware can cut the servo return — that is what the on-pad relax
+  behaviour uses. Do not use these as a chassis ground.
+
+Each net maps to a fixed ESP32-P4 GPIO:
+
+| Net | GPIO | | Net | GPIO | | Net | GPIO |
+|---|---|---|---|---|---|---|---|
+| `EXP_01` | 45 | | `EXP_05` | 39 | | `EXP_09` | 38 |
+| `EXP_02` | 44 | | `EXP_06` | 40 | | `EXP_10` | 37 |
+| `EXP_03` | 43 | | `EXP_07` | 29 | | `EXP_11` | 34 |
+| `EXP_04` | 54 | | `EXP_08` | 28 | | `EXP_12` | 33 |
+
+#### Which mapping is set where
+
+| Mapping | Set in | Changeable from the app |
+|---|---|---|
+| servo → GPIO pin | flight-computer board header, compile time | **No** |
+| servo → fin azimuth and reversal | `FinConfigData`, BLE command 66 | Yes |
+| PWM rate, pulse limits, per-servo bias, fin travel | `ServoConfigData` | Yes |
+
+So which connector pin drives which servo is fixed when the firmware is built; where that
+servo points, and how far it moves, are set live from the app.
+
 ## Flight Data
 
 Data starts as **binary** on the rocket and stays that way until something needs to read

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
@@ -67,14 +67,29 @@ struct board_pins
     static constexpr uint8_t PYRO4_CONT_PIN = 14;  // PYRO4_CONT
 
     // ### Fin servos ###
-    // TODO: CONFIRM which EXP_* nets carry the four fin-servo signals.
-    // Parked on EXP_01..04 in order (EXP_01=45, EXP_02=44, EXP_03=43,
-    // EXP_04=54) — verify servo numbering with the app's servo test /
-    // fin-cal wiggle before trusting the mapping.
-    static constexpr uint8_t SERVO_PIN_1 = 45;  // EXP_01 (TODO confirm)
-    static constexpr uint8_t SERVO_PIN_2 = 44;  // EXP_02 (TODO confirm)
-    static constexpr uint8_t SERVO_PIN_3 = 43;  // EXP_03 (TODO confirm)
-    static constexpr uint8_t SERVO_PIN_4 = 54;  // EXP_04 (TODO confirm)
+    // CONFIRMED against the board files: each EXP net's package pin was read
+    // out of hardware/rocket-computer/rocket-computer.kicad_pcb and matched to
+    // the ESP32-P4 pin assignment in the schematic. The four servo signals are
+    // EXP_01..04 in order, which is what was already assumed here.
+    //
+    // The full expansion map, for anyone wiring the other eight channels:
+    //
+    //   net       GPIO   pkg pin      net       GPIO   pkg pin
+    //   EXP_01     45      87         EXP_07     29      58
+    //   EXP_02     44      86         EXP_08     28      57
+    //   EXP_03     43      84         EXP_09     38      70
+    //   EXP_04     54      98         EXP_10     37      69
+    //   EXP_05     39      80         EXP_11     34      65
+    //   EXP_06     40      81         EXP_12     33      64
+    //
+    // All twelve come out on the 16-pin Molex 878321620: pins 3..8 carry
+    // EXP_01..06 ascending, then pins 9..14 carry EXP_12..07 DESCENDING --
+    // pin 9 is EXP_12, not EXP_07. Pins 1-2 are a MOSFET-switched return
+    // (Q8, PMPB14XNX, source on GND); pins 15-16 are VBATT.
+    static constexpr uint8_t SERVO_PIN_1 = 45;  // EXP_01, connector pin 3
+    static constexpr uint8_t SERVO_PIN_2 = 44;  // EXP_02, connector pin 4
+    static constexpr uint8_t SERVO_PIN_3 = 43;  // EXP_03, connector pin 5
+    static constexpr uint8_t SERVO_PIN_4 = 54;  // EXP_04, connector pin 6
 
     // ### Indicators ###
     static constexpr uint8_t PIEZO_PIN = 17;      // PIEZZO


### PR DESCRIPTION
Resolves the `TODO: CONFIRM` on the servo pins and documents where to actually plug a servo in.

## The firmware values were already right

`board_v8.h` carried this on all four servo pins:

```c
// TODO: CONFIRM which EXP_* nets carry the four fin-servo signals.
static constexpr uint8_t SERVO_PIN_1 = 45;  // EXP_01 (TODO confirm)
```

The schematic settles it, and the four values were correct. **Only comments change — the
constants are byte-identical.**

Verified rather than taken on trust: each `EXP_` net's package pin was read out of
`rocket-computer.kicad_pcb` and matched against the ESP32-P4 pin assignment. All twelve agree.

| Net | pkg pin | GPIO | | Net | pkg pin | GPIO |
|---|---|---|---|---|---|---|
| `EXP_01` | 87 | 45 | | `EXP_07` | 58 | 29 |
| `EXP_02` | 86 | 44 | | `EXP_08` | 57 | 28 |
| `EXP_03` | 84 | 43 | | `EXP_09` | 70 | 38 |
| `EXP_04` | 98 | 54 | | `EXP_10` | 69 | 37 |
| `EXP_05` | 80 | 39 | | `EXP_11` | 65 | 34 |
| `EXP_06` | 81 | 40 | | `EXP_12` | 64 | 33 |

The full map is now recorded in the header for anyone wiring the other eight channels.

## The connector pinout is in the README

"Which pin do I plug a servo into" isn't answerable from firmware constants. **Servos 1-4 are
pins 3, 4, 5, 6**, with the return on 1-2 and VBATT on 15-16 — so a three-wire lead is
satisfied inside the connector.

Two traps are called out:

- **The numbering reverses at pin 9.** Pins 3-8 are `EXP_01`→`EXP_06` ascending; pins 9-14 are
  `EXP_12`→`EXP_07` descending. Pin 9 is `EXP_12`, not `EXP_07`.
- **Pins 1-2 are a switched return, not a ground.** They run through Q8 (PMPB14XNX), source on
  GND, so firmware can open the servo return — that's what the on-pad relax uses. Treating them
  as chassis ground would be a mistake.

## Three things called "servo config"

| Mapping | Set in | App-changeable |
|---|---|---|
| servo → GPIO | board header, compile time | **No** |
| servo → fin azimuth / reversal | `FinConfigData`, BLE cmd 66 | Yes |
| PWM rate, pulse limits, bias, travel | `ServoConfigData` | Yes |

## One thing to resolve

The repo's schematic and PCB both reference this connector as **J3**. Your screenshot shows
**J5** — so the working copy has been re-annotated since the import, and the only `J5` in the
committed tree is a different connector in `esp32s3_outputs.kicad_sch`.

The **pinout is identical either way** and the docs avoid naming a designator, but the board
files should be re-exported so the repo matches what's on the silkscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
