### PR TITLE
android(#624): in-app update checker + v0.9.1 — the sideload loop closes

### DIFF
--- a/TinkerRocketAndroid/app/build.gradle.kts
+++ b/TinkerRocketAndroid/app/build.gradle.kts
@@ -16,8 +16,10 @@ android {
         applicationId = "com.tinkerbug.tinkerrocket"
         minSdk = 31
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0-phase3"
+        // versionCode must only ever increase (Play + sideload "update"
+        // installs both key on it); bump BOTH before tagging android-v<name>.
+        versionCode = 2
+        versionName = "0.9.1"
     }
 
     buildFeatures {

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
@@ -51,6 +51,9 @@ class AppContainer(app: Application) {
     /** Phone GPS + heading (ref-counted; consumers start/stop). */
     val phoneLocation = PhoneLocationManager(app)
 
+    /** GitHub-releases update check (plan §1); throttled + failure-silent. */
+    val updateChecker = UpdateChecker(app)
+
     /**
      * Voice callouts (#643): policy in :core:session, TextToSpeech behind the
      * AnnouncerSpeech seam.  App-scoped, unlike iOS's per-DashboardView

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
@@ -67,6 +67,11 @@ class MainActivity : ComponentActivity() {
             container.fleet.resumeLastSession()
         }
 
+        // Update check: once per app start, one network hit per day, silent on
+        // every failure (no signal at a launch site is normal). Fleet scope so
+        // it survives the activity; the banner reads the StateFlow whenever.
+        container.fleetScope.launch { container.updateChecker.checkThrottled() }
+
         setContent {
             val scheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
             MaterialTheme(colorScheme = scheme) {
@@ -217,6 +222,7 @@ class MainActivity : ComponentActivity() {
                                     onBack = { showMyDevices = false },
                                 )
                             } else {
+                                val update by container.updateChecker.available.collectAsState()
                                 ScannerScreen(
                                     fleet = container.fleet,
                                     onDemo = {
@@ -229,6 +235,17 @@ class MainActivity : ComponentActivity() {
                                     },
                                     onMyDevices = { showMyDevices = true },
                                     onSavedFlights = { showSavedFlights = true },
+                                    updateVersion = update?.versionName,
+                                    onGetUpdate = {
+                                        update?.let {
+                                            startActivity(
+                                                android.content.Intent(
+                                                    android.content.Intent.ACTION_VIEW,
+                                                    android.net.Uri.parse(it.htmlUrl),
+                                                ),
+                                            )
+                                        }
+                                    },
                                 )
                             }
                         }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
@@ -30,6 +30,8 @@ fun ScannerScreen(
     onDemo: () -> Unit,
     onMyDevices: () -> Unit = {},
     onSavedFlights: () -> Unit = {},
+    updateVersion: String? = null,
+    onGetUpdate: () -> Unit = {},
 ) {
     val discovered by fleet.discoveredDevices.collectAsState()
     val scanning by fleet.isScanning.collectAsState()
@@ -40,6 +42,18 @@ fun ScannerScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text("TinkerRocket", style = MaterialTheme.typography.headlineMedium)
+        // Update banner (plan §1 sideload loop): informational, never modal —
+        // launch-day work must be able to ignore it entirely.
+        updateVersion?.let { v ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Update available: v$v",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedButton(onClick = onGetUpdate) { Text("Get") }
+            }
+        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             Button(onClick = { fleet.scan(userInitiated = true) }, enabled = !scanning) {
                 Text(if (scanning) "Scanning…" else "Scan")

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/UpdateChecker.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/UpdateChecker.kt
@@ -1,0 +1,89 @@
+package com.tinkerbug.tinkerrocket.app
+
+import android.app.Application
+import android.content.Context
+import com.tinkerbug.tinkerrocket.session.UpdateCheck
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Thin shell around [UpdateCheck]: fetch GitHub releases, throttle to one
+ * network hit per day, persist a found update so a throttled restart still
+ * shows the banner. Every failure path is silent-null — no signal at a launch
+ * site is NORMAL, and an update check must never cost anything there.
+ */
+class UpdateChecker(private val app: Application) {
+
+    private val prefs = app.getSharedPreferences("update_check", Context.MODE_PRIVATE)
+
+    private val _available = MutableStateFlow(storedIfStillAhead())
+    val available: StateFlow<UpdateCheck.ReleaseCandidate?> = _available
+
+    val currentVersionName: String by lazy {
+        try {
+            app.packageManager.getPackageInfo(app.packageName, 0).versionName ?: "0.0.0"
+        } catch (_: Exception) {
+            "0.0.0"
+        }
+    }
+
+    /** Once per app start; hits the network at most every [THROTTLE_MS]. */
+    suspend fun checkThrottled() {
+        val now = System.currentTimeMillis()
+        if (now - prefs.getLong("last_check_ms", 0) < THROTTLE_MS) return
+        val body = fetch() ?: return
+        prefs.edit().putLong("last_check_ms", now).apply()
+
+        val update = UpdateCheck.updateAvailable(currentVersionName, body)
+        if (update != null) {
+            prefs.edit()
+                .putString("found_version", update.versionName)
+                .putString("found_tag", update.tag)
+                .putString("found_url", update.htmlUrl)
+                .apply()
+        } else {
+            prefs.edit()
+                .remove("found_version").remove("found_tag").remove("found_url")
+                .apply()
+        }
+        _available.value = update
+    }
+
+    /** A previously-found update survives restarts, but never outlives an install that caught up. */
+    private fun storedIfStillAhead(): UpdateCheck.ReleaseCandidate? {
+        val v = prefs.getString("found_version", null) ?: return null
+        val tag = prefs.getString("found_tag", null) ?: return null
+        val url = prefs.getString("found_url", null) ?: return null
+        return UpdateCheck.ReleaseCandidate(v, tag, url)
+            .takeIf { UpdateCheck.compareVersions(it.versionName, currentVersionName) > 0 }
+    }
+
+    private suspend fun fetch(): String? = withContext(Dispatchers.IO) {
+        try {
+            val conn = URL(RELEASES_URL).openConnection() as HttpURLConnection
+            conn.connectTimeout = 10_000
+            conn.readTimeout = 10_000
+            // GitHub rejects UA-less requests outright.
+            conn.setRequestProperty("User-Agent", "TinkerRocket-Android")
+            conn.setRequestProperty("Accept", "application/vnd.github+json")
+            try {
+                if (conn.responseCode != 200) return@withContext null
+                conn.inputStream.bufferedReader().readText()
+            } finally {
+                conn.disconnect()
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        private const val THROTTLE_MS = 24L * 60 * 60 * 1000
+        private const val RELEASES_URL =
+            "https://api.github.com/repos/Tinkerbug-Robotics/TinkerRocket/releases?per_page=30"
+    }
+}

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/UpdateCheck.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/UpdateCheck.kt
@@ -1,0 +1,98 @@
+package com.tinkerbug.tinkerrocket.session
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * In-app update check against GitHub Releases (plan §1: sideload APK via
+ * GitHub Releases + trivial update check → open browser). Android-only BY
+ * DESIGN — iOS updates ride the App Store; ledger records the divergence.
+ *
+ * Pure logic: parsing and version ordering live here so they're JVM-testable;
+ * the network fetch and throttle are the app's thin `UpdateChecker`.
+ *
+ * Release tags look like `android-v0.9.1` — the `android-` prefix keeps app
+ * releases distinct from any future firmware releases in the same repo, so
+ * everything else (drafts, prereleases, foreign tags) is ignored rather than
+ * compared.
+ */
+public object UpdateCheck {
+
+    public data class ReleaseCandidate(
+        val versionName: String,   // "0.9.1" — tag minus the android-v prefix
+        val tag: String,           // "android-v0.9.1"
+        val htmlUrl: String,       // release page; the browser handles the APK
+    )
+
+    /**
+     * Version ordering for `major.minor.patch[-suffix]` names.
+     *
+     * Semver's one non-obvious rule matters here: a suffixed version precedes
+     * its unsuffixed base — `0.1.0-phase3` < `0.1.0`. The phase builds carried
+     * suffixes, so getting this backwards would offer "updates" to older
+     * releases. Missing numeric parts read as 0 (`1.0` == `1.0.0`); two
+     * suffixes compare lexically, which is as much precision as our tag
+     * history needs.
+     */
+    public fun compareVersions(a: String, b: String): Int {
+        val (na, sa) = split(a)
+        val (nb, sb) = split(b)
+        for (i in 0 until 3) {
+            val d = na[i].compareTo(nb[i])
+            if (d != 0) return d
+        }
+        return when {
+            sa == sb -> 0
+            sa.isEmpty() -> 1     // release > its own pre-release
+            sb.isEmpty() -> -1
+            else -> sa.compareTo(sb)
+        }
+    }
+
+    private fun split(v: String): Pair<IntArray, String> {
+        val dash = v.indexOf('-')
+        val numeric = if (dash >= 0) v.substring(0, dash) else v
+        val suffix = if (dash >= 0) v.substring(dash + 1) else ""
+        val parts = numeric.split('.')
+        val nums = IntArray(3) { parts.getOrNull(it)?.toIntOrNull() ?: 0 }
+        return nums to suffix
+    }
+
+    /**
+     * Parse the GitHub `/releases` JSON array into candidates, keeping only
+     * published (non-draft, non-prerelease) `android-v*` tags. Anything
+     * malformed is skipped, never thrown — an update check must not be able
+     * to break the app over API drift.
+     */
+    public fun parseReleases(json: String): List<ReleaseCandidate> = try {
+        Json.parseToJsonElement(json).jsonArray.mapNotNull { el ->
+            try {
+                val o = el.jsonObject
+                if (o["draft"]?.jsonPrimitive?.booleanOrNull() != false) return@mapNotNull null
+                if (o["prerelease"]?.jsonPrimitive?.booleanOrNull() != false) return@mapNotNull null
+                val tag = o["tag_name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                if (!tag.startsWith("android-v")) return@mapNotNull null
+                val url = o["html_url"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                ReleaseCandidate(tag.removePrefix("android-v"), tag, url)
+            } catch (_: Exception) {
+                null
+            }
+        }
+    } catch (_: Exception) {
+        emptyList()
+    }
+
+    /** The newest applicable release strictly ahead of [currentVersionName], or null. */
+    public fun updateAvailable(
+        currentVersionName: String,
+        releasesJson: String,
+    ): ReleaseCandidate? =
+        parseReleases(releasesJson)
+            .maxWithOrNull { x, y -> compareVersions(x.versionName, y.versionName) }
+            ?.takeIf { compareVersions(it.versionName, currentVersionName) > 0 }
+
+    private fun kotlinx.serialization.json.JsonPrimitive.booleanOrNull(): Boolean? =
+        content.toBooleanStrictOrNull()
+}

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/UpdateCheckTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/UpdateCheckTest.kt
@@ -1,0 +1,86 @@
+package com.tinkerbug.tinkerrocket.session
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UpdateCheckTest {
+
+    // ── version ordering ─────────────────────────────────────────────────
+
+    @Test
+    fun compare_numericTriples() {
+        assertTrue(UpdateCheck.compareVersions("0.9.1", "0.9.0") > 0)
+        assertTrue(UpdateCheck.compareVersions("0.10.0", "0.9.9") > 0)
+        assertTrue(UpdateCheck.compareVersions("1.0.0", "0.99.99") > 0)
+        assertEquals(0, UpdateCheck.compareVersions("1.2.3", "1.2.3"))
+    }
+
+    @Test
+    fun compare_suffixPrecedesItsBase() {
+        // THE rule that matters here: the phase builds carried suffixes, and
+        // getting this backwards would offer "updates" to older releases.
+        assertTrue(UpdateCheck.compareVersions("0.1.0", "0.1.0-phase3") > 0)
+        assertTrue(UpdateCheck.compareVersions("0.1.0-phase3", "0.1.0") < 0)
+        // A newer numeric beats any suffix state of an older one.
+        assertTrue(UpdateCheck.compareVersions("0.9.1", "0.1.0-phase3") > 0)
+    }
+
+    @Test
+    fun compare_missingPartsReadAsZero() {
+        assertEquals(0, UpdateCheck.compareVersions("1.0", "1.0.0"))
+        assertTrue(UpdateCheck.compareVersions("1.0.1", "1.0") > 0)
+    }
+
+    // ── release JSON parsing ─────────────────────────────────────────────
+
+    private val fixture = """
+        [
+          {"tag_name":"android-v0.9.1","html_url":"https://x/r/android-v0.9.1",
+           "draft":false,"prerelease":false},
+          {"tag_name":"android-v0.9.2","html_url":"https://x/r/android-v0.9.2",
+           "draft":true,"prerelease":false},
+          {"tag_name":"android-v0.9.3-rc1","html_url":"https://x/r/android-v0.9.3-rc1",
+           "draft":false,"prerelease":true},
+          {"tag_name":"fw-v2.0.0","html_url":"https://x/r/fw-v2.0.0",
+           "draft":false,"prerelease":false},
+          {"tag_name":"android-v0.8.0","html_url":"https://x/r/android-v0.8.0",
+           "draft":false,"prerelease":false}
+        ]
+    """.trimIndent()
+
+    @Test
+    fun parse_keepsOnlyPublishedAndroidTags() {
+        val got = UpdateCheck.parseReleases(fixture)
+        // Draft 0.9.2 out, prerelease 0.9.3-rc1 out, firmware tag out.
+        assertEquals(listOf("0.9.1", "0.8.0"), got.map { it.versionName })
+        assertEquals("android-v0.9.1", got[0].tag)
+    }
+
+    @Test
+    fun parse_neverThrows() {
+        assertEquals(emptyList(), UpdateCheck.parseReleases("not json at all"))
+        assertEquals(emptyList(), UpdateCheck.parseReleases("{}"))
+        assertEquals(emptyList(), UpdateCheck.parseReleases("[{\"tag_name\":42}]"))
+    }
+
+    // ── the decision ─────────────────────────────────────────────────────
+
+    @Test
+    fun update_offeredWhenBehind() {
+        val got = UpdateCheck.updateAvailable("0.1.0-phase3", fixture)
+        assertEquals("0.9.1", got?.versionName)
+    }
+
+    @Test
+    fun update_silentWhenCurrentOrAhead() {
+        assertNull(UpdateCheck.updateAvailable("0.9.1", fixture))
+        assertNull(UpdateCheck.updateAvailable("1.0.0", fixture))
+    }
+
+    @Test
+    fun update_silentOnGarbage() {
+        assertNull(UpdateCheck.updateAvailable("0.1.0", "service unavailable"))
+    }
+}

--- a/docs/android-parity-ledger.md
+++ b/docs/android-parity-ledger.md
@@ -29,6 +29,7 @@ is restored. "Parity at v1.0" is checkable ⇔ this file is honest.
 | 2026-07-27 | FreqScan's fixed-frequency **Apply** (transactional relay + verify + rollback) is iOS-only; Android shows a "use iOS" note | The fleet runs hopping mode (#150 default) where Apply is refused by design — the mask auto-applies. Port the transactional flow when a fixed-frequency need reappears |
 | 2026-07-23 | Scan restart within 15 s is NOT truncated (epoch-guarded timeout); iOS's unguarded timer truncates a restarted scan | The iOS behavior is a timer-hygiene bug; a restarted scan deserves its full window |
 | 2026-07-23 | KnownDeviceStore device list sorts plain case-insensitive; iOS uses `localizedCaseInsensitiveCompare` | Locale-dependent ordering is cosmetic; plain ordering is deterministic across devices |
+| 2026-07-30 | In-app update checker (GitHub Releases → scanner banner → browser) is Android-only | Distribution differs by design (plan §1): iOS updates ride the App Store; Android sideloads from GitHub Releases, so the app itself must notice a new `android-v*` tag. Pure logic in `UpdateCheck.kt` (JVM-tested); fetch is throttled to one hit/day and silent on every failure — no signal at a launch site is normal |
 
 ## Feature lag (session layer, deferred to Phase 3)
 


### PR DESCRIPTION
First Phase 9 item, chosen because it completes the loop #647 opened: signing CI ships APKs on
`android-v*` tags — now the app notices and tells the operator.

## Design (plan §1: "trivial in-app update check — GitHub API → compare versionName → open browser")

- **Pure logic, JVM-tested** (`UpdateCheck.kt`, `:core:session`, 8 tests): release-JSON parsing
  that keeps only published (non-draft, non-prerelease) `android-v*` tags — firmware releases in
  the same repo never enter the comparison — and semver-ish ordering where **a suffixed version
  precedes its base** (`0.1.0-phase3` < `0.1.0`), the rule that keeps phase-suffixed installs
  from being offered "updates" to older releases. Parse failures return empty, never throw.
- **App shell** (`UpdateChecker.kt`): `HttpURLConnection` (zero new deps), one network hit per
  24 h, a found update **persists across restarts** (a throttled start still shows the banner)
  but never outlives an install that caught up. Every failure path is silent-null — no signal
  at a launch site is normal, and the checker must never cost anything there.
- **UI**: one banner row on the scanner — "Update available: vX" + `Get` → browser at the
  release page. Informational, never modal; launch-day work can ignore it entirely.
- **Version bump**: versionCode 2 / versionName `0.9.1`, with a comment pinning the
  bump-before-tag discipline at the definition site.
- **Ledger**: recorded as an Android-only divergence by design — iOS updates ride the App Store.

## Verification

JVM suite green (8 new tests: ordering incl. the suffix rule, tag filtering, draft/prerelease
exclusion, never-throws, offered-when-behind / silent-when-current); `assembleDebug` green;
`preflight_protocol.sh` PASS. Live two-state device verification (banner appears on an old
version; silent on current) happens right after merge — it needs a real `android-v0.9.1`
release to exist, which is the tag this PR's merge enables.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
