### PR TITLE
android: release signing — public source, private key, Play door open

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,78 @@
+name: Android Release
+
+# Signed release APK on tag push (android-port plan §2.5: "Release CI signs
+# and attaches the APK on tag push").  Tag scheme: android-v<versionName>,
+# e.g. android-v1.0.0.  The keystore reaches the runner only as a base64
+# repo secret, decoded to a runner-local file that never enters the repo;
+# see docs/android-release-signing.md for minting, custody, and secret setup.
+#
+# Runs the full JVM suite first — a release must never outrun the tests.
+
+on:
+  push:
+    tags:
+      - 'android-v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the GitHub release + upload the APK
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Run JVM unit tests
+        run: ./gradlew --no-daemon test
+        working-directory: TinkerRocketAndroid
+
+      - name: Decode release keystore
+        env:
+          TR_ANDROID_KEYSTORE_B64: ${{ secrets.TR_ANDROID_KEYSTORE_B64 }}
+        run: |
+          if [ -z "$TR_ANDROID_KEYSTORE_B64" ]; then
+            echo "::error::TR_ANDROID_KEYSTORE_B64 secret is not set — cannot sign a release"
+            exit 1
+          fi
+          echo "$TR_ANDROID_KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+
+      - name: Build signed release APK
+        env:
+          TR_ANDROID_KEYSTORE: ${{ runner.temp }}/release.keystore
+          TR_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.TR_ANDROID_KEYSTORE_PASSWORD }}
+          TR_ANDROID_KEY_ALIAS: ${{ secrets.TR_ANDROID_KEY_ALIAS }}
+          TR_ANDROID_KEY_PASSWORD: ${{ secrets.TR_ANDROID_KEY_PASSWORD }}
+        run: ./gradlew --no-daemon :app:assembleRelease
+        working-directory: TinkerRocketAndroid
+
+      - name: Verify the APK is signed with the release key (not debug)
+        run: |
+          APK=TinkerRocketAndroid/app/build/outputs/apk/release/app-release.apk
+          ls -la "$APK"
+          # apksigner prints the signer cert DN; the debug key's is CN=Android Debug.
+          SIGNER=$("$ANDROID_HOME"/build-tools/*/apksigner verify --print-certs "$APK" \
+                   | grep -m1 "certificate DN")
+          echo "$SIGNER"
+          case "$SIGNER" in
+            *"Android Debug"*)
+              echo "::error::APK is debug-signed — the release signing env did not take"
+              exit 1 ;;
+          esac
+
+      - name: Attach APK to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          APK=TinkerRocketAndroid/app/build/outputs/apk/release/app-release.apk
+          OUT="TinkerRocket-${GITHUB_REF_NAME}.apk"
+          cp "$APK" "$OUT"
+          gh release create "$GITHUB_REF_NAME" "$OUT" \
+            --title "TinkerRocket Android ${GITHUB_REF_NAME#android-}" \
+            --generate-notes

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -56,9 +56,11 @@ jobs:
         run: |
           APK=TinkerRocketAndroid/app/build/outputs/apk/release/app-release.apk
           ls -la "$APK"
+          # Runners ship several build-tools versions — a bare glob expands to
+          # multiple paths and the first binary eats the second as an argument.
+          APKSIGNER=$(ls -d "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
           # apksigner prints the signer cert DN; the debug key's is CN=Android Debug.
-          SIGNER=$("$ANDROID_HOME"/build-tools/*/apksigner verify --print-certs "$APK" \
-                   | grep -m1 "certificate DN")
+          SIGNER=$("$APKSIGNER" verify --print-certs "$APK" | grep -m1 "certificate DN")
           echo "$SIGNER"
           case "$SIGNER" in
             *"Android Debug"*)

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ TinkerRocketApp/DerivedData/
 
 # Claude Code working files
 .claude/
+
+# Android release signing — the keystore must NEVER enter the repo
+# (docs/android-release-signing.md); belt-and-suspenders for a mis-placed file.
+*.keystore
+*.jks

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Validates sensor rates, frame integrity, timestamp health, and data completeness
 
 ### CI/CD
 
-Eight GitHub Actions workflows run automatically, each path-filtered to what it covers:
+Nine GitHub Actions workflows run automatically, each path-filtered to what it covers:
 
 | Workflow | What it does |
 |----------|--------------|
@@ -408,6 +408,7 @@ Eight GitHub Actions workflows run automatically, each path-filtered to what it 
 | **sim-tests.yml** | pytest for `tinkerrocket-sim/` and the component sources it binds to |
 | **ios-tests.yml** | XCTest for `TinkerRocketApp/` |
 | **android-tests.yml** | Pure-JVM JUnit for `TinkerRocketAndroid/` (protocol/session/maps modules) against the same golden-vector corpus the C++ and iOS suites consume |
