### PR TITLE
hardware: CHIP_PU RC fix on BS + rocket-computer, and WIP JST VH battery input

### DIFF
--- a/hardware/base-station/esp32_p3.kicad_sch
+++ b/hardware/base-station/esp32_p3.kicad_sch
@@ -3738,10 +3738,10 @@
 		(uuid "908c56f1-8343-424b-83dc-56d79c94d7e3")
 	)
 	(junction
-		(at 113.03 29.845)
+		(at 111.125 45.085)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "ab07e999-814e-49ff-8d39-d0bbce60df6a")
+		(uuid "c0140c95-5bcf-46f2-823d-2d492f1ab008")
 	)
 	(junction
 		(at 198.755 48.895)
@@ -3772,6 +3772,16 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ff239d5a-eee6-473c-b44e-b16af7957edc")
+	)
+	(wire
+		(pts
+			(xy 120.65 45.085) (xy 120.65 53.975)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00593746-4a2d-4384-8823-4977b2b7fd04")
 	)
 	(wire
 		(pts
@@ -3882,6 +3892,16 @@
 			(type default)
 		)
 		(uuid "2b85675a-8707-433e-8296-70aed23f24a2")
+	)
+	(wire
+		(pts
+			(xy 111.125 42.545) (xy 111.125 45.085)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2cab3399-06d0-4a98-8372-4a0423718e46")
 	)
 	(wire
 		(pts
@@ -4065,6 +4085,16 @@
 	)
 	(wire
 		(pts
+			(xy 111.125 45.085) (xy 120.65 45.085)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "77cf6eae-7ef4-4ef4-8784-98a6deb9d421")
+	)
+	(wire
+		(pts
 			(xy 175.895 33.02) (xy 183.515 33.02)
 		)
 		(stroke
@@ -4105,13 +4135,13 @@
 	)
 	(wire
 		(pts
-			(xy 113.03 29.845) (xy 113.03 53.975)
+			(xy 111.125 32.385) (xy 111.125 34.925)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "95892bc5-53c9-4cf6-b0d3-4c8e89e70c5e")
+		(uuid "9b315020-8fa8-4e27-a3d0-594b3f7b40f1")
 	)
 	(wire
 		(pts
@@ -4132,16 +4162,6 @@
 			(type default)
 		)
 		(uuid "a38f8c12-0851-4372-b597-77705e84215e")
-	)
-	(wire
-		(pts
-			(xy 113.03 29.845) (xy 118.11 29.845)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a814f52f-8301-4bc8-b638-59d13bf82493")
 	)
 	(wire
 		(pts
@@ -4342,16 +4362,6 @@
 			(type default)
 		)
 		(uuid "e677bda9-b576-412b-b1ba-3794a9dc1dd1")
-	)
-	(wire
-		(pts
-			(xy 113.03 28.575) (xy 113.03 29.845)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e6dd3989-ec9f-4212-9f9f-51410defb2ac")
 	)
 	(wire
 		(pts
@@ -6921,7 +6931,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 118.11 37.465 0)
+		(at 111.125 52.705 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -6931,7 +6941,7 @@
 		(dnp no)
 		(uuid "50bdcc8e-fc2a-4d96-b3af-b0a2c7c4f7aa")
 		(property "Reference" "#PWR011"
-			(at 118.11 43.815 0)
+			(at 111.125 59.055 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6942,7 +6952,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 120.015 41.275 0)
+			(at 113.03 56.515 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -6953,7 +6963,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 118.11 37.465 0)
+			(at 111.125 52.705 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6964,7 +6974,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 118.11 37.465 0)
+			(at 111.125 52.705 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -6975,7 +6985,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 118.11 37.465 0)
+			(at 111.125 52.705 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8341,7 +8351,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 113.03 28.575 0)
+		(at 111.125 32.385 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -8352,7 +8362,7 @@
 		(fields_autoplaced yes)
 		(uuid "7c90a65b-14ae-4d1b-aaee-cccc963a81a1")
 		(property "Reference" "#PWR010"
-			(at 113.03 32.385 0)
+			(at 111.125 36.195 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8363,7 +8373,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 113.03 24.13 0)
+			(at 111.125 27.94 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -8373,7 +8383,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 113.03 28.575 0)
+			(at 111.125 32.385 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8384,7 +8394,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 113.03 28.575 0)
+			(at 111.125 32.385 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8395,7 +8405,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 113.03 28.575 0)
+			(at 111.125 32.385 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9364,7 +9374,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 118.11 33.655 0)
+		(at 111.125 48.895 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -9374,7 +9384,7 @@
 		(dnp no)
 		(uuid "b705ab6a-1e8e-4dfd-a7f8-0243823dc6cb")
 		(property "Reference" "C8"
-			(at 118.11 31.115 0)
+			(at 111.125 46.355 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -9385,7 +9395,7 @@
 			)
 		)
 		(property "Value" "1 uF"
-			(at 118.11 36.195 0)
+			(at 111.125 51.435 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -9396,7 +9406,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
-			(at 119.0752 37.465 0)
+			(at 112.0902 52.705 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9407,7 +9417,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 118.11 33.655 0)
+			(at 111.125 48.895 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9418,7 +9428,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 118.11 33.655 0)
+			(at 111.125 48.895 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -10982,7 +10992,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 116.84 53.975 270)
+		(at 111.125 38.735 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -10993,27 +11003,29 @@
 		(fields_autoplaced yes)
 		(uuid "ff95c4cf-a926-4bf7-a39a-4a5ce3ee65e8")
 		(property "Reference" "R1"
-			(at 116.84 47.625 90)
+			(at 113.665 37.4649 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Value" "10 k"
-			(at 116.84 50.165 90)
+			(at 113.665 40.0049 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
-			(at 116.586 54.991 90)
+			(at 112.141 38.989 90)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -11024,7 +11036,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 116.84 53.975 0)
+			(at 111.125 38.735 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -11035,7 +11047,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 116.84 53.975 0)
+			(at 111.125 38.735 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)

--- a/hardware/lora-daughterboard/lora-daughterboard.kicad_pro
+++ b/hardware/lora-daughterboard/lora-daughterboard.kicad_pro
@@ -704,7 +704,7 @@
         "uuid": "ae61c2c4-72e9-4776-93ae-2e716b9dc70f"
       }
     ],
-    "used_designators": "R8,CR1,CR3,L8",
+    "used_designators": "FB1,R8,CR1,CR3,L8",
     "variants": []
   },
   "sheets": [

--- a/hardware/rocket-computer/esp32s3_outputs.kicad_sch
+++ b/hardware/rocket-computer/esp32s3_outputs.kicad_sch
@@ -4913,6 +4913,12 @@
 		(uuid "0ce31ae4-a798-41d9-89fe-aa53e8502770")
 	)
 	(junction
+		(at 154.94 36.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "16764f1c-c82b-47e5-a38e-5e27447553d7")
+	)
+	(junction
 		(at 126.365 161.925)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4935,6 +4941,12 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "37f3857f-5928-44c0-bc0f-831eef74347b")
+	)
+	(junction
+		(at 144.145 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3bba0e52-afe8-415c-a8ac-2e5b0a21e853")
 	)
 	(junction
 		(at 130.175 31.75)
@@ -4983,12 +4995,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "6ac1e5b4-5c5d-4e80-b3f2-b4e01d301b23")
-	)
-	(junction
-		(at 144.145 31.75)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "6b5267a3-1385-4928-8acc-0bc9a504b7ef")
 	)
 	(junction
 		(at 212.725 40.64)
@@ -5043,12 +5049,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bd527658-3929-4b2d-8431-e9986ee15e69")
-	)
-	(junction
-		(at 154.305 24.13)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "bf71470f-4e25-4341-a947-2b77556ad64b")
 	)
 	(junction
 		(at 217.17 27.305)
@@ -5111,6 +5111,16 @@
 			(type default)
 		)
 		(uuid "039e499d-db41-4177-8999-74d37ab25eee")
+	)
+	(wire
+		(pts
+			(xy 154.94 36.83) (xy 154.94 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "099e85a8-a73b-4f57-9ba1-a11f28b7d9a1")
 	)
 	(wire
 		(pts
@@ -5254,6 +5264,26 @@
 	)
 	(wire
 		(pts
+			(xy 154.94 35.56) (xy 154.94 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "49aff6d6-6c02-4e40-942b-add171a11b60")
+	)
+	(wire
+		(pts
+			(xy 154.94 24.13) (xy 154.94 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "49ef5e33-4e34-4583-bc24-5524780d65e8")
+	)
+	(wire
+		(pts
 			(xy 248.92 40.64) (xy 254.635 40.64)
 		)
 		(stroke
@@ -5261,16 +5291,6 @@
 			(type default)
 		)
 		(uuid "4bff50ea-316c-494a-ac76-0cee03c1fa6f")
-	)
-	(wire
-		(pts
-			(xy 154.305 24.13) (xy 154.305 48.26)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4d9692c1-7996-4fef-919a-87e4d4cc8c72")
 	)
 	(wire
 		(pts
@@ -5534,23 +5554,13 @@
 	)
 	(wire
 		(pts
-			(xy 152.4 31.75) (xy 152.4 53.34)
+			(xy 151.13 31.75) (xy 151.13 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "8d23fd8a-c315-4d64-b341-0553e27c3f25")
-	)
-	(wire
-		(pts
-			(xy 154.305 24.13) (xy 159.385 24.13)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "9822e2eb-d79f-4b51-8f43-0f51a9710fa6")
 	)
 	(wire
 		(pts
@@ -5581,16 +5591,6 @@
 			(type default)
 		)
 		(uuid "a05bd228-2b78-4cca-86c1-627fee6c342b")
-	)
-	(wire
-		(pts
-			(xy 154.305 22.86) (xy 154.305 24.13)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a2b33f12-b50f-4cb1-a234-a89001ef2e44")
 	)
 	(wire
 		(pts
@@ -5644,6 +5644,16 @@
 	)
 	(wire
 		(pts
+			(xy 161.925 48.26) (xy 161.925 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad71a268-4fcc-4e73-b2ae-daa336e25665")
+	)
+	(wire
+		(pts
 			(xy 144.78 57.785) (xy 146.05 57.785)
 		)
 		(stroke
@@ -5661,6 +5671,16 @@
 			(type default)
 		)
 		(uuid "aeec78bb-9baf-4dfd-888b-443efea57d57")
+	)
+	(wire
+		(pts
+			(xy 161.925 36.83) (xy 154.94 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b428446a-242b-421a-916a-35c06b2c6b48")
 	)
 	(wire
 		(pts
@@ -5744,7 +5764,7 @@
 	)
 	(wire
 		(pts
-			(xy 144.145 31.75) (xy 152.4 31.75)
+			(xy 144.145 31.75) (xy 151.13 31.75)
 		)
 		(stroke
 			(width 0)
@@ -5884,7 +5904,7 @@
 	)
 	(wire
 		(pts
-			(xy 152.4 53.34) (xy 161.925 53.34)
+			(xy 151.13 53.34) (xy 161.925 53.34)
 		)
 		(stroke
 			(width 0)
@@ -7862,7 +7882,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 158.115 48.26 270)
+		(at 154.94 31.75 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -7873,27 +7893,29 @@
 		(fields_autoplaced yes)
 		(uuid "31bf4161-78a8-4f42-a655-d6f6010dbed2")
 		(property "Reference" "R36"
-			(at 158.115 41.91 90)
+			(at 156.845 30.4799 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Value" "10 k"
-			(at 158.115 44.45 90)
+			(at 156.845 33.0199 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
-			(at 157.861 49.276 90)
+			(at 155.956 32.004 90)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -7904,7 +7926,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 158.115 48.26 0)
+			(at 154.94 31.75 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -7915,7 +7937,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 158.115 48.26 0)
+			(at 154.94 31.75 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9147,7 +9169,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 159.385 27.94 0)
+		(at 154.94 41.91 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -9157,7 +9179,7 @@
 		(dnp no)
 		(uuid "5fc77d8e-da47-44c1-a0d5-61c76cb5df2b")
 		(property "Reference" "C25"
-			(at 159.385 25.4 0)
+			(at 154.94 39.37 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -9168,7 +9190,7 @@
 			)
 		)
 		(property "Value" "1 uF"
-			(at 159.385 30.48 0)
+			(at 154.94 44.45 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -9179,7 +9201,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
-			(at 160.3502 31.75 0)
+			(at 155.9052 45.72 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9190,7 +9212,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 159.385 27.94 0)
+			(at 154.94 41.91 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9201,7 +9223,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 159.385 27.94 0)
+			(at 154.94 41.91 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9309,7 +9331,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 159.385 31.75 0)
+		(at 154.94 45.72 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -9319,7 +9341,7 @@
 		(dnp no)
 		(uuid "6456e36e-594b-4c8c-9e80-d0822b99ad4d")
 		(property "Reference" "#PWR067"
-			(at 159.385 38.1 0)
+			(at 154.94 52.07 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9330,7 +9352,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 161.29 35.56 0)
+			(at 156.845 49.53 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -9341,7 +9363,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 159.385 31.75 0)
+			(at 154.94 45.72 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9352,7 +9374,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 159.385 31.75 0)
+			(at 154.94 45.72 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -9363,7 +9385,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 159.385 31.75 0)
+			(at 154.94 45.72 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -10672,7 +10694,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 154.305 22.86 0)
+		(at 154.94 24.13 0)
 		(unit 1)
 		(body_style 1)
 		(exclude_from_sim no)
@@ -10683,7 +10705,7 @@
 		(fields_autoplaced yes)
 		(uuid "973c29cf-70e0-4b90-9fb1-220fa9eef7be")
 		(property "Reference" "#PWR066"
-			(at 154.305 26.67 0)
+			(at 154.94 27.94 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -10694,7 +10716,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 154.305 18.415 0)
+			(at 154.94 19.685 0)
 			(show_name no)
 			(do_not_autoplace no)
 			(effects
@@ -10704,7 +10726,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 154.305 22.86 0)
+			(at 154.94 24.13 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -10715,7 +10737,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 154.305 22.86 0)
+			(at 154.94 24.13 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -10726,7 +10748,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 154.305 22.86 0)
+			(at 154.94 24.13 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)

--- a/hardware/rocket-computer/power.kicad_sch
+++ b/hardware/rocket-computer/power.kicad_sch
@@ -15484,4 +15484,98 @@
 			)
 		)
 	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x02")
+		(at 180.34 88.9 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "7448e12f-fd37-41be-b141-eb389f224338")
+		(property "Reference" "J8"
+			(at 177.165 88.9001 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "JST_B2P-VH"
+			(at 177.165 86.3601 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_JST:JST_VH_B2P-VH_1x02_P3.96mm_Vertical"
+			(at 180.34 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 180.34 88.9 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ee823f9e-32b2-4ffe-8242-974006196843")
+		)
+		(pin "2"
+			(uuid "0d653f04-a9a8-4618-afe1-e085ac0f1c85")
+		)
+		(instances
+			(project "rocket-computer"
+				(path "/ae61c2c4-72e9-4776-93ae-2e716b9dc70f/4387b4db-c729-4e1d-84b2-dffd80f2e21f"
+					(reference "J8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(text "#658 fit trial -- JST VH 2-pin (B2P-VH, 3.96 mm) candidate to replace\nthe 2 A JST PH battery input J7. Intentionally UNCONNECTED: placed only to\ncheck mechanical fit on the PCB. Through-hole, 1.7 mm drills. Delete or wire\nup once the connector decision is made."
+		(exclude_from_sim no)
+		(at 165.1 71.12 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0344bdb0-b130-4487-a9ce-0490dc538298")
+	)
+
 )

--- a/hardware/rocket-computer/rocket-computer.kicad_pcb
+++ b/hardware/rocket-computer/rocket-computer.kicad_pcb
@@ -4129,10 +4129,10 @@
 	(footprint "Footprints:CAPMP7.6X4.3_3.1N_KEM"
 		(layer "F.Cu")
 		(uuid "1775ed41-ba9d-46a5-96cd-8bb37e18710a")
-		(at 91.36 137.032194 -90)
+		(at 90.51 126.05)
 		(tags "T491D227K016AT ")
 		(property "Reference" "C56"
-			(at 0 0 270)
+			(at 0 0 0)
 			(unlocked yes)
 			(layer "F.SilkS")
 			(hide yes)
@@ -4145,7 +4145,7 @@
 			)
 		)
 		(property "Value" "TCJE337M016R0050"
-			(at 0 0 270)
+			(at 0 0 0)
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
@@ -4158,7 +4158,7 @@
 			)
 		)
 		(property "Datasheet" "https://content.kemet.com/datasheets/KEM_T2005_T491.pdf"
-			(at 0 0 90)
+			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
 			(uuid "309dac0c-aec5-458b-9f66-78d74e46c8d1")
@@ -4170,7 +4170,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 0 0 90)
+			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
 			(uuid "2cb20c68-ec66-489b-b41e-7485f99e4055")
@@ -4194,36 +4194,6 @@
 		(attr smd)
 		(duplicate_pad_numbers_are_jumpers no)
 		(fp_line
-			(start -3.926992 2.276996)
-			(end 3.926992 2.276996)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "3c843968-f4e2-43a5-bb07-24d8bf03f965")
-		)
-		(fp_line
-			(start 3.926992 2.276996)
-			(end 3.926992 1.582738)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "7d43a892-010b-46a2-aa5e-a16ad29501c4")
-		)
-		(fp_line
-			(start -3.926992 1.582738)
-			(end -3.926992 2.276996)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "93e12132-e346-4522-b765-d8d995e66f28")
-		)
-		(fp_line
 			(start -4.2 -1.525)
 			(end -4.205 1.535)
 			(stroke
@@ -4232,16 +4202,6 @@
 			)
 			(layer "F.SilkS")
 			(uuid "fd435ce4-3dd4-489a-92bf-cd50d0039fa4")
-		)
-		(fp_line
-			(start 3.926992 -1.582738)
-			(end 3.926992 -2.276996)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "353741e7-e71a-4ac7-ba0b-afbf8ed01cce")
 		)
 		(fp_line
 			(start -3.926992 -2.276996)
@@ -4254,6 +4214,26 @@
 			(uuid "84602a09-72f5-46ef-af51-c4e04224a3a1")
 		)
 		(fp_line
+			(start -3.926992 1.582738)
+			(end -3.926992 2.276996)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "93e12132-e346-4522-b765-d8d995e66f28")
+		)
+		(fp_line
+			(start -3.926992 2.276996)
+			(end 3.926992 2.276996)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3c843968-f4e2-43a5-bb07-24d8bf03f965")
+		)
+		(fp_line
 			(start 3.926992 -2.276996)
 			(end -3.926992 -2.276996)
 			(stroke
@@ -4264,64 +4244,24 @@
 			(uuid "ea5ed240-b0ad-4122-a961-6be54a234480")
 		)
 		(fp_line
-			(start -4.053992 2.403996)
-			(end -4.053992 1.503998)
+			(start 3.926992 -1.582738)
+			(end 3.926992 -2.276996)
 			(stroke
 				(width 0.1524)
 				(type solid)
 			)
-			(layer "F.CrtYd")
-			(uuid "483cd475-c82a-420c-8f6b-37dfe838de7f")
+			(layer "F.SilkS")
+			(uuid "353741e7-e71a-4ac7-ba0b-afbf8ed01cce")
 		)
 		(fp_line
-			(start 4.053992 2.403996)
-			(end -4.053992 2.403996)
+			(start 3.926992 2.276996)
+			(end 3.926992 1.582738)
 			(stroke
 				(width 0.1524)
 				(type solid)
 			)
-			(layer "F.CrtYd")
-			(uuid "23953fec-b63d-4a5d-bd84-e4311c68e4c3")
-		)
-		(fp_line
-			(start -4.206392 1.503998)
-			(end -4.206392 -1.503998)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "ffa2c5aa-a6ca-4354-bff1-2f3f663d2a0c")
-		)
-		(fp_line
-			(start -4.053992 1.503998)
-			(end -4.206392 1.503998)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "5234fb51-a5da-4d5a-8020-14b1eb071770")
-		)
-		(fp_line
-			(start 4.053992 1.503998)
-			(end 4.053992 2.403996)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "8ce3de4a-438e-4fa5-b7eb-6d726aec1037")
-		)
-		(fp_line
-			(start 4.206392 1.503998)
-			(end 4.053992 1.503998)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "50ae3c47-6580-4ff4-994e-47475e3a1485")
+			(layer "F.SilkS")
+			(uuid "7d43a892-010b-46a2-aa5e-a16ad29501c4")
 		)
 		(fp_line
 			(start -4.206392 -1.503998)
@@ -4334,34 +4274,14 @@
 			(uuid "9e9dcaec-5056-40f8-864b-c5bb0288545c")
 		)
 		(fp_line
-			(start -4.053992 -1.503998)
-			(end -4.053992 -2.403996)
+			(start -4.206392 1.503998)
+			(end -4.206392 -1.503998)
 			(stroke
 				(width 0.1524)
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2d456801-6f5d-4acb-8bb8-78d7aead677b")
-		)
-		(fp_line
-			(start 4.053992 -1.503998)
-			(end 4.206392 -1.503998)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "b89acf11-bbdb-41cc-b099-29521c6ea6c8")
-		)
-		(fp_line
-			(start 4.206392 -1.503998)
-			(end 4.206392 1.503998)
-			(stroke
-				(width 0.1524)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "4f67211a-47fb-4bf5-a94c-a3b9a320adb3")
+			(uuid "ffa2c5aa-a6ca-4354-bff1-2f3f663d2a0c")
 		)
 		(fp_line
 			(start -4.053992 -2.403996)
@@ -4374,6 +4294,36 @@
 			(uuid "a5b42d79-6e4c-4518-85fd-a3e1ce24e8d3")
 		)
 		(fp_line
+			(start -4.053992 -1.503998)
+			(end -4.053992 -2.403996)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2d456801-6f5d-4acb-8bb8-78d7aead677b")
+		)
+		(fp_line
+			(start -4.053992 1.503998)
+			(end -4.206392 1.503998)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5234fb51-a5da-4d5a-8020-14b1eb071770")
+		)
+		(fp_line
+			(start -4.053992 2.403996)
+			(end -4.053992 1.503998)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "483cd475-c82a-420c-8f6b-37dfe838de7f")
+		)
+		(fp_line
 			(start 4.053992 -2.403996)
 			(end 4.053992 -1.503998)
 			(stroke
@@ -4384,34 +4334,54 @@
 			(uuid "afe25efe-0d81-4b44-8ca1-5be42130549a")
 		)
 		(fp_line
-			(start -3.799992 2.149996)
-			(end 3.799992 2.149996)
+			(start 4.053992 -1.503998)
+			(end 4.206392 -1.503998)
 			(stroke
-				(width 0.0254)
+				(width 0.1524)
 				(type solid)
 			)
-			(layer "F.Fab")
-			(uuid "db91f44c-4fdc-4970-864f-a6c24b9c8a86")
+			(layer "F.CrtYd")
+			(uuid "b89acf11-bbdb-41cc-b099-29521c6ea6c8")
 		)
 		(fp_line
-			(start 3.799992 2.149996)
-			(end 3.799992 -2.149996)
+			(start 4.053992 1.503998)
+			(end 4.053992 2.403996)
 			(stroke
-				(width 0.0254)
+				(width 0.1524)
 				(type solid)
 			)
-			(layer "F.Fab")
-			(uuid "a76d896b-fec0-4d94-909b-7835c65622de")
+			(layer "F.CrtYd")
+			(uuid "8ce3de4a-438e-4fa5-b7eb-6d726aec1037")
 		)
 		(fp_line
-			(start -5.188991 0)
-			(end -5.950991 0)
+			(start 4.053992 2.403996)
+			(end -4.053992 2.403996)
 			(stroke
-				(width 0.0254)
+				(width 0.1524)
 				(type solid)
 			)
-			(layer "F.Fab")
-			(uuid "19c5c4de-8aba-4a34-afe8-8e4767043b27")
+			(layer "F.CrtYd")
+			(uuid "23953fec-b63d-4a5d-bd84-e4311c68e4c3")
+		)
+		(fp_line
+			(start 4.206392 -1.503998)
+			(end 4.206392 1.503998)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4f67211a-47fb-4bf5-a94c-a3b9a320adb3")
+		)
+		(fp_line
+			(start 4.206392 1.503998)
+			(end 4.053992 1.503998)
+			(stroke
+				(width 0.1524)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "50ae3c47-6580-4ff4-994e-47475e3a1485")
 		)
 		(fp_line
 			(start -5.569991 -0.381)
@@ -4424,6 +4394,16 @@
 			(uuid "70348be0-93e5-49d5-bc26-1a6cd6d33524")
 		)
 		(fp_line
+			(start -5.188991 0)
+			(end -5.950991 0)
+			(stroke
+				(width 0.0254)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "19c5c4de-8aba-4a34-afe8-8e4767043b27")
+		)
+		(fp_line
 			(start -3.799992 -2.149996)
 			(end -3.799992 2.149996)
 			(stroke
@@ -4432,6 +4412,16 @@
 			)
 			(layer "F.Fab")
 			(uuid "4741381d-8aa9-4eb2-90e0-5646c71f1dc6")
+		)
+		(fp_line
+			(start -3.799992 2.149996)
+			(end 3.799992 2.149996)
+			(stroke
+				(width 0.0254)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "db91f44c-4fdc-4970-864f-a6c24b9c8a86")
 		)
 		(fp_line
 			(start 3.799992 -2.149996)
@@ -4443,8 +4433,18 @@
 			(layer "F.Fab")
 			(uuid "9df6a570-b6b6-4364-a9b3-c22d4ae7f3b1")
 		)
+		(fp_line
+			(start 3.799992 2.149996)
+			(end 3.799992 -2.149996)
+			(stroke
+				(width 0.0254)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a76d896b-fec0-4d94-909b-7835c65622de")
+		)
 		(pad "1" smd rect
-			(at -2.672194 0)
+			(at -2.672194 0 90)
 			(size 2.499995 2.560396)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(net "V_MCU_2S")
@@ -4452,7 +4452,7 @@
 			(uuid "dd585204-90ea-4e3d-ac03-08d126b0951b")
 		)
 		(pad "2" smd rect
-			(at 2.672194 0)
+			(at 2.672194 0 90)
 			(size 2.499995 2.560396)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(net "GND")
@@ -7220,6 +7220,341 @@
 			)
 		)
 	)
+	(footprint "Footprints:IND_VLS3012CX-2R2M-1"
+		(layer "F.Cu")
+		(uuid "33e056dc-cd5f-43f6-a5b2-d28a2a581504")
+		(at 88.02 130.23)
+		(property "Reference" "L5"
+			(at 0.282 -2.4064 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c0350f8e-09b9-4878-906d-5f4a374b5fb2")
+			(effects
+				(font
+					(size 0.64 0.64)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "VLS3012CX-2R2M-1"
+			(at 6.378 2.4064 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "90a44cc4-b7dc-4841-b2a1-80b9b618692f")
+			(effects
+				(font
+					(size 0.64 0.64)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3d291964-7f05-4ae0-bb84-92c58ea958db")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Inductor Power Shielded Wirewound 2.2uH 20% 1MHz Ferrite 2.55A 0.074Ohm DCR 1212 T/R"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "583f0203-64c3-4553-8f0b-5ba3618defb4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MF" "TDK Corporation"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8153efe1-f273-42ae-84ed-7353aeca2887")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "MAXIMUM_PACKAGE_HEIGHT" "1.2 mm"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "821589a3-b17a-4150-9941-4a8bca101d19")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Package" "NON STANDARD-2 TDK"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "802c7673-c2c1-4df6-b943-0f612b990d6f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Price" "None"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "80f0beb6-a9b0-4cec-b06e-f11d929c5b0b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Check_prices" "https://www.snapeda.com/parts/VLS3012CX-2R2M-1/TDK/view-part/?ref=eda"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "465c8273-fa50-4009-8ae9-9f2c7e1d7eaf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "STANDARD" "Manufacturer Recommendations"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ea4e96ab-da2d-4f51-9d04-a9d1c43f2cb4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "PARTREV" "N/A"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fc8592ef-7ad4-4eb0-a94f-01a8ce472f33")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "SnapEDA_Link" "https://www.snapeda.com/parts/VLS3012CX-2R2M-1/TDK/view-part/?ref=snap"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9c82a673-13f2-48f3-b4e4-959de764837f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "MP" "VLS3012CX-2R2M-1"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "52ed1afa-9e8f-4bea-a5f9-ca2f4084e173")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Availability" "In Stock"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "75a50e02-81b7-49b5-93e0-b6e9f29fe854")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "MANUFACTURER" "TDK"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ad65090c-f63c-45e7-b62d-42fefd3c172b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(path "/4387b4db-c729-4e1d-84b2-dffd80f2e21f/812b9f47-c051-438c-87b6-3444617affb0")
+		(sheetname "/Power/")
+		(sheetfile "power.kicad_sch")
+		(units
+			(unit
+				(name "A")
+				(pins "1" "2")
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.18 -1.5)
+			(end 0.18 -1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "40d46792-8967-4b98-8885-dff82ff9459d")
+		)
+		(fp_line
+			(start -0.18 1.5)
+			(end 0.18 1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0851239b-b96c-4ff7-99fc-701bf362d5df")
+		)
+		(fp_line
+			(start -1.75 -1.75)
+			(end -1.75 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c9a5c09b-8986-4ea1-85ff-2f3804dfa089")
+		)
+		(fp_line
+			(start -1.75 1.75)
+			(end 1.75 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "837af870-d601-46db-9c1f-8e977b14b86f")
+		)
+		(fp_line
+			(start 1.75 -1.75)
+			(end -1.75 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3e19d410-dfce-443d-833d-9508f9b4aeef")
+		)
+		(fp_line
+			(start 1.75 1.75)
+			(end 1.75 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0fe5ee95-6f18-42d1-af11-297abb99aeae")
+		)
+		(fp_line
+			(start -1.5 -1.5)
+			(end -1.5 1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fdc28e3c-6b14-48e0-b6c1-4b7847cd156a")
+		)
+		(fp_line
+			(start -1.5 -1.5)
+			(end 1.5 -1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cf22e4d0-ad5a-43cd-9044-05ff60163eb0")
+		)
+		(fp_line
+			(start -1.5 1.5)
+			(end 1.5 1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2973ca8c-9b29-4855-9f78-9ab1c90dde26")
+		)
+		(fp_line
+			(start 1.5 -1.5)
+			(end 1.5 1.5)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5d5269eb-aa41-4a5b-ab8c-e8114b43f1a8")
+		)
+		(pad "1" smd rect
+			(at -1 0)
+			(size 1 3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "V_MCU_2S")
+			(pintype "passive")
+			(solder_mask_margin 0.05)
+			(uuid "e256bcb4-11ef-48df-894f-c164863add0c")
+		)
+		(pad "2" smd rect
+			(at 1 0)
+			(size 1 3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(U18-AVIN)")
+			(pintype "passive")
+			(solder_mask_margin 0.05)
+			(uuid "14291cea-9928-4aec-8e0d-64f688c7d540")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/../3dmodels/VLS3012CX-2R2M-1.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 -0 -0)
+			)
+		)
+	)
 	(footprint "Capacitor_SMD:C_0402_1005Metric"
 		(layer "F.Cu")
 		(uuid "3621fb1c-ca28-40b6-9ac4-8d6363eca052")
@@ -8892,292 +9227,6 @@
 		)
 		(embedded_fonts no)
 		(model "${KIPRJMOD}/../3dmodels/VLS3012CX-2R2M-1.step"
-			(offset
-				(xyz 0 0 0)
-			)
-			(scale
-				(xyz 1 1 1)
-			)
-			(rotate
-				(xyz -90 -0 -0)
-			)
-		)
-	)
-	(footprint "Footprints:SOIC-8_W25Q128JVSIQ"
-		(layer "F.Cu")
-		(uuid "476e0ac4-ef07-4866-b536-a680c388f018")
-		(at 91.795 146.075 -90)
-		(descr "Winbond W25Q128JVSIQ 128Mbit (16MB) SPI NOR flash, SOIC-8 208mil (SOIC127P790X216-8N). Replaces W25Q64JVXGIQ (DFN/WSON) - LARGER footprint, needs re-placement. LCSC C97521.")
-		(property "Reference" "U13"
-			(at -1.485 -3.702 90)
-			(layer "F.SilkS")
-			(hide yes)
-			(uuid "062b2efb-8be6-4d2c-a3fc-b31db93c5316")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "W25Q128JVSIQ"
-			(at 6.77 3.702 90)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "d85f00c2-7871-4534-8262-8234a5bc680a")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" "W25Q64JVXGIQ TR"
-			(at 0 0 90)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "89a96572-5e8c-4121-85cc-33fbbddc6f1e")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 90)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "350a2a70-cf58-4e5a-8a92-ba1f9d9b5fa6")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property ki_fp_filters "DFN_XGIQ TR_WIN DFN_XGIQ TR_WIN-M DFN_XGIQ TR_WIN-L")
-		(path "/eab70588-b031-4461-adac-e038e88381cb/5c937874-e78c-407c-836e-a199d2bca1c6")
-		(sheetname "/OUT - ESP32-S3 Outputs/")
-		(sheetfile "esp32s3_outputs.kicad_sch")
-		(units
-			(unit
-				(name "A")
-				(pins "8" "4" "1" "6" "5" "2" "3" "7")
-			)
-		)
-		(attr smd)
-		(duplicate_pad_numbers_are_jumpers no)
-		(fp_line
-			(start -2.64 2.64)
-			(end 2.64 2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "8c8851c1-36cb-4a87-98a7-f89d879410a1")
-		)
-		(fp_line
-			(start -2.64 -2.64)
-			(end 2.64 -2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.SilkS")
-			(uuid "300abf83-9b65-4f0e-9c39-73388b781913")
-		)
-		(fp_circle
-			(center -5.215 -1.905)
-			(end -5.115 -1.905)
-			(stroke
-				(width 0.2)
-				(type solid)
-			)
-			(fill no)
-			(layer "F.SilkS")
-			(uuid "f42874d9-c12d-43ec-a0e1-b5056d6ada0e")
-		)
-		(fp_line
-			(start -4.66 2.89)
-			(end 4.66 2.89)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "e729e925-d07d-46fc-93bf-020eddd93ac4")
-		)
-		(fp_line
-			(start -4.66 -2.89)
-			(end -4.66 2.89)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "202e416a-15ba-4ada-8796-cf1d1616cb34")
-		)
-		(fp_line
-			(start -4.66 -2.89)
-			(end 4.66 -2.89)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "0707b1cd-4b33-4ecd-81a2-49e9f795a180")
-		)
-		(fp_line
-			(start 4.66 -2.89)
-			(end 4.66 2.89)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "F.CrtYd")
-			(uuid "a7a0f5e7-1007-46d1-a994-661c91ce07ed")
-		)
-		(fp_line
-			(start -2.64 2.64)
-			(end 2.64 2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.Fab")
-			(uuid "f6d9850c-c6b3-413c-afac-98c7068452d4")
-		)
-		(fp_line
-			(start -2.64 -2.64)
-			(end -2.64 2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.Fab")
-			(uuid "35130709-a52d-4f71-93f6-e612a97065c1")
-		)
-		(fp_line
-			(start -2.64 -2.64)
-			(end 2.64 -2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.Fab")
-			(uuid "e8d0f998-ccd7-4dbc-8485-0e74eded19ae")
-		)
-		(fp_line
-			(start 2.64 -2.64)
-			(end 2.64 2.64)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "F.Fab")
-			(uuid "a734a147-fdf0-4fab-84b0-ef2316378089")
-		)
-		(fp_circle
-			(center -5.215 -1.905)
-			(end -5.115 -1.905)
-			(stroke
-				(width 0.2)
-				(type solid)
-			)
-			(fill no)
-			(layer "F.Fab")
-			(uuid "146c9dd4-5888-4e93-be54-3d2b8cc8b9da")
-		)
-		(pad "1" smd roundrect
-			(at -3.605 -1.905 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_CS0")
-			(pinfunction "/CS_1")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "4b1df13b-6d8d-47a8-81f5-7e9694dafff1")
-		)
-		(pad "2" smd roundrect
-			(at -3.605 -0.635 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_Q")
-			(pinfunction "DO_(IO1)_2")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "5fd30201-3037-456b-88ce-91f4bed41d86")
-		)
-		(pad "3" smd roundrect
-			(at -3.605 0.635 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_WP")
-			(pinfunction "IO2_3")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "fdb0c0a7-d384-4e88-8741-aeb94d3ee594")
-		)
-		(pad "4" smd roundrect
-			(at -3.605 1.905 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "GND")
-			(pinfunction "GND_4")
-			(pintype "power_out")
-			(solder_mask_margin 0.102)
-			(uuid "69240720-64aa-42cb-a612-9801cbbff679")
-		)
-		(pad "5" smd roundrect
-			(at 3.605 1.905 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_D")
-			(pinfunction "DI_(IO0)_5")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "97b8f184-7dbe-47ed-a58a-630afab53774")
-		)
-		(pad "6" smd roundrect
-			(at 3.605 0.635 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_CLK")
-			(pinfunction "CLK_6")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "e1a12122-3c5c-4ff6-912d-50e7028efbe5")
-		)
-		(pad "7" smd roundrect
-			(at 3.605 -0.635 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_SPI_HD")
-			(pinfunction "/HOLD_or_/RESET_(IO3)_7")
-			(pintype "unspecified")
-			(solder_mask_margin 0.102)
-			(uuid "05329727-1c93-4104-a667-0e4284ecc179")
-		)
-		(pad "8" smd roundrect
-			(at 3.605 -1.905 270)
-			(size 1.61 0.58)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.125)
-			(net "OUT_VDD_SPI")
-			(pinfunction "VCC_8")
-			(pintype "power_in")
-			(solder_mask_margin 0.102)
-			(uuid "2d184b6a-9665-4323-90a4-312b4a9c7866")
-		)
-		(embedded_fonts no)
-		(model "${KIPRJMOD}/../3dmodels/W25Q128JVSIQ.step"
 			(offset
 				(xyz 0 0 0)
 			)
@@ -17177,7 +17226,7 @@
 			(size 0.56 0.62)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(net "+3V3")
+			(net "Net-(U15-CHIP_PU)")
 			(pintype "passive")
 			(uuid "a788815a-4562-417a-aff4-b654b2dae910")
 		)
@@ -25033,7 +25082,7 @@
 	(footprint "Footprints:8L_WSON_8x6x3p4x4p3_MAC"
 		(layer "F.Cu")
 		(uuid "a9484391-5aee-4af9-9ac0-39f147885528")
-		(at 86.495 127.3257 -90)
+		(at 91.495 137.2543 -90)
 		(tags "MX35UF4G24AD-Z4I8 ")
 		(property "Reference" "U11"
 			(at 0 0 270)
@@ -28566,7 +28615,7 @@
 			(size 0.54 0.64)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(net "Net-(U15-CHIP_PU)")
+			(net "+3V3")
 			(pintype "passive")
 			(uuid "35508d8f-c905-4662-8f71-a22d65d9e0e6")
 		)
@@ -28575,7 +28624,7 @@
 			(size 0.54 0.64)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(net "+3V3")
+			(net "Net-(U15-CHIP_PU)")
 			(pintype "passive")
 			(uuid "535f9aae-9008-4485-afb1-739b52a8b866")
 		)
@@ -38417,356 +38466,6 @@
 			)
 		)
 	)
-	(footprint "Footprints:IND_VLS3012CX-2R2M-1"
-		(layer "B.Cu")
-		(uuid "33e056dc-cd5f-43f6-a5b2-d28a2a581504")
-		(at 89.65 134.7)
-		(property "Reference" "L5"
-			(at 0.282 2.4064 180)
-			(layer "B.SilkS")
-			(hide yes)
-			(uuid "c0350f8e-09b9-4878-906d-5f4a374b5fb2")
-			(effects
-				(font
-					(size 0.64 0.64)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Value" "VLS3012CX-2R2M-1"
-			(at 6.378 -2.4064 180)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "90a44cc4-b7dc-4841-b2a1-80b9b618692f")
-			(effects
-				(font
-					(size 0.64 0.64)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 180)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "3d291964-7f05-4ae0-bb84-92c58ea958db")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Description" "Inductor Power Shielded Wirewound 2.2uH 20% 1MHz Ferrite 2.55A 0.074Ohm DCR 1212 T/R"
-			(at 0 0 180)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "583f0203-64c3-4553-8f0b-5ba3618defb4")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify mirror)
-			)
-		)
-		(property "MF" "TDK Corporation"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "8153efe1-f273-42ae-84ed-7353aeca2887")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "MAXIMUM_PACKAGE_HEIGHT" "1.2 mm"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "821589a3-b17a-4150-9941-4a8bca101d19")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Package" "NON STANDARD-2 TDK"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "802c7673-c2c1-4df6-b943-0f612b990d6f")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Price" "None"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "80f0beb6-a9b0-4cec-b06e-f11d929c5b0b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Check_prices" "https://www.snapeda.com/parts/VLS3012CX-2R2M-1/TDK/view-part/?ref=eda"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "465c8273-fa50-4009-8ae9-9f2c7e1d7eaf")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "STANDARD" "Manufacturer Recommendations"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "ea4e96ab-da2d-4f51-9d04-a9d1c43f2cb4")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "PARTREV" "N/A"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "fc8592ef-7ad4-4eb0-a94f-01a8ce472f33")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "SnapEDA_Link" "https://www.snapeda.com/parts/VLS3012CX-2R2M-1/TDK/view-part/?ref=snap"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "9c82a673-13f2-48f3-b4e4-959de764837f")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "MP" "VLS3012CX-2R2M-1"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "52ed1afa-9e8f-4bea-a5f9-ca2f4084e173")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "Availability" "In Stock"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "75a50e02-81b7-49b5-93e0-b6e9f29fe854")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(property "MANUFACTURER" "TDK"
-			(at 0 0 180)
-			(unlocked yes)
-			(layer "B.Fab")
-			(hide yes)
-			(uuid "ad65090c-f63c-45e7-b62d-42fefd3c172b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-				(justify mirror)
-			)
-		)
-		(path "/4387b4db-c729-4e1d-84b2-dffd80f2e21f/812b9f47-c051-438c-87b6-3444617affb0")
-		(sheetname "/Power/")
-		(sheetfile "power.kicad_sch")
-		(units
-			(unit
-				(name "A")
-				(pins "1" "2")
-			)
-		)
-		(attr smd)
-		(duplicate_pad_numbers_are_jumpers no)
-		(fp_line
-			(start -0.18 -1.5)
-			(end 0.18 -1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.SilkS")
-			(uuid "0851239b-b96c-4ff7-99fc-701bf362d5df")
-		)
-		(fp_line
-			(start -0.18 1.5)
-			(end 0.18 1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.SilkS")
-			(uuid "40d46792-8967-4b98-8885-dff82ff9459d")
-		)
-		(fp_line
-			(start -1.75 -1.75)
-			(end 1.75 -1.75)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "B.CrtYd")
-			(uuid "837af870-d601-46db-9c1f-8e977b14b86f")
-		)
-		(fp_line
-			(start -1.75 1.75)
-			(end -1.75 -1.75)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "B.CrtYd")
-			(uuid "c9a5c09b-8986-4ea1-85ff-2f3804dfa089")
-		)
-		(fp_line
-			(start 1.75 -1.75)
-			(end 1.75 1.75)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "B.CrtYd")
-			(uuid "0fe5ee95-6f18-42d1-af11-297abb99aeae")
-		)
-		(fp_line
-			(start 1.75 1.75)
-			(end -1.75 1.75)
-			(stroke
-				(width 0.05)
-				(type solid)
-			)
-			(layer "B.CrtYd")
-			(uuid "3e19d410-dfce-443d-833d-9508f9b4aeef")
-		)
-		(fp_line
-			(start -1.5 -1.5)
-			(end 1.5 -1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.Fab")
-			(uuid "2973ca8c-9b29-4855-9f78-9ab1c90dde26")
-		)
-		(fp_line
-			(start -1.5 1.5)
-			(end -1.5 -1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.Fab")
-			(uuid "fdc28e3c-6b14-48e0-b6c1-4b7847cd156a")
-		)
-		(fp_line
-			(start -1.5 1.5)
-			(end 1.5 1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.Fab")
-			(uuid "cf22e4d0-ad5a-43cd-9044-05ff60163eb0")
-		)
-		(fp_line
-			(start 1.5 1.5)
-			(end 1.5 -1.5)
-			(stroke
-				(width 0.127)
-				(type solid)
-			)
-			(layer "B.Fab")
-			(uuid "5d5269eb-aa41-4a5b-ab8c-e8114b43f1a8")
-		)
-		(pad "1" smd rect
-			(at -1 0)
-			(size 1 3)
-			(layers "B.Cu" "B.Mask" "B.Paste")
-			(net "V_MCU_2S")
-			(pintype "passive")
-			(solder_mask_margin 0.05)
-			(uuid "e256bcb4-11ef-48df-894f-c164863add0c")
-		)
-		(pad "2" smd rect
-			(at 1 0)
-			(size 1 3)
-			(layers "B.Cu" "B.Mask" "B.Paste")
-			(net "Net-(U18-AVIN)")
-			(pintype "passive")
-			(solder_mask_margin 0.05)
-			(uuid "14291cea-9928-4aec-8e0d-64f688c7d540")
-		)
-		(embedded_fonts no)
-		(model "${KIPRJMOD}/../3dmodels/VLS3012CX-2R2M-1.step"
-			(offset
-				(xyz 0 0 0)
-			)
-			(scale
-				(xyz 1 1 1)
-			)
-			(rotate
-				(xyz -90 -0 -0)
-			)
-		)
-	)
 	(footprint "Footprints:QFN50P300X300X100-17N"
 		(layer "B.Cu")
 		(uuid "37fcb06d-a807-4e81-8f05-c8223ea9ce85")
@@ -39806,6 +39505,296 @@
 			)
 			(rotate
 				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Footprints:SOIC-8_W25Q128JVSIQ"
+		(layer "B.Cu")
+		(uuid "476e0ac4-ef07-4866-b536-a680c388f018")
+		(at 91.82 145.69 90)
+		(descr "Winbond W25Q128JVSIQ 128Mbit (16MB) SPI NOR flash, SOIC-8 208mil (SOIC127P790X216-8N). Replaces W25Q64JVXGIQ (DFN/WSON) - LARGER footprint, needs re-placement. LCSC C97521.")
+		(property "Reference" "U13"
+			(at -1.485 3.702 90)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "062b2efb-8be6-4d2c-a3fc-b31db93c5316")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "W25Q128JVSIQ"
+			(at 6.77 -3.702 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "d85f00c2-7871-4534-8262-8234a5bc680a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" "W25Q64JVXGIQ TR"
+			(at 0 0 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "89a96572-5e8c-4121-85cc-33fbbddc6f1e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "350a2a70-cf58-4e5a-8a92-ba1f9d9b5fa6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify mirror)
+			)
+		)
+		(property ki_fp_filters "DFN_XGIQ TR_WIN DFN_XGIQ TR_WIN-M DFN_XGIQ TR_WIN-L")
+		(path "/eab70588-b031-4461-adac-e038e88381cb/5c937874-e78c-407c-836e-a199d2bca1c6")
+		(sheetname "/OUT - ESP32-S3 Outputs/")
+		(sheetfile "esp32s3_outputs.kicad_sch")
+		(units
+			(unit
+				(name "A")
+				(pins "8" "4" "1" "6" "5" "2" "3" "7")
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.64 -2.64)
+			(end 2.64 -2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8c8851c1-36cb-4a87-98a7-f89d879410a1")
+		)
+		(fp_line
+			(start -2.64 2.64)
+			(end 2.64 2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "300abf83-9b65-4f0e-9c39-73388b781913")
+		)
+		(fp_circle
+			(center -5.215 1.905)
+			(end -5.115 1.905)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.SilkS")
+			(uuid "f42874d9-c12d-43ec-a0e1-b5056d6ada0e")
+		)
+		(fp_line
+			(start -4.66 -2.89)
+			(end 4.66 -2.89)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "e729e925-d07d-46fc-93bf-020eddd93ac4")
+		)
+		(fp_line
+			(start 4.66 2.89)
+			(end 4.66 -2.89)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "a7a0f5e7-1007-46d1-a994-661c91ce07ed")
+		)
+		(fp_line
+			(start -4.66 2.89)
+			(end -4.66 -2.89)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "202e416a-15ba-4ada-8796-cf1d1616cb34")
+		)
+		(fp_line
+			(start -4.66 2.89)
+			(end 4.66 2.89)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "0707b1cd-4b33-4ecd-81a2-49e9f795a180")
+		)
+		(fp_line
+			(start -2.64 -2.64)
+			(end 2.64 -2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "f6d9850c-c6b3-413c-afac-98c7068452d4")
+		)
+		(fp_line
+			(start 2.64 2.64)
+			(end 2.64 -2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "a734a147-fdf0-4fab-84b0-ef2316378089")
+		)
+		(fp_line
+			(start -2.64 2.64)
+			(end -2.64 -2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "35130709-a52d-4f71-93f6-e612a97065c1")
+		)
+		(fp_line
+			(start -2.64 2.64)
+			(end 2.64 2.64)
+			(stroke
+				(width 0.127)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "e8d0f998-ccd7-4dbc-8485-0e74eded19ae")
+		)
+		(fp_circle
+			(center -5.215 1.905)
+			(end -5.115 1.905)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.Fab")
+			(uuid "146c9dd4-5888-4e93-be54-3d2b8cc8b9da")
+		)
+		(pad "1" smd roundrect
+			(at -3.605 1.905 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_CS0")
+			(pinfunction "/CS_1")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "4b1df13b-6d8d-47a8-81f5-7e9694dafff1")
+		)
+		(pad "2" smd roundrect
+			(at -3.605 0.635 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_Q")
+			(pinfunction "DO_(IO1)_2")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "5fd30201-3037-456b-88ce-91f4bed41d86")
+		)
+		(pad "3" smd roundrect
+			(at -3.605 -0.635 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_WP")
+			(pinfunction "IO2_3")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "fdb0c0a7-d384-4e88-8741-aeb94d3ee594")
+		)
+		(pad "4" smd roundrect
+			(at -3.605 -1.905 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "GND")
+			(pinfunction "GND_4")
+			(pintype "power_out")
+			(solder_mask_margin 0.102)
+			(uuid "69240720-64aa-42cb-a612-9801cbbff679")
+		)
+		(pad "5" smd roundrect
+			(at 3.605 -1.905 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_D")
+			(pinfunction "DI_(IO0)_5")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "97b8f184-7dbe-47ed-a58a-630afab53774")
+		)
+		(pad "6" smd roundrect
+			(at 3.605 -0.635 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_CLK")
+			(pinfunction "CLK_6")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "e1a12122-3c5c-4ff6-912d-50e7028efbe5")
+		)
+		(pad "7" smd roundrect
+			(at 3.605 0.635 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_SPI_HD")
+			(pinfunction "/HOLD_or_/RESET_(IO3)_7")
+			(pintype "unspecified")
+			(solder_mask_margin 0.102)
+			(uuid "05329727-1c93-4104-a667-0e4284ecc179")
+		)
+		(pad "8" smd roundrect
+			(at 3.605 1.905 90)
+			(size 1.61 0.58)
+			(layers "B.Cu" "B.Mask" "B.Paste")
+			(roundrect_rratio 0.125)
+			(net "OUT_VDD_SPI")
+			(pinfunction "VCC_8")
+			(pintype "power_in")
+			(solder_mask_margin 0.102)
+			(uuid "2d184b6a-9665-4323-90a4-312b4a9c7866")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/../3dmodels/W25Q128JVSIQ.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz -90 -0 -0)
 			)
 		)
 	)
@@ -40894,6 +40883,317 @@
 		)
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Connector_JST:JST_VH_B2P-VH_1x02_P3.96mm_Vertical"
+		(layer "B.Cu")
+		(uuid "4b2b0d68-9f7a-45c6-a307-1da6bbe8475a")
+		(at 84.65 125.59 -90)
+		(descr "JST VH series connector, B2P-VH (http://www.jst-mfg.com/product/pdf/eng/eVH.pdf)")
+		(tags "connector JST VH vertical")
+		(property "Reference" "J8"
+			(at 1.98 4.9 90)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "4518722b-357e-4eaf-b32e-cf55186bed17")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "JST_B2P-VH"
+			(at 1.98 -6 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "19ef7375-948f-444c-8f2e-684f4286dfdb")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "981434c9-322a-4f8b-8f64-833c13b92ad5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 0 0 90)
+			(layer "B.Fab")
+			(hide yes)
+			(uuid "b346919c-b89c-4bbe-91e0-58400c736d32")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify mirror)
+			)
+		)
+		(property "KiLib_Generator" "connector/JST"
+			(at 0 0 90)
+			(layer "B.SilkS")
+			(hide yes)
+			(uuid "4468411d-f915-46d9-b0aa-d54e75b17849")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property ki_fp_filters "Connector*:*_1x??_*")
+		(path "/4387b4db-c729-4e1d-84b2-dffd80f2e21f/7448e12f-fd37-41be-b141-eb389f224338")
+		(sheetname "/Power/")
+		(sheetfile "power.kicad_sch")
+		(units
+			(unit
+				(name "A")
+				(pins "1" "2")
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.86 3.81)
+			(end 4.82 3.81)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "54fb7ec5-1d7e-4634-8dda-0532debfcb1d")
+		)
+		(fp_line
+			(start 4.82 3.81)
+			(end 4.82 2.11)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8170e2a4-9a26-4317-96c6-c59e29b1353c")
+		)
+		(fp_line
+			(start -2.06 2.11)
+			(end -0.86 2.11)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2f681d6d-4f20-4b1a-a7d4-b601df61235f")
+		)
+		(fp_line
+			(start -0.86 2.11)
+			(end -0.86 3.81)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "62d05555-4bb7-4bc8-b9d2-2f41e15cd3fa")
+		)
+		(fp_line
+			(start 4.82 2.11)
+			(end 6.02 2.11)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "17fb478b-2a33-48d6-a110-ed04595ee9e4")
+		)
+		(fp_line
+			(start 6.02 2.11)
+			(end 6.02 -4.91)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "aa7b57f7-7903-431e-96c6-a0d13d9c4e1d")
+		)
+		(fp_line
+			(start -2.86 0.3)
+			(end -2.26 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9633791c-95a0-430b-a958-0c7ee04ec479")
+		)
+		(fp_line
+			(start -2.26 0)
+			(end -2.86 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5a3e9564-a429-41dc-b0cb-a881ce3f72f7")
+		)
+		(fp_line
+			(start -2.86 -0.3)
+			(end -2.86 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "80980f34-f37a-4998-8e46-a38e38e7b8a5")
+		)
+		(fp_line
+			(start -2.06 -4.91)
+			(end -2.06 2.11)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c60a16bb-8544-4eec-bb20-4b49b2ba81ea")
+		)
+		(fp_line
+			(start 6.02 -4.91)
+			(end -2.06 -4.91)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "16bc8abc-0345-4ef9-91ff-3e7d3535243e")
+		)
+		(fp_rect
+			(start -2.45 4.2)
+			(end 6.41 -5.3)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.CrtYd")
+			(uuid "3b56e42e-d8d5-477b-9aec-8af948c896c0")
+		)
+		(fp_line
+			(start -0.75 3.7)
+			(end 4.71 3.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "9f246fa4-9dda-47e4-b672-d7bf02cdf4ba")
+		)
+		(fp_line
+			(start 4.71 3.7)
+			(end 4.71 2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "a59a76b1-d5ab-40c8-92a0-212cf9c35ac9")
+		)
+		(fp_line
+			(start -0.75 2)
+			(end -0.75 3.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "309bbd82-b123-4884-af27-23ebb85112b0")
+		)
+		(fp_line
+			(start -1.95 1)
+			(end -0.95 0)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "3866933f-e8f7-4667-a00f-97fbc8bc740b")
+		)
+		(fp_line
+			(start -1.95 -1)
+			(end -0.95 0)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.Fab")
+			(uuid "1a6c860e-3763-4a94-9d26-fa1cd4d1dc0f")
+		)
+		(fp_rect
+			(start -1.95 2)
+			(end 5.91 -4.8)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "B.Fab")
+			(uuid "3960d994-4a1b-4a73-87e9-f056d3071775")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 1.98 -4.1 90)
+			(layer "B.Fab")
+			(uuid "15b10ad1-c745-4805-999a-ee6c8007b9e5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 2.7 2.7)
+			(drill 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.092593)
+			(net "unconnected-(J8-Pin_1-Pad1)")
+			(pinfunction "Pin_1_1")
+			(pintype "passive")
+			(uuid "4efdf677-6e0a-4a44-9672-f65e7c2b5b8a")
+		)
+		(pad "2" thru_hole circle
+			(at 3.96 0 270)
+			(size 2.7 2.7)
+			(drill 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "unconnected-(J8-Pin_2-Pad2)")
+			(pinfunction "Pin_2_2")
+			(pintype "passive")
+			(uuid "782291b0-a5fb-448e-a8fa-d00ba386998b")
+		)
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_JST.3dshapes/JST_VH_B2P-VH_1x02_P3.96mm_Vertical.step"
 			(offset
 				(xyz 0 0 0)
 			)
@@ -48665,7 +48965,7 @@
 	(footprint "Footprints:JST_B2B-PH-SM4-TB"
 		(layer "B.Cu")
 		(uuid "8311adf6-cea4-482e-8a01-b9ec6dad094d")
-		(at 85.44 126.81 180)
+		(at 100.6 126.85 180)
 		(property "Reference" "J7"
 			(at -1.275 4.385 0)
 			(layer "B.SilkS")
@@ -62838,14 +63138,6 @@
 		(uuid "3a7f9fb4-d656-4584-9dff-acbbffb73444")
 	)
 	(segment
-		(start 73.41 143.35)
-		(end 73.41 144.29)
-		(width 0.127)
-		(layer "F.Cu")
-		(net "+3V3")
-		(uuid "3c606184-1442-4915-ad57-fecbd2d959d6")
-	)
-	(segment
 		(start 90.36 128.15)
 		(end 88.41 130.1)
 		(width 0.2)
@@ -62948,14 +63240,6 @@
 		(layer "F.Cu")
 		(net "+3V3")
 		(uuid "95832117-9959-4f38-905c-80b1caeee9e0")
-	)
-	(segment
-		(start 73.41 144.29)
-		(end 73.43 144.31)
-		(width 0.127)
-		(layer "F.Cu")
-		(net "+3V3")
-		(uuid "99eaef8b-9aad-473e-bf8e-9ac5a91f1905")
 	)
 	(segment
 		(start 81.737759 140.675133)
@@ -63445,6 +63729,14 @@
 		(uuid "1cb84101-04f2-446c-a5c1-3456248053e4")
 	)
 	(via
+		(at 86.42 126.72)
+		(size 0.4)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(net "V_MCU_2S")
+		(uuid "2e9769c2-c42c-4936-b64e-cad00f461769")
+	)
+	(via
 		(at 86.3 136.5)
 		(size 0.4)
 		(drill 0.3)
@@ -63928,14 +64220,6 @@
 		(layers "F.Cu" "B.Cu")
 		(net "GND")
 		(uuid "2b6b6bd9-e25c-48ff-aba1-41ae63ebbc23")
-	)
-	(via
-		(at 86.42 126.72)
-		(size 0.4)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(net "GND")
-		(uuid "2e9769c2-c42c-4936-b64e-cad00f461769")
 	)
 	(via
 		(at 73.69 105.82)
@@ -68226,6 +68510,30 @@
 		(layer "In3.Cu")
 		(net "SEL0")
 		(uuid "c84ad77d-35b6-4dbd-90a0-5bde5660625a")
+	)
+	(segment
+		(start 88.510612 115.780612)
+		(end 90.489388 115.780612)
+		(width 0.1)
+		(layer "F.Cu")
+		(net "VDD_HP_1")
+		(uuid "0197e343-6e46-41fa-896a-5fdf96ed8784")
+	)
+	(segment
+		(start 90.489388 115.780612)
+		(end 90.83 115.44)
+		(width 0.1)
+		(layer "F.Cu")
+		(net "VDD_HP_1")
+		(uuid "0e02f7f9-368c-4256-9e71-351f33498d69")
+	)
+	(segment
+		(start 88.51 115.78)
+		(end 88.510612 115.780612)
+		(width 0.1)
+		(layer "F.Cu")
+		(net "VDD_HP_1")
+		(uuid "282cdc7b-058a-488b-bd0a-c05453995fd7")
 	)
 	(segment
 		(start 90.32 155.12)
@@ -79220,14 +79528,6 @@
 		(uuid "9099caa1-30f2-4eea-ab4c-7144a91bf40c")
 	)
 	(segment
-		(start 89.57 99.3)
-		(end 89.09 98.82)
-		(width 0.1)
-		(layer "F.Cu")
-		(net "BMP585_CS")
-		(uuid "a08e449a-fa08-410b-a88d-fc00ef07475c")
-	)
-	(segment
 		(start 88.91 98.67)
 		(end 88.91 97.44)
 		(width 0.1)
@@ -80962,6 +81262,22 @@
 		(layer "F.Cu")
 		(net "Net-(U15-CHIP_PU)")
 		(uuid "12bc05ec-5a64-4ce5-91d6-a93934496917")
+	)
+	(segment
+		(start 73.41 143.35)
+		(end 73.41 144.29)
+		(width 0.127)
+		(layer "F.Cu")
+		(net "Net-(U15-CHIP_PU)")
+		(uuid "3c606184-1442-4915-ad57-fecbd2d959d6")
+	)
+	(segment
+		(start 73.41 144.29)
+		(end 73.43 144.31)
+		(width 0.127)
+		(layer "F.Cu")
+		(net "Net-(U15-CHIP_PU)")
+		(uuid "99eaef8b-9aad-473e-bf8e-9ac5a91f1905")
 	)
 	(segment
 		(start 75.53 143.67)
@@ -85434,30 +85750,6 @@
 		(layer "B.Cu")
 		(net "Net-(J3-Pad1)")
 		(uuid "d69f8e4b-1998-4fdb-826a-c39bc297e4d2")
-	)
-	(segment
-		(start 88.510612 115.780612)
-		(end 90.489388 115.780612)
-		(width 0.1)
-		(layer "F.Cu")
-		(net "VDD_HP_1")
-		(uuid "0197e343-6e46-41fa-896a-5fdf96ed8784")
-	)
-	(segment
-		(start 90.489388 115.780612)
-		(end 90.83 115.44)
-		(width 0.1)
-		(layer "F.Cu")
-		(net "VDD_HP_1")
-		(uuid "0e02f7f9-368c-4256-9e71-351f33498d69")
-	)
-	(segment
-		(start 88.51 115.78)
-		(end 88.510612 115.780612)
-		(width 0.1)
-		(layer "F.Cu")
-		(net "VDD_HP_1")
-		(uuid "282cdc7b-058a-488b-bd0a-c05453995fd7")
 	)
 	(zone
 		(net "Net-(CR1-Pad2)")


### PR DESCRIPTION
Follow-up hand edits from the LoRa V3 review (#692), applied to the other two boards.

> ⚠️ **This PR knowingly lands the rocket-computer PCB in a broken intermediate state — 252 DRC errors. Do not fabricate from the resulting revision.** Merged deliberately to get the work onto main; see the WIP commit below.

## `7a39c93` — CHIP_PU reset RC fix (complete)

The LoRa V3 review found Espressif's 10 k / 1 µF reset network drawn with the capacitor on the **supply** side of the pull-up, where it decouples the rail instead of delaying the pin. The same construction was on all three boards.

| board | change |
|---|---|
| base-station | C8 (1 µF): +3V3 → `Net-(U3-CHIP_PU)`, R1 reversed |
| rocket-computer | C25 (1 µF): +3V3 → `Net-(U15-CHIP_PU)`, R36 reversed |

With the cap on the supply side the only capacitance on the CHIP_PU node is the pin's own (~5 pF) — τ ≈ 50 ns, so CHIP_PU tracks the rail. On the pin, τ = 10 k × 1 µF = 10 ms, past Espressif's 50 µs t_STBL floor. **Closes the rocket-computer pre-fab review's H8.**

Verified by netlist export: `Net-(U3-CHIP_PU)` = {C8.1, R1.2, U3.4}, `Net-(U15-CHIP_PU)` = {C25.1, R36.2, U15.4}; component counts unchanged on both boards.

## `3c804d5` — JST VH battery input (**WIP, board not re-routed**)

Start of the fix for review blocker **B-3**: J7 is a JST PH rated 2 A/contact and is the sole battery input feeding an eFuse strapped for 14.7 A, against a 12–14 A servo-stall worst case.

**Done:** J8 added (`JST_B2P-VH`, 2-pos 3.96 mm, 10 A class) in `power.kicad_sch`, placed on B.Cu at (84.65, 125.59); J7 relocated (85.44,126.81) → (100.6,126.85) to clear space; L5 moved B.Cu → F.Cu; U13 (log flash) moved F.Cu → B.Cu; U11 and C56 shifted.

**Not done:** J8's pins are unwired — the netlist carries `unconnected-(J8-Pin_1-Pad1)` and `unconnected-(J8-Pin_2-Pad2)`, so **J7 is still the actual battery input**. The reworked region has not been re-routed.

**Measured impact** (`kicad-cli pcb drc --severity-error --schematic-parity`): **1 error → 252**. 60 `shorting_items`, 22 unconnected, 88 solder-mask bridges, 40 zone-clearance, 31 hole-clearance, 12 courtyard overlaps — all inside x 73.3–94.5, y 126.0–150.8, exactly the reworked area. Old traces from the moved parts now cross other nets: `M_MOSI` to J8's floating pad, `PYRO4_FIRE` to `OUT_SPI_CS0`, `GND` to `V_CAP`, others.

## `6189a1f` — project bookkeeping

`used_designators` gained FB1 after its value was set in #692.

## Note on CI

Only the `Docs` workflow applies here — every other workflow is path-filtered to `android/`, `ios/` or `tinkerrocket-idf/`. **Nothing in CI validates `hardware/`**, so a green check on this PR says nothing about the board. The DRC numbers above are the only gate.

## Next

Wire J8 (VBAT_Terminal / GND), decide J7's fate, re-route the region, re-run DRC to clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
