### PR TITLE
Dynamic IMU logging rate, driven by a recovery-deployment detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ tinkerrocket-sim/build/
 tinkerrocket-sim/**/*.egg-info/
 tinkerrocket-sim/**/*.so
 
+# replay_deployment_detector.py compiles this from the firmware headers on
+# demand and rebuilds it whenever they change — committing it would be a stale
+# copy of the very thresholds the tool exists to read live.
+Data_Analysis/*.so
+
 # Xcode
 TinkerRocketApp/DerivedData/
 *.xcuserdata

--- a/Data_Analysis/_deployment_detector_shim.cpp
+++ b/Data_Analysis/_deployment_detector_shim.cpp
@@ -1,0 +1,99 @@
+// C shim so replay_deployment_detector.py can drive the REAL deployment
+// detector over a recorded flight instead of a Python port of it.
+//
+// Two firmware sources are pulled in directly, and that is the whole point of
+// this file:
+//
+//   DeploymentDetector.h  — the detector itself, the same translation unit the
+//                           flight computer compiles.
+//   flight_computer/main/config.h — the shipped config::DEPLOY_* tunables.
+//                           The FC's config.h has no ESP-IDF dependency (pins
+//                           live in board/board_v*.h, which is plain constants
+//                           over <stdint.h>), so it compiles host-side as-is.
+//
+// So a replay can never disagree with the vehicle because someone edited a
+// threshold and forgot the analysis tool: the driver rebuilds this shim
+// whenever either header changes, and reports the values it actually got.
+//
+// Built on demand by the Python driver — see _build_shim() there. Not a
+// standalone program.
+
+#include <cstdint>
+#include "DeploymentDetector.h"
+#include "config.h"
+
+extern "C" {
+
+// The shipped tunables, as the flight computer defines them.  Split into a
+// float and an unsigned bank so ctypes never has to know a struct layout.
+//   f = [shock_ms2, baro_step_m, ballistic_mps, canopy_mps]
+//   u = [shock_count, coincidence_ms, canopy_count, launch_lockout_ms,
+//        flight_loop_update_rate_hz]
+void tr_deploy_shipped_cfg(float* f, unsigned* u)
+{
+    f[0] = config::DEPLOY_SHOCK_MS2;
+    f[1] = config::DEPLOY_BARO_STEP_M;
+    f[2] = config::DEPLOY_BALLISTIC_MPS;
+    f[3] = config::DEPLOY_CANOPY_MPS;
+    u[0] = config::DEPLOY_SHOCK_COUNT;
+    u[1] = config::DEPLOY_COINCIDENCE_MS;
+    u[2] = config::DEPLOY_CANOPY_COUNT;
+    u[3] = config::DEPLOY_LAUNCH_LOCKOUT_MS;
+    u[4] = config::FLIGHT_LOOP_UPDATE_RATE;
+}
+
+// Run one reconstructed flight-loop stream through the detector.
+//
+// The caller supplies one entry per loop TICK (not per IMU sample) — the
+// detector's counts are in loop iterations, so a replay that stepped once per
+// logged IMU sample would make every count threshold fire in less wall time
+// than it does on the vehicle.
+//
+// Returns 1 if the detector latched, 0 if it never did.  On a latch, *out_t is
+// the tick time and *out_reason the tr::kDeployReason* bitmask.  *out_ballistic
+// reports whether the descent-collapse path ever armed, which is how a replay
+// tells "the slow path voted no" from "the slow path was never in play".
+int tr_deploy_run(float shock_ms2, unsigned shock_count,
+                  float baro_step_m, unsigned coincidence_ms,
+                  float ballistic_mps, float canopy_mps, unsigned canopy_count,
+                  unsigned launch_lockout_ms,
+                  const unsigned* t_ms, const float* acc_ms2, const float* palt_m,
+                  const unsigned char* new_baro, const float* rate_mps,
+                  const unsigned char* burnout, const unsigned char* stop,
+                  int n,
+                  unsigned* out_t, unsigned char* out_reason,
+                  unsigned char* out_ballistic)
+{
+    tr::DeploymentConfig cfg{};
+    cfg.shock_ms2         = shock_ms2;
+    cfg.shock_count       = (uint16_t)shock_count;
+    cfg.baro_step_m       = baro_step_m;
+    cfg.coincidence_ms    = coincidence_ms;
+    cfg.ballistic_mps     = ballistic_mps;
+    cfg.canopy_mps        = canopy_mps;
+    cfg.canopy_count      = (uint16_t)canopy_count;
+    cfg.launch_lockout_ms = launch_lockout_ms;
+
+    tr::DeploymentState st;
+    int latched = 0;
+    for (int i = 0; i < n; ++i)
+    {
+        // Mirrors the flight loop's own gate: it stops stepping the detector
+        // once the airframe is down, so a replay must too or it scores the
+        // landing impact as a deployment.
+        if (stop[i]) break;
+        if (tr::deploymentDetectStep(st, cfg, t_ms[i], acc_ms2[i], palt_m[i],
+                                     new_baro[i] != 0, rate_mps[i],
+                                     burnout[i] != 0))
+        {
+            *out_t      = st.detected_ms;
+            *out_reason = st.reason;
+            latched     = 1;
+            break;
+        }
+    }
+    *out_ballistic = st.ballistic ? 1 : 0;
+    return latched;
+}
+
+}  // extern "C"

--- a/Data_Analysis/analyze_pyro_apogee.py
+++ b/Data_Analysis/analyze_pyro_apogee.py
@@ -40,6 +40,11 @@ NSF_PYRO_ARMED  = (1 << 6)
 NSF2_GPS_APOGEE    = (1 << 0)
 NSF2_PITCH_APOGEE  = (1 << 1)
 NSF2_MASTER_APOGEE = (1 << 2)
+# Recovery deployment detected (sticky).  Independent of the apogee vote: it
+# observes the charge going off, where the vote decides when to fire it, so the
+# gap between the two is the real ejection delay.  Also the row where a dynamic
+# logging rate steps down.  Zero on logs predating the detector.
+NSF2_DEPLOYED      = (1 << 7)
 
 # Pyro status byte bits — paired (CONT, FIRED) per channel.  Layout must match
 # the PSF_* constants in TR_RocketComputerTypes/RocketComputerTypes.h.  The
@@ -168,6 +173,7 @@ def parse(filepath):
                 "gps_apogee":    bool(apogee_flags & NSF2_GPS_APOGEE),
                 "pitch_apogee":  bool(apogee_flags & NSF2_PITCH_APOGEE),
                 "master_apogee": bool(apogee_flags & NSF2_MASTER_APOGEE),
+                "deployed":      bool(apogee_flags & NSF2_DEPLOYED),
             })
             stats["ns_ok"] += 1
 
@@ -239,7 +245,8 @@ def main():
     # never fires on simulated logs (sim attitude isn't realistic).
     for key, label in (("gps_apogee",    "GPS apogee flag"),
                        ("pitch_apogee",  "pitch apogee flag"),
-                       ("master_apogee", "MASTER apogee flag (pyro trigger point)")):
+                       ("master_apogee", "MASTER apogee flag (pyro trigger point)"),
+                       ("deployed",      "DEPLOYED flag (recovery detected)")):
         hit = next((r for r in ns if r[key]), None)
         if hit:
             print(f"  t={(hit['time_us'] - t0) / 1e6:+8.3f}s  {label} SET")

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -186,6 +186,7 @@ NSF2_REBOOT_RECOVERY  = (1 << 3)
 NSF2_GUIDANCE_ENABLED = (1 << 4)
 NSF2_ORIENT_THRUST_MISMATCH = (1 << 5)
 NSF2_FC_IMU_DROP      = (1 << 6)  # #474: FC loop stalled -> ISM6 queue overflow (sticky)
+NSF2_DEPLOYED         = (1 << 7)  # recovery deployment detected (sticky)
 
 # Pyro status byte bits — paired (CONT, FIRED) per channel.  Layout must match
 # the PSF_* constants in TR_RocketComputerTypes/RocketComputerTypes.h.  An
@@ -583,6 +584,10 @@ def parse_binary_file(filepath):
                     "reboot_recovery":    bool(apogee_flags_b & NSF2_REBOOT_RECOVERY),
                     "guidance_enabled":   bool(apogee_flags_b & NSF2_GUIDANCE_ENABLED),
                     "fc_imu_drop":        bool(apogee_flags_b & NSF2_FC_IMU_DROP),
+                    # Recovery deployment detected.  False on logs predating
+                    # the detector — check has_apogee_flags to tell "flight
+                    # never deployed" from "firmware never reported it".
+                    "deployed":           bool(apogee_flags_b & NSF2_DEPLOYED),
                     # #529: free-running EKF update-tick counter (uint16 wrap);
                     # None on logs that predate the field.  The replay derives
                     # the achieved EKF rate from this instead of a constant.

--- a/Data_Analysis/replay_deployment_detector.py
+++ b/Data_Analysis/replay_deployment_detector.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Replay a binary flight log through the REAL recovery-deployment detector.
+
+Drives ``tr::deploymentDetectStep`` (TR_KinematicChecks/DeploymentDetector.h)
+with the shipped ``config::DEPLOY_*`` tunables, both compiled straight out of
+the firmware tree by ``_deployment_detector_shim.cpp``. Nothing here is a
+Python port of the detector: the header exists specifically so the host tests
+and this tool exercise the same code the vehicle flies, and a mirror would
+reintroduce exactly the silent divergence it was written to avoid.
+
+Reports when the detector latches, which path fired, how the latch lines up
+against the firmware's own logged events, and how much margin the thresholds
+had — the peak acceleration and largest baro step in each flight phase, which
+is what says whether a threshold is comfortable or lucky. ``--sweep`` walks
+each tunable to show where the detection window's edges actually are.
+
+Usage:
+    python replay_deployment_detector.py <binary> [<binary>...] [--sweep]
+                                         [--loop-hz N] [--verbose]
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from plot_flight_data_mini import parse_binary_file  # noqa: E402
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parent
+_DETECTOR_DIR = _REPO / "tinkerrocket-idf" / "components" / "TR_KinematicChecks"
+_FC_MAIN_DIR = _REPO / "tinkerrocket-idf" / "projects" / "flight_computer" / "main"
+_SHIM_SRC = _HERE / "_deployment_detector_shim.cpp"
+
+G_MS2 = 9.80665
+NSF_BURNOUT = 1 << 4
+NSF2_DEPLOYED = 1 << 7
+
+# Reason bitmask, mirroring tr::kDeployReason* in DeploymentDetector.h.
+REASON_SHOCK_BARO = 1 << 0
+REASON_DESCENT_COLLAPSE = 1 << 1
+
+
+def reason_names(mask: int) -> str:
+    parts = []
+    if mask & REASON_SHOCK_BARO:
+        parts.append("shock+baro")
+    if mask & REASON_DESCENT_COLLAPSE:
+        parts.append("descent-collapse")
+    return " + ".join(parts) if parts else "none"
+
+
+# --------------------------------------------------------------------------
+# Firmware binding
+# --------------------------------------------------------------------------
+
+def _build_shim() -> Path:
+    """Compile the shim if it is older than any firmware source it pulls in.
+
+    The staleness check is the no-drift guarantee: edit a DEPLOY_* threshold or
+    the detector and the next replay rebuilds instead of quietly reporting the
+    previous build's answer.
+    """
+    out = _HERE / "_deployment_detector_shim.so"
+    deps = [_SHIM_SRC, _DETECTOR_DIR / "DeploymentDetector.h", _FC_MAIN_DIR / "config.h"]
+    deps += sorted((_FC_MAIN_DIR / "board").glob("*.h"))
+    if out.exists() and all(out.stat().st_mtime >= d.stat().st_mtime for d in deps):
+        return out
+    cmd = [
+        "c++", "-std=c++17", "-O2", "-shared", "-fPIC",
+        f"-I{_DETECTOR_DIR}", f"-I{_FC_MAIN_DIR}",
+        str(_SHIM_SRC), "-o", str(out),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.exit(f"failed to build {out.name}:\n{proc.stderr}\ncommand: {' '.join(cmd)}")
+    return out
+
+
+class Detector:
+    """ctypes binding to the compiled firmware detector."""
+
+    def __init__(self):
+        self._lib = ctypes.CDLL(str(_build_shim()))
+        self._lib.tr_deploy_shipped_cfg.argtypes = [
+            ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_uint)]
+        self._lib.tr_deploy_run.restype = ctypes.c_int
+        self._lib.tr_deploy_run.argtypes = [
+            ctypes.c_float, ctypes.c_uint, ctypes.c_float, ctypes.c_uint,
+            ctypes.c_float, ctypes.c_float, ctypes.c_uint, ctypes.c_uint,
+            ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_float),
+            ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_ubyte),
+            ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_ubyte),
+            ctypes.POINTER(ctypes.c_ubyte), ctypes.c_int,
+            ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_ubyte),
+            ctypes.POINTER(ctypes.c_ubyte)]
+
+        f = (ctypes.c_float * 4)()
+        u = (ctypes.c_uint * 5)()
+        self._lib.tr_deploy_shipped_cfg(f, u)
+        self.shipped = {
+            "shock_ms2": f[0], "baro_step_m": f[1],
+            "ballistic_mps": f[2], "canopy_mps": f[3],
+            "shock_count": u[0], "coincidence_ms": u[1],
+            "canopy_count": u[2], "launch_lockout_ms": u[3],
+        }
+        self.loop_hz = u[4]
+
+    def run(self, ticks, **overrides):
+        """Run one tick stream. Returns (latched_ms|None, reason, ballistic)."""
+        cfg = dict(self.shipped)
+        cfg.update(overrides)
+        out_t = ctypes.c_uint(0)
+        out_reason = ctypes.c_ubyte(0)
+        out_ballistic = ctypes.c_ubyte(0)
+        latched = self._lib.tr_deploy_run(
+            ctypes.c_float(cfg["shock_ms2"]), ctypes.c_uint(int(cfg["shock_count"])),
+            ctypes.c_float(cfg["baro_step_m"]), ctypes.c_uint(int(cfg["coincidence_ms"])),
+            ctypes.c_float(cfg["ballistic_mps"]), ctypes.c_float(cfg["canopy_mps"]),
+            ctypes.c_uint(int(cfg["canopy_count"])),
+            ctypes.c_uint(int(cfg["launch_lockout_ms"])),
+            ticks.t, ticks.acc, ticks.palt, ticks.new_baro,
+            ticks.rate, ticks.burnout, ticks.stop, ticks.n,
+            ctypes.byref(out_t), ctypes.byref(out_reason), ctypes.byref(out_ballistic))
+        return (out_t.value if latched else None,
+                out_reason.value, bool(out_ballistic.value))
+
+
+# --------------------------------------------------------------------------
+# Flight-loop reconstruction
+# --------------------------------------------------------------------------
+
+class Ticks:
+    """One entry per reconstructed flight-loop iteration, as ctypes arrays."""
+
+    __slots__ = ("t", "acc", "palt", "new_baro", "rate", "burnout", "stop", "n", "py")
+
+    def __init__(self, rows):
+        self.n = len(rows)
+        self.py = rows
+        self.t = (ctypes.c_uint * self.n)(*[r[0] for r in rows])
+        self.acc = (ctypes.c_float * self.n)(*[r[1] for r in rows])
+        self.palt = (ctypes.c_float * self.n)(*[r[2] for r in rows])
+        self.new_baro = (ctypes.c_ubyte * self.n)(*[r[3] for r in rows])
+        self.rate = (ctypes.c_float * self.n)(*[r[4] for r in rows])
+        self.burnout = (ctypes.c_ubyte * self.n)(*[r[5] for r in rows])
+        self.stop = (ctypes.c_ubyte * self.n)(*[r[6] for r in rows])
+
+
+def pressure_to_altitude_firmware(p_pa: float, p_ground: float) -> float:
+    return 44330.0 * (1.0 - (p_pa / p_ground) ** (1.0 / 5.255))
+
+
+def accel_norm_firmware(low_xyz, high_xyz, low_g_fs_g: float) -> float:
+    """Mirror of the flight loop's channel pick, not of the detector.
+
+    The FC switches to the high-g accelerometer as any low-g axis nears
+    saturation, which is the only reason an ejection shock reads tens of g
+    instead of clipping at full scale.
+    """
+    sat = (low_g_fs_g - 0.5) * G_MS2
+    ax, ay, az = high_xyz if any(abs(v) > sat for v in low_xyz) else low_xyz
+    return math.sqrt(ax * ax + ay * ay + az * az)
+
+
+def estimate_ground_pressure(baro_recs, nonsensor_recs) -> float:
+    """Pre-launch mean, matching replay_kinematic_checks.py."""
+    if not baro_recs or not nonsensor_recs:
+        return 101325.0
+    launch_us = next((r["time_us"] for r in nonsensor_recs if r["launch"]), None)
+    cutoff = launch_us if launch_us is not None else baro_recs[-1]["time_us"]
+    pre = [r["pressure_pa"] for r in baro_recs if r["time_us"] < cutoff]
+    return sum(pre) / len(pre) if pre else sum(
+        r["pressure_pa"] for r in baro_recs[:50]) / min(50, len(baro_recs))
+
+
+def build_ticks(records, loop_hz: int):
+    """Merge the logged streams back into the flight loop the FC actually ran.
+
+    A tick is emitted per IMU sample but never faster than the loop rate: the
+    IMU can log at up to 3840 Hz while loop_fc() runs near 1 kHz and consumes
+    only the freshest sample, so stepping per IMU sample would compress every
+    tick-count threshold. Logs whose IMU rate is below the loop rate (anything
+    predating the deepened handoff queue) simply tick per sample.
+    """
+    imu, baro, ns = records["ISM6HG256"], records["BMP585"], records["NonSensor"]
+    if not imu or not ns:
+        return None, {}
+
+    ground_pa = estimate_ground_pressure(baro, ns)
+    launch_us = next((r["time_us"] for r in ns if r["launch"]), None)
+    if launch_us is None:
+        return None, {"no_launch": True}
+
+    events = ([(r["time_us"], 0, r) for r in baro] +
+              [(r["time_us"], 1, r) for r in ns] +
+              [(r["time_us"], 2, r) for r in imu])
+    events.sort(key=lambda e: (e[0], e[1]))
+
+    low_g_fs = records.get("_low_g_fs_g", 16.0)
+    min_dt_us = 1_000_000.0 / loop_hz
+
+    palt = 0.0
+    new_baro = False
+    rate = 0.0
+    burnout = False
+    landed = False
+    last_tick_us = None
+    rows = []
+    for t_us, kind, r in events:
+        if kind == 0:
+            palt = pressure_to_altitude_firmware(r["pressure_pa"], ground_pa)
+            new_baro = True
+            continue
+        if kind == 1:
+            rate = r["baro_alt_rate"]
+            burnout = bool(r["flags"] & NSF_BURNOUT)
+            landed = landed or bool(r["alt_landed"])
+            continue
+        if t_us < launch_us:
+            continue
+        if last_tick_us is not None and (t_us - last_tick_us) < min_dt_us:
+            continue
+        last_tick_us = t_us
+        acc = accel_norm_firmware(
+            (r["low_acc_x"], r["low_acc_y"], r["low_acc_z"]),
+            (r["high_acc_x"], r["high_acc_y"], r["high_acc_z"]), low_g_fs)
+        rows.append(((t_us - launch_us) // 1000, acc, palt,
+                     1 if new_baro else 0, rate, 1 if burnout else 0,
+                     1 if landed else 0))
+        new_baro = False
+
+    def first(pred):
+        return next((( r["time_us"] - launch_us) / 1000.0
+                     for r in ns if pred(r)), None)
+
+    logged = {
+        "burnout_ms": first(lambda r: r["flags"] & NSF_BURNOUT),
+        "apogee_ms": first(lambda r: r["apogee_flag"]),
+        "landed_ms": first(lambda r: r["alt_landed"]),
+        # The firmware's own latch, present only on logs flown with the
+        # detector. None means "never reported", which for a log predating the
+        # detector is not the same claim as "the flight never deployed" —
+        # has_apogee_flags separates the two.
+        "deployed_ms": first(lambda r: r.get("deployed")),
+        "has_apogee_flags": bool(ns and ns[0].get("has_apogee_flags")),
+        "ground_pa": ground_pa,
+        "tick_hz": (len(rows) / ((rows[-1][0] - rows[0][0]) / 1000.0)
+                    if len(rows) > 1 and rows[-1][0] > rows[0][0] else 0.0),
+    }
+    return Ticks(rows), logged
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+def phase_margins(ticks, logged, latch_ms):
+    """Peak |a| and largest baro step per phase.
+
+    This is the part that says whether a threshold is comfortable or merely
+    lucky: the detection thresholds have to sit above everything boost and
+    coast produce and below what the ejection produces.
+    """
+    burnout = logged.get("burnout_ms") or 0.0
+    landed = logged.get("landed_ms")
+    ej = latch_ms if latch_ms is not None else None
+    bounds = [("boost  (launch->burnout)", 0.0, burnout)]
+    if ej is not None:
+        bounds += [("coast  (burnout->latch-100ms)", burnout, ej - 100),
+                   ("latch  (+/-300 ms)", ej - 300, ej + 300),
+                   ("descent(latch+2s->landing)", ej + 2000,
+                    landed if landed else float("inf"))]
+    else:
+        bounds += [("post-burnout (all)", burnout,
+                    landed if landed else float("inf"))]
+
+    out = []
+    for name, lo, hi in bounds:
+        sub = [r for r in ticks.py if lo <= r[0] < hi]
+        if not sub:
+            continue
+        pk = max(sub, key=lambda r: r[1])
+        prev = None
+        step = (0.0, 0)
+        for r in sub:
+            if r[3] and prev is not None and r[2] != prev:
+                d = abs(r[2] - prev)
+                if d > step[0]:
+                    step = (d, r[0])
+            if r[3]:
+                prev = r[2]
+        out.append((name, len(sub), pk[1] / G_MS2, pk[0], step[0], step[1]))
+    return out
+
+
+def sweep(det, ticks):
+    print("\n  threshold sweep (one tunable at a time, others shipped):")
+    plans = [
+        ("shock_ms2", "shock", "g", [2, 4, 6, 8, 12, 20, 30, 40, 60],
+         lambda v: v * G_MS2),
+        ("baro_step_m", "baro step", "m", [0.5, 1, 2, 3, 5, 20, 80, 120],
+         lambda v: v),
+        ("shock_count", "shock count", "ticks", [1, 3, 10, 30, 100],
+         lambda v: v),
+        ("canopy_count", "canopy count", "ticks", [50, 200, 500, 2000],
+         lambda v: v),
+        ("ballistic_mps", "ballistic", "m/s", [5, 10, 18, 30],
+         lambda v: v),
+        ("coincidence_ms", "coincidence", "ms", [5, 25, 100, 250, 1000],
+         lambda v: v),
+    ]
+    for key, label, unit, values, conv in plans:
+        cells = []
+        for v in values:
+            t, reason, _ = det.run(ticks, **{key: conv(v)})
+            cells.append(f"{v:g}{unit}:" + ("never" if t is None else f"{t}ms"))
+        print(f"    {label:12s} " + "  ".join(cells))
+
+
+def replay(path: str, loop_hz_override: int | None, do_sweep: bool, verbose: bool) -> bool:
+    records, _stats, cfg = parse_binary_file(path)
+    records["_low_g_fs_g"] = float(cfg.get("low_g_fs_g", 16))
+
+    det = Detector()
+    loop_hz = loop_hz_override or det.loop_hz
+    ticks, logged = build_ticks(records, loop_hz)
+
+    print(f"\n=== {Path(path).name} ===")
+    if ticks is None:
+        print("  no launch / no usable streams — skipping")
+        return False
+    print(f"  IMU={len(records['ISM6HG256']):,}  Baro={len(records['BMP585']):,}  "
+          f"NS={len(records['NonSensor']):,}   ground={logged['ground_pa']:.0f} Pa")
+    print(f"  reconstructed {ticks.n:,} loop ticks at {logged['tick_hz']:.0f} Hz "
+          f"(loop rate cap {loop_hz} Hz)")
+    print("  shipped config: " + ", ".join(
+        f"{k}={v:g}" for k, v in det.shipped.items()))
+
+    for name, key in (("burnout", "burnout_ms"), ("apogee", "apogee_ms"),
+                      ("landed", "landed_ms")):
+        v = logged.get(key)
+        print(f"    firmware {name:8s} T{'+%.0f ms' % v if v is not None else '  (never)'}")
+
+    latch_ms, reason, ballistic = det.run(ticks)
+    if latch_ms is None:
+        print("\n  >>> detector NEVER latched")
+    else:
+        print(f"\n  >>> latched T+{latch_ms} ms   via {reason_names(reason)}")
+        apo = logged.get("apogee_ms")
+        if apo is not None:
+            print(f"      {latch_ms - apo:+.0f} ms relative to the firmware's apogee flag")
+    print(f"      descent-collapse path armed: {'yes' if ballistic else 'NO (never ballistic)'}")
+
+    # The firmware's own latch, when the flight was flown with the detector.
+    if logged.get("deployed_ms") is not None:
+        d = logged["deployed_ms"]
+        print(f"      firmware logged NSF2_DEPLOYED at T+{d:.0f} ms "
+              f"(replay differs by {latch_ms - d:+.0f} ms)"
+              if latch_ms is not None else
+              f"      firmware logged NSF2_DEPLOYED at T+{d:.0f} ms but the replay did NOT latch")
+    elif not logged.get("has_apogee_flags"):
+        print("      firmware NSF2_DEPLOYED: log predates the apogee_flags byte entirely")
+    else:
+        # The bit's absence alone can't separate these two: the log records
+        # whether the detector fired, not whether the build had one.
+        print("      firmware NSF2_DEPLOYED: never set "
+              "(flight predates the detector, or it genuinely never fired)")
+
+    print("\n  phase margins (thresholds must clear every pre-ejection row):")
+    print(f"    {'phase':30s} {'ticks':>7s} {'peak |a|':>10s} {'at':>10s} "
+          f"{'max baro step':>14s} {'at':>10s}")
+    for name, n, pk_g, pk_t, st_m, st_t in phase_margins(ticks, logged, latch_ms):
+        print(f"    {name:30s} {n:7,d} {pk_g:8.1f} g  T+{pk_t:6.0f}ms "
+              f"{st_m:12.1f} m  T+{st_t:6.0f}ms")
+
+    if do_sweep:
+        sweep(det, ticks)
+    if verbose and latch_ms is not None:
+        print("\n  ticks around the latch:")
+        for r in ticks.py:
+            if abs(r[0] - latch_ms) <= 12:
+                print(f"    T+{r[0]:6d} ms  |a|={r[1]/G_MS2:6.1f} g  palt={r[2]:8.1f} m"
+                      f"  new_baro={r[3]}  rate={r[4]:+6.1f} m/s  burnout={r[5]}")
+    return latch_ms is not None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("binaries", nargs="+", help="flight .bin log(s)")
+    ap.add_argument("--sweep", action="store_true",
+                    help="walk each tunable to show the detection window's edges")
+    ap.add_argument("--loop-hz", type=int, default=None,
+                    help="override the reconstructed loop rate "
+                         "(default: config::FLIGHT_LOOP_UPDATE_RATE)")
+    ap.add_argument("--verbose", action="store_true",
+                    help="dump the loop ticks around the latch")
+    args = ap.parse_args()
+
+    any_latch = False
+    for b in args.binaries:
+        any_latch |= replay(b, args.loop_hz, args.sweep, args.verbose)
+    return 0 if any_latch else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -934,8 +934,10 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         }
     }
 
-    /// IMU logging rate in Hz — whitelisted ISM6HG256 ODR (960/1920/3840).
-    /// The FC applies it live on the pad and persists it in FC NVS.
+    /// IMU logging rate — `RocketProfile.imuRateDynamic` (0) or a whitelisted
+    /// ISM6HG256 ODR (960/1920/3840). The FC applies it live on the pad and
+    /// persists it in FC NVS. In dynamic mode the FC owns the in-flight
+    /// step-down; the app sends the mode once and never revisits it.
     func sendImuRateConfig(_ rateHz: UInt16) {
         var payload = Data()
         payload.append(UInt8(rateHz & 0xFF))

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift
@@ -558,6 +558,10 @@ nonisolated class CSVGenerator {
         columns.append("Apogee Detector: Pitch")
         columns.append("Apogee Flag (Master)")
         columns.append("Launch Flag")
+        // Sticky recovery-deployment latch. In dynamic logging mode this is
+        // also the row where the IMU sample rate steps down. Flights predating
+        // the detector emit 0.
+        columns.append("Deployed Flag")
 
         // Pyro status bits — 4 channels (legacy files emit 0s for ch3/4)
         columns.append("Pyro 1 Continuity")
@@ -670,6 +674,7 @@ nonisolated class CSVGenerator {
         values.append(nonSensor.map { $0.pitch_apogee_flag ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.apogee_flag ? "1" : "0" } ?? "")
         values.append(nonSensor.map { $0.launch_flag ? "1" : "0" } ?? "")
+        values.append(nonSensor.map { $0.deployed_flag ? "1" : "0" } ?? "")
 
         // Pyro status bits (4 channels)
         values.append(nonSensor.map { $0.pyro1_continuity ? "1" : "0" } ?? "")
@@ -746,6 +751,7 @@ nonisolated struct FlightSettings: Codable, Sendable {
             low_g_fs_g: Int(raw.ism6_low_g_fs_g),
             high_g_fs_g: Int(raw.ism6_high_g_fs_g),
             update_rate_hz: raw.ism6_update_rate_hz.map(Int.init),
+            dynamic_rate: raw.imuRateDynamic,
             mounting: MountingSettings(from: raw)
         )
     }
@@ -899,8 +905,14 @@ nonisolated struct IMUSettings: Codable, Sendable {
     let low_g_fs_g: Int
     let high_g_fs_g: Int
     /// Logged IMU sample rate in Hz (v5 settings frames). nil on older
-    /// logs, which ran the then-fixed build default.
+    /// logs, which ran the then-fixed build default. When `dynamic_rate` is
+    /// true this is the rate at the snapshot — i.e. the boost rate — not the
+    /// rate for the whole flight.
     let update_rate_hz: Int?
+    /// The rocket flew the dynamic logging rate: `update_rate_hz` through
+    /// boost and coast, then a step down to a lower rate at the first row
+    /// whose "Deployed Flag" column is 1.
+    let dynamic_rate: Bool
     /// Board→rocket mounting orientation (v2 settings frames). nil on
     /// pre-orientation logs, which always meant the +X-nose mounting.
     let mounting: MountingSettings?

--- a/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift
@@ -56,7 +56,8 @@ struct FlightCSVData {
             "GNSS Horizontal Accuracy (m)", "GNSS Vertical Accuracy (m)"
         ]),
         ("Flags", [
-            "Launch Flag", "Altitude Apogee Flag", "Velocity Apogee Flag", "Landed Flag"
+            "Launch Flag", "Altitude Apogee Flag", "Velocity Apogee Flag", "Landed Flag",
+            "Deployed Flag"
         ])
     ]
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift
@@ -128,10 +128,22 @@ struct RocketProfile: Codable, Equatable, Identifiable {
     /// off-axis board; optional for non-controlled flights.
     var imuOrientSetting: UInt8 = 0   // default: manual identity (+X nose/up); 0xFF = pad auto-detect
 
-    /// IMU logging rate in Hz (ISM6HG256 ODR): 960, 1920, or 3840. Logged
-    /// samples follow this rate; the control loop always consumes the
-    /// freshest sample regardless.
-    var imuRateHz: UInt16 = 1920
+    /// IMU logging rate: `RocketProfile.imuRateDynamic` (0) for the dynamic
+    /// mode, or a fixed ISM6HG256 ODR of 960, 1920, or 3840 Hz. Logged samples
+    /// follow this rate; the control loop always consumes the freshest sample
+    /// regardless.
+    ///
+    /// Dynamic is the default: the rocket logs at 3840 Hz from the pad through
+    /// boost and coast, then drops to 960 Hz once its deployment detector sees
+    /// the recovery device come out. The switch happens entirely on the flight
+    /// computer — the app only selects the mode.
+    var imuRateHz: UInt16 = RocketProfile.imuRateDynamic
+
+    /// Sentinel for the dynamic logging rate, matching `IMU_RATE_DYNAMIC` in
+    /// RocketComputerTypes.h. Rides in the same 2-byte cmd-67 field as a fixed
+    /// rate; firmware predating dynamic mode rejects it and keeps its current
+    /// rate.
+    static let imuRateDynamic: UInt16 = 0
 
     // MARK: Servo
     // #561: default 0 (neutral) to match config.h SERVO_BIAS_N and biases 2-4.

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift
@@ -409,6 +409,7 @@ nonisolated class SensorConverter {
             pyro4_fired: false,
             reboot_recovery: false,
             guidance_enabled: false,
+            deployed_flag: false,
             ekf_ticks: nil
         )
     }
@@ -465,11 +466,13 @@ nonisolated class SensorConverter {
         let NSF2_MASTER_APOGEE: UInt8    = (1 << 2)
         let NSF2_REBOOT_RECOVERY: UInt8  = (1 << 3)
         let NSF2_GUIDANCE_ENABLED: UInt8 = (1 << 4)
+        let NSF2_DEPLOYED: UInt8         = (1 << 7)
         let gps_apogee_flag   = (raw.apogee_flags & NSF2_GPS_APOGEE) != 0
         let pitch_apogee_flag = (raw.apogee_flags & NSF2_PITCH_APOGEE) != 0
         let apogee_flag       = (raw.apogee_flags & NSF2_MASTER_APOGEE) != 0
         let reboot_recovery   = (raw.apogee_flags & NSF2_REBOOT_RECOVERY) != 0
         let guidance_enabled  = (raw.apogee_flags & NSF2_GUIDANCE_ENABLED) != 0
+        let deployed_flag     = (raw.apogee_flags & NSF2_DEPLOYED) != 0
 
         let rocket_state = RocketState(rawValue: raw.rocket_state) ?? .initialization
 
@@ -519,6 +522,7 @@ nonisolated class SensorConverter {
             pyro4_fired:      (raw.pyro_status & PSF_CH4_FIRED) != 0,
             reboot_recovery:  reboot_recovery,
             guidance_enabled: guidance_enabled,
+            deployed_flag:    deployed_flag,
             ekf_ticks:        raw.ekf_ticks   // #529
         )
     }

--- a/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift
@@ -119,6 +119,7 @@ nonisolated struct FlightSettingsData {
     static let fServoEnabled: UInt8    = 3
     static let fFwDirty: UInt8         = 4
     static let fSounds: UInt8          = 5
+    static let fImuRateDynamic: UInt8  = 7
 
     let time_us: UInt32
     let version: UInt8
@@ -203,6 +204,11 @@ nonisolated struct FlightSettingsData {
     var servoEnabled: Bool { flags & (1 << FlightSettingsData.fServoEnabled) != 0 }
     var fwDirty: Bool { flags & (1 << FlightSettingsData.fFwDirty) != 0 }
     var soundsEnabled: Bool { flags & (1 << FlightSettingsData.fSounds) != 0 }
+    /// The flight ran the dynamic logging rate, so `ism6_update_rate_hz` is
+    /// the rate at the snapshot (the boost rate) and the log steps down at the
+    /// first frame carrying NSF2_DEPLOYED. Flights predating dynamic mode
+    /// decode as false and ran one fixed rate throughout.
+    var imuRateDynamic: Bool { flags & (1 << FlightSettingsData.fImuRateDynamic) != 0 }
 
     init(from data: Data) throws {
         guard data.count >= 188 else {
@@ -566,6 +572,7 @@ nonisolated struct NonSensorData {
     //   bit 2 NSF2_MASTER_APOGEE  — voted result driving pyro logic
     //   bit 3 NSF2_REBOOT_RECOVERY  — moved from pyro_status bit 4
     //   bit 4 NSF2_GUIDANCE_ENABLED — moved from pyro_status bit 5
+    //   bit 7 NSF2_DEPLOYED         — recovery deployment detected (sticky)
     // Older logs (43-byte struct) decode this field as 0.
     let apogee_flags: UInt8
 
@@ -902,6 +909,13 @@ nonisolated struct NonSensorDataSI {
     let pyro4_fired: Bool
     let reboot_recovery: Bool
     let guidance_enabled: Bool
+
+    /// Recovery deployment detected (NSF2_DEPLOYED, bit 7 of apogee_flags).
+    /// Sticky once the rocket's deployment detector latches, so the first
+    /// frame carrying it is the detection time. In dynamic logging mode this
+    /// is also where the IMU rate steps down from 3840 to 960 Hz. Logs
+    /// predating the detector decode as false.
+    let deployed_flag: Bool
 
     // #529: free-running EKF update-tick counter (uint16 wrap), carried through
     // verbatim for the CSV so the achieved EKF rate is recoverable from an app

--- a/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift
@@ -756,12 +756,15 @@ struct SettingsView: View {
 
         Section("IMU Logging Rate") {
             Picker("Rate", selection: imuRateBinding) {
+                Text("Dynamic").tag(RocketProfile.imuRateDynamic)
                 Text("1k").tag(UInt16(960))
                 Text("2k").tag(UInt16(1920))
                 Text("4k").tag(UInt16(3840))
             }
             .pickerStyle(.segmented)
-            Text("Samples logged per second from the IMU (actual: 960 / 1920 / 3840 Hz). Higher rates capture faster shock and vibration detail; the control loop is unaffected. Applies on the pad \u{2014} never mid-flight.")
+            Text(profile.imuRateHz == RocketProfile.imuRateDynamic
+                ? "Logs at 4k (3840 Hz) from the pad through boost and coast, then drops to 1k (960 Hz) once the rocket detects its recovery deployment \u{2014} full shock and vibration detail where it matters, without filling the log under canopy."
+                : "Samples logged per second from the IMU (actual: 960 / 1920 / 3840 Hz). Higher rates capture faster shock and vibration detail; the control loop is unaffected. Applies on the pad \u{2014} never mid-flight.")
                 .font(.caption).foregroundColor(.secondary)
         }
 

--- a/docs/architecture/generated/flight-computer-map.md
+++ b/docs/architecture/generated/flight-computer-map.md
@@ -3,52 +3,52 @@
 
 # Flight Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,359 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,493 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
 
 | Section | Lines | Span |
 |---------|-------|------|
-| [**Includes, board selection, and compile-time configuration**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1-L77) | 77 | 1-77 |
-| [**Sensor collector and hardware objects**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L78-L194) | 117 | 78-194 |
-| [**I2C link to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L195-L272) | 78 | 195-272 |
-| [**Command lockout and flight-state flags**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L273-L365) | 93 | 273-365 |
-| [**Camera phase state machines**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L366-L405) | 40 | 366-405 |
-| [**Roll control: gains, PID, and roll profile**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L406-L505) | 100 | 406-505 |
-| [**Pyro channel state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L506-L553) | 48 | 506-553 |
-| [**Flight snapshot (crash recovery)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L554-L651) | 98 | 554-651 |
-| [**Reset-reason reporting**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L652-L672) | 21 | 652-672 |
-| [**Servo control and config-frame reads**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L673-L865) | 193 | 673-865 |
-| [**Pyro channels: init, safing, and servicing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L866-L1153) | 288 | 866-1153 |
-| [**Roll-profile waypoint lookup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1154-L1230) | 77 | 1154-1230 |
-| [**I2S transmit to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1231-L1301) | 71 | 1231-1301 |
-| [**OTA relay receiver (image in over I2S)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1302-L1528) | 227 | 1302-1528 |
-| [**Board-to-rocket orientation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1529-L1664) | 136 | 1529-1664 |
-| [**Guidance configuration and flight settings**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1665-L1814) | 150 | 1665-1814 |
-| [**I2S sender task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1815-L1862) | 48 | 1815-1862 |
-| [**Status LED**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1863-L1885) | 23 | 1863-1885 |
-| [**Calibration status publishing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1886-L1955) | 70 | 1886-1955 |
-| [**Piezo buzzer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1956-L2043) | 88 | 1956-2043 |
-| [**Camera control (GoPro pulse, RunCam serial)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2044-L2362) | 319 | 2044-2362 |
-| [**Boot chirp and heartbeat beep**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2363-L2438) | 76 | 2363-2438 |
-| [**OTA boot validation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2439-L2456) | 18 | 2439-2456 |
-| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2457-L3344) | 888 | 2457-3344 |
-| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3345-L3413) | 69 | 3345-3413 |
-| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3414-L3547) | 134 | 3414-3547 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3548-L7344) | 3,797 | 3548-7344 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3585-L3725) | 141 | 3585-3725 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3726-L3829) | 104 | 3726-3829 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3830-L3947) | 118 | 3830-3947 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3948-L4366) | 419 | 3948-4366 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4367-L4531) | 165 | 4367-4531 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4532-L6123) | 1,592 | 4532-6123 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6124-L6193) | 70 | 6124-6193 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6194-L6323) | 130 | 6194-6323 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6324-L6845) | 522 | 6324-6845 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6846-L6889) | 44 | 6846-6889 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6890-L7144) | 255 | 6890-7144 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7145-L7344) | 200 | 7145-7344 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7345-L7359) | 15 | 7345-7359 |
+| [**Includes, board selection, and compile-time configuration**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1-L78) | 78 | 1-78 |
+| [**Sensor collector and hardware objects**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L79-L195) | 117 | 79-195 |
+| [**I2C link to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L196-L273) | 78 | 196-273 |
+| [**Command lockout and flight-state flags**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L274-L366) | 93 | 274-366 |
+| [**Camera phase state machines**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L367-L406) | 40 | 367-406 |
+| [**Roll control: gains, PID, and roll profile**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L407-L529) | 123 | 407-529 |
+| [**Pyro channel state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L530-L577) | 48 | 530-577 |
+| [**Flight snapshot (crash recovery)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L578-L675) | 98 | 578-675 |
+| [**Reset-reason reporting**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L676-L696) | 21 | 676-696 |
+| [**Servo control and config-frame reads**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L697-L889) | 193 | 697-889 |
+| [**Pyro channels: init, safing, and servicing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L890-L1177) | 288 | 890-1177 |
+| [**Roll-profile waypoint lookup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1178-L1254) | 77 | 1178-1254 |
+| [**I2S transmit to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1255-L1325) | 71 | 1255-1325 |
+| [**OTA relay receiver (image in over I2S)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1326-L1552) | 227 | 1326-1552 |
+| [**Board-to-rocket orientation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1553-L1688) | 136 | 1553-1688 |
+| [**Guidance configuration and flight settings**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1689-L1846) | 158 | 1689-1846 |
+| [**I2S sender task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1847-L1894) | 48 | 1847-1894 |
+| [**Status LED**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1895-L1917) | 23 | 1895-1917 |
+| [**Calibration status publishing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1918-L1987) | 70 | 1918-1987 |
+| [**Piezo buzzer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1988-L2075) | 88 | 1988-2075 |
+| [**Camera control (GoPro pulse, RunCam serial)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2076-L2394) | 319 | 2076-2394 |
+| [**Boot chirp and heartbeat beep**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2395-L2470) | 76 | 2395-2470 |
+| [**OTA boot validation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2471-L2488) | 18 | 2471-2488 |
+| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2489-L3397) | 909 | 2489-3397 |
+| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3398-L3474) | 77 | 3398-3474 |
+| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3475-L3616) | 142 | 3475-3616 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3617-L7478) | 3,862 | 3617-7478 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3654-L3794) | 141 | 3654-3794 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3795-L3898) | 104 | 3795-3898 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3899-L4016) | 118 | 3899-4016 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4017-L4435) | 419 | 4017-4435 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4436-L4600) | 165 | 4436-4600 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4601-L6208) | 1,608 | 4601-6208 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6209-L6326) | 118 | 6209-6326 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6327-L6456) | 130 | 6327-6456 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6457-L6978) | 522 | 6457-6978 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6979-L7022) | 44 | 6979-7022 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7023-L7278) | 256 | 7023-7278 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7279-L7478) | 200 | 7279-7478 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7479-L7493) | 15 | 7479-7493 |
 
-Total: 28 sections (12 nested) across 7,359 lines.
+Total: 28 sections (12 nested) across 7,493 lines.

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 25,498 lines across 65 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 25,546 lines across 65 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -29,20 +29,20 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 29 files, 11,295 lines
+## `Models/` — 29 files, 11,340 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 1,959 | `BLEDeviceType`, `BLEDevice` |
+| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 1,961 | `BLEDeviceType`, `BLEDevice` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published per-device state · Device identity (populated from config_identity readback) · Internal state · Init · Connection lifecycle (called by BLEFleet) · BLE RSSI Polling · Sim state · Commands · OTA helpers (#8 phase 2) · Magnetometer hard-iron calibration (issue #96) · Identity commands · File operations · File chunk handling (private) · CSV Generation · Download State Management · CBPeripheralDelegate · Telemetry parsing |
-| [SensorTypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift) | 974 | `MessageType`, `RocketState`, `ParseError` |
+| [SensorTypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift) | 988 | `MessageType`, `RocketState`, `ParseError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
-| [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 935 | `DeviceType`, `CSVError` |
+| [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 947 | `DeviceType`, `CSVError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Device Auto-Detection · Main CSV Generation · Rotation Configuration · Helper Functions · Flight Summary · Flight Settings (#165) · CSV Errors |
 | [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
 | [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 537 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
-| [SensorConverter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift) | 525 | — |
+| [SensorConverter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift) | 529 | — |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Rotation Configuration · GNSS Conversion · Power Conversion · BMP585 Conversion · ISM6HG256 Conversion · MMC5983MA Conversion · IIS2MDC Conversion (new Mini PCB rev) · Legacy Sensor Conversions · Mini NonSensor Conversion |
 | [LandingPredictor.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LandingPredictor.swift) | 510 | `LandingSnapshotSource`, `LandingPrediction`, `LandingPredictor` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Telemetry handling · Wind prefetch · DriftCast adapter · Uncertainty model (#191 item 2) · Ascent ballistic (#191 item 1) |
@@ -52,14 +52,14 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | CachedFlight Model · Device-scoped path helpers · Summary File Caching · Binary File Caching · Direct CSV Caching (for base station LoRa logs that are already CSV) · Flight Caching Status · Delete Cached Flight · List All Cached Flights |
 | [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 472 | `TelemetryAnnouncer`, `FlightAnnouncer` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Private State · Constants · Init · Audio Session · Main Entry Point · Event Detectors · Horizontal Distance · Speech Engine · AVSpeechSynthesizerDelegate · State Reset |
+| [RocketProfile.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift) | 396 | `RollSegmentMode`, `RollWaypoint`, `MagCalData`, `SensorCalData`, `RocketProfile` |
 | [MagCalStatus.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift) | 395 | `MagCalSubType`, `MagCalRejectCode`, `MagCalStatus`, `MagCalAxis`, `MagCalComponent`, `MagCalConstants` |
 | [ActiveRocketSyncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift) | 393 | `ActiveRocketSyncer` |
-| [RocketProfile.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift) | 384 | `RollSegmentMode`, `RollWaypoint`, `MagCalData`, `SensorCalData`, `RocketProfile` |
 | [BLETypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift) | 340 | `FileInfo`, `DownloadState`, `DiscoveredDevice`, `RocketConfig` |
 | [KnownDeviceStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift) | 325 | `DeviceIdentityPusher`, `KnownDevice`, `KnownDeviceStore` |
 | [RocketProfileStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift) | 278 | `RocketProfileStore` |
 | [OTASession.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift) | 272 | `OTASession` |
-| [CSVParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift) | 270 | `FlightCSVData`, `CSVParserError`, `CSVParser` |
+| [CSVParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift) | 271 | `FlightCSVData`, `CSVParserError`, `CSVParser` |
 | [UnitFormatter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift) | 204 | `UnitSystem`, `UnitFormatter` |
 | [RocketRoster.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketRoster.swift) | 197 | `RocketKey`, `RocketFreshness`, `RelayPath`, `RocketCommandLink`, `RocketSubject`, `RocketRoster` |
 | [MagCalCells.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MagCalCells.swift) | 161 | `MagCalCells` |
@@ -73,13 +73,13 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 13,546 lines
+## `Views/` — 27 files, 13,549 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
 | [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,821 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +37 more |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
-| [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,665 | `SettingsView`, `PyroChannelTestControls` |
+| [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,668 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
 | [DriftCastView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift) | 1,428 | `DriftCastMapView`, `Trajectory3DView`, `DriftCastView`, `DriftCastSendButton` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Map Representable · 3D Trajectory View (SceneKit + ArcGIS Satellite Imagery) · Geo Conversion · USGS Satellite Imagery (cached) · Scene Builder · Scene Helpers · Main Drift Cast View · Computed Properties · Body · Map Section · Form Content · Results Section · Wind Profile Section · UI Helpers · Actions · Profile sync (#191) · Send-to-Unit Button · Preview |
@@ -117,4 +117,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 65 files, 25,498 lines.
+Total: 65 files, 25,546 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,520 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,541 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -16,28 +16,28 @@ and leading comments.
 | [**LoRa radio backend and shared device state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L411-L437) | 27 | 411-437 |
 | [**FC command queue (OC -> FC over I2C)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L438-L583) | 146 | 438-583 |
 | [**LoRa frequency lock and channel hopping**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L584-L789) | 206 | 584-789 |
-| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L965) | 176 | 790-965 |
-| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L966-L1099) | 134 | 966-1099 |
-| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1100-L1311) | 212 | 1100-1311 |
-| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1312-L1424) | 113 | 1312-1424 |
-| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1425-L1496) | 72 | 1425-1496 |
-| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1497-L1536) | 40 | 1497-1536 |
-| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1537-L1676) | 140 | 1537-1676 |
-| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1677-L1784) | 108 | 1677-1784 |
-| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1785-L1959) | 175 | 1785-1959 |
-| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1960-L2221) | 262 | 1960-2221 |
-| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2222-L2944) | 723 | 2222-2944 |
-| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2945-L3067) | 123 | 2945-3067 |
-| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3068-L3085) | 18 | 3068-3085 |
-| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3086-L3415) | 330 | 3086-3415 |
-| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3416-L3694) | 279 | 3416-3694 |
-| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3695-L4209) | 515 | 3695-4209 |
-| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4210-L4542) | 333 | 4210-4542 |
-| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4543-L5276) | 734 | 4543-5276 |
-| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5277-L5773) | 497 | 5277-5773 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5774-L6051) | 278 | 5774-6051 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6052-L7511) | 1,460 | 6052-7511 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6401-L7511) | 1,111 | 6401-7511 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7512-L7520) | 9 | 7512-7520 |
+| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L967) | 178 | 790-967 |
+| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L968-L1101) | 134 | 968-1101 |
+| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1102-L1313) | 212 | 1102-1313 |
+| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1314-L1426) | 113 | 1314-1426 |
+| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1427-L1498) | 72 | 1427-1498 |
+| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1499-L1538) | 40 | 1499-1538 |
+| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1539-L1678) | 140 | 1539-1678 |
+| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1679-L1786) | 108 | 1679-1786 |
+| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1787-L1961) | 175 | 1787-1961 |
+| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1962-L2223) | 262 | 1962-2223 |
+| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2224-L2946) | 723 | 2224-2946 |
+| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2947-L3069) | 123 | 2947-3069 |
+| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3070-L3087) | 18 | 3070-3087 |
+| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3088-L3417) | 330 | 3088-3417 |
+| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3418-L3696) | 279 | 3418-3696 |
+| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3697-L4211) | 515 | 3697-4211 |
+| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4212-L4544) | 333 | 4212-4544 |
+| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4545-L5278) | 734 | 4545-5278 |
+| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5279-L5785) | 507 | 5279-5785 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5786-L6063) | 278 | 5786-6063 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6064-L7532) | 1,469 | 6064-7532 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6413-L7532) | 1,120 | 6413-7532 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7533-L7541) | 9 | 7533-7541 |
 
-Total: 28 sections (1 nested) across 7,520 lines.
+Total: 28 sections (1 nested) across 7,541 lines.

--- a/docs/architecture/generated/protocol-reference.md
+++ b/docs/architecture/generated/protocol-reference.md
@@ -241,7 +241,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 | 64 |  | IMU mounting orientation: [setting:1] — IMU_ORIENT_AUTO or a TR_Orientation code (0..23, manual incl. roll… |
 | 65 |  | Full guidance config (GuidanceConfigData): relay the whole struct to the FC |
 | 66 |  | Full fin layout (FinConfigData): relay the whole struct to the FC |
-| 67 |  | IMU logging rate: [rate_hz:2 LE] — whitelisted ISM6HG256 ODR (960/1920/3840). Relayed to the FC, which… |
+| 67 |  | IMU logging rate: [rate_hz:2 LE] — IMU_RATE_DYNAMIC (0) or a whitelisted ISM6HG256 ODR (960/1920/3840).… |
 
 > 10 of these have no comment in the dispatch and so no
 > description here: 6, 7, 15, 16, 21, 51, 52, 53, 54, 57. Adding a comment to the branch
@@ -300,6 +300,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 | 4 | `NSF2_GUIDANCE_ENABLED` | FC's live guidance_enabled config |
 | 5 | `NSF2_ORIENT_THRUST_MISMATCH` |  |
 | 6 | `NSF2_FC_IMU_DROP` |  |
+| 7 | `NSF2_DEPLOYED` | recovery deployment detected (sticky) |
 
 ## Sensor health field
 

--- a/tests_cpp/CMakeLists.txt
+++ b/tests_cpp/CMakeLists.txt
@@ -443,6 +443,18 @@ target_include_directories(test_burnout_detector PRIVATE
 target_link_libraries(test_burnout_detector GTest::gtest_main)
 gtest_discover_tests(test_burnout_detector)
 
+# ---------- test_deployment_detector ----------
+# Recovery-deployment detector shared with the firmware via
+# components/TR_KinematicChecks/DeploymentDetector.h — the test exercises the
+# real code, not a mirror.  Drives the dynamic logging rate (IMU_RATE_DYNAMIC).
+add_executable(test_deployment_detector test_deployment_detector.cpp)
+target_include_directories(test_deployment_detector PRIVATE
+    ${SHIM_DIR}
+    ${LIB_DIR}/TR_KinematicChecks
+)
+target_link_libraries(test_deployment_detector GTest::gtest_main)
+gtest_discover_tests(test_deployment_detector)
+
 # ---------- test_tr_flightlog_wire_format ----------
 # Golden-file regression guard on the BLE wire formats iOS depends on.
 # Fixtures under tests_cpp/fixtures/ble_wire_format/ are the source of truth.

--- a/tests_cpp/test_deployment_detector.cpp
+++ b/tests_cpp/test_deployment_detector.cpp
@@ -1,0 +1,515 @@
+// Tests for the recovery-deployment detector, exercising the REAL firmware
+// logic in tinkerrocket-idf/components/TR_KinematicChecks/DeploymentDetector.h
+// (no hand-copied mirror).  The flight loop calls the same
+// tr::deploymentDetectStep() once per iteration; these tests are the single
+// source of truth for its behavior.
+//
+// The detector is threshold-driven, so a suite pinned to one config could not
+// tell a real threshold dependency from a hardcoded constant.  Every behavioral
+// case below either sweeps the tunable it is about, or asserts a relationship
+// that must hold across configs (see the *_Swept and *_Param tests).
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+#include "DeploymentDetector.h"
+
+namespace {
+
+constexpr float G = 9.80665f;
+
+// Mirror of config::DEPLOY_* in
+// tinkerrocket-idf/projects/flight_computer/main/config.h.
+tr::DeploymentConfig baseConfig()
+{
+    tr::DeploymentConfig c{};
+    c.shock_ms2         = 8.0f * G;
+    c.shock_count       = 3;
+    c.baro_step_m       = 3.0f;
+    c.coincidence_ms    = 250;
+    c.ballistic_mps     = 18.0f;
+    c.canopy_mps        = 10.0f;
+    c.canopy_count      = 200;
+    c.launch_lockout_ms = 1000;
+    return c;
+}
+
+// One flight-loop iteration's worth of inputs.
+struct Sample {
+    float acc_ms2      = 1.0f * G;
+    float palt_m       = 0.0f;
+    bool  new_baro     = true;
+    float palt_rate    = 0.0f;
+    bool  burnout      = true;
+};
+
+// Drives the detector at 1 kHz (1 ms per iteration) from t_start_ms, returning
+// the t_since_launch_ms of the latch or 0 if it never fired.
+uint32_t run(tr::DeploymentState& st, const tr::DeploymentConfig& cfg,
+             uint32_t t_start_ms, const std::vector<Sample>& samples)
+{
+    uint32_t fired_at = 0;
+    uint32_t t = t_start_ms;
+    for (const Sample& s : samples) {
+        if (tr::deploymentDetectStep(st, cfg, t, s.acc_ms2, s.palt_m,
+                                     s.new_baro, s.palt_rate, s.burnout)
+            && fired_at == 0) {
+            fired_at = t;
+        }
+        ++t;
+    }
+    return fired_at;
+}
+
+// Coasting: 1 g of drag decel, descending gently, altitude tracking the rate.
+std::vector<Sample> coast(size_t n, float palt_start, float rate_mps)
+{
+    std::vector<Sample> out;
+    out.reserve(n);
+    float palt = palt_start;
+    for (size_t i = 0; i < n; ++i) {
+        Sample s;
+        s.acc_ms2   = 1.0f * G;
+        s.palt_m    = palt;
+        s.palt_rate = rate_mps;
+        out.push_back(s);
+        palt += rate_mps * 0.001f;   // 1 ms per iteration
+    }
+    return out;
+}
+
+// --------------------------------------------------------------------------
+// FAST path: shock AND baro step, coincident
+// --------------------------------------------------------------------------
+
+TEST(DeploymentDetector, FastPath_ShockPlusBaroStep_Latches)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    // Ejection: a 40 g shock and a 12 m indicated-altitude step, together.
+    for (int i = 0; i < 5; ++i) {
+        Sample e;
+        e.acc_ms2   = 40.0f * G;
+        e.palt_m    = 300.0f + 12.0f;
+        e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    const uint32_t fired = run(st, cfg, 5000, s);
+    EXPECT_NE(fired, 0u);
+    EXPECT_TRUE(st.detected);
+    EXPECT_EQ(st.reason & tr::kDeployReasonShockBaro, tr::kDeployReasonShockBaro);
+    EXPECT_EQ(st.detected_ms, fired);
+}
+
+TEST(DeploymentDetector, FastPath_ShockAlone_DoesNotLatch)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int i = 0; i < 500; ++i) {          // sustained hard shock, no baro step
+        Sample e;
+        e.acc_ms2   = 60.0f * G;
+        e.palt_m    = 300.0f;
+        e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+TEST(DeploymentDetector, FastPath_BaroStepAlone_DoesNotLatch)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int i = 0; i < 500; ++i) {          // baro sawtooth, no shock
+        Sample e;
+        e.acc_ms2   = 1.0f * G;
+        e.palt_m    = (i % 2 == 0) ? 320.0f : 300.0f;
+        e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+TEST(DeploymentDetector, FastPath_NonCoincidentFeatures_DoNotLatch)
+{
+    auto cfg = baseConfig();
+    cfg.coincidence_ms = 100;
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int i = 0; i < 5; ++i) {            // baro step first
+        Sample e; e.acc_ms2 = 1.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    auto gap = coast(400, 320.0f, -5.0f);    // 400 ms of quiet, well past the window
+    s.insert(s.end(), gap.begin(), gap.end());
+    for (int i = 0; i < 5; ++i) {            // shock much later
+        Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 318.0f; e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+// The coincidence window is a real parameter, not a constant: the same
+// separated pair must latch when the window is wide enough to span it.
+TEST(DeploymentDetector, FastPath_CoincidenceWindow_Swept)
+{
+    for (uint32_t window : {50u, 150u, 300u, 600u}) {
+        auto cfg = baseConfig();
+        cfg.coincidence_ms = window;
+        tr::DeploymentState st;
+
+        constexpr uint32_t kSeparationMs = 200;
+        auto s = coast(50, 300.0f, -5.0f);
+        for (int i = 0; i < 5; ++i) {
+            Sample e; e.acc_ms2 = 1.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        auto gap = coast(kSeparationMs, 320.0f, -5.0f);
+        s.insert(s.end(), gap.begin(), gap.end());
+        for (int i = 0; i < 5; ++i) {
+            Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        const bool expect_fire = (window > kSeparationMs);
+        EXPECT_EQ(st.detected, false) << "window=" << window;
+        run(st, cfg, 5000, s);
+        EXPECT_EQ(st.detected, expect_fire)
+            << "coincidence_ms=" << window << " separation=" << kSeparationMs;
+    }
+}
+
+// The shock threshold must actually gate: the SAME acceleration is a shock
+// under a low threshold and is not under a high one.
+TEST(DeploymentDetector, ShockThreshold_Swept)
+{
+    constexpr float kShockG = 20.0f;
+    for (float thresh_g : {5.0f, 10.0f, 25.0f, 50.0f}) {
+        auto cfg = baseConfig();
+        cfg.shock_ms2 = thresh_g * G;
+        tr::DeploymentState st;
+
+        auto s = coast(50, 300.0f, -5.0f);
+        for (int i = 0; i < 10; ++i) {
+            Sample e;
+            e.acc_ms2   = kShockG * G;
+            e.palt_m    = 315.0f;
+            e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        run(st, cfg, 5000, s);
+        EXPECT_EQ(st.detected, thresh_g <= kShockG)
+            << "shock threshold " << thresh_g << " g vs " << kShockG << " g event";
+    }
+}
+
+// Likewise the baro-step threshold.
+TEST(DeploymentDetector, BaroStepThreshold_Swept)
+{
+    constexpr float kStepM = 6.0f;
+    for (float thresh_m : {1.0f, 5.0f, 8.0f, 20.0f}) {
+        auto cfg = baseConfig();
+        cfg.baro_step_m = thresh_m;
+        tr::DeploymentState st;
+
+        auto s = coast(50, 300.0f, -5.0f);
+        for (int i = 0; i < 10; ++i) {
+            Sample e;
+            e.acc_ms2   = 40.0f * G;
+            e.palt_m    = 300.0f + kStepM;
+            e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        run(st, cfg, 5000, s);
+        EXPECT_EQ(st.detected, thresh_m <= kStepM)
+            << "baro step threshold " << thresh_m << " m vs " << kStepM << " m event";
+    }
+}
+
+TEST(DeploymentDetector, ShockCount_RequiresConsecutiveSamples)
+{
+    auto cfg = baseConfig();
+    cfg.shock_count = 5;
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int burst = 0; burst < 20; ++burst) {   // 4-on / 1-off, never 5 in a row
+        for (int i = 0; i < 4; ++i) {
+            Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        Sample q; q.acc_ms2 = 1.0f * G; q.palt_m = 320.0f; q.palt_rate = -5.0f;
+        s.push_back(q);
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+// --------------------------------------------------------------------------
+// SLOW path: descent-rate collapse
+// --------------------------------------------------------------------------
+
+TEST(DeploymentDetector, SlowPath_DescentCollapse_Latches)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(2000, 400.0f, -30.0f);              // ballistic drogue-less fall
+    auto under = coast(cfg.canopy_count + 50, 340.0f, -5.0f);   // canopy grabs
+    s.insert(s.end(), under.begin(), under.end());
+
+    const uint32_t fired = run(st, cfg, 5000, s);
+    EXPECT_NE(fired, 0u);
+    EXPECT_EQ(st.reason & tr::kDeployReasonDescentCollapse,
+              tr::kDeployReasonDescentCollapse);
+}
+
+TEST(DeploymentDetector, SlowPath_NeverBallistic_DoesNotLatch)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    // Gentle descent that never reaches ballistic_mps — the collapse test must
+    // stay disarmed even though the rate is below canopy_mps the whole time.
+    auto s = coast(5000, 400.0f, -6.0f);
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.ballistic);
+    EXPECT_FALSE(st.detected);
+}
+
+TEST(DeploymentDetector, SlowPath_BallisticOnly_DoesNotLatch)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(5000, 900.0f, -45.0f);   // still falling fast: no canopy
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_TRUE(st.ballistic);
+    EXPECT_FALSE(st.detected);
+}
+
+TEST(DeploymentDetector, SlowPath_CanopyCount_RequiresSustained)
+{
+    auto cfg = baseConfig();
+    cfg.canopy_count = 300;
+    tr::DeploymentState st;
+
+    auto s = coast(2000, 900.0f, -40.0f);
+    for (int burst = 0; burst < 20; ++burst) {      // 100 ms slow, then fast again
+        auto slow = coast(100, 500.0f, -4.0f);
+        auto fast = coast(50, 500.0f, -40.0f);
+        s.insert(s.end(), slow.begin(), slow.end());
+        s.insert(s.end(), fast.begin(), fast.end());
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+// canopy_count is a real dwell requirement: the same 250 ms of canopy-rate
+// descent latches under a short dwell and does not under a long one.
+TEST(DeploymentDetector, SlowPath_CanopyCount_Swept)
+{
+    constexpr size_t kSlowMs = 250;
+    for (uint16_t dwell : {uint16_t(50), uint16_t(200), uint16_t(400), uint16_t(1000)}) {
+        auto cfg = baseConfig();
+        cfg.canopy_count = dwell;
+        tr::DeploymentState st;
+
+        auto s = coast(1500, 900.0f, -40.0f);
+        auto slow = coast(kSlowMs, 800.0f, -4.0f);
+        s.insert(s.end(), slow.begin(), slow.end());
+
+        run(st, cfg, 5000, s);
+        EXPECT_EQ(st.detected, dwell <= kSlowMs) << "canopy_count=" << dwell;
+    }
+}
+
+// A canopy_count of 0 must still mean "one slow sample", never "fire the
+// instant the ballistic flag arms while still falling at full speed".
+TEST(DeploymentDetector, SlowPath_ZeroCanopyCount_StillNeedsASlowSample)
+{
+    auto cfg = baseConfig();
+    cfg.canopy_count = 0;
+    tr::DeploymentState st;
+
+    auto s = coast(2000, 900.0f, -40.0f);      // ballistic arms, never slows
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_TRUE(st.ballistic);
+    EXPECT_FALSE(st.detected);
+}
+
+// --------------------------------------------------------------------------
+// Gating
+// --------------------------------------------------------------------------
+
+TEST(DeploymentDetector, UnderThrust_NoDetection)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    // Boost: sustained high g and a fast-climbing (noisy) baro, but burnout has
+    // not latched — nothing may fire.
+    std::vector<Sample> s;
+    for (int i = 0; i < 3000; ++i) {
+        Sample e;
+        e.acc_ms2   = 15.0f * G;
+        e.palt_m    = (i % 2 == 0) ? 100.0f + i * 0.2f : 100.0f + i * 0.2f + 10.0f;
+        e.palt_rate = 200.0f;
+        e.burnout   = false;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 0, s), 0u);
+    EXPECT_FALSE(st.detected);
+}
+
+TEST(DeploymentDetector, LaunchLockout_Swept)
+{
+    constexpr uint32_t kEventAtMs = 1500;
+    for (uint32_t lockout : {500u, 1000u, 2000u, 4000u}) {
+        auto cfg = baseConfig();
+        cfg.launch_lockout_ms = lockout;
+        tr::DeploymentState st;
+
+        // Quiet up to kEventAtMs, then an unambiguous ejection signature.
+        auto s = coast(kEventAtMs, 300.0f, -5.0f);
+        for (int i = 0; i < 20; ++i) {
+            Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+            s.push_back(e);
+        }
+        run(st, cfg, 0, s);
+        EXPECT_EQ(st.detected, lockout < kEventAtMs) << "launch_lockout_ms=" << lockout;
+    }
+}
+
+// Boost-phase shock must not carry a partial count across the gate: the very
+// first armed iteration cannot inherit credit earned under thrust.
+TEST(DeploymentDetector, ShockCountDoesNotCarryAcrossTheGate)
+{
+    auto cfg = baseConfig();
+    cfg.shock_count       = 50;
+    cfg.launch_lockout_ms = 100;
+    tr::DeploymentState st;
+
+    std::vector<Sample> s;
+    for (int i = 0; i < 200; ++i) {          // hard shaking, still under thrust
+        Sample e;
+        e.acc_ms2 = 40.0f * G; e.palt_m = 100.0f; e.palt_rate = 100.0f;
+        e.burnout = false;
+        s.push_back(e);
+    }
+    for (int i = 0; i < 49; ++i) {           // burnout: 49 shocks, one short of 50
+        Sample e;
+        e.acc_ms2 = 40.0f * G; e.palt_m = 120.0f; e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 0, s), 0u);
+    EXPECT_FALSE(st.shock_seen);
+    EXPECT_FALSE(st.detected);
+}
+
+// --------------------------------------------------------------------------
+// Latch semantics
+// --------------------------------------------------------------------------
+
+TEST(DeploymentDetector, RisingEdgeFiresExactlyOnce)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int i = 0; i < 2000; ++i) {         // ejection signature held forever
+        Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+
+    int edges = 0;
+    uint32_t t = 5000;
+    for (const Sample& x : s) {
+        if (tr::deploymentDetectStep(st, cfg, t, x.acc_ms2, x.palt_m,
+                                     x.new_baro, x.palt_rate, x.burnout)) {
+            ++edges;
+        }
+        ++t;
+    }
+    EXPECT_EQ(edges, 1);
+    EXPECT_TRUE(st.detected);
+}
+
+TEST(DeploymentDetector, ResetClearsTheLatchForANewFlight)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    auto s = coast(50, 300.0f, -5.0f);
+    for (int i = 0; i < 20; ++i) {
+        Sample e; e.acc_ms2 = 40.0f * G; e.palt_m = 320.0f; e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_NE(run(st, cfg, 5000, s), 0u);
+
+    tr::deploymentReset(st);
+    EXPECT_FALSE(st.detected);
+    EXPECT_EQ(st.reason, 0);
+    EXPECT_EQ(st.detected_ms, 0u);
+    EXPECT_FALSE(st.ballistic);
+    EXPECT_FALSE(st.shock_seen);
+    EXPECT_FALSE(st.baro_step_seen);
+
+    // And it detects again on the next flight.
+    EXPECT_NE(run(st, cfg, 5000, s), 0u);
+}
+
+// A stale baro reading (no fresh sample) must not manufacture a step, and the
+// altitude carried across the lockout must be fresh — otherwise the first
+// armed sample compares against a pad-era altitude and always "steps".
+TEST(DeploymentDetector, NoFreshBaro_NoStep)
+{
+    const auto cfg = baseConfig();
+    tr::DeploymentState st;
+
+    std::vector<Sample> s;
+    for (int i = 0; i < 2000; ++i) {
+        Sample e;
+        e.acc_ms2   = 40.0f * G;
+        e.palt_m    = 300.0f + i;   // would be a huge step if it counted
+        e.new_baro  = false;        // ...but no fresh baro sample ever arrives
+        e.palt_rate = -5.0f;
+        s.push_back(e);
+    }
+    EXPECT_EQ(run(st, cfg, 5000, s), 0u);
+    EXPECT_FALSE(st.baro_step_seen);
+}
+
+TEST(DeploymentDetector, AltitudeDriftDuringLockoutIsNotAStep)
+{
+    auto cfg = baseConfig();
+    cfg.launch_lockout_ms = 1000;
+    tr::DeploymentState st;
+
+    // 0-1000 ms: boost climbs 500 m while locked out. If baro history were only
+    // tracked once armed, the first armed sample would look like a 500 m step.
+    std::vector<Sample> s;
+    float palt = 0.0f;
+    for (int i = 0; i < 1200; ++i) {
+        Sample e;
+        e.acc_ms2   = 40.0f * G;      // shock feature satisfied throughout
+        e.palt_m    = palt;
+        e.palt_rate = 150.0f;
+        e.burnout   = (i >= 900);
+        s.push_back(e);
+        palt += 0.15f;                // 150 m/s, smooth — no real step
+    }
+    EXPECT_EQ(run(st, cfg, 0, s), 0u);
+    EXPECT_FALSE(st.baro_step_seen);
+    EXPECT_FALSE(st.detected);
+}
+
+}  // namespace

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -101,12 +101,14 @@ TEST(RocketComputerTypes, NSF_FlagBits_NoOverlap) {
 TEST(RocketComputerTypes, NSF2_ApogeeFlagBits_NoOverlap) {
     // apogee_flags byte: 3 apogee detector bits + 2 relocated signals
     // (reboot_recovery, guidance_enabled) that used to live in pyro_status,
-    // plus the orientation-mismatch flag (bit 5) and the #474 FC IMU-drop
-    // witness (bit 6).
+    // plus the orientation-mismatch flag (bit 5), the #474 FC IMU-drop
+    // witness (bit 6), and the deployment latch (bit 7).  The byte is now
+    // FULL — a new signal needs a new field, not a bit.
     uint8_t all = NSF2_GPS_APOGEE | NSF2_PITCH_APOGEE | NSF2_MASTER_APOGEE |
                   NSF2_REBOOT_RECOVERY | NSF2_GUIDANCE_ENABLED |
-                  NSF2_ORIENT_THRUST_MISMATCH | NSF2_FC_IMU_DROP;
-    EXPECT_EQ(all, 0x7F);  // bits 0-6 used, none overlapping
+                  NSF2_ORIENT_THRUST_MISMATCH | NSF2_FC_IMU_DROP |
+                  NSF2_DEPLOYED;
+    EXPECT_EQ(all, 0xFF);  // bits 0-7 used, none overlapping
     EXPECT_EQ(__builtin_popcount(NSF2_GPS_APOGEE),            1);
     EXPECT_EQ(__builtin_popcount(NSF2_PITCH_APOGEE),          1);
     EXPECT_EQ(__builtin_popcount(NSF2_MASTER_APOGEE),         1);
@@ -114,6 +116,8 @@ TEST(RocketComputerTypes, NSF2_ApogeeFlagBits_NoOverlap) {
     EXPECT_EQ(__builtin_popcount(NSF2_GUIDANCE_ENABLED),      1);
     EXPECT_EQ(__builtin_popcount(NSF2_ORIENT_THRUST_MISMATCH), 1);
     EXPECT_EQ(__builtin_popcount(NSF2_FC_IMU_DROP),           1);
+    EXPECT_EQ(__builtin_popcount(NSF2_DEPLOYED),              1);
+    EXPECT_EQ(NSF2_DEPLOYED, 1u << 7);
 }
 
 TEST(RocketComputerTypes, PSF_FlagBits_NoOverlap) {
@@ -985,8 +989,55 @@ TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
                             (1u << FlightSettingsData::F_SERVO_ENABLED) |
                             (1u << FlightSettingsData::F_FW_DIRTY) |
                             (1u << FlightSettingsData::F_SOUNDS) |
-                            (1u << FlightSettingsData::F_GUIDANCE_STATION_KEEP));
-    EXPECT_EQ(all, 0x7Fu);  // bits 0-6, no overlap
+                            (1u << FlightSettingsData::F_GUIDANCE_STATION_KEEP) |
+                            (1u << FlightSettingsData::F_IMU_RATE_DYNAMIC));
+    EXPECT_EQ(all, 0xFFu);  // bits 0-7, no overlap — the flags byte is now FULL
+}
+
+// ============================================================================
+// Dynamic IMU logging rate (BLE cmd 67, IMU_RATE_DYNAMIC)
+// ============================================================================
+// The dynamic sentinel rides in the existing 2-byte rate_hz field. Two
+// validators exist on purpose and must NOT be conflated: imuRateValid() gates
+// what may be programmed as a chip ODR, imuRateSettingValid() gates what a
+// user may select.
+TEST(RocketComputerTypes, ImuRate_DynamicSentinel_IsNotAProgrammableOdr) {
+    EXPECT_TRUE(imuRateIsDynamic(IMU_RATE_DYNAMIC));
+    EXPECT_TRUE(imuRateSettingValid(IMU_RATE_DYNAMIC));
+    // Must stay false: SensorCollector::setIsm6Rate() is guarded by this, and
+    // handing it the mode sentinel would try to program a 0 Hz ODR.
+    EXPECT_FALSE(imuRateValid(IMU_RATE_DYNAMIC));
+
+    for (uint16_t hz : IMU_RATE_OPTIONS_HZ) {
+        EXPECT_TRUE(imuRateValid(hz)) << hz;
+        EXPECT_TRUE(imuRateSettingValid(hz)) << hz;
+        EXPECT_FALSE(imuRateIsDynamic(hz)) << hz;
+    }
+
+    for (uint16_t hz : {1u, 500u, 1000u, 4000u, 7680u, 65535u}) {
+        EXPECT_FALSE(imuRateValid((uint16_t)hz)) << hz;
+        EXPECT_FALSE(imuRateSettingValid((uint16_t)hz)) << hz;
+    }
+}
+
+// The dynamic endpoints must be real whitelist steps: the FC programs them
+// straight into the ODR ladder, so a value the chip cannot reach would leave
+// the collector at whatever it was and the mode would silently do nothing.
+TEST(RocketComputerTypes, ImuRate_DynamicEndpoints_AreProgrammable) {
+    EXPECT_TRUE(imuRateValid(IMU_RATE_DYNAMIC_BOOST_HZ));
+    EXPECT_TRUE(imuRateValid(IMU_RATE_DYNAMIC_POST_HZ));
+    EXPECT_GT(IMU_RATE_DYNAMIC_BOOST_HZ, IMU_RATE_DYNAMIC_POST_HZ);
+}
+
+TEST(RocketComputerTypes, ImuRate_Resolve) {
+    // Dynamic: boost rate until deployment latches, post rate after.
+    EXPECT_EQ(imuRateResolve(IMU_RATE_DYNAMIC, false), IMU_RATE_DYNAMIC_BOOST_HZ);
+    EXPECT_EQ(imuRateResolve(IMU_RATE_DYNAMIC, true),  IMU_RATE_DYNAMIC_POST_HZ);
+    // Fixed: the deployment latch must not move the rate.
+    for (uint16_t hz : IMU_RATE_OPTIONS_HZ) {
+        EXPECT_EQ(imuRateResolve(hz, false), hz);
+        EXPECT_EQ(imuRateResolve(hz, true),  hz);
+    }
 }
 
 // ============================================================================

--- a/tinkerrocket-idf/components/TR_KinematicChecks/DeploymentDetector.h
+++ b/tinkerrocket-idf/components/TR_KinematicChecks/DeploymentDetector.h
@@ -1,0 +1,223 @@
+#pragma once
+#include <cstdint>
+
+// Single source of truth for the recovery-DEPLOYMENT detector: the moment the
+// ejection charge fires and the recovery device (drogue on a dual-deploy, main
+// on a single) comes out.  Pure, dependency-free logic — the host unit test
+// (tests_cpp/test_deployment_detector.cpp) exercises the *real* firmware code
+// rather than a hand-copied mirror, same contract as BurnoutDetector.h.
+//
+// This OBSERVES deployment; it never commands it.  Pyro firing stays on the
+// apogee voter in TR_KinematicChecks — a detector that fired the charges it is
+// trying to detect would be a circular trigger.  Current consumer is the
+// dynamic logging rate (IMU_RATE_DYNAMIC): log at 3840 Hz from the pad through
+// boost and coast, step down to 960 Hz once the airframe is under canopy and
+// nothing fast is left to capture.  The latch is exported on the wire as
+// NSF2_DEPLOYED so later features (recovery-phase telemetry cadence, landing
+// prediction hand-off, post-flight event marking) can share one definition.
+//
+// Two independent paths latch it, because they fail in different places:
+//
+//   FAST  (shock + baro step, coincident)
+//         The charge is a near-simultaneous pair: a structural shock on the
+//         accelerometer and an abrupt step in indicated altitude as ejection
+//         gas vents past the static port and the airframe separates.  Fires
+//         within milliseconds, which is what the logging step-down wants.
+//         Requires BOTH — either alone is too easy to fake.  Baro noise is
+//         ~0.1-0.3 m RMS at the BMP585's 500 Hz, and 100 m/s of real motion
+//         moves indicated altitude only ~0.2 m between samples, so a
+//         several-metre step between consecutive samples is not something
+//         flight can produce.
+//
+//   SLOW  (descent-rate collapse)
+//         Descent rate having been ballistic and then holding well below that
+//         for a sustained window is the unambiguous signature of a canopy,
+//         and it survives a charge whose shock or pressure signature the FC
+//         missed.  Costs ~1-2 s of canopy inflation before it fires.
+//
+// Known limits, deliberately not papered over:
+//   * On a single-deploy flight that goes straight to main at apogee, descent
+//     may never reach the ballistic threshold, so the SLOW path never arms and
+//     detection rests on the FAST path.
+//   * On a ballistic (no-deploy) flight the SLOW path fires at ground impact,
+//     where descent rate genuinely does collapse.  Harmless for the logging
+//     step-down; consumers needing a strict "recovery deployed" reading should
+//     stop stepping the detector at LANDED, as the flight loop does.
+
+namespace tr {
+
+// Which path latched, as a bitmask — both may be set if they fire on the same
+// step.  Logged and printed so a post-flight read says WHY, not just when.
+inline constexpr uint8_t kDeployReasonShockBaro       = (1u << 0);
+inline constexpr uint8_t kDeployReasonDescentCollapse = (1u << 1);
+
+// Tunables.  Owned by config::DEPLOY_* on the FC; passed in rather than baked
+// as constants so the host test can sweep them — a suite pinned to one
+// parameter set cannot tell a threshold-dependent invariant from a constant.
+struct DeploymentConfig
+{
+    // FAST path
+    float    shock_ms2;         // |specific force| at or above this = shock
+    uint16_t shock_count;       // consecutive loop iterations required
+    float    baro_step_m;       // |Δ indicated altitude| between consecutive
+                                // baro samples that flight cannot produce
+    uint32_t coincidence_ms;    // shock and baro step must both be this recent
+
+    // SLOW path
+    float    ballistic_mps;     // descent rate that arms the collapse test
+    float    canopy_mps;        // descent rate that counts as "under canopy"
+    uint16_t canopy_count;      // consecutive loop iterations required
+
+    // Both paths
+    uint32_t launch_lockout_ms; // no detection this soon after launch
+};
+
+// Caller-owned state; persists across calls for one flight.  Reset it for a
+// new flight (deploymentReset) — the latch is per-flight, like burnout.
+struct DeploymentState
+{
+    bool     detected    = false;
+    uint32_t detected_ms = 0;    // t_since_launch_ms at the latch
+    uint8_t  reason      = 0;    // kDeployReason* bitmask
+
+    // FAST path
+    uint16_t shock_count  = 0;
+    bool     shock_seen   = false;
+    uint32_t shock_ms     = 0;
+    bool     baro_step_seen = false;
+    uint32_t baro_step_ms = 0;
+
+    // Baro tracking runs even while locked out, so the first armed sample
+    // compares against a fresh altitude instead of a stale one.
+    bool     have_palt   = false;
+    float    last_palt_m = 0.0f;
+
+    // SLOW path
+    bool     ballistic    = false;
+    uint16_t canopy_count = 0;
+};
+
+inline void deploymentReset(DeploymentState& st) { st = DeploymentState{}; }
+
+// Advance the detector by one flight-loop iteration.
+//
+//   st, cfg           : caller-owned state and tunables.
+//   t_since_launch_ms : milliseconds since launch was latched.
+//   acc_mag_ms2       : |specific force| (m/s^2) — the flight loop's
+//                       accel_norm, which auto-switches to the high-g channel
+//                       near low-g saturation, so an ejection shock is
+//                       measured rather than clipped.
+//   palt_m, new_baro  : RAW pressure altitude and whether this iteration
+//                       carries a fresh baro sample.  Raw on purpose: the
+//                       rate gate inside TR_KinematicChecks exists precisely
+//                       to swallow ejection spikes, which is the signal here.
+//   palt_rate_mps     : filtered altitude rate (negative = descending).
+//   burnout_detected  : motor cutoff latched.  Gates both paths — under thrust
+//                       the airframe is already shaking and climbing, and
+//                       nothing has deployed.
+//
+// Counts are in flight-loop iterations (~1 kHz), not IMU samples, matching
+// LANDING_IMPACT_COUNT in TR_KinematicChecks — the loop calls this once per
+// pass no matter what ODR the IMU is running.
+//
+// Returns true exactly once, on the rising edge that latches deployment, so
+// the caller can stamp the time and act.  A no-op returning false thereafter.
+inline bool deploymentDetectStep(DeploymentState& st, const DeploymentConfig& cfg,
+                                 uint32_t t_since_launch_ms,
+                                 float acc_mag_ms2,
+                                 float palt_m, bool new_baro,
+                                 float palt_rate_mps,
+                                 bool burnout_detected)
+{
+    if (st.detected) return false;
+
+    // Baro history tracks unconditionally; only the verdict is gated.
+    float baro_step = 0.0f;
+    bool  have_step = false;
+    if (new_baro)
+    {
+        if (st.have_palt)
+        {
+            baro_step = palt_m - st.last_palt_m;
+            have_step = true;
+        }
+        st.last_palt_m = palt_m;
+        st.have_palt   = true;
+    }
+
+    if (!burnout_detected || t_since_launch_ms <= cfg.launch_lockout_ms)
+    {
+        // Under thrust / just off the pad: hold the transient counters at zero
+        // so boost vibration cannot carry a partial count into the live window.
+        st.shock_count = 0;
+        return false;
+    }
+
+    // --- FAST path feature 1: structural shock ---
+    if (acc_mag_ms2 >= cfg.shock_ms2)
+    {
+        if (++st.shock_count >= cfg.shock_count)
+        {
+            st.shock_seen = true;
+            st.shock_ms   = t_since_launch_ms;
+        }
+    }
+    else
+    {
+        st.shock_count = 0;
+    }
+
+    // --- FAST path feature 2: baro step ---
+    if (have_step)
+    {
+        const float mag = (baro_step < 0.0f) ? -baro_step : baro_step;
+        if (mag >= cfg.baro_step_m)
+        {
+            st.baro_step_seen = true;
+            st.baro_step_ms   = t_since_launch_ms;
+        }
+    }
+
+    // --- SLOW path: descent-rate collapse ---
+    if (palt_rate_mps <= -cfg.ballistic_mps)
+    {
+        st.ballistic = true;
+    }
+    if (st.ballistic)
+    {
+        if (palt_rate_mps > -cfg.canopy_mps)
+        {
+            if (st.canopy_count < 0xFFFFu) st.canopy_count++;
+        }
+        else
+        {
+            st.canopy_count = 0;
+        }
+    }
+
+    uint8_t reason = 0;
+    if (st.shock_seen && st.baro_step_seen &&
+        (t_since_launch_ms - st.shock_ms)    <= cfg.coincidence_ms &&
+        (t_since_launch_ms - st.baro_step_ms) <= cfg.coincidence_ms)
+    {
+        reason |= kDeployReasonShockBaro;
+    }
+    // canopy_count > 0 is required independently of the configured threshold:
+    // a threshold of 0 must still mean "one slow sample", never "fires the
+    // instant the ballistic flag arms, while still falling at full speed".
+    if (st.ballistic && st.canopy_count > 0 && st.canopy_count >= cfg.canopy_count)
+    {
+        reason |= kDeployReasonDescentCollapse;
+    }
+
+    if (reason != 0)
+    {
+        st.detected    = true;
+        st.detected_ms = t_since_launch_ms;
+        st.reason      = reason;
+        return true;
+    }
+    return false;
+}
+
+} // namespace tr

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1441,6 +1441,14 @@ static constexpr uint8_t NSF2_ORIENT_THRUST_MISMATCH = (1u << 5);
 // instead of vanishing with no counter.  Post-flight witness; the app ignores
 // this bit.  Pairs with the deepened ISM6_QUEUE_DEPTH that should keep it clear.
 static constexpr uint8_t NSF2_FC_IMU_DROP = (1u << 6);
+// Recovery deployment detected this flight (tr::deploymentDetectStep).  Sticky
+// once latched, cleared only by a new flight.  Drives the dynamic logging-rate
+// step-down (IMU_RATE_DYNAMIC) and is the post-flight witness for WHEN the
+// detector fired — the .bin timestamps the first frame carrying this bit, so
+// the detector can be scored against the actual ejection signature without
+// re-running anything.  Deliberately a telemetry bit and not a pyro output:
+// this observes deployment, it does not command it.
+static constexpr uint8_t NSF2_DEPLOYED = (1u << 7);
 
 // Pyro status byte — 4 channels × (continuity, fired) = exactly 8 bits.
 static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);
@@ -1992,12 +2000,39 @@ static_assert(sizeof(ImuOrientConfigData) == 1, "ImuOrientConfigData must be 1 b
 
 // IMU logging rate setting (IMU_RATE_CONFIG_MSG payload).
 static constexpr uint16_t IMU_RATE_OPTIONS_HZ[] = {960, 1920, 3840};
+
+// DYNAMIC logging rate (the default).  Sent as a sentinel in the SAME 2-byte
+// rate_hz field rather than a wider struct: growing ImuRateConfigData would
+// ripple the OC/FC config frame, the BLE cmd-67 length check, and every wire
+// test for one extra mode.  0 is the safe choice for the sentinel — firmware
+// predating dynamic mode rejects it (imuRateValid(0) == false) and keeps the
+// rate it already had, instead of silently reading it as some other ODR.
+//
+// In dynamic mode the FC logs at BOOST_HZ from the pad through boost and
+// coast, then drops to POST_HZ the moment the deployment detector latches
+// (tr::deploymentDetectStep, TR_KinematicChecks/DeploymentDetector.h).  The
+// two steps are the ODR-ladder rungs nearest the intended 4 kHz / 1 kHz —
+// the ISM6HG256 has no 4000/1000 Hz step — and are exactly the endpoints of
+// the fixed whitelist above, so dynamic adds no new link-budget case.
+//
+// Boost rate runs from the pad (not from launch detect) deliberately: an ODR
+// switch is staged for the poll task and takes effect on the next DRDY, so
+// arming the change AT launch would sample the first milliseconds of boost —
+// the highest-jerk part of the flight — at the low rate.  Pad dwell costs no
+// flash because pre-launch data lives in the OC's pre-launch ring.
+static constexpr uint16_t IMU_RATE_DYNAMIC          = 0;
+static constexpr uint16_t IMU_RATE_DYNAMIC_BOOST_HZ = 3840;  // pad → deployment
+static constexpr uint16_t IMU_RATE_DYNAMIC_POST_HZ  = 960;   // deployment → landing
+
 typedef struct __attribute__((packed))
 {
-    uint16_t rate_hz;  // one of IMU_RATE_OPTIONS_HZ
+    uint16_t rate_hz;  // IMU_RATE_DYNAMIC or one of IMU_RATE_OPTIONS_HZ
 } ImuRateConfigData;
 static_assert(sizeof(ImuRateConfigData) == 2, "ImuRateConfigData must be 2 bytes");
 
+// True for a FIXED ODR the chip can be programmed to. Deliberately excludes
+// the dynamic sentinel: callers that hand a rate straight to the hardware
+// (SensorCollector::setIsm6Rate) must never be given a mode value.
 inline bool imuRateValid(uint16_t hz)
 {
     for (uint16_t opt : IMU_RATE_OPTIONS_HZ)
@@ -2005,6 +2040,24 @@ inline bool imuRateValid(uint16_t hz)
         if (hz == opt) return true;
     }
     return false;
+}
+
+inline bool imuRateIsDynamic(uint16_t hz) { return hz == IMU_RATE_DYNAMIC; }
+
+// True for any valid user SETTING — dynamic or a fixed step. This is what the
+// BLE/config intake validates against; imuRateValid() is what the ODR
+// programming path validates against.
+inline bool imuRateSettingValid(uint16_t hz)
+{
+    return imuRateIsDynamic(hz) || imuRateValid(hz);
+}
+
+// The ODR a setting resolves to right now. `deployed` is the FC's latched
+// deployment flag for the current flight; it is ignored for a fixed setting.
+inline uint16_t imuRateResolve(uint16_t setting_hz, bool deployed)
+{
+    if (!imuRateIsDynamic(setting_hz)) return setting_hz;
+    return deployed ? IMU_RATE_DYNAMIC_POST_HZ : IMU_RATE_DYNAMIC_BOOST_HZ;
 }
 
 // Pyro trigger modes
@@ -2278,6 +2331,11 @@ struct __attribute__((packed)) FlightSettingsData
     //  bumping it would force a sweep of the Data_Analysis parsers, which
     //  hardcode message lengths, for a bit that older readers already ignore.)
     // v6: appended the flown guidance target (guid_tgt_* tail, #435).
+    // (no version bump for the dynamic logging rate: F_IMU_RATE_DYNAMIC claims
+    //  the last free flags bit, bit 7. Layout is byte-identical — same reasoning
+    //  as F_GUIDANCE_STATION_KEEP above; older readers ignore the bit and read
+    //  ism6_update_rate_hz as the flown rate, which is exactly what it is up to
+    //  the deployment step-down.)
     static constexpr uint8_t VERSION = 6;
 
     // flags bit positions
@@ -2289,6 +2347,12 @@ struct __attribute__((packed)) FlightSettingsData
     static constexpr uint8_t F_SOUNDS            = 5;  // piezo sounds enabled
     static constexpr uint8_t F_GUIDANCE_STATION_KEEP = 6;  // guidance law: 1 = station-keep, 0 = PN
                                                            // (meaningful only when F_GUIDANCE set)
+    static constexpr uint8_t F_IMU_RATE_DYNAMIC      = 7;  // logging rate was DYNAMIC, not fixed:
+                                                           // ism6_update_rate_hz below is the rate
+                                                           // at the snapshot (the boost rate), and
+                                                           // the log steps down to
+                                                           // IMU_RATE_DYNAMIC_POST_HZ at the frame
+                                                           // that first carries NSF2_DEPLOYED
 
     uint32_t time_us;            // micros() at snapshot
     uint8_t  version;            // = VERSION

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1448,7 +1448,7 @@ static constexpr uint8_t NSF2_FC_IMU_DROP = (1u << 6);
 // the detector can be scored against the actual ejection signature without
 // re-running anything.  Deliberately a telemetry bit and not a pyro output:
 // this observes deployment, it does not command it.
-static constexpr uint8_t NSF2_DEPLOYED = (1u << 7);
+static constexpr uint8_t NSF2_DEPLOYED = (1u << 7);  // recovery deployment detected (sticky)
 
 // Pyro status byte — 4 channels × (continuity, fired) = exactly 8 bits.
 static constexpr uint8_t PSF_CH1_CONT  = (1u << 0);

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -38,9 +38,15 @@ struct config : board_pins
     // MMC5983MA hardware supports 1/10/20/50/100/200/1000 Hz only.
     // 200 Hz is the highest step that fits within I2C budget.
     static constexpr uint16_t MMC5983MA_UPDATE_RATE = 200;
-    // DEFAULT IMU logging rate — the user can select 960/1920/3840 Hz from
-    // the app (BLE cmd 67); the FC persists the choice in NVS ("imu"/"rate")
-    // and stages it into the collector before begin().  The poll task's
+    // Collector-construction IMU rate.  No longer the effective default: the
+    // shipped default setting is IMU_RATE_DYNAMIC (3840 Hz to deployment, then
+    // 960 Hz), which setup() stages over this value before begin().  This
+    // constant is what the collector is built with and the fallback the NVS
+    // whitelist logs against.  The user can also select a FIXED 960/1920/3840
+    // Hz from the app (BLE cmd 67); the FC persists the choice in NVS
+    // ("imu"/"rate") and stages it into the collector before begin().  The
+    // link budget below is unchanged — dynamic only ever runs at the 3840 and
+    // 960 endpoints already covered here.  The poll task's
     // handoff queue + the loop's drain-all consumption log EVERY sample
     // regardless of loop rate (~980/s); control/EKF/guidance still consume
     // the freshest sample at loop rate.  Link budget on the 44100 Hz I2S
@@ -406,6 +412,45 @@ struct config : board_pins
     // drop body_ax below zero during boost, short enough to catch real
     // motor cutoff within one PN coast delay tick. See issue #197.
     static constexpr uint16_t BURNOUT_NEG_HYSTERESIS = 50;
+
+    // ### Deployment Detection ###
+    // Tunables for tr::deploymentDetectStep (TR_KinematicChecks/
+    // DeploymentDetector.h) — see that header for what each path measures and
+    // where it fails.  Counts are FLIGHT-LOOP TICKS (~1 kHz), same convention
+    // as BURNOUT_NEG_HYSTERESIS above and LANDING_IMPACT_COUNT in
+    // TR_KinematicChecks: the loop steps the detector once per pass no matter
+    // what ODR the IMU is logging at.
+    //
+    // FAST path — the ejection charge's two coincident signatures.
+    // 8 g: post-burnout coast decel is ~1-2 g on the motors we fly and never
+    // exceeds ~12 g even in a descent tumble (the LANDING_IMPACT_G rationale),
+    // while an ejection charge and canopy snap read tens of g. accel_norm
+    // switches to the high-g channel near low-g saturation, so the shock is
+    // measured, not clipped.
+    static constexpr float    DEPLOY_SHOCK_G          = 8.0f;
+    static constexpr float    DEPLOY_SHOCK_MS2        = DEPLOY_SHOCK_G * 9.80665f;
+    static constexpr uint16_t DEPLOY_SHOCK_COUNT      = 3;      // ~3 ms
+    // 3 m between consecutive BMP585 samples (500 Hz, ~0.1-0.3 m RMS noise).
+    // Real motion moves indicated altitude ~0.2 m per sample even at 100 m/s,
+    // so this is ~10 sigma of noise and an order of magnitude past flight.
+    static constexpr float    DEPLOY_BARO_STEP_M      = 3.0f;
+    // Shock and baro step must both be this recent. Wide enough to also catch
+    // the case where the FC sees the pressure spike at the charge but the
+    // acceleration only at canopy inflation a fraction of a second later.
+    static constexpr uint32_t DEPLOY_COINCIDENCE_MS   = 250;
+    //
+    // SLOW path — descent-rate collapse (the canopy signature).
+    // Arm above 18 m/s, confirm sustained below 10 m/s. Drogue descent runs
+    // 25-30 m/s and a main 5-7 m/s, so the gap is wide; the 200 ms dwell
+    // rejects the momentary rate wobble at inflation.
+    static constexpr float    DEPLOY_BALLISTIC_MPS    = 18.0f;
+    static constexpr float    DEPLOY_CANOPY_MPS       = 10.0f;
+    static constexpr uint16_t DEPLOY_CANOPY_COUNT     = 200;    // ~200 ms
+    //
+    // No detection this soon after launch, on top of the burnout gate. Covers
+    // a short-burn motor whose burnout latches while the airframe is still in
+    // the high-vibration part of the flight.
+    static constexpr uint32_t DEPLOY_LAUNCH_LOCKOUT_MS = 1000;
 
     // ### Ground Test ###
     // Attitude-hold gain: virtual accel command per unit tilt (m/s² per rad)

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -18,6 +18,7 @@
 #include <TR_GeoMag.h>
 #include <TR_KinematicChecks.h>
 #include <BurnoutDetector.h>      // shared burnout detector (#197/#256)
+#include <DeploymentDetector.h>   // shared recovery-deployment detector
 #include <TR_MagCalibrator.h>
 #include <TR_ServoControl_ledc_mult.h>
 #include <TR_GuidancePN.h>
@@ -459,6 +460,29 @@ static uint32_t burnout_time_ms = 0;
 // single-sample noise / vibration / wind dips from latching the flag
 // prematurely; require N consecutive negative body_ax samples first.
 static uint16_t burnout_neg_count = 0;
+
+// --- Recovery deployment detection + dynamic logging rate ---
+// The user's logging-rate SETTING (BLE cmd 67, persisted in NVS "imu"/"rate").
+// IMU_RATE_DYNAMIC means "let the flight drive it"; anything else is a fixed
+// ODR.  Kept separate from the collector's live rate on purpose: in dynamic
+// mode the live rate changes mid-flight, and the setting must not.
+static uint16_t imu_rate_setting = IMU_RATE_DYNAMIC;
+static tr::DeploymentState deployment_state;
+// Sticky per-flight latch mirroring deployment_state.detected, for the
+// telemetry bit and the rate step-down.  Cleared wherever burnout is cleared.
+static bool     deployment_detected = false;
+static uint32_t deployment_time_ms  = 0;
+
+// Put the collector on the ODR the current setting resolves to. Called on the
+// deployment edge, at every new-flight reset, and when the setting changes.
+// Cheap and idempotent: setIsm6Rate stages for the poll task, and re-staging
+// the rate already running is a no-op the task applies and forgets.
+static void applyImuRateForFlightPhase()
+{
+    const uint16_t hz = imuRateResolve(imu_rate_setting, deployment_detected);
+    if (hz != sensor_collector_hw.ism6Rate()) sensor_collector_hw.setIsm6Rate(hz);
+}
+
 static bool mach_locked_out = false;    // promoted from baro block for apogee voting
 static bool gps_new_for_kc = false;     // new GPS sample available for kinematic checks
 static bool guidance_active = false;
@@ -1765,6 +1789,14 @@ static void buildFlightSettings(FlightSettingsData& s)
     s.ism6_high_g_fs_g = config::ISM6_HIGH_G_FS_G;
     s.ism6_gyro_fs_dps = config::ISM6_GYRO_FS_DPS;
     s.ism6_update_rate_hz = sensor_collector_hw.ism6Rate();  // live (v5+)
+    // Dynamic mode: the rate above is the live one at the snapshot (taken at
+    // launch, so the boost rate). The log steps down to
+    // IMU_RATE_DYNAMIC_POST_HZ at the first frame carrying NSF2_DEPLOYED —
+    // this flag tells a reader to expect that step instead of one fixed rate.
+    if (imuRateIsDynamic(imu_rate_setting))
+    {
+        s.flags |= (uint8_t)(1u << FlightSettingsData::F_IMU_RATE_DYNAMIC);
+    }
 
     // Servo trim + timing (live values from servo_control).
     for (int i = 0; i < 4; ++i) {
@@ -2780,23 +2812,44 @@ static void setup_fc()
                   (double)fin_az[0], (double)fin_az[1], (double)fin_az[2], (double)fin_az[3],
                   (unsigned)fin_rev, (unsigned)fin_rrev);
 
-    // Restore the user-selected IMU logging rate (BLE cmd 67, namespace
-    // "imu").  Staged into the collector BEFORE sensor_collector.begin()
-    // below, which programs the chip ODR from it.  Whitelist on read so a
-    // corrupted NVS value can't run the IMU at an unplanned rate.
+    // Restore the user-selected IMU logging rate setting (BLE cmd 67,
+    // namespace "imu").  Staged into the collector BEFORE
+    // sensor_collector.begin() below, which programs the chip ODR from it.
+    // Whitelist on read so a corrupted NVS value can't run the IMU at an
+    // unplanned rate.
+    //
+    // A boot always starts pre-deployment, so DYNAMIC resolves to the boost
+    // rate here.  That includes a mid-flight reboot recovery: re-entering a
+    // descent under canopy at the boost rate costs some flash and self-corrects
+    // only if the detector fires again, which it may not have signal for — an
+    // acceptable trade against the alternative of guessing the airframe is
+    // already deployed and logging a boost at 960 Hz.
     prefs.begin("imu", false);
     if (prefs.isKey("rate"))
     {
         const uint16_t nvs_rate = prefs.getUShort("rate", config::ISM6HG256_UPDATE_RATE);
-        if (imuRateValid(nvs_rate))
+        if (imuRateSettingValid(nvs_rate))
         {
-            sensor_collector_hw.setIsm6Rate(nvs_rate);
-            ESP_LOGI(TAG, "NVS IMU logging rate: %u Hz", (unsigned)nvs_rate);
+            imu_rate_setting = nvs_rate;
         }
         else
         {
-            ESP_LOGW(TAG, "NVS IMU logging rate %u invalid — using default %u",
-                     (unsigned)nvs_rate, (unsigned)config::ISM6HG256_UPDATE_RATE);
+            ESP_LOGW(TAG, "NVS IMU logging rate %u invalid — using default",
+                     (unsigned)nvs_rate);
+        }
+    }
+    {
+        const uint16_t boot_hz = imuRateResolve(imu_rate_setting, /*deployed=*/false);
+        sensor_collector_hw.setIsm6Rate(boot_hz);
+        if (imuRateIsDynamic(imu_rate_setting))
+        {
+            ESP_LOGI(TAG, "IMU logging rate: DYNAMIC (%u Hz to deployment, then %u Hz)",
+                     (unsigned)IMU_RATE_DYNAMIC_BOOST_HZ,
+                     (unsigned)IMU_RATE_DYNAMIC_POST_HZ);
+        }
+        else
+        {
+            ESP_LOGI(TAG, "IMU logging rate: %u Hz (fixed)", (unsigned)boot_hz);
         }
     }
     prefs.end();
