### PR TITLE
FC-relay OTA: cap the pump at a rate the OC can drain, plus the bench flag that made it findable

### DIFF
--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaSession.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaSession.kt
@@ -32,6 +32,13 @@ public class OtaSession(
     /** Resolves the CURRENT session for this device, or null between reconnects. */
     private val sessionLookup: () -> DeviceSession?,
     private val sha256: (ByteArray) -> ByteArray = { MessageDigest.getInstance("SHA-256").digest(it) },
+    /**
+     * Wall clock for the #627 FC-relay pacing only.  Injectable because the
+     * pacer credits real elapsed time against the rate budget, and under
+     * `runTest` a real clock would read ~0 while virtual time races ahead —
+     * tests supply their own so the pacing is deterministic.
+     */
+    private val nanoTime: () -> Long = System::nanoTime,
 ) {
 
     public sealed interface State {
@@ -139,6 +146,10 @@ public class OtaSession(
         try {
             val chunkSize = Commands.otaMaxChunkSize(pumpSession?.negotiatedMtu?.value ?: 23)
             var offset = 0
+            // #627: the relay path has a drain rate the OC can actually sustain;
+            // exceed it and its BLE stack wedges (see FC_RELAY_MAX_BYTES_PER_SEC).
+            // A local OC OTA has no relay and stays uncapped.
+            val pumpStartNs = if (targetIsFc) nanoTime() else 0L
             _state.value = State.Uploading(0, image.size.toLong())
             while (offset < image.size) {
                 if (!scope.isActive) return
@@ -171,6 +182,12 @@ public class OtaSession(
                 }
                 offset = end
                 _state.value = State.Uploading(offset.toLong(), image.size.toLong())
+
+                if (targetIsFc && offset < image.size) {
+                    val elapsedMs = (nanoTime() - pumpStartNs) / 1_000_000L
+                    val pause = OtaTimeouts.fcRelayPaceDelayMs(offset.toLong(), elapsedMs)
+                    if (pause > 0) delay(pause)
+                }
             }
         } finally {
             sessionLookup()?.releaseConnectionPriority()

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeouts.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeouts.kt
@@ -89,7 +89,7 @@ public object OtaTimeouts {
         OtaStage.FINISH -> if (targetIsFc) 60_000 else 15_000
         // FC reboots, then the OC re-queries its identity before the new
         // version can reach the app.
-        OtaStage.FW_PUBLISH -> if (targetIsFc) 40_000 else 10_000
+        OtaStage.FW_PUBLISH -> if (targetIsFc) 120_000 else 10_000
         // Local link events — the relay plays no part, so no FC stretch.
         OtaStage.DISCONNECT -> 5_000
         OtaStage.RECONNECT -> 60_000

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeouts.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeouts.kt
@@ -50,6 +50,37 @@ public object OtaTimeouts {
     /** Poll interval for every await in the flow. */
     public const val POLL_MS: Long = 50
 
+    /**
+     * Ceiling on the chunk pump for FC-relay OTAs only — a local OC OTA stays
+     * uncapped (straight to flash, no relay, happy at ~68 kB/s).
+     *
+     * #627: on the relay path the OC re-sends every chunk to the FC over I2S.
+     * Outrun that drain and the OC's 16-deep feed queue fills, receive buffers
+     * stop being retired, NimBLE's ACL mbuf pool exhausts and the link wedges
+     * — the OC stops receiving entirely (bench 2026-07-28: `enq` frozen at
+     * 3418 for 135 s amid thousands of `ACL buf alloc failed`). The FC then
+     * sees a hole and, being forward-only, discards everything after it.
+     *
+     * Measured on one board, one image: iOS pumps 11.4 kB/s and the relay
+     * works; Android pumps ~68 kB/s and it fails. iOS was never *correct*, only
+     * slow enough to stay under a limit nobody had written down. This writes it
+     * down — nearly a no-op on iOS, the actual fix on Android.
+     */
+    public const val FC_RELAY_MAX_BYTES_PER_SEC: Long = 12_000
+
+    /**
+     * How long to wait before sending the next chunk to keep the FC-relay pump
+     * under [FC_RELAY_MAX_BYTES_PER_SEC].
+     *
+     * Paced against total bytes sent rather than per-chunk, so the real time
+     * the write itself took is credited instead of added — a fixed per-chunk
+     * sleep would drift the effective rate well below the cap.
+     */
+    public fun fcRelayPaceDelayMs(bytesSent: Long, elapsedMs: Long): Long {
+        val targetMs = bytesSent * 1000L / FC_RELAY_MAX_BYTES_PER_SEC
+        return if (targetMs > elapsedMs) targetMs - elapsedMs else 0L
+    }
+
     public fun millis(stage: OtaStage, targetIsFc: Boolean): Long = when (stage) {
         // FC erases its OTA slot before it can answer ready.
         OtaStage.BEGIN -> if (targetIsFc) 20_000 else 5_000

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/OtaSessionTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/OtaSessionTest.kt
@@ -43,7 +43,13 @@ class OtaSessionTest {
         )
         session!!.start()
         runCurrent()
-        val ota = OtaSession(scope = backgroundScope, sessionLookup = { session })
+        val ota = OtaSession(
+            scope = backgroundScope,
+            sessionLookup = { session },
+            // Tie the #627 pacer's clock to virtual time, so a paced pump
+            // is deterministic instead of reading ~0 elapsed forever.
+            nanoTime = { currentTime * 1_000_000L },
+        )
         return Rig(fw, ota, { session }, { session = it })
     }
 
@@ -298,6 +304,57 @@ class OtaSessionTest {
         // The FC begin window is the long one — still waiting at the local timeout.
         advanceTimeBy(OtaSession.BEGIN_TIMEOUT_MS + 500); runCurrent()
         assertIs<OtaSession.State.Loading>(r.ota.state.value.let { if (it is OtaSession.State.Loading) it else it })
+    }
+
+    // ── #627 relay pacing ────────────────────────────────────────────────
+
+    @Test
+    fun fcRelayPumpIsPacedButTheLocalPumpIsNot() = runTest {
+        // 60 kB at the 12 kB/s relay cap = ~5 s of pacing. The local path has
+        // no relay to overrun, so it must stay uncapped — a cap there would
+        // turn the bench-proven ~68 kB/s OC flash into a 60-second crawl.
+        val bytes = 60_000
+
+        val local = rig()
+        advanceTimeBy(1_200); runCurrent()
+        val localStart = currentTime
+        local.ota.start(image(bytes), targetIsFc = false)
+        advanceTimeBy(100); runCurrent()
+        local.fw.emitOtaStatus("ready")
+        advanceTimeBy(500); runCurrent()
+        val localElapsed = currentTime - localStart
+        assertIs<OtaSession.State.Verifying>(
+            local.ota.state.value,
+            "local pump should have run straight through",
+        )
+        assertTrue(
+            localElapsed < 2_000,
+            "local pump must not be throttled (took ${localElapsed}ms)",
+        )
+
+        val relay = rig()
+        advanceTimeBy(1_200); runCurrent()
+        val relayStart = currentTime
+        relay.ota.start(image(bytes), targetIsFc = true)
+        advanceTimeBy(100); runCurrent()
+        relay.fw.emitOtaStatus("ready")
+        // Well past the local pump's duration, the relay pump is still going.
+        advanceTimeBy(2_000); runCurrent()
+        assertIs<OtaSession.State.Uploading>(
+            relay.ota.state.value,
+            "relay pump should still be throttled here, not finished",
+        )
+
+        advanceTimeBy(10_000); runCurrent()
+        assertIs<OtaSession.State.Verifying>(relay.ota.state.value)
+        val relayElapsed = currentTime - relayStart
+        val impliedRate = bytes * 1000L / relayElapsed
+        assertTrue(
+            impliedRate <= OtaTimeouts.FC_RELAY_MAX_BYTES_PER_SEC,
+            "relay pump ran at ${impliedRate} B/s, over the " +
+                "${OtaTimeouts.FC_RELAY_MAX_BYTES_PER_SEC} B/s cap that keeps " +
+                "the OC's mbuf pool alive (#627)",
+        )
     }
 
     // ── Chunk sizing ─────────────────────────────────────────────────────

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeoutsTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/OtaTimeoutsTest.kt
@@ -83,6 +83,36 @@ class OtaTimeoutsTest {
             )
         }
         assertEquals(json["pollMs"]!!.jsonPrimitive.long, OtaTimeouts.POLL_MS)
+        assertEquals(
+            json["fcRelayMaxBytesPerSec"]!!.jsonPrimitive.long,
+            OtaTimeouts.FC_RELAY_MAX_BYTES_PER_SEC,
+            "#627 relay cap disagrees with the fixture",
+        )
+    }
+
+    @Test
+    fun fcRelayPacerHoldsTheCapAndCreditsElapsedTime() {
+        val rate = OtaTimeouts.FC_RELAY_MAX_BYTES_PER_SEC
+
+        // One second's worth of bytes, no time spent yet → wait the full second.
+        assertEquals(1000L, OtaTimeouts.fcRelayPaceDelayMs(rate, elapsedMs = 0))
+
+        // Same bytes, but the writes themselves already took 400 ms — credit
+        // that instead of adding to it, or the effective rate drifts under the
+        // cap and a 591.7 kB FC image takes far longer than the 60 s finish
+        // window assumes.
+        assertEquals(600L, OtaTimeouts.fcRelayPaceDelayMs(rate, elapsedMs = 400))
+
+        // Already slower than the cap → never wait, never go backwards.
+        assertEquals(0L, OtaTimeouts.fcRelayPaceDelayMs(rate, elapsedMs = 1000))
+        assertEquals(0L, OtaTimeouts.fcRelayPaceDelayMs(rate, elapsedMs = 5000))
+
+        // The rate it actually enforces is the one measured working on the
+        // bench: iOS ran the relay at 11.4 kB/s, Android at ~68 kB/s wedged it.
+        assertTrue(
+            rate in 11_000..13_000,
+            "cap should sit at iOS's proven-good relay rate, was $rate B/s",
+        )
     }
 
     @Test

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift
@@ -145,6 +145,10 @@ final class OTASession: ObservableObject {
         // check is what catches a dropped chunk.
         let chunkSize = max(64, beginDevice.otaMaxChunkSize)
         var offset = 0
+        // #627: the relay path has a drain rate the OC can actually sustain;
+        // exceed it and its BLE stack wedges (see fcRelayMaxBytesPerSec). A
+        // local OC OTA has no relay and stays uncapped.
+        let pumpStart = Date()
         state = .uploading(bytesSent: 0, totalBytes: fileData.count)
         while offset < fileData.count {
             if Task.isCancelled { return }
@@ -173,6 +177,14 @@ final class OTASession: ObservableObject {
             }
             offset = end
             state = .uploading(bytesSent: offset, totalBytes: fileData.count)
+
+            if targetIsFC, offset < fileData.count {
+                let pause = OTATimeouts.fcRelayPaceDelay(
+                    bytesSent: offset, elapsed: Date().timeIntervalSince(pumpStart))
+                if pause > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(pause * 1_000_000_000))
+                }
+            }
         }
 
         // ---- 5. OTA_FINISH ----

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift
@@ -37,6 +37,33 @@ enum OTATimeouts {
     /// Poll interval for every await in the flow.
     static let pollSeconds: TimeInterval = 0.05
 
+    /// Ceiling on the chunk pump for FC-relay OTAs only — a local OC OTA stays
+    /// uncapped (straight to flash, no relay).
+    ///
+    /// #627: on the relay path the OC re-sends every chunk to the FC over I2S.
+    /// Outrun that drain and the OC's 16-deep feed queue fills, receive buffers
+    /// stop being retired, NimBLE's ACL mbuf pool exhausts and the link wedges —
+    /// the OC stops receiving entirely (bench 2026-07-28: `enq` frozen at 3418
+    /// for 135 s amid thousands of `ACL buf alloc failed`). The FC then sees a
+    /// hole and, being forward-only, discards everything after it.
+    ///
+    /// Measured on one board, one image: iOS pumps 11.4 kB/s and the relay
+    /// works; Android pumps ~68 kB/s and it fails. iOS was never *correct*
+    /// here, only slow enough to stay under a limit nobody had written down.
+    /// This writes it down — nearly a no-op on iOS, the actual fix on Android.
+    static let fcRelayMaxBytesPerSec: Double = 12_000
+
+    /// Seconds to wait before the next chunk to hold the FC-relay pump under
+    /// `fcRelayMaxBytesPerSec`.
+    ///
+    /// Paced against total bytes sent rather than per-chunk, so the time the
+    /// write itself took is credited instead of added — a fixed per-chunk sleep
+    /// would drift the effective rate well below the cap.
+    static func fcRelayPaceDelay(bytesSent: Int, elapsed: TimeInterval) -> TimeInterval {
+        let target = Double(bytesSent) / fcRelayMaxBytesPerSec
+        return target > elapsed ? target - elapsed : 0
+    }
+
     static func seconds(_ stage: OTAStage, targetIsFC: Bool) -> TimeInterval {
         switch stage {
         // FC erases its OTA slot before it can answer ready.

--- a/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift
@@ -73,7 +73,7 @@ enum OTATimeouts {
         case .finish:     return targetIsFC ? 60.0 : 15.0
         // FC reboots, then the OC re-queries its identity before the new
         // version can reach the app.
-        case .fwPublish:  return targetIsFC ? 40.0 : 10.0
+        case .fwPublish:  return targetIsFC ? 120.0 : 10.0
         // Local link events — the relay plays no part, so no FC stretch.
         case .disconnect: return 5.0
         case .reconnect:  return 60.0

--- a/TinkerRocketApp/TinkerRocketAppTests/OTATimeoutsTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/OTATimeoutsTests.swift
@@ -71,5 +71,35 @@ final class OTATimeoutsTests: XCTestCase {
 
         XCTAssertEqual(try XCTUnwrap(json["pollMs"] as? Double) / 1000.0,
                        OTATimeouts.pollSeconds)
+        XCTAssertEqual(try XCTUnwrap(json["fcRelayMaxBytesPerSec"] as? Double),
+                       OTATimeouts.fcRelayMaxBytesPerSec,
+                       "#627 relay cap disagrees with the fixture")
+    }
+
+    func testFCRelayPacerHoldsTheCapAndCreditsElapsedTime() {
+        let rate = OTATimeouts.fcRelayMaxBytesPerSec
+        let oneSecond = Int(rate)
+
+        // One second's worth of bytes, no time spent yet → wait the full second.
+        XCTAssertEqual(
+            OTATimeouts.fcRelayPaceDelay(bytesSent: oneSecond, elapsed: 0), 1.0,
+            accuracy: 0.001)
+
+        // Same bytes, but the writes already took 0.4 s — credit that rather
+        // than adding to it, or the effective rate drifts under the cap.
+        XCTAssertEqual(
+            OTATimeouts.fcRelayPaceDelay(bytesSent: oneSecond, elapsed: 0.4), 0.6,
+            accuracy: 0.001)
+
+        // Already slower than the cap → never wait, never go backwards.
+        XCTAssertEqual(
+            OTATimeouts.fcRelayPaceDelay(bytesSent: oneSecond, elapsed: 1.0), 0)
+        XCTAssertEqual(
+            OTATimeouts.fcRelayPaceDelay(bytesSent: oneSecond, elapsed: 5.0), 0)
+
+        // The rate enforced is the one measured working on the bench: iOS ran
+        // the relay at 11.4 kB/s, Android at ~68 kB/s wedged the OC's mbuf pool.
+        XCTAssertTrue((11_000...13_000).contains(rate),
+                      "cap should sit at iOS's proven-good relay rate, was \(rate) B/s")
     }
 }

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 25,608 lines across 66 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 25,647 lines across 66 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -29,7 +29,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 30 files, 11,402 lines
+## `Models/` — 30 files, 11,441 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
@@ -57,7 +57,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ActiveRocketSyncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift) | 393 | `ActiveRocketSyncer` |
 | [BLETypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift) | 340 | `FileInfo`, `DownloadState`, `DiscoveredDevice`, `RocketConfig` |
 | [KnownDeviceStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift) | 325 | `DeviceIdentityPusher`, `KnownDevice`, `KnownDeviceStore` |
-| [OTASession.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift) | 279 | `OTASession` |
+| [OTASession.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift) | 291 | `OTASession` |
 | [RocketProfileStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift) | 278 | `RocketProfileStore` |
 | [CSVParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift) | 271 | `FlightCSVData`, `CSVParserError`, `CSVParser` |
 | [UnitFormatter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift) | 204 | `UnitSystem`, `UnitFormatter` |
@@ -66,8 +66,8 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [MessageParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MessageParser.swift) | 151 | — |
 | [LocationManager.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift) | 109 | `LocationManager` |
 | [StorageStats.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift) | 89 | `RocketStorageStats`, `BaseStationStorageStats` |
+| [OTATimeouts.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift) | 82 | `OTAStage`, `OTATimeouts` |
 | [LastValidRocketFix.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LastValidRocketFix.swift) | 56 | `LastValidRocketFix` |
-| [OTATimeouts.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift) | 55 | `OTAStage`, `OTATimeouts` |
 | [SensorCalStatus.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorCalStatus.swift) | 50 | `SensorCalStatus` |
 | [RemoteRocket.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RemoteRocket.swift) | 48 | `RemoteRocket` |
 | [OTAStatus.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTAStatus.swift) | 42 | `OTAStatusUpdate` |
@@ -118,4 +118,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 66 files, 25,608 lines.
+Total: 66 files, 25,647 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,541 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,570 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -18,26 +18,26 @@ and leading comments.
 | [**LoRa frequency lock and channel hopping**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L584-L789) | 206 | 584-789 |
 | [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L967) | 178 | 790-967 |
 | [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L968-L1101) | 134 | 968-1101 |
-| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1102-L1313) | 212 | 1102-1313 |
-| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1314-L1426) | 113 | 1314-1426 |
-| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1427-L1498) | 72 | 1427-1498 |
-| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1499-L1538) | 40 | 1499-1538 |
-| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1539-L1678) | 140 | 1539-1678 |
-| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1679-L1786) | 108 | 1679-1786 |
-| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1787-L1961) | 175 | 1787-1961 |
-| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1962-L2223) | 262 | 1962-2223 |
-| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2224-L2946) | 723 | 2224-2946 |
-| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2947-L3069) | 123 | 2947-3069 |
-| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3070-L3087) | 18 | 3070-3087 |
-| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3088-L3417) | 330 | 3088-3417 |
-| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3418-L3696) | 279 | 3418-3696 |
-| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3697-L4211) | 515 | 3697-4211 |
-| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4212-L4544) | 333 | 4212-4544 |
-| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4545-L5278) | 734 | 4545-5278 |
-| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5279-L5785) | 507 | 5279-5785 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5786-L6063) | 278 | 5786-6063 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6064-L7532) | 1,469 | 6064-7532 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6413-L7532) | 1,120 | 6413-7532 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7533-L7541) | 9 | 7533-7541 |
+| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1102-L1342) | 241 | 1102-1342 |
+| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1343-L1455) | 113 | 1343-1455 |
+| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1456-L1527) | 72 | 1456-1527 |
+| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1528-L1567) | 40 | 1528-1567 |
+| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1568-L1707) | 140 | 1568-1707 |
+| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1708-L1815) | 108 | 1708-1815 |
+| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1816-L1990) | 175 | 1816-1990 |
+| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1991-L2252) | 262 | 1991-2252 |
+| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2253-L2975) | 723 | 2253-2975 |
+| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2976-L3098) | 123 | 2976-3098 |
+| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3099-L3116) | 18 | 3099-3116 |
+| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3117-L3446) | 330 | 3117-3446 |
+| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3447-L3725) | 279 | 3447-3725 |
+| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3726-L4240) | 515 | 3726-4240 |
+| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4241-L4573) | 333 | 4241-4573 |
+| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4574-L5307) | 734 | 4574-5307 |
+| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5308-L5814) | 507 | 5308-5814 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5815-L6092) | 278 | 5815-6092 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6093-L7561) | 1,469 | 6093-7561 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6442-L7561) | 1,120 | 6442-7561 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7562-L7570) | 9 | 7562-7570 |
 
