### PR TITLE
oc: catch loop_oc preemption between iterations

### DIFF
--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,570 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,595 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -36,8 +36,8 @@ and leading comments.
 | [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4574-L5307) | 734 | 4574-5307 |
 | [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5308-L5814) | 507 | 5308-5814 |
 | [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5815-L6092) | 278 | 5815-6092 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6093-L7561) | 1,469 | 6093-7561 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6442-L7561) | 1,120 | 6442-7561 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7562-L7570) | 9 | 7562-7570 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6093-L7586) | 1,494 | 6093-7586 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6466-L7586) | 1,121 | 6466-7586 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7587-L7595) | 9 | 7587-7595 |
 
-Total: 28 sections (1 nested) across 7,570 lines.
+Total: 28 sections (1 nested) across 7,595 lines.

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6132,6 +6132,30 @@ static void loop_oc()
     // Use ESP-IDF console component or BLE commands for debug interaction.
     const int64_t _loop_oc_t0 = esp_timer_get_time();
 
+    // Preemption catch: wall time spent OUTSIDE this function, measured from
+    // the previous iteration's exit to this one's entry.  The catch-all below
+    // times the body only, so it is structurally blind to the case where
+    // oc_loop passes its body-end timer, yields at vTaskDelay(1), and then a
+    // higher-priority Core-1 task (the I2S parser at prio 6, NimBLE, an IRQ)
+    // holds the core for a long stretch before oc_loop is scheduled again.
+    // That window looks like a clean loop from inside the body but still gaps
+    // every stream the loop feeds.
+    //
+    // Measured exit→entry, not entry→entry, so a slow body is reported once by
+    // the catch-all rather than twice.  Nominal gap is the ~1 ms vTaskDelay(1)
+    // (CONFIG_FREERTOS_HZ=1000) in both active and idle mode — the 20 ms
+    // IDLE_LOOP_DELAY_MS sleep happens inside the body — so at a 100 ms
+    // threshold this only fires on a genuine multi-tick deschedule.
+    static int64_t _loop_oc_last_exit_us = 0;
+    if (_loop_oc_last_exit_us != 0) {
+        const int64_t _preempt_dt = _loop_oc_t0 - _loop_oc_last_exit_us;
+        if (_preempt_dt > LOOP_STALL_THRESHOLD_US) {
+            ESP_LOGW("LOOP_STALL",
+                     "loop_oc off-core %lld us between iterations (preempted)",
+                     (long long)_preempt_dt);
+        }
+    }
+
     // #398 item 3: drain one paced config-readback frame (if any) per pass.
     // Outside the pwr_pin_on gate so connect-time readback (low-power mode)
     // drains too. Replaces the old inline delay(50) chain in sendCurrentConfig.
@@ -7556,6 +7580,7 @@ static void loop_oc()
                  (long long)_loop_oc_dt);
     }
 
+    _loop_oc_last_exit_us = esp_timer_get_time();
     vTaskDelay(1);  // yield to FreeRTOS scheduler
 }
 


### PR DESCRIPTION
## Summary

Adds a preemption catch to `loop_oc`: logs when the loop spends longer than `LOOP_STALL_THRESHOLD_US` **outside** the function, between one iteration's exit and the next one's entry.

This is the one piece worth keeping from #127 (now closed). That PR's threshold changes were investigation-only and are obsolete — the stalls it was chasing were root-caused and fixed in #129 (FC `saveFlightSnapshot()` NVS writes disabling the P4 instruction cache) and #131 (I2S parser starved at priority 1 vs `oc_loop` at 5). The inter-iteration check is independent of that and fills a blind spot that is still open on main.

## The blind spot

`loop_oc` has two layers of stall instrumentation, both of which only ever run *inside* the function:

- `LOOP_STALL_INSTR(name, expr)` — times individual wrapped callsites
- the catch-all at the end — times the whole body, entry to exit

Neither can see the window where `loop_oc` passes its body-end timer, yields at `vTaskDelay(1)`, and is then not scheduled again for a long stretch because a higher-priority Core-1 task holds the core — the I2S parser at prio 6 (raised in #131, deliberately above `oc_loop` at 5), NimBLE, or an IRQ. From inside the body every iteration looks clean, but the streams `loop_oc` feeds gap anyway. That is exactly the shape of the bug class #94/#104 turned out to be, so it is worth being able to see directly rather than inferring it from log gaps.

## Change

One `static int64_t` and a comparison at the top of `loop_oc`, plus a timestamp write before the existing `vTaskDelay(1)`.

```
W (…) LOOP_STALL: loop_oc off-core 143210 us between iterations (preempted)
```

**Measured exit→entry, not entry→entry.** #127 measured entry→entry, which includes the previous iteration's body time — so a slow body would be reported twice, once by the catch-all and again as a "preemption" it wasn't. Exit→entry isolates the descheduled window and keeps each stall attributed to one cause.

## Threshold and false positives

Left at the existing `LOOP_STALL_THRESHOLD_US` (100 ms) — no threshold changes in this PR. Nominal exit→entry gap is the ~1 ms `vTaskDelay(1)` (`CONFIG_FREERTOS_HZ=1000`) in both active and idle mode; the 20 ms `IDLE_LOOP_DELAY_MS` sleep happens *inside* the body, so it is already accounted for by the catch-all and does not reach this check. At 100 ms this only fires on a genuine multi-tick deschedule, so it adds no steady-state serial noise.

Cost is two `esp_timer_get_time()` calls per iteration and one comparison.

## Test

- `__idf_main` compiles clean (ESP32-S3, IDF v6). The local full link did **not** complete — this host's storage kept faulting on unrelated components during the build (a `file write failed (Operation timed out)` on `sections.ld.in`, then `cc1: map.c is shorter than expected` on the managed `espressif__dhara` component, then a hang in `spi_nand_flash`). None of those touch this change, and `__idf_main` built through every attempt. **CI is the authoritative full build here.**
- Not bench-run. This is log-only instrumentation — no control flow, timing, or wire format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