+| **android-release.yml** | Signed release APK on `android-v*` tag push — JVM suite, then `assembleRelease` signed from repo secrets, with an `apksigner` gate that fails if the APK came out debug-signed (see `docs/android-release-signing.md`) |
 | **flight-report-tests.yml** | Flight-report tooling |
 | **wire-codes.yml** | Fails on duplicate BLE command numbers — the dispatch is a first-match chain, so a duplicate silently makes the later handler dead code |
 | **docs.yml** | Fails if a generated section map or the protocol reference disagrees with its source, or if the prose contradicts it — broken links, a stale ESP-IDF version, a missing workflow, a wrong struct size. The only workflow with **no path filter**: it runs on every push and PR, because docs drift as a side effect of changes anywhere |

--- a/TinkerRocketAndroid/app/build.gradle.kts
+++ b/TinkerRocketAndroid/app/build.gradle.kts
@@ -24,6 +24,38 @@ android {
         compose = true
     }
 
+    // Release signing (plan §2.5): source is public, the key is not.  The
+    // keystore lives OUTSIDE the repo and reaches builds only via env vars —
+    // locally from the operator's shell, in CI from repo secrets (see
+    // .github/workflows/android-release.yml and docs/android-release-signing.md).
+    // Forks build without any of this set and get a debug-signed release —
+    // installable everywhere, but unable to impersonate an UPDATE to a real
+    // install, which is the entire security model.
+    val keystorePath: String? = System.getenv("TR_ANDROID_KEYSTORE")
+    signingConfigs {
+        if (keystorePath != null) {
+            create("release") {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("TR_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("TR_ANDROID_KEY_ALIAS") ?: "tinkerrocket"
+                keyPassword = System.getenv("TR_ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            // Minification stays OFF for v1.0: R8 vs MapLibre/GMS keep-rules is
+            // real risk with zero payoff at this APK size and fleet size.
+            isMinifyEnabled = false
+            signingConfig = if (keystorePath != null) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
+        }
+    }
+
     sourceSets {
         getByName("main") {
             // Demo mode serves the emitter-generated synthetic flight as a
@@ -58,4 +90,9 @@ dependencies {
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.activity:activity-compose:1.10.1")
+    // Not used directly (MainActivity is a ComponentActivity) — pins the
+    // transitive fragment above 1.3.0 so the ActivityResult APIs are safe on
+    // every resolved path; release-only lintVital fails the build without it
+    // (InvalidFragmentVersionForActivityResult).
+    implementation("androidx.fragment:fragment:1.8.5")
 }

--- a/docs/android-release-signing.md
+++ b/docs/android-release-signing.md
@@ -1,0 +1,105 @@
+# Android release signing — key custody and setup
+
+*Android port plan §2.5. Source is public and forkable; the signing key is not. The key IS
+the app's update identity: Android refuses any update whose signature differs from the
+installed app, and a fork signed with its own key can build and run TinkerRocket but can
+never impersonate an update to a real install. `applicationId com.tinkerbug.tinkerrocket`
+is the other half of that identity.*
+
+## Custody model
+
+- The keystore lives **outside the repo** (suggested: `~/.tinkerrocket/release.keystore`)
+  and reaches builds only via env vars. `.gitignore` blocks `*.keystore` / `*.jks` as
+  belt-and-suspenders.
+- **Two backups you control**, because until Play enrollment there is no escrow and a lost
+  keystore means every phone must uninstall (losing profiles, saved flights, offline tiles)
+  to accept a new key:
+  1. a password-manager entry holding the base64'd keystore file + both passwords;
+  2. one offline copy (USB stick / second machine).
+  GitHub secrets are *not* a backup — they can't be read back out, and losing GitHub access
+  is one of the failure modes the backup exists for.
+- CI (`android-release.yml`) gets the keystore as a base64 repo secret, decodes it to a
+  runner-temp file, signs on `android-v*` tag push, and refuses to ship a debug-signed APK.
+
+## One-time setup (operator runs these; keeps secrets out of transcripts/history)
+
+Mint the key (prompts interactively for the two passwords — use the password manager's
+generator; 25+ years validity is deliberate, the key must outlive the fleet):
+
+```bash
+mkdir -p ~/.tinkerrocket && keytool -genkeypair -v -keystore ~/.tinkerrocket/release.keystore -alias tinkerrocket -keyalg RSA -keysize 4096 -validity 10000 -dname "CN=TinkerRocket, O=Tinkerbug Robotics"
+```
+
+Add the four repo secrets (each prompts on stdin; paste from the password manager):
+
+```bash
+base64 -i ~/.tinkerrocket/release.keystore | gh secret set TR_ANDROID_KEYSTORE_B64
+```
+
+```bash
+gh secret set TR_ANDROID_KEYSTORE_PASSWORD
+```
+
+```bash
+gh secret set TR_ANDROID_KEY_ALIAS --body tinkerrocket
+```
+
+```bash
+gh secret set TR_ANDROID_KEY_PASSWORD
+```
+
+Then back up: password-manager entry with the base64 blob + both passwords, plus one
+offline copy of the file.
+
+## Cutting a release
+
+```bash
+git tag android-v1.0.0 && git push origin android-v1.0.0
+```
+
+CI runs the JVM suite, builds `:app:assembleRelease` signed with the release key, verifies
+the signer isn't the debug cert, and attaches `TinkerRocket-android-v1.0.0.apk` to a GitHub
+release. Bump `versionCode`/`versionName` in `app/build.gradle.kts` before tagging —
+`versionCode` must increase monotonically (Play requires it; sideloads want it too so
+"update" installs work without uninstalling).
+
+Local signed build, when needed:
+
+```bash
+export TR_ANDROID_KEYSTORE=~/.tinkerrocket/release.keystore TR_ANDROID_KEY_ALIAS=tinkerrocket
+```
+
+then set the two password vars from the password manager and run
+`./gradlew :app:assembleRelease` in `TinkerRocketAndroid/`.
+
+## Forks
+
+Nothing to configure: with no `TR_ANDROID_KEYSTORE` in the environment, `assembleRelease`
+falls back to the debug signing config — installable everywhere, distinct identity, cannot
+update a real install. Forks that want to distribute must mint their own key and rename
+`applicationId`.
+
+## The Play Store path (when the app matures)
+
+Play App Signing is mandatory for new apps: Google holds the **app signing key** in escrow
+and you sign uploads with an **upload key** (recoverable through support if lost). The
+wrinkle for our sideload-first fleet: if Google *generates* the app signing key, the Play
+build's signature won't match sideloaded installs — every fleet phone would need an
+uninstall (data loss) to switch to Play.
+
+**The plan: enroll with "use existing key"** — upload THIS release key as the Play app
+signing key. Sideloads and Play installs then share a signature, fleet phones migrate to
+Play seamlessly, and Google's escrow takes over long-term custody from that day. Until
+enrollment, the password-manager + offline backups above are the only copies in the world.
+
+Also required for Play, handled at that time: AAB uploads instead of APKs (a one-job
+addition to the workflow), and the closed-testing gauntlet for new personal accounts
+(20 testers × 14 days) — the reason v1.0 ships via GitHub Releases (plan §1 Distribution).
+
+## Debug builds and `run-as`
+
+Bench phones run debug builds signed by each dev machine's auto-generated
+`~/.android/debug.keystore`. Debug builds are `debuggable`, which is what allows `adb
+run-as` file pulls during bench work (used by the Checkpoint A CSV-parity test) — release
+builds correctly forbid that. The shadow-outing phone should carry the **release-signed**
+APK: it's the artifact v1.0 actually ships, and the outing is its validation pass.


### PR DESCRIPTION
Implements plan §2.5's release-signing half: **source public, key private**, with the Play
Store door held open. Companion doc: `docs/android-release-signing.md`.

## Design

- **Gradle**: `signingConfigs.release` reads `TR_ANDROID_KEYSTORE` + password/alias env vars.
  Nothing set → `assembleRelease` silently falls back to the **debug** key: forks build
  installable APKs with zero setup, but a fork's signature can never impersonate an update to
  a real install. Minification stays off for v1.0 (R8-vs-MapLibre risk, zero payoff at this
  size).
- **CI** (`android-release.yml`, `android-v*` tags): JVM suite → decode keystore from a base64
  repo secret into runner temp → signed `assembleRelease` → **apksigner gate that fails the job
  if the APK came out debug-signed** (that's exactly what a missing/broken secret would
  otherwise ship silently) → APK attached to a GitHub release.
- **.gitignore**: `*.keystore` / `*.jks` blocked repo-wide.

## Verified both ways locally

| env | signer DN | result |
|---|---|---|
| none (fork path) | `CN=Android Debug` | 67 MB APK, builds clean |
| scratch keystore via env | `CN=ScratchTestOnly` | release config took |

The scratch keystore was a throwaway minted for the test and deleted; the real key does not
exist yet — minting is the operator step below.

Bonus find from the first-ever `lintVitalRelease` run (release-only lint, so no debug build
ever hit it): a transitive `androidx.fragment` below 1.3.0
(`InvalidFragmentVersionForActivityResult`). Fixed by pinning `fragment:1.8.5` — the real
resolution, not a lint suppression. Full JVM suite + debug build still green.

## Operator steps (deliberately not automatable by an agent — keeps key material and
passwords out of transcripts and shell history)

1. Mint: the `keytool -genkeypair` command in the doc (prompts for passwords interactively).
2. Secrets: four `gh secret set` commands in the doc.
3. Backup: password-manager entry (base64 blob + both passwords) + one offline copy.

## Play path (recorded in the doc for future-us)

Enroll Play App Signing with **"use existing key"** — upload this key as the app signing key.
Sideloaded fleet phones then migrate to Play installs without the uninstall-and-lose-data
step, and Google's escrow takes over custody from enrollment day.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