-Total: 28 sections (1 nested) across 7,541 lines.
+Total: 28 sections (1 nested) across 7,570 lines.

--- a/tests_cpp/fixtures/app_behavior/ota_timeouts.json
+++ b/tests_cpp/fixtures/app_behavior/ota_timeouts.json
@@ -36,8 +36,8 @@
       "name": "fwPublish",
       "crossesRelay": true,
       "localMs": 10000,
-      "fcMs": 40000,
-      "why": "FC reboots, then the OC has to re-query its identity before the new version reaches the app"
+      "fcMs": 120000,
+      "why": "FC reboots, then the OC has to re-query its identity before the new version reaches the app. Bench 2026-07-28: a SUCCESSFUL FC update published its new fc_identity 73.9 s after ready_to_boot, so the old 40 s window expired first and the app reported 'Rollback detected' on an update that had in fact worked."
     },
     {
       "name": "disconnect",

--- a/tests_cpp/fixtures/app_behavior/ota_timeouts.json
+++ b/tests_cpp/fixtures/app_behavior/ota_timeouts.json
@@ -54,5 +54,28 @@
       "why": "phone re-establishes its own link to the OC; already generous"
     }
   ],
-  "pollMs": 50
+  "pollMs": 50,
+
+  "_fcRelayPumpComment": [
+    "Ceiling on the chunk pump for FC-relay OTAs ONLY; a local OC OTA stays",
+    "uncapped (it writes straight to flash, no relay, and runs happily at",
+    "~68 kB/s from Android).",
+    "",
+    "#627: on the relay path the OC re-sends each chunk to the FC over I2S. Pump",
+    "faster than it can drain and the 16-deep feed queue fills, receive buffers",
+    "stop being retired, NimBLE's ACL mbuf pool exhausts and the BLE link wedges",
+    "— thousands of 'ACL buf alloc failed' / 'MBUF alloc stuck', then the OC",
+    "simply stops receiving (bench 2026-07-28: enq frozen at 3418 for 135 s).",
+    "The FC then sees a hole and, being forward-only, discards everything after.",
+    "",
+    "Bench-measured on the same board and image: iOS pumps 11.4 kB/s and the",
+    "relay works; Android pumps ~68 kB/s and it fails. iOS was never CORRECT",
+    "here, just slow enough to stay under an unstated limit. 12000 keeps the",
+    "proven-good rate for both platforms and makes it explicit — on iOS this is",
+    "very nearly a no-op, on Android it is the fix.",
+    "",
+    "A 591.7 kB FC image therefore takes ~50 s to upload, which is why the FC",
+    "finish window is 60 s (see the finish stage above)."
+  ],
+  "fcRelayMaxBytesPerSec": 12000
 }