@@ -3385,6 +3438,14 @@ static void resetFlightStateForSim(const char* edge)
     burnout_detected = false;
     burnout_time_ms = 0;
     burnout_neg_count = 0;
+    // Deployment is a per-flight latch like burnout. Clearing it also puts a
+    // dynamic logging rate back to the boost rate for the new flight — without
+    // this, a second flight in one boot would log its whole boost at the
+    // post-deployment rate.
+    tr::deploymentReset(deployment_state);
+    deployment_detected = false;
+    deployment_time_ms  = 0;
+    applyImuRateForFlightPhase();
     guidance_active = false;
     reboot_recovery = false;
     reboot_recovery_telem = false;
@@ -3524,6 +3585,14 @@ static void enterInflight(uint32_t now_ms, const char* from_state)
     burnout_detected = false;
     burnout_time_ms = 0;
     burnout_neg_count = 0;
+    // Deployment is a per-flight latch like burnout. Clearing it also puts a
+    // dynamic logging rate back to the boost rate for the new flight — without
+    // this, a second flight in one boot would log its whole boost at the
+    // post-deployment rate.
+    tr::deploymentReset(deployment_state);
+    deployment_detected = false;
+    deployment_time_ms  = 0;
+    applyImuRateForFlightPhase();
     guidance_active = false;
     guidance_tilt_inhibited = false;   // clear tilt-limit latch
     // Reset pyro channels on launch. ARM stays LOW until a
