### PR TITLE
android: tapping Scan with Bluetooth off crashed the app (Checkpoint A Group 1)

### DIFF
--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/FleetManager.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/FleetManager.kt
@@ -6,6 +6,7 @@ import com.tinkerbug.tinkerrocket.protocol.TelemetryData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -214,6 +215,23 @@ public class FleetManager<S : Any>(
                 }
             } catch (_: TimeoutCancellationException) {
                 if (epoch == scanEpoch) onScanTimeout()
+            } catch (e: CancellationException) {
+                throw e          // structured cancellation is not a failure
+            } catch (e: Exception) {
+                // The scanner flow can fail rather than time out — most often
+                // "BLE scanner unavailable (adapter off?)" when the adapter is
+                // off, but any transport error lands here.  Left uncaught this
+                // escapes the launch and the default handler KILLS THE PROCESS:
+                // tapping Scan with Bluetooth off crashed the app outright
+                // (Checkpoint A Group 1, bench 2026-07-29 — APP CRASH(EXCEPTION)).
+                //
+                // Report it and stop scanning instead; the adapter coming back
+                // is a normal thing to recover from, not a fatal condition.
+                if (epoch == scanEpoch) {
+                    _isScanning.value = false
+                    _userInitiatedScan.value = false
+                    _statusMessage.value = e.message ?: "Scan failed"
+                }
             }
         }
     }

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetManagerTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetManagerTest.kt
@@ -494,4 +494,42 @@ class FleetManagerTest {
         assertNotSame(first.session, second.session,
             "Every connection gets a NEW session object — survivors live on the fleet")
     }
+
+    // ── scanner failure must not be fatal ────────────────────────────────
+
+    @Test
+    fun scannerFailure_reportsAndStopsInsteadOfCrashing() = runTest {
+        // The real scanner throws "BLE scanner unavailable (adapter off?)" when
+        // the adapter is off.  Uncaught, it escaped scan()'s launch and the
+        // default handler killed the process — tapping Scan with Bluetooth off
+        // crashed the app outright (bench 2026-07-29, APP CRASH(EXCEPTION)).
+        val h = fleetHarness()
+        h.scanner.failWith = IllegalStateException("BLE scanner unavailable (adapter off?)")
+
+        h.fleet.scan(userInitiated = true)
+        advanceTimeBy(1_000); runCurrent()
+
+        // Survived, and says so rather than pretending to scan forever.
+        assertFalse(h.fleet.isScanning.value, "should stop scanning on failure")
+        assertFalse(h.fleet.userInitiatedScan.value, "spinner flag must clear too")
+        assertTrue(
+            h.fleet.statusMessage.value.contains("unavailable", ignoreCase = true),
+            "status should surface the reason, was '${h.fleet.statusMessage.value}'",
+        )
+    }
+
+    @Test
+    fun scannerRecoversOnASubsequentScan_afterAFailure() = runTest {
+        val h = fleetHarness()
+        h.scanner.failWith = IllegalStateException("BLE scanner unavailable (adapter off?)")
+        h.fleet.scan(userInitiated = true)
+        advanceTimeBy(1_000); runCurrent()
+        assertFalse(h.fleet.isScanning.value)
+
+        // Adapter comes back — the next scan must work, not stay poisoned.
+        h.scanner.failWith = null
+        h.fleet.scan(userInitiated = true)
+        runCurrent()
+        assertTrue(h.fleet.isScanning.value, "a later scan should start normally")
+    }
 }

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetTestFakes.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetTestFakes.kt
@@ -21,8 +21,15 @@ class FakeScanner : BleScanner {
     var activeCollections = 0
         private set
 
+    /**
+     * Set to make the flow FAIL instead of emitting — what the real scanner
+     * does when the adapter is off ("BLE scanner unavailable"). Left uncaught
+     * this used to kill the process (Checkpoint A Group 1).
+     */
+    var failWith: Throwable? = null
+
     override fun advertisements(): Flow<BleAdvertisement> = emissions
-        .onStart { activeCollections++ }
+        .onStart { activeCollections++; failWith?.let { throw it } }
         .onCompletion { activeCollections-- }
 }
 

--- a/docs/plans/624-checkpoint-a-matrix.md
+++ b/docs/plans/624-checkpoint-a-matrix.md
@@ -35,14 +35,34 @@ re-run needlessly.
 
 ---
 
-## Group 1 — Permissions and cold-start
+## Group 1 — Permissions and cold-start ✅ DONE 2026-07-29 (found a crash)
 