--- a/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
@@ -35,7 +35,21 @@ if(TR_BOARD_V8)
 else()
     set(TR_BOARD_SUFFIX "")
 endif()
-set(PROJECT_VER "${TR_GIT_SHA}${TR_BOARD_SUFFIX}+${TR_BUILD_DATE}")
+# Bench-debug marker: a TR_OC_BENCH_DEBUG image keeps light sleep off for the
+# whole session (see main/CMakeLists.txt), so it draws ~22 mA instead of ~1 mA.
+# Stamping it here makes that visible everywhere the version travels — boot
+# log, BLE config_identity "fw", the app's Firmware screen, OTA metadata — so
+# one can't end up on a rocket unnoticed.
+#
+# esp_app_desc.version is 32 bytes, and "<sha>-dirty-bench+<date>" overflows it
+# — the suffixes come BEFORE the timestamp deliberately, so the safety marker
+# always survives and only the build date gets clipped.
+if(TR_OC_BENCH_DEBUG)
+    set(TR_BENCH_SUFFIX "-bench")
+else()
+    set(TR_BENCH_SUFFIX "")
+endif()
+set(PROJECT_VER "${TR_GIT_SHA}${TR_BOARD_SUFFIX}${TR_BENCH_SUFFIX}+${TR_BUILD_DATE}")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(out_computer)

