### PR TITLE
docs: remove the Performance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,24 +449,6 @@ does.
 
 The flight computer streams sensor data to the out computer via I2S DMA at 22,050 Hz sample rate (88 KB/s bandwidth). Frames are zero-copy from ISR callbacks into an MRAM ring buffer, then flushed to NAND flash.
 
-## Performance
-
-Measured on the bench, not recomputed from configuration — treat these as a snapshot
-from a specific run rather than current targets. Where a figure disagrees with the
-[Sensors](#sensors) table, the configured rate there is the authority.
-
-| Metric | Target | Achieved |
-|--------|--------|----------|
-| IMU rate | 960 Hz | 960 Hz |
-| Barometer rate | 500 Hz | 490 Hz |
-| Magnetometer rate | 200 Hz | 220 Hz |
-| EKF output rate | 500 Hz | 490 Hz |
-| GNSS rate | 18 Hz | 34 Hz |
-| I2S frame drops | 0 | 0 |
-| Max IMU gap | < 10 ms | 9.4 ms |
-| Standby power | -- | ~1 mA |
-| Active power | -- | 130 mA |
-
 ## iOS App
 
 <!-- TODO: add an app screenshot, then restore this:


### PR DESCRIPTION
Removes the Performance table.

It was a snapshot of one bench run that nobody re-measures, and **two rows had already gone
stale** — IMU listed at 960 Hz against a 1920 Hz default, and GNSS "achieving" 34 Hz against a
configured 18. A table of numbers that drift silently is worse than no table, because it reads
as current.

## What it uniquely held

| Figure | Now |
|---|---|
| Standby current | Already in the Overview prose, with the reason it matters |
| Active current (130 mA) | **Goes with the section** |
| I2S frame drops (0) | **Goes with the section** |
| Max IMU gap (9.4 ms) | **Goes with the section** |

Those three are bench measurements referenced nowhere else. If any belongs in the README, it's
worth re-measuring and placing deliberately rather than carrying forward an old run.

Nothing linked to the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)