### PR TITLE
android: Google Satellite online basemap via Map Tiles API (offline stays USGS)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -49,6 +49,9 @@ jobs:
           TR_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.TR_ANDROID_KEYSTORE_PASSWORD }}
           TR_ANDROID_KEY_ALIAS: ${{ secrets.TR_ANDROID_KEY_ALIAS }}
           TR_ANDROID_KEY_PASSWORD: ${{ secrets.TR_ANDROID_KEY_PASSWORD }}
+          # Google Map Tiles key — releases must carry the Google Satellite
+          # basemap; without this secret the picker silently omits it.
+          TR_ANDROID_MAPS_API_KEY: ${{ secrets.TR_ANDROID_MAPS_API_KEY }}
         run: ./gradlew --no-daemon :app:assembleRelease
         working-directory: TinkerRocketAndroid
 

--- a/TinkerRocketAndroid/app/build.gradle.kts
+++ b/TinkerRocketAndroid/app/build.gradle.kts
@@ -20,10 +20,23 @@ android {
         // installs both key on it); bump BOTH before tagging android-v<name>.
         versionCode = 5
         versionName = "1.0.1"
+
+        // Google Map Tiles API key (online-only satellite basemap).  Same
+        // env-var discipline as release signing below: never in the repo;
+        // forks without it just don't get the Google source in the picker.
+        // A client-side Maps key necessarily ships in the APK — it is
+        // API-restricted server-side to the Map Tiles API only.
+        buildConfigField(
+            "String",
+            "TR_MAPS_API_KEY",
+            "\"${System.getenv("TR_ANDROID_MAPS_API_KEY").orEmpty()}\"",
+        )
     }
 
     buildFeatures {
         compose = true
+        // For the Maps key constant below — AGP 9 defaults buildConfig off.
+        buildConfig = true
     }
 
     // Release signing (plan §2.5): source is public, the key is not.  The
