### PR TITLE
virtual rocket: teach the script fluent firmware — full voice callouts

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DemoMode.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DemoMode.kt
@@ -10,14 +10,12 @@ import com.tinkerbug.tinkerrocket.session.FleetSessionFactory
 import com.tinkerbug.tinkerrocket.session.KnownDeviceStorage
 import com.tinkerbug.tinkerrocket.session.KnownDeviceStore
 import com.tinkerbug.tinkerrocket.session.TransportFactory
+import com.tinkerbug.tinkerrocket.session.VirtualFlightScript
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
-import java.util.Locale
-import kotlin.math.max
-import kotlin.math.roundToInt
 
 /**
  * Virtual Rocket (né demo mode): the SAME fleet/session/UI stack over
@@ -96,15 +94,14 @@ private class DemoTransportFactory(
 }
 
 /**
- * READY idle at 1 Hz until SIM_START arrives, then ONE ~40 s flight at 5 Hz
- * (the script's first 12 s are the pad phase — a countdown after Launch);
- * SIM_STOP aborts back to READY.  Commands are read off
+ * READY idle at 1 Hz until SIM_START arrives, then ONE 42 s flight at 5 Hz —
+ * the frames come from [VirtualFlightScript] (shared with the announcer
+ * regression test; the script's first 12 s are a PRELAUNCH countdown after
+ * Launch).  SIM_STOP aborts back to READY.  Commands are read off
  * [FakeFirmware.commandFrames] by index — cheap polling at telemetry cadence.
  */
 private suspend fun runVirtualRocket(fw: FakeFirmware) {
-    // OK (01) at baro/imu/ekf/mag/gnss/batt/storage shifts; pyro NA (hidden).
-    val health = 0x100555
-    var maxAlt = 0f
+    val health = VirtualFlightScript.HEALTH
     var cmdCursor = 0
 
     fun sawCommand(id: Int): Boolean {
@@ -132,55 +129,12 @@ private suspend fun runVirtualRocket(fw: FakeFirmware) {
         }
 
         var aborted = false
-        for (tick in 0 until 200) {
+        for (tick in 0 until VirtualFlightScript.TICKS) {
             if (sawCommand(com.tinkerbug.tinkerrocket.protocol.BleCommandId.SIM_STOP)) {
                 aborted = true
                 break
             }
-            val t = tick / 5.0f    // seconds into the flight
-            val phase = when {
-                t < 12f -> "READY"
-                t < 14.5f -> "INFLIGHT"       // boost
-                t < 22f -> "INFLIGHT"         // coast
-                t < 36f -> "DESCENT"
-                else -> "LANDED"
-            }
-            val alt = when {
-                t < 12f -> 0f
-                t < 22f -> {
-                    val tt = t - 12f
-                    max(0f, 80f * tt - 4f * tt * tt)
-                }
-                t < 36f -> max(0f, 400f - (t - 22f) * 28f)
-                else -> 0f
-            }
-            maxAlt = max(maxAlt, alt)
-            var fs = 0x10 or 0x40                      // pwr on + logging
-            if (t >= 12f) fs = fs or 0x01              // launch
-            if (t >= 14.5f) fs = fs or 0x200           // burnout
-            if (t >= 22f) fs = fs or 0x02 or 0x04      // apogee votes
-            if (t >= 36f) fs = fs or 0x08              // landed
-            val vol = 8.2f - t * 0.004f
-            val sats = if (t < 2f) (t * 4).roundToInt() else 9
-            fw.emitTelemetryJson(
-                String.format(
-                    Locale.ROOT,
-                    """{"rid":1,"run":"Booster","st":"%s","fs":%d,"ps":%d,"h":%d,""" +
-                        """"nsat":%d,"vol":%.2f,"cur":%.1f,"soc":%.1f,"palt":%.1f,""" +
-                        """"malt":%.1f,"arate":%.1f,"lat":34.6572,"lon":-118.2015}""",
-                    phase, fs,
-                    0x00A or 0x080,        // ch1+ch4 continuity (demo)
-                    health, sats, vol,
-                    120f + (if (phase == "INFLIGHT") 900f else 0f),
-                    87f - t * 0.1f, alt, maxAlt,
-                    when {
-                        t in 12f..14.5f -> 95f
-                        t in 14.5f..22f -> 30f - (t - 14.5f) * 4f
-                        t in 22f..36f -> -28f
-                        else -> 0f
-                    },
-                ),
-            )
+            fw.emitTelemetryJson(VirtualFlightScript.frameJson(tick))
             // Second relayed rocket sits READY on the pad (1 Hz).
             if (tick % 5 == 0) {
                 fw.emitTelemetryJson(
@@ -188,7 +142,7 @@ private suspend fun runVirtualRocket(fw: FakeFirmware) {
                         """"h":$health,"nsat":8,"vol":8.31,"palt":0.4}""",
                 )
             }
-            delay(200)
+            delay(VirtualFlightScript.TICK_MS)
         }
         // Flight over or aborted: back to the READY idle above.  The sim
         // banner latch (DeviceSession) clears on the next READY frame; the
@@ -200,7 +154,6 @@ private suspend fun runVirtualRocket(fw: FakeFirmware) {
                     """"nsat":9,"vol":8.20,"palt":0.2}""",
             )
         }
-        maxAlt = 0f
     }
 }
 

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/VirtualFlightScript.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/VirtualFlightScript.kt
@@ -1,0 +1,95 @@
+package com.tinkerbug.tinkerrocket.session
+
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * The Virtual Rocket's canned flight, one JSON frame per tick — pure so the
+ * announcer regression test can replay the exact frames the demo emits
+ * (`VirtualFlightAnnouncerTest`).  iOS twin: `VirtualRocketDriver.flightFrameJSON`.
+ *
+ * The script speaks fluent firmware, because every consumer in the app keys
+ * off real conventions (voice-callout outage, 2026-07-30):
+ *  - The countdown phase is **PRELAUNCH** — the state a real FC arms through,
+ *    and the announcer's reset edge.  Without it the one-shot callout flags
+ *    stay latched from the previous flight and the second demo flight is mute.
+ *  - Descent is **INFLIGHT** + the apogee flag — there is no "DESCENT" state
+ *    in firmware, and both announcers gate descent callouts on INFLIGHT.
+ *  - **mspd** ramps to a stable max — burnout detection watches max-speed
+ *    stability, and ascent altitude callouts are gated behind burnout.
+ *  - The rocket **drifts east under canopy** so the landed callout has a real
+ *    horizontal distance (and the bearing arrow moves).
+ *
+ * Full callout sequence per flight: burnout ~15 s, altitude cadence to
+ * apogee at 22 s (400 m), descent callouts at 27 s and 37 s, landed at 38 s.
+ */
+public object VirtualFlightScript {
+
+    /** Frames per flight (42 s at 5 Hz: 12 s countdown, 10 s up, 16 s down). */
+    public const val TICKS: Int = 210
+
+    /** Telemetry cadence during the flight. */
+    public const val TICK_MS: Long = 200
+
+    /** Launch pad position (also the idle frames' fix). */
+    public const val PAD_LAT: Double = 34.6572
+    public const val PAD_LON: Double = -118.2015
+
+    /** OK (01) at baro/imu/ekf/mag/gnss/batt/storage shifts; pyro NA. */
+    public const val HEALTH: Int = 0x100555
+
+    /** The focused rocket's frame for `tick` (0 until [TICKS]). */
+    public fun frameJson(tick: Int): String {
+        val t = tick / 5.0f    // seconds into the flight
+        val phase = when {
+            t < 12f -> "PRELAUNCH"
+            t < 38f -> "INFLIGHT"
+            else -> "LANDED"
+        }
+        val alt = when {
+            t < 12f -> 0f
+            t < 22f -> {
+                val tt = t - 12f
+                max(0f, 80f * tt - 4f * tt * tt)   // apogee 400 m at t=22
+            }
+            t < 38f -> max(0f, 400f - (t - 22f) * 25f)
+            else -> 0f
+        }
+        // Running max the same way the FC reports it.
+        val maxAlt = when {
+            t < 12f -> 0f
+            t < 22f -> alt
+            else -> 400f
+        }
+        val maxSpeed = if (t < 12f) 0f else min(95f, (t - 12f) * 38f)
+        var fs = 0x10 or 0x40                      // pwr on + logging
+        if (t >= 12f) fs = fs or 0x01              // launch
+        if (t >= 14.5f) fs = fs or 0x200           // burnout
+        if (t >= 22f) fs = fs or (0x02 or 0x04)    // apogee votes
+        if (t >= 38f) fs = fs or 0x08              // landed
+        val rate = when {
+            t < 12f -> 0f
+            t < 14.5f -> 95f
+            t < 22f -> 30f - (t - 14.5f) * 4f
+            t < 38f -> -25f
+            else -> 0f
+        }
+        // ~73 m of easterly drift under canopy → "Landed. 75 meters away".
+        val lon = PAD_LON + 0.00005 * (min(t, 38f).coerceAtLeast(22f) - 22f)
+        return String.format(
+            Locale.ROOT,
+            """{"rid":1,"run":"Booster","st":"%s","fs":%d,"ps":%d,"h":%d,""" +
+                """"nsat":9,"vol":%.2f,"cur":%.1f,"soc":%.1f,"palt":%.1f,""" +
+                """"malt":%.1f,"arate":%.1f,"mspd":%.1f,"lat":%.6f,"lon":%.6f}""",
+            phase, fs,
+            0x00A or 0x080,        // ch1+ch4 continuity (demo)
+            HEALTH,
+            8.2f - t * 0.004f,
+            // High-rate logging draw until deployment drops the rate (#623).
+            120f + (if (t >= 12f && t < 22f) 900f else 0f),
+            87f - t * 0.1f, alt, maxAlt, rate, maxSpeed,
+            PAD_LAT, lon,
+        )
+    }
+}

--- a/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/VirtualFlightAnnouncerTest.kt
+++ b/TinkerRocketAndroid/core/session/src/test/kotlin/com/tinkerbug/tinkerrocket/session/VirtualFlightAnnouncerTest.kt
@@ -1,0 +1,100 @@
+package com.tinkerbug.tinkerrocket.session
+
+import com.tinkerbug.tinkerrocket.protocol.TelemetryData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Replays the EXACT Virtual Rocket frames ([VirtualFlightScript]) through the
+ * real announcer policy — the regression for the 2026-07-30 voice-callout
+ * outage, where the script spoke a dialect of firmware the announcer's gates
+ * couldn't hear:
+ *  - "DESCENT" isn't a firmware state (descent = INFLIGHT + alt_apo), so
+ *    every descent callout was skipped;
+ *  - `mspd` was never fed, so burnout never announced — and ascent altitude
+ *    callouts are gated behind burnout;
+ *  - no PRELAUNCH countdown, so the one-shot flags never reset and a SECOND
+ *    demo flight was completely mute.
+ *
+ * The script is replayed twice (with a READY idle frame between, as the demo
+ * loop does) and must produce the identical callout sequence both times.
+ * iOS twin: `VirtualRocketTests.testVirtualFlightScript_drivesFullCalloutSequence`.
+ */
+class VirtualFlightAnnouncerTest {
+
+    private class FakeSpeech : AnnouncerSpeech {
+        val spoken = mutableListOf<String>()
+        override var isBusy: Boolean = false
+        override fun speak(text: String, interrupt: Boolean) {
+            spoken += text
+        }
+        override fun stop() = Unit
+    }
+
+    private fun flyOnce(announcer: FlightAnnouncer, clock: (Long) -> Unit) {
+        for (tick in 0 until VirtualFlightScript.TICKS) {
+            clock(tick * VirtualFlightScript.TICK_MS)
+            val frame = TelemetryData.decode(VirtualFlightScript.frameJson(tick))
+                ?: fail("script frame $tick did not decode")
+            announcer.processTelemetry(frame)
+        }
+    }
+
+    @Test
+    fun `virtual flight drives the full callout sequence, twice`() {
+        val speech = FakeSpeech()
+        var nowMs = 0L
+        val announcer = FlightAnnouncer(
+            speech = speech,
+            initialEnabled = true,
+            clock = { nowMs },
+        )
+
+        val idleReady = TelemetryData.decode(
+            """{"rid":1,"run":"Booster","st":"READY","fs":16,"palt":0.2}""",
+        ) ?: fail("idle frame did not decode")
+
+        var flightBase = 0L
+        repeat(2) { flight ->
+            val startCount = speech.spoken.size
+            flyOnce(announcer) { offset -> nowMs = flightBase + offset }
+            val calls = speech.spoken.drop(startCount)
+
+            // One-shots: exactly one each, in flight order.
+            assertEquals(1, calls.count { it.startsWith("Burnout") }, "flight $flight: $calls")
+            assertEquals(1, calls.count { it.startsWith("Apogee") }, "flight $flight: $calls")
+            assertEquals(1, calls.count { it.startsWith("Landed") }, "flight $flight: $calls")
+            assertTrue(
+                calls.first().startsWith("Burnout"),
+                "nothing may speak before burnout (flight $flight): $calls",
+            )
+            assertTrue(calls.last().startsWith("Landed"), "flight $flight: $calls")
+
+            // Apogee altitude reaches the callout (script max = 400 m).
+            val apogee = calls.first { it.startsWith("Apogee") }
+            assertTrue("400" in apogee, apogee)
+
+            // Descent cadence: first 5 s after apogee, then every 10 s — the
+            // 16 s descent yields exactly two, both saying "descending".
+            val descent = calls.filter { "descending" in it }
+            assertEquals(2, descent.size, "flight $flight: $calls")
+
+            // Ascent altitude cadence between burnout and apogee, climbing.
+            val apogeeIx = calls.indexOfFirst { it.startsWith("Apogee") }
+            val ascent = calls.subList(1, apogeeIx)
+            assertTrue(ascent.isNotEmpty(), "flight $flight: $calls")
+            assertTrue(ascent.all { "climbing" in it }, "flight $flight: $calls")
+
+            // The drift under canopy gives the landed callout a distance.
+            assertTrue("away" in calls.last(), calls.last())
+
+            // Back to the READY idle, then the next flight's PRELAUNCH edge
+            // must reset the one-shots (the second-flight-mute regression).
+            nowMs = flightBase + VirtualFlightScript.TICKS * VirtualFlightScript.TICK_MS
+            announcer.processTelemetry(idleReady)
+            flightBase = nowMs + 5_000
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -352,6 +352,24 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         simSawNonReady = false
     }
 
+    /// Drop the SIM MODE banner once a launched sim's flight completes: arm
+    /// on the first non-READY state, clear on the return to READY.  Called
+    /// for direct-rocket frames AND the focused rocket's relayed frames —
+    /// on a base-station link the sim runs relay-wrapped (#390), and the
+    /// latch used to only clear on the direct path, leaving the banner
+    /// stuck after every relayed sim flight (found via the Virtual Rocket,
+    /// which is a BS; Android's latch already watches the focused stream).
+    private func updateSimBannerLatch(_ t: TelemetryData) {
+        guard simLaunched else { return }
+        if t.state != "READY" && t.state != "INITIALIZATION" {
+            simSawNonReady = true
+        }
+        if simSawNonReady && t.state == "READY" {
+            simLaunched = false
+            simSawNonReady = false
+        }
+    }
+
     // MARK: - Commands
 
     /// Wire-tap for outgoing commands.  The Virtual Rocket driver is the
@@ -1800,6 +1818,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                     key: RocketKey(networkID: networkID, rocketID: rocketID))
 
                 if rocketID == focusRocketID {
+                    self.updateSimBannerLatch(newTelemetry)
                     self.telemetry = newTelemetry
                     // Mirror the latched fix (#140).  Only assign when the
                     // cache returns a non-nil value so a GPS-less packet
@@ -1816,15 +1835,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 return
             }
 
-            if self.simLaunched {
-                if newTelemetry.state != "READY" && newTelemetry.state != "INITIALIZATION" {
-                    self.simSawNonReady = true
-                }
-                if self.simSawNonReady && newTelemetry.state == "READY" {
-                    self.simLaunched = false
-                    self.simSawNonReady = false
-                }
-            }
+            self.updateSimBannerLatch(newTelemetry)
             self.telemetry = newTelemetry
             // #159: the rocket has finished flushing and powered on — drop the
             // Power On button's busy state.  Guarded so we don't republish on

--- a/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift
@@ -390,7 +390,16 @@ final class SystemSpeech: NSObject, AnnouncerSpeech, AVSpeechSynthesizerDelegate
     var onStatusChange: (() -> Void)?
 
     private var speaking = false
-    var isBusy: Bool { speaking }
+    private var speakingSince = Date.distantPast
+    /// didFinish/didCancel normally clear `speaking`, but if the delegate
+    /// callback is lost (audio session dying mid-utterance) a latched value
+    /// would make the policy skip every skippable callout for the rest of
+    /// the flight.  No utterance runs anywhere near this long — treat an
+    /// older claim as stale rather than staying mute.
+    private static let busyStaleAfter: TimeInterval = 15
+    var isBusy: Bool {
+        speaking && Date().timeIntervalSince(speakingSince) < Self.busyStaleAfter
+    }
 
     override init() {
         super.init()
@@ -442,6 +451,7 @@ final class SystemSpeech: NSObject, AnnouncerSpeech, AVSpeechSynthesizerDelegate
         utterance.postUtteranceDelay = 0.1
 
         speaking = true
+        speakingSince = Date()
         synthesizer.speak(utterance)
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/VirtualRocket.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/VirtualRocket.swift
@@ -7,7 +7,7 @@ import Foundation
 ///
 /// Behavior converged with Android's `DemoMode.kt`, frame for frame: the
 /// virtual base station relays a "Booster" that idles in READY like a real
-/// rocket and flies ONE canned ~40 s flight per SIM_START — the standard
+/// rocket and flies ONE canned 42 s flight per SIM_START — the standard
 /// Simulation sheet is the start control, exactly the ritual a real rocket
 /// uses — honoring SIM_STOP mid-flight.  A second relayed rocket sits on the
 /// pad so the roster and focus-switching are demonstrable.
@@ -70,7 +70,82 @@ final class VirtualRocketDriver {
     }
 
     // OK (01) at baro/imu/ekf/mag/gnss/batt/storage shifts; pyro NA (hidden).
-    private let health = 0x100555
+    static let health = 0x100555
+
+    /// Frames per flight (42 s at 5 Hz: 12 s countdown, 10 s up, 16 s down).
+    static let flightTicks = 210
+    /// Telemetry cadence during the flight, seconds.
+    static let flightTickSeconds = 0.2
+
+    /// The focused rocket's frame for `tick` — pure, so the announcer
+    /// regression test can replay the exact frames the demo emits
+    /// (`testVirtualFlightScript_drivesFullCalloutSequence`).  Android twin:
+    /// `VirtualFlightScript.frameJson` — keep them converged frame for frame.
+    ///
+    /// The script speaks fluent firmware, because every consumer keys off
+    /// real conventions (voice-callout outage, 2026-07-30):
+    ///  - The countdown is **PRELAUNCH** — the state a real FC arms through,
+    ///    and the announcer's reset edge; without it the one-shot callout
+    ///    flags stay latched and a SECOND demo flight is mute.
+    ///  - Descent is **INFLIGHT** + the apogee flag — firmware has no
+    ///    "DESCENT" state, and the announcer gates descent callouts on
+    ///    INFLIGHT.
+    ///  - **mspd** ramps to a stable max — burnout detection watches
+    ///    max-speed stability, and ascent altitude callouts gate on burnout.
+    ///  - The rocket **drifts east under canopy** so the landed callout has
+    ///    a real horizontal distance (and the bearing arrow moves).
+    ///
+    /// Callouts per flight: burnout ~15 s, altitude cadence to apogee at
+    /// 22 s (400 m), descent at 27 s and 37 s, landed at 38 s.
+    static func flightFrameJSON(tick: Int) -> String {
+        let t = Double(tick) / 5.0
+        let phase: String
+        switch t {
+        case ..<12: phase = "PRELAUNCH"
+        case ..<38: phase = "INFLIGHT"
+        default:    phase = "LANDED"
+        }
+        let alt: Double
+        switch t {
+        case ..<12: alt = 0
+        case ..<22:
+            let tt = t - 12
+            alt = max(0, 80 * tt - 4 * tt * tt)   // apogee 400 m at t=22
+        case ..<38: alt = max(0, 400 - (t - 22) * 25)
+        default:    alt = 0
+        }
+        // Running max the same way the FC reports it.
+        let maxAlt = t < 12 ? 0 : (t < 22 ? alt : 400)
+        let maxSpeed = t < 12 ? 0 : min(95, (t - 12) * 38)
+        var fs = 0x10 | 0x40                      // pwr on + logging
+        if t >= 12 { fs |= 0x01 }                 // launch
+        if t >= 14.5 { fs |= 0x200 }              // burnout
+        if t >= 22 { fs |= 0x02 | 0x04 }          // apogee votes
+        if t >= 38 { fs |= 0x08 }                 // landed
+        let rate: Double
+        switch t {
+        case ..<12:   rate = 0
+        case ..<14.5: rate = 95
+        case ..<22:   rate = 30 - (t - 14.5) * 4
+        case ..<38:   rate = -25
+        default:      rate = 0
+        }
+        // ~73 m of easterly drift under canopy → "Landed. 75 meters away".
+        let lon = -118.2015 + 0.00005 * (max(22, min(t, 38)) - 22)
+        return String(
+            format: """
+                {"rid":1,"run":"Booster","st":"%@","fs":%d,"ps":%d,"h":%d,\
+                "nsat":9,"vol":%.2f,"cur":%.1f,"soc":%.1f,"palt":%.1f,\
+                "malt":%.1f,"arate":%.1f,"mspd":%.1f,"lat":%.6f,"lon":%.6f}
+                """,
+            phase, fs, 0x00A | 0x080, health,
+            8.2 - t * 0.004,
+            // High-rate logging draw until deployment drops the rate (#623).
+            120 + (t >= 12 && t < 22 ? 900.0 : 0.0),
+            87 - t * 0.1, alt, maxAlt, rate, maxSpeed,
+            34.6572, lon
+        )
+    }
 
     private func run() async {
         while !Task.isCancelled {
@@ -79,73 +154,30 @@ final class VirtualRocketDriver {
             while !startRequested && !Task.isCancelled {
                 feed("""
                     {"rid":1,"run":"Booster","st":"READY","fs":16,"ps":\(0x00A | 0x080),\
-                    "h":\(health),"nsat":9,"vol":8.20,"soc":87.0,"palt":0.2,\
+                    "h":\(Self.health),"nsat":9,"vol":8.20,"soc":87.0,"palt":0.2,\
                     "lat":34.6572,"lon":-118.2015}
                     """)
                 feed("""
                     {"rid":2,"run":"Pad Rocket","st":"READY","fs":16,"ps":2,\
-                    "h":\(health),"nsat":8,"vol":8.31,"palt":0.4}
+                    "h":\(Self.health),"nsat":8,"vol":8.31,"palt":0.4}
                     """)
                 await sleep(1.0)
             }
             if Task.isCancelled { return }
 
-            // One flight: 200 ticks at 5 Hz (12 s pad countdown, boost,
-            // coast, apogee, descent, landed) — SIM_STOP aborts to READY.
+            // One flight off the shared script — SIM_STOP aborts to READY.
             stopRequested = false
-            var maxAlt: Double = 0
-            for tick in 0..<200 {
+            for tick in 0..<Self.flightTicks {
                 if Task.isCancelled { return }
                 if stopRequested { break }
-                let t = Double(tick) / 5.0
-                let phase: String
-                switch t {
-                case ..<12: phase = "READY"
-                case ..<22: phase = "INFLIGHT"
-                case ..<36: phase = "DESCENT"
-                default:    phase = "LANDED"
-                }
-                let alt: Double
-                switch t {
-                case ..<12: alt = 0
-                case ..<22:
-                    let tt = t - 12
-                    alt = max(0, 80 * tt - 4 * tt * tt)
-                case ..<36: alt = max(0, 400 - (t - 22) * 28)
-                default:    alt = 0
-                }
-                maxAlt = max(maxAlt, alt)
-                var fs = 0x10 | 0x40                      // pwr on + logging
-                if t >= 12 { fs |= 0x01 }                 // launch
-                if t >= 14.5 { fs |= 0x200 }              // burnout
-                if t >= 22 { fs |= 0x02 | 0x04 }          // apogee votes
-                if t >= 36 { fs |= 0x08 }                 // landed
-                let rate: Double
-                switch t {
-                case 12..<14.5: rate = 95
-                case 14.5..<22: rate = 30 - (t - 14.5) * 4
-                case 22..<36:   rate = -28
-                default:        rate = 0
-                }
-                let frame = String(
-                    format: """
-                        {"rid":1,"run":"Booster","st":"%@","fs":%d,"ps":%d,"h":%d,\
-                        "nsat":9,"vol":%.2f,"cur":%.1f,"soc":%.1f,"palt":%.1f,\
-                        "malt":%.1f,"arate":%.1f,"lat":34.6572,"lon":-118.2015}
-                        """,
-                    phase, fs, 0x00A | 0x080, health,
-                    8.2 - t * 0.004,
-                    120 + (phase == "INFLIGHT" ? 900.0 : 0.0),
-                    87 - t * 0.1, alt, maxAlt, rate
-                )
-                feed(frame)
+                feed(Self.flightFrameJSON(tick: tick))
                 if tick % 5 == 0 {
                     feed("""
                         {"rid":2,"run":"Pad Rocket","st":"READY","fs":16,"ps":2,\
-                        "h":\(health),"nsat":8,"vol":8.31,"palt":0.4}
+                        "h":\(Self.health),"nsat":8,"vol":8.31,"palt":0.4}
                         """)
                 }
-                await sleep(0.2)
+                await sleep(Self.flightTickSeconds)
             }
             // Flight over or aborted: loop back to the READY idle, like a
             // real rocket after touchdown + reset.

--- a/TinkerRocketApp/TinkerRocketAppTests/VirtualRocketTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/VirtualRocketTests.swift
@@ -71,4 +71,70 @@ final class VirtualRocketTests: XCTestCase {
         try await waitUntil("aborted to READY") { device.telemetry.state == "READY" }
         XCTAssertFalse(device.telemetry.landed_flag, "aborted flight never landed")
     }
+
+    /// Replays the EXACT Virtual Rocket frames through the real announcer
+    /// policy — the regression for the 2026-07-30 voice-callout outage,
+    /// where the script spoke a dialect of firmware the announcer's gates
+    /// couldn't hear ("DESCENT" isn't a firmware state; `mspd` was never
+    /// fed so burnout — and the ascent altitude cadence gated behind it —
+    /// never fired; no PRELAUNCH edge, so the one-shot flags never reset
+    /// and a SECOND flight was completely mute).  Two replays, identical
+    /// callouts each.  Android twin: `VirtualFlightAnnouncerTest`.
+    func testVirtualFlightScript_drivesFullCalloutSequence() throws {
+        let spy = FlightAnnouncerPolicyTests.SpySpeech()
+        let clock = FlightAnnouncerPolicyTests.Clock()
+        let announcer = FlightAnnouncer(speech: spy, now: { clock.t },
+                                        unitSystem: { .metric },
+                                        persistEnabled: false)
+        announcer.isEnabled = true
+        spy.spoken.removeAll()   // drop the "Voice ready" confirmation
+
+        let decoder = JSONDecoder()
+        let idleReady = try decoder.decode(
+            TelemetryData.self,
+            from: Data(#"{"rid":1,"run":"Booster","st":"READY","fs":16,"palt":0.2}"#.utf8))
+
+        for flight in 0..<2 {
+            let startCount = spy.spoken.count
+            for tick in 0..<VirtualRocketDriver.flightTicks {
+                clock.t = clock.t.addingTimeInterval(VirtualRocketDriver.flightTickSeconds)
+                let json = VirtualRocketDriver.flightFrameJSON(tick: tick)
+                let frame = try decoder.decode(TelemetryData.self, from: Data(json.utf8))
+                announcer.processTelemetry(frame)
+            }
+            let calls = spy.texts.dropFirst(startCount)
+
+            // One-shots: exactly one each, in flight order.
+            XCTAssertEqual(calls.filter { $0.hasPrefix("Burnout") }.count, 1, "flight \(flight): \(calls)")
+            XCTAssertEqual(calls.filter { $0.hasPrefix("Apogee") }.count, 1, "flight \(flight): \(calls)")
+            XCTAssertEqual(calls.filter { $0.hasPrefix("Landed") }.count, 1, "flight \(flight): \(calls)")
+            XCTAssertTrue(calls.first?.hasPrefix("Burnout") ?? false,
+                          "nothing may speak before burnout (flight \(flight)): \(calls)")
+            XCTAssertTrue(calls.last?.hasPrefix("Landed") ?? false, "flight \(flight): \(calls)")
+
+            // Apogee altitude reaches the callout (script max = 400 m).
+            let apogee = calls.first { $0.hasPrefix("Apogee") } ?? ""
+            XCTAssertTrue(apogee.contains("400"), apogee)
+
+            // Descent cadence: first 5 s after apogee, then every 10 s — the
+            // 16 s descent yields exactly two, both saying "descending".
+            XCTAssertEqual(calls.filter { $0.contains("descending") }.count, 2,
+                           "flight \(flight): \(calls)")
+
+            // Ascent altitude cadence between burnout and apogee, climbing.
+            let ordered = Array(calls)
+            let apogeeIx = ordered.firstIndex { $0.hasPrefix("Apogee") } ?? 1
+            let ascent = ordered.isEmpty ? [] : Array(ordered[1..<max(apogeeIx, 1)])
+            XCTAssertFalse(ascent.isEmpty, "flight \(flight): \(calls)")
+            XCTAssertTrue(ascent.allSatisfy { $0.contains("climbing") }, "flight \(flight): \(calls)")
+
+            // The drift under canopy gives the landed callout a distance.
+            XCTAssertTrue(calls.last?.contains("away") ?? false, "\(calls.last ?? "")")
+
+            // Back to READY idle, then the next flight's PRELAUNCH edge must
+            // reset the one-shots (the second-flight-mute regression).
+            clock.advance(5)
+            announcer.processTelemetry(idleReady)
+        }
+    }
 }

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,068 lines across 68 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,121 lines across 68 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -29,11 +29,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 32 files, 11,766 lines
+## `Models/` — 32 files, 11,819 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 1,969 | `BLEDeviceType`, `BLEDevice` |
+| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 1,980 | `BLEDeviceType`, `BLEDevice` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published per-device state · Device identity (populated from config_identity readback) · Internal state · Init · Connection lifecycle (called by BLEFleet) · BLE RSSI Polling · Sim state · Commands · OTA helpers (#8 phase 2) · Magnetometer hard-iron calibration (issue #96) · Identity commands · File operations · File chunk handling (private) · CSV Generation · Download State Management · CBPeripheralDelegate · Telemetry parsing |
 | [SensorTypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift) | 988 | `MessageType`, `RocketState`, `ParseError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
@@ -42,7 +42,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
 | [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 572 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Virtual Rocket (iOS twin of Android demo mode, 2026-07-30) · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
-| [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 548 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
+| [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 558 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Seams · Private State · Constants · Init · Main Entry Point · Event Detectors · Horizontal Distance · Speak policy · State Reset · Production speech engine |
 | [SensorConverter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift) | 529 | — |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Rotation Configuration · GNSS Conversion · Power Conversion · BMP585 Conversion · ISM6HG256 Conversion · MMC5983MA Conversion · IIS2MDC Conversion (new Mini PCB rev) · Legacy Sensor Conversions · Mini NonSensor Conversion |
@@ -62,8 +62,8 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [CSVParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVParser.swift) | 271 | `FlightCSVData`, `CSVParserError`, `CSVParser` |
 | [UnitFormatter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift) | 204 | `UnitSystem`, `UnitFormatter` |
 | [RocketRoster.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketRoster.swift) | 197 | `RocketKey`, `RocketFreshness`, `RelayPath`, `RocketCommandLink`, `RocketSubject`, `RocketRoster` |
+| [VirtualRocket.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/VirtualRocket.swift) | 186 | `VirtualRocketDriver` |
 | [MagCalCells.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MagCalCells.swift) | 161 | `MagCalCells` |
-| [VirtualRocket.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/VirtualRocket.swift) | 154 | `VirtualRocketDriver` |
 | [MessageParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MessageParser.swift) | 151 | — |
 | [LocationManager.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift) | 109 | `LocationManager` |
 | [StorageStats.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift) | 89 | `RocketStorageStats`, `BaseStationStorageStats` |
@@ -120,4 +120,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 68 files, 26,068 lines.
+Total: 68 files, 26,121 lines.


### PR DESCRIPTION
User report: voice during the virtual flight only called out apogee and landing. Root cause on **both platforms** (the scripts were converged frame for frame — flaws included): the demo spoke a dialect of firmware the announcer's gates couldn't hear.

- **"DESCENT" isn't a firmware state** (descent = INFLIGHT + alt_apo) and both announcers gate descent callouts on `state == INFLIGHT` → every descent call skipped.
- **`mspd` never fed** → burnout couldn't announce, and the ascent altitude cadence is gated behind burnout → silent all the way up. That early silence is also the likely story behind "had to toggle voice to get anything" — there was nothing to hear until apogee.
- **No PRELAUNCH countdown** → the announcer's reset edge never fired → a SECOND virtual flight was completely mute (latent, would have bitten next).

The script now arms through PRELAUNCH, flies INFLIGHT to touchdown, ramps `mspd`, stretches descent to 16 s (two descent callouts), and drifts ~73 m under canopy so "Landed" reports a real distance. Shared shape via a pure per-tick frame generator on each platform (`VirtualFlightScript` / `flightFrameJSON`), pinned by a per-platform regression test that replays the EXACT demo frames through the real announcer policy — twice.

Adjacent iOS fixes from the same dig: the SIM MODE banner latch now clears on relayed (BS-link) sim flights, not just direct links (Android already did); `SystemSpeech.isBusy` gets a 15 s staleness floor so a lost `didFinish` can't mute every skippable callout (Android's engine already clears busy on error).

Simulator-verified live — full transcript: Burnout 95 m/s → 384 m climbing → Apogee 400 m → 280 m descending → 40 m descending → "Landed. 73 meters away", dashboard back to READY, no stuck banner. iOS 324/324; Android :core:session green.

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)