--- a/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
@@ -31,3 +31,28 @@ target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format -Wno-narr
 if(TR_BOARD_V8)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V8=1)
 endif()
+
+# Bench-debug image: `idf.py -B build_bench -DTR_OC_BENCH_DEBUG=1 build`.
+#
+# The OC's console is USB Serial/JTAG ONLY (ESP_CONSOLE_UART_NUM=-1, secondary
+# none), and light sleep powers that peripheral down — so a normal image goes
+# permanently silent to a host ~11 s after boot, when the #541 USB-enumeration
+# grace lock releases. Before #519 the BT controller's own no_light_sleep lock
+# on MAIN_XTAL kept the OC awake whenever BLE was up, which masked this; #519
+# moved the BT LP clock to the 32k crystal and took that lifeline with it.
+# Found 2026-07-28 while chasing OC-side evidence for #627.
+#
+# This flag holds ESP_PM_NO_LIGHT_SLEEP for the whole session so serial keeps
+# flowing. It costs the entire #519 power win (~22 mA vs ~1 mA), so it is
+# opt-in AND stamped "-bench" into the app version string (see the parent
+# CMakeLists) — an image built this way is identifiable in the boot log, the
+# BLE config_identity "fw" field, and its OTA metadata. Never fly it.
+#
+# Same trap as TR_BS_BOARD: the build-dir name is cosmetic, the flag is what
+# counts, so surface the choice at configure time.
+if(TR_OC_BENCH_DEBUG)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_OC_BENCH_DEBUG=1)
+    message(WARNING "out_computer: BENCH DEBUG build — light sleep disabled so "
+                    "the USB console survives; idle current ~22 mA instead of "
+                    "~1 mA. Version string carries '-bench'. Do NOT fly this.")
+endif()

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -1135,12 +1135,35 @@ static constexpr uint32_t   kBootUsjGraceMs = 10000;
 
 static void bootUsjGraceExpired(void*)
 {
+#if defined(TR_OC_BENCH_DEBUG)
+    // Bench-debug image: never release. Light sleep powers down the USB
+    // Serial/JTAG peripheral the console rides on (ESP_CONSOLE_UART_NUM=-1,
+    // secondary none — USJ is the ONLY console), so once this lock drops the
+    // OC goes permanently silent to a host, ~11 s after every boot.
+    //
+    // That used to be masked: before #519 the BT controller took its own
+    // no_light_sleep lock on MAIN_XTAL, so an OC with BLE up never slept and
+    // the console stayed alive. #519 moved the BT LP clock to the 32k crystal
+    // — the power win — and with it went the accidental console lifeline.
+    // Found on the bench 2026-07-28 while trying to get OC-side evidence for
+    // #627: four capture attempts, all silent from exactly this line onward.
+    //
+    // Holding forever costs the whole #519 saving (~22 mA vs ~1 mA), which is
+    // why this is opt-in and stamped into the version string — a bench image
+    // must never be mistaken for a flight image.
+    ESP_LOGW("PWR", "BENCH DEBUG: holding ESP_PM_NO_LIGHT_SLEEP for the whole "
+                    "session so the USJ console stays alive — light sleep is "
+                    "DISABLED and idle current is ~22 mA. Do NOT fly this image.");
+    (void)s_boot_usj_grace_held;
+    return;
+#else
     if (s_boot_usj_grace_held)
     {
         s_boot_usj_grace_held = false;
         esp_pm_lock_release(s_boot_usj_grace_lock);
         ESP_LOGI("PWR", "USB-enumeration grace over — light sleep unblocked");
     }
+#endif
 }
 
 static void holdBootUsjGrace()
