### PR TITLE
android: 3D flight trajectory — the shared orbit-camera component

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightChartScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightChartScreen.kt
@@ -180,7 +180,14 @@ fun FlightChartScreen(csvFile: File, onBack: () -> Unit) {
         }
 
         if (showPath) {
-            csvData?.let { TrajectoryCanvas(it) }
+            // 2D ground track / 3D orbit view (Phase 9). Defaults to 2D —
+            // the glanceable answer; 3D is the explore mode.
+            var threeD by remember { mutableStateOf(false) }
+            Row(Modifier.padding(horizontal = 8.dp)) {
+                TextButton(onClick = { threeD = false }) { Text(if (!threeD) "● 2D" else "2D") }
+                TextButton(onClick = { threeD = true }) { Text(if (threeD) "● 3D" else "3D") }
+            }
+            csvData?.let { if (threeD) Trajectory3DCanvas(it) else TrajectoryCanvas(it) }
             return@Column
         }
 

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightTrajectoryScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/FlightTrajectoryScreen.kt
@@ -29,21 +29,8 @@ import kotlin.math.pow
  */
 @Composable
 fun TrajectoryCanvas(data: FlightCsvData) {
-    // Clean finite (E, N, U) triples, EKF position columns.
-    val track = remember(data) {
-        val e = data.columns["Position East (m)"] ?: emptyList()
-        val n = data.columns["Position North (m)"] ?: emptyList()
-        val u = data.columns["Position Up (m)"]
-            ?: data.columns["Pressure Altitude (m)"] ?: emptyList()
-        val rows = minOf(e.size, n.size, u.size)
-        (0 until rows).mapNotNull { i ->
-            if (e[i].isFinite() && n[i].isFinite() && u[i].isFinite()) {
-                Triple(e[i], n[i], u[i])
-            } else {
-                null
-            }
-        }
-    }
+    // Clean finite (E, N, U) triples — shared with the 3D view.
+    val track = remember(data) { ekfTrack(data) }
 
     val textMeasurer = rememberTextMeasurer()
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -89,7 +76,7 @@ fun TrajectoryCanvas(data: FlightCsvData) {
             val (e1, n1, u1) = track[i]
             val t = ((u1 - minU) / uSpan).toFloat().coerceIn(0f, 1f)
             drawLine(
-                color = lerpColor(Color(0xFF1E88E5), Color(0xFFE53935), t),
+                color = trajectoryAltitudeColor(t),
                 start = px(e0, n0),
                 end = px(e1, n1),
                 strokeWidth = 3.dp.toPx(),
@@ -97,10 +84,12 @@ fun TrajectoryCanvas(data: FlightCsvData) {
             )
         }
 
-        // Launch (green) + landing (red) markers.
-        drawCircle(Color(0xFF43A047), 6.dp.toPx(), px(track.first().first, track.first().second))
+        // Launch (red) + landing (green) markers — iOS palette; the 2D and
+        // 3D views and both platforms now agree (was green/red here, the
+        // opposite of iOS: a field-confusion hazard with two phones out).
+        drawCircle(Color(0xFFFF6B6B), 6.dp.toPx(), px(track.first().first, track.first().second))
         drawCircle(
-            Color(0xFFE53935), 6.dp.toPx(),
+            Color(0xFF52CF66), 6.dp.toPx(),
             px(track.last().first, track.last().second),
         )
 
@@ -122,12 +111,6 @@ fun TrajectoryCanvas(data: FlightCsvData) {
     }
 }
 
-private fun lerpColor(a: Color, b: Color, t: Float): Color = Color(
-    red = a.red + (b.red - a.red) * t,
-    green = a.green + (b.green - a.green) * t,
-    blue = a.blue + (b.blue - a.blue) * t,
-    alpha = 1f,
-)
 
 /** 1/2/5 × 10ⁿ round-down for the scale bar. */
 private fun niceRound(v: Double): Double {

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/Trajectory3DCanvas.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/Trajectory3DCanvas.kt
@@ -1,0 +1,215 @@
+package com.tinkerbug.tinkerrocket.app
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.tinkerbug.tinkerrocket.protocol.FlightCsvData
+import com.tinkerbug.tinkerrocket.protocol.Trajectory3D
+import com.tinkerbug.tinkerrocket.protocol.Trajectory3D.V3
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * Orbit-camera 3D flight trajectory — the Phase 9 port of iOS's SceneKit
+ * `FlightScene3DView`, rendered per plan §1 as a 2D-projected Compose Canvas
+ * (no 3D engine; the value is orientation + shape, not shading).  All camera
+ * and projection math is [Trajectory3D] in `:core:protocol`, where the axis
+ * conventions are pinned by tests — a mirrored trajectory looks plausible,
+ * which is exactly why the math doesn't live in this file.
+ *
+ * Gestures: one-finger drag orbits (yaw/pitch), pinch zooms, double-tap
+ * resets to the iOS-parity initial framing (broadside to the climb, 1.8×
+ * extent, 15° elevation).
+ *
+ * Scene, matching iOS: ground grid, altitude-colored path (painter-sorted
+ * far→near), apogee drop line, launch/apogee/landing markers + labels with
+ * the apogee altitude callout.
+ */
+@Composable
+fun Trajectory3DCanvas(data: FlightCsvData) {
+    val track = remember(data) {
+        Trajectory3D.downsample(ekfTrack(data).map { V3(it.first, it.second, it.third) }, 700)
+    }
+    val initial = remember(track) { Trajectory3D.initialCamera(track) }
+
+    var yaw by remember(track) { mutableDoubleStateOf(initial.yawRad) }
+    var pitch by remember(track) { mutableDoubleStateOf(initial.pitchRad) }
+    var dist by remember(track) { mutableDoubleStateOf(initial.distance) }
+
+    val extent = remember(track) { Trajectory3D.extent(track) }
+    val textMeasurer = rememberTextMeasurer()
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val gridColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
+
+    Canvas(
+        Modifier
+            .fillMaxSize()
+            .pointerInput(track) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    yaw -= pan.x * 0.006
+                    pitch = (pitch + pan.y * 0.006)
+                        .coerceIn(Math.toRadians(5.0), Math.toRadians(85.0))
+                    if (zoom != 0f) {
+                        dist = (dist / zoom).coerceIn(extent * 0.3, extent * 8.0)
+                    }
+                }
+            }
+            .pointerInput(track) {
+                detectTapGestures(onDoubleTap = {
+                    yaw = initial.yawRad
+                    pitch = initial.pitchRad
+                    dist = initial.distance
+                })
+            },
+    ) {
+        if (track.size < 2) {
+            val msg = textMeasurer.measure(
+                "No EKF position data in this log",
+                TextStyle(fontSize = 12.sp, color = labelColor),
+            )
+            drawText(msg, topLeft = Offset((size.width - msg.size.width) / 2, size.height / 2))
+            return@Canvas
+        }
+
+        val cam = initial.copy(yawRad = yaw, pitchRad = pitch, distance = dist)
+        val w = size.width.toDouble()
+        val h = size.height.toDouble()
+        fun proj(p: V3): Trajectory3D.Projected? = Trajectory3D.project(p, cam, w, h)
+        fun Trajectory3D.Projected.o() = Offset(x.toFloat(), y.toFloat())
+
+        val lm = Trajectory3D.landmarks(track)!!
+        val groundU = track.minOf { it.u }
+
+        // ── Ground grid ──────────────────────────────────────────────────
+        val spacing = Trajectory3D.niceGridSpacing(extent)
+        val half = extent * 1.5
+        val c = cam.center
+        val lines = mutableListOf<Pair<V3, V3>>()
+        var g = floor((c.e - half) / spacing) * spacing
+        while (g <= ceil((c.e + half) / spacing) * spacing) {
+            lines.add(V3(g, c.n - half, groundU) to V3(g, c.n + half, groundU))
+            g += spacing
+        }
+        g = floor((c.n - half) / spacing) * spacing
+        while (g <= ceil((c.n + half) / spacing) * spacing) {
+            lines.add(V3(c.e - half, g, groundU) to V3(c.e + half, g, groundU))
+            g += spacing
+        }
+        for ((a, b) in lines) {
+            val pa = proj(a) ?: continue
+            val pb = proj(b) ?: continue
+            drawLine(gridColor, pa.o(), pb.o(), strokeWidth = 1f)
+        }
+
+        // ── Apogee drop line (under the path) ────────────────────────────
+        val apoGround = V3(lm.apogee.e, lm.apogee.n, groundU)
+        val pApo = proj(lm.apogee)
+        val pApoGround = proj(apoGround)
+        if (pApo != null && pApoGround != null) {
+            drawLine(
+                Color(0xFF64B5F6).copy(alpha = 0.35f), pApo.o(), pApoGround.o(),
+                strokeWidth = 1.5.dp.toPx(),
+            )
+        }
+
+        // ── Path, altitude-colored, painter-sorted far→near ──────────────
+        val minU = track.minOf { it.u }
+        val maxU = track.maxOf { it.u }
+        val uSpan = (maxU - minU).coerceAtLeast(1e-6)
+        data class Seg(val a: Offset, val b: Offset, val t: Float, val depth: Double)
+        val segs = mutableListOf<Seg>()
+        var prev: Trajectory3D.Projected? = proj(track[0])
+        for (i in 1 until track.size) {
+            val cur = proj(track[i])
+            val p0 = prev
+            prev = cur
+            if (p0 == null || cur == null) continue   // culled vertex splits the line
+            val midU = (track[i - 1].u + track[i].u) / 2
+            segs.add(Seg(
+                p0.o(), cur.o(),
+                ((midU - minU) / uSpan).toFloat().coerceIn(0f, 1f),
+                (p0.depth + cur.depth) / 2,
+            ))
+        }
+        segs.sortByDescending { it.depth }
+        for (s in segs) {
+            drawLine(
+                trajectoryAltitudeColor(s.t), s.a, s.b,
+                strokeWidth = 3.dp.toPx(), cap = StrokeCap.Round,
+            )
+        }
+
+        // ── Markers + labels (iOS colors: launch red, apogee blue, landing
+        // green — the 2D track was aligned to the same palette in this
+        // change) ────────────────────────────────────────────────────────
+        fun marker(p: V3, color: Color, label: String, r: Float) {
+            val pp = proj(p) ?: return
+            drawCircle(color, r, pp.o())
+            val t = textMeasurer.measure(label, TextStyle(fontSize = 11.sp, color = labelColor))
+            drawText(t, topLeft = Offset(pp.x.toFloat() - t.size.width / 2, pp.y.toFloat() - r - t.size.height - 2))
+        }
+        marker(lm.launch, Color(0xFFFF6B6B), "Launch", 5.dp.toPx().coerceAtLeast(1f))
+        marker(lm.landing, Color(0xFF52CF66), "Landing", 5.dp.toPx())
+        marker(lm.apogee, Color(0xFF4DABF7), "Apogee", 6.dp.toPx())
+        pApo?.let {
+            val altText = textMeasurer.measure(
+                "%.0f m AGL".format(lm.apogee.u - groundU),
+                TextStyle(fontSize = 10.sp, color = labelColor),
+            )
+            drawText(altText, topLeft = Offset(it.x.toFloat() - altText.size.width / 2, it.y.toFloat() + 8.dp.toPx()))
+        }
+
+        // Hint + north cue.
+        val hint = textMeasurer.measure(
+            "drag to orbit · pinch to zoom · double-tap to reset",
+            TextStyle(fontSize = 10.sp, color = labelColor),
+        )
+        drawText(hint, topLeft = Offset(8.dp.toPx(), size.height - hint.size.height - 6.dp.toPx()))
+        val north = proj(V3(c.e, c.n + extent * 1.4, groundU))
+        north?.let {
+            val nl = textMeasurer.measure("N", TextStyle(fontSize = 12.sp, color = labelColor))
+            drawText(nl, topLeft = Offset(it.x.toFloat() - nl.size.width / 2, it.y.toFloat() - nl.size.height / 2))
+        }
+    }
+}
+
+/** Blue ground → red apogee, shared with the 2D track. */
+internal fun trajectoryAltitudeColor(t: Float): Color = Color(
+    red = 0.12f + (0.90f - 0.12f) * t,
+    green = 0.53f + (0.22f - 0.53f) * t,
+    blue = 0.90f + (0.21f - 0.90f) * t,
+    alpha = 1f,
+)
+
+/** Clean finite EKF (E, N, U) triples — the shared source for 2D and 3D. */
+internal fun ekfTrack(data: FlightCsvData): List<Triple<Double, Double, Double>> {
+    val e = data.columns["Position East (m)"] ?: emptyList()
+    val n = data.columns["Position North (m)"] ?: emptyList()
+    val u = data.columns["Position Up (m)"]
+        ?: data.columns["Pressure Altitude (m)"] ?: emptyList()
+    val rows = minOf(e.size, n.size, u.size)
+    return (0 until rows).mapNotNull { i ->
+        if (e[i].isFinite() && n[i].isFinite() && u[i].isFinite()) {
+            Triple(e[i], n[i], u[i])
+        } else {
+            null
+        }
+    }
+}

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/Trajectory3D.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/Trajectory3D.kt
@@ -1,0 +1,201 @@
+package com.tinkerbug.tinkerrocket.protocol
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
+
+/**
+ * Orbit-camera math for the 3D flight-trajectory view (plan §1: all SceneKit
+ * views project to Compose Canvas through ONE shared orbit-camera component;
+ * this is that component's math, kept pure-JVM so the projection, culling and
+ * camera conventions are testable without a Canvas).
+ *
+ * Coordinates are EKF local ENU meters, straight from the CSV columns the 2D
+ * ground track already uses (`Position East/North/Up (m)`) — unlike iOS,
+ * which reconstructs local coordinates from GPS lat/lon.  Same rendered
+ * shape, better source: the EKF track is smoother and exists even for
+ * GNSS-degraded flights.
+ *
+ * Conventions (pinned by Trajectory3DTest):
+ *  - Camera azimuth `yawRad` is the direction of the CAMERA from the center,
+ *    compass-style (0 = camera due north of center, π = due south, looking
+ *    back at the center either way).  `pitchRad` elevates it.
+ *  - Screen: +x right, +y down (Compose Canvas).  A point due east of center
+ *    appears screen-RIGHT when the camera sits south looking north; higher
+ *    altitude appears screen-UP.
+ *  - `project` returns null for points at or behind the near plane — a
+ *    culled vertex splits the polyline rather than smearing across it.
+ */
+public object Trajectory3D {
+
+    /** ENU meters. */
+    public data class V3(val e: Double, val n: Double, val u: Double)
+
+    public data class Landmarks(
+        val launch: V3,
+        val apogee: V3,
+        val landing: V3,
+        val apogeeIndex: Int,
+    )
+
+    public fun landmarks(track: List<V3>): Landmarks? {
+        if (track.isEmpty()) return null
+        var apogeeIndex = 0
+        track.forEachIndexed { i, p -> if (p.u > track[apogeeIndex].u) apogeeIndex = i }
+        return Landmarks(track.first(), track[apogeeIndex], track.last(), apogeeIndex)
+    }
+
+    /** Largest axis span across E/N/U, floored at 100 m (iOS parity). */
+    public fun extent(track: List<V3>): Double {
+        if (track.isEmpty()) return 100.0
+        val spanE = track.maxOf { it.e } - track.minOf { it.e }
+        val spanN = track.maxOf { it.n } - track.minOf { it.n }
+        val spanU = track.maxOf { it.u } - track.minOf { it.u }
+        return max(max(spanE, spanN), max(spanU, 100.0))
+    }
+
+    public fun center(track: List<V3>): V3 {
+        if (track.isEmpty()) return V3(0.0, 0.0, 0.0)
+        return V3(
+            (track.maxOf { it.e } + track.minOf { it.e }) / 2,
+            (track.maxOf { it.n } + track.minOf { it.n }) / 2,
+            (track.maxOf { it.u } + track.minOf { it.u }) / 2,
+        )
+    }
+
+    /**
+     * Stride-downsample to at most [maxCount] points, always keeping the
+     * first, the last, AND the apogee sample — the one point a stride can
+     * shave that a human will notice missing (the chart LOD learned the same
+     * lesson; its test pins apogee surviving LTTB).
+     */
+    public fun downsample(track: List<V3>, maxCount: Int): List<V3> {
+        if (track.size <= maxCount || maxCount < 3) return track
+        val lm = landmarks(track) ?: return track
+        val stride = (track.size + maxCount - 1) / maxCount
+        val out = ArrayList<V3>(maxCount + 2)
+        var lastKept = -1
+        for (i in track.indices step stride) {
+            if (i == lm.apogeeIndex) {
+                out.add(track[i]); lastKept = i
+            } else {
+                // Keep apogee if the stride would step over it.
+                if (lastKept < lm.apogeeIndex && i > lm.apogeeIndex) out.add(track[lm.apogeeIndex])
+                out.add(track[i]); lastKept = i
+            }
+        }
+        if (lastKept < lm.apogeeIndex) out.add(track[lm.apogeeIndex])
+        if (out.last() != track.last()) out.add(track.last())
+        return out
+    }
+
+    public data class Camera(
+        val yawRad: Double,
+        val pitchRad: Double,
+        val distance: Double,
+        val center: V3,
+        val fovDeg: Double = 50.0,
+    )
+
+    /**
+     * iOS parity: side view perpendicular to the launch→apogee horizontal
+     * bearing, at 1.8× extent, elevated ~15° so the ground plane reads as a
+     * plane.  With no horizontal travel (a perfectly vertical flight) any
+     * side works; use east.
+     */
+    public fun initialCamera(track: List<V3>): Camera {
+        val lm = landmarks(track)
+        val ext = extent(track)
+        val c = center(track)
+        val yaw = if (lm != null) {
+            val de = lm.apogee.e - lm.launch.e
+            val dn = lm.apogee.n - lm.launch.n
+            if (abs(de) < 1e-6 && abs(dn) < 1e-6) PI / 2
+            else atan2(de, dn) + PI / 2   // bearing of travel + 90° = broadside
+        } else {
+            PI / 2
+        }
+        return Camera(
+            yawRad = yaw,
+            pitchRad = Math.toRadians(15.0),
+            distance = ext * 1.8,
+            center = c,
+        )
+    }
+
+    public fun cameraPosition(cam: Camera): V3 {
+        val ch = cos(cam.pitchRad) * cam.distance
+        return V3(
+            cam.center.e + ch * sin(cam.yawRad),
+            cam.center.n + ch * cos(cam.yawRad),
+            cam.center.u + sin(cam.pitchRad) * cam.distance,
+        )
+    }
+
+    /** Projected point: screen fraction of viewport (0..1 each axis when on
+     *  screen) + camera-space depth for painter's ordering. */
+    public data class Projected(val x: Double, val y: Double, val depth: Double)
+
+    /**
+     * World → screen.  [x]/[y] are in PIXELS for a viewport of
+     * [widthPx]×[heightPx]; null when the point is at/behind the near plane.
+     */
+    public fun project(p: V3, cam: Camera, widthPx: Double, heightPx: Double): Projected? {
+        val camPos = cameraPosition(cam)
+
+        // View basis: forward toward the center, world-up = +U.
+        val f = norm(sub(cam.center, camPos)) ?: return null
+        val upWorld = V3(0.0, 0.0, 1.0)
+        val r = norm(cross(f, upWorld)) ?: return null
+        val up = cross(r, f)
+
+        val d = sub(p, camPos)
+        val cx = dot(d, r)
+        val cy = dot(d, up)
+        val cz = dot(d, f)
+
+        val near = max(cam.distance * 0.001, 0.1)
+        if (cz <= near) return null
+
+        val focal = (heightPx / 2.0) / tan(Math.toRadians(cam.fovDeg) / 2.0)
+        return Projected(
+            x = widthPx / 2.0 + cx * focal / cz,
+            y = heightPx / 2.0 - cy * focal / cz,
+            depth = cz,
+        )
+    }
+
+    /** 1/2/5 × 10ⁿ round-down (shared convention with the 2D scale bar). */
+    public fun niceGridSpacing(extent: Double): Double {
+        val target = extent / 4.0
+        if (target <= 0) return 25.0
+        val exp = kotlin.math.floor(kotlin.math.log10(target))
+        val base = Math.pow(10.0, exp)
+        val m = target / base
+        return when {
+            m >= 5 -> 5 * base
+            m >= 2 -> 2 * base
+            else -> base
+        }
+    }
+
+    // ── Vector helpers ───────────────────────────────────────────────────
+
+    private fun sub(a: V3, b: V3) = V3(a.e - b.e, a.n - b.n, a.u - b.u)
+    private fun dot(a: V3, b: V3) = a.e * b.e + a.n * b.n + a.u * b.u
+    private fun cross(a: V3, b: V3) = V3(
+        a.n * b.u - a.u * b.n,
+        a.u * b.e - a.e * b.u,
+        a.e * b.n - a.n * b.e,
+    )
+    private fun norm(v: V3): V3? {
+        val len = sqrt(dot(v, v))
+        if (len < 1e-9) return null
+        return V3(v.e / len, v.n / len, v.u / len)
+    }
+}

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/Trajectory3DTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/Trajectory3DTest.kt
@@ -1,0 +1,171 @@
+package com.tinkerbug.tinkerrocket.protocol
+
+import com.tinkerbug.tinkerrocket.protocol.Trajectory3D.Camera
+import com.tinkerbug.tinkerrocket.protocol.Trajectory3D.V3
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the orbit-camera conventions the Canvas renders with.  The point of
+ * testing PROJECTION rather than pixels: a flipped axis or swapped yaw sign
+ * produces a plausible-looking trajectory that is silently mirrored — the
+ * same class of failure as the compass arrow, invisible to an eyeball check.
+ */
+class Trajectory3DTest {
+
+    private val w = 1000.0
+    private val h = 800.0
+
+    /** Camera due south of origin, level-ish, looking north at the center. */
+    private fun southCam(pitchDeg: Double = 0.0, dist: Double = 1000.0) = Camera(
+        yawRad = PI,               // camera azimuth: due south of center
+        pitchRad = Math.toRadians(pitchDeg),
+        distance = dist,
+        center = V3(0.0, 0.0, 0.0),
+    )
+
+    // ── Projection conventions ───────────────────────────────────────────
+
+    @Test
+    fun centerProjectsToViewportCenter_atAnyOrbit() {
+        for (yawDeg in intArrayOf(0, 45, 137, 233, 359)) {
+            for (pitchDeg in intArrayOf(5, 30, 80)) {
+                val cam = Camera(Math.toRadians(yawDeg.toDouble()),
+                    Math.toRadians(pitchDeg.toDouble()), 500.0, V3(10.0, -20.0, 30.0))
+                val p = Trajectory3D.project(cam.center, cam, w, h)
+                assertNotNull(p, "yaw=$yawDeg pitch=$pitchDeg")
+                assertEquals(w / 2, p.x, 1e-6)
+                assertEquals(h / 2, p.y, 1e-6)
+            }
+        }
+    }
+
+    @Test
+    fun eastIsScreenRight_whenCameraLooksNorth() {
+        val p = Trajectory3D.project(V3(100.0, 0.0, 0.0), southCam(), w, h)
+        assertNotNull(p)
+        assertTrue(p.x > w / 2, "east must be screen-right, got x=${p.x}")
+    }
+
+    @Test
+    fun upIsScreenUp() {
+        val p = Trajectory3D.project(V3(0.0, 0.0, 100.0), southCam(), w, h)
+        assertNotNull(p)
+        assertTrue(p.y < h / 2, "higher altitude must be screen-UP, got y=${p.y}")
+    }
+
+    @Test
+    fun behindCamera_isCulled() {
+        // Camera is 1000 m south of center; a point 2000 m south is behind it.
+        assertNull(Trajectory3D.project(V3(0.0, -2000.0, 0.0), southCam(), w, h))
+    }
+
+    @Test
+    fun nearerPointHasSmallerDepth() {
+        val near = Trajectory3D.project(V3(0.0, -500.0, 0.0), southCam(), w, h)
+        val far = Trajectory3D.project(V3(0.0, 500.0, 0.0), southCam(), w, h)
+        assertNotNull(near); assertNotNull(far)
+        assertTrue(near.depth < far.depth)
+    }
+
+    @Test
+    fun yawOrbit_movesAPointOppositeToTheCamera() {
+        // Orbiting the camera clockwise must swing the scene the other way —
+        // the compass-arrow property, one abstraction up.
+        val east = V3(100.0, 0.0, 0.0)
+        val p0 = Trajectory3D.project(east, southCam(), w, h)!!
+        val turned = southCam().copy(yawRad = PI - 0.3)
+        val p1 = Trajectory3D.project(east, turned, w, h)!!
+        assertTrue(p1.x != p0.x, "orbiting must move off-center points")
+    }
+
+    // ── Landmarks / extent / downsample ──────────────────────────────────
+
+    private fun hop(n: Int = 101, apogeeAt: Int = 50): List<V3> =
+        (0 until n).map { i ->
+            V3(i.toDouble(), 0.0, 400.0 - abs(i - apogeeAt).toDouble() * 8)
+        }
+
+    @Test
+    fun landmarks_firstApexLast() {
+        val lm = Trajectory3D.landmarks(hop())!!
+        assertEquals(0.0, lm.launch.e)
+        assertEquals(50.0, lm.apogee.e)
+        assertEquals(100.0, lm.landing.e)
+        assertEquals(50, lm.apogeeIndex)
+    }
+
+    @Test
+    fun extent_flooredAt100() {
+        val tiny = listOf(V3(0.0, 0.0, 0.0), V3(1.0, 2.0, 3.0))
+        assertEquals(100.0, Trajectory3D.extent(tiny))
+        // hop(): e spans 100, u spans 0..400 → the U span wins.
+        assertEquals(400.0, Trajectory3D.extent(hop()), 1.0)
+    }
+
+    @Test
+    fun downsample_keepsFirstLastAndApogee() {
+        val track = hop(n = 5001, apogeeAt = 2500)
+        val out = Trajectory3D.downsample(track, 200)
+        assertTrue(out.size <= 205, "got ${out.size}")
+        assertEquals(track.first(), out.first())
+        assertEquals(track.last(), out.last())
+        assertTrue(track[2500] in out, "the apogee sample must survive downsampling")
+    }
+
+    @Test
+    fun downsample_belowLimit_untouched() {
+        val track = hop(n = 50)
+        assertEquals(track, Trajectory3D.downsample(track, 200))
+    }
+
+    // ── Initial camera ───────────────────────────────────────────────────
+
+    @Test
+    fun initialCamera_isBroadsideToTheClimb() {
+        // Flight travels due north.  Broadside (camera east/west) shows the
+        // arc PROFILE: the horizontal travel spreads across screen-x — the
+        // exact opposite of a head-on view (camera on the travel bearing),
+        // which collapses it.  Assert the spread dominates head-on, and the
+        // climb still reads upward.
+        val track = (0..100).map { i ->
+            V3(0.0, i.toDouble() * 5, 400.0 - abs(i - 50).toDouble() * 8)
+        }
+        val cam = Trajectory3D.initialCamera(track)
+        val lm = Trajectory3D.landmarks(track)!!
+        val pl = Trajectory3D.project(lm.launch, cam, w, h)!!
+        val pa = Trajectory3D.project(lm.apogee, cam, w, h)!!
+        val broadsideSpread = abs(pl.x - pa.x)
+
+        val headOn = cam.copy(yawRad = cam.yawRad - Math.PI / 2)
+        val hl = Trajectory3D.project(lm.launch, headOn, w, h)!!
+        val ha = Trajectory3D.project(lm.apogee, headOn, w, h)!!
+        val headOnSpread = abs(hl.x - ha.x)
+
+        assertTrue(broadsideSpread > headOnSpread * 3 + 1,
+            "broadside must maximise the visible profile: " +
+                "broadside=$broadsideSpread headOn=$headOnSpread")
+        assertTrue(pa.y < pl.y, "apogee renders above launch")
+    }
+
+    @Test
+    fun initialCamera_verticalFlight_stillDefined() {
+        val track = (0..10).map { V3(0.0, 0.0, it.toDouble() * 40) }
+        val cam = Trajectory3D.initialCamera(track)
+        assertTrue(cam.distance >= 100.0 * 1.8 - 1e-9)
+        assertNotNull(Trajectory3D.project(track.last(), cam, w, h))
+    }
+
+    @Test
+    fun gridSpacing_is125() {
+        // Round-DOWN to a 1/2/5 number: extent/4 = 25 → 20 (25 is not 1-2-5).
+        assertEquals(20.0, Trajectory3D.niceGridSpacing(100.0))
+        assertEquals(100.0, Trajectory3D.niceGridSpacing(450.0))
+        assertEquals(200.0, Trajectory3D.niceGridSpacing(1000.0))
+    }
+}

