### PR TITLE
fc: simulated flights dry-fire pyros — state machine runs, rail stays cold

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
@@ -154,6 +154,7 @@ fun SimulationScreen(session: DeviceSession, onBack: () -> Unit) {
     var burnS by remember { mutableStateOf(prefs.getString("burnTimeSeconds", "1.5")!!) }
     var descentMps by remember { mutableStateOf(prefs.getString("descentRateMps", "5.0")!!) }
     var launching by remember { mutableStateOf(false) }
+    var confirmLaunch by remember { mutableStateOf(false) }
 
     fun persist() {
         prefs.edit()
@@ -198,28 +199,53 @@ fun SimulationScreen(session: DeviceSession, onBack: () -> Unit) {
                 EstRow("Flight Duration", est?.let { "%.0f s".format(it.totalTime) } ?: "—")
             }
         }
+        if (confirmLaunch) {
+            // Same informational confirm as iOS (design language): sim pyros
+            // DRY-FIRE as of the 2026-07-30 firmware — sequence and report,
+            // never energize.
+            androidx.compose.material3.AlertDialog(
+                onDismissRequest = { confirmLaunch = false },
+                title = { Text("Simulated flight") },
+                text = {
+                    Text(
+                        "The rocket flies the full pipeline on synthetic " +
+                            "sensors. Pyro channels sequence and report but " +
+                            "are dry-fired — no charges are energized " +
+                            "(requires current FC firmware).",
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        confirmLaunch = false
+                        launching = true
+                        scope.launch {
+                            session.sendTimeSync()
+                            session.sendCommandFrame(
+                                Commands.simConfig(
+                                    massGrams = massGrams.toFloat(),
+                                    thrustN = thrustN.toFloat(),
+                                    burnTimeS = burnS.toFloat(),
+                                    descentRateMps = descentMps.toFloat(),
+                                ),
+                            )
+                            delay(if (session.isBaseStation) 1000L else 300L)
+                            session.markSimLaunched()
+                            session.sendBareCommand(BleCommandId.SIM_START)
+                            launching = false
+                            onBack()
+                        }
+                    }) { Text("Launch") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { confirmLaunch = false }) { Text("Cancel") }
+                },
+            )
+        }
         Button(
             enabled = connected && inputsValid && !launching,
             onClick = {
-                launching = true
-                scope.launch {
-                    // Fresh phone time for unique sim filenames, then config,
-                    // then start after the relay-dependent delay (iOS timing).
-                    session.sendTimeSync()
-                    session.sendCommandFrame(
-                        Commands.simConfig(
-                            massGrams = massGrams.toFloat(),
-                            thrustN = thrustN.toFloat(),
-                            burnTimeS = burnS.toFloat(),
-                            descentRateMps = descentMps.toFloat(),
-                        ),
-                    )
-                    delay(if (session.isBaseStation) 1000L else 300L)
-                    session.markSimLaunched()
-                    session.sendBareCommand(BleCommandId.SIM_START)
-                    launching = false
-                    onBack()
-                }
+                persist()
+                confirmLaunch = true
             },
             modifier = Modifier.fillMaxWidth(),
         ) { Text(if (launching) "Launching…" else "🔥 Launch Simulation") }
