### PR TITLE
android: white circle chip under the Tinkerbug logo

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ScannerScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -45,6 +46,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -139,11 +142,21 @@ fun ScannerScreen(
                 }
             }
             Spacer(Modifier.weight(1f))
-            Image(
-                painterResource(R.drawable.tinkerbug_logo),
-                contentDescription = "Tinkerbug Robotics",
-                modifier = Modifier.height(30.dp),
-            )
+            // White circle chip like the iOS toolbar — the purple bug is
+            // invisible straight on a dark background.
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .shadow(2.dp, CircleShape)
+                    .background(Color.White, CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painterResource(R.drawable.tinkerbug_logo),
+                    contentDescription = "Tinkerbug Robotics",
+                    modifier = Modifier.height(28.dp),
+                )
+            }
         }
 
         Text("TinkerRocket", fontSize = 34.sp, fontWeight = FontWeight.Bold)


### PR DESCRIPTION
The purple bug was invisible against the dark theme (user report). Same treatment as the iOS toolbar: a white 40 dp circle with a soft shadow behind the logo, readable on both themes. Verified on the Pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)