### PR TITLE
hardware(lora): LoRa V3 pre-fab review + capacitor MPNs and COUT resize

### DIFF
--- a/hardware/lora-daughterboard/lora-daughterboard.kicad_sch
+++ b/hardware/lora-daughterboard/lora-daughterboard.kicad_sch
@@ -7631,6 +7631,12 @@
 		(uuid "f7cef179-e85e-451a-9a89-e70d17429788")
 	)
 	(junction
+		(at 179.07 146.685)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "42256b6f-284d-4403-8f31-2efb428c652f")
+	)
+	(junction
 		(at 139.065 52.705)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -7685,12 +7691,6 @@
 		(uuid "14a10de9-173b-4fd3-83b1-b0d36d0fc9f6")
 	)
 	(junction
-		(at 154.94 26.67)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "17d75101-ddf2-4851-96b2-1153c3902560")
-	)
-	(junction
 		(at 238.76 115.57)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -7743,6 +7743,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4a2a21a7-799d-4ec9-a90a-3fcab16ef023")
+	)
+	(junction
+		(at 149.86 40.005)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4f0380a8-6a6a-4a4b-a27c-47c309b4681c")
 	)
 	(junction
 		(at 30.48 38.735)
@@ -8034,6 +8040,16 @@
 	)
 	(wire
 		(pts
+			(xy 160.02 50.8) (xy 160.02 40.005)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2754307c-16a9-455f-baab-e75777c91e28")
+	)
+	(wire
+		(pts
 			(xy 240.665 45.085) (xy 240.665 45.72)
 		)
 		(stroke
@@ -8314,6 +8330,16 @@
 	)
 	(wire
 		(pts
+			(xy 160.02 50.8) (xy 162.56 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63e96d6c-38e0-4f7e-9916-3eec6e169834")
+	)
+	(wire
+		(pts
 			(xy 217.805 29.845) (xy 225.425 29.845)
 		)
 		(stroke
@@ -8454,6 +8480,16 @@
 	)
 	(wire
 		(pts
+			(xy 160.02 40.005) (xy 149.86 40.005)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81e41d6e-8cf1-4dbf-bde7-7a0a8281470a")
+	)
+	(wire
+		(pts
 			(xy 156.845 68.58) (xy 156.845 73.025)
 		)
 		(stroke
@@ -8481,16 +8517,6 @@
 			(type default)
 		)
 		(uuid "870a5a53-021c-494a-b97f-d554a38c3ab8")
-	)
-	(wire
-		(pts
-			(xy 154.94 26.67) (xy 154.94 50.8)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8b062480-f9d1-4627-ba4d-8710cd7e5932")
 	)
 	(wire
 		(pts
@@ -8551,16 +8577,6 @@
 			(type default)
 		)
 		(uuid "9665a2e8-1fd2-4f48-bec9-1bb6b7fdf3e6")
-	)
-	(wire
-		(pts
-			(xy 154.94 25.4) (xy 154.94 26.67)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "980f5ab0-a201-4357-a6ac-cbd1eec1d86a")
 	)
 	(wire
 		(pts
@@ -8704,6 +8720,16 @@
 	)
 	(wire
 		(pts
+			(xy 149.86 29.21) (xy 149.86 31.115)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3da13bf-4667-4c75-b805-a61434a74254")
+	)
+	(wire
+		(pts
 			(xy 217.805 146.685) (xy 248.285 146.685)
 		)
 		(stroke
@@ -8724,13 +8750,13 @@
 	)
 	(wire
 		(pts
-			(xy 154.94 26.67) (xy 160.02 26.67)
+			(xy 149.86 38.735) (xy 149.86 40.005)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b7f08caf-8d3a-457d-9754-63f9bee488d3")
+		(uuid "b75bbfb2-3595-429d-bd6a-b553652dec74")
 	)
 	(wire
 		(pts
@@ -10270,6 +10296,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05C180JB5NNNC"
+			(at 127.635 50.8 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 127.635 50.8 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 127.635 50.8 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "015f6268-4ca7-4bf2-a079-6caec25d01e5")
 		)
@@ -10342,6 +10401,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 45.72 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 45.72 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 45.72 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 45.72 149.225 0)
 			(hide yes)
 			(show_name no)
@@ -11116,87 +11208,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Custom:WE-CBA_0805")
-		(at 196.215 146.685 0)
-		(unit 1)
-		(body_style 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(in_pos_files yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "11b8b395-5e7c-4eee-9c3c-8ba772b26b13")
-		(property "Reference" "FB1"
-			(at 196.215 140.97 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "WE-CBA_0805"
-			(at 196.215 143.51 0)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "Footprints:WE-CBA_0805_W4.0"
-			(at 196.215 146.685 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify bottom)
-			)
-		)
-		(property "Datasheet" ""
-			(at 196.215 146.685 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 196.215 146.685 0)
-			(hide yes)
-			(show_name no)
-			(do_not_autoplace no)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(pin "2"
-			(uuid "91dcf456-6fee-4844-b937-b1393661386d")
-		)
-		(pin "1"
-			(uuid "9220a090-95dc-4b70-b2c5-cff37043480f")
-		)
-		(instances
-			(project "lora-daughterboard"
-				(path "/ae61c2c4-72e9-4776-93ae-2e716b9dc70f"
-					(reference "FB1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:C")
 		(at 70.485 149.225 0)
 		(unit 1)
@@ -11253,6 +11264,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 70.485 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0402KRX7R9BB222"
+			(at 70.485 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Yageo"
+			(at 70.485 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 70.485 149.225 0)
 			(hide yes)
 			(show_name no)
@@ -12080,7 +12124,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 154.94 25.4 0)
+		(at 149.86 29.21 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -12091,7 +12135,7 @@
 		(fields_autoplaced yes)
 		(uuid "278a7603-d337-4e80-988a-e6ff645a2438")
 		(property "Reference" "#PWR0235"
-			(at 154.94 29.21 0)
+			(at 149.86 33.02 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -12102,7 +12146,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 154.94 20.955 0)
+			(at 149.86 24.765 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -12112,7 +12156,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 154.94 25.4 0)
+			(at 149.86 29.21 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -12123,7 +12167,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 154.94 25.4 0)
+			(at 149.86 29.21 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -12134,7 +12178,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 154.94 25.4 0)
+			(at 149.86 29.21 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -12300,6 +12344,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A106MQ5NUNC"
+			(at 225.425 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 225.425 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 225.425 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "2ae433d7-2d6e-493d-9a8f-5fd2a556d296")
 		)
@@ -12449,6 +12526,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 240.665 49.53 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05B104KO5NNNC"
+			(at 240.665 49.53 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 240.665 49.53 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 240.665 49.53 0)
 			(hide yes)
 			(show_name no)
@@ -13101,6 +13211,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05B104KO5NNNC"
+			(at 249.555 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 249.555 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 249.555 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "237eb487-39c0-4fc3-aa1c-111ddd408ce5")
 		)
@@ -13655,6 +13798,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A105KO5NNNC"
+			(at 240.03 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 240.03 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 240.03 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "80ee71f7-77e1-4bdd-9b7d-3ca12b529505")
 		)
@@ -13864,6 +14040,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 130.81 87.63 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05C220JB5NNNC"
+			(at 130.81 87.63 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 130.81 87.63 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
 			(at 130.81 87.63 0)
 			(hide yes)
 			(show_name no)
@@ -14211,6 +14420,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A106MQ5NUNC"
+			(at 279.4 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 279.4 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 279.4 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "395c29e1-2365-4267-8497-a6e78326cd89")
 		)
@@ -14370,6 +14612,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05C180JB5NNNC"
+			(at 139.065 67.31 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 139.065 67.31 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 139.065 67.31 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "e3513901-1945-4349-810b-2159adc8bed9")
 		)
@@ -14387,7 +14662,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 160.02 34.29 0)
+		(at 149.86 47.625 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -14397,7 +14672,7 @@
 		(dnp no)
 		(uuid "60e29cb5-86ac-437e-a8b5-40835a43ff6e")
 		(property "Reference" "#PWR0238"
-			(at 160.02 40.64 0)
+			(at 149.86 53.975 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14408,7 +14683,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 161.925 38.1 0)
+			(at 151.765 51.435 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -14419,7 +14694,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 160.02 34.29 0)
+			(at 149.86 47.625 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14430,7 +14705,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 160.02 34.29 0)
+			(at 149.86 47.625 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14441,7 +14716,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 160.02 34.29 0)
+			(at 149.86 47.625 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14704,6 +14979,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A105KO5NNNC"
+			(at 272.415 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 272.415 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 272.415 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "6aa56fd0-84f0-4b08-b553-3d544f4cb5a6")
 		)
@@ -14721,7 +15029,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 158.75 50.8 270)
+		(at 149.86 34.925 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -14732,27 +15040,29 @@
 		(fields_autoplaced yes)
 		(uuid "62f518d6-ad84-44a8-9178-5b74c9794769")
 		(property "Reference" "R73"
-			(at 158.75 44.45 90)
+			(at 152.4 33.6549 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Value" "10 k"
-			(at 158.75 46.99 90)
+			(at 152.4 36.1949 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
-			(at 158.496 51.816 90)
+			(at 150.876 35.179 90)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14763,7 +15073,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 158.75 50.8 0)
+			(at 149.86 34.925 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -14774,7 +15084,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 158.75 50.8 0)
+			(at 149.86 34.925 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -15011,6 +15321,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 217.805 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 217.805 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 217.805 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 217.805 150.495 0)
 			(hide yes)
 			(show_name no)
@@ -15353,6 +15696,87 @@
 		)
 	)
 	(symbol
+		(lib_id "Custom:WE-CBA_0805")
+		(at 196.215 146.685 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "716083cf-40e9-4f43-af23-442b8de1dede")
+		(property "Reference" "FB1"
+			(at 196.215 140.97 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "782853200"
+			(at 196.215 143.51 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Footprints:WE-CBA_0805_W4.0"
+			(at 196.215 146.685 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify bottom)
+			)
+		)
+		(property "Datasheet" ""
+			(at 196.215 146.685 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 196.215 146.685 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "2"
+			(uuid "a9687125-4774-4ea5-aa88-f945abd7fddf")
+		)
+		(pin "1"
+			(uuid "a3d57a86-678f-47f6-9a20-67f80539f717")
+		)
+		(instances
+			(project "lora-daughterboard"
+				(path "/ae61c2c4-72e9-4776-93ae-2e716b9dc70f"
+					(reference "FB1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:C")
 		(at 119.38 76.835 0)
 		(unit 1)
@@ -15418,6 +15842,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05C220JB5NNNC"
+			(at 119.38 76.835 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 119.38 76.835 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 119.38 76.835 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "de3d64d9-bcf2-4128-8190-365e563c3ee7")
 		)
@@ -15435,7 +15892,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 160.02 30.48 0)
+		(at 149.86 43.815 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -15445,7 +15902,7 @@
 		(dnp no)
 		(uuid "75892946-0dd0-4e94-b3a7-8f411337a4a6")
 		(property "Reference" "C95"
-			(at 160.02 27.94 0)
+			(at 149.86 41.275 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -15456,7 +15913,7 @@
 			)
 		)
 		(property "Value" "1 uF"
-			(at 160.02 33.02 0)
+			(at 149.86 46.355 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -15467,7 +15924,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
-			(at 160.9852 34.29 0)
+			(at 150.8252 47.625 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -15478,7 +15935,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 160.02 30.48 0)
+			(at 149.86 43.815 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -15489,7 +15946,40 @@
 			)
 		)
 		(property "Description" ""
-			(at 160.02 30.48 0)
+			(at 149.86 43.815 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05A105KO5NNNC"
+			(at 149.86 43.815 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 149.86 43.815 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 149.86 43.815 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -16160,6 +16650,199 @@
 	)
 	(symbol
 		(lib_id "Device:C")
+		(at 179.07 150.495 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d144f1e7-fa5a-40f8-81a5-c56e8eaa3e78")
+		(property "Reference" "C14"
+			(at 182.88 149.2249 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "22 uF"
+			(at 182.88 151.7649 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
+			(at 180.0352 154.305 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 179.07 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 179.07 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 179.07 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 179.07 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 179.07 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3277dfe9-8645-46e0-bc80-00dca8bffd08")
+		)
+		(pin "2"
+			(uuid "1dc39af0-3f63-4ae4-866a-323e9720085e")
+		)
+		(instances
+			(project "lora-daughterboard"
+				(path "/ae61c2c4-72e9-4776-93ae-2e716b9dc70f"
+					(reference "C14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 179.07 154.305 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ff35aea-d433-4a68-8840-4bdf68865ed5")
+		(property "Reference" "#PWR096"
+			(at 179.07 160.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 179.07 158.75 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 179.07 154.305 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 179.07 154.305 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 179.07 154.305 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a8ef9d19-3e2c-4c1c-9419-8c55a1541fa1")
+		)
+		(instances
+			(project "lora-daughterboard"
+				(path "/ae61c2c4-72e9-4776-93ae-2e716b9dc70f"
+					(reference "#PWR096")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
 		(at 158.115 150.495 0)
 		(unit 1)
 		(body_style 1)
@@ -16181,7 +16864,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "47 uF"
+		(property "Value" "22 uF"
 			(at 161.925 151.7649 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -16215,6 +16898,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 158.115 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 158.115 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 158.115 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 158.115 150.495 0)
 			(hide yes)
 			(show_name no)
@@ -16657,7 +17373,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "47 uF"
+		(property "Value" "22 uF"
 			(at 173.99 151.7649 0)
 			(show_name no)
 			(do_not_autoplace no)
@@ -16691,6 +17407,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 170.18 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 170.18 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 170.18 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 170.18 150.495 0)
 			(hide yes)
 			(show_name no)
@@ -17007,6 +17756,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 217.805 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05A105KO5NNNC"
+			(at 217.805 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 217.805 33.655 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 217.805 33.655 0)
 			(hide yes)
 			(show_name no)
@@ -18170,6 +18952,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A474KP5NNNC"
+			(at 128.27 168.91 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 128.27 168.91 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 128.27 168.91 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "38c2cd8b-84d3-4db8-a66a-6a1d883117d0")
 		)
@@ -18695,6 +19510,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05A106MQ5NUNC"
+			(at 247.015 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 247.015 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
+			(at 247.015 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "acf3be4b-a8ca-4629-9ba2-38691d7b070f")
 		)
@@ -18854,6 +19702,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05B104KO5NNNC"
+			(at 263.525 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 263.525 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 263.525 46.99 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "09ef5760-f859-4404-83cc-8aa7244455f3")
 		)
@@ -18926,6 +19807,39 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
+			(at 58.42 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 58.42 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 58.42 149.225 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 58.42 149.225 0)
 			(hide yes)
 			(show_name no)
@@ -19162,6 +20076,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 233.045 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05B103KB5NNNC"
+			(at 233.045 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 233.045 24.13 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "6.3 V"
 			(at 233.045 24.13 0)
 			(hide yes)
 			(show_name no)
@@ -19955,6 +20902,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL05B104KO5NNNC"
+			(at 233.045 52.07 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 233.045 52.07 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 233.045 52.07 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "6d082bd8-aea8-4f51-ae2d-5a8cb20c484e")
 		)
@@ -20027,6 +21007,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 43.18 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL05B104KO5NNNC"
+			(at 43.18 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 43.18 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 43.18 34.925 0)
 			(hide yes)
 			(show_name no)
@@ -20430,6 +21443,39 @@
 				)
 			)
 		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 205.105 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 205.105 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
+			(at 205.105 150.495 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "124bb915-eb37-4e3a-b39c-426e4d745a92")
 		)
@@ -20503,6 +21549,39 @@
 			)
 		)
 		(property "Description" ""
+			(at 30.48 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CL21A226MOQNNNE"
+			(at 30.48 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Mfr" "Samsung"
+			(at 30.48 34.925 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MinVRating" "16 V"
 			(at 30.48 34.925 0)
 			(hide yes)
 			(show_name no)

--- a/hardware/lora-daughterboard/prefab-review-2026-07-30.md
+++ b/hardware/lora-daughterboard/prefab-review-2026-07-30.md
@@ -34,10 +34,25 @@ Bottom: ESP32-S3RH2 (QFN-56), W25Q128 boot flash, USB-C, JST-SH host link, both 
 
 ## Must fix before fab
 
-### 1. CHIP_PU has the 10 kΩ pull-up but no capacitor — violates the 50 µs t_STBL requirement
-`Net-(U28-CHIP_PU)` = {U28.4, R73.1} only; R73.2 → +3V3. No cap anywhere on the net.
-Espressif's ESP32-S3 schematic checklist requires ≥50 µs between the rails being stable and CHIP_PU going high, and prescribes **R = 10 kΩ and C = 1 µF**. With only a pull-up to the same rail, CHIP_PU tracks +3V3 with ~zero delay — every cold boot and every brownout recovery is out of spec. This is the same defect the rocket-computer review raised (H8); it is repeated verbatim here.
-**Fix:** one 1 µF 0402 from U28 pin 4 to GND, placed at the pin (R73 is at (89.63,123.78), pin 4 at (90.20,122.61) — there is room).
+### 1. The CHIP_PU RC capacitor is on the wrong side of the resistor
+Both parts of Espressif's reset network are present and both are the prescribed values (**R = 10 kΩ, C = 1 µF**) — but C95 is wired to the supply side of R73 instead of the CHIP_PU node, so it acts as rail decoupling and forms no delay.
+
+As drawn:
+```
++3V3 (#PWR0235 @154.94,25.4)
+  |
+  +---- junction (154.94,26.67) ---- C95 1 uF ---- GND (#PWR0238 @160.02,34.29)
+  |
+  +---- R73 10 k ---- CHIP_PU ---- U28.4
+```
+Netlist confirms: `+3V3` contains {C95.1, R73.2, ...}; `Net-(U28-CHIP_PU)` = {R73.1, U28.4} — two nodes.
+
+Espressif's ESP32-S3 schematic checklist requires ≥50 µs between the rails being stable and CHIP_PU going high. That delay comes from the 10 kΩ charging a capacitor **on the pin**. With C95 on the supply side, the only capacitance on the CHIP_PU node is pin 4's input capacitance plus trace (~5 pF): **τ ≈ 10 kΩ × 5 pF ≈ 50 ns**, i.e. CHIP_PU rises in lockstep with +3V3 (and C95, by slowing the rail slightly, if anything tightens that lockstep). Moved to the pin: **τ = 10 kΩ × 1 µF = 10 ms**, comfortably past the 50 µs floor.
+
+Every cold boot and every brownout recovery is currently out of spec. The rocket-computer review raised the same issue (H8) as a missing capacitor; here the capacitor exists and is simply on the wrong node.
+
+**Fix (schematic, one wire):** move C95's top plate from the +3V3 junction to the R73↔U28.4 node. The 1 µF lost from +3V3 is negligible against the ~90 µF already there (C100/C105 1 µF, C102/C106 10 µF, C12/C15/C16 22 µF); alternatively add a second 0402 and leave C95 as bypass.
+**Fix (layout):** C95 is at (86.75,123.91) B.Cu, **3.7 mm** from pin 4 at (90.20,122.61) — acceptable for a bypass cap, too far for a reset RC. Move it adjacent to pin 4, alongside R73 at (89.63,123.78).
 **While you are there:** there is no reset button and no CHIP_PU test point. The only way to reset this board is to unplug it. Add at least a pad.
 
 ### 2. FB1 is specified as "WE-CBA_0805" — no impedance value, and the bead is inside the control loop
@@ -144,7 +159,7 @@ Also: 0.09 mm/0.09 mm is an advanced spec that pushes the price up; only L_MOSI 
 
 ## Suggested order of work
 
-1. **Schematic edits:** CHIP_PU 1 µF; move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
+1. **Schematic edits:** move C95 to the CHIP_PU node; move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
 2. **BOM:** add a real MPN column; pin FB1 first (8–20 Ω @100 MHz / <10 mΩ), then C11/C13 with a DC-bias-derated check against 40–80 µF, C8/C9 at ≥25 V, the three LEDs, and Y5's ESR grade.
 3. **Layout:** relocate Y6 + its caps + L10 next to pins 53/54; pull C8/C9 in toward VIN; via at PSNS; three 1 mm fiducials per side (delete FID1 from under J2); vias out of U28.29 and U3.4; refdes silkscreen; tie H1–H4 to GND; fix the SMA board-edge offset.
 4. **Fab package:** declare the F/In1 prepreg (or full controlled impedance) on the fab notes; raise the netclass minimum off 0.09 mm if you want a cheaper tier; re-enable the courtyard DRC checks and re-run; clear the silk violations.

--- a/hardware/lora-daughterboard/prefab-review-2026-07-30.md
+++ b/hardware/lora-daughterboard/prefab-review-2026-07-30.md
@@ -34,10 +34,12 @@ Bottom: ESP32-S3RH2 (QFN-56), W25Q128 boot flash, USB-C, JST-SH host link, both 
 
 ## Must fix before fab
 
-### 1. The CHIP_PU RC capacitor is on the wrong side of the resistor
-Both parts of Espressif's reset network are present and both are the prescribed values (**R = 10 kΩ, C = 1 µF**) — but C95 is wired to the supply side of R73 instead of the CHIP_PU node, so it acts as rail decoupling and forms no delay.
+### 1. The CHIP_PU RC capacitor was on the wrong side of the resistor — **FIXED (schematic), PCB pending**
+Both parts of Espressif's reset network were present and both were the prescribed values (**R = 10 kΩ, C = 1 µF**) — but C95 was wired to the supply side of R73 instead of the CHIP_PU node, so it acted as rail decoupling and formed no delay.
 
-As drawn:
+**Fixed in the schematic 2026-07-30.** `Net-(U28-CHIP_PU)` is now {C95.1, R73.2, U28.4} and R73 pin 1 goes to +3V3 — the RC is correct. **PCB still pending:** the layout was not touched, so C95's copper still ties to +3V3 (pad at (86.75,123.91) B.Cu). Run *Update PCB from Schematic*, re-route, and move C95 next to U28 pin 4 at (90.20,122.61) — alongside R73 at (89.63,123.78) — since 3.7 mm is fine for a bypass cap but too far for a reset RC.
+
+The original analysis, for the record — as drawn:
 ```
 +3V3 (#PWR0235 @154.94,25.4)
   |
@@ -49,10 +51,8 @@ Netlist confirms: `+3V3` contains {C95.1, R73.2, ...}; `Net-(U28-CHIP_PU)` = {R7
 
 Espressif's ESP32-S3 schematic checklist requires ≥50 µs between the rails being stable and CHIP_PU going high. That delay comes from the 10 kΩ charging a capacitor **on the pin**. With C95 on the supply side, the only capacitance on the CHIP_PU node is pin 4's input capacitance plus trace (~5 pF): **τ ≈ 10 kΩ × 5 pF ≈ 50 ns**, i.e. CHIP_PU rises in lockstep with +3V3 (and C95, by slowing the rail slightly, if anything tightens that lockstep). Moved to the pin: **τ = 10 kΩ × 1 µF = 10 ms**, comfortably past the 50 µs floor.
 
-Every cold boot and every brownout recovery is currently out of spec. The rocket-computer review raised the same issue (H8) as a missing capacitor; here the capacitor exists and is simply on the wrong node.
+As drawn, every cold boot and every brownout recovery was out of spec. The rocket-computer review raised the same issue (H8) as a missing capacitor; here the capacitor existed and was simply on the wrong node.
 
-**Fix (schematic, one wire):** move C95's top plate from the +3V3 junction to the R73↔U28.4 node. The 1 µF lost from +3V3 is negligible against the ~90 µF already there (C100/C105 1 µF, C102/C106 10 µF, C12/C15/C16 22 µF); alternatively add a second 0402 and leave C95 as bypass.
-**Fix (layout):** C95 is at (86.75,123.91) B.Cu, **3.7 mm** from pin 4 at (90.20,122.61) — acceptable for a bypass cap, too far for a reset RC. Move it adjacent to pin 4, alongside R73 at (89.63,123.78).
 **While you are there:** there is no reset button and no CHIP_PU test point. The only way to reset this board is to unplug it. Add at least a pad.
 
 ### 2. FB1 — RESOLVED: the intended part is Würth **782853200**, and it checks out
@@ -74,13 +74,42 @@ The land pattern already matches: Würth's recommended pad is 1.0 × 1.2 mm with
 **Remaining action:** none electrically — just get `782853200` into the BOM (see finding 3), because nothing in the schematic, BOM or footprint records it today.
 **Note for bench:** TI's own examples cluster at 8–10 Ω / 12.7–15.9 nH, so this runs ~2× their inductance — worth ~3 dB more ripple attenuation at 2.2 MHz at the cost of phase margin. In spec, but it makes the first-article loop-response measurement (work order step 6) worth doing rather than skipping.
 
-### 3. BOM has no MPN field, and several parts are value-only where the value is not sufficient
-No component carries an MPN column; a handful of SnapEDA-sourced parts (J2, L8, S3, U3) have inconsistent `MP`/`MF`/`MANUFACTURER`/`DigiKey_Part_Number` fields, so no single export produces a purchasable BOM. **No passive has a voltage rating, dielectric or tolerance.** Where that actually bites:
-- **C11/C13 (47 µF 0805) are COUT**, which TI specifies as **40 µF min / 47 nom / 80 µF max effective**. An 0805 47 µF is almost certainly 6.3 V X5R, which loses 50–65 % at 3.3 V DC bias — two of them can land at ~35–45 µF, i.e. straddling the minimum. Pin the part and check the derated value.
-- **C8/C9 (22 µF) sit on VIN at up to 8.4 V.** A 10 V part is not acceptable here; 25 V is the safe call.
+### 3. BOM had no MPN field — **capacitors DONE**, remaining parts still open
+No component carried an MPN field; a handful of SnapEDA-sourced parts (J2, L8, S3, U3) have inconsistent `MP`/`MF`/`MANUFACTURER`/`DigiKey_Part_Number` fields, so no single export produced a purchasable BOM, and **no passive had a voltage rating, dielectric or tolerance.**
+
+**Done 2026-07-30 (capacitors).** All 27 capacitors now carry `MPN`, `Mfr` and `MinVRating` fields in the schematic, sourced from `Circuit Board BOMs/TinkerRocket_CrossBoard_BOM.xlsx` (sheet "Cross-Board BOM"). Field names mirror the spreadsheet columns so the two stay diff-checkable; `MinVRating` is the *design requirement*, not the part's rating (e.g. the 470 nF requirement is 6.3 V while `CL05A474KP5NNNC` is a 10 V part). Verified: nets unchanged, ERC error count unchanged, BOM export emits all three fields on every capacitor row.
+
+| Value | MPN | Mfr | MinVRating | Refs |
+|---|---|---|---|---|
+| 2.2 nF 0402 | CC0402KRX7R9BB222 | Yageo | 16 V | C7 |
+| 22 uF 0805 | CL21A226MOQNNNE | Samsung | 16 V | C8, C9, C11–C16 |
+| 470 nF 0402 | CL05A474KP5NNNC | Samsung | 6.3 V | C10 |
+| 100 nF 0402 | CL05B104KO5NNNC | Samsung | 16 V | C17, C99, C101, C103, C104 |
+| 22 pF 0402 | CL05C220JB5NNNC | Samsung | 6.3 V | C89, C91 |
+| 18 pF 0402 | CL05C180JB5NNNC | Samsung | 6.3 V | C90, C92 |
+| 1 uF 0402 | CL05A105KO5NNNC | Samsung | 16 V | C95, C96, C100, C105 |
+| 10 uF 0402 | CL05A106MQ5NUNC | Samsung | 6.3 V | C97, C102, C106 |
+| 10 nF 0402 | CL05B103KB5NNNC | Samsung | 6.3 V | C98 |
+
+**COUT changed in the same pass — see finding 3a.**
+
+**Still open (non-capacitor):**
 - **D4 "Blue" / D5 "Red" / D6 "LED"** — no part, no Vf (see finding 6).
 - **Y5 "SC-32S-32.768kHz-12.5pF"** — Espressif requires **ESR ≤ 70 kΩ**, which is exactly the typical max for this size class. Pin the grade.
-- U22's `Datasheet` field still reads `W25Q64JVXGIQ TR`, inherited from the symbol it was derived from (the Description property says so). Harmless today because nothing orders from it — but it is a live trap the moment an MPN column is added. Clear it.
+- FB1 = 782853200 (finding 2) — the Value field carries it; it should also get `MPN`/`Mfr` for consistency with the caps.
+- U22's `Datasheet` field still reads `W25Q64JVXGIQ TR`, inherited from the symbol it was derived from (the Description property says so). Harmless today because nothing orders from it — but it is a live trap now that MPN fields exist. Clear it.
+- The resistors, inductors, connectors, crystals and ICs still have no `MPN`/`Mfr`; the spreadsheet has rows for them, so the same one-pass annotation would close it.
+
+### 3a. COUT: 2 × 47 µF 6.3 V → 3 × 22 µF 16 V — **DONE (schematic), PCB pending**
+C11/C13 were `CL21A476MQYNNNE` (47 µF, **6.3 V** X5R, 0805) on `Net-(U3-VO)`, which is the TPS62913's COUT — specified as **40 µF min / 47 nom / 80 µF max effective**. A 6.3 V 0805 X5R sitting at 3.3 V is at 52 % of rated voltage, where that class typically loses 55–70 %: two of them land ≈28–42 µF, straddling and probably under the floor.
+
+Changed to **three × `CL21A226MOQNNNE`** (22 µF, **16 V**, 0805) — already a stocked line on this board, so no new BOM row. At 3.3 V it is only at 21 % of rated, so it derates far less: ≈42–53 µF for three, inside the window. This also matches TI's own Table 8-5 recommendation ("3 × 22 µF, 10 V, X7S, 0805").
+
+Applied: C11 and C13 revalued, **C14 added** at schematic (179.07, 150.495) with `#PWR096` GND and a junction on the VO wire at (179.07, 146.685). Netlist verified: `Net-(U3-VO)` = {C11.1, C13.1, C14.1, FB1.1, L8.2, R4.2, U3.3}.
+
+**PCB pending:** run *Update PCB from Schematic*, then place C14. Free F.Cu slot confirmed at **(93.40, 128.8)** — 2.6 × 1.8 mm clear, directly under L8's VO pad and already inside the `Net-(U3-VO)` pour.
+
+**Caveat:** the derating percentages are the usual range for the class, not measured — confirm both parts against Samsung's DC-bias curves. If the 22 µF derates worse than expected, a fourth (≈56–70 µF) still fits inside the 80 µF ceiling.
 
 ### 4. VDD_SPI: no 0.1 µF at the pin, a 10 µF where Espressif says not to, both 6 mm away — and the boot flash shares the internal 14 Ω
 `OUT_VDD_SPI` = {U28.29, U22.8 (VCC), C96 1 µF, C97 10 µF}. C96/C97 are at (92.15, 113.6–114.6) — **1.6 mm from the flash but 6.1–6.3 mm from U28 pin 29** at (86.20,115.76). The rail reaches the chip over a 0.2 mm, 6.6 mm-long trace cut through the In2 plane.
@@ -173,9 +202,9 @@ Also: 0.09 mm/0.09 mm is an advanced spec that pushes the price up; only L_MOSI 
 
 ## Suggested order of work
 
-1. **Schematic edits:** move C95 to the CHIP_PU node; move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
-2. **BOM:** add a real MPN column; FB1 = **782853200** (verified, finding 2), then C11/C13 with a DC-bias-derated check against 40–80 µF, C8/C9 at ≥25 V, the three LEDs, and Y5's ESR grade.
-3. **Layout:** relocate Y6 + its caps + L10 next to pins 53/54; pull C8/C9 in toward VIN; via at PSNS; three 1 mm fiducials per side (delete FID1 from under J2); vias out of U28.29 and U3.4; refdes silkscreen; tie H1–H4 to GND; fix the SMA board-edge offset.
+1. **Schematic edits:** ~~move C95 to the CHIP_PU node~~ (done); ~~COUT 2x47 uF -> 3x22 uF~~ (done, finding 3a); move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
+2. **BOM:** ~~capacitors~~ (done, finding 3 — MPN/Mfr/MinVRating on all 27); still to do: FB1 MPN/Mfr fields, the three LEDs, Y5's ESR grade, and the same annotation pass over resistors/inductors/connectors/crystals/ICs.
+3. **Layout:** *Update PCB from Schematic* first (C95 re-route + place C14 at ~(93.40,128.8)); relocate Y6 + its caps + L10 next to pins 53/54; pull C8/C9 in toward VIN; via at PSNS; three 1 mm fiducials per side (delete FID1 from under J2); vias out of U28.29 and U3.4; refdes silkscreen; tie H1–H4 to GND; fix the SMA board-edge offset.
 4. **Fab package:** declare the F/In1 prepreg (or full controlled impedance) on the fab notes; raise the netclass minimum off 0.09 mm if you want a cheaper tier; re-enable the courtyard DRC checks and re-run; clear the silk violations.
 5. **Firmware:** `HOST_UART_TX = 6`, `HOST_UART_RX = 5`; flash size to 16 MB; document "never init RF" and "never enable PSRAM unless VDD_SPI is re-fed".
 6. **Bench, once boards exist:** confirm the 40 MHz frequency error and trim C90/C92; scope VIN on hot-plug against the 18 V limit; measure the buck's loop response with the real ferrite bead; verify the SMA's return loss at 915 MHz.

--- a/hardware/lora-daughterboard/prefab-review-2026-07-30.md
+++ b/hardware/lora-daughterboard/prefab-review-2026-07-30.md
@@ -9,7 +9,7 @@
 Top: E220-900MM22S LoRa module, edge SMA, TPS62913 buck + L8 + ferrite bead, ORing Schottkys, CM choke.
 Bottom: ESP32-S3RH2 (QFN-56), W25Q128 boot flash, USB-C, JST-SH host link, both crystals.
 
-**Baseline health: DRC 23 violations (1 error), 0 unconnected, 0 schematic-parity issues.** Nothing here is a "this board is dead" defect — the RF path, the buck topology and the module wiring are all correct. The list below is a must-fix set plus a decide-consciously set.
+**Baseline health: DRC 23 violations (1 error), 0 unconnected, 0 schematic-parity issues.** Nothing here is a "this board is dead" defect — the RF path, the buck topology and the module wiring are all correct. The list below is a must-fix set plus a decide-consciously set. (Finding 2 was closed during review — the intended ferrite bead was confirmed and verified compliant.)
 
 ---
 
@@ -55,10 +55,24 @@ Every cold boot and every brownout recovery is currently out of spec. The rocket
 **Fix (layout):** C95 is at (86.75,123.91) B.Cu, **3.7 mm** from pin 4 at (90.20,122.61) — acceptable for a bypass cap, too far for a reset RC. Move it adjacent to pin 4, alongside R73 at (89.63,123.78).
 **While you are there:** there is no reset button and no CHIP_PU test point. The only way to reset this board is to unplug it. Add at least a pad.
 
-### 2. FB1 is specified as "WE-CBA_0805" — no impedance value, and the bead is inside the control loop
-The FB divider senses **after** FB1, so the bead is part of the compensated plant. TI is explicit: choose a bead with **8 Ω to 20 Ω at 100 MHz**, **DC resistance below 10 mΩ**, and a current rating well above the load; internal compensation "has been designed to be stable with up to **50 nH**" (5–10 nH is what you actually want). Their examples are BLE18PS080SN1 (8.5 Ω → 13.5 nH → 4 mΩ), 7427922808 (8 Ω → 12.7 nH → 5 mΩ).
-The Würth **WE-CBA** family spans roughly 10 Ω to >2 kΩ. A default 600 Ω-class 0805 is ≈**950 nH** — nearly 20× the stability limit — with several hundred mΩ of DCR. Nothing in the schematic, BOM or footprint (`WE-CBA_0805_W4.0`) pins which one.
-**Fix:** put a real MPN on FB1 (8–20 Ω @100 MHz, <10 mΩ, ≥1 A). This is the single highest-risk BOM gap on the board.
+### 2. FB1 — RESOLVED: the intended part is Würth **782853200**, and it checks out
+*(Raised in review as "value-only, could be anything"; the designer confirmed the intended order code. Verified against the datasheet and TI's requirements — no change needed beyond recording it.)*
+
+The FB divider senses **after** FB1, so the bead is part of the compensated plant. TI: **8 Ω to 20 Ω at 100 MHz**, **DCR below 10 mΩ**, current rating well above the load, and internal compensation "designed to be stable with up to **50 nH**".
+
+| TI requirement (§8.2.2.2.4, Table 8-6) | 782853200 | |
+|---|---|---|
+| Impedance 8–20 Ω @ 100 MHz | 20 Ω ±25 % | ✓ top of window |
+| DC resistance below 10 mΩ | 0.008 Ω max | ✓ |
+| Current rating >> load | 5000 mA vs ~180 mA (28×) | ✓ |
+| Inductance ≤ 50 nH | 31.8 nH nom, **39.8 nH at +25 %** | ✓ worst-case unit inside |
+
+The tolerance case is the one that matters and it passes. It is also the only compliant choice at this size: **782853200 is the lowest-impedance 0805 High Current member Würth makes**; the next step up (782853270, 27 Ω) is 43 nH nominal / 54 nH at +25 %, which breaks the 50 nH limit.
+
+The land pattern already matches: Würth's recommended pad is 1.0 × 1.2 mm with total span **W = 4.0 for the High Current type**, and the footprint is literally named `WE-CBA_0805_W4.0` (pads 1.4 × 1.0 at ±1.3 → span 4.0, width 1.0 — 0.2 mm extra toe, otherwise identical). Fab outline 2.0 × 1.2 mm matches the body.
+
+**Remaining action:** none electrically — just get `782853200` into the BOM (see finding 3), because nothing in the schematic, BOM or footprint records it today.
+**Note for bench:** TI's own examples cluster at 8–10 Ω / 12.7–15.9 nH, so this runs ~2× their inductance — worth ~3 dB more ripple attenuation at 2.2 MHz at the cost of phase margin. In spec, but it makes the first-article loop-response measurement (work order step 6) worth doing rather than skipping.
 
 ### 3. BOM has no MPN field, and several parts are value-only where the value is not sufficient
 No component carries an MPN column; a handful of SnapEDA-sourced parts (J2, L8, S3, U3) have inconsistent `MP`/`MF`/`MANUFACTURER`/`DigiKey_Part_Number` fields, so no single export produces a purchasable BOM. **No passive has a voltage rating, dielectric or tolerance.** Where that actually bites:
@@ -160,7 +174,7 @@ Also: 0.09 mm/0.09 mm is an advanced spec that pushes the price up; only L_MOSI 
 ## Suggested order of work
 
 1. **Schematic edits:** move C95 to the CHIP_PU node; move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
-2. **BOM:** add a real MPN column; pin FB1 first (8–20 Ω @100 MHz / <10 mΩ), then C11/C13 with a DC-bias-derated check against 40–80 µF, C8/C9 at ≥25 V, the three LEDs, and Y5's ESR grade.
+2. **BOM:** add a real MPN column; FB1 = **782853200** (verified, finding 2), then C11/C13 with a DC-bias-derated check against 40–80 µF, C8/C9 at ≥25 V, the three LEDs, and Y5's ESR grade.
 3. **Layout:** relocate Y6 + its caps + L10 next to pins 53/54; pull C8/C9 in toward VIN; via at PSNS; three 1 mm fiducials per side (delete FID1 from under J2); vias out of U28.29 and U3.4; refdes silkscreen; tie H1–H4 to GND; fix the SMA board-edge offset.
 4. **Fab package:** declare the F/In1 prepreg (or full controlled impedance) on the fab notes; raise the netclass minimum off 0.09 mm if you want a cheaper tier; re-enable the courtyard DRC checks and re-run; clear the silk violations.
 5. **Firmware:** `HOST_UART_TX = 6`, `HOST_UART_RX = 5`; flash size to 16 MB; document "never init RF" and "never enable PSRAM unless VDD_SPI is re-fed".

--- a/hardware/lora-daughterboard/prefab-review-2026-07-30.md
+++ b/hardware/lora-daughterboard/prefab-review-2026-07-30.md
@@ -1,0 +1,152 @@
+# TinkerRocket LoRa daughterboard ("LoRa V3") — Pre-Manufacturing Review
+
+**Date:** 2026-07-30
+**Source:** `TinkerRocket-Hardware/hardware/lora-daughterboard/` @ `4eebebe` (branch `hw/657-p4-v3x-provisions`, tree clean)
+**Scope:** every component + its supporting parts, system architecture, PCB layout beyond DRC (datasheet compliance, best practice), and "anything dumb" — the lora-missing-ground class.
+**Method:** fresh `kicad-cli` netlist / ERC / DRC / BOM / gerber / render export from a scratch copy of the live files; s-expression parsing of the `.kicad_pcb` for geometry; gerber-level verification of mask/paste/copper; datasheets pulled for TPS62913, E220-900MM22S, ESP32-S3 HDG, ECS crystal, CUS10S30; cross-checks against `rocket-computer`, `base-station` and `gnss-*` netlists and against `tinkerrocket-idf/projects/radio_board`.
+
+**Board:** 22.0 × 27.5 mm, 6-layer (F / In1 GND / In2 +3V3 / In3 GND+routing / In4 GND / B), 1.6 mm.
+Top: E220-900MM22S LoRa module, edge SMA, TPS62913 buck + L8 + ferrite bead, ORing Schottkys, CM choke.
+Bottom: ESP32-S3RH2 (QFN-56), W25Q128 boot flash, USB-C, JST-SH host link, both crystals.
+
+**Baseline health: DRC 23 violations (1 error), 0 unconnected, 0 schematic-parity issues.** Nothing here is a "this board is dead" defect — the RF path, the buck topology and the module wiring are all correct. The list below is a must-fix set plus a decide-consciously set.
+
+---
+
+## What is verified correct (worth stating — a lot of this is done well)
+
+- **E220-900MM22S wiring is pin-for-pin correct against the datasheet**, all 20 pins: VCC/GND/NRST/ANT/GND/TXEN/RXEN/BUSY/MISO/MOSI/NSS/SCK/GND/DIO1, NC on 4/5/8/17, DIO3 floating. Critically, **DIO2 → TXEN and RXEN → MCU GPIO** is exactly the split EBYTE prescribes ("DIO2 can be connected with TXEN, not with the IO port of MCU"). The `radio_board` firmware already models it (`LORA_RXEN_PIN = 35 // TX side is DIO2-driven`).
+- **RF path is genuinely well executed.** ANT → SMA is 3.53 mm of 0.2 mm F.Cu over a solid In1 GND plane at 0.1 mm prepreg, with a 0.1275 mm coplanar gap → ≈46–48 Ω GCPW (calculated); GND stitching vias flank both sides at ~0.75 mm pitch, 1.3–1.4 mm off the centreline; In1 is unbroken under the whole corridor; the SMA is grounded on both F and B. Module GND pads 2/7/16 each have vias in-pad.
+- **TPS62913 circuit is TI's front-page typical application**: R6 15.4 k / R7 4.87 k → 0.8 × 4.162 = **3.33 V**, C10 470 nF on NR/SS, C7 2.2 nF on VIN, L8 2.2 µH — the exact reference values. VO (pin 3) senses directly after L8 and the FB divider senses after the bead: that is the intended remote-sense-through-the-second-stage-filter topology, not a mistake.
+- **S-CONF = 7.5 kΩ → 2.2 MHz + random spread spectrum, discharge off.** A deliberate and good choice for a board with a receiver on it.
+- **EN/SYNC tied to VIN is legal** — TPS62913 abs max on VIN/EN/SYNC/PG/S-CONF is 18 V; the 2S pack tops out at 8.4 V.
+- **FB1 is 9.4 mm from U3 and 6.55 mm from L8** — well outside TI's ferrite-bead keepout region (Fig. 10-2).
+- **L10 = 24 nH in series with XTAL_P is prescribed**, not a mystery part: ESP32-S3 HDG says "add a series component on the XTAL_P clock trace… an inductor of 24 nH to reduce the impact of high-frequency crystal harmonics."
+- **R75/R76 = 22 Ω on USB D+/D− is per Espressif** ("reserve series resistors (initial value can be 22/33 Ω)"), and they sit ~2 mm from the S3 pins with the TVS at the connector.
+- **USB-C**: 5.11 k Rd on both CC (correct UFP), SP0503BAHTG TVS on VBUS/D+/D−, ORing Schottkys CUS10S30 (30 V/1 A, Vf 230 mV @100 mA) — CR3 also gives reverse-polarity protection on the battery input.
+- **Cross-board link is correct**: J6.1/2/3/4 = GND / +BATT / host-RX / host-TX matches rocket-computer J5 (`Net-(J5-Pin_1)` via Q10, `Net-(J5-Pin_2)` via FL2→VBATT, `LoRa_RX`→U15 GPIO10, `LoRa_TX`→U15 GPIO11) and base-station J6 (GND, V_LORA≈5.0 V from the TPS61023, GPIO36/GPIO35). Both host supplies land inside the TPS62913's 3–17 V VIN window (≈4.5 V from the BS after the Schottky + choke; 6.0–8.0 V from the rocket).
+- **Firmware pin map matches the schematic 1:1** on all eight LoRa signals (SCK 17, MISO 33, MOSI 21, CS 18, DIO1 2, RST 38, BUSY 34, RXEN 35) and both LEDs (GPIO7→D5 red, GPIO8→D4 blue).
+- **GPIO45 NC → internal pulldown → 3.3 V VDD_SPI mode** ✓; GPIO46 pulled down ✓; GPIO0 on the tact switch with the S3's internal pull-up ✓. No strapping pin is mis-set.
+- **The odd `(layers "B.Cu" "B.Paste")` / `(layers "B.Cu" "B.Mask")` pad layer lists in the custom footprints are cosmetic only.** Verified at gerber level: every SMD pad gets a mask opening, and the S3 thermal pad gets a proper 3×3 × 1.0 mm windowpane paste pattern (~54 % coverage). Only the two fiducials lack paste, which is correct. *(This does make file-level audits misleading and would bite on export to another tool — worth tidying, but it is not a defect.)*
+- No different-net via inside any pad; D+/D− do not cross the In2 plane slots; all footprints have courtyards.
+
+---
+
+## Must fix before fab
+
+### 1. CHIP_PU has the 10 kΩ pull-up but no capacitor — violates the 50 µs t_STBL requirement
+`Net-(U28-CHIP_PU)` = {U28.4, R73.1} only; R73.2 → +3V3. No cap anywhere on the net.
+Espressif's ESP32-S3 schematic checklist requires ≥50 µs between the rails being stable and CHIP_PU going high, and prescribes **R = 10 kΩ and C = 1 µF**. With only a pull-up to the same rail, CHIP_PU tracks +3V3 with ~zero delay — every cold boot and every brownout recovery is out of spec. This is the same defect the rocket-computer review raised (H8); it is repeated verbatim here.
+**Fix:** one 1 µF 0402 from U28 pin 4 to GND, placed at the pin (R73 is at (89.63,123.78), pin 4 at (90.20,122.61) — there is room).
+**While you are there:** there is no reset button and no CHIP_PU test point. The only way to reset this board is to unplug it. Add at least a pad.
+
+### 2. FB1 is specified as "WE-CBA_0805" — no impedance value, and the bead is inside the control loop
+The FB divider senses **after** FB1, so the bead is part of the compensated plant. TI is explicit: choose a bead with **8 Ω to 20 Ω at 100 MHz**, **DC resistance below 10 mΩ**, and a current rating well above the load; internal compensation "has been designed to be stable with up to **50 nH**" (5–10 nH is what you actually want). Their examples are BLE18PS080SN1 (8.5 Ω → 13.5 nH → 4 mΩ), 7427922808 (8 Ω → 12.7 nH → 5 mΩ).
+The Würth **WE-CBA** family spans roughly 10 Ω to >2 kΩ. A default 600 Ω-class 0805 is ≈**950 nH** — nearly 20× the stability limit — with several hundred mΩ of DCR. Nothing in the schematic, BOM or footprint (`WE-CBA_0805_W4.0`) pins which one.
+**Fix:** put a real MPN on FB1 (8–20 Ω @100 MHz, <10 mΩ, ≥1 A). This is the single highest-risk BOM gap on the board.
+
+### 3. BOM has no MPN field, and several parts are value-only where the value is not sufficient
+No component carries an MPN column; a handful of SnapEDA-sourced parts (J2, L8, S3, U3) have inconsistent `MP`/`MF`/`MANUFACTURER`/`DigiKey_Part_Number` fields, so no single export produces a purchasable BOM. **No passive has a voltage rating, dielectric or tolerance.** Where that actually bites:
+- **C11/C13 (47 µF 0805) are COUT**, which TI specifies as **40 µF min / 47 nom / 80 µF max effective**. An 0805 47 µF is almost certainly 6.3 V X5R, which loses 50–65 % at 3.3 V DC bias — two of them can land at ~35–45 µF, i.e. straddling the minimum. Pin the part and check the derated value.
+- **C8/C9 (22 µF) sit on VIN at up to 8.4 V.** A 10 V part is not acceptable here; 25 V is the safe call.
+- **D4 "Blue" / D5 "Red" / D6 "LED"** — no part, no Vf (see finding 6).
+- **Y5 "SC-32S-32.768kHz-12.5pF"** — Espressif requires **ESR ≤ 70 kΩ**, which is exactly the typical max for this size class. Pin the grade.
+- U22's `Datasheet` field still reads `W25Q64JVXGIQ TR`, inherited from the symbol it was derived from (the Description property says so). Harmless today because nothing orders from it — but it is a live trap the moment an MPN column is added. Clear it.
+
+### 4. VDD_SPI: no 0.1 µF at the pin, a 10 µF where Espressif says not to, both 6 mm away — and the boot flash shares the internal 14 Ω
+`OUT_VDD_SPI` = {U28.29, U22.8 (VCC), C96 1 µF, C97 10 µF}. C96/C97 are at (92.15, 113.6–114.6) — **1.6 mm from the flash but 6.1–6.3 mm from U28 pin 29** at (86.20,115.76). The rail reaches the chip over a 0.2 mm, 6.6 mm-long trace cut through the In2 plane.
+Espressif: "add extra **0.1 µF and 1 µF** decoupling capacitors **close to VDD_SPI**. Please do not add excessively large capacitors." There is no 0.1 µF at all, the 1 µF is 6 mm away, and the 10 µF is the thing they warn against.
+Separately, this is the same **R_SPI budget** question as the rocket computer (H7): in 3.3 V mode VDD_SPI is fed internally from VDD3P3_RTC through a **14 Ω** resistor, and on the **S3RH2 the in-package 2 MB quad PSRAM hangs on that same node** (min 2.7 V), as does the external W25Q128 (min 2.7 V, ≤20 mA read, ≤25 mA program/erase). Flash alone: 3.3 − 0.025×14 = 2.95 V — fine. Flash + PSRAM active (~50 mA): 3.3 − 0.70 = **2.60 V, below both minimums**, on the chip's *boot* flash.
+**Fix:** move U22 pin 8 off `OUT_VDD_SPI` to +3V3 (this board's +3V3 is a low-noise TPS62913 output, so it is clean), leave VDD_SPI with 0.1 µF + 1 µF **at pin 29**, and drop C97 to 1 µF.
+**If instead you keep the shared node:** it only works while firmware never enables PSRAM. `radio_board/sdkconfig.defaults` does not enable SPIRAM today — write that constraint down, because turning it on later silently breaks the rail.
+
+### 5. The 40 MHz crystal is 11 mm from the S3 and sits in the buck section
+Y6 is at (97.98, 126.19) with 10.9 mm and 11.5 mm of 0.1 mm B.Cu trace to XTAL_P/XTAL_N (pins 53/54 at x≈92.2). Y5 (32.768 kHz) is 2.24 mm away and is fine — the 40 MHz one is the outlier. It also lands right beside the converter cluster (U3 at 96.68,124.44; L8 at 93.47,125.92 — opposite side, so the four intervening planes do most of the shielding, but the placement is still backwards).
+The trace pair adds ~1 pF per leg of stray on the oscillator's high-impedance node and degrades startup margin on a 40 Ω-ESR part. There is no reason for it: the area immediately outboard of pins 53/54 is free.
+**Fix:** move Y6 + C90/C92 + L10 adjacent to U28 pins 53/54.
+
+### 6. Load caps on Y6 are ~2 pF too high for a 10 pF crystal
+ECS-400-10-37B2-CKY-TR is **CL = 10 pF**, 40 Ω ESR, ±10 ppm. The board fits **18 pF** on each leg: C_L = 18·18/36 + C_stray = 9 + (~1 pF trace + ~0.5 pF pad + ~2 pF pin) ≈ **12.5 pF**, i.e. roughly **−30 ppm** of pulling — outside the crystal's own ±10 ppm and outside Espressif's "tune to within ±10 ppm" instruction.
+Harmless for USB (±2500 ppm) and irrelevant to the LoRa link (the E220 has its own 32 MHz crystal), so it is not a boot risk — but fix it while the crystal is moving anyway.
+**Fix:** start at **12–15 pF** (once the traces are short, 15 pF; with the current 11 mm routing, 12 pF), then trim on the first article.
+
+### 7. Host-UART polarity: the firmware placeholder is the reverse of the hardware
+Cable pin 3 = host RX ↔ daughterboard **GPIO6**; cable pin 4 = host TX ↔ daughterboard **GPIO5**. Both hosts confirm the convention (`out_computer/board_v8.h`: `LORA_UART_TX_PIN = 11 // LoRa_TX (label-perspective)` → J5.4; `base_station/board_v3.h`: TX = 35 → J6.4).
+`radio_board/main/config.h` currently has:
+```
+static constexpr int HOST_UART_TX = 5;   // TODO: TBD from V8 schematic
+static constexpr int HOST_UART_RX = 6;   // TODO: TBD from V8 schematic
+```
+That is backwards. As written the modem drives GPIO5 onto cable pin 4 — **the same wire the host is driving** (two push-pull CMOS outputs in contention) — and listens on GPIO6, which nothing drives. The TODO comments say the values were never resolved; now they can be: **TX = 6, RX = 5**.
+Note the root cause is a naming trap worth fixing in the schematic too: on the daughterboard the net named `LoRa_TX` is the pin the daughterboard **receives** on (the labels are host-perspective on all three boards). Rename to `HOST_TX`/`HOST_RX`, or annotate the sheet, or the next person will re-derive it wrong.
+
+---
+
+## Should fix / decide consciously
+
+### 8. VDD3P3_RTC (pin 20) has no local 0.1 µF
+Espressif asks for a 0.1 µF close to each digital supply pin. Pin 46 (VDD3P3_CPU) has C101 at 1.34 mm ✓; **pin 20's nearest cap on +3V3 is 4.27 mm away** (C99), because the space to the left of U28 is taken by Y5 and the USB resistors. A 0402 fits around (84.3, 118.5).
+
+### 9. LED series resistors are 10 kΩ — the blue LED may not light at all
+R59/R60/R3 = 10 kΩ from a 3.3 V rail. Red (Vf ≈ 1.9 V) → **140 µA**; blue (Vf ≈ 2.7–3.4 V) → **0–70 µA**, and a blue part with Vf > 3.3 V simply does not conduct. Typical indicator design is 1–2 mA.
+If the intent was low power, 2.2–4.7 kΩ (0.3–0.7 mA) is the sensible compromise; if these are meant to be readable on a launch rail in daylight, 1 kΩ. Either way pin actual LED MPNs so Vf is known.
+
+### 10. Two fiducials, one per side, 0.5 mm — and FID1 is inside the USB connector's courtyard
+FID1 (B.Cu, 102.08,115.73) sits fully inside J2's courtyard (x 95.76–104.19, y 111.41–124.31) — that is the board's **only DRC error**. FID2 is at the same X/Y on the front. A 0.5 mm copper dot is below the 1 mm many assemblers require, and one fiducial per side gives no rotational reference for a 0.4 mm-pitch QFN-56 plus a 1.27 mm-pitch shielded module.
+**Fix:** three fiducials per populated side, 1.0 mm copper / 2.0 mm mask, asymmetric, ≥5 mm from the edge, clear of all courtyards. Same finding as rocket-computer H12 — the same mistake has been made twice.
+
+### 11. There are no reference designators on the silkscreen
+All 66 refdes properties are `(hide yes)`. The silkscreen gerbers contain only outlines, pin-1 marks and four board texts (`LoRa V3`, `PWR`, `T`, `R`). Nothing on this board can be identified during assembly inspection, bring-up or rework. On a 22 × 27 mm board you will not fit all of them — but at minimum the ICs, connectors, the LEDs, the crystals and the ferrite bead should be marked, and a pin-1 dot for U28 and U22.
+
+### 12. Hot-plug onto a live 2S pack, with no TVS and no bulk on VSYS
+Rocket-computer J5 pin 2 is unswitched VBATT (`Net-(J5-Pin_2)` = {FL2.2, J5.2}), so plugging the daughterboard in always hot-connects a live 6.4–8.4 V pack. On this board VBUS/+BATT go straight through a Schottky into **VSYS, which has no capacitor at all** — the first bulk is C8/C9 (44 µF nominal) *behind* the CM choke. Cable + choke leakage inductance ringing into that cap can approach 2 × V_pack ≈ 16.8 V against the TPS62913's **18 V** abs max; the DCR of the choke and diode probably damp it, but "probably" on a 3-cent part is the wrong trade.
+**Fix:** a TVS on VSYS (SMAJ12A / SMBJ13A class, standoff above 8.4 V, clamp well under 18 V), and consider a small bulk cap on VSYS ahead of the choke. This also covers the USB side, where 44 µF of ceramic behind a diode exceeds the USB inrush guidance.
+
+### 13. 921.6 kbaud host UART with no series termination and a ground return that only exists through the CM choke
+`HOST_UART_BAUD = 921'600` over an unshielded 1 mm-pitch JST-SH cable running next to a 22 dBm 915 MHz transmitter, with **no series resistors at either driver** and no ESD on LoRa_TX/LoRa_RX.
+More interesting: **`VSS` (J6.1) reaches board GND only through FL1's second winding** — the same house pattern as the GNSS daughterboards (verified: their J4.3/J4.4 → FL1 → VIN/GND is identical). That is a deliberate common-mode filter on the power pair, and it is fine for DC. But the UART's return current has no counterpart in the other winding, so it sees the choke as common mode, and the signal pair itself is unfiltered while the power pair is. Worth a conscious decision rather than inheritance.
+**Suggest:** 33 Ω series source terminators at each driver (there is room on this board; the host side is a separate change), and confirm the DLW21SN670HQ2L's rated current and DCR against the real load — measured budget is **~90 mA from the rocket (7.4 V) and ~145 mA from the base station (4.6 V)**, against a nominal ~370–400 mA rating for this 0805 class. Comfortable, but it has never been written down.
+
+### 14. Power-good goes nowhere, and the base station cannot power-cycle the modem
+`Net-(U3-PG)` = {U3.5, R4.1} with R4 pulled up to `Net-(U3-VO)`. No GPIO sees it. Free telemetry left on the table — and PG is the one signal that would distinguish "modem hung" from "modem rail collapsed".
+Related: the rocket computer *can* power-cycle this board (J5 pin 1 is switched by Q10). The base station cannot — J6 pin 1 is hard GND, and V_LORA comes from a TPS61023 **boost** whose EN is tied to VCC; even if EN were driven, a boost passes VIN through its body diode, so the rail never actually falls. On the ground station the only recovery from a wedged modem is unplugging the base station.
+
+### 15. Buck layout details that miss the datasheet
+- **C9 is 2.76 mm and C8 is 4.77 mm from VIN** (C7's 2.2 nF is at 1.25 mm and does carry the fastest edges). TI: place the input capacitors "as close as possible" to VIN/PGND. At 2.2 MHz this is the loop that matters most.
+- **PSNS (pin 7) — "Connect directly to the system GND plane with a via."** The nearest via is **1.19 mm** away; the pin reaches ground through the F.Cu pour. Put a via at the pad.
+- The FB divider's high side taps +3V3 next to R6, i.e. near the converter rather than at the load, so the remote sense is nominal rather than real. With a full In2 plane the IR drop is small — noting it for completeness.
+
+### 16. SMA: the board edge is 0.38 mm short of where the footprint puts the connector face
+J8's fab outline draws the connector body to **y = 103.32** and the board-slot region from 103.32 → 104.97, where the pads begin. The actual Edge.Cuts top edge is **y = 103.70**. The board therefore does not bottom out in the connector by 0.38 mm; retention becomes solder-only, and the pin/tab overlap shifts. Pads are 3.5 mm long so there is solderable area either way.
+**Fix:** check against the RF Solutions CON-SMA-EDGE-S mechanical drawing and move the edge (or the footprint) to match. On a high-g vehicle with a coax pigtail hanging off it, a connector that is not butted is worth 10 minutes.
+
+### 17. 54 unplugged vias-in-pad, two of them in sub-0.25 mm lands
+Board settings are `tenting yes / plugging no / filling no`. Same-net via-in-pad appears in 54 SMD pads. Most are benign (0805 GND pads, the 3×3 EPAD array). Two are not:
+- **U28 pad 29 (VDD_SPI): a 0.3 mm-drill / 0.4 mm-pad via inside a 0.22 mm-wide QFN land** on a 0.4 mm-pitch part — the annulus is wider than the land.
+- **U3 pad 4 (PGND): a 0.3 mm-drill via inside a 1.0 × 0.2 mm land.**
+Both are solder-wicking and bridging hazards. Either move them out of the land or specify IPC-4761 Type VII (filled and capped) on the fab notes.
+
+### 18. Stackup declares no impedance control, and there is one netclass at 0.09 mm
+`dielectric_constraints: no`, `copper_finish: None`, and a single `Default` netclass with **track width 0.09 mm and clearance 0.09 mm**. For a 915 MHz board whose antenna feed depends on the F.Cu-to-In1 prepreg being 0.1 mm, the fab needs to be told (a) this is a controlled-impedance layer pair, or at minimum (b) that the F/In1 prepreg thickness is not theirs to substitute. Most 6-layer house stackups will not give you 0.1 mm there by default — and the calculated 46–48 Ω moves with it.
+Also: 0.09 mm/0.09 mm is an advanced spec that pushes the price up; only L_MOSI actually uses 0.09 mm (2.9 mm of it). Raising the class minimum to 0.1 mm and re-routing that one net would likely drop a fab tier.
+
+### 19. Smaller items
+- **`missing_courtyard` is set to `ignore`** in the DRC config (along with `pth_inside_courtyard`/`npth_inside_courtyard`). Every footprint here does have a courtyard, so nothing is hiding — but this is the exact setting that made the rocket-computer C12 collision invisible. Turn it back on.
+- **Silkscreen DRC:** 4 × clipped by board edge (U22 circle, three J2 segments), 2 × silk over copper (Y5 outline over C91's pads), 1 × silk overlap (Y5/C91). Cosmetic, but the Y5 outline over C91's pads can cause solder defects on a 0402.
+- **Mounting-hole pads (H1–H4) are floating copper** — 3.8 mm annular pads on both sides with no net, and the plated barrel joins them. Four unterminated 3.8 mm plates on a 915 MHz board, which a metal screw will bond to the surrounding GND pour anyway. Tie them to GND deliberately.
+- **No test points anywhere, and U0TXD/U0RXD (pins 49/50) are unconnected.** USB-C is the only console and the only programming path (`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y`). If the USB path is damaged the board is a brick. Six pads (3V3, GND, TXD0, RXD0, CHIP_PU, GPIO0) cost nothing.
+- **Flash size is stated three different ways:** the part is a **W25Q128** (16 MB), the stale `Datasheet` field says W25Q64 (8 MB), and `radio_board/sdkconfig.defaults` sets `CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y` with a comment about not knowing the final part. Settle it on 16 MB now — this is the same class as the OC 512 MB lesson (#492).
+- **ESP32-S3 LNA_IN (pin 1) is unconnected** with no matching network. Espressif explicitly permits this ("if RF function is not required, it is recommended not to initialize the RF stack in firmware. In this case, the RF pin can be left floating"), and the RF supply is only a 2 nH 0402 + 100 nF, so it is clearly intentional. Record it as a **firmware constraint**: this board must never init Wi-Fi/BT.
+- **In2 (+3V3 plane) is cut by three slots** — VSS (0.4 mm × 15 mm), +BATT (0.4 mm × 8.9 mm), OUT_VDD_SPI (0.2 mm × 6.6 mm). Only LoRa_RX/LoRa_TX on In3 cross them (at the J6 fan-out); at 921 kbaud with In4 GND 0.535 mm below as a continuous second reference, this is negligible. Noted so it is not re-discovered.
+- **ERC's 294 violations are almost entirely noise** — 172 off-grid endpoints, 46 lib-symbol mismatches, 15 missing-library warnings. The 7 `power_pin_not_driven` and 25 `pin_not_connected` errors are all explained (deliberate NCs plus flag-less power nets). Worth a cleanup pass so real ERC errors are visible next time, but nothing is hiding in there.
+
+---
+
+## Suggested order of work
+
+1. **Schematic edits:** CHIP_PU 1 µF; move U22 VCC to +3V3; VDD_SPI 0.1 µF + 1 µF (C97 10 µF → 1 µF); 0.1 µF at VDD3P3_RTC; PG → a spare GPIO; VSYS TVS; LED resistors; Y6 load caps 18 pF → 12–15 pF; series terminators on LoRa_TX/RX; rename `LoRa_TX`/`LoRa_RX` to host-perspective-explicit names.
+2. **BOM:** add a real MPN column; pin FB1 first (8–20 Ω @100 MHz / <10 mΩ), then C11/C13 with a DC-bias-derated check against 40–80 µF, C8/C9 at ≥25 V, the three LEDs, and Y5's ESR grade.
+3. **Layout:** relocate Y6 + its caps + L10 next to pins 53/54; pull C8/C9 in toward VIN; via at PSNS; three 1 mm fiducials per side (delete FID1 from under J2); vias out of U28.29 and U3.4; refdes silkscreen; tie H1–H4 to GND; fix the SMA board-edge offset.
+4. **Fab package:** declare the F/In1 prepreg (or full controlled impedance) on the fab notes; raise the netclass minimum off 0.09 mm if you want a cheaper tier; re-enable the courtyard DRC checks and re-run; clear the silk violations.
+5. **Firmware:** `HOST_UART_TX = 6`, `HOST_UART_RX = 5`; flash size to 16 MB; document "never init RF" and "never enable PSRAM unless VDD_SPI is re-fed".
+6. **Bench, once boards exist:** confirm the 40 MHz frequency error and trim C90/C92; scope VIN on hot-plug against the 18 V limit; measure the buck's loop response with the real ferrite bead; verify the SMA's return loss at 915 MHz.


### PR DESCRIPTION
Pre-manufacturing review of the LoRa daughterboard ("LoRa V3"), plus the two schematic changes that came out of it.

## Review report

`hardware/lora-daughterboard/prefab-review-2026-07-30.md` — same shape as the rocket-computer V9 report. Every component and its support parts, the power/host architecture, and a layout pass beyond DRC (datasheet compliance, RF, DFM).

Method: fresh `kicad-cli` netlist / ERC / DRC / BOM / gerber / render exports from a scratch copy, s-expression geometry parsing of the `.kicad_pcb`, gerber-level mask/paste/copper verification, datasheets for TPS62913 / E220-900MM22S / ESP32-S3 HDG / ECS-400-10-37B2 / CUS10S30 / Würth 782853200, and cross-checks against the rocket-computer, base-station and gnss-* netlists plus `tinkerrocket-idf/projects/radio_board`.

**Baseline health:** DRC 23 violations (1 error), 0 unconnected, 0 schematic-parity issues. No board-killers.

**Confirmed correct** (worth stating — much of this board is well done): the E220 wiring is pin-for-pin right across all 20 pins including the datasheet-prescribed DIO2→TXEN / RXEN→MCU split; the antenna feed is a properly executed GCPW (~46–48 Ω, stitched both sides, solid In1 reference); the TPS62913 circuit is TI's reference verbatim with a deliberate spread-spectrum S-CONF choice; the 24 nH on XTAL_P and 22 Ω USB resistors are both straight out of Espressif's checklist; the J6 link matches both hosts and the firmware pin map matches the schematic 1:1.

## Schematic changes in this PR

**Capacitor MPNs (finding 3).** All 27 capacitors now carry `MPN` / `Mfr` / `MinVRating`, sourced from `Circuit Board BOMs/TinkerRocket_CrossBoard_BOM.xlsx`. Field names mirror the spreadsheet columns so the two stay diff-checkable. `MinVRating` is the design *requirement*, not the part's own rating — the 470 nF requirement is 6.3 V while `CL05A474KP5NNNC` is a 10 V part.

**COUT resize (finding 3a).** C11/C13 were `CL21A476MQYNNNE` (47 µF, **6.3 V** X5R) on `Net-(U3-VO)`. At 3.3 V that is 52 % of rated voltage, where the class derates 55–70 % — roughly 28–42 µF against the TPS62913's **40 µF minimum effective COUT**. Changed to three × `CL21A226MOQNNNE` (22 µF, **16 V**), already a stocked line on this board, ~42–53 µF effective, matching TI Table 8-5 (3 × 22 µF 0805). C14 added.

Also swept in (uncommitted hand edits that were sitting in the same file): FB1 value → `782853200`, and the C95 → CHIP_PU rewire that fixes finding 1.

**Verification** (`kicad-cli`, identical project context before/after): nets unchanged apart from the intended C14 addition — `Net-(U3-VO)` = {C11.1, C13.1, C14.1, FB1.1, L8.2, R4.2, U3.3}; ERC 301 → 304 with the **error count unchanged at 32**. The three new warnings are `endpoint_off_grid` ×2 and `lib_symbol_mismatch` ×1, inherited from the C13 / #PWR013 blocks they were cloned from.

## Not in this PR — PCB work still to do by hand

- *Update PCB from Schematic*, then place **C14** — free 2.6 × 1.8 mm F.Cu slot confirmed at **(93.40, 128.8)**, under L8's VO pad and already inside the `Net-(U3-VO)` pour.
- Re-route **C95**, whose schematic side moved to CHIP_PU while its copper still ties to +3V3; move it beside U28 pin 4 at (90.20, 122.61).

## Remaining must-fix items from the report

VDD_SPI decoupling + the R_SPI budget (move U22 VCC to +3V3), the 40 MHz crystal placement (11 mm of trace), its load caps (18 pF → 12–15 pF for a 10 pF-CL part), and the reversed host-UART pin placeholders in `radio_board` firmware (`HOST_UART_TX` should be 6, `RX` 5 — as written the modem drives the same wire the host drives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