@@ -229,12 +255,11 @@ fun SimulationScreen(session: DeviceSession, onBack: () -> Unit) {
             Text("All fields must be positive numbers", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
         }
         Text(
-            // Was "Voice announcements, LoRa, and data logging all work during
-            // simulation" — ported verbatim from iOS, but Android has no voice
-            // announcements at all (#643).  Don't promise what isn't there.
             "The simulator runs a 1D physics model on the ESP32, generating " +
                 "synthetic sensor data through the full telemetry pipeline. " +
-                "LoRa and data logging both work during simulation.",
+                "Voice, LoRa, and data logging all work during simulation. " +
+                "Pyro channels dry-fire: they sequence and report, but are " +
+                "never energized.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -2446,13 +2446,17 @@ struct TestingControlsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(.systemGray6))
         .cornerRadius(10)
-        .alert("Warning", isPresented: $showSimWarning) {
-            Button("Continue", role: .destructive) {
+        // Sim pyros DRY-FIRE as of the 2026-07-30 firmware: channels
+        // sequence and report, the squib rail never energizes.  The old
+        // destructive "charges will fire" warning was the only protection
+        // before the firmware gate existed.
+        .alert("Simulated flight", isPresented: $showSimWarning) {
+            Button("Launch") {
                 launchSim()
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Any attached pyro charges will fire in the sim mode flight. Continue?")
+            Text("The rocket flies the full pipeline on synthetic sensors. Pyro channels sequence and report but are dry-fired — no charges are energized (requires current FC firmware).")
         }
     }
 

--- a/docs/architecture/generated/flight-computer-map.md
+++ b/docs/architecture/generated/flight-computer-map.md
@@ -3,7 +3,7 @@
 
 # Flight Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,493 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,506 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -20,35 +20,35 @@ and leading comments.
 | [**Flight snapshot (crash recovery)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L578-L675) | 98 | 578-675 |
 | [**Reset-reason reporting**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L676-L696) | 21 | 676-696 |
 | [**Servo control and config-frame reads**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L697-L889) | 193 | 697-889 |
-| [**Pyro channels: init, safing, and servicing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L890-L1177) | 288 | 890-1177 |
-| [**Roll-profile waypoint lookup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1178-L1254) | 77 | 1178-1254 |
-| [**I2S transmit to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1255-L1325) | 71 | 1255-1325 |
-| [**OTA relay receiver (image in over I2S)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1326-L1552) | 227 | 1326-1552 |
-| [**Board-to-rocket orientation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1553-L1688) | 136 | 1553-1688 |
-| [**Guidance configuration and flight settings**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1689-L1846) | 158 | 1689-1846 |
-| [**I2S sender task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1847-L1894) | 48 | 1847-1894 |
-| [**Status LED**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1895-L1917) | 23 | 1895-1917 |
-| [**Calibration status publishing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1918-L1987) | 70 | 1918-1987 |
-| [**Piezo buzzer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1988-L2075) | 88 | 1988-2075 |
-| [**Camera control (GoPro pulse, RunCam serial)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2076-L2394) | 319 | 2076-2394 |
-| [**Boot chirp and heartbeat beep**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2395-L2470) | 76 | 2395-2470 |
-| [**OTA boot validation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2471-L2488) | 18 | 2471-2488 |
-| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2489-L3397) | 909 | 2489-3397 |
-| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3398-L3474) | 77 | 3398-3474 |
-| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3475-L3616) | 142 | 3475-3616 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3617-L7478) | 3,862 | 3617-7478 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3654-L3794) | 141 | 3654-3794 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3795-L3898) | 104 | 3795-3898 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3899-L4016) | 118 | 3899-4016 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4017-L4435) | 419 | 4017-4435 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4436-L4600) | 165 | 4436-4600 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4601-L6208) | 1,608 | 4601-6208 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6209-L6326) | 118 | 6209-6326 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6327-L6456) | 130 | 6327-6456 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6457-L6978) | 522 | 6457-6978 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6979-L7022) | 44 | 6979-7022 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7023-L7278) | 256 | 7023-7278 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7279-L7478) | 200 | 7279-7478 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7479-L7493) | 15 | 7479-7493 |
+| [**Pyro channels: init, safing, and servicing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L890-L1190) | 301 | 890-1190 |
+| [**Roll-profile waypoint lookup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1191-L1267) | 77 | 1191-1267 |
+| [**I2S transmit to the Out Computer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1268-L1338) | 71 | 1268-1338 |
+| [**OTA relay receiver (image in over I2S)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1339-L1565) | 227 | 1339-1565 |
+| [**Board-to-rocket orientation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1566-L1701) | 136 | 1566-1701 |
+| [**Guidance configuration and flight settings**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1702-L1859) | 158 | 1702-1859 |
+| [**I2S sender task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1860-L1907) | 48 | 1860-1907 |
+| [**Status LED**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1908-L1930) | 23 | 1908-1930 |
+| [**Calibration status publishing**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L1931-L2000) | 70 | 1931-2000 |
+| [**Piezo buzzer**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2001-L2088) | 88 | 2001-2088 |
+| [**Camera control (GoPro pulse, RunCam serial)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2089-L2407) | 319 | 2089-2407 |
+| [**Boot chirp and heartbeat beep**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2408-L2483) | 76 | 2408-2483 |
+| [**OTA boot validation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2484-L2501) | 18 | 2484-2501 |
+| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2502-L3410) | 909 | 2502-3410 |
+| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3411-L3487) | 77 | 3411-3487 |
+| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3488-L3629) | 142 | 3488-3629 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3630-L7491) | 3,862 | 3630-7491 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3667-L3807) | 141 | 3667-3807 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3808-L3911) | 104 | 3808-3911 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3912-L4029) | 118 | 3912-4029 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4030-L4448) | 419 | 4030-4448 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4449-L4613) | 165 | 4449-4613 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4614-L6221) | 1,608 | 4614-6221 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6222-L6339) | 118 | 6222-6339 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6340-L6469) | 130 | 6340-6469 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6470-L6991) | 522 | 6470-6991 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6992-L7035) | 44 | 6992-7035 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7036-L7291) | 256 | 7036-7291 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7292-L7491) | 200 | 7292-7491 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7492-L7506) | 15 | 7492-7506 |
 