@@ -1173,8 +1196,14 @@ static void holdBootUsjGrace()
     esp_timer_stop(s_boot_usj_grace_timer);
     esp_timer_start_once(s_boot_usj_grace_timer,
                          (uint64_t)kBootUsjGraceMs * 1000ULL);
+#if defined(TR_OC_BENCH_DEBUG)
+    ESP_LOGW("PWR", "BENCH DEBUG build — the USB console will stay alive past "
+                    "the %lu ms grace instead of going quiet (#627 bench).",
+             (unsigned long)kBootUsjGraceMs);
+#else
     ESP_LOGI("PWR", "Light sleep held %lu ms for USB enumeration (#541)",
              (unsigned long)kBootUsjGraceMs);
+#endif
 }
 #endif  // CONFIG_PM_ENABLE
 


### PR DESCRIPTION
Fixes the FC-relay OTA, which failed from Android and worked from iOS. The difference was
never correctness — it was 6x of pump speed against a limit nobody had written down.

Verified end to end on both platforms tonight.

## What was actually wrong

The original issue blamed the FC's forward-only receiver and its 8 kB ring overflowing. Both
were wrong. The FC is the victim; the loss happens a hop earlier.

On the relay path the OC re-sends every chunk to the FC over I2S. Pump faster than that
drains and its 16-deep feed queue fills, receive buffers stop being retired, NimBLE's ACL
mbuf pool exhausts, and the BLE link wedges:

