### PR TITLE
android(#635): Saved Flights — reach downloaded logs with nothing connected

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FilesScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FilesScreen.kt
@@ -1,7 +1,6 @@
 package com.tinkerbug.tinkerrocket.app
 
 import android.content.Context
-import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
 import com.tinkerbug.tinkerrocket.protocol.CsvGenerator
 import com.tinkerbug.tinkerrocket.protocol.FileInfo
 import com.tinkerbug.tinkerrocket.session.DeviceSession
@@ -162,21 +160,15 @@ private fun FileRow(
     }
 }
 
-/** iOS FileCache mirror: durable app files, shallow flight_* naming. */
-private fun binFileFor(context: Context, name: String) =
-    File(File(context.filesDir, "BinaryCache").apply { mkdirs() }, name)
+// iOS FileCache mirror.  Moved to FlightCache for #635 so Saved Flights can
+// browse the same layout with no device attached; these stay as thin aliases
+// to keep this screen readable.
+private fun binFileFor(context: Context, name: String) = FlightCache.binFileFor(context, name)
 
-private fun csvFileFor(context: Context, name: String) =
-    File(
-        File(context.filesDir, "CSVCache").apply { mkdirs() },
-        name.removeSuffix(".bin") + ".csv",
-    )
+private fun csvFileFor(context: Context, name: String) = FlightCache.csvFileFor(context, name)
 
 private fun summaryFileFor(context: Context, name: String) =