@@ -4923,6 +4992,9 @@ static void loop_fc()
                     kinematics.reset();
                     burnout_detected = false;
                     burnout_neg_count = 0;
+                    tr::deploymentReset(deployment_state);
+                    deployment_detected = false;
+                    deployment_time_ms  = 0;
                 }
             }
             else if (out_pending_command == MAG_CAL_ABORT)
@@ -5521,23 +5593,36 @@ static void loop_fc()
                     {
                         // Never mid-flight: the ODR switch produces one
                         // odd-length inter-sample gap and changes the log
-                        // cadence — fine on the pad, not during boost.
+                        // cadence — fine on the pad, not during boost.  This
+                        // guard is for the USER setting only; the dynamic
+                        // mode's own step-down at deployment is deliberate and
+                        // runs from the flight loop, not through here.
                         ESP_LOGW(TAG, "[CFG] IMU rate change ignored INFLIGHT");
                     }
-                    else if (imuRateValid(rate_hz))
+                    else if (imuRateSettingValid(rate_hz))
                     {
-                        if (sensor_collector_hw.setIsm6Rate(rate_hz))
+                        imu_rate_setting = rate_hz;
+                        applyImuRateForFlightPhase();
+                        prefs.begin("imu", false);
+                        prefs.putUShort("rate", rate_hz);
+                        prefs.end();
+                        if (imuRateIsDynamic(rate_hz))
                         {
-                            prefs.begin("imu", false);
-                            prefs.putUShort("rate", rate_hz);
-                            prefs.end();
+                            ESP_LOGI(TAG, "[CFG] IMU logging rate: DYNAMIC "
+                                          "(%u Hz to deployment, then %u Hz) (persisted)",
+                                     (unsigned)IMU_RATE_DYNAMIC_BOOST_HZ,
+                                     (unsigned)IMU_RATE_DYNAMIC_POST_HZ);
+                        }
+                        else
+                        {
                             ESP_LOGI(TAG, "[CFG] IMU logging rate: %u Hz (persisted)",
                                      (unsigned)rate_hz);
                         }
                     }
                     else
                     {
-                        ESP_LOGW(TAG, "[CFG] IMU rate %u Hz rejected (not 960/1920/3840)",
+                        ESP_LOGW(TAG, "[CFG] IMU rate %u Hz rejected "
+                                      "(not dynamic/960/1920/3840)",
                                  (unsigned)rate_hz);
                     }
                 }