```
W (441608) OC: [OTA feed] enq=651  sent=635  idle=3461 qdepth=16   <- queue full
MBUF alloc stuck                        x204
ACL buf alloc failed 5..25 times        x2300+
W (462699) OC: [OTA feed] enq=3418 sent=3418 idle=135334 qdepth=0  <- frozen, 135 s
```

`enq` freezes and never moves again — the OC stops receiving entirely. The FC then sees a
hole and, being forward-only, discards every byte after it.

The clincher arrived on the final iOS run, which printed the FC's own receive summary for
the first time:

```
[OTA RX] frames_ok=3621 gap=0 crc_fail=0 write_fail=0 ring_ovf=0
```

`ring_ovf=0`. The ring never overflowed, on the run that worked or on any other. The
firmware's own comment says `gap>0, crc_fail~0` means frames lost upstream — which is
exactly the mbuf exhaustion.

## The fix

`fcRelayMaxBytesPerSec = 12000` on the FC path only, in the shared fixture both app suites
read. Local OC OTAs stay uncapped — no relay, no queue to overrun, and capping them would
turn a bench-proven ~68 kB/s flash into a 60 s crawl.

Pacing is against total bytes sent, not per-chunk, so the time each write actually took is
credited rather than added; a fixed per-chunk sleep drifts the effective rate well under the
cap and would push a 591.7 kB image past the finish window.