@@ -81,6 +94,9 @@ dependencies {
     // (plan §1 Maps row — Google Maps ToS forbids tile caching; MapLibre's
     // own OfflineManager is evictable SQLite, the silent-data-loss iOS
     // designed around).  Pinned per the dependency policy.
+    // Google satellite (Map Tiles API) later joined as an ONLINE-ONLY
+    // source riding the same proxy, never cached — offline stays USGS, so
+    // the ToS objection above doesn't apply to it.
     implementation("org.maplibre.gl:android-sdk:11.8.8")
 
     // Phone GPS for direction/distance-to-rocket (fused provider; Pixel/GMS).

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
@@ -115,7 +115,22 @@ class AppContainer(app: Application) {
     val tileCache = com.tinkerbug.tinkerrocket.maps.OfflineTileCache(
         File(app.noBackupFilesDir, "OfflineTiles"),
     )
-    val tileProxy = com.tinkerbug.tinkerrocket.maps.TileProxyServer(tileCache).apply { start() }
+    // Google satellite (Map Tiles API) is the online-only extra basemap:
+    // keyed builds offer it in the picker; keyless forks never construct
+    // the upstream and the picker skips it.  The proxy never lets these
+    // tiles near the offline cache (provider terms) — offline stays USGS.
+    val googleMapsAvailable: Boolean =
+        com.tinkerbug.tinkerrocket.BuildConfig.TR_MAPS_API_KEY.isNotEmpty()
+    val tileProxy = com.tinkerbug.tinkerrocket.maps.TileProxyServer(
+        tileCache,
+        googleUpstream = if (googleMapsAvailable) {
+            com.tinkerbug.tinkerrocket.maps.GoogleTileUpstream(
+                com.tinkerbug.tinkerrocket.BuildConfig.TR_MAPS_API_KEY,
+            )
+        } else {
+            null
+        },
+    ).apply { start() }
     // Saved-region manifest lives beside the tile tree (iOS: App Support root).
     val regionStore = com.tinkerbug.tinkerrocket.maps.OfflineRegionStore(app.noBackupFilesDir, tileCache)
 

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
@@ -138,7 +138,13 @@ class AppContainer(app: Application) {
         tileCache,
         googleUpstream = if (googleMapsAvailable) {
             com.tinkerbug.tinkerrocket.maps.GoogleTileUpstream(
-                com.tinkerbug.tinkerrocket.BuildConfig.TR_MAPS_API_KEY,
+                apiKey = com.tinkerbug.tinkerrocket.BuildConfig.TR_MAPS_API_KEY,
+                // App-attestation for the Android-restricted key: computed
+                // from whatever cert actually signed THIS apk, so debug and
+                // release builds each present their own fingerprint (both
+                // are enrolled in the key's console restriction).
+                appPackage = app.packageName,
+                appCertSha1 = signingCertSha1(app),
             )
         } else {
             null
@@ -146,6 +152,24 @@ class AppContainer(app: Application) {
     ).apply { start() }
     // Saved-region manifest lives beside the tile tree (iOS: App Support root).
     val regionStore = com.tinkerbug.tinkerrocket.maps.OfflineRegionStore(app.noBackupFilesDir, tileCache)
+
+    /**
+     * SHA-1 of this APK's signing certificate, uppercase hex without
+     * separators — the X-Android-Cert format Google validates against the
+     * Maps key's "Android apps" restriction.
+     */
+    private fun signingCertSha1(app: Application): String? = runCatching {
+        @Suppress("DEPRECATION")
+        val info = app.packageManager.getPackageInfo(
+            app.packageName,
+            android.content.pm.PackageManager.GET_SIGNING_CERTIFICATES,
+        )
+        val signer = info.signingInfo?.apkContentsSigners?.firstOrNull()
+            ?: return@runCatching null
+        java.security.MessageDigest.getInstance("SHA-1")
+            .digest(signer.toByteArray())
+            .joinToString("") { "%02X".format(it) }
+    }.getOrNull()
 
     val fleet: FleetManager<DeviceSession> = run {
         lateinit var fleetRef: FleetManager<DeviceSession>

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt
@@ -109,6 +109,19 @@ class AppContainer(app: Application) {
             )
         }
 
+    // MapLibre keeps its own on-disk HTTP/tile cache (mbgl-offline.db) and
+    // its native Cache-Control parser ignores no-store — left enabled it
+    // would persist Google satellite tiles (forbidden by provider terms)
+    // and shadow the proxy's cache semantics.  ALL intended caching lives
+    // in OfflineTileCache, so kill the ambient cache: purge anything ever
+    // stored, then cap it at zero.
+    init {
+        org.maplibre.android.MapLibre.getInstance(app)
+        val offline = org.maplibre.android.offline.OfflineManager.getInstance(app)
+        offline.clearAmbientCache(null)
+        offline.setMaximumAmbientCacheSize(0, null)
+    }
+
     // Offline maps: flat-file cache in noBackupFilesDir (never OS-purged,
     // never backed up — field data must survive storage pressure) + the
     // localhost read-through proxy MapLibre's raster sources fetch from.

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MapScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MapScreen.kt
@@ -79,6 +79,8 @@ fun MapScreen(
     session: DeviceSession?,
     predictor: LandingPredictor? = null,
     phoneLocation: PhoneLocationManager? = null,
+    /** True when the build carries a Map Tiles API key (AppContainer). */
+    googleAvailable: Boolean = false,
 ) {
     // Phone dot runs with the map (ref-counted manager).
     if (phoneLocation != null) {
@@ -114,8 +116,10 @@ fun MapScreen(
     var source by remember { mutableStateOf(TileSource.USGS_IMAGERY_TOPO) }
     // Basemap-decision (plan §8 #2): USGS raster = DEFAULT + the only
     // offline/cacheable path; OpenFreeMap Liberty (keyless vector, ODbL)
-    // is the online-only option for international browsing.
+    // and Google Satellite (Map Tiles API, key'd builds) are the
+    // online-only options.
     var openFreeMap by remember { mutableStateOf(false) }
+    var googleAttribution by remember { mutableStateOf<String?>(null) }
     var follow by remember { mutableStateOf(true) }
 
     // The map handle once ready; state so recomposition sees it.
@@ -238,9 +242,22 @@ fun MapScreen(
                     }
                     source == TileSource.USGS_IMAGERY_TOPO -> source = TileSource.USGS_TOPO
                     source == TileSource.USGS_TOPO -> source = TileSource.USGS_IMAGERY
-                    else -> openFreeMap = true
+                    source == TileSource.USGS_IMAGERY && googleAvailable ->
+                        source = TileSource.GOOGLE_SATELLITE
+                    else -> {
+                        source = TileSource.USGS_IMAGERY_TOPO
+                        openFreeMap = true
+                    }
                 }
-            }) { Text(if (openFreeMap) "OpenFreeMap (online)" else source.displayName) }
+            }) {
+                Text(
+                    when {
+                        openFreeMap -> "OpenFreeMap (online)"
+                        source == TileSource.GOOGLE_SATELLITE -> "Google Satellite (online)"
+                        else -> source.displayName
+                    },
+                )
+            }
             if (!follow) {
                 OutlinedButton(onClick = {
                     follow = true
@@ -261,11 +278,25 @@ fun MapScreen(
         ) {
             Row {
                 Text(
-                    if (openFreeMap) OPENFREEMAP_ATTRIBUTION else TileSource.ATTRIBUTION,
+                    when {
+                        openFreeMap -> OPENFREEMAP_ATTRIBUTION
+                        source == TileSource.GOOGLE_SATELLITE ->
+                            googleAttribution?.let { "Google · $it" }
+                                ?: TileSource.GOOGLE_ATTRIBUTION
+                        else -> TileSource.ATTRIBUTION
+                    },
                     style = MaterialTheme.typography.labelSmall,
                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
                 )
             }
+        }
+    }
+
+    // Map Tiles display policy wants the live copyright string alongside the
+    // Google name; the proxy memoizes it — fetch when the source comes up.
+    LaunchedEffect(source, mapRef) {
+        if (source == TileSource.GOOGLE_SATELLITE && googleAttribution == null) {
+            googleAttribution = fetchGoogleAttribution(proxy)
         }
     }
 
@@ -283,6 +314,27 @@ fun MapScreen(
 private const val OPENFREEMAP_STYLE_URI = "https://tiles.openfreemap.org/styles/liberty"
 private const val OPENFREEMAP_ATTRIBUTION =
     "OpenFreeMap · © OpenMapTiles · © OpenStreetMap contributors"
+
+/** Live Google copyright via the proxy's memoized /meta route. */
+private suspend fun fetchGoogleAttribution(proxy: TileProxyServer): String? =
+    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        runCatching {
+            val conn = java.net.URL(
+                "http://127.0.0.1:${proxy.port}/meta/googleSatellite/attribution",
+            ).openConnection() as java.net.HttpURLConnection
+            conn.connectTimeout = 5_000
+            conn.readTimeout = 10_000
+            try {
+                if (conn.responseCode == 200) {
+                    conn.inputStream.readBytes().decodeToString()
+                } else {
+                    null
+                }
+            } finally {
+                conn.disconnect()
+            }
+        }.getOrNull()
+    }
 
 private const val ROCKET_SOURCE = "rocket-src"
 private const val ROCKET_LAYER = "rocket-layer"

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MapScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MapScreen.kt
@@ -160,6 +160,15 @@ fun MapScreen(
             Style.Builder().fromJson(rasterStyleJson(proxy, source))
         }
         map.setStyle(builder) { style ->
+            if (!openFreeMap && !source.cacheable) {
+                // Online-only source: MapLibre's native Cache-Control parser
+                // reads only max-age/must-revalidate, so the proxy's
+                // no-store alone would NOT keep tiles out of the on-disk
+                // ambient cache — volatile is the per-source "never
+                // persist" switch.  The ambient cache is also disabled
+                // app-wide in AppContainer; this is defense in depth.
+                style.getSource("usgs")?.isVolatile = true
+            }
             installPredictionLayers(style, prediction)
             installPhoneDot(style, phoneFix)
             installRocketMarker(style, fix?.latitude, fix?.longitude)
@@ -293,10 +302,13 @@ fun MapScreen(
     }
 
     // Map Tiles display policy wants the live copyright string alongside the
-    // Google name; the proxy memoizes it — fetch when the source comes up.
-    LaunchedEffect(source, mapRef) {
-        if (source == TileSource.GOOGLE_SATELLITE && googleAttribution == null) {
+    // Google name; the proxy memoizes it.  Keep retrying while the source is
+    // active — a first fetch racing a slow createSession must not pin the
+    // static fallback for the whole session.  Cancelled on source switch.
+    LaunchedEffect(source) {
+        while (source == TileSource.GOOGLE_SATELLITE && googleAttribution == null) {
             googleAttribution = fetchGoogleAttribution(proxy)
+            if (googleAttribution == null) kotlinx.coroutines.delay(10_000)
         }
     }
 

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/OfflineMapsScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/OfflineMapsScreen.kt
@@ -85,6 +85,7 @@ fun MapTab(container: AppContainer, session: DeviceSession?) {
                 session = session,
                 predictor = predictor,
                 phoneLocation = container.phoneLocation,
+                googleAvailable = container.googleMapsAvailable,
             )
             Row(Modifier.align(Alignment.BottomEnd).padding(8.dp)) {
                 TextButton(onClick = { route = "driftcast" }) { Text("Drift Cast") }
@@ -288,6 +289,9 @@ fun SaveAreaScreen(container: AppContainer, initialCenter: LatLng, onDone: () ->
                     TileSource.USGS_IMAGERY_TOPO -> TileSource.USGS_TOPO
                     TileSource.USGS_TOPO -> TileSource.USGS_IMAGERY
                     TileSource.USGS_IMAGERY -> TileSource.USGS_IMAGERY_TOPO
+                    // Online-only source: never offered for download
+                    // (provider terms); unreachable from this cycle.
+                    TileSource.GOOGLE_SATELLITE -> TileSource.USGS_IMAGERY_TOPO
                 }
             }) { Text(source.displayName, style = MaterialTheme.typography.labelSmall) }
         }

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
@@ -27,6 +27,16 @@ public class GoogleTileUpstream(
     /** Floor between forced renewals — bounds createSession spam when a run
      *  of tiles genuinely 4xxes.  Tests pass 0 for deterministic renewal. */
     private val renewMinIntervalMs: Long = 5_000,
+    /**
+     * App-attestation headers for an Android-application-restricted key:
+     * the calling package plus its signing-cert SHA-1 (uppercase hex, no
+     * colons).  Google validates X-Android-Package/X-Android-Cert against
+     * the key's "Android apps" restriction, so an extracted key is useless
+     * outside an APK signed with the same cert.  Null = headers omitted
+     * (unrestricted key).
+     */
+    private val appPackage: String? = null,
+    private val appCertSha1: String? = null,
 ) {
     private class Session(val token: String, val expiryEpochSec: Long)
 
@@ -146,7 +156,7 @@ public class GoogleTileUpstream(
     private fun createSession(): Session? = runCatching {
         val conn = URL("$baseUrl/v1/createSession?key=$apiKey").openConnection() as HttpURLConnection
         conn.requestMethod = "POST"
-        conn.setRequestProperty("User-Agent", userAgent)
+        applyCommonHeaders(conn)
         conn.setRequestProperty("Content-Type", "application/json")
         conn.connectTimeout = 10_000
         conn.readTimeout = 15_000
@@ -190,7 +200,7 @@ public class GoogleTileUpstream(
 
     private fun <T> httpGet(url: String, read: (HttpURLConnection) -> T): T {
         val conn = URL(url).openConnection() as HttpURLConnection
-        conn.setRequestProperty("User-Agent", userAgent)
+        applyCommonHeaders(conn)
         conn.connectTimeout = 10_000
         conn.readTimeout = 15_000
         try {
@@ -198,6 +208,12 @@ public class GoogleTileUpstream(
         } finally {
             conn.disconnect()
         }
+    }
+
+    private fun applyCommonHeaders(conn: HttpURLConnection) {
+        conn.setRequestProperty("User-Agent", userAgent)
+        appPackage?.let { conn.setRequestProperty("X-Android-Package", it) }
+        appCertSha1?.let { conn.setRequestProperty("X-Android-Cert", it) }
     }
 
     private companion object {

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
@@ -32,38 +32,57 @@ public class GoogleTileUpstream(
 
     private val lock = Any()
     private var session: Session? = null
-    private var lastCreateMs: Long = 0
+    private var lastCreateAttemptMs: Long = 0
     private var cachedAttribution: String? = null
+    private var createLatch: java.util.concurrent.CountDownLatch? = null
+
+    /** Outcome of a tile fetch — the proxy maps these to HTTP semantics. */
+    public sealed interface TileFetch {
+        public class Ok(public val bytes: ByteArray) : TileFetch
+
+        /**
+         * Transient — session pending, network hiccup, upstream 5xx.  The
+         * proxy answers 503 so MapLibre retries with backoff; a 200
+         * placeholder would be sticky for the whole style session.
+         */
+        public object Retry : TileFetch
+
+        /** Definitive no-imagery (404) — render the no-data placeholder. */
+        public object NoData : TileFetch
+    }
 
     /**
-     * Fetch one satellite tile (slippy z/x/y).  Null on any failure — the
-     * proxy then serves its placeholder, matching template-source semantics.
-     * A 4xx that looks like a dead session triggers ONE renew-and-retry.
+     * Fetch one satellite tile (slippy z/x/y).  A 4xx that looks like a
+     * dead session triggers ONE renew-and-retry, never a loop.
      */
-    public fun fetchTile(z: Int, x: Int, y: Int): ByteArray? {
-        val token = ensureSession(force = false) ?: return null
+    public fun fetchTile(z: Int, x: Int, y: Int): TileFetch {
+        val token = ensureSession(force = false) ?: return TileFetch.Retry
         val first = getTile(z, x, y, token)
-        if (first.body != null) return first.body
-        if (first.code !in SESSION_DEAD_CODES) return null
-        val renewed = ensureSession(force = true) ?: return null
-        return getTile(z, x, y, renewed).body
+        first.body?.let { return TileFetch.Ok(it) }
+        if (first.code in SESSION_DEAD_CODES) {
+            val renewed = ensureSession(force = true) ?: return TileFetch.Retry
+            val second = getTile(z, x, y, renewed)
+            second.body?.let { return TileFetch.Ok(it) }
+            return if (second.code == 404) TileFetch.NoData else TileFetch.Retry
+        }
+        return if (first.code == 404) TileFetch.NoData else TileFetch.Retry
     }
 
     /**
      * The copyright string the Map Tiles API display policy requires while
-     * these tiles are shown.  Fetched once from the viewport endpoint at a
+     * these tiles are shown.  Fetched from the viewport endpoint at a
      * world-spanning bound and memoized; null until a fetch succeeds.
+     * Mirrors [fetchTile]'s one renew-and-retry on a dead session.
      */
     public fun attribution(): String? {
         synchronized(lock) { cachedAttribution?.let { return it } }
         val token = ensureSession(force = false) ?: return null
-        val url = "$baseUrl/tile/v1/viewport?session=$token&key=$apiKey" +
-            "&zoom=1&north=85&south=-85&east=180&west=-180"
-        val body = runCatching {
-            httpGet(url) { conn ->
-                if (conn.responseCode != 200) null else conn.inputStream.readBytes()
-            }
-        }.getOrNull() ?: return null
+        var result = getViewport(token)
+        if (result.body == null && result.code in SESSION_DEAD_CODES) {
+            val renewed = ensureSession(force = true) ?: return null
+            result = getViewport(renewed)
+        }
+        val body = result.body ?: return null
         val copyright = runCatching {
             Json.parseToJsonElement(body.decodeToString())
                 .jsonObject["copyright"]?.jsonPrimitive?.content
@@ -76,19 +95,52 @@ public class GoogleTileUpstream(
 
     /**
      * Returns a usable token, creating a session if absent, expired, or
-     * [force]d.  Single-flight under [lock]; forced renewals are throttled
-     * so a run of genuine 4xx tiles can't spam createSession.
+     * [force]d.  createSession runs OUTSIDE the lock and single-flight:
+     * one thread creates while concurrent callers WAIT on a latch, bounded
+     * by [SESSION_WAIT_MS] — on a healthy network the whole first viewport
+     * of tiles just waits ~300 ms for the one createSession and renders
+     * real imagery, while on a dead network waiters unblock quickly and
+     * the proxy's fixed worker pool can't wedge for minutes.  EVERY create
+     * attempt (not just forced renewals) honors the [renewMinIntervalMs]
+     * floor, so a dead network can't spam billed createSession calls.
      */
-    private fun ensureSession(force: Boolean): String? = synchronized(lock) {
+    private fun ensureSession(force: Boolean): String? {
         val now = System.currentTimeMillis()
-        val current = session
-        val fresh = current != null && now / 1000 < current.expiryEpochSec - EXPIRY_MARGIN_SEC
-        if (fresh && !force) return current.token
-        if (force && now - lastCreateMs < renewMinIntervalMs) return current?.token
-        lastCreateMs = now
-        val created = createSession()
-        session = created ?: session
-        created?.token
+        var awaitLatch: java.util.concurrent.CountDownLatch? = null
+        synchronized(lock) {
+            val current = session
+            val fresh = current != null && now / 1000 < current.expiryEpochSec - EXPIRY_MARGIN_SEC
+            if (fresh && !force) return current.token
+            val inFlight = createLatch
+            if (inFlight != null) {
+                awaitLatch = inFlight
+            } else {
+                if (now - lastCreateAttemptMs < renewMinIntervalMs) {
+                    return if (fresh) current?.token else null
+                }
+                lastCreateAttemptMs = now
+                createLatch = java.util.concurrent.CountDownLatch(1)
+            }
+        }
+        awaitLatch?.let { latch ->
+            latch.await(SESSION_WAIT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+            synchronized(lock) {
+                val current = session
+                val fresh = current != null &&
+                    System.currentTimeMillis() / 1000 < current.expiryEpochSec - EXPIRY_MARGIN_SEC
+                return if (fresh) current.token else null
+            }
+        }
+        try {
+            val created = createSession()
+            synchronized(lock) { if (created != null) session = created }
+            return created?.token
+        } finally {
+            synchronized(lock) {
+                createLatch?.countDown()
+                createLatch = null
+            }
+        }
     }
 
     private fun createSession(): Session? = runCatching {
@@ -104,8 +156,13 @@ public class GoogleTileUpstream(
             if (conn.responseCode != 200) return@runCatching null
             val obj = Json.parseToJsonElement(conn.inputStream.readBytes().decodeToString()).jsonObject
             val token = obj["session"]?.jsonPrimitive?.content ?: return@runCatching null
-            // Docs serialize expiry as a string of epoch seconds; be lenient.
-            val expiry = obj["expiry"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+            // Docs serialize expiry as a string of epoch seconds; be lenient —
+            // an absent/unparseable expiry must NOT read as "already stale"
+            // (that would silently pair every tile with a billed
+            // createSession), so fall back to a conservative week (the
+            // documented lifetime is ~two weeks).
+            val expiry = obj["expiry"]?.jsonPrimitive?.content?.toLongOrNull()
+                ?: (System.currentTimeMillis() / 1000 + FALLBACK_TTL_SEC)
             Session(token, expiry)
         } finally {
             conn.disconnect()
@@ -116,6 +173,16 @@ public class GoogleTileUpstream(
 
     private fun getTile(z: Int, x: Int, y: Int, token: String): TileResult = runCatching {
         httpGet("$baseUrl/v1/2dtiles/$z/$x/$y?session=$token&key=$apiKey") { conn ->
+            val code = conn.responseCode
+            TileResult(code, if (code == 200) conn.inputStream.readBytes() else null)
+        }
+    }.getOrElse { TileResult(-1, null) }
+
+    private fun getViewport(token: String): TileResult = runCatching {
+        httpGet(
+            "$baseUrl/tile/v1/viewport?session=$token&key=$apiKey" +
+                "&zoom=1&north=85&south=-85&east=180&west=-180",
+        ) { conn ->
             val code = conn.responseCode
             TileResult(code, if (code == 200) conn.inputStream.readBytes() else null)
         }
@@ -139,6 +206,12 @@ public class GoogleTileUpstream(
 
         /** Renew this long before the server-reported expiry. */
         const val EXPIRY_MARGIN_SEC = 3_600L
+
+        /** Session TTL assumed when the response omits a parseable expiry. */
+        const val FALLBACK_TTL_SEC = 7L * 24 * 3_600
+
+        /** Longest a tile fetch waits for another thread's createSession. */
+        const val SESSION_WAIT_MS = 6_000L
 
         /**
          * Codes that plausibly mean "session token dead" (expired/revoked).

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstream.kt
@@ -1,0 +1,149 @@
+package com.tinkerbug.tinkerrocket.maps
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Authenticated upstream for [TileSource.GOOGLE_SATELLITE] — Google Map
+ * Tiles API (2D satellite tiles).  Unlike the template sources, Google
+ * requires a session token: `POST /v1/createSession` once (valid ~2 weeks),
+ * then `GET /v1/2dtiles/{z}/{x}/{y}?session=…&key=…` per tile.
+ *
+ * Provider terms forbid persisting these tiles, so this class is the ONLY
+ * fetch path for the source and [TileProxyServer] never lets its responses
+ * near [OfflineTileCache].  The API key is compiled into the app (any
+ * client-side Maps key ships in the APK) and is API-restricted server-side;
+ * forks without a key simply never construct this class.
+ *
+ * [baseUrl] is injectable for tests, same idiom as the proxy's template map.
+ */
+public class GoogleTileUpstream(
+    private val apiKey: String,
+    private val baseUrl: String = "https://tile.googleapis.com",
+    private val userAgent: String = "TinkerRocketApp/1.0 (offline map cache)",
+    /** Floor between forced renewals — bounds createSession spam when a run
+     *  of tiles genuinely 4xxes.  Tests pass 0 for deterministic renewal. */
+    private val renewMinIntervalMs: Long = 5_000,
+) {
+    private class Session(val token: String, val expiryEpochSec: Long)
+
+    private val lock = Any()
+    private var session: Session? = null
+    private var lastCreateMs: Long = 0
+    private var cachedAttribution: String? = null
+
+    /**
+     * Fetch one satellite tile (slippy z/x/y).  Null on any failure — the
+     * proxy then serves its placeholder, matching template-source semantics.
+     * A 4xx that looks like a dead session triggers ONE renew-and-retry.
+     */
+    public fun fetchTile(z: Int, x: Int, y: Int): ByteArray? {
+        val token = ensureSession(force = false) ?: return null
+        val first = getTile(z, x, y, token)
+        if (first.body != null) return first.body
+        if (first.code !in SESSION_DEAD_CODES) return null
+        val renewed = ensureSession(force = true) ?: return null
+        return getTile(z, x, y, renewed).body
+    }
+
+    /**
+     * The copyright string the Map Tiles API display policy requires while
+     * these tiles are shown.  Fetched once from the viewport endpoint at a
+     * world-spanning bound and memoized; null until a fetch succeeds.
+     */
+    public fun attribution(): String? {
+        synchronized(lock) { cachedAttribution?.let { return it } }
+        val token = ensureSession(force = false) ?: return null
+        val url = "$baseUrl/tile/v1/viewport?session=$token&key=$apiKey" +
+            "&zoom=1&north=85&south=-85&east=180&west=-180"
+        val body = runCatching {
+            httpGet(url) { conn ->
+                if (conn.responseCode != 200) null else conn.inputStream.readBytes()
+            }
+        }.getOrNull() ?: return null
+        val copyright = runCatching {
+            Json.parseToJsonElement(body.decodeToString())
+                .jsonObject["copyright"]?.jsonPrimitive?.content
+        }.getOrNull() ?: return null
+        synchronized(lock) { cachedAttribution = copyright }
+        return copyright
+    }
+
+    // ── Session lifecycle ────────────────────────────────────────────────
+
+    /**
+     * Returns a usable token, creating a session if absent, expired, or
+     * [force]d.  Single-flight under [lock]; forced renewals are throttled
+     * so a run of genuine 4xx tiles can't spam createSession.
+     */
+    private fun ensureSession(force: Boolean): String? = synchronized(lock) {
+        val now = System.currentTimeMillis()
+        val current = session
+        val fresh = current != null && now / 1000 < current.expiryEpochSec - EXPIRY_MARGIN_SEC
+        if (fresh && !force) return current.token
+        if (force && now - lastCreateMs < renewMinIntervalMs) return current?.token
+        lastCreateMs = now
+        val created = createSession()
+        session = created ?: session
+        created?.token
+    }
+
+    private fun createSession(): Session? = runCatching {
+        val conn = URL("$baseUrl/v1/createSession?key=$apiKey").openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("User-Agent", userAgent)
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 15_000
+        conn.doOutput = true
+        try {
+            conn.outputStream.use { it.write(SESSION_REQUEST_BODY.toByteArray()) }
+            if (conn.responseCode != 200) return@runCatching null
+            val obj = Json.parseToJsonElement(conn.inputStream.readBytes().decodeToString()).jsonObject
+            val token = obj["session"]?.jsonPrimitive?.content ?: return@runCatching null
+            // Docs serialize expiry as a string of epoch seconds; be lenient.
+            val expiry = obj["expiry"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+            Session(token, expiry)
+        } finally {
+            conn.disconnect()
+        }
+    }.getOrNull()
+
+    private class TileResult(val code: Int, val body: ByteArray?)
+
+    private fun getTile(z: Int, x: Int, y: Int, token: String): TileResult = runCatching {
+        httpGet("$baseUrl/v1/2dtiles/$z/$x/$y?session=$token&key=$apiKey") { conn ->
+            val code = conn.responseCode
+            TileResult(code, if (code == 200) conn.inputStream.readBytes() else null)
+        }
+    }.getOrElse { TileResult(-1, null) }
+
+    private fun <T> httpGet(url: String, read: (HttpURLConnection) -> T): T {
+        val conn = URL(url).openConnection() as HttpURLConnection
+        conn.setRequestProperty("User-Agent", userAgent)
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 15_000
+        try {
+            return read(conn)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private companion object {
+        const val SESSION_REQUEST_BODY =
+            """{"mapType":"satellite","language":"en-US","region":"US"}"""
+
+        /** Renew this long before the server-reported expiry. */
+        const val EXPIRY_MARGIN_SEC = 3_600L
+
+        /**
+         * Codes that plausibly mean "session token dead" (expired/revoked).
+         * 404 is excluded — that's missing imagery, not a dead session.
+         */
+        val SESSION_DEAD_CODES = setOf(400, 401, 403)
+    }
+}

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileDownloader.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileDownloader.kt
@@ -26,9 +26,13 @@ public const val ESTIMATED_TILE_BYTES: Long = 25_000
 public class TileDownloader(
     private val cache: OfflineTileCache,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
-    /** source key → upstream URL template; injectable for tests. */
+    /**
+     * source key → upstream URL template; injectable for tests.  Sources
+     * with a null template (online-only, e.g. Google) are absent, so
+     * [start] no-ops for them — they can never be region-downloaded.
+     */
     private val upstreamTemplates: Map<String, String> =
-        TileSource.entries.associate { it.key to it.urlTemplate },
+        TileSource.entries.mapNotNull { s -> s.urlTemplate?.let { s.key to it } }.toMap(),
     private val userAgent: String = "TinkerRocketApp/1.0 (offline map cache)",
 ) {
     public enum class Phase { IDLE, DOWNLOADING, FINISHED, CANCELLED }

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileProxyServer.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileProxyServer.kt
@@ -121,18 +121,28 @@ public class TileProxyServer(
 
             // Online-only sources (provider terms forbid persistence) bypass
             // the offline cache in BOTH directions — a stale cached tile from
-            // any earlier state must never serve — and carry no-store so
-            // MapLibre's own HTTP cache doesn't persist them either.
+            // any earlier state must never serve.  no-store is stamped as
+            // HTTP hygiene, but MapLibre's native parser ignores it — the
+            // client-side guarantees are the volatile source flag plus the
+            // app-wide ambient-cache kill (see MapScreen / AppContainer).
             if (TileSource.fromKey(source)?.cacheable == false) {
-                val fetched = if (source == TileSource.GOOGLE_SATELLITE.key) {
+                val fetch = if (source == TileSource.GOOGLE_SATELLITE.key) {
                     googleUpstream?.fetchTile(z, x, y)
                 } else {
                     null
                 }
-                if (fetched != null) {
-                    respond(sock, 200, contentType(fetched), fetched, noStore = true)
-                } else {
-                    respond(sock, 200, "image/png", placeholder, noStore = true)
+                when (fetch) {
+                    is GoogleTileUpstream.TileFetch.Ok ->
+                        respond(sock, 200, contentType(fetch.bytes), fetch.bytes, noStore = true)
+                    // 503 = temporary to MapLibre: it retries with backoff,
+                    // so tiles that raced session creation fill in.  A 200
+                    // placeholder would stick for the whole style session.
+                    GoogleTileUpstream.TileFetch.Retry ->
+                        respond(sock, 503, "text/plain", "tile pending".toByteArray(), noStore = true)
+                    // Definitive no-imagery, or no upstream at all (keyless
+                    // build): the neutral hatch, like any offline gap.
+                    GoogleTileUpstream.TileFetch.NoData, null ->
+                        respond(sock, 200, "image/png", placeholder, noStore = true)
                 }
                 return
             }

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileProxyServer.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileProxyServer.kt
@@ -30,8 +30,14 @@ public class TileProxyServer(
     private val cache: OfflineTileCache,
     /** source key → upstream URL template; injectable for tests. */
     private val upstreamTemplates: Map<String, String> =
-        TileSource.entries.associate { it.key to it.urlTemplate },
+        TileSource.entries.mapNotNull { s -> s.urlTemplate?.let { s.key to it } }.toMap(),
     private val userAgent: String = "TinkerRocketApp/1.0 (offline map cache)",
+    /**
+     * Session-token upstream for [TileSource.GOOGLE_SATELLITE]; null when no
+     * API key is configured — the source then serves placeholders.  Online-
+     * only by provider terms: this path never reads or writes [cache].
+     */
+    private val googleUpstream: GoogleTileUpstream? = null,
 ) {
     private var serverSocket: ServerSocket? = null
     private val running = AtomicBoolean(false)
@@ -93,6 +99,16 @@ public class TileProxyServer(
                 if (line.isEmpty()) break
             }
 
+            if (ATTRIBUTION_RE.matches(requestLine)) {
+                val attr = googleUpstream?.attribution()
+                if (attr != null) {
+                    respond(sock, 200, "text/plain; charset=utf-8", attr.toByteArray(), noStore = true)
+                } else {
+                    respond(sock, 404, "text/plain", "no attribution".toByteArray())
+                }
+                return
+            }
+
             val m = REQUEST_RE.matchEntire(requestLine)
             if (m == null) {
                 respond(sock, 404, "text/plain", "not found".toByteArray())
@@ -102,6 +118,24 @@ public class TileProxyServer(
             val z = zs.toInt()
             val x = xs.toInt()
             val y = ys.toInt()
+
+            // Online-only sources (provider terms forbid persistence) bypass
+            // the offline cache in BOTH directions — a stale cached tile from
+            // any earlier state must never serve — and carry no-store so
+            // MapLibre's own HTTP cache doesn't persist them either.
+            if (TileSource.fromKey(source)?.cacheable == false) {
+                val fetched = if (source == TileSource.GOOGLE_SATELLITE.key) {
+                    googleUpstream?.fetchTile(z, x, y)
+                } else {
+                    null
+                }
+                if (fetched != null) {
+                    respond(sock, 200, contentType(fetched), fetched, noStore = true)
+                } else {
+                    respond(sock, 200, "image/png", placeholder, noStore = true)
+                }
+                return
+            }
 
             cache.tileData(source, z, x, y)?.let {
                 respond(sock, 200, contentType(it), it)
@@ -141,15 +175,23 @@ public class TileProxyServer(
         }.getOrNull()
     }
 
-    private fun respond(sock: Socket, code: Int, type: String, body: ByteArray) {
+    private fun respond(
+        sock: Socket,
+        code: Int,
+        type: String,
+        body: ByteArray,
+        noStore: Boolean = false,
+    ) {
         runCatching {
             val out = sock.getOutputStream()
             val status = if (code == 200) "200 OK" else "$code Error"
+            val cacheControl = if (noStore) "Cache-Control: no-store\r\n" else ""
             out.write(
                 (
                     "HTTP/1.1 $status\r\n" +
                         "Content-Type: $type\r\n" +
                         "Content-Length: ${body.size}\r\n" +
+                        cacheControl +
                         "Access-Control-Allow-Origin: *\r\n" +
                         "Connection: close\r\n\r\n"
                     ).toByteArray(),
@@ -168,5 +210,8 @@ public class TileProxyServer(
 
     private companion object {
         val REQUEST_RE = Regex("""GET /tile/([A-Za-z0-9_]+)/(\d+)/(\d+)/(\d+) HTTP/1\.[01]""")
+
+        /** Copyright string for the active Google session (display policy). */
+        val ATTRIBUTION_RE = Regex("""GET /meta/googleSatellite/attribution HTTP/1\.[01]""")
     }
 }

--- a/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileSource.kt
+++ b/TinkerRocketAndroid/core/maps/src/main/kotlin/com/tinkerbug/tinkerrocket/maps/TileSource.kt
@@ -6,6 +6,12 @@ package com.tinkerbug.tinkerrocket.maps
  * public domain and are the only sources cached for offline use (the point
  * of the feature — see the iOS file for the Esri/Google rationale).
  *
+ * GOOGLE_SATELLITE plays the iOS "Apple basemap" role on Android: a global,
+ * online-only imagery layer whose provider terms forbid persistence.  It is
+ * `cacheable = false` with a null template — the proxy fetches it through
+ * [GoogleTileUpstream] (Map Tiles API session tokens) and never touches the
+ * offline cache in either direction.
+ *
  * The `key` doubles as the on-disk cache directory name and MUST match the
  * iOS rawValue so a future cache import/export stays byte-compatible.
  */
@@ -15,11 +21,21 @@ public enum class TileSource(
     /**
      * Upstream URL template.  ArcGIS REST tile endpoints are ordered
      * `z/y/x` — NOT the slippy-map `z/x/y` used on disk and by MapLibre
-     * templates; the proxy owns that transposition.
+     * templates; the proxy owns that transposition.  Null for sources
+     * fetched via a dedicated authenticated upstream instead of template
+     * substitution — null also drops the source from every default
+     * template map, so it can never be region-downloaded.
      */
-    public val urlTemplate: String,
+    public val urlTemplate: String?,
     /** Provider's max native zoom; the map may overzoom beyond it. */
     public val maxZoom: Int,
+    /**
+     * Whether tiles may be persisted to the offline cache (mirrors iOS
+     * `isCacheable`).  False = online-only by provider terms: the proxy
+     * neither reads nor writes the cache for this source and stamps
+     * responses `Cache-Control: no-store`.
+     */
+    public val cacheable: Boolean = true,
 ) {
     USGS_IMAGERY(
         key = "usgsImagery",
@@ -39,6 +55,13 @@ public enum class TileSource(
         urlTemplate = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}",
         maxZoom = 16,
     ),
+    GOOGLE_SATELLITE(
+        key = "googleSatellite",
+        displayName = "Google Satellite",
+        urlTemplate = null,
+        maxZoom = 22,
+        cacheable = false,
+    ),
     ;
 
     public companion object {
@@ -46,5 +69,12 @@ public enum class TileSource(
 
         /** Attribution shown while a USGS source is active (provider terms). */
         public const val ATTRIBUTION: String = "USGS · The National Map"
+
+        /**
+         * Fallback attribution while Google Satellite is active; the proxy's
+         * `/meta/googleSatellite/attribution` route serves the live copyright
+         * string (Map Tiles API display requirement) once a session is up.
+         */
+        public const val GOOGLE_ATTRIBUTION: String = "© Google"
     }
 }

--- a/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
+++ b/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
@@ -26,6 +26,8 @@ private class FakeGoogleApi : AutoCloseable {
     val sessionAttempts = AtomicInteger(0)
     val tileCalls = AtomicInteger(0)
     val viewportCalls = AtomicInteger(0)
+    val lastSessionHeaders = java.util.concurrent.ConcurrentHashMap<String, String>()
+    val lastTileHeaders = java.util.concurrent.ConcurrentHashMap<String, String>()
     @Volatile var failSessions = false
     @Volatile var rejectAllTiles = false
     @Volatile var omitExpiry = false
@@ -46,12 +48,13 @@ private class FakeGoogleApi : AutoCloseable {
                     val reader = c.getInputStream().bufferedReader(Charsets.ISO_8859_1)
                     val requestLine = reader.readLine() ?: return@use
                     var contentLength = 0
+                    val headers = mutableMapOf<String, String>()
                     while (true) {
                         val line = reader.readLine() ?: break
                         if (line.isEmpty()) break
-                        if (line.startsWith("Content-Length:", ignoreCase = true)) {
-                            contentLength = line.substringAfter(':').trim().toInt()
-                        }
+                        val name = line.substringBefore(':').trim().lowercase()
+                        headers[name] = line.substringAfter(':').trim()
+                        if (name == "content-length") contentLength = headers[name]!!.toInt()
                     }
                     if (contentLength > 0) {
                         val buf = CharArray(contentLength)
@@ -78,6 +81,8 @@ private class FakeGoogleApi : AutoCloseable {
                     when {
                         requestLine.startsWith("POST /v1/createSession") -> {
                             sessionAttempts.incrementAndGet()
+                            lastSessionHeaders.clear()
+                            lastSessionHeaders.putAll(headers)
                             if (failSessions) {
                                 send(500, "boom".toByteArray())
                             } else {
@@ -93,6 +98,8 @@ private class FakeGoogleApi : AutoCloseable {
                         }
                         path.startsWith("/v1/2dtiles/") -> {
                             tileCalls.incrementAndGet()
+                            lastTileHeaders.clear()
+                            lastTileHeaders.putAll(headers)
                             if (sessionParam == currentToken && !rejectAllTiles) {
                                 send(200, tileBody)
                             } else {
@@ -219,6 +226,29 @@ class GoogleTileUpstreamTest {
         assertIs<GoogleTileUpstream.TileFetch.Retry>(upstream.fetchTile(5, 4, 3))
         assertEquals(2, api.tileCalls.get(), "exactly initial + one retry")
         assertEquals(2, api.sessionCalls.get(), "exactly initial + one renewal")
+    }
+
+    @Test
+    fun appAttestationHeaders_sentOnSessionAndTiles_whenConfigured() {
+        val upstream = GoogleTileUpstream(
+            apiKey = "test-key",
+            baseUrl = api.baseUrl,
+            renewMinIntervalMs = 0,
+            appPackage = "com.tinkerbug.tinkerrocket",
+            appCertSha1 = "E0DAC586432101BC48A5158E65908ECD15E2B432",
+        )
+        assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, 3)))
+        assertEquals("com.tinkerbug.tinkerrocket", api.lastSessionHeaders["x-android-package"])
+        assertEquals("E0DAC586432101BC48A5158E65908ECD15E2B432", api.lastSessionHeaders["x-android-cert"])
+        assertEquals("com.tinkerbug.tinkerrocket", api.lastTileHeaders["x-android-package"])
+        assertEquals("E0DAC586432101BC48A5158E65908ECD15E2B432", api.lastTileHeaders["x-android-cert"])
+    }
+
+    @Test
+    fun appAttestationHeaders_absentByDefault() {
+        val upstream = upstreamFor(api)
+        okBytes(upstream.fetchTile(5, 4, 3))
+        assertNull(api.lastTileHeaders["x-android-package"], "unconfigured upstream must not attest")
     }
 
     @Test

--- a/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
+++ b/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -22,9 +23,12 @@ import kotlin.test.assertTrue
 private class FakeGoogleApi : AutoCloseable {
     val socket = ServerSocket(0, 10, InetAddress.getLoopbackAddress())
     val sessionCalls = AtomicInteger(0)
+    val sessionAttempts = AtomicInteger(0)
     val tileCalls = AtomicInteger(0)
     val viewportCalls = AtomicInteger(0)
     @Volatile var failSessions = false
+    @Volatile var rejectAllTiles = false
+    @Volatile var omitExpiry = false
     @Volatile var currentToken = "tok-0" // pre-rotation: nothing accepted yet
     val tileBody = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 1, 2, 3) // JPEG magic
     val copyright = "Imagery ©2026 TerraMetrics"
@@ -73,21 +77,27 @@ private class FakeGoogleApi : AutoCloseable {
                     val sessionParam = Regex("""[?&]session=([^&]+)""").find(path)?.groupValues?.get(1)
                     when {
                         requestLine.startsWith("POST /v1/createSession") -> {
+                            sessionAttempts.incrementAndGet()
                             if (failSessions) {
                                 send(500, "boom".toByteArray())
                             } else {
                                 val tok = "tok-${sessionCalls.incrementAndGet()}"
                                 currentToken = tok
+                                val expiryField = if (omitExpiry) "" else ""","expiry":"9999999999""""
                                 send(
                                     200,
-                                    ("""{"session":"$tok","expiry":"9999999999",""" +
+                                    ("""{"session":"$tok"$expiryField,""" +
                                         """"tileWidth":256,"tileHeight":256,"imageFormat":"jpeg"}""").toByteArray(),
                                 )
                             }
                         }
                         path.startsWith("/v1/2dtiles/") -> {
                             tileCalls.incrementAndGet()
-                            if (sessionParam == currentToken) send(200, tileBody) else send(403, ByteArray(0))
+                            if (sessionParam == currentToken && !rejectAllTiles) {
+                                send(200, tileBody)
+                            } else {
+                                send(403, ByteArray(0))
+                            }
                         }
                         path.startsWith("/tile/v1/viewport") -> {
                             viewportCalls.incrementAndGet()
@@ -110,6 +120,9 @@ private class FakeGoogleApi : AutoCloseable {
 private fun upstreamFor(api: FakeGoogleApi): GoogleTileUpstream =
     GoogleTileUpstream(apiKey = "test-key", baseUrl = api.baseUrl, renewMinIntervalMs = 0)
 
+private fun okBytes(f: GoogleTileUpstream.TileFetch): ByteArray =
+    assertIs<GoogleTileUpstream.TileFetch.Ok>(f).bytes
+
 class GoogleTileUpstreamTest {
 
     private val api = FakeGoogleApi()
@@ -121,27 +134,49 @@ class GoogleTileUpstreamTest {
     fun sessionCreatedLazily_thenReusedAcrossTiles() {
         val upstream = upstreamFor(api)
         assertEquals(0, api.sessionCalls.get(), "no session before first tile")
-        repeat(3) { i -> assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, i)) }
+        repeat(3) { i -> assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, i))) }
         assertEquals(1, api.sessionCalls.get(), "one session shared by all tiles")
     }
 
     @Test
     fun deadSession_renewsOnceAndRetries() {
         val upstream = upstreamFor(api)
-        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 3))
+        assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, 3)))
         api.invalidateSessions()
-        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 4), "renew-and-retry must recover")
+        assertContentEquals(
+            api.tileBody,
+            okBytes(upstream.fetchTile(5, 4, 4)),
+            "renew-and-retry must recover",
+        )
         assertEquals(2, api.sessionCalls.get())
     }
 
     @Test
-    fun createSessionFailure_yieldsNullTile() {
+    fun createSessionFailure_isRetryThenRecovers() {
         api.failSessions = true
         val upstream = upstreamFor(api)
-        assertNull(upstream.fetchTile(5, 4, 3))
+        assertIs<GoogleTileUpstream.TileFetch.Retry>(upstream.fetchTile(5, 4, 3))
         // Recovery once the API comes back.
         api.failSessions = false
-        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 3))
+        assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, 3)))
+    }
+
+    @Test
+    fun concurrentFirstFetch_allWaitForOneSession() {
+        // The first viewport: MapLibre fires many tile requests at once.
+        // All must ride ONE createSession and return real imagery — the
+        // losers wait on the latch instead of degrading to placeholders.
+        val upstream = upstreamFor(api)
+        val results = java.util.Collections.synchronizedList(
+            mutableListOf<GoogleTileUpstream.TileFetch>(),
+        )
+        val threads = (0 until 6).map { i ->
+            Thread { results.add(upstream.fetchTile(5, 4, i)) }.apply { start() }
+        }
+        threads.forEach { it.join(15_000) }
+        assertEquals(6, results.size)
+        results.forEach { assertContentEquals(api.tileBody, okBytes(it)) }
+        assertEquals(1, api.sessionAttempts.get(), "one createSession shared by all racers")
     }
 
     @Test
@@ -150,6 +185,50 @@ class GoogleTileUpstreamTest {
         assertEquals(api.copyright, upstream.attribution())
         assertEquals(api.copyright, upstream.attribution())
         assertEquals(1, api.viewportCalls.get(), "second call must be memoized")
+    }
+
+    @Test
+    fun attribution_renewsOnDeadSession() {
+        val upstream = upstreamFor(api)
+        assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, 3)))
+        api.invalidateSessions()
+        assertEquals(api.copyright, upstream.attribution(), "must renew-and-retry like fetchTile")
+    }
+
+    @Test
+    fun noSession_createAttemptsHonorFloor_noSpamAndNoWedge() {
+        // Dead network at the field: create attempts must be bounded by the
+        // floor and every throttled call must return Retry IMMEDIATELY —
+        // queued proxy workers may not stack behind serialized createSession.
+        api.failSessions = true
+        val upstream = GoogleTileUpstream(
+            apiKey = "test-key",
+            baseUrl = api.baseUrl,
+            renewMinIntervalMs = 60_000,
+        )
+        repeat(10) { assertIs<GoogleTileUpstream.TileFetch.Retry>(upstream.fetchTile(5, 4, it)) }
+        assertEquals(1, api.sessionAttempts.get(), "floor must bound createSession attempts")
+    }
+
+    @Test
+    fun persistentTileRejection_renewsExactlyOnce() {
+        // Revoked/misrestricted key: every token 403s.  fetchTile must do
+        // initial + one renewed retry, then give up — never loop.
+        api.rejectAllTiles = true
+        val upstream = upstreamFor(api)
+        assertIs<GoogleTileUpstream.TileFetch.Retry>(upstream.fetchTile(5, 4, 3))
+        assertEquals(2, api.tileCalls.get(), "exactly initial + one retry")
+        assertEquals(2, api.sessionCalls.get(), "exactly initial + one renewal")
+    }
+
+    @Test
+    fun missingExpiry_sessionStillReused() {
+        // An absent expiry must fall back to a sane TTL, not "always
+        // stale" — which would silently bill a createSession per tile.
+        api.omitExpiry = true
+        val upstream = upstreamFor(api)
+        repeat(3) { assertContentEquals(api.tileBody, okBytes(upstream.fetchTile(5, 4, it))) }
+        assertEquals(1, api.sessionCalls.get())
     }
 }
 
@@ -202,11 +281,12 @@ class TileProxyServerGoogleTest {
     }
 
     @Test
-    fun googleUpstreamFailure_servesPlaceholderNoStore() {
+    fun googleUpstreamFailure_serves503NoStore() {
+        // Transient failure → 503 so MapLibre retries with backoff; a 200
+        // placeholder would stick for the whole style session.
         api.failSessions = true
-        val (code, body, cacheControl) = get("/tile/googleSatellite/5/4/3")
-        assertEquals(200, code)
-        assertEquals(0x89.toByte(), body[0], "hatch placeholder on failure")
+        val (code, _, cacheControl) = get("/tile/googleSatellite/5/4/3")
+        assertEquals(503, code)
         assertEquals("no-store", cacheControl)
     }
 

--- a/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
+++ b/TinkerRocketAndroid/core/maps/src/test/kotlin/com/tinkerbug/tinkerrocket/maps/GoogleTileUpstreamTest.kt
@@ -1,0 +1,263 @@
+package com.tinkerbug.tinkerrocket.maps
+
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.URL
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Fake Map Tiles API endpoint: POST /v1/createSession mints tok-N and
+ * rotates the accepted token; tile/viewport GETs 403 any other token.
+ * Per-connection threads — the proxy pool fetches concurrently.
+ */
+private class FakeGoogleApi : AutoCloseable {
+    val socket = ServerSocket(0, 10, InetAddress.getLoopbackAddress())
+    val sessionCalls = AtomicInteger(0)
+    val tileCalls = AtomicInteger(0)
+    val viewportCalls = AtomicInteger(0)
+    @Volatile var failSessions = false
+    @Volatile var currentToken = "tok-0" // pre-rotation: nothing accepted yet
+    val tileBody = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 1, 2, 3) // JPEG magic
+    val copyright = "Imagery ©2026 TerraMetrics"
+
+    val baseUrl: String get() = "http://127.0.0.1:${socket.localPort}"
+
+    /** Server-side invalidation: previously issued tokens now 403. */
+    fun invalidateSessions() { currentToken = "tok-invalidated" }
+
+    val thread = Thread {
+        while (!socket.isClosed) {
+            val client = try { socket.accept() } catch (_: Exception) { break }
+            Thread {
+                client.use { c ->
+                    val reader = c.getInputStream().bufferedReader(Charsets.ISO_8859_1)
+                    val requestLine = reader.readLine() ?: return@use
+                    var contentLength = 0
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (line.isEmpty()) break
+                        if (line.startsWith("Content-Length:", ignoreCase = true)) {
+                            contentLength = line.substringAfter(':').trim().toInt()
+                        }
+                    }
+                    if (contentLength > 0) {
+                        val buf = CharArray(contentLength)
+                        var read = 0
+                        while (read < contentLength) {
+                            val n = reader.read(buf, read, contentLength - read)
+                            if (n < 0) break
+                            read += n
+                        }
+                    }
+                    val out = c.getOutputStream()
+                    fun send(code: Int, body: ByteArray) {
+                        val status = if (code == 200) "200 OK" else "$code Error"
+                        out.write(
+                            ("HTTP/1.1 $status\r\nContent-Length: ${body.size}\r\n" +
+                                "Connection: close\r\n\r\n").toByteArray(),
+                        )
+                        out.write(body)
+                        out.flush()
+                    }
+
+                    val path = requestLine.split(" ").getOrNull(1).orEmpty()
+                    val sessionParam = Regex("""[?&]session=([^&]+)""").find(path)?.groupValues?.get(1)
+                    when {
+                        requestLine.startsWith("POST /v1/createSession") -> {
+                            if (failSessions) {
+                                send(500, "boom".toByteArray())
+                            } else {
+                                val tok = "tok-${sessionCalls.incrementAndGet()}"
+                                currentToken = tok
+                                send(
+                                    200,
+                                    ("""{"session":"$tok","expiry":"9999999999",""" +
+                                        """"tileWidth":256,"tileHeight":256,"imageFormat":"jpeg"}""").toByteArray(),
+                                )
+                            }
+                        }
+                        path.startsWith("/v1/2dtiles/") -> {
+                            tileCalls.incrementAndGet()
+                            if (sessionParam == currentToken) send(200, tileBody) else send(403, ByteArray(0))
+                        }
+                        path.startsWith("/tile/v1/viewport") -> {
+                            viewportCalls.incrementAndGet()
+                            if (sessionParam == currentToken) {
+                                send(200, """{"copyright":"$copyright","maxZoomRects":[]}""".toByteArray())
+                            } else {
+                                send(403, ByteArray(0))
+                            }
+                        }
+                        else -> send(404, ByteArray(0))
+                    }
+                }
+            }.apply { isDaemon = true }.start()
+        }
+    }.apply { isDaemon = true; start() }
+
+    override fun close() { socket.close() }
+}
+
+private fun upstreamFor(api: FakeGoogleApi): GoogleTileUpstream =
+    GoogleTileUpstream(apiKey = "test-key", baseUrl = api.baseUrl, renewMinIntervalMs = 0)
+
+class GoogleTileUpstreamTest {
+
+    private val api = FakeGoogleApi()
+
+    @AfterTest
+    fun tearDown() = api.close()
+
+    @Test
+    fun sessionCreatedLazily_thenReusedAcrossTiles() {
+        val upstream = upstreamFor(api)
+        assertEquals(0, api.sessionCalls.get(), "no session before first tile")
+        repeat(3) { i -> assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, i)) }
+        assertEquals(1, api.sessionCalls.get(), "one session shared by all tiles")
+    }
+
+    @Test
+    fun deadSession_renewsOnceAndRetries() {
+        val upstream = upstreamFor(api)
+        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 3))
+        api.invalidateSessions()
+        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 4), "renew-and-retry must recover")
+        assertEquals(2, api.sessionCalls.get())
+    }
+
+    @Test
+    fun createSessionFailure_yieldsNullTile() {
+        api.failSessions = true
+        val upstream = upstreamFor(api)
+        assertNull(upstream.fetchTile(5, 4, 3))
+        // Recovery once the API comes back.
+        api.failSessions = false
+        assertContentEquals(api.tileBody, upstream.fetchTile(5, 4, 3))
+    }
+
+    @Test
+    fun attribution_fetchedOnce_thenMemoized() {
+        val upstream = upstreamFor(api)
+        assertEquals(api.copyright, upstream.attribution())
+        assertEquals(api.copyright, upstream.attribution())
+        assertEquals(1, api.viewportCalls.get(), "second call must be memoized")
+    }
+}
+
+/** googleSatellite through the proxy: online-only in both directions. */
+class TileProxyServerGoogleTest {
+
+    private val api = FakeGoogleApi()
+    private val root = File.createTempFile("tiles", "").let { f -> f.delete(); File(f.path).apply { mkdirs() } }
+    private val cache = OfflineTileCache(root)
+    private val proxy = TileProxyServer(
+        cache = cache,
+        upstreamTemplates = emptyMap(),
+        googleUpstream = upstreamFor(api),
+    ).apply { start() }
+
+    @AfterTest
+    fun tearDown() {
+        proxy.stop()
+        api.close()
+    }
+
+    private fun get(path: String): Triple<Int, ByteArray, String?> {
+        val conn = URL("http://127.0.0.1:${proxy.port}$path").openConnection() as HttpURLConnection
+        conn.connectTimeout = 5000
+        conn.readTimeout = 5000
+        val code = conn.responseCode
+        val body = (if (code == 200) conn.inputStream else conn.errorStream)?.readBytes() ?: ByteArray(0)
+        val cacheControl = conn.getHeaderField("Cache-Control")
+        conn.disconnect()
+        return Triple(code, body, cacheControl)
+    }
+
+    @Test
+    fun googleTile_served_noStore_andNeverPersisted() {
+        val (code, body, cacheControl) = get("/tile/googleSatellite/12/1195/1551")
+        assertEquals(200, code)
+        assertContentEquals(api.tileBody, body)
+        assertEquals("no-store", cacheControl, "MapLibre's HTTP cache must be told not to persist")
+        assertNull(cache.tileData("googleSatellite", 12, 1195, 1551), "provider terms: never cached")
+        assertFalse(File(root, "googleSatellite").exists(), "no cache dir may even be created")
+    }
+
+    @Test
+    fun staleCachedGoogleTile_isIgnoredNotServed() {
+        // Hostile/legacy state: something put a googleSatellite tile on disk.
+        val stale = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 9, 9)
+        cache.store(stale, "googleSatellite", 5, 4, 3)
+        val (_, body, _) = get("/tile/googleSatellite/5/4/3")
+        assertContentEquals(api.tileBody, body, "must come from upstream, not the cache")
+    }
+
+    @Test
+    fun googleUpstreamFailure_servesPlaceholderNoStore() {
+        api.failSessions = true
+        val (code, body, cacheControl) = get("/tile/googleSatellite/5/4/3")
+        assertEquals(200, code)
+        assertEquals(0x89.toByte(), body[0], "hatch placeholder on failure")
+        assertEquals("no-store", cacheControl)
+    }
+
+    @Test
+    fun attributionRoute_servesCopyright() {
+        val (code, body, _) = get("/meta/googleSatellite/attribution")
+        assertEquals(200, code)
+        assertEquals(api.copyright, body.decodeToString())
+    }
+
+    @Test
+    fun withoutGoogleUpstream_placeholderAndNoAttribution() {
+        val bare = TileProxyServer(cache = cache, upstreamTemplates = emptyMap()).apply { start() }
+        try {
+            val conn = URL("http://127.0.0.1:${bare.port}/tile/googleSatellite/1/0/0")
+                .openConnection() as HttpURLConnection
+            assertEquals(200, conn.responseCode)
+            assertEquals(0x89.toByte(), conn.inputStream.readBytes()[0])
+            conn.disconnect()
+            val meta = URL("http://127.0.0.1:${bare.port}/meta/googleSatellite/attribution")
+                .openConnection() as HttpURLConnection
+            assertEquals(404, meta.responseCode)
+            meta.disconnect()
+        } finally {
+            bare.stop()
+        }
+    }
+}
+
+/** The online-only source must be structurally excluded from offline paths. */
+class GoogleSourcePolicyTest {
+
+    @Test
+    fun enumPins() {
+        val g = TileSource.GOOGLE_SATELLITE
+        assertEquals("googleSatellite", g.key)
+        assertNull(g.urlTemplate)
+        assertFalse(g.cacheable)
+        assertEquals(22, g.maxZoom)
+        assertEquals(g, TileSource.fromKey("googleSatellite"))
+        TileSource.entries.filter { it != g }.forEach {
+            assertTrue(it.cacheable, "${it.key} must stay cacheable")
+        }
+    }
+
+    @Test
+    fun downloader_defaultTemplates_excludeGoogle() {
+        val root = File.createTempFile("tiles", "").let { f -> f.delete(); File(f.path).apply { mkdirs() } }
+        val downloader = TileDownloader(OfflineTileCache(root))
+        val region = RegionSpec(centerLat = 39.0, centerLon = -95.0, radiusMeters = 500.0, maxZoom = 12)
+        downloader.start(region, TileSource.GOOGLE_SATELLITE.key)
+        assertEquals(TileDownloader.Phase.IDLE, downloader.phase.value, "google region download must no-op")
+    }
+}


### PR DESCRIPTION
## What

Adds **Google Satellite** as an online-only basemap option in the Android app's map picker, riding the existing MapLibre + localhost-proxy stack. Offline capability is untouched: USGS remains the only cacheable/downloadable source, exactly as the offline-maps plan prescribes — Google plays the role Apple's basemap plays on iOS (global online imagery, never persisted).

## How

- `TileSource.GOOGLE_SATELLITE` — key `googleSatellite` (iOS-parity naming), **null urlTemplate** and new `cacheable=false` flag (mirrors iOS `isCacheable`). The null template drops it from every default template map, so `TileDownloader` structurally cannot region-download it.
- `GoogleTileUpstream` (core:maps, pure JVM) owns the Map Tiles API contract: `createSession` (~2-week token), `2dtiles` fetch with one renew-and-retry on dead-session 4xx, memoized `viewport` copyright. Session creation is **latch-single-flighted outside the lock** with a bounded waiter timeout and a create-attempt floor — a dead network at the field can't wedge the proxy's worker pool or spam billed createSession calls (bench-reproduced under airplane mode).
- `TileProxyServer` routes the source through it, bypassing `OfflineTileCache` in **both** directions, and answers transient failures with **503** so MapLibre retries with backoff (a 200 placeholder is sticky for the whole style session). Serves the live copyright at `/meta/googleSatellite/attribution`.
- **MapLibre's ambient cache is killed app-wide** (`clearAmbientCache` + zero cap, plus `volatile` on the source): its native Cache-Control parser only reads `max-age`/`must-revalidate`, so `no-store` alone would NOT have kept Google tiles off disk (verified against the shipped 11.8.8 binary). All intended caching lives in `OfflineTileCache`.
- Key: `TR_ANDROID_MAPS_API_KEY` env → `BuildConfig`, same never-in-repo/fork-graceful discipline as release signing; keyless builds hide the picker entry. Release CI passes the secret through (repo secret is set).
- Key hardening: `X-Android-Package`/`X-Android-Cert` attestation headers on every request, cert SHA-1 computed at runtime from the APK's actual signer; the console key is restricted to the app package + debug/release fingerprints and to the Map Tiles API only.

## Verification

- 35/35 core:maps JVM tests (13 new: session lifecycle, renewal bounds, createSession floor/no-wedge, concurrent first-viewport latch, cache-bypass both directions, no-store header, downloader exclusion, attestation headers).
- Live API contract smoke-tested against `tile.googleapis.com`.
- Bench-verified on the Pixel 8: full-canvas satellite imagery with live "Google · Imagery ©2026 NASA" attribution; `mbgl-offline.db` confirmed dead across Google sessions; restricted key verified both ways (bare key → 403 "Android client application <empty> blocked", attested requests → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)