@@ -6162,6 +6247,54 @@ static void loop_fc()
                                        (float)gnss_latest_si.vel_u,
                                        ekf_healthy,
                                        baro_healthy);
+
+            // --- Recovery deployment detection ---
+            // Stepped from the same block, once per loop pass, on the same
+            // inputs — but with the RAW pressure altitude rather than the
+            // filtered estimate: the rate gate inside kinematicChecks exists
+            // to swallow ejection spikes, which are exactly the signal here.
+            // Runs only INFLIGHT: on the ground the descent-collapse path
+            // would read a stationary airframe as a canopy, and post-landing
+            // the latch would be meaningless.
+            if (rocket_state == INFLIGHT && !kinematics.alt_landed_flag)
+            {
+                static constexpr tr::DeploymentConfig kDeployCfg = {
+                    config::DEPLOY_SHOCK_MS2,
+                    config::DEPLOY_SHOCK_COUNT,
+                    config::DEPLOY_BARO_STEP_M,
+                    config::DEPLOY_COINCIDENCE_MS,
+                    config::DEPLOY_BALLISTIC_MPS,
+                    config::DEPLOY_CANOPY_MPS,
+                    config::DEPLOY_CANOPY_COUNT,
+                    config::DEPLOY_LAUNCH_LOCKOUT_MS,
+                };
+                const uint32_t t_since_launch = now_ms - launch_time_millis;
+                if (tr::deploymentDetectStep(deployment_state, kDeployCfg,
+                                             t_since_launch, accel_norm,
+                                             pressure_altitude_m, bmp_new_for_kf,
+                                             kinematics.d_alt_est_,
+                                             burnout_detected))
+                {
+                    deployment_detected = true;
+                    deployment_time_ms  = now_ms;
+                    ESP_LOGI(TAG, "[DEPLOY] detected T+%.2f s (reason %s%s), alt %.0f m",
+                             t_since_launch / 1000.0f,
+                             (deployment_state.reason & tr::kDeployReasonShockBaro)
+                                 ? "shock+baro " : "",
+                             (deployment_state.reason & tr::kDeployReasonDescentCollapse)
+                                 ? "descent-collapse" : "",
+                             (double)kinematics.alt_est);
+                    // Dynamic logging rate: nothing fast is left to capture
+                    // under canopy, so step the ODR down. A no-op for a fixed
+                    // rate setting.
+                    if (imuRateIsDynamic(imu_rate_setting))
+                    {
+                        applyImuRateForFlightPhase();
+                        ESP_LOGI(TAG, "[DEPLOY] IMU logging rate -> %u Hz (dynamic)",
+                                 (unsigned)IMU_RATE_DYNAMIC_POST_HZ);
+                    }
+                }
+            }
         }
         bmp_new_for_kf = false;
         gps_new_for_kc = false;