The rate is iOS's measured working rate. iOS was never *correct* here — it was slow enough
to stay under an unstated limit, and the same firmware would fail on iOS if CoreBluetooth
ever got faster. Now it's explicit on both.

## A second bug the fix exposed

With the data path clean, the Android run completed and the app then reported "Rollback
detected", claiming the FC was still on the old version. It wasn't:

```
I (685551) OC: OTA relay: FC status state=3 err=0 bytes=605856
I (759422) CFG: Queued fc_identity (fc_fw=d9a2679a+20260728-2201)
```

73.9 s from ready_to_boot to the new version reaching the app, against a 40 s window. Since
the flow reads "reconnected but version unchanged" as a rollback, a success was reported as
a revert — worse than a spurious failure, because it tells the user their firmware reverted
when it is running fine. Now 120 s on the FC path.

Worth noting what this says about the `crossesRelay` invariant added in #628: it held here
and always did — fwPublish was already 4x its local counterpart. That invariant protects the
*shape* of the table, not the magnitudes, and magnitudes only come from hardware. Both real
FC-path timeout bugs needed the bench to find.

## Why none of this was diagnosable before

The OC cannot be watched on serial past ~11 s of uptime. Its console is USB Serial/JTAG only
(`ESP_CONSOLE_UART_NUM=-1`, secondary none) and light sleep powers that peripheral down.
Before #519 the BT controller held its own `no_light_sleep` lock on MAIN_XTAL, so an OC with
BLE up never slept and the console stayed alive *by accident*. #519 moved the BT LP clock to
the 32 k crystal — the 22 mA -> ~1 mA win — and took the lifeline with it. Four capture
attempts today died at exactly `USB-enumeration grace over`.

