### PR TITLE
android: v1.0.1 — dashboard sections, 3D trajectory, DriftCast 3D

### DIFF
--- a/TinkerRocketAndroid/app/build.gradle.kts
+++ b/TinkerRocketAndroid/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         targetSdk = 36
         // versionCode must only ever increase (Play + sideload "update"
         // installs both key on it); bump BOTH before tagging android-v<name>.
-        versionCode = 4
-        versionName = "1.0.0"
+        versionCode = 5
+        versionName = "1.0.1"
     }
 
     buildFeatures {


### PR DESCRIPTION
Version bump (versionCode 5 / `1.0.1`) collecting everything merged since v1.0.0: the iOS dashboard-section ports (status card, relay-aware controls, storage bars, go/no-go banner, LOG-chip re-convergence), the shared orbit-camera component with the 3D flight trajectory and DriftCast 3D, and the marker-palette convergence. Tag `android-v1.0.1` follows the merge; the signed APK goes onto the Pixel.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)