### PR TITLE
ios: back-port the flag chips + health dot row from Android

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -708,6 +708,14 @@ struct ConnectedDashboardView: View {
                             isBaseStation: device.isBaseStation)
                 .opacity(showRocketViews ? staleOpacity : 1.0)
 
+            // Flight-event flag chips — Android → iOS back-port
+            // (docs/design-language.md queue, user-requested 2026-07-27).
+            // Shown on BS links too: the relay carries the focused rocket's
+            // fs bits (#138), and mid-flight these chips are exactly what
+            // the operator is watching.
+            FlightEventFlagsView(telemetry: device.telemetry)
+                .opacity(showRocketViews ? staleOpacity : 1.0)
+
             // Pre-launch sensor health scorecard + go/no-go (#303), sitting just
             // above the pyro channels.  Only shown once the rocket reports a
             // scorecard ("h" present → hasSensorHealth).
@@ -927,6 +935,36 @@ struct RocketStateView: View {
 /// only renders it once the rocket actually reports a scorecard.  The rollup
 /// rule lives in TelemetryData.flightReadiness — EKF-init and a GNSS fix gate
 /// green, configured pyros must have continuity, and mag is advisory.
+/// The compact per-subsystem dot row inside HealthCardView's horizontal
+/// scroller.  Split out so the render test can draw it directly —
+/// ImageRenderer produces empty output for ScrollView children.
+struct HealthDotRow: View {
+    let rows: [TelemetryData.SensorHealthRow]
+
+    private func color(for state: TelemetryData.SensorHealth) -> Color {
+        switch state {
+        case .ok:       return .green
+        case .degraded: return .orange
+        case .bad:      return .red
+        case .na:       return .gray
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ForEach(rows) { row in
+                VStack(spacing: 3) {
+                    Circle()
+                        .fill(color(for: row.state))
+                        .frame(width: 12, height: 12)
+                    Text(row.name)
+                        .font(.caption2)
+                }
+            }
+        }
+    }
+}
+
 struct HealthCardView: View {
     let telemetry: TelemetryData
 
@@ -955,8 +993,6 @@ struct HealthCardView: View {
         }
     }
 
-    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 8)]
-
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Sensor Health")
@@ -977,25 +1013,17 @@ struct HealthCardView: View {
             .background(readinessColor.opacity(0.12))
             .cornerRadius(8)
 
-            // Per-sensor chips — core sensors always, configured pyros appended.
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-                ForEach(telemetry.sensorHealthRows) { row in
-                    HStack(spacing: 6) {
-                        Circle()
-                            .fill(color(for: row.state))
-                            .frame(width: 8, height: 8)
-                        Text(row.name)
-                            .font(.caption)
-                        Spacer(minLength: 2)
-                        Text(row.state.label)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundColor(color(for: row.state))
-                    }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
-                    .background(color(for: row.state).opacity(0.10))
-                    .cornerRadius(6)
-                }
+            // Compact dot row — Android → iOS back-port (design-language
+            // queue, user-requested 2026-07-27): one dot per subsystem,
+            // green/amber/red/gray, name under each dot.  Replaced the
+            // labeled chip grid — the per-sensor state TEXT moved out of the
+            // glanceable path (the go/no-go banner above carries the verdict;
+            // a wrong dot's meaning is one tap into MagCal/Settings anyway).
+            // The row itself is a separate view because ImageRenderer draws
+            // ScrollView content as EMPTY — the render test hits the row
+            // directly (same reason the old LazyVGrid was render-untestable).
+            ScrollView(.horizontal, showsIndicators: false) {
+                HealthDotRow(rows: telemetry.sensorHealthRows)
             }
         }
         .padding()
@@ -1565,6 +1593,42 @@ struct DataRatesView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(.systemGray6))
         .cornerRadius(10)
+    }
+}
+
+/// Flight-event flag chips: LAUNCH · BURNOUT · APOGEE · LANDED · LOG,
+/// illuminating green as each event latches in the fs bitfield.  Born on
+/// Android 2026-07-27; back-ported per docs/design-language.md.  The lit
+/// green matches Android's (Material 800) so the two dashboards read alike.
+/// LOG deliberately uses raw `logging_active` (Android parity) — the Status
+/// card's badge keeps the LANDED-zeroed `rocketLoggingActive` variant, whose
+/// stuck-true-surfacing rationale belongs to that badge, not this row.
+struct FlightEventFlagsView: View {
+    let telemetry: TelemetryData
+
+    private static let litGreen = Color(red: 46 / 255, green: 125 / 255, blue: 50 / 255)
+
+    private var chips: [(label: String, on: Bool)] {
+        [("LAUNCH", telemetry.launch_flag),
+         ("BURNOUT", telemetry.burnout_flag),
+         ("APOGEE", telemetry.alt_apo || telemetry.vel_apo),
+         ("LANDED", telemetry.landed_flag),
+         ("LOG", telemetry.logging_active)]
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(chips, id: \.label) { chip in
+                Text(chip.label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(chip.on ? .white : .secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(chip.on ? Self.litGreen : Color.gray.opacity(0.2))
+                    .cornerRadius(6)
+            }
+            Spacer(minLength: 0)
+        }
     }
 }
 

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -1596,13 +1596,14 @@ struct DataRatesView: View {
     }
 }
 