-- [ ] Fresh install, all permissions denied → app explains rather than dead-ends
-- [ ] Grant BLUETOOTH_SCAN/CONNECT only (deny location) → scanning still works; the
-      direction-to-rocket arrow degrades with a stated reason, never blocks
-- [ ] Deny POST_NOTIFICATIONS → FGS still runs; no crash on the notification path
-- [ ] Revoke a permission from Settings while connected → app recovers, no crash
-- [ ] Cold start with Bluetooth OFF → clear prompt, recovers when enabled
+- [x] All permissions denied → **PASS**. No crash; the app explains itself — "Bluetooth access
+      needed / TinkerRocket finds and talks to your flight computers over Bluetooth.
+      Nearby-devices permission is required." with a Grant button. Correctly gates on BLE only
+- [x] Scan/connect granted, location denied → **PASS on both halves**. Scanning is unaffected
+      (both boards found) — that's `neverForLocation` and minSdk 31 paying off. The bearing card
+      degrades with a stated reason and an in-place remedy: "Location permission is needed to
+      show direction and distance to the rocket." + `Grant location`
+- [x] POST_NOTIFICATIONS denied → **PASS**. `Background started FGS: Allowed`, connection
+      established, no `SecurityException` on the notification path — the OS suppresses the
+      notification rather than throwing, which is what the pad wait depends on
+- [x] Revoke while connected → **PASS**. Android kills the process on revoke BY DESIGN (not a
+      crash); relaunch recovers cleanly with no crash loop.
+      PLATFORM NOTE: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` share the `NEARBY_DEVICES` group,
+      so revoking CONNECT alone gets it auto-re-granted on the next request (it comes back
+      WITHOUT the `USER_SET` flag — that's the tell). "Connected with CONNECT denied" isn't
+      reachable that way; revoke both, which the first item covers
+- [x] Cold start with Bluetooth OFF → **CRASH FOUND, then FIXED**. Launch was fine, but tapping
+      **Scan** with the adapter off killed the app:
+      ```
+      E AndroidRuntime: BleTransportException: BLE scanner unavailable (adapter off?)
+      I ActivityManager: Process ... has died: prcp CRE      # exit-info: APP CRASH(EXCEPTION)
+      ```
+      `FleetManager.scan()` caught only `TimeoutCancellationException`, so a scanner-flow
+      failure escaped the `launch` and reached the default handler. Now caught: scanning stops,
+      the reason is surfaced ("BLE scanner unavailable (adapter off?)"), the spinner clears, and
+      a later scan works once the adapter returns — verified on-device, same pid throughout
 
 ## Group 2 — Scan throttle and discovery ✅ DONE 2026-07-29
 


### PR DESCRIPTION
Found by Checkpoint A Group 1 (#632), the last unrun group. Launching with the Bluetooth
adapter off was fine — tapping **Scan** killed the app.

```
E AndroidRuntime: com.tinkerbug.tinkerrocket.ble.BleTransportException:
                  BLE scanner unavailable (adapter off?)
I ActivityManager: Process com.tinkerbug.tinkerrocket has died: prcp CRE
```

`dumpsys activity exit-info` records it as `APP CRASH(EXCEPTION)`.

## Cause

The exception is *correct* — `AndroidBleScanner` closes its `callbackFlow` with it when
`getSystemService` returns no scanner. But `FleetManager.scan()` caught only
`TimeoutCancellationException`:

```kotlin
} catch (_: TimeoutCancellationException) {
    if (epoch == scanEpoch) onScanTimeout()
}
```

so a scanner-flow *failure* escaped the `launch` and reached the default handler, which kills
the process.

## Fix

Catch it: stop scanning, surface the reason in `statusMessage`, clear both scanning flags so
the spinner doesn't spin forever. `CancellationException` is rethrown first, so structured
cancellation still behaves (a cancelled scan isn't a failure). An adapter coming back is an
ordinary thing to recover from, not a fatal condition.

## Verified on-device

With Bluetooth off, tapping Scan now leaves the app alive showing
`BLE scanner unavailable (adapter off?)` with the spinner cleared. Re-enabling Bluetooth and
scanning then finds both boards — **same pid throughout, never restarted**.

Tests: `FakeScanner` gains `failWith` so the flow can fail rather than emit; two cases pin that
a scanner failure reports-and-stops instead of crashing, and that a later scan still works
afterwards. 34/34 `FleetManagerTest`, full JVM suite green, preflight green.

## Group 1 is now complete

All five items pass — permission-denied messaging, location-denied degradation (scanning
unaffected, bearing card explains itself), FGS surviving denied notifications, and revoke-while-
connected recovery.

One platform note worth recording: `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` share the
`NEARBY_DEVICES` group, so revoking CONNECT alone gets it auto-re-granted on the next request —
it returns *without* the `USER_SET` flag, which is the tell. "Connected with CONNECT denied"
isn't reachable that way.

This is the second crash Checkpoint A has found (after the chart OOM, #636), and the pattern is
identical both times: an error path that was correct about the error and fatal about reporting
it.

Refs #624, #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
