### PR TITLE
android: unit-test the compass math the arrow can't show you (Checkpoint A group 7)

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -365,7 +365,8 @@ private fun DirectionToRocketCard(
                     val bear = com.tinkerbug.tinkerrocket.session.DriftCast.bearingDeg(
                         p.lat, p.lon, fix.latitude, fix.longitude,
                     )
-                    val arrowAngle = ((bear - heading + 180.0).mod(360.0) - 180.0).toFloat()
+                    val arrowAngle = com.tinkerbug.tinkerrocket.session.HeadingMath
+                        .arrowAngleDeg(bear, heading).toFloat()
                     Text(
                         "➤",
                         style = MaterialTheme.typography.displayMedium,

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/PhoneLocationManager.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/PhoneLocationManager.kt
@@ -1,5 +1,6 @@
 package com.tinkerbug.tinkerrocket.app
 
+import com.tinkerbug.tinkerrocket.session.HeadingMath
 import android.Manifest
 import android.app.Application
 import android.content.Context
@@ -20,7 +21,6 @@ import com.google.android.gms.location.Priority
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlin.math.abs
 
 /**
  * Phone GPS + compass heading for direction/distance to the rocket — port
@@ -80,10 +80,13 @@ class PhoneLocationManager(private val app: Application) {
             SensorManager.getRotationMatrixFromVector(rotation, event.values)
             SensorManager.getOrientation(rotation, orientation)
             val magnetic = Math.toDegrees(orientation[0].toDouble())
-            val trueHeading = (magnetic + declinationDeg).mod(360.0)
-            // ≥1° guard, wrap-aware (359.5 → 0.5 is a 1° move, not 359°).
-            val delta = abs((trueHeading - _headingDeg.value + 180.0).mod(360.0) - 180.0)
-            if (delta >= 1.0) _headingDeg.value = trueHeading
+            // Math lives in HeadingMath (:core:session) so it is unit-tested —
+            // the wrap cases can't be caught by looking at the arrow, since 359°
+            // wrong and 1° wrong render identically (Checkpoint A Group 7).
+            val trueHeading = HeadingMath.trueHeading(magnetic, declinationDeg)
+            if (HeadingMath.shouldPublish(trueHeading, _headingDeg.value)) {
+                _headingDeg.value = trueHeading
+            }
         }
 
         override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
@@ -229,10 +229,12 @@ fun SimulationScreen(session: DeviceSession, onBack: () -> Unit) {
             Text("All fields must be positive numbers", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
         }
         Text(
+            // Was "Voice announcements, LoRa, and data logging all work during
+            // simulation" — ported verbatim from iOS, but Android has no voice
+            // announcements at all (#643).  Don't promise what isn't there.
             "The simulator runs a 1D physics model on the ESP32, generating " +
                 "synthetic sensor data through the full telemetry pipeline. " +
-                "Voice announcements, LoRa, and data logging all work during " +
-                "simulation.",
+                "LoRa and data logging both work during simulation.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/HeadingMath.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/HeadingMath.kt
@@ -1,0 +1,59 @@
+package com.tinkerbug.tinkerrocket.session
+
+import kotlin.math.abs
+
+/**
+ * Compass-heading arithmetic for the direction-to-rocket arrow.
+ *
+ * Extracted from `PhoneLocationManager`'s `SensorEventListener` and
+ * `DashboardScreen`'s arrow rotation (Checkpoint A Group 7): all three of these
+ * are pure functions that were buried in an Android sensor callback and a
+ * Composable, where nothing could test them. Every one has a wrap-around case
+ * that a visual check at the bench would not catch — an arrow that is 359° off
+ * looks identical to one that is 1° off.
+ *
+ * Angles are degrees, compass convention: 0 = true north, increasing clockwise.
+ */
+public object HeadingMath {
+
+    /**
+     * Magnetic heading + geomagnetic declination → true heading, normalised to
+     * [0, 360).
+     *
+     * Declination is signed (east positive). `mod` rather than `%` matters here:
+     * Kotlin's `%` keeps the sign of the dividend, so a westerly declination
+     * that pushes the result negative would yield e.g. -5° instead of 355°.
+     */
+    public fun trueHeading(magneticDeg: Double, declinationDeg: Double): Double =
+        (magneticDeg + declinationDeg).mod(360.0)
+
+    /**
+     * Smallest angular distance between two headings, always in [0, 180].
+     *
+     * The published-heading guard uses this so 359.5° → 0.5° reads as a 1°
+     * move rather than a 359° one. Naive subtraction would make every pass
+     * through north look like a huge jump — which, with a "publish on ≥1°
+     * change" rule, would publish constantly while the phone sits still
+     * pointing north, and iOS memory growth from exactly that kind of
+     * over-publishing is why the guard exists.
+     */
+    public fun angularDeltaDeg(a: Double, b: Double): Double =
+        abs((a - b + 180.0).mod(360.0) - 180.0)
+
+    /** Publish a new heading only once it has moved at least [minDeltaDeg]. */
+    public fun shouldPublish(newDeg: Double, currentDeg: Double, minDeltaDeg: Double = 1.0): Boolean =
+        angularDeltaDeg(newDeg, currentDeg) >= minDeltaDeg
+
+    /**
+     * Rotation for the on-screen arrow: where the rocket is, relative to where
+     * the phone is pointing. Signed, in **[-180, 180)** — negative is left of
+     * the phone's nose, positive is right — so a rotation applied to the glyph
+     * takes the short way round instead of spinning 350° the wrong way.
+     *
+     * The exact antipode (rocket directly behind) lands at **-180, not +180**.
+     * Harmless for a rotation — the two are the same direction — but it is the
+     * half-open end of the range, so don't assert +180 for it.
+     */
+    public fun arrowAngleDeg(bearingToRocketDeg: Double, phoneHeadingDeg: Double): Double =
+        (bearingToRocketDeg - phoneHeadingDeg + 180.0).mod(360.0) - 180.0
+}

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/HeadingMathTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/HeadingMathTest.kt
@@ -1,0 +1,140 @@
+package com.tinkerbug.tinkerrocket.session
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Compass arithmetic for the direction-to-rocket arrow (Checkpoint A Group 7).
+ *
+ * The point of these is the wrap cases. An arrow 359° wrong looks exactly like
+ * an arrow 1° wrong on a phone screen, so the physical 8-heading walk-around
+ * cannot catch a sign or modulo error — only this can.
+ */
+class HeadingMathTest {
+
+    // ── true heading = magnetic + declination ────────────────────────────
+
+    @Test
+    fun trueHeading_appliesDeclinationAndNormalises() {
+        // Easterly declination (positive) rotates clockwise.
+        assertEquals(10.0, HeadingMath.trueHeading(0.0, 10.0), 1e-9)
+        assertEquals(100.0, HeadingMath.trueHeading(90.0, 10.0), 1e-9)
+    }
+
+    @Test
+    fun trueHeading_westerlyDeclinationPastNorthStaysPositive() {
+        // The bug this guards: Kotlin's `%` keeps the dividend's sign, so
+        // 2 + (-13) would be -11 instead of 349.  New Jersey's declination is
+        // about -13°, so this is the everyday case, not an edge case.
+        assertEquals(349.0, HeadingMath.trueHeading(2.0, -13.0), 1e-9)
+        assertEquals(347.0, HeadingMath.trueHeading(0.0, -13.0), 1e-9)
+    }
+
+    @Test
+    fun trueHeading_easterlyDeclinationPastNorthWrapsDown() {
+        assertEquals(5.0, HeadingMath.trueHeading(355.0, 10.0), 1e-9)
+    }
+
+    @Test
+    fun trueHeading_isAlwaysInRange() {
+        for (mag in 0 until 360) {
+            for (dec in listOf(-25.0, -13.0, 0.0, 7.5, 25.0)) {
+                val h = HeadingMath.trueHeading(mag.toDouble(), dec)
+                assertTrue(h >= 0.0 && h < 360.0, "mag=$mag dec=$dec gave $h")
+            }
+        }
+    }
+
+    // ── angular delta / publish guard ────────────────────────────────────
+
+    @Test
+    fun angularDelta_acrossNorthIsSmall() {
+        // THE case the guard exists for: 359.5 -> 0.5 is a 1° move, not 359°.
+        assertEquals(1.0, HeadingMath.angularDeltaDeg(0.5, 359.5), 1e-9)
+        assertEquals(1.0, HeadingMath.angularDeltaDeg(359.5, 0.5), 1e-9)
+        assertEquals(2.0, HeadingMath.angularDeltaDeg(1.0, 359.0), 1e-9)
+    }
+
+    @Test
+    fun angularDelta_isSymmetricAndBounded() {
+        val pairs = listOf(0.0 to 90.0, 90.0 to 0.0, 10.0 to 200.0, 350.0 to 170.0, 45.0 to 45.0)
+        for ((a, b) in pairs) {
+            val d = HeadingMath.angularDeltaDeg(a, b)
+            assertEquals(HeadingMath.angularDeltaDeg(b, a), d, 1e-9, "asymmetric for $a/$b")
+            assertTrue(d in 0.0..180.0, "$a/$b gave $d")
+        }
+    }
+
+    @Test
+    fun angularDelta_antipodalIs180() {
+        assertEquals(180.0, HeadingMath.angularDeltaDeg(0.0, 180.0), 1e-9)
+        assertEquals(180.0, HeadingMath.angularDeltaDeg(90.0, 270.0), 1e-9)
+    }
+
+    @Test
+    fun shouldPublish_holdsStillNearNorthInsteadOfSpamming() {
+        // Sitting still pointing north, jittering either side of 0: without a
+        // wrap-aware delta every one of these would look like a ~359° move and
+        // publish, which is the over-publishing the guard was added to stop.
+        assertFalse(HeadingMath.shouldPublish(newDeg = 0.2, currentDeg = 359.8))
+        assertFalse(HeadingMath.shouldPublish(newDeg = 359.8, currentDeg = 0.2))
+        // A real 1° move does publish.
+        assertTrue(HeadingMath.shouldPublish(newDeg = 1.0, currentDeg = 0.0))
+        assertTrue(HeadingMath.shouldPublish(newDeg = 0.0, currentDeg = 359.0))
+    }
+
+    // ── arrow rotation ───────────────────────────────────────────────────
+
+    @Test
+    fun arrowAngle_pointsAheadWhenFacingTheRocket() {
+        assertEquals(0.0, HeadingMath.arrowAngleDeg(bearingToRocketDeg = 90.0, phoneHeadingDeg = 90.0), 1e-9)
+    }
+
+    @Test
+    fun arrowAngle_takesTheShortWayRound() {
+        // Rocket just east of north, phone pointing just west of north: the
+        // arrow should nudge 20° RIGHT, not 340° left.
+        assertEquals(20.0, HeadingMath.arrowAngleDeg(10.0, 350.0), 1e-9)
+        // And the mirror case: 20° LEFT, not 340° right.
+        assertEquals(-20.0, HeadingMath.arrowAngleDeg(350.0, 10.0), 1e-9)
+    }
+
+    @Test
+    fun arrowAngle_signIsRightRelativeToTheNose() {
+        // Phone facing north, rocket due east → arrow right (+90).
+        assertEquals(90.0, HeadingMath.arrowAngleDeg(90.0, 0.0), 1e-9)
+        // Phone facing north, rocket due west → arrow left (-90).
+        assertEquals(-90.0, HeadingMath.arrowAngleDeg(270.0, 0.0), 1e-9)
+        // Directly behind lands on the half-open end: -180, NOT +180.  Same
+        // direction for a rotation, but the range is [-180, 180).
+        assertEquals(-180.0, HeadingMath.arrowAngleDeg(180.0, 0.0), 1e-9)
+    }
+
+    @Test
+    fun arrowAngle_isAlwaysInRange() {
+        for (bear in 0 until 360 step 7) {
+            for (head in 0 until 360 step 11) {
+                val a = HeadingMath.arrowAngleDeg(bear.toDouble(), head.toDouble())
+                assertTrue(a >= -180.0 && a < 180.0, "bear=$bear head=$head gave $a")
+            }
+        }
+    }
+
+    @Test
+    fun arrowAngle_counterRotatesWithThePhone() {
+        // The property the physical walk-around actually checks: turning the
+        // phone by D must swing the arrow by -D, so it keeps pointing at the
+        // same patch of ground.
+        val bearing = 42.0
+        var prev = HeadingMath.arrowAngleDeg(bearing, 0.0)
+        for (step in 1..11) {
+            val head = step * 30.0
+            val now = HeadingMath.arrowAngleDeg(bearing, head)
+            val swing = HeadingMath.angularDeltaDeg(prev, now)
+            assertEquals(30.0, swing, 1e-9, "phone turned 30° at head=$head; arrow swung $swing")
+            prev = now
+        }
+    }
+}

--- a/docs/plans/624-checkpoint-a-matrix.md
+++ b/docs/plans/624-checkpoint-a-matrix.md
@@ -229,11 +229,53 @@ and velocity, GNSS frozen. Fine for pipeline tests, NOT for judging flight-data 
 
 ## Group 7 — Sensors and audio
 
-- [ ] Heading arrow vs a physical compass, 8 headings → declination applied, wrap-around
-      correct at N
-- [ ] Arrow behaviour when location permission is denied → stated, not silently wrong
-- [ ] TTS announcements duck background audio and restore it
-- [ ] Announcements still fire with the screen off
+- [x] Heading arrow vs a physical compass, 8 headings → declination applied, wrap-around
+      correct at N — **PARTIAL: math verified, physical walk-around deferred to the outing**
+- [x] Arrow behaviour when location permission is denied → stated, not silently wrong —
+      **PASS** (covered in Group 1)
+- [ ] ~~TTS announcements duck background audio and restore it~~ — **N/A, FEATURE ABSENT (#643)**
+- [ ] ~~Announcements still fire with the screen off~~ — **N/A, FEATURE ABSENT (#643)**
+
+### 7.1 Heading arrow — what was actually verified
+
+The bearing card needs **both** a phone fix and a latched rocket GPS fix before it renders an
+arrow at all (`DashboardScreen` otherwise shows "Getting phone location…" / "Waiting for rocket
+GPS"). So the 8-heading comparison is inherently outdoors with a rocket powered and locked — it
+pairs with the shadow-phone outing, not the bench.
+
+What a visual comparison would not catch anyway: **an arrow 359° wrong looks identical to an
+arrow 1° wrong.** The failure modes here are sign and modulo errors, and they are invisible on a
+round dial. So the arithmetic was lifted out of where it could not be tested — a
+`SensorEventListener` callback and a Composable's rotation — into
+`core/session/…/HeadingMath.kt`, with 13 unit tests. Both call sites now use it, so the tests
+cover shipped code rather than a copy.
+
+Covered: declination east/west/across-north (Kotlin's `%` keeps the dividend's sign, so a
+westerly declination — New Jersey is ≈ −13°, the everyday case — would give −11° instead of 349°
+without `mod`); full 0–359 × 5-declination range sweep; wrap-aware angular delta (359.5 → 0.5 is
+1°, not 359°, which is what stops the publish guard from firing continuously while the phone
+sits still pointing north); arrow sign relative to the nose; short-way-round; and the property
+the physical test is really checking — **turn the phone 30° and the arrow must swing exactly 30°
+the other way**, asserted around a full circle.
+
+One correction worth recording: the arrow range is **[-180, 180)**, and the exact antipode
+yields **−180, not +180**. My first two assertions had this backwards. Harmless for a rotation
+(same direction), but don't assert +180.
+
+Still open, for the outing: that the phone's magnetometer is *calibrated* and that declination
+is being fetched for the actual launch site. Those are device/environment facts no unit test
+reaches.
+
+### 7.3 / 7.4 TTS — the feature does not exist
+
+Android has no `TextToSpeech`, `AudioManager`, `AudioAttributes`, `MediaPlayer` or `SoundPool`
+anywhere; there is no audio output of any kind. iOS has `FlightAnnouncer.swift` plus
+`FlightAnnouncerDispatchTests.swift`. These two boxes were scoped against a port that never
+happened — not a test failure, a **scope gap**, filed as #643 along with the plan inconsistency
+it exposes (the v1.0 launch-day loop names "voice"; the only scheduled announcer work is Phase
+9's post-v1.0 "announcer polish"). Also caught in passing: `ToolsScreens.kt:234` tells the user
+"Voice announcements, LoRa, and data logging all work during simulation" — ported verbatim from
+iOS and false on Android.
 
 ---
 


### PR DESCRIPTION
Checkpoint A Group 7 (sensors and audio). Two of its four boxes turned out to test a feature
Android doesn't have; the compass box turned out to be untestable in the way it was written.

## The compass box, and why it got rewritten as unit tests

As scoped — "arrow vs a physical compass, 8 headings" — this check can't catch what actually
breaks. **An arrow 359° wrong looks identical to one 1° wrong on a round dial**, and the failure
modes in this code are sign and modulo errors. It's also inherently outdoors: the card needs
*both* a phone fix and a latched rocket GPS fix before it renders an arrow (otherwise "Getting
phone location…" / "Waiting for rocket GPS"), so it belongs with the shadow-phone outing, not the
bench.

So the arithmetic moved out of the two places nothing could reach it — a `SensorEventListener`
callback and a Composable's rotation modifier — into `HeadingMath` in `:core:session`, with 13
tests. **The expressions are copied verbatim** (see the call-site diff — same code, relocated),
and both call sites delegate, so the tests cover shipped code rather than a parallel copy.

What they pin:

- **Declination across north.** Kotlin's `%` keeps the dividend's sign, so New Jersey's ≈ −13°
  would give −11° instead of 349° without `mod`. That's the everyday case, not an edge case.
- Full 0–359 × 5-declination **range sweep** — output always in [0, 360).
- The **wrap-aware delta**: 359.5° → 0.5° is a 1° move, not 359°. This is what stops the
  "publish on ≥1° change" guard from firing continuously while the phone sits still pointing
  north.
- Arrow **sign relative to the nose**, and **short-way-round** (20° right, not 340° left).
- The property the physical walk-around is really checking: **turn the phone 30° and the arrow
  swings exactly 30° the other way**, asserted around a full circle.

One correction: the arrow range is **[-180, 180)** and the exact antipode yields **−180, not
+180**. My first two assertions had that backwards — the code was right all along, the spec I
wrote for it wasn't.

Still open for the outing, because no unit test reaches it: that the phone's magnetometer is
calibrated, and that declination is being fetched for the actual launch site.

## The two TTS boxes: feature absent, filed as #643

Android has no `TextToSpeech`, `AudioManager`, `AudioAttributes`, `MediaPlayer` or `SoundPool`
anywhere — no audio output of any kind. iOS has `FlightAnnouncer.swift` plus
`FlightAnnouncerDispatchTests.swift`. Not a test failure; a scope gap, and it exposes a plan
inconsistency (the v1.0 launch-day loop names "voice", but the only scheduled announcer work is
Phase 9's post-v1.0 "announcer polish"). #643 has the detail and three ways to resolve it.

Caught in passing and fixed here: `ToolsScreens.kt` told the user "Voice announcements, LoRa, and
data logging all work during simulation" — ported verbatim from iOS and **false on Android**. Now
says LoRa and data logging.

## Verification

- `:core:session:test` — 13/13 in `HeadingMathTest`, **0 skipped** (checked the JUnit XML, not
  just the exit code).
- Full Android JVM suite green; `:app:assembleDebug` green.
- `tools/preflight_protocol.sh` — PASS.

The remaining Group 7 item, "arrow behaviour when location permission is denied", already passed
in Group 1: the card states "Location permission is needed to show direction and distance to the
rocket" with a `Grant location` button — stated, not silently wrong.

Refs #632, #624, #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