`idf.py -B build_bench -DTR_OC_BENCH_DEBUG=1 build` holds `ESP_PM_NO_LIGHT_SLEEP` for the
whole session. Console verified running past 41 s where it previously stopped dead at 11 s.
Every piece of evidence above came from that build.

It costs the entire #519 saving, so it is opt-in and stamped `-bench` into
`esp_app_desc.version` — visible in the boot log, BLE `config_identity`, the app's Firmware
screen and OTA metadata. The suffixes deliberately precede the timestamp: that field is 32
bytes and `<sha>-dirty-bench+<date>` overflows, so the marker survives and only the date is
clipped. Configure-time WARNING too, following the `TR_BS_BOARD` precedent.

## Bench results

**Android** — the case that failed three times:

| | before | after |
|---|---|---|
| `MBUF alloc stuck` | 204x | 0 |
| `ACL buf alloc failed` | 2300x+ | 0 |
| feed `qdepth` | pegged at 16 | max 2 |
| FC received | hole at 32128, rest discarded | all 605856 B, `state=3` |

**iOS** — pacing is a no-op at 11.4 kB/s, as intended:

```
[OTA] FINISH (bytes_written=605856/605856)
[OTA RX] frames_ok=3621 gap=0 crc_fail=0 write_fail=0 ring_ovf=0
```

FC flash read back afterwards: `ota_0 = c812aacd+20260729-0031` (the flashed image) at
otadata seq 3, `ota_1` holding the previous build intact as fallback.

## Tests

`fcRelayPumpIsPacedButTheLocalPumpIsNot` pins both halves — relay throttled, local not —
plus the implied rate. Pacer arithmetic including credit-elapsed is checked on both
platforms, and the shared fixture keeps the two tables from drifting.

Full JVM suite and iOS suite green; `tools/preflight_protocol.sh` green.

Closes #627. Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