@@ -6940,6 +7073,7 @@ static void loop_fc()
         if (reboot_recovery_telem)        non_sensor_data.apogee_flags |= NSF2_REBOOT_RECOVERY;
         if (guidance_enabled)             non_sensor_data.apogee_flags |= NSF2_GUIDANCE_ENABLED;
         if (orient_thrust_mismatch)       non_sensor_data.apogee_flags |= NSF2_ORIENT_THRUST_MISMATCH;
+        if (deployment_detected)          non_sensor_data.apogee_flags |= NSF2_DEPLOYED;
         // #474: sticky witness for a stalled sensor loop.  Nonzero drops mean
         // loop_fc() blocked long enough (an I2C poll/config-read) to overflow the
         // ISM6 handoff queue and lose IMU samples — the previously-silent all-

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -834,7 +834,9 @@ static void stageImuOrientConfig()
 // IMU logging rate setting (BLE cmd 67).  Cached here for app readback and
 // re-push on connect; the FC persists it in its own NVS and re-applies at
 // boot, so no status-query self-heal is needed (unlike orientation).
-static uint16_t cfg_imu_rate = 1920;
+// IMU_RATE_DYNAMIC (the default) is a MODE, not a rate — the OC only relays
+// it; the step-down at deployment is entirely the FC's business.
+static uint16_t cfg_imu_rate = IMU_RATE_DYNAMIC;
 
 static void stageImuRateConfig()
 {
@@ -5579,9 +5581,19 @@ void initPeripherals()
         // Load cached IMU logging rate.  Readback/cache only — the FC owns
         // application (its own NVS survives FC reboots independently).
         prefs.begin("imurate", false);
-        cfg_imu_rate = prefs.getUShort("hz", cfg_imu_rate);
+        {
+            const uint16_t nvs_rate = prefs.getUShort("hz", cfg_imu_rate);
+            // Whitelist on read: a corrupted value must not be relayed to the
+            // FC or echoed to the app as if it were a real setting.
+            if (imuRateSettingValid(nvs_rate)) cfg_imu_rate = nvs_rate;
+            else ESP_LOGW("CFG", "NVS IMU logging rate %u invalid — keeping default",
+                          (unsigned)nvs_rate);
+        }
         prefs.end();
-        ESP_LOGI("CFG", "NVS IMU logging rate: %u Hz", (unsigned)cfg_imu_rate);
+        if (imuRateIsDynamic(cfg_imu_rate))
+            ESP_LOGI("CFG", "NVS IMU logging rate: DYNAMIC");
+        else
+            ESP_LOGI("CFG", "NVS IMU logging rate: %u Hz", (unsigned)cfg_imu_rate);
 
         // Load cached pyro config from NVS (4 channels)
         prefs.begin("pyro", true);
@@ -7245,16 +7257,17 @@ static void loop_oc()
         }
         else if (ble_cmd == 67)
         {
-            // IMU logging rate: [rate_hz:2 LE] — whitelisted ISM6HG256 ODR
-            // (960/1920/3840).  Relayed to the FC, which applies the ODR
-            // live (except INFLIGHT) and persists it in FC NVS.
+            // IMU logging rate: [rate_hz:2 LE] — IMU_RATE_DYNAMIC (0) or a
+            // whitelisted ISM6HG256 ODR (960/1920/3840).  Relayed to the FC,
+            // which applies the ODR live (except INFLIGHT) and persists it in
+            // FC NVS.
             const uint8_t* payload = ble_app.getCommandPayload();
             const size_t plen = ble_app.getCommandPayloadLength();
             if (plen >= 2)
             {
                 uint16_t rate_hz;
                 memcpy(&rate_hz, payload, sizeof(rate_hz));
-                if (imuRateValid(rate_hz))
+                if (imuRateSettingValid(rate_hz))
                 {
                     cfg_imu_rate = rate_hz;
                     stageImuRateConfig();
@@ -7262,12 +7275,20 @@ static void loop_oc()
                     p2.begin("imurate", false);
                     p2.putUShort("hz", cfg_imu_rate);
                     p2.end();
-                    ESP_LOGI("BLE", "IMU logging rate: %u Hz -> FlightComputer",
-                             (unsigned)cfg_imu_rate);
+                    if (imuRateIsDynamic(rate_hz))
+                    {
+                        ESP_LOGI("BLE", "IMU logging rate: DYNAMIC -> FlightComputer");
+                    }
+                    else
+                    {
+                        ESP_LOGI("BLE", "IMU logging rate: %u Hz -> FlightComputer",
+                                 (unsigned)cfg_imu_rate);
+                    }
                 }
                 else
                 {
-                    ESP_LOGW("BLE", "IMU logging rate %u Hz rejected (not 960/1920/3840)",
+                    ESP_LOGW("BLE", "IMU logging rate %u Hz rejected "
+                                    "(not dynamic/960/1920/3840)",
                              (unsigned)rate_hz);
                 }
             }


### PR DESCRIPTION
Adds a **Dynamic** IMU logging rate and makes it the default: log at 3840 Hz from the pad through boost and coast, then step down to 960 Hz once the recovery device is out. Those are the ODR-ladder rungs nearest the intended 4 kHz / 1 kHz — the ISM6HG256 has no 4000 or 1000 Hz step — and are already the endpoints of the fixed whitelist, so dynamic introduces no new link-budget case.

## The detector

`TR_KinematicChecks/DeploymentDetector.h` is pure and dependency-free in the same shape as `BurnoutDetector.h`, so the host test and the replay tool drive the shipping code rather than a mirror. Two paths latch it, because they fail in different places:

- **Fast** — a coincident acceleration shock **and** an abrupt indicated-altitude step, the ejection charge's two simultaneous signatures. Fires in milliseconds. Requires both; either alone is too easy to fake. Reads the *raw* pressure altitude, since the rate gate inside `kinematicChecks` exists precisely to swallow ejection spikes.
- **Slow** — descent-rate collapse, the canopy signature ~1–2 s later, which survives a charge whose shock or pressure trace the FC missed.

It observes deployment and never commands it — pyro firing stays on the apogee voter. The latch ships as `NSF2_DEPLOYED` so later features can share one definition.

Two limits are documented in the header rather than papered over: on a single-deploy flight straight to main at apogee the slow path may never arm, and on a ballistic no-deploy flight it fires at ground impact — which is why the flight loop stops stepping the detector at landing.

## Design notes

- The mode rides as a sentinel in the existing 2-byte `rate_hz` field rather than a wider struct. `0` is chosen so firmware predating dynamic mode rejects it and keeps the rate it had.
- Boost rate starts on the pad, not at launch detect: an ODR change is staged for the poll task and lands on the next DRDY, so arming it *at* launch would sample the highest-jerk part of the flight at the low rate. Pad dwell costs no flash — pre-launch data lives in the OC's ring.
- A mid-flight reboot comes back at the boost rate, since a boot always starts pre-deployment.
- `NSF2_DEPLOYED` and `FlightSettingsData::F_IMU_RATE_DYNAMIC` each claim their byte's last free bit. Layout is unchanged, so `FlightSettingsData` stays v6 and older parsers are unaffected.

## Validation against a real flight

`Data_Analysis/replay_deployment_detector.py` drives the real detector with the real `config::DEPLOY_*` values (the shim includes the FC's `config.h` directly and rebuilds when either header changes, so the tool cannot drift from the vehicle).

On the 2026-07-05 CENJARS flight (Rolly Polly 54 mm, motor ejection, no pyro channels enabled) it latches at **T+6801 ms via shock+baro**, 1.2 s before the apogee vote. The EKF vertical velocity confirms that is the ejection independently of the baro — climb collapses from +22.4 to −2.0 m/s over the following 0.7 s, so the "apogee" flag is a canopy-arrested float, not a ballistic peak.

Phase margins on that flight:

| Phase | peak accel | max baro step |
|---|---|---|
| Boost | 9.5 g | 0.8 m |
| Coast | **1.3 g** | **0.8 m** |
| Ejection | **38.6 g** | **100.4 m** |

Against thresholds of 8 g / 3 m. Sweeping shows the detection window is 2–30 g and 0.5–80 m, so both shipped values sit near the middle.

Two things the sweep corrected: `shock_count` is the tightest parameter (works at 1–10 ticks, never at 30 — the spike is only ~12 ms), and boost peaks at 9.5 g, *above* the shock threshold, so the burnout gate is load-bearing with the baro AND as backup.

## Known, not fixed

On a no-deploy flight the stop-at-landed gate beats the first ≥3 m landing baro step by **~4 ms**. The thresholds do not reject ground impact; the gate does. Harmless for logging (the latch has long since fired, and dropping to 1 kHz at touchdown costs nothing), but a consumer wanting a strict "recovery deployed" reading should know. Deliberately left as-is for now — a floor trades against catching a genuinely low deployment.

## Verification

- 661/661 host gtests pass on a clean rebuild (21 new, parameter-swept rather than pinned to one config). Mutation-checked: the fast path's AND fails 12 tests as an OR, and the lockout test fails when baro history goes stale across boost.
- FC, OC, and base station all build under IDF v6; iOS app builds and its tests pass.
- **Not bench-flown.** The thresholds are validated against one recorded flight, not against hardware running this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