--- a/docs/plans/624-android-port.md
+++ b/docs/plans/624-android-port.md
@@ -112,7 +112,7 @@ Estimating unit: 1 evening ≈ 2–3 h. Cadence ~3 sessions/week. Every phase en
 
 **Screen order rationale** — the launch-day loop defines v1.0: scan/connect → pad dashboard (readiness, power gate, continuity, staleness) → flight (telemetry, voice, prediction) → recovery (map pin, arrow) → post-flight (download, chart). Settings/syncer is non-negotiable in v1.0: the app is the config source of truth; a syncer-less Android app silently flies stale NVS settings. Relay routing (cmd-50 targeting, sticky focus) ships in Phases 2–3 — at a real launch the phone talks through the BS LoRa relay most of the time; only the multi-rocket UI chrome trails. OTA trails: firmware can be flashed at home via iOS/USB indefinitely.
 
-**v1.0 = Phases 0–7 + Checkpoint A** (the shadow outing was ungated by user decision 2026-07-30 — it validates v1.0 in the field, it doesn't gate it). Trailing: 3D views, PyroTest video, DriftCast send flow (guided flight is gated behind FIRST-GUIDED-FLIGHT anyway), fleet chrome, iOS-profile import. OTA and the update checker, once trailing, both shipped before v1.0.
+**v1.0 = Phases 0–7 + Checkpoint A** (the shadow outing was ungated by user decision 2026-07-30 — it validates v1.0 in the field, it doesn't gate it). Trailing: 3D views, PyroTest video, DriftCast send flow (guided flight is gated behind FIRST-GUIDED-FLIGHT anyway), fleet chrome. ~~iOS-profile import~~ DROPPED by user decision 2026-07-30 (no cross-device profile sharing needed). OTA and the update checker, once trailing, both shipped before v1.0.
 
 **Spike verdicts**
 - **S1 (emulator BLE)**: mooted — the Pixel 8 arrived before the spike ran; Phase 2's bench seam validated the real stack directly.


### PR DESCRIPTION
Phase 9's big rock. iOS's SceneKit `FlightScene3DView`, rendered per plan §1 as a **2D-projected Compose Canvas over pure-JVM math** — no 3D engine. `Trajectory3D` in `:core:protocol` owns the camera + projection (ENU world, compass-style azimuth, perspective with near-plane culling, painter's depth ordering) with **13 tests pinning the conventions** — a mirrored trajectory looks perfectly plausible, which is the compass-arrow failure class one abstraction up. Three first-run test failures were all bugs in my *assertions*, not the code (25 isn't a 1-2-5 number; the synthetic track dove underground; a broadside view **spreads** the travel across the screen rather than stacking it).

Deliberate data divergence from iOS, recorded in code docs: EKF `Position E/N/U` straight from the CSV (same columns as the 2D track) instead of GPS-reconstructed local coordinates — smoother, and present even on GNSS-degraded flights.

Scene matches iOS: 1-2-5 ground grid, altitude-gradient path, apogee drop line + AGL callout, three markers + labels, initial camera broadside to the climb at 1.8× extent. Drag orbits (pitch 5–85°), pinch zooms (0.3–8× extent), double-tap resets. A `2D | 3D` toggle on the chart's Path view.

Rode along: the 2D track's launch/landing markers were the **opposite of iOS's palette** — a genuine field-confusion hazard with two phones out. Both views and both platforms now agree (launch red, apogee blue, landing green). Plan doc also records the user's drop of iOS-profile import.

On-device screenshots in the thread (initial framing + drag-orbit). JVM suite green.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)