### PR TITLE
android(#633): reconnect on cold start to whatever we were connected to

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
@@ -12,6 +12,7 @@ import com.tinkerbug.tinkerrocket.session.FleetManager
 import com.tinkerbug.tinkerrocket.session.FleetSessionFactory
 import com.tinkerbug.tinkerrocket.session.KnownDeviceStorage
 import com.tinkerbug.tinkerrocket.session.KnownDeviceStore
+import com.tinkerbug.tinkerrocket.session.LastSessionStore
 import com.tinkerbug.tinkerrocket.session.RocketProfileStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -121,6 +122,7 @@ class AppContainer(app: Application) {
             transportFactory = AndroidTransportFactory(app),
             sessionFactory = sessionFactory,
             knownDevices = knownDevices,
+            lastSession = PrefsLastSessionStore(app),
         )
         fleetRef
     }
@@ -145,6 +147,30 @@ class AppNetworkStore(app: Application) {
         _name.value = name
         _id.value = id
         prefs.edit().putString("networkName", name).putInt("networkID", id).apply()
+    }
+}
+
+/**
+ * #633 cold-start resume hint, prefs-backed.
+ *
+ * Deliberately survives process death — that IS the case it exists for. A
+ * crash, an OEM kill or a phone reboot must still resume; only an explicit
+ * user disconnect clears it (FleetManager owns that rule).
+ */
+private class PrefsLastSessionStore(app: Application) : LastSessionStore {
+    private val prefs = app.getSharedPreferences("last_session", Context.MODE_PRIVATE)
+
+    override fun saveLastConnected(deviceId: String, name: String) {
+        prefs.edit().putString("device_id", deviceId).putString("name", name).apply()
+    }
+
+    override fun clearLastConnected() {
+        prefs.edit().remove("device_id").remove("name").apply()
+    }
+
+    override fun loadLastConnected(): LastSessionStore.LastConnected? {
+        val id = prefs.getString("device_id", null) ?: return null
+        return LastSessionStore.LastConnected(id, prefs.getString("name", null) ?: "rocket")
     }
 }
 

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
@@ -55,7 +55,17 @@ class MainActivity : ComponentActivity() {
         val container = (application as TinkerRocketApp).container
 
         permissionsGranted.value = bleGranted()
-        if (!permissionsGranted.value) requestPermissions.launch(blePermissions)
+        if (!permissionsGranted.value) {
+            requestPermissions.launch(blePermissions)
+        } else {
+            // #633: resume whatever we were connected to before the app went
+            // away.  Android has no CoreBluetooth state restoration, so a
+            // crash, OEM kill or reboot otherwise left the user tapping Scan
+            // then Connect.  No-ops when there's nothing to resume, and only
+            // ever after permissions are already granted — a resume must never
+            // be what triggers a permission prompt.
+            container.fleet.resumeLastSession()
+        }
 
         setContent {
             val scheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/FleetManager.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/FleetManager.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.min
 
 /**
@@ -66,6 +67,12 @@ public class FleetManager<S : Any>(
     public val knownDevices: KnownDeviceStore,
     /** Injected clock (no wall-clock reads in the session layer). */
     private val nowMillis: () -> Long = System::currentTimeMillis,
+    /**
+     * Where the "we were connected when the app went away" hint lives (#633).
+     * Defaults to an in-memory no-op so tests and any existing construction
+     * keep working; the app supplies a persistent one.
+     */
+    private val lastSession: LastSessionStore = LastSessionStore.InMemory(),
 ) {
 
     // ------------------------------------------------------------- published
@@ -162,6 +169,7 @@ public class FleetManager<S : Any>(
     private var scanJob: Job? = null
     private var scanEpoch: Int = 0
     private val reconnectJobs = mutableMapOf<String, Job>()
+    private var resumeJob: Job? = null
     private val connectJobs = mutableMapOf<String, Job>()
 
     public companion object {
@@ -169,6 +177,15 @@ public class FleetManager<S : Any>(
 
         /** #291: was 3 (~7 s); raised for flight dropouts. */
         public const val MAX_RECONNECT_ATTEMPTS: Int = 8
+
+        /**
+         * How long a cold-start resume waits to SEE the last device before
+         * giving up (#633).  Bounded on purpose — the mid-flight endgame waits
+         * forever because a flight is in the air; at startup nothing is, and an
+         * endless background scan is just battery.  20 s covers a board that is
+         * already powered and advertising, which is the case worth serving.
+         */
+        public const val RESUME_SIGHTING_TIMEOUT_MS: Long = 20_000
 
         /**
          * Backoff before reconnect attempt `n` (1-based): `min(8, 2^(n-1))` s
@@ -348,6 +365,12 @@ public class FleetManager<S : Any>(
         return try {
             transport.connect()
             adopt(deviceId, name, transport)
+            // #633: remember what we were talking to, so a cold start can
+            // resume it.  Written on every successful connect, cleared only by
+            // an explicit user disconnect — so "was connected" survives a
+            // crash, an OEM kill, or a phone reboot, which are exactly the
+            // cases the field cares about.
+            lastSession.saveLastConnected(deviceId, name)
             true
         } catch (_: Exception) {
             watcher.cancel()
@@ -416,11 +439,67 @@ public class FleetManager<S : Any>(
             reconnectJobs.remove(deviceId)?.cancel()
             _statusMessage.value = "Disconnected"
             _discoveredDevices.value = emptyList()
+            // Deliberate: walking away is the ONE case we don't resume from.
+            // Anything else (crash, OEM kill, reboot, battery pull) leaves the
+            // hint in place (#633).
+            lastSession.clearLastConnected()
             return
         }
 
         // Unexpected drop → reconnect ladder.
         launchReconnectLadder(deviceId, dev?.advertisedName ?: "rocket")
+    }
+
+    // -------------------------------------------------------- cold-start resume
+
+    /**
+     * Reconnect on a cold start to whatever we were connected to (#633).
+     *
+     * The gap this closes: mid-session recovery was already solid — a board
+     * power-cycle comes back in under 6 s — but nothing resumed after the app
+     * itself restarted.  `scan()` was only ever called from the Scan button, so
+     * a crash, an OEM kill or a phone reboot left the user tapping Scan then
+     * Connect at exactly the moment they'd rather be watching the pad.  iOS
+     * never had this: state restoration hands its connections back, and it
+     * re-scans on Bluetooth power-on.
+     *
+     * Reuses the ladder's endgame shape — scan, wait for a real advertisement,
+     * THEN autoConnect — because the rule that made that safe still applies: an
+     * `autoConnect=true` transport for an address the adapter hasn't recently
+     * seen can silently never fire, so we never autoConnect blind from a MAC.
+     *
+     * BOUNDED, unlike the mid-flight endgame's unbounded wait.  That one is
+     * unbounded on purpose: a flight is in progress and abandoning it is worse
+     * than scanning. Here nothing is in the air, and a cold start that scans
+     * forever is just a battery drain — so it gives up after
+     * [RESUME_SIGHTING_TIMEOUT_MS] and leaves the user on a normal scanner.
+     *
+     * Safe to call unconditionally at startup: no hint, or already connected,
+     * and it does nothing.
+     */
+    public fun resumeLastSession() {
+        val last = lastSession.loadLastConnected() ?: return
+        if (_devices.value.isNotEmpty()) return          // already connected
+        resumeJob?.cancel()
+        resumeJob = scope.launch {
+            _statusMessage.value = "Looking for ${last.name}…"
+            // Background scan — NOT user-initiated, so no modal pops (#394).
+            scan(userInitiated = false)
+            val seen = withTimeoutOrNull(RESUME_SIGHTING_TIMEOUT_MS) {
+                scanner.advertisements().first { it.deviceId == last.deviceId }
+            }
+            if (seen == null) {
+                // Not here — say so plainly instead of implying we're still
+                // trying.  The device list keeps whatever the scan turned up.
+                if (_devices.value.isEmpty()) {
+                    _statusMessage.value = "${last.name} not found"
+                }
+                return@launch
+            }
+            // Connected by other means while we waited (user tapped it).
+            if (_devices.value.containsKey(last.deviceId)) return@launch
+            tryConnect(last.deviceId, last.name, autoConnect = true)
+        }
     }
 
     // ----------------------------------------------------- reconnect ladder

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/LastSessionStore.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/LastSessionStore.kt
@@ -1,0 +1,43 @@
+package com.tinkerbug.tinkerrocket.session
+
+/**
+ * Remembers which device the app was connected to when it last went away, so a
+ * cold start can resume it (#633).
+ *
+ * Android has no equivalent of CoreBluetooth state restoration: iOS gets its
+ * connections handed back by the OS after a relaunch and additionally re-scans
+ * on Bluetooth power-on (`BLEFleet.swift:397`). Android wakes up knowing
+ * nothing, so the app has to remember for itself.
+ *
+ * Deliberately just an id and a display name, not a whole session: the point is
+ * only to know *what to look for*. The reconnect itself goes through the normal
+ * sighting-gated path, which never autoConnects blind from a MAC.
+ */
+public interface LastSessionStore {
+
+    /** Called on every successful connect. */
+    public fun saveLastConnected(deviceId: String, name: String)
+
+    /** Called ONLY on an explicit user disconnect — see [FleetManager]. */
+    public fun clearLastConnected()
+
+    /** The last connected device, or null if there is nothing to resume. */
+    public fun loadLastConnected(): LastConnected?
+
+    public data class LastConnected(val deviceId: String, val name: String)
+
+    /**
+     * Non-persistent default, so existing constructions (tests, composition
+     * fakes) keep working unchanged and simply never resume across a restart.
+     */
+    public class InMemory : LastSessionStore {
+        private var value: LastConnected? = null
+        override fun saveLastConnected(deviceId: String, name: String) {
+            value = LastConnected(deviceId, name)
+        }
+        override fun clearLastConnected() {
+            value = null
+        }
+        override fun loadLastConnected(): LastConnected? = value
+    }
+}

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetManagerTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetManagerTest.kt
@@ -532,4 +532,83 @@ class FleetManagerTest {
         runCurrent()
         assertTrue(h.fleet.isScanning.value, "a later scan should start normally")
     }
+
+    // ── #633 cold-start resume ───────────────────────────────────────────
+
+    @Test
+    fun connectRecordsTheResumeHint_andUserDisconnectClearsIt() = runTest {
+        val h = fleetHarness()
+        discoverAndConnect(h, "aa:01", "TR-R-Rocket")
+        assertEquals("aa:01", h.lastSession.loadLastConnected()?.deviceId)
+
+        // Walking away is the one case we must NOT resume from.
+        h.fleet.disconnect("aa:01")
+        runCurrent()
+        assertNull(h.lastSession.loadLastConnected(), "user disconnect must clear the hint")
+    }
+
+    @Test
+    fun unexpectedDropKeepsTheHint_soARestartCanResume() = runTest {
+        val h = fleetHarness()
+        discoverAndConnect(h, "aa:01", "TR-R-Rocket")
+        // Not user-initiated: a crash/OEM kill/reboot looks like this.
+        h.transports.lastFor("aa:01").dropUnexpectedly()
+        runCurrent()
+        assertEquals(
+            "aa:01",
+            h.lastSession.loadLastConnected()?.deviceId,
+            "an unexpected drop must leave the hint for a cold start",
+        )
+    }
+
+    @Test
+    fun resumeLastSession_scansThenConnectsOnceSighted() = runTest {
+        val h = fleetHarness()
+        h.lastSession.saveLastConnected("aa:01", "TR-R-Rocket")
+
+        h.fleet.resumeLastSession()
+        runCurrent()
+        // Scanning, and NOT user-initiated — a resume must not pop a modal (#394).
+        assertTrue(h.fleet.isScanning.value, "resume should start a scan")
+        assertFalse(h.fleet.userInitiatedScan.value, "resume scan must be silent")
+        assertTrue(h.fleet.devices.value.isEmpty(), "must not connect before a sighting")
+
+        // Only a real advertisement unlocks the connect — never blind from a MAC.
+        h.scanner.emissions.emit(BleAdvertisement("aa:01", "TR-R-Rocket", rssi = -40))
+        advanceTimeBy(500); runCurrent()
+        assertTrue(h.fleet.devices.value.containsKey("aa:01"), "should have reconnected")
+    }
+
+    @Test
+    fun resumeLastSession_givesUpBoundedWhenTheDeviceIsAbsent() = runTest {
+        val h = fleetHarness()
+        h.lastSession.saveLastConnected("aa:01", "TR-R-Rocket")
+        h.fleet.resumeLastSession()
+        runCurrent()
+
+        // Never sighted: bounded wait, unlike the mid-flight endgame.
+        advanceTimeBy(FleetManager.RESUME_SIGHTING_TIMEOUT_MS + 1_000)
+        runCurrent()
+        assertTrue(h.fleet.devices.value.isEmpty())
+        assertTrue(
+            h.fleet.statusMessage.value.contains("not found", ignoreCase = true),
+            "should say so plainly, was '${h.fleet.statusMessage.value}'",
+        )
+    }
+
+    @Test
+    fun resumeLastSession_isANoOpWithNoHintOrWhenAlreadyConnected() = runTest {
+        val h = fleetHarness()
+        // No hint at all.
+        h.fleet.resumeLastSession()
+        runCurrent()
+        assertFalse(h.fleet.isScanning.value, "nothing to resume — must not scan")
+
+        // Already connected: a hint exists but there's nothing to do.
+        discoverAndConnect(h, "aa:01", "TR-R-Rocket")
+        val before = h.fleet.statusMessage.value
+        h.fleet.resumeLastSession()
+        runCurrent()
+        assertEquals(before, h.fleet.statusMessage.value, "should not disturb a live session")
+    }
 }

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetTestFakes.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/FleetTestFakes.kt
@@ -137,6 +137,8 @@ class FleetHarness(scope: CoroutineScope, currentTime: () -> Long) {
     val transports = FakeTransportFactory(currentTime)
     val sessions = FakeSessionFactory()
     val knownDevices = KnownDeviceStore(InMemoryKnownStorage(), nowEpochMillis = { 0L })
+    /** #633 resume hint; exposed so tests can seed or inspect it. */
+    val lastSession = LastSessionStore.InMemory()
     val fleet: FleetManager<FakeSession> = FleetManager(
         scope = scope,
         scanner = scanner,
@@ -144,6 +146,7 @@ class FleetHarness(scope: CoroutineScope, currentTime: () -> Long) {
         sessionFactory = sessions,
         knownDevices = knownDevices,
         nowMillis = currentTime,
+        lastSession = lastSession,
     )
 }
 

--- a/docs/plans/624-checkpoint-a-matrix.md
+++ b/docs/plans/624-checkpoint-a-matrix.md
@@ -123,10 +123,14 @@ The one I'd least want to discover in the field. Result: clean except cold start
       stays a watch-for-it during other work rather than a step
 - [x] Airplane mode on → off → **PASS**, back inside 10 s. Usefully, the ladder is visible
       and honest in the UI: `Reconnecting (5/8)...`
-- [ ] Phone reboot with board live → **FAIL** → issue #633. Mid-session reconnect is solid;
-      this is specifically cold start. iOS scans on BT power-on (`BLEFleet.swift:397`) plus
-      state restoration, so it reconnects itself; Android's `scan()` is only ever called from
-      the Scan button, and the sighting-gated autoConnect endgame never engages from cold
+- [x] Phone reboot with board live → **WAS #633, NOW FIXED**. Mid-session reconnect was always
+      solid; cold start wasn't. iOS gets state restoration plus a re-scan on BT power-on
+      (`BLEFleet.swift:397`); Android's `scan()` was only ever called from the Scan button, so
+      a crash, OEM kill or reboot left the user tapping Scan then Connect. `resumeLastSession()`
+      now scans on launch when the last session ended connected, waits for a real advertisement,
+      then autoConnects — bounded at 20 s, unlike the mid-flight endgame's deliberate forever.
+      Verified: relaunch after a kill reconnected in **under 5 s with zero taps**; an explicit
+      user disconnect clears the hint and relaunch correctly stays put
 - [x] **FGS survival** → **PASS**: 47 min 56 s, 95 samples, 0 process deaths, 0 GATT drops,
       deep Doze held for every sample, PID stable
 - [ ] OC current during the wait → NOT MEASURED (needs a meter; the app's own battery figure


### PR DESCRIPTION
Mid-session recovery was always solid — a board power-cycle comes back in under 6 s — but
nothing resumed after the **app** restarted. `scan()` was only ever called from the Scan
button, so a crash, an OEM kill or a phone reboot left the user tapping Scan then Connect at
exactly the moment they'd rather be watching the pad.

iOS never had this: state restoration hands its connections back, and it re-scans on Bluetooth
power-on (`BLEFleet.swift:397`). Android wakes up knowing nothing, so the app has to remember
for itself.

## Change

| | |
|---|---|
| `LastSessionStore` | a two-field hint (device id + display name) behind its own seam, with an `InMemory` default so existing constructions and tests are untouched. The app supplies a prefs-backed one that survives process death — that *is* the case it exists for |
| `resumeLastSession()` | scan → wait for a real advertisement → autoConnect |

The hint is written on **every successful connect** and cleared **only by an explicit user
disconnect**. Walking away is the one case we must not resume from; everything else — crash,
OEM kill, reboot, battery pull — leaves it in place, which is what the field cares about.

## Design notes

**Reuses the ladder endgame's shape** rather than inventing a second path, because the rule
that made that safe still holds: an `autoConnect=true` transport for an address the adapter
hasn't recently seen can silently never fire. So we never autoConnect blind from a MAC — only a
fresh sighting unlocks the attempt.

**Bounded at 20 s**, deliberately unlike the mid-flight endgame's unbounded wait. That one is
unbounded because a flight is in the air and giving up is worse than scanning; at startup
nothing is airborne and an endless background scan is just battery.

The resume scan is **not** user-initiated (#394 — no modal), and only runs when permissions are
already granted: a resume must never be the thing that triggers a permission prompt.

## Verified on-device, both directions

- after a **force-stop** (what an OEM kill looks like): relaunch reconnected in **under 5 s
  with zero taps**, hint intact in prefs across the kill
- after an **explicit user disconnect**: hint gone from prefs, relaunch stays put with the
  radio idle for 24 s of observation

Tests: hint recorded on connect, cleared on user disconnect, **kept** on an unexpected drop;
resume scans-then-connects only once sighted; bounded give-up reports "not found"; no-ops with
no hint or when already connected. 39/39 `FleetManagerTest`, full JVM suite green, preflight
green.

Closes #633 — the last open issue from Checkpoint A. Refs #624, #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