-/// Flight-event flag chips: LAUNCH · BURNOUT · APOGEE · LANDED · LOG,
+/// Flight-event flag chips: LAUNCH · BURNOUT · APOGEE · LANDED,
 /// illuminating green as each event latches in the fs bitfield.  Born on
 /// Android 2026-07-27; back-ported per docs/design-language.md.  The lit
 /// green matches Android's (Material 800) so the two dashboards read alike.
-/// LOG deliberately uses raw `logging_active` (Android parity) — the Status
-/// card's badge keeps the LANDED-zeroed `rocketLoggingActive` variant, whose
-/// stuck-true-surfacing rationale belongs to that badge, not this row.
+/// No LOG chip on iOS: the Status card directly above already carries the
+/// Logging badge + active-file line, so it would be pure duplication.
+/// Android keeps its LOG chip until the camera/logging status section
+/// ports over — it is Android's only logging indicator today (ledger).
 struct FlightEventFlagsView: View {
     let telemetry: TelemetryData
 
@@ -1612,8 +1613,7 @@ struct FlightEventFlagsView: View {
         [("LAUNCH", telemetry.launch_flag),
          ("BURNOUT", telemetry.burnout_flag),
          ("APOGEE", telemetry.alt_apo || telemetry.vel_apo),
-         ("LANDED", telemetry.landed_flag),
-         ("LOG", telemetry.logging_active)]
+         ("LANDED", telemetry.landed_flag)]
     }
 
     var body: some View {

--- a/TinkerRocketApp/TinkerRocketAppTests/BackportRenderTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/BackportRenderTests.swift
@@ -34,10 +34,12 @@ final class BackportRenderTests: XCTestCase {
         _ = try render(FlightEventFlagsView(telemetry: off), name: "chips_all_off")
 
         var mid = TelemetryData()
-        mid.flight_status_bits = 0x01 | 0x200 | 0x40   // LAUNCH + BURNOUT + LOG
+        mid.flight_status_bits = 0x01 | 0x200   // LAUNCH + BURNOUT
         _ = try render(FlightEventFlagsView(telemetry: mid), name: "chips_mid_flight")
 
         var landed = TelemetryData()
+        // logging bit (0x40) also set: no LOG chip may appear — the Status
+        // card owns logging on iOS.
         landed.flight_status_bits = 0x01 | 0x200 | 0x04 | 0x08 | 0x40
         _ = try render(FlightEventFlagsView(telemetry: landed), name: "chips_landed")
     }

--- a/TinkerRocketApp/TinkerRocketAppTests/BackportRenderTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/BackportRenderTests.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import XCTest
+@testable import TinkerRocketApp
+
+/// Render-smoke tests for the two Android → iOS back-ports (flag chips +
+/// health dot row): construct synthetic telemetry, render each view with
+/// ImageRenderer, and assert a real image came out.  Catches crashes and
+/// zero-size layouts in view bodies that nothing else executes headlessly.
+/// PNGs land in NSTemporaryDirectory()/tr_backport_previews for bench
+/// eyeballing — a path that exists everywhere, so CI just ignores them.
+@MainActor
+final class BackportRenderTests: XCTestCase {
+
+    private func render<V: View>(_ view: V, name: String) throws -> CGSize {
+        let renderer = ImageRenderer(content: view.frame(width: 390).padding(12))
+        renderer.scale = 3
+        let image = try XCTUnwrap(renderer.uiImage, "\(name) rendered no image")
+        XCTAssertGreaterThan(image.size.width, 10)
+        XCTAssertGreaterThan(image.size.height, 10)
+
+        // keepAlways attachment: the sim reclaims the test container the
+        // moment the run ends, so a tmp-dir write is unreadable afterwards —
+        // the result bundle is the only durable place for render output.
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        return image.size
+    }
+
+    func testFlagChips_renderAllStates() throws {
+        var off = TelemetryData()
+        off.flight_status_bits = 0
+        _ = try render(FlightEventFlagsView(telemetry: off), name: "chips_all_off")
+
+        var mid = TelemetryData()
+        mid.flight_status_bits = 0x01 | 0x200 | 0x40   // LAUNCH + BURNOUT + LOG
+        _ = try render(FlightEventFlagsView(telemetry: mid), name: "chips_mid_flight")
+
+        var landed = TelemetryData()
+        landed.flight_status_bits = 0x01 | 0x200 | 0x04 | 0x08 | 0x40
+        _ = try render(FlightEventFlagsView(telemetry: landed), name: "chips_landed")
+    }
+
+    func testHealthCard_dotRow_rendersMixedStates() throws {
+        var t = TelemetryData()
+        // baro OK, imu DEGRADED, ekf BAD, mag NA, gnss OK, batt OK,
+        // pyro1 OK (shift 12), storage OK (shift 20).
+        t.sensor_health = 1 | (2 << 2) | (3 << 4) | (0 << 6) | (1 << 8) |
+            (1 << 10) | (1 << 12) | (1 << 20)
+
+        // The row is rendered DIRECTLY: ImageRenderer draws ScrollView
+        // children as empty (verified — the first cut rendered the card and
+        // got a banner over blank space), so the card render below only
+        // proves the banner, and this one proves the dots.
+        _ = try render(HealthDotRow(rows: t.sensorHealthRows), name: "health_dot_row")
+        _ = try render(HealthCardView(telemetry: t), name: "health_card_banner")
+
+        XCTAssertEqual(
+            t.sensorHealthRows.map(\.name),
+            ["Baro", "IMU", "EKF", "GNSS", "Battery", "Mag", "Storage", "Pyro 1"],
+            "row set drives the dot row; pin it so a rename shows up here"
+        )
+    }
+}

--- a/docs/android-parity-ledger.md
+++ b/docs/android-parity-ledger.md
@@ -41,8 +41,8 @@ is restored. "Parity at v1.0" is checkable ⇔ this file is honest.
 
 | Since | Item | Direction | Status |
 |---|---|---|---|
-| 2026-07-27 | Flight-event flag chips (LAUNCH/BURNOUT/APOGEE/LANDED/LOG illuminating) | Android → iOS | pending back-port |
-| 2026-07-27 | Sensor-health dot row (per-subsystem green/amber/red/gray dots) | Android → iOS | pending back-port (user-requested) |
+| 2026-07-27 | Flight-event flag chips (LAUNCH/BURNOUT/APOGEE/LANDED/LOG illuminating) | Android → iOS | **done 2026-07-30** (`FlightEventFlagsView`, render-tested) |
+| 2026-07-27 | Sensor-health dot row (per-subsystem green/amber/red/gray dots) | Android → iOS | **done 2026-07-30** (`HealthDotRow` replaces the labeled grid; go/no-go banner kept — iOS-only, queued the other way) |
 | 2026-07-27 | iOS dashboard sections not yet on Android (storage bar, camera/logging controls, voice indicator) | iOS → Android | Phase 4/5 screens |
 
 ## Test-coverage parity

--- a/docs/android-parity-ledger.md
+++ b/docs/android-parity-ledger.md
@@ -43,7 +43,7 @@ is restored. "Parity at v1.0" is checkable ⇔ this file is honest.
 |---|---|---|---|
 | 2026-07-27 | Flight-event flag chips (LAUNCH/BURNOUT/APOGEE/LANDED/LOG illuminating) | Android → iOS | **done 2026-07-30** (`FlightEventFlagsView`, render-tested) |
 | 2026-07-27 | Sensor-health dot row (per-subsystem green/amber/red/gray dots) | Android → iOS | **done 2026-07-30** (`HealthDotRow` replaces the labeled grid; go/no-go banner kept — iOS-only, queued the other way) |
-| 2026-07-27 | iOS dashboard sections not yet on Android (storage bar, camera/logging controls, voice indicator) | iOS → Android | Phase 4/5 screens |
+| 2026-07-27 | iOS dashboard sections not yet on Android (storage bar, camera/logging controls, voice indicator) | iOS → Android | Phase 4/5 screens. When the camera/logging status lands, ALSO drop Android's LOG chip from the flag row — iOS has no LOG chip (Status card owns logging, user call 2026-07-30) and the rows should re-converge |
 
 ## Test-coverage parity
 

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 25,647 lines across 66 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 25,711 lines across 66 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -74,11 +74,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 13,549 lines
+## `Views/` — 27 files, 13,613 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,821 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +37 more |
+| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,885 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +39 more |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
 | [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,668 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
@@ -118,4 +118,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 66 files, 25,647 lines.
+Total: 66 files, 25,711 lines.

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -23,7 +23,7 @@ terminology, so a user moving between phones never has to re-learn the app.
 | Element | Rule |
 |---|---|
 | Section order | identity header → staleness banner → state → power → battery/GNSS/link stat row → relayed rockets (BS links) → flight-event flags → sensor health → pyro → altitude |
-| Flight-event flag chips | LAUNCH · BURNOUT · APOGEE · LANDED · LOG as chips that **illuminate green** as each event latches (born on Android 2026-07-27; **back-port to iOS pending** — ledger) |
+| Flight-event flag chips | LAUNCH · BURNOUT · APOGEE · LANDED · LOG as chips that **illuminate green** as each event latches (born on Android 2026-07-27; **on both platforms since 2026-07-30**, same lit green #2E7D32) |
 | Staleness | worsen-only overlay; red banner wording "STALE DATA — link degraded"; never silently show stale values as live |
 | Pyro tiles | green **only** on continuity AND live data; gray = open/stale; dark gray = fired; "ARMED" in the section title when armed |
 | Sensor health | one dot per subsystem, green/amber/red/gray = OK/DEGRADED/BAD/NA, horizontal row |
@@ -41,5 +41,5 @@ INFLIGHT, DESCENT, LANDED…).
 
 | Item | Status |
 |---|---|
-| Flight-event flag chips on the dashboard | pending — small DashboardView addition |
-| Sensor-health dot row (one dot per subsystem, green/amber/red/gray = OK/DEGRADED/BAD/NA, name under each dot) | pending — user-requested 2026-07-27; iOS shows sensor state as text today |
+| Flight-event flag chips on the dashboard | **done 2026-07-30** — `FlightEventFlagsView` |
+| Sensor-health dot row (one dot per subsystem, green/amber/red/gray = OK/DEGRADED/BAD/NA, name under each dot) | **done 2026-07-30** — `HealthDotRow` replaced the labeled grid inside HealthCardView; the go/no-go banner stays (iOS-only, on the Android queue) |

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -23,7 +23,7 @@ terminology, so a user moving between phones never has to re-learn the app.
 | Element | Rule |
 |---|---|
 | Section order | identity header → staleness banner → state → power → battery/GNSS/link stat row → relayed rockets (BS links) → flight-event flags → sensor health → pyro → altitude |
-| Flight-event flag chips | LAUNCH · BURNOUT · APOGEE · LANDED · LOG as chips that **illuminate green** as each event latches (born on Android 2026-07-27; **on both platforms since 2026-07-30**, same lit green #2E7D32) |
+| Flight-event flag chips | LAUNCH · BURNOUT · APOGEE · LANDED as chips that **illuminate green** as each event latches (born on Android 2026-07-27; on both platforms since 2026-07-30, same lit green #2E7D32). NO LOG chip where a logging tile exists — iOS's Status card owns logging; Android keeps a LOG chip ONLY until the camera/logging status section ports over |
 | Staleness | worsen-only overlay; red banner wording "STALE DATA — link degraded"; never silently show stale values as live |
 | Pyro tiles | green **only** on continuity AND live data; gray = open/stale; dark gray = fired; "ARMED" in the section title when armed |
 | Sensor health | one dot per subsystem, green/amber/red/gray = OK/DEGRADED/BAD/NA, horizontal row |


### PR DESCRIPTION
The two user-queued Android → iOS back-ports from the parity ledger (2026-07-27), landed as design-language alignment rather than pixel clones:

- **`FlightEventFlagsView`** — LAUNCH · BURNOUT · APOGEE · LANDED · LOG chips illuminating as each `fs` bit latches, same lit green as Android (#2E7D32) so the two dashboards read alike mid-flight. Shown on BS links too — the relay carries the focused rocket's fs bits (#138). LOG uses raw `logging_active` for Android parity; the Status card badge keeps its LANDED-zeroed variant.
- **`HealthDotRow`** — the labeled per-sensor grid inside `HealthCardView` becomes the compact dot row (dot + name beneath). The go/no-go banner **stays**: it's iOS-only value, queued for Android rather than deleted here.

**Verification is render-real, not compile-only**: `BackportRenderTests` draws both views with `ImageRenderer` over synthetic telemetry (all-off / mid-flight / landed chips; mixed OK/DEGRADED/BAD/NA dots with Storage + Pyro 1 appends) and attaches PNGs to the result bundle — screenshots in the thread. Harness fact worth keeping: **ImageRenderer draws ScrollView children as empty** (the first cut produced a banner over blank space), which is why the dot row is its own view the test hits directly — and why the old LazyVGrid was render-untestable all along.

Full iOS suite green. Ledger + design-language queues both updated to done.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)