### PR TITLE
ble: rocket + base station show as 'nimble' in the app scanner

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -467,6 +467,23 @@ extension BLEFleet: CBCentralManagerDelegate {
 
         if let idx = discoveredDevices.firstIndex(where: { $0.id == peripheral.identifier }) {
             discoveredDevices[idx].rssi = RSSI.intValue
+            // Upgrade the name when a later report brings a real one. The
+            // board carries its name in the SCAN RESPONSE — flags plus the
+            // 128-bit service UUID leave only 8 characters of the 31-byte
+            // primary payload, too few for a unit name — and iOS reports the
+            // plain ADV_IND before the scan response merges into it, so a
+            // peripheral's FIRST sighting routinely has no local name and
+            // falls back to peripheral.name (the iOS-cached GAP name).
+            // Latching that first value pinned the fallback in the row
+            // forever, even once the real name arrived milliseconds later.
+            // Only a genuinely advertised name upgrades (never the
+            // peripheral.name fallback), so the row can't flap between the
+            // two sources.
+            if let advertisedName, advertisedName != discoveredDevices[idx].name {
+                discoveredDevices[idx].name = advertisedName
+                discoveredDevices[idx].knownType =
+                    knownDevices.deviceType(forAdvertisedName: advertisedName)
+            }
         } else {
             let device = DiscoveredDevice(
                 id: peripheral.identifier,

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift
@@ -72,7 +72,10 @@ enum DownloadState {
 struct DiscoveredDevice: Identifiable {
     let id: UUID
     let peripheral: CBPeripheral
-    let name: String
+    /// Mutable: the first advertising report for a peripheral often carries no
+    /// local name, so the name is upgraded when a later report brings the real
+    /// one (see BLEFleet.centralManager(_:didDiscover:...)).
+    var name: String
     var rssi: Int
 
     /// Type recovered from the known-device registry at discovery time

--- a/docs/architecture/generated/base-station-map.md
+++ b/docs/architecture/generated/base-station-map.md
@@ -3,7 +3,7 @@
 
 # Base Station -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/base_station/main/main.cpp` is 5,209 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/base_station/main/main.cpp` is 5,212 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -29,14 +29,14 @@ and leading comments.
 | [**Heartbeat to the rocket**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2558-L2651) | 94 | 2558-2651 |
 | [**Coordinated noise scan and channel set**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2652-L3275) | 624 | 2652-3275 |
 | [**Auto-acquire**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3276-L3382) | 107 | 3276-3382 |
-| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3383-L3949) | 567 | 3383-3949 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3950-L5199) | 1,250 | 3950-5199 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [LoRa service and hop management](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3961-L4024) | 64 | 3961-4024 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Packet receive: beacon, telemetry, tracker](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4025-L4507) | 483 | 4025-4507 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Log lifecycle timeouts and flush](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4508-L4575) | 68 | 4508-4575 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Battery read and standalone BLE update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4576-L4665) | 90 | 4576-4665 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4666-L5112) | 447 | 4666-5112 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Scan completion and periodic service chain](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5113-L5199) | 87 | 5113-5199 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5200-L5209) | 10 | 5200-5209 |
+| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3383-L3952) | 570 | 3383-3952 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3953-L5202) | 1,250 | 3953-5202 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [LoRa service and hop management](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3964-L4027) | 64 | 3964-4027 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Packet receive: beacon, telemetry, tracker](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4028-L4510) | 483 | 4028-4510 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Log lifecycle timeouts and flush](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4511-L4578) | 68 | 4511-4578 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Battery read and standalone BLE update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4579-L4668) | 90 | 4579-4668 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4669-L5115) | 447 | 4669-5115 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Scan completion and periodic service chain](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5116-L5202) | 87 | 5116-5202 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5203-L5212) | 10 | 5203-5212 |
 
