### PR TITLE
android: unclip the Disconnect button the voice chip shoved off-screen

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -95,7 +95,12 @@ fun DashboardScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column {
+            // weight(1f) so a wide device name YIELDS instead of shoving the
+            // action row off-screen: #645's voice chip widened the right side
+            // and "Rocket Computer V6" pushed Disconnect past the screen edge
+            // — clipped to invisible, leaving no way off the device. The name
+            // wraps; the actions never move.
+            Column(Modifier.weight(1f)) {
                 Text(
                     (identity.unitName.ifEmpty { device.advertisedName }) +
                         if (demo) "  (demo)" else "",


### PR DESCRIPTION
Found live while setting up the backyard compass check: the dashboard's Disconnect button was
**clipped off the right edge of the screen** — a #645 regression, and worse than cosmetic,
because the scanner only returns when the fleet empties, so a connected phone had **no
reachable way off the device**.

Mechanics: the header is a `SpaceBetween` Row with no weights. The device-name column takes
its intrinsic width, and once the announcer's voice chip widened the action row, "Rocket
Computer V6" + chip + button no longer fit in 1080 px — Compose clips the overflow silently.
Pre-#645 the right side was Disconnect alone and happened to fit, which is why no checkpoint
sitting ever caught it.

Fix: `weight(1f)` on the name column — a long name now wraps; the action row never moves.

Verified on-device on both link types (OC and BS dashboards show Disconnect on-screen).
Honest caveat: eyeball-verified only — no instrumentation harness exists to assert layout
bounds, and the JVM suite can't see clipping. If Compose screenshot tests ever land (Phase 9
candidate), this header is the first case for them.

Also validated incidentally this session, on the release build: the direction-to-rocket card
renders on a live BS link (arrow + distance + relative altitude via LoRa relay), matching the
iOS base-station-only gate — the physical walk-around against a compass happens next, outdoors.

Refs #624, #645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