-Total: 28 sections (12 nested) across 7,493 lines.
+Total: 28 sections (12 nested) across 7,506 lines.

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 25,839 lines across 67 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 25,843 lines across 67 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -75,11 +75,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 13,613 lines
+## `Views/` — 27 files, 13,617 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,885 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +39 more |
+| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,889 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +39 more |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
 | [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,668 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
@@ -119,4 +119,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 67 files, 25,839 lines.
+Total: 67 files, 25,843 lines.

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -1120,10 +1120,19 @@ static void servicePyroChannels(uint32_t now_ms)
             }
         }
 
-        // ArmSettle → Firing once the settle elapses
+        // ArmSettle → Firing once the settle elapses.
+        // SIM DRY-FIRE: during a simulated flight the full state machine
+        // runs — states, fired flags, telemetry, deployment logging — but
+        // the FIRE pin is never driven HIGH, so charges connected on a
+        // bench stay cold. The apps' "pyros will fire" warning used to be
+        // the only protection. PYRO_FIRE_TEST (the explicit user ground
+        // test) is deliberately NOT gated — that command means "energize
+        // this channel now" regardless of sim state.
         if (ch.state == PyroChState::ArmSettle &&
             (now_ms - ch.phase_start_ms) >= config::PYRO_ARM_SETTLE_MS) {
-            gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 1);
+            if (!sensor_collector.isSimActive()) {
+                gpio_set_level((gpio_num_t)PYRO_FIRE_PINS[i], 1);
+            }
             ch.state          = PyroChState::Firing;
             ch.phase_start_ms = now_ms;
             just_fired[i]     = true;
@@ -1156,6 +1165,8 @@ static void servicePyroChannels(uint32_t now_ms)
     }
 
     // Compute ARM demand: any channel mid-fire keeps the pin HIGH.
+    // Sim dry-fire: the ARM rail stays LOW too — the whole squib circuit
+    // remains unpowered while the state machine sequences.
     bool any_demand = false;
     for (int i = 0; i < 4; ++i) {
         if (pyro_ch[i].state == PyroChState::ArmSettle ||
@@ -1164,13 +1175,15 @@ static void servicePyroChannels(uint32_t now_ms)
             break;
         }
     }
-    pyroSetArmLocked(any_demand);
+    pyroSetArmLocked(any_demand && !sensor_collector.isSimActive());
 
     portEXIT_CRITICAL(&pyro_spinlock);
 
+    const bool dry = sensor_collector.isSimActive();
     for (int i = 0; i < 4; ++i) {
-        if (just_fired[i]) ESP_LOGW(TAG, "[PYRO] CH%d FIRED at alt=%.1f m",
-                                    i + 1, (double)pressure_alt_m);
+        if (just_fired[i]) ESP_LOGW(TAG, "[PYRO] CH%d %s at alt=%.1f m",
+                                    i + 1, dry ? "DRY-FIRED (sim)" : "FIRED",
+                                    (double)pressure_alt_m);
         if (pulse_done[i]) ESP_LOGI(TAG, "[PYRO] CH%d fire pulse complete", i + 1);
     }
 }


### PR DESCRIPTION
User call: firing real charges during a sim was never a good idea, and the apps' popup was the only protection. The gate lives where it belongs — **firmware**: during a sim the pyro state machine sequences fully (states, fired flags, telemetry, deployment logging) but the FIRE pin write is inhibited and the **ARM rail stays LOW**, so the squib circuit is never powered. `PYRO_FIRE_TEST` (explicit user ground test) is deliberately not gated.

Dry-fire rather than a hard trigger gate keeps every sim-observable behavior identical — fired chips still light in both apps, and #623's rate switch keys on `deployment_detected` (verified: its own kinematic detector, independent of pyro fire).

Both apps updated in lockstep: iOS's destructive warning becomes an informational confirm; Android **gains** the matching confirm it never had, plus the dry-fire sentence in the sim description. No wire change.

Honest verification scope: the bench can demonstrate fired *flags* during a sim (proving the state machine still runs) but has no meter on the FET pins and no FC serial — the GPIO inhibit is review-verified, with a `DRY-FIRED (sim)` log line waiting for the next serial-attached session. FC image builds; both app suites green.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)