-    File(
-        File(context.filesDir, "CSVCache").apply { mkdirs() },
-        name.removeSuffix(".bin") + ".json",
-    )
+    FlightCache.summaryFileFor(context, name)
 
 /** Runs on the fleet dispatcher (downloadFile contract); CSV work hops to Default. */
 private suspend fun downloadAndConvert(
@@ -199,18 +191,5 @@ private suspend fun downloadAndConvert(
     else -> "Download failed: $result"
 }
 
-private fun shareCsvIfPresent(context: Context, file: FileInfo) {
-    val csv = csvFileFor(context, file.name)
-    if (!csv.exists()) return
-    val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", csv)
-    context.startActivity(
-        Intent.createChooser(
-            Intent(Intent.ACTION_SEND).apply {
-                type = "text/csv"
-                putExtra(Intent.EXTRA_STREAM, uri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            },
-            "Share ${csv.name}",
-        ),
-    )
-}
+private fun shareCsvIfPresent(context: Context, file: FileInfo) =
+    FlightCache.shareCsv(context, csvFileFor(context, file.name))

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightCache.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightCache.kt
@@ -1,0 +1,102 @@
+package com.tinkerbug.tinkerrocket.app
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * On-phone flight storage — the iOS FileCache mirror.
+ *
+ * `filesDir/BinaryCache` and `filesDir/CSVCache`: durable app files, NEVER
+ * `cacheDir`, because the OS may purge that under storage pressure and this is
+ * field data that only exists here until it's exported.
+ *
+ * Extracted from FilesScreen for #635: nothing about reading these needs a BLE
+ * connection, but they used to be private to the screen that does. Saved
+ * Flights browses the same layout with no device attached.
+ */
+internal object FlightCache {
+
+    fun binDir(context: Context): File =
+        File(context.filesDir, "BinaryCache").apply { mkdirs() }
+
+    fun csvDir(context: Context): File =
+        File(context.filesDir, "CSVCache").apply { mkdirs() }
+
+    fun binFileFor(context: Context, name: String): File =
+        File(binDir(context), name)
+
+    fun csvFileFor(context: Context, name: String): File =
+        File(csvDir(context), name.removeSuffix(".bin") + ".csv")
+
+    fun summaryFileFor(context: Context, name: String): File =
+        File(csvDir(context), name.removeSuffix(".bin") + ".json")
+
+    /**
+     * One downloaded flight as it exists on the phone.
+     *
+     * A flight can be half-present: the download writes the `.bin` first and
+     * keeps it even if CSV conversion throws, deliberately, so a converter bug
+     * never costs the data. So [csv] is nullable and the UI has to cope with a
+     * `.bin` that can't be charted yet.
+     */
+    data class SavedFlight(
+        val name: String,          // "flight_20260729_163740.bin"
+        val bin: File?,
+        val csv: File?,
+        val sizeBytes: Long,
+        val lastModified: Long,
+    ) {
+        val displayName: String get() = name.removeSuffix(".bin")
+        val hasCsv: Boolean get() = csv != null
+    }
+
+    /**
+     * Everything downloaded to this phone, newest first.
+     *
+     * Unions both directories rather than listing one: a `.bin` whose CSV
+     * conversion failed still belongs in the list (it can be shared and
+     * re-converted), and a `.csv` whose `.bin` was cleared is still chartable.
+     */
+    fun listSavedFlights(context: Context): List<SavedFlight> {
+        val bins = binDir(context).listFiles()?.filter { it.isFile && it.name.endsWith(".bin") }
+            ?: emptyList()
+        val csvs = csvDir(context).listFiles()?.filter { it.isFile && it.name.endsWith(".csv") }
+            ?: emptyList()
+
+        val names = LinkedHashSet<String>()
+        bins.forEach { names += it.name }
+        csvs.forEach { names += it.name.removeSuffix(".csv") + ".bin" }
+
+        return names.map { name ->
+            val bin = bins.firstOrNull { it.name == name }
+            val csv = csvs.firstOrNull { it.name == name.removeSuffix(".bin") + ".csv" }
+            SavedFlight(
+                name = name,
+                bin = bin,
+                csv = csv,
+                // Prefer the .bin's size — it's what came off the board, and
+                // what a "how big was this flight" glance means.
+                sizeBytes = bin?.length() ?: csv?.length() ?: 0L,
+                lastModified = maxOf(bin?.lastModified() ?: 0L, csv?.lastModified() ?: 0L),
+            )
+        }.sortedByDescending { it.lastModified }
+    }
+
+    /** Share a converted CSV through the app's FileProvider. No-op if absent. */
+    fun shareCsv(context: Context, csv: File?) {
+        if (csv == null || !csv.exists()) return
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", csv)
+        context.startActivity(
+            Intent.createChooser(
+                Intent(Intent.ACTION_SEND).apply {
+                    type = "text/csv"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                },
+                "Share ${csv.name}",
+            ),
+        )
+    }
+}

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
@@ -173,7 +173,11 @@ class MainActivity : ComponentActivity() {
 
                         else -> {
                             var showMyDevices by remember { mutableStateOf(false) }
-                            if (showMyDevices) {
+                            var showSavedFlights by remember { mutableStateOf(false) }
+                            if (showSavedFlights) {
+                                // #635: local cache only — no session needed.
+                                SavedFlightsScreen(onBack = { showSavedFlights = false })
+                            } else if (showMyDevices) {
                                 DeviceManagerScreen(
                                     store = container.knownDevices,
                                     fleet = container.fleet,
@@ -193,6 +197,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     onMyDevices = { showMyDevices = true },
+                                    onSavedFlights = { showSavedFlights = true },
                                 )
                             }
                         }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/SavedFlightsScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/SavedFlightsScreen.kt
@@ -1,0 +1,130 @@
+package com.tinkerbug.tinkerrocket.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Flights already downloaded to this phone — browsable with nothing connected.
+ *
+ * #635: the chart and share paths read purely from `filesDir`, but they lived
+ * only inside FilesScreen, which is mounted in the connected-device tab row.
+ * That made the normal post-flight workflow impossible: download logs at the
+ * pad, drive home, and the data was unreachable without powering a board and
+ * reconnecting to it. iOS has had "Saved Flights" on its main screen all along
+ * (`DashboardView.swift:92`).
+ *
+ * Deliberately does NOT list the device's own files — that half genuinely needs
+ * a session. This is the local cache only, which is the half that never did.
+ */
+@Composable
+fun SavedFlightsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+
+    // Re-listed on every entry: a download that happened while connected must
+    // show up here without an app restart.
+    val flights = remember { FlightCache.listSavedFlights(context) }
+
+    var chartCsv by remember { mutableStateOf<File?>(null) }
+    chartCsv?.let { csv ->
+        FlightChartScreen(csvFile = csv, onBack = { chartCsv = null })
+        return
+    }
+
+    Column(Modifier.fillMaxSize().padding(12.dp)) {
+        Row(
+            Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(onClick = onBack) { Text("← Back") }
+            Text("Saved Flights", style = MaterialTheme.typography.titleMedium)
+        }
+
+        if (flights.isEmpty()) {
+            Text(
+                "No flights downloaded yet.\n\nConnect to a rocket, open Files, and download a " +
+                    "flight log — it will appear here afterwards, with or without a connection.",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            return@Column
+        }
+
+        Text(
+            "${flights.size} flight${if (flights.size == 1) "" else "s"} on this phone",
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(flights, key = { it.name }) { flight ->
+                SavedFlightRow(
+                    flight = flight,
+                    onChart = { flight.csv?.let { chartCsv = it } },
+                    onShare = { FlightCache.shareCsv(context, flight.csv) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SavedFlightRow(
+    flight: FlightCache.SavedFlight,
+    onChart: () -> Unit,
+    onShare: () -> Unit,
+) {
+    Card(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(12.dp)) {
+            Text(flight.displayName, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                "${formatSize(flight.sizeBytes)} · ${formatDate(flight.lastModified)}" +
+                    if (flight.hasCsv) "" else " · .bin only (not converted)",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Row(
+                Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // Both need the CSV: the chart parses it and the share sends it.
+                // A .bin whose conversion failed is still listed, so the row has
+                // to say why its buttons are dead rather than just disabling them.
+                OutlinedButton(onClick = onChart, enabled = flight.hasCsv) { Text("Chart") }
+                OutlinedButton(onClick = onShare, enabled = flight.hasCsv) { Text("Share") }
+            }
+        }
+    }
+}
+
+private fun formatSize(bytes: Long): String = when {
+    bytes >= 1_000_000 -> String.format(Locale.US, "%.1f MB", bytes / 1_000_000.0)
+    bytes >= 1_000 -> String.format(Locale.US, "%.1f kB", bytes / 1_000.0)
+    else -> "$bytes B"
+}
+
+private fun formatDate(millis: Long): String =
+    if (millis <= 0) "—"
+    else SimpleDateFormat("MMM d, HH:mm", Locale.US).format(Date(millis))

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
@@ -29,6 +29,7 @@ fun ScannerScreen(
     fleet: FleetManager<DeviceSession>,
     onDemo: () -> Unit,
     onMyDevices: () -> Unit = {},
+    onSavedFlights: () -> Unit = {},
 ) {
     val discovered by fleet.discoveredDevices.collectAsState()
     val scanning by fleet.isScanning.collectAsState()
@@ -48,6 +49,11 @@ fun ScannerScreen(
             OutlinedButton(onClick = onMyDevices) { Text("My Devices") }
             OutlinedButton(onClick = onDemo, modifier = Modifier.padding(start = 6.dp)) { Text("Demo") }
         }
+        // #635: flights already on the phone, reachable with nothing connected.
+        // The post-flight workflow is download at the pad, then review later —
+        // which was impossible while the only route to a log was the
+        // connected-device tab row.
+        OutlinedButton(onClick = onSavedFlights) { Text("Saved Flights") }
         Text(status, style = MaterialTheme.typography.bodyMedium)
 
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {


### PR DESCRIPTION
The post-flight workflow was impossible on Android: download logs at the pad, pack up, drive
home — and the data was unreachable.

`FilesScreen` is only mounted inside the connected-device tab row (`MainActivity.kt:151`).
Disconnect, and the app falls back to a scanner offering only **Scan / My Devices / Demo**.
iOS has had **Saved Flights** on its main screen the whole time (`DashboardView.swift:92`).

Nothing about viewing a downloaded flight needs a radio. The files are already on the phone in
`filesDir/BinaryCache` and `filesDir/CSVCache`, and the chart and share paths read purely from
disk — they were simply private to the screen that also talks to a device.

## Change

| | |
|---|---|
| `FlightCache` | the cache layout + share, extracted from `FilesScreen` so both screens share one definition instead of duplicating it |
| `SavedFlightsScreen` | the local half only — newest first, with size and date, Chart and Share per flight |
| `ScannerScreen` | a Saved Flights entry point |

It deliberately does **not** list the device's own files. That half genuinely needs a session;
this is the cache, which never did. Roughly the split iOS draws between `FileManagerView`
(device) and `FlightLogsView` (local).

## Half-present flights

`downloadAndConvert` writes the `.bin` first and keeps it even if CSV conversion throws —
deliberately, so a converter bug never costs the data. The list therefore unions both
directories and shows such a flight as **".bin only (not converted)"** with its buttons
disabled, rather than hiding it: it can still be shared and re-converted later. Hiding it
would make a successful download look like it never happened.

## Verified

With **Bluetooth off** — the strongest form of "nothing connected":

- both flights listed with sizes and dates, newest first
- the 10.5 MB flight charted in **5 s**, to a plot identical to the connected run: peak 460 m
  at 4.5 s, the simulator's constant 5 m/s descent as a straight line to touchdown at ~103 s

Full JVM suite green; `tools/preflight_protocol.sh` green.

Found by Checkpoint A Group 6 (#632), where it also blocked the chart performance test
outright — the chart lives behind the Files tab, so there was no way to reach it without a
board powered.

Closes #635. Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
