### PR TITLE
android: scanner design pass + Demo becomes the Virtual Rocket

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -103,7 +103,7 @@ fun DashboardScreen(
             Column(Modifier.weight(1f)) {
                 Text(
                     (identity.unitName.ifEmpty { device.advertisedName }) +
-                        if (demo) "  (demo)" else "",
+                        if (demo) "  (virtual)" else "",
                     style = MaterialTheme.typography.titleLarge,
                 )
                 Text(

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DemoMode.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DemoMode.kt
@@ -20,11 +20,15 @@ import kotlin.math.max
 import kotlin.math.roundToInt
 
 /**
- * Demo mode: the SAME fleet/session/UI stack over [FakeFirmware], flying a
- * canned ~40 s flight on loop — pad wait → boost → coast → apogee → descent
- * → landed.  This is the replay-transport seam from the plan (§3) earning
- * its keep as the no-hardware dev path: every screen is developable against
- * it in the emulator, and it doubles as the in-app demo.
+ * Virtual Rocket (né demo mode): the SAME fleet/session/UI stack over
+ * [FakeFirmware].  The virtual rocket sits in READY like a real one and
+ * flies ONE canned ~40 s flight per SIM_START — the standard Simulation
+ * tool is the start control, exactly the ritual a real rocket uses, and
+ * SIM_STOP aborts mid-flight (user call 2026-07-30: no endless loop).
+ * Nothing is recorded; the downloadable log in Files is the pre-staged
+ * golden corpus flight, not a capture of the show.  This is the replay-
+ * transport seam from the plan (§3) earning its keep as the no-hardware
+ * dev path; Android-only by design (ledger).
  */
 fun buildDemoFleet(context: android.content.Context, scope: CoroutineScope): FleetManager<DeviceSession> {
     lateinit var fleet: FleetManager<DeviceSession>
@@ -64,7 +68,7 @@ fun buildDemoFleet(context: android.content.Context, scope: CoroutineScope): Fle
 private class DemoScanner : BleScanner {
     override fun advertisements(): Flow<BleAdvertisement> = flow {
         while (true) {
-            emit(BleAdvertisement("demo:01", "TR-B-Demo Base", rssi = -47))
+            emit(BleAdvertisement("demo:01", "TR-B-Virtual", rssi = -47))
             delay(500)
         }
     }
@@ -77,7 +81,7 @@ private class DemoTransportFactory(
     override fun create(deviceId: String, autoConnect: Boolean): BleTransport {
         val fw = FakeFirmware(scope)
         fw.configIdentityJson =
-            """{"type":"config_identity","uid":"demo0001","un":"Demo Base Station",""" +
+            """{"type":"config_identity","uid":"demo0001","un":"Virtual Base Station",""" +
                 """"nid":7,"dt":"B","fw":"demo+sim"}"""
         // A real downloadable flight log: the emitter's synthetic golden
         // flight, bundled from the corpus as an asset.
@@ -86,19 +90,54 @@ private class DemoTransportFactory(
         }.getOrNull()?.let { bytes ->
             fw.deviceFiles += FakeFirmware.FakeFile("flight_20260723_141100.bin", bytes)
         }
-        scope.launch { flyDemoFlight(fw) }
+        scope.launch { runVirtualRocket(fw) }
         return fw
     }
 }
 
-/** ~40 s looped flight profile, 5 Hz telemetry, all-healthy sensors. */
-private suspend fun flyDemoFlight(fw: FakeFirmware) {
+/**
+ * READY idle at 1 Hz until SIM_START arrives, then ONE ~40 s flight at 5 Hz
+ * (the script's first 12 s are the pad phase — a countdown after Launch);
+ * SIM_STOP aborts back to READY.  Commands are read off
+ * [FakeFirmware.commandFrames] by index — cheap polling at telemetry cadence.
+ */
+private suspend fun runVirtualRocket(fw: FakeFirmware) {
     // OK (01) at baro/imu/ekf/mag/gnss/batt/storage shifts; pyro NA (hidden).
     val health = 0x100555
     var maxAlt = 0f
+    var cmdCursor = 0
+
+    fun sawCommand(id: Int): Boolean {
+        var hit = false
+        while (cmdCursor < fw.commandFrames.size) {
+            if (fw.commandFrames[cmdCursor].firstOrNull()?.toInt() == id) hit = true
+            cmdCursor++
+        }
+        return hit
+    }
+
     while (true) {
+        // READY idle until the Simulation tool starts a flight.
+        while (!sawCommand(com.tinkerbug.tinkerrocket.protocol.BleCommandId.SIM_START)) {
+            fw.emitTelemetryJson(
+                """{"rid":1,"run":"Booster","st":"READY","fs":16,"ps":${0x00A or 0x080},""" +
+                    """"h":$health,"nsat":9,"vol":8.20,"soc":87.0,"palt":0.2,""" +
+                    """"lat":34.6572,"lon":-118.2015}""",
+            )
+            fw.emitTelemetryJson(
+                """{"rid":2,"run":"Pad Rocket","st":"READY","fs":16,"ps":2,""" +
+                    """"h":$health,"nsat":8,"vol":8.31,"palt":0.4}""",
+            )
+            delay(1000)
+        }
+
+        var aborted = false
         for (tick in 0 until 200) {
-            val t = tick / 5.0f    // seconds into the loop
+            if (sawCommand(com.tinkerbug.tinkerrocket.protocol.BleCommandId.SIM_STOP)) {
+                aborted = true
+                break
+            }
+            val t = tick / 5.0f    // seconds into the flight
             val phase = when {
                 t < 12f -> "READY"
                 t < 14.5f -> "INFLIGHT"       // boost
@@ -150,6 +189,16 @@ private suspend fun flyDemoFlight(fw: FakeFirmware) {
                 )
             }
             delay(200)
+        }
+        // Flight over or aborted: back to the READY idle above.  The sim
+        // banner latch (DeviceSession) clears on the next READY frame; the
+        // `aborted` distinction exists only for readability — both paths
+        // reset the same way, like a real rocket after touchdown + reset.
+        if (aborted) {
+            fw.emitTelemetryJson(
+                """{"rid":1,"run":"Booster","st":"READY","fs":16,"h":$health,""" +
+                    """"nsat":9,"vol":8.20,"palt":0.2}""",
+            )
         }
         maxAlt = 0f
     }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
@@ -73,13 +73,13 @@ fun ScannerScreen(
             OutlinedButton(onClick = onMyDevices) { Text("My Devices") }
         }
         // Secondary row = the no-hardware world: cached flights (#635) and
-        // demo mode (Android-only by design — the FakeFirmware dev/test path;
-        // iOS has no equivalent, ledger-documented). Demoted from the primary
-        // row in the design pass: a field operator never needs Demo.
+        // the Virtual Rocket (a FakeFirmware fleet in the real app stack —
+        // the no-hardware dev path, doubling as the try-the-app mode).
+        // "Virtual Rocket" names the THING; "Simulation" flies the real one.
         Row(verticalAlignment = Alignment.CenterVertically) {
             OutlinedButton(onClick = onSavedFlights) { Text("Saved Flights") }
             Spacer(Modifier.weight(1f))
-            OutlinedButton(onClick = onDemo) { Text("Demo") }
+            OutlinedButton(onClick = onDemo) { Text("Virtual Rocket") }
         }
         Text(status, style = MaterialTheme.typography.bodyMedium)
 

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Card
@@ -54,20 +55,32 @@ fun ScannerScreen(
                 OutlinedButton(onClick = onGetUpdate) { Text("Get") }
             }
         }
+        // Primary row = the connected world; the spinner lives INSIDE the
+        // Scan button so the row's geometry never changes mid-scan (design
+        // pass 2026-07-30: a floating spinner squeezed the row and wrapped
+        // a button label — the clipped-Disconnect lesson again).
         Row(verticalAlignment = Alignment.CenterVertically) {
             Button(onClick = { fleet.scan(userInitiated = true) }, enabled = !scanning) {
+                if (scanning) {
+                    CircularProgressIndicator(
+                        Modifier.padding(end = 8.dp).size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
                 Text(if (scanning) "Scanning…" else "Scan")
             }
-            if (scanning) CircularProgressIndicator(Modifier.padding(start = 12.dp))
             Spacer(Modifier.weight(1f))
             OutlinedButton(onClick = onMyDevices) { Text("My Devices") }
-            OutlinedButton(onClick = onDemo, modifier = Modifier.padding(start = 6.dp)) { Text("Demo") }
         }
-        // #635: flights already on the phone, reachable with nothing connected.
-        // The post-flight workflow is download at the pad, then review later —
-        // which was impossible while the only route to a log was the
-        // connected-device tab row.
-        OutlinedButton(onClick = onSavedFlights) { Text("Saved Flights") }
+        // Secondary row = the no-hardware world: cached flights (#635) and
+        // demo mode (Android-only by design — the FakeFirmware dev/test path;
+        // iOS has no equivalent, ledger-documented). Demoted from the primary
+        // row in the design pass: a field operator never needs Demo.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedButton(onClick = onSavedFlights) { Text("Saved Flights") }
+            Spacer(Modifier.weight(1f))
+            OutlinedButton(onClick = onDemo) { Text("Demo") }
+        }
         Text(status, style = MaterialTheme.typography.bodyMedium)
 
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {


### PR DESCRIPTION
Design-pass screen 1 plus the Virtual Rocket decisions, verified on-device:

**Scanner fixes**: the scan spinner lives inside the Scan button (a floating spinner squeezed the row and wrapped a button label — the clipped-Disconnect lesson: state changes must not move row geometry), and the top screen reorganizes into a *connected world* row (Scan · My Devices) and a *no-hardware world* row (Saved Flights · Virtual Rocket).

**Demo → Virtual Rocket** (user decisions 2026-07-30): renamed to name the THING — you connect to a virtual rocket, versus Simulation which flies the real one. And **no more endless loop**: the virtual rocket idles in READY and flies ONE canned flight per SIM_START from the standard Simulation tool, honoring SIM_STOP mid-flight — the demo now teaches the exact ritual a real rocket uses, confirm dialog included. Nothing is recorded; the Files log is the pre-staged golden corpus flight (now documented in the KDoc).

On-device: READY idle confirmed, one launch → full flight → LANDED → back to READY and *stays* there. JVM suite green.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)