-Total: 22 sections (6 nested) across 5,209 lines.
+Total: 22 sections (6 nested) across 5,212 lines.

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,172 lines across 69 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,192 lines across 69 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,7 +30,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 32 files, 11,819 lines
+## `Models/` — 32 files, 11,839 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
@@ -41,7 +41,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 947 | `DeviceType`, `CSVError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Device Auto-Detection · Main CSV Generation · Rotation Configuration · Helper Functions · Flight Summary · Flight Settings (#165) · CSV Errors |
 | [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
-| [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 572 | `BLEFleet` |
+| [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 589 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Virtual Rocket (iOS twin of Android demo mode, 2026-07-30) · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
 | [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 558 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Seams · Private State · Constants · Init · Main Entry Point · Event Detectors · Horizontal Distance · Speak policy · State Reset · Production speech engine |
@@ -56,7 +56,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [RocketProfile.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfile.swift) | 396 | `RollSegmentMode`, `RollWaypoint`, `MagCalData`, `SensorCalData`, `RocketProfile` |
 | [MagCalStatus.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MagCalStatus.swift) | 395 | `MagCalSubType`, `MagCalRejectCode`, `MagCalStatus`, `MagCalAxis`, `MagCalComponent`, `MagCalConstants` |
 | [ActiveRocketSyncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/ActiveRocketSyncer.swift) | 393 | `ActiveRocketSyncer` |
-| [BLETypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift) | 340 | `FileInfo`, `DownloadState`, `DiscoveredDevice`, `RocketConfig` |
+| [BLETypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLETypes.swift) | 343 | `FileInfo`, `DownloadState`, `DiscoveredDevice`, `RocketConfig` |
 | [KnownDeviceStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/KnownDeviceStore.swift) | 325 | `DeviceIdentityPusher`, `KnownDevice`, `KnownDeviceStore` |
 | [OTASession.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTASession.swift) | 319 | `OTASession` |
 | [RocketProfileStore.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketProfileStore.swift) | 278 | `RocketProfileStore` |
@@ -121,4 +121,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 69 files, 26,172 lines.
+Total: 69 files, 26,192 lines.

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1024,7 +1024,12 @@ bool TR_BLE_To_APP::begin()
     nimble_port_freertos_init(nimble_host_task);
 
     ESP_LOGI(BLE_TAG, "Server started (NimBLE)");
-    ESP_LOGI(BLE_TAG, "Device name: %s", device_name_);
+    // Read the name back OUT of the stack rather than echoing our own copy:
+    // the bug this line now guards was the stack silently keeping "nimble"
+    // while device_name_ held the right string, so a log of device_name_
+    // looked perfectly healthy and proved nothing.
+    ESP_LOGI(BLE_TAG, "Device name: %s (GAP reports '%s')",
+             device_name_, ble_svc_gap_device_name());
 
     return true;
 }

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -151,7 +151,12 @@ void TR_BLE_To_APP::setName(const char* name)
     // so scanners see the new name immediately.
     if (s_instance_ == this)
     {
-        ble_svc_gap_device_name_set(device_name_);
+        int rc = ble_svc_gap_device_name_set(device_name_);
+        if (rc != 0)
+        {
+            ESP_LOGE(BLE_TAG, "ble_svc_gap_device_name_set('%s') failed, rc=%d",
+                     device_name_, rc);
+        }
         ble_gap_adv_stop();
         startAdvertising();
         ESP_LOGI(BLE_TAG, "BLE name changed to: %s", device_name_);
@@ -976,9 +981,6 @@ bool TR_BLE_To_APP::begin()
         return false;
     }
 
-    // Set the device name for GAP
-    ble_svc_gap_device_name_set(device_name_);
-
     // Request larger MTU (default is 23, max is 517)
     rc = ble_att_set_preferred_mtu(512);
     if (rc != 0)
@@ -990,6 +992,26 @@ bool TR_BLE_To_APP::begin()
     // Register mandatory GAP and GATT services
     ble_svc_gap_init();
     ble_svc_gatt_init();
+
+    // Set the GAP device name — AFTER ble_svc_gap_init(), never before.
+    //
+    // IDF v6 defaults CONFIG_BT_NIMBLE_STATIC_TO_DYNAMIC=y, and in that mode
+    // ble_svc_gap_init() calls ble_svc_gap_init_name(), which unconditionally
+    // reallocates the name buffer and copies the Kconfig default back into it
+    // ("nimble").  A name set before init is therefore silently thrown away
+    // (and leaked).  Under v5.3.2 the name was a plain static array that init
+    // never touched, so set-then-init worked — which is why every board's GAP
+    // Device Name characteristic read back as "nimble" after the v5 -> v6
+    // upgrade.  The scan response still carried the right name, but any
+    // scanner that falls back to the cached GAP name (CoreBluetooth's
+    // peripheral.name — the iOS scanner list, and bleak on macOS) showed
+    // "nimble" instead of TR-R-xxxx / TR-B-xxxx.
+    rc = ble_svc_gap_device_name_set(device_name_);
+    if (rc != 0)
+    {
+        ESP_LOGE(BLE_TAG, "ble_svc_gap_device_name_set('%s') failed, rc=%d",
+                 device_name_, rc);
+    }
 
     // Register our custom GATT services
     registerGattServices();

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -3940,7 +3940,10 @@ static void setup_bs()
     }
     else
     {
-        ESP_LOGI(TAG, "BLE advertising as 'TinkerBaseStation'");
+        // The live unit name, not the compile-time default: this line read
+        // "TinkerBaseStation" on a board named "BaseStation V4", which is
+        // exactly the wrong thing to print while chasing a naming bug.
+        ESP_LOGI(TAG, "BLE advertising as '%s'", unit_name);
     }
 
     last_stats_ms = millis();


### PR DESCRIPTION
The iOS scanner listed both boards as **nimble** with an unknown-type `?` glyph instead of their real names.

## What was actually wrong — two independent bugs

**App (the proximate cause of the screenshot).** The scan-result name was latched on a peripheral's *first* advertising report and never updated — the existing-device branch only refreshed RSSI. The board's name rides in the **scan response** (flags + the 128-bit service UUID leave 8 characters of the 31-byte primary payload, too few for a unit name), and iOS reports the plain ADV_IND before the scan response merges into it. So a first sighting routinely has no local name, falls back to `peripheral.name` — the iOS-cached GAP name — and pinned that value in the row forever, even once the real name arrived milliseconds later. Now a later report carrying a genuinely advertised name upgrades the row and re-resolves its registry type (which also clears the `?` glyph). Only an advertised name upgrades, never the `peripheral.name` fallback, so the row can't flap between the two sources.

**Firmware (why the fallback value was garbage).** `begin()` set the GAP device name *before* `ble_svc_gap_init()`. IDF v6 defaults `CONFIG_BT_NIMBLE_STATIC_TO_DYNAMIC=y` — confirmed `=y` in both the OC's and BS's generated sdkconfigs — and in that mode `ble_svc_gap_init()` calls `ble_svc_gap_init_name()`, which unconditionally reallocates the name buffer and copies the Kconfig default `"nimble"` back over it, discarding (and leaking) the name just set. Under v5.3.2 the name was a plain `static char[]` that init never touched, so the same order worked — the v5→v6 upgrade turned it into a bug, which is why both boards changed together. Fixed by setting the name after `ble_svc_gap_init()`, plus rc logging here and in `setName()`.

## Bench verification

Both boards flashed from this branch (BS `usbmodem101`, OC `usbmodem2101`, each identified by reading its app descriptor immediately before its own flash — same chip on both, so a wrong-port flash succeeds silently):

```
BLE: Device name: BaseStation V4 (GAP reports 'BaseStation V4')
BLE: Device name: Rocket Computer V6 (GAP reports 'Rocket Computer V6')
```

That readback is new. `begin()` used to log its own `device_name_` copy, which looked perfectly healthy all through the bug while the stack held `"nimble"` — it proved nothing. Reading the name back *out of NimBLE* would have caught this on the first boot after the IDF v6 upgrade. The BS also announced a hardcoded `'TinkerBaseStation'` at bring-up on a board named "BaseStation V4"; it now prints `unit_name`.

A raw service-UUID scan confirms the air side, and corrects an assumption worth recording:

```
adv local_name: 'Rocket Computer V6'   cached name: 'nimble'
adv local_name: 'BaseStation V4'       cached name: 'nimble'
```

The scan response was **always** carrying the right name, including before the firmware fix — so the app latch, not the firmware, is what put `nimble` on screen. And CoreBluetooth's per-peripheral name cache still reads `nimble` after the fix, reflash, and reconnect: the OS does not re-read a GAP name just because it changed. Assume the same stale cache on the phone; it doesn't matter, because the app now reads the advertised name. (macOS also hides GAP service 0x1800 from apps, so char 0x2A00 can't be read from a Mac central at all — the boot log is the only way to verify the GAP name.)

## Test status

- `out_computer` + `base_station` build clean on IDF v6.0, both flashed and boot-verified above.
- iOS app builds; full test suite green.
- **Not** verified on-device: the Simulator has no BLE, so the app-side upgrade path is covered by review and by the confirmed fact that the advertised name on the air is correct. Worth a look on the phone before this is considered closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
