### PR TITLE
Radio-modem integration fixes + the BLE, GNSS and telemetry bugs the bench surfaced

### DIFF
--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -169,6 +169,17 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
     /// switches it explicitly. nil = no rocket heard yet this session.
     @Published var focusRocketID: UInt8?
 
+    /// Earliest moment the sticky focus pin may be re-evaluated (#390 follow-up).
+    /// Set whenever the pin is applied — on first latch and on every fleet
+    /// re-seed — so a rocket that simply has not transmitted yet since reconnect
+    /// cannot lose focus to whichever rocket happens to speak first.
+    var focusPinGraceUntil: Date?
+    /// How long after the pin is applied before staleness is considered at all.
+    static let focusPinGraceInterval: TimeInterval = 20
+    /// A pinned rocket unheard for longer than this is treated as gone.
+    /// Rockets relay at ~2 Hz, so this is ~30 missed frames.
+    static let focusPinStaleAfter: TimeInterval = 15
+
     /// When the last telemetry frame (any kind) was decoded on this link.
     /// Roster freshness for direct rocket links reads this.
     private(set) var lastTelemetryAt: Date?
@@ -1805,7 +1816,45 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
                 // reconnect). This is what kills the last-heard recency race.
                 if focusRocketID == nil {
                     focusRocketID = rocketID
+                    focusPinGraceUntil = Date().addingTimeInterval(Self.focusPinGraceInterval)
                     fleet?.noteAutoFocus(baseStation: self, rocketID: rocketID)
+                } else if let pinned = focusRocketID, pinned != rocketID,
+                          Date() >= (focusPinGraceUntil ?? .distantPast),
+                          !remoteRockets.contains(where: {
+                              $0.rocketID == pinned &&
+                              Date().timeIntervalSince($0.lastSeen) < Self.focusPinStaleAfter
+                          }) {
+                    // SELF-HEAL a dangling pin. "Sticky" must not mean
+                    // "unfalsifiable": the pin is latched once above, re-seeded
+                    // from the in-memory fleet cache on every reconnect
+                    // (BLEFleet.adopt), and re-pushed to the BS as cmd 45 on
+                    // every reconnect — and that push sets focus_rid_pinned,
+                    // which DISABLES the BS's own 30 s auto-fallback. So a pin
+                    // naming a rocket that is no longer on the air wedged the
+                    // app onto the relay branch (no Signal card, no arrow, no
+                    // bars) with nothing left to recover it. Seen on the bench
+                    // 2026-08-03: strip showed "Rocket 1" while the section
+                    // header resolved the rocket actually being heard.
+                    //
+                    // Both guards are load-bearing. The grace window stops a
+                    // rocket that has merely not transmitted since reconnect
+                    // from losing focus to whoever speaks first — without it
+                    // this fires immediately after adopt(), when the roster is
+                    // still empty, and steals focus every single reconnect. The
+                    // lastSeen test (not mere roster membership) stops a stale
+                    // roster entry from propping up a pin for a rocket that has
+                    // been off the air for minutes.
+                    print("[BS] focus pin rid=\(pinned) is stale — re-latching to rid=\(rocketID)")
+                    focusPinGraceUntil = Date().addingTimeInterval(Self.focusPinGraceInterval)
+                    // setFocus, NOT noteAutoFocus. noteAutoFocus only writes the
+                    // fleet cache when it is still nil, so healing through it
+                    // would fix this device and leave the STALE rid in bsFocus —
+                    // which BLEFleet.adopt re-seeds on the very next reconnect,
+                    // resurrecting the wedge. setFocus overwrites the cache and
+                    // also re-mirrors telemetry, re-points the latched fix, and
+                    // pushes cmd 45 so the BS stops relaying under the pin we
+                    // just abandoned (its own fallback is disabled while pinned).
+                    fleet?.setFocus(baseStation: self, rocketID: rocketID)
                 }
 
                 // Record the fix for EVERY relayed rocket (map/roster read the

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift
@@ -172,6 +172,11 @@ class BLEFleet: NSObject, ObservableObject {
             bsFocus[pid] = rocketID
         }
         baseStation.focusRocketID = rocketID
+        // A deliberate choice — by the user or by the staleness heal — earns a
+        // fresh grace window, so the newly pinned rocket cannot be re-healed
+        // away before it has had a chance to transmit.
+        baseStation.focusPinGraceUntil =
+            Date().addingTimeInterval(BLEDevice.focusPinGraceInterval)
         if let remote = baseStation.remoteRockets.first(where: { $0.rocketID == rocketID }) {
             baseStation.telemetry = remote.telemetry
         }
@@ -223,6 +228,12 @@ class BLEFleet: NSObject, ObservableObject {
         seedTypeFromRegistry(device, peripheralID: peripheralID)
         if let focus = bsFocus[peripheralID] {
             device.focusRocketID = focus
+            // Arm the same grace window the first-latch path uses. Without it
+            // the re-seeded pin is immediately eligible for the staleness check
+            // in BLEDevice, whose roster is empty at this instant — so the
+            // first rocket heard after every reconnect would steal focus.
+            device.focusPinGraceUntil =
+                Date().addingTimeInterval(BLEDevice.focusPinGraceInterval)
         }
         deviceObservers[peripheralID] = device.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -438,7 +438,9 @@ struct ConnectedFleetView: View {
                 RelayRocketSectionView(subject: subject,
                                        via: relay.baseStation,
                                        remote: relay.remote,
-                                       collapsible: multi)
+                                       collapsible: multi,
+                                       fleet: fleet,
+                                       locationManager: locationManager)
             }
         }
 
@@ -648,81 +650,26 @@ struct ConnectedDashboardView: View {
                 }
             }
 
-            if showRocketViews && device.isBaseStation {
-                FlightSummaryView(telemetry: device.telemetry)
-                    .opacity(staleOpacity)
-            }
-
-            SignalStrengthView(
+            // The whole rocket telemetry stack — see RocketTelemetryCards.
+            // Rendered from the same definition the BS-relay branch uses, so
+            // the two can no longer drift. Orientation on a BS link comes from
+            // the LoRa-relayed flags2 field (#390); the shared view picks that
+            // over the direct-link values below.
+            RocketTelemetryCards(
                 telemetry: device.telemetry,
-                bleRSSI: device.connectedRSSI,
                 isBaseStation: device.isBaseStation,
-                locationManager: device.isBaseStation ? locationManager : nil,
-                rocketFix: device.isBaseStation ? device.lastValidRocketFix : nil,
-                trackingHealthy: dataStatus == .live
+                bleRSSI: device.connectedRSSI,
+                locationManager: locationManager,
+                rocketFix: device.lastValidRocketFix,
+                trackingHealthy: dataStatus == .live,
+                directOrientationName: device.imuOrientationName,
+                directOrientationMode: device.imuOrientationMode,
+                staleOpacity: staleOpacity,
+                showRocketViews: showRocketViews,
+                // On SYNCING (searching, no rocket data yet) keep the BS-only
+                // battery so the operator still has a live indicator.
+                showBSOnlyBattery: device.isBaseStation && dataStatus == .syncing
             )
-
-            // Rocket battery. The BS battery row moved to the BS strip +
-            // BaseStationDetailView (#390) — this section is about the
-            // rocket, whatever link carries it. On SYNCING (searching, no
-            // rocket data yet) keep the BS-only battery so the operator
-            // still has a live indicator.
-            if device.isBaseStation && dataStatus == .syncing {
-                BSOnlyBatteryView(telemetry: device.telemetry)
-            } else {
-                // Rocket row + "Base Stn" row on a BS link, same as
-                // pre-#390: the strip-tile bare % phone-tested as ambiguous,
-                // and splitting battery info across two places wasn't worth
-                // a shorter card.
-                BatteryView(telemetry: device.telemetry,
-                            isBaseStation: device.isBaseStation)
-                    .opacity(staleOpacity)
-            }
-
-            if showRocketViews {
-                // Orientation on a BS link comes from the LoRa-relayed
-                // flags2 field (#390) — before that the BS had no way to
-                // know it and this line was blanked deliberately.
-                IMUView(telemetry: device.telemetry,
-                        isBaseStation: device.isBaseStation,
-                        orientationName: device.isBaseStation
-                            ? device.telemetry.relayedOrientationName
-                            : device.imuOrientationName,
-                        orientationMode: device.isBaseStation
-                            ? device.telemetry.relayedOrientationMode
-                            : device.imuOrientationMode)
-                    .opacity(staleOpacity)
-            }
-
-            if showRocketViews && !device.isBaseStation {
-                FlightSummaryView(telemetry: device.telemetry)
-                    .opacity(staleOpacity)
-            }
-
-            if showRocketViews {
-                GPSView(telemetry: device.telemetry, compact: true)
-                    .opacity(staleOpacity)
-            }
-
-            StatusFlagsView(telemetry: device.telemetry,
-                            isBaseStation: device.isBaseStation)
-                .opacity(showRocketViews ? staleOpacity : 1.0)
-
-            // Flight-event flag chips — Android → iOS back-port
-            // (docs/design-language.md queue, user-requested 2026-07-27).
-            // Shown on BS links too: the relay carries the focused rocket's
-            // fs bits (#138), and mid-flight these chips are exactly what
-            // the operator is watching.
-            FlightEventFlagsView(telemetry: device.telemetry)
-                .opacity(showRocketViews ? staleOpacity : 1.0)
-
-            // Pre-launch sensor health scorecard + go/no-go (#303), sitting just
-            // above the pyro channels.  Only shown once the rocket reports a
-            // scorecard ("h" present → hasSensorHealth).
-            if showRocketViews && device.telemetry.hasSensorHealth {
-                HealthCardView(telemetry: device.telemetry)
-                    .opacity(staleOpacity)
-            }
 
             if !device.isBaseStation {
                 PyroChannelsView(device: device)
@@ -749,6 +696,132 @@ struct ConnectedDashboardView: View {
                     .background(Color.red)
                     .foregroundColor(.white)
                     .cornerRadius(10)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Shared rocket telemetry cards
+
+/// The rocket telemetry card stack, rendered identically on every link type.
+///
+/// This exists because the two dashboards used to assemble this list by hand
+/// and drifted apart. `ConnectedDashboardView` had the full set;
+/// `RelayRocketSectionView` — the branch you land on when watching a rocket
+/// through a base station — was silently missing `SignalStrengthView` and with
+/// it the direction arrow, the GNSS bar AND the LoRa bars, plus `IMUView`,
+/// `StatusFlagsView`, `FlightEventFlagsView` and `HealthCardView`. Bench
+/// 2026-08-03: three "features" appeared to vanish at once, which is what a
+/// missing shared container looks like from the outside.
+///
+/// One definition, two call sites. A card added here cannot exist on one path
+/// and not the other, which is the actual bug being fixed — the missing cards
+/// were only the symptom.
+///
+/// Card ORDER reproduces the previous ConnectedDashboardView exactly, including
+/// the quirk that FlightSummaryView sits ABOVE the signal card on a base-station
+/// link and BELOW the IMU card on a direct one. That is deliberate: preserving
+/// it keeps this refactor invisible on the dashboard that already worked.
+struct RocketTelemetryCards: View {
+    let telemetry: TelemetryData
+    let isBaseStation: Bool
+    var bleRSSI: Int? = nil
+    var locationManager: LocationManager? = nil
+    var rocketFix: LastValidRocketFix? = nil
+    var trackingHealthy: Bool = false
+    /// Board→rocket mounting orientation for a DIRECT link. On a BS link the
+    /// orientation is relayed in flags2 (#390) and read off the telemetry
+    /// instead, so callers only supply the direct-link values.
+    var directOrientationName: String = ""
+    var directOrientationMode: IMUOrientationMode = .unknown
+    /// Dimming applied while the stream is stale; 1.0 when live.
+    var staleOpacity: Double = 1.0
+    /// False while a BS link is still searching and has no rocket data yet —
+    /// suppresses the rocket-specific cards without hiding link status.
+    var showRocketViews: Bool = true
+    /// BS link that is syncing: show the BS-only battery so the operator keeps
+    /// a live indicator before any rocket data arrives.
+    var showBSOnlyBattery: Bool = false
+
+    var body: some View {
+        Group {
+            Group {
+                if showRocketViews && isBaseStation {
+                    FlightSummaryView(telemetry: telemetry)
+                        .opacity(staleOpacity)
+                }
+
+                SignalStrengthView(
+                    telemetry: telemetry,
+                    bleRSSI: bleRSSI,
+                    isBaseStation: isBaseStation,
+                    locationManager: isBaseStation ? locationManager : nil,
+                    rocketFix: isBaseStation ? rocketFix : nil,
+                    trackingHealthy: trackingHealthy
+                )
+
+                if showBSOnlyBattery {
+                    BSOnlyBatteryView(telemetry: telemetry)
+                } else {
+                    // Rocket row + "Base Stn" row on a BS link, same as
+                    // pre-#390: the strip-tile bare % phone-tested as
+                    // ambiguous, and splitting battery info across two places
+                    // wasn't worth a shorter card.
+                    BatteryView(telemetry: telemetry, isBaseStation: isBaseStation)
+                        .opacity(staleOpacity)
+                }
+
+                if showRocketViews {
+                    IMUView(telemetry: telemetry,
+                            isBaseStation: isBaseStation,
+                            orientationName: isBaseStation
+                                ? telemetry.relayedOrientationName
+                                : directOrientationName,
+                            orientationMode: isBaseStation
+                                ? telemetry.relayedOrientationMode
+                                : directOrientationMode)
+                        .opacity(staleOpacity)
+                }
+
+                if showRocketViews && !isBaseStation {
+                    FlightSummaryView(telemetry: telemetry)
+                        .opacity(staleOpacity)
+                }
+            }
+
+            Group {
+                if showRocketViews {
+                    GPSView(telemetry: telemetry, compact: true)
+                        .opacity(staleOpacity)
+                }
+
+                // Numeric RSSI/SNR. The signal card's LoRa bar carries RSSI but
+                // NOT snr, and this is the only place snr surfaces at all — it
+                // used to be relay-only, so a BS link on the focused path could
+                // never show it. LoRa-carried links only; a direct rocket link
+                // has no LoRa hop to report.
+                if isBaseStation {
+                    LoRaSignalView(telemetry: telemetry)
+                        .opacity(staleOpacity)
+                }
+
+                StatusFlagsView(telemetry: telemetry, isBaseStation: isBaseStation)
+                    .opacity(showRocketViews ? staleOpacity : 1.0)
+
+                // Flight-event flag chips — Android → iOS back-port
+                // (docs/design-language.md queue, user-requested 2026-07-27).
+                // Shown on BS links too: the relay carries the focused rocket's
+                // fs bits (#138), and mid-flight these chips are exactly what
+                // the operator is watching.
+                FlightEventFlagsView(telemetry: telemetry)
+                    .opacity(showRocketViews ? staleOpacity : 1.0)
+
+                // Pre-launch sensor health scorecard + go/no-go (#303).  Only
+                // shown once the rocket reports a scorecard ("h" present).
+                if showRocketViews && telemetry.hasSensorHealth {
+                    HealthCardView(telemetry: telemetry)
+                        .opacity(staleOpacity)
                 }
             }
         }

--- a/TinkerRocketApp/TinkerRocketApp/Views/FleetDashboardComponents.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/FleetDashboardComponents.swift
@@ -298,7 +298,27 @@ struct RelayRocketSectionView: View {
     let via: BLEDevice
     @ObservedObject var remote: RemoteRocket
     let collapsible: Bool
+    /// Supplies the latched per-rocket fix that the direction arrow needs —
+    /// BLEDevice.lastValidRocketFix only tracks the BS's FOCUSED rocket, and
+    /// this view renders the non-focused ones.
+    var fleet: BLEFleet? = nil
+    /// Phone location, also for the arrow. Optional so previews stay cheap.
+    var locationManager: LocationManager? = nil
     @State private var collapsed = false
+
+    /// Latched fix for THIS rocket, keyed by (network, rocket) — rocket ids
+    /// are only unique per network (#390).
+    private var rocketFix: LastValidRocketFix? {
+        fleet?.lastValidRocketFixes[RocketKey(networkID: via.networkID,
+                                              rocketID: remote.rocketID)]
+    }
+
+    /// Live if the last relayed frame is recent. Recomputed on every frame
+    /// (remote.lastSeen is @Published), so it only flips to stale once a newer
+    /// frame arrives — enough for the signal card's warning styling.
+    private var trackingHealthy: Bool {
+        Date().timeIntervalSince(remote.lastSeen) < 5
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -309,15 +329,21 @@ struct RelayRocketSectionView: View {
                 CollapsedRocketSummary(telemetry: remote.telemetry)
             } else {
                 RocketStateView(state: remote.telemetry.state)
-                FlightSummaryView(telemetry: remote.telemetry)
-                // isBaseStation: relayed frames carry the relaying BS's own
-                // battery fields, so the card shows the Rocket row AND the
-                // "Base Stn" row (charge/voltage/current) — same layout as
-                // the pre-#390 dashboard.  The strip's % is just a glance;
-                // this card is the real numbers.
-                BatteryView(telemetry: remote.telemetry, isBaseStation: true)
-                GPSView(telemetry: remote.telemetry, compact: true)
-                LoRaSignalView(telemetry: remote.telemetry)
+                // The same card stack the focused/direct dashboard renders.
+                // This branch used to hand-assemble a shorter list and had
+                // silently lost SignalStrengthView (arrow + GNSS bar + LoRa
+                // bars), IMUView, StatusFlagsView, FlightEventFlagsView and
+                // HealthCardView. isBaseStation: true — relayed frames carry
+                // the relaying BS's own battery fields, so the battery card
+                // shows the Rocket row AND the "Base Stn" row, same as before.
+                RocketTelemetryCards(
+                    telemetry: remote.telemetry,
+                    isBaseStation: true,
+                    bleRSSI: via.connectedRSSI,
+                    locationManager: locationManager,
+                    rocketFix: rocketFix,
+                    trackingHealthy: trackingHealthy
+                )
                 relayActions
             }
         }

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,192 lines across 69 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,252 lines across 69 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,19 +30,19 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 32 files, 11,839 lines
+## `Models/` — 32 files, 11,899 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 1,980 | `BLEDeviceType`, `BLEDevice` |
+| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 2,029 | `BLEDeviceType`, `BLEDevice` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published per-device state · Device identity (populated from config_identity readback) · Internal state · Init · Connection lifecycle (called by BLEFleet) · BLE RSSI Polling · Sim state · Commands · OTA helpers (#8 phase 2) · Magnetometer hard-iron calibration (issue #96) · Identity commands · File operations · File chunk handling (private) · CSV Generation · Download State Management · CBPeripheralDelegate · Telemetry parsing |
 | [SensorTypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift) | 988 | `MessageType`, `RocketState`, `ParseError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
 | [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 947 | `DeviceType`, `CSVError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Device Auto-Detection · Main CSV Generation · Rotation Configuration · Helper Functions · Flight Summary · Flight Settings (#165) · CSV Errors |
-| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
-| [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 589 | `BLEFleet` |
+| [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 600 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Virtual Rocket (iOS twin of Android demo mode, 2026-07-30) · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
+| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
 | [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 558 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Seams · Private State · Constants · Init · Main Entry Point · Event Detectors · Horizontal Distance · Speak policy · State Reset · Production speech engine |
 | [SensorConverter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift) | 529 | — |
@@ -121,4 +121,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 69 files, 26,192 lines.
+Total: 69 files, 26,252 lines.

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,252 lines across 69 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,351 lines across 69 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -77,12 +77,12 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 13,636 lines
+## `Views/` — 27 files, 13,735 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,908 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +39 more |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
+| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,981 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +40 more |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Shared rocket telemetry cards · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
 | [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,668 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
 | [DriftCastView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift) | 1,428 | `DriftCastMapView`, `Trajectory3DView`, `DriftCastView`, `DriftCastSendButton` |
@@ -97,12 +97,12 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Zoom & Pan State · Zoom Helpers · Body · Chart View · Zoom Indicator · Gestures · Data Loading · Chart Series Update · Progressive LOD Re-decimation · Binary Search Helpers |
 | [PyroTestView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/PyroTestView.swift) | 503 | `PyroTestState`, `TickCounter`, `PyroTestView`, `SlowMoCameraManager`, `CameraPreviewView` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | State Machine · Tick Counter (ObservableObject so SwiftUI can observe it) · View · Top Bar · Center Display · Bottom Controls · Actions · Slow-Mo Camera Manager · Camera Preview (UIViewRepresentable) |
+| [FleetDashboardComponents.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/FleetDashboardComponents.swift) | 426 | `PairSwitcherView`, `UnitsBarView`, `RocketChip`, `BaseStationStripView`, `RocketSectionHeader`, `RelayRocketSectionView`, +1 more |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Pair switcher (≥2 base stations) · Units bar (roster chips) · Base-station strip · Rocket section header · Non-focused relayed rocket section |
 | [DeviceManagerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DeviceManagerView.swift) | 421 | `DeviceManagerView`, `KnownDeviceDetailView` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Network · Devices · Detail / editor |
 | [MapView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/MapView.swift) | 411 | `PredictedLandingAnnotation`, `RocketMapView`, `MapView` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | UIViewRepresentable MKMapView wrapper · Main Map View · Preview |
-| [FleetDashboardComponents.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/FleetDashboardComponents.swift) | 400 | `PairSwitcherView`, `UnitsBarView`, `RocketChip`, `BaseStationStripView`, `RocketSectionHeader`, `RelayRocketSectionView`, +1 more |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Pair switcher (≥2 base stations) · Units bar (roster chips) · Base-station strip · Rocket section header · Non-focused relayed rocket section |
 | [MagCalSphereView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/MagCalSphereView.swift) | 355 | `MagCalSphereView` |
 | [FrequencyScanView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/FrequencyScanView.swift) | 305 | `FrequencyScanView` |
 | [FirmwareUpdateView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/FirmwareUpdateView.swift) | 273 | `FirmwareUpdateView`, `FirmwareUpdateContent`, `LabeledRow` |
@@ -121,4 +121,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 69 files, 26,252 lines.
+Total: 69 files, 26,351 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,595 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,605 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -31,13 +31,13 @@ and leading comments.
 | [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3099-L3116) | 18 | 3099-3116 |
 | [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3117-L3446) | 330 | 3117-3446 |
 | [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3447-L3725) | 279 | 3447-3725 |
-| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3726-L4240) | 515 | 3726-4240 |
-| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4241-L4573) | 333 | 4241-4573 |
-| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4574-L5307) | 734 | 4574-5307 |
-| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5308-L5814) | 507 | 5308-5814 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5815-L6092) | 278 | 5815-6092 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6093-L7586) | 1,494 | 6093-7586 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6466-L7586) | 1,121 | 6466-7586 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7587-L7595) | 9 | 7587-7595 |
+| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3726-L4250) | 525 | 3726-4250 |
+| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4251-L4583) | 333 | 4251-4583 |
+| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4584-L5317) | 734 | 4584-5317 |
+| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5318-L5824) | 507 | 5318-5824 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5825-L6102) | 278 | 5825-6102 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6103-L7596) | 1,494 | 6103-7596 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6476-L7596) | 1,121 | 6476-7596 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7597-L7605) | 9 | 7597-7605 |
 
-Total: 28 sections (1 nested) across 7,595 lines.
+Total: 28 sections (1 nested) across 7,605 lines.

--- a/tests/integration/test_radio_modem_codec.py
+++ b/tests/integration/test_radio_modem_codec.py
@@ -1,0 +1,78 @@
+"""CI guard for the bench host's copy of the radio-modem wire format (#409).
+
+tools/bench_radio_modem.py reimplements the tr_msg codec in Python so the
+daughterboard can be driven from a laptop without a rocket attached. Two
+independent implementations of one wire format is exactly the arrangement
+that drifts, so both ends are pinned to the same literal frames:
+
+  * the C++ side in tests_cpp/test_uart_link_codec.cpp (PackGoldenFrame)
+  * the Python side here, via the tool's own --selftest constants
+
+If someone changes the CRC parameters, the SOF, or a payload struct, one of
+those two fails. Neither can be satisfied by "recompute it the same wrong
+way", which is the failure mode a computed-expectation test has.
+
+No hardware and no pyserial: the tool imports serial lazily, inside
+ModemLink.__init__, precisely so this runs anywhere.
+"""
+import importlib.util
+import struct
+from pathlib import Path
+
+import pytest
+
+TOOL = Path(__file__).resolve().parents[2] / "tools" / "bench_radio_modem.py"
+
+
+@pytest.fixture(scope="module")
+def modem():
+    spec = importlib.util.spec_from_file_location("bench_radio_modem", TOOL)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_tool_exists():
+    assert TOOL.is_file(), f"{TOOL} missing — the bench acceptance path needs it"
+
+
+def test_golden_frames_match_firmware(modem):
+    """The frames here were emitted by tr_msg::pack itself, not hand-computed."""
+    for msg_type, payload_hex, expect in modem.GOLDEN:
+        got = modem.pack(msg_type, bytes.fromhex(payload_hex)).hex().upper()
+        assert got == expect, f"pack(0x{msg_type:02X}, {payload_hex!r})"
+
+
+def test_crc_parameters(modem):
+    # Pinned independently of pack() so a SOF change and a CRC change are
+    # distinguishable when this file goes red.
+    assert modem.crc16(bytes([0x42, 0x03, 0x01, 0x02, 0x03])) == 0x0066
+    assert modem.crc16(b"") == 0x0000
+
+
+def test_deframer_recovers_from_garbage_and_corruption(modem):
+    d = modem.Deframer()
+    good = modem.pack(0x33, b"\x01\x02")
+    assert list(d.feed(b"\x00\xFF\xAA\xAA\x13\x55" + good)) == [(0x33, b"\x01\x02")]
+    assert d.resync_bytes == 6
+
+    d = modem.Deframer()
+    bad = bytearray(modem.pack(0x44, b"\x0A\x14\x1E"))
+    bad[7] ^= 0xFF
+    assert list(d.feed(bytes(bad) + modem.pack(0x55, b"\x2A"))) == [(0x55, b"\x2A")]
+    assert d.crc_fails == 1
+
+
+def test_payload_struct_sizes(modem):
+    """Mirrors the static_asserts in RadioModemProtocol.h."""
+    for fmt, size in ((modem.FMT_CONFIG, 16), (modem.FMT_HOP, 4),
+                      (modem.FMT_RX_HEADER, 8), (modem.FMT_TX_RESULT, 2),
+                      (modem.FMT_IDENTITY, 44), (modem.FMT_STATUS, 52),
+                      (modem.FMT_SCAN_REQ, 12), (modem.FMT_SCAN_HEADER, 12)):
+        assert struct.calcsize(fmt) == size, fmt
+
+
+def test_selftest_passes(modem, capsys):
+    """The tool's own --selftest, so the two never diverge in coverage."""
+    rc = modem.selftest()
+    assert rc == 0, capsys.readouterr().out

--- a/tests/integration/test_radio_modem_codec.py
+++ b/tests/integration/test_radio_modem_codec.py
@@ -54,12 +54,29 @@ def test_deframer_recovers_from_garbage_and_corruption(modem):
     d = modem.Deframer()
     good = modem.pack(0x33, b"\x01\x02")
     assert list(d.feed(b"\x00\xFF\xAA\xAA\x13\x55" + good)) == [(0x33, b"\x01\x02")]
-    assert d.resync_bytes == 6
+    # 5, not 6 — see the note in Deframer. Confirmed against the on-chip
+    # self-test and pinned identically in tests_cpp.
+    assert d.resync_bytes == 5
 
     d = modem.Deframer()
     bad = bytearray(modem.pack(0x44, b"\x0A\x14\x1E"))
     bad[7] ^= 0xFF
     assert list(d.feed(bytes(bad) + modem.pack(0x55, b"\x2A"))) == [(0x55, b"\x2A")]
+    assert d.crc_fails == 1
+
+
+def test_truncated_frame_costs_exactly_two(modem):
+    """The behaviour a scan-for-SOF host implementation gets wrong.
+
+    Length-driven framing means a truncated frame eats the next frame's SOF
+    as its own payload/CRC. A host that instead re-anchors on the next SOF
+    loses one frame where the modem loses two, and would report better link
+    quality than the link actually has.
+    """
+    d = modem.Deframer()
+    truncated = modem.pack(0x66, bytes(range(1, 9)))[:-4]
+    stream = truncated + modem.pack(0x77, b"\xEE") + modem.pack(0x78, b"\xEF")
+    assert list(d.feed(stream)) == [(0x78, b"\xEF")]  # 0x77 is the casualty
     assert d.crc_fails == 1
 
 

--- a/tests_cpp/test_uart_link_codec.cpp
+++ b/tests_cpp/test_uart_link_codec.cpp
@@ -80,6 +80,32 @@ TEST(UartLinkCodec, PackGoldenFrame)
     const uint16_t crc = calcCRC16(crc_input, sizeof(crc_input));
     EXPECT_EQ(frame[9], static_cast<uint8_t>(crc >> 8));
     EXPECT_EQ(frame[10], static_cast<uint8_t>(crc & 0xFF));
+
+    // The check above proves pack() calls calcCRC16 — it cannot catch a change
+    // to the CRC *parameters*, because the expectation moves with them. Pin
+    // the literal bytes too. These same constants are carried by the bench
+    // host (tools/bench_radio_modem.py, GOLDEN), which reimplements the CRC
+    // rather than linking this one, so the two implementations cannot drift
+    // apart silently — which is the entire point of a golden-byte test.
+    const std::vector<uint8_t> golden = {0xAA, 0x55, 0xAA, 0x55, 0x42, 0x03,
+                                         0x01, 0x02, 0x03, 0x00, 0x66};
+    EXPECT_EQ(frame, golden);
+}
+
+TEST(UartLinkCodec, PackGoldenEmptyPayload)
+{
+    // len = 0 is the common case on this link (GET_STATUS / GET_IDENTITY /
+    // START_RX are all payload-free), and it is the edge a length-handling
+    // regression breaks first.
+    using namespace radio_modem;
+    const std::vector<uint8_t> golden_identity = {0xAA, 0x55, 0xAA, 0x55,
+                                                  MSG_GET_IDENTITY, 0x00,
+                                                  0x04, 0x00};
+    const std::vector<uint8_t> golden_status = {0xAA, 0x55, 0xAA, 0x55,
+                                                MSG_GET_STATUS, 0x00,
+                                                0x06, 0x00};
+    EXPECT_EQ(packVec(MSG_GET_IDENTITY, {}), golden_identity);
+    EXPECT_EQ(packVec(MSG_GET_STATUS, {}), golden_status);
 }
 
 TEST(UartLinkCodec, PackRejectsBadArgs)

--- a/tests_cpp/test_uart_link_codec.cpp
+++ b/tests_cpp/test_uart_link_codec.cpp
@@ -173,7 +173,15 @@ TEST(UartLinkCodec, ResyncThroughLeadingGarbage)
     const auto got = run(d, stream);
     ASSERT_EQ(got.size(), 1u);
     EXPECT_EQ(got[0].type, 0x33);
-    EXPECT_GT(d.stats().resync_bytes, 0u);
+
+    // Exactly 5, not "> 0" and not 6. Six bytes of garbage go in, but the
+    // counter tracks what the state machine DISCARDS, and one of the two
+    // 0xAAs is consumed as a SOF candidate rather than dropped (see rehunt).
+    // This is pinned rather than loose because the value is reported to hosts
+    // as STATUS.uart_rx_resync_bytes, and anything that recomputes it must
+    // agree — tools/bench_radio_modem.py got 6 with a scan-for-SOF deframer,
+    // and only the on-hardware self-test caught it.
+    EXPECT_EQ(d.stats().resync_bytes, 5u);
 }
 
 TEST(UartLinkCodec, CorruptedFrameDroppedNextFrameSurvives)
@@ -204,18 +212,20 @@ TEST(UartLinkCodec, TruncatedFrameThenNewSofRecovers)
     std::vector<uint8_t> stream = truncated;
     stream.insert(stream.end(), good.begin(), good.end());
 
-    // The truncated frame's tail is consumed as payload bytes of the partial
-    // frame; the CRC check then fails on whatever lands in the CRC slots, and
-    // the good frame that follows must still be recovered — worst case after
-    // one more frame's worth of resync. Send the good frame twice to prove
-    // the parser can't wedge permanently.
-    stream.insert(stream.end(), good.begin(), good.end());
+    // A truncation costs EXACTLY TWO frames. This framer is length-driven, so
+    // the partial frame keeps consuming: it swallows the next frame's SOF as
+    // its own payload/CRC, fails the CRC, and recovers on the frame after.
+    // The second frame is given a different type so the test can prove WHICH
+    // one was eaten rather than just that something got through.
+    const auto survivor = packVec(0x78, {0xEF});
+    stream.insert(stream.end(), survivor.begin(), survivor.end());
 
     const auto got = run(d, stream);
-    ASSERT_GE(got.size(), 1u);
-    EXPECT_EQ(got.back().type, 0x77);
-    ASSERT_EQ(got.back().payload.size(), 1u);
-    EXPECT_EQ(got.back().payload[0], 0xEE);
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_EQ(got[0].type, 0x78);  // 0x77 is the expected casualty
+    ASSERT_EQ(got[0].payload.size(), 1u);
+    EXPECT_EQ(got[0].payload[0], 0xEF);
+    EXPECT_EQ(d.stats().crc_fails, 1u);
 }
 
 TEST(UartLinkCodec, BackToBackFramesNoLoss)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -32,6 +32,39 @@ static const char* phyName(uint8_t phy)
     }
 }
 
+// Disconnect reasons arrive as NimBLE host codes. Controller-originated ones are
+// BLE_HS_HCI_ERR(x) = 0x200 + x, so the raw number tells you nothing without the
+// spec open — the 2026-08-03 bench burned real time working out that the "520"
+// flooding the console was a supervision timeout and not somebody hanging up.
+// Decode the handful that actually show up on this link; anything else still
+// prints its number.
+//
+// The three worth recognising instantly:
+//   520 (0x08) timeout  — link died ON AIR. Nobody asked for it: RF, PHY or
+//                         connection-parameter margin. See the 1M|2M PHY fix.
+//   531 (0x13) remote   — the peer hung up cleanly (app backgrounded, user tap).
+//   534 (0x16) local    — we hung up. Normal after our own disconnect() call.
+static const char* disconnectReasonName(int reason)
+{
+    switch (reason)
+    {
+        case BLE_HS_HCI_ERR(BLE_ERR_CONN_SPVN_TMO):    return "supervision timeout — link lost on air";
+        case BLE_HS_HCI_ERR(BLE_ERR_REM_USER_CONN_TERM): return "remote user terminated";
+        case BLE_HS_HCI_ERR(BLE_ERR_CONN_TERM_LOCAL):  return "terminated locally";
+        case BLE_HS_HCI_ERR(BLE_ERR_CONN_ESTABLISHMENT): return "connection failed to be established";
+        case BLE_HS_HCI_ERR(BLE_ERR_CONN_TERM_MIC):    return "MIC failure";
+        case BLE_HS_HCI_ERR(BLE_ERR_UNSUPP_REM_FEATURE): return "unsupported remote feature";
+        case BLE_HS_HCI_ERR(BLE_ERR_INSTANT_PASSED):   return "instant passed — PHY/param update desync";
+        default:                                       return "see BLE_ERR_* / BLE_HS_*";
+    }
+}
+
+// Max airtime for a 251-octet LL PDU on the 1M PHY, per Core spec Vol 6 Part B
+// 4.5.10: (1 preamble + 4 access-address + 2 header + 251 payload + 4 MIC + 3 CRC)
+// bytes = 265 * 8 us = 2120 us. The 2M figure is half that; requesting the 1M
+// number is the safe ask because it covers whichever PHY the link settles on.
+static constexpr uint16_t kDleTxTime1MUs = 2120;
+
 // Spinlock protecting the command ring (#517) against races between the BLE
 // callback (runs on the NimBLE host task) and the main loop reading it.
 static portMUX_TYPE s_cmd_mux = portMUX_INITIALIZER_UNLOCKED;
@@ -341,9 +374,19 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     // fragmented into ~19 LL packets, each with its own header and inter-frame
     // spacing. 251 octets collapses that to two. Purely a request — if the peer
     // declines, the link simply stays at 27 and nothing breaks.
+    //
+    // Ask for the octet maximum but NOT the time maximum. BLE_HCI_SET_DATALEN_TX_TIME_MAX
+    // is 0x4290 = 17040 us, which is the LE CODED PHY ceiling — the time it takes to
+    // put 251 octets on air at 125 kbps. We never use Coded. On 1M the same 251 octets
+    // occupy 2120 us, and on 2M about 1064 us, so asking for 17040 requests an airtime
+    // budget ~8x larger than the PDU can possibly need. Controllers are expected to
+    // clamp it, but it is a request no honest 1M/2M link should make, and an oversized
+    // max_tx_time is one of the inputs a controller uses when deciding what fits in a
+    // connection event. Ask for the real 1M ceiling instead; the octet count is what
+    // actually buys the throughput, and it is unchanged.
     const int dle_rc = ble_gap_set_data_len(conn_handle,
                                             BLE_HCI_SET_DATALEN_TX_OCTETS_MAX,
-                                            BLE_HCI_SET_DATALEN_TX_TIME_MAX);
+                                            kDleTxTime1MUs);
     if (dle_rc != 0)
     {
         ESP_LOGW(BLE_TAG, "Data-length extension request failed, rc=%d "
@@ -550,7 +593,7 @@ void TR_BLE_To_APP::onDisconnect(uint16_t conn_handle, int reason)
     // would be wrong.
     conn_param_due_ms_ = 0;
     conn_param_attempts_ = 0;
-    ESP_LOGW(BLE_TAG, "Device DISCONNECTED, reason=%d", reason);
+    ESP_LOGW(BLE_TAG, "Device DISCONNECTED, reason=%d (%s)", reason, disconnectReasonName(reason));
 
     // Restart advertising so new devices can connect. Disconnect re-opens the
     // fast window (#541): reconnects are the common case right here.

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -1654,6 +1654,10 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     size_t pos = 0;
     bool first = true;
     bool dropped = false;   // set when a field is skipped for lack of MTU room (#282)
+    // Set once Tier 1 finishes having lost anything. See the note at the Tier 2
+    // boundary: without it the packer is best-fit, not priority-ordered, and a
+    // tiny MTU keeps the LEAST important field while dropping every vital one.
+    bool tier1_incomplete = false;
 
     // #282: budget the build against the *actual* BLE send window, not just the
     // backing buffer.  sendTelemetry() drops the WHOLE notification when the
@@ -1684,6 +1688,9 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     // Returns true if `n` more bytes (plus the reserved tail) still fit within
     // the MTU-derived budget.
     auto room = [&](size_t n) -> bool {
+        // Hard stop once Tier 1 came up short: nothing below it is worth
+        // emitting if the operator-critical set did not survive.
+        if (tier1_incomplete) return false;
         return pos + n + kReserve <= cap;
     };
 
@@ -1757,7 +1764,14 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     // and battery live, and only loses low-value extras (filename, link
     // stats, unit name) during the brief peak-payload window.
 
-    // ── Tier 1: recovery + dashboard-critical (never sacrificed) ──────────
+    // ── Tier 1: recovery + dashboard-critical ─────────────────────────────
+    // "Never sacrificed" in the sense that nothing BELOW this tier is emitted
+    // once any of it has been dropped (see the floor at the Tier 2 boundary).
+    // Under a genuinely tiny MTU some of Tier 1 can still be lost — the frame
+    // then carries only what fit, plus "tr":1. It is not a guarantee that every
+    // field here always ships; it is a guarantee that they outrank everything
+    // that follows, which is what the old wording wrongly implied was already
+    // true.
 
     // #570: source rocket id FIRST — it is the multi-rocket DEMUX KEY. The BS
     // relays every rocket on one characteristic and the app attributes each
@@ -1850,6 +1864,26 @@ String TR_BLE_To_APP::buildTelemetryJSON(const TelemetryData& data)
     addFloat("soc", data.soc, 1);
     addFloat("cur", data.current, 1);
     addFloat("vol", data.voltage, 2);
+
+    // Tier 1 is over. If ANY of it was dropped, stop here — do not let Tiers 2
+    // and 3 backfill the space it could not use.
+    //
+    // The packer is best-fit, not priority-ordered: room() skips a field that
+    // does not fit and keeps going, so a SMALLER field further down slips into
+    // the gap a bigger, more important one just failed to fill. Worse,
+    // keyBytes() charges one byte less while `first` is still true, so a field
+    // reached after everything above it was dropped is actively CHEAPER than
+    // the ones it outranks. At MTU 23 those two effects combine to emit
+    // {"af":"","tr":1} — the empty active-filename, a Tier 3 diagnostic, as the
+    // sole survivor while state, position, altitude and battery were all
+    // dropped. Observed on the bench 2026-08-03 and initially mistaken for a
+    // wire-format break. The header above claimed Tier 1 was "never
+    // sacrificed"; it was the only tier fully sacrificed.
+    //
+    // Best-fit is still right WITHIN the discretionary tiers — losing one bulky
+    // field to keep three small ones is a good trade there — so the floor is
+    // applied only at this boundary, not between Tier 2 and Tier 3.
+    tier1_incomplete = dropped;
 
     // ── Tier 2: attitude + IMU detail (dropped only under MTU pressure) ───
     // ("rid" moved to the head of Tier 1 — #570: it is the demux key.)

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -362,12 +362,25 @@ void TR_BLE_To_APP::onConnect(uint16_t conn_handle,
     // ~1.5-2x slower as the price of being correct.
     //
     // 2M doubles the raw PHY rate and is independent of the connection interval, so
-    // it more than buys that back without going back outside the spec. If the peer
-    // declines, the link simply stays on 1M — hence the PHY_UPDATE_COMPLETE handler,
-    // which logs what we actually got rather than what we hoped for.
+    // it more than buys that back without going back outside the spec.
+    //
+    // BOTH bits, and this is load-bearing. The mask is not "which PHY do I prefer",
+    // it is "which PHYs am I willing to use at all" — a 2M-only mask forbids 1M, so
+    // the controller has nowhere to retreat to when 2M stops closing. 2M trades ~3 dB
+    // of sensitivity for the rate, and on a board whose BLE antenna is marginal that
+    // is the difference between a link and a supervision timeout: bench 2026-08-03
+    // saw connect -> DLE -> "PHY now: TX=2M RX=2M" -> reason=520 (HCI 0x08) within
+    // 0.6-1.6 s, every cycle, forever. With 1M in the mask the controller simply
+    // stays on (or falls back to) 1M and the link survives, slower but alive.
+    //
+    // The original comment here claimed "if the peer declines, the link simply stays
+    // on 1M". That was the intent and it was NOT what the code did — a peer that
+    // accepts 2M and then cannot sustain it is a different case from a peer that
+    // declines, and only the second one was handled. The PHY_UPDATE_COMPLETE handler
+    // still logs what we actually got rather than what we hoped for.
     const int phy_rc = ble_gap_set_prefered_le_phy(conn_handle,
-                                                   BLE_GAP_LE_PHY_2M_MASK,
-                                                   BLE_GAP_LE_PHY_2M_MASK,
+                                                   BLE_GAP_LE_PHY_1M_MASK | BLE_GAP_LE_PHY_2M_MASK,
+                                                   BLE_GAP_LE_PHY_1M_MASK | BLE_GAP_LE_PHY_2M_MASK,
                                                    BLE_GAP_LE_PHY_CODED_ANY);
     if (phy_rc != 0)
     {

--- a/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
+++ b/tinkerrocket-idf/components/TR_GNSSReceiverUBlox_Serial/TR_GNSSReceiverUBlox_Serial.cpp
@@ -71,22 +71,42 @@ bool TR_GNSSReceiverUBloxSerial::begin(uint8_t update_rate_hz_in,
 
     const uint32_t preferred_baud = 460800U;
     const uint32_t bootstrap_baud = preferred_baud;
-    const uint32_t probe_bauds[] = {9600U, 230400U, 115200U, 460800U, 38400U, 57600U};
+    // Order matters far more than it looks — see the deadline note below.
+    // 38400 FIRST because this is an M10-generation module: the SAM-M10Q's
+    // factory-default UART1 rate is 38400 8N1 (9600 is only used in safeboot).
+    // The old list led with 9600, which is the M8-era default, and buried 38400
+    // in 5th place — where the 35 s deadline expired before ever reaching it.
+    // A cold module therefore NEVER got probed at the one rate it was actually
+    // talking at (bench 2026-08-03: bytes seen on the wire, zero handshakes).
+    // 460800 is our own configured rate, tried by the bootstrap above already.
+    const uint32_t probe_bauds[] = {38400U, 9600U, 230400U, 115200U, 460800U, 57600U};
     uint32_t connected_baud = 0U;
     uint8_t active_rx = GNSS_RX;
     uint8_t active_tx = GNSS_TX;
 
     // Bring-up deadline (#557).  A dead or deaf-UART module used to hang begin()
     // forever in the retry loops below — delay() feeds the WDT, so the FC sat
-    // silently on the pad with no telemetry and no flight.  One full baud sweep
-    // (6 bauds x 2 orientations, each with a ~1.5 s begin() timeout) is ~27 s, so
-    // the budget must cover at least one complete sweep; 35 s leaves margin for
-    // the pre-sweep bootstrap/orientation probes.  On expiry begin() returns
+    // silently on the pad with no telemetry and no flight.
+    //
+    // THE OLD BUDGET WAS SIZED AGAINST A TIMING MODEL THAT IS ~6x OPTIMISTIC.
+    // It assumed "6 bauds x 2 orientations, each with a ~1.5 s begin() timeout
+    // is ~27 s".  A baud only costs ~1.5 s when hasSerialActivity() sees
+    // NOTHING.  That check is a bare uartAvailable() > 0 with no framing
+    // validation, so a real stream sampled at the WRONG baud still delivers
+    // bytes and still trips it — and then the expensive branch runs a 4500 ms
+    // begin(), a 250 ms drain, an activity window, and a second 4500 ms
+    // assumeSuccess begin().  Measured on the bench 2026-08-03: "Trying 9600"
+    // at t=7530 ms to "Trying 230400" at t=17006 ms = 9.5 s for ONE baud.
+    // Six of those is ~57 s, not 27 s, so 35 s never covered a full sweep — it
+    // died around the third entry.  With 38400 moved to the front a healthy
+    // cold module now connects on the first try, but keep the budget honest:
+    // 60 s covers a real worst-case sweep instead of silently truncating it.
+    // On expiry begin() returns
     // false and the collector continues in a GNSS-absent degraded mode.  The
     // loops still run one full attempt first (the deadline is only checked before
     // a *retry*), so a live-but-slow module is never cut off mid-sweep.  Compared
     // wrap-safe; boot-time millis() never wraps, but keep the idiom consistent.
-    const uint32_t kBeginTimeoutMs   = 35000U;
+    const uint32_t kBeginTimeoutMs   = 60000U;
     const uint32_t begin_deadline_ms = millis() + kBeginTimeoutMs;
     auto beginExpired = [&]() -> bool {
         return (int32_t)(millis() - begin_deadline_ms) >= 0;

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.cpp
@@ -572,6 +572,71 @@ rollback:
 }
 
 // ============================================================================
+// Frame-format parameters (preamble/CRC/gain/syncword) — runtime application
+// ============================================================================
+
+bool TR_LoRa_Comms::applyFrameParams(uint16_t preamble_len, bool crc_on,
+                                     bool rx_boosted_gain,
+                                     bool syncword_private)
+{
+    if (!enabled_ || radio_ == nullptr)
+    {
+        return false;
+    }
+    if (tx_ongoing_ || isScanActive())
+    {
+        // Same no-retune-mid-TX rule as reconfigure(); the caller retries
+        // when idle. No wait mode — the one caller (the UART modem's
+        // SET_CONFIG path, #409) runs right after a completed reconfigure.
+        return false;
+    }
+
+    // Exit RX mode, mirroring reconfigure(): SetPacketParams while the
+    // receiver is armed is exactly the ambiguity we avoid there.
+    rx_mode_ = false;
+    rx_done_ = false;
+
+    int16_t st = radio_->setPreambleLength(preamble_len);
+    if (st != RADIOLIB_ERR_NONE)
+    {
+        stats_.last_error = st;
+        if (debug_) ESP_LOGE(TAG, "applyFrameParams setPreamble failed: %d", st);
+        return false;
+    }
+    st = radio_->setCRC(crc_on);
+    if (st != RADIOLIB_ERR_NONE)
+    {
+        stats_.last_error = st;
+        if (debug_) ESP_LOGE(TAG, "applyFrameParams setCRC failed: %d", st);
+        return false;
+    }
+    st = radio_->setRxBoostedGainMode(rx_boosted_gain);
+    if (st != RADIOLIB_ERR_NONE)
+    {
+        stats_.last_error = st;
+        if (debug_) ESP_LOGE(TAG, "applyFrameParams setRxBoostedGain failed: %d", st);
+        return false;
+    }
+    st = radio_->setSyncWord(syncword_private ? RADIOLIB_SX126X_SYNC_WORD_PRIVATE
+                                              : RADIOLIB_SX126X_SYNC_WORD_PUBLIC);
+    if (st != RADIOLIB_ERR_NONE)
+    {
+        stats_.last_error = st;
+        if (debug_) ESP_LOGE(TAG, "applyFrameParams setSyncWord failed: %d", st);
+        return false;
+    }
+
+    if (debug_)
+    {
+        ESP_LOGI(TAG, "frame params applied: preamble=%u crc=%d boost=%d "
+                      "syncword=%s",
+                 (unsigned)preamble_len, (int)crc_on, (int)rx_boosted_gain,
+                 syncword_private ? "private" : "public");
+    }
+    return true;
+}
+
+// ============================================================================
 // Lightweight frequency-only retune for per-packet hopping (#40 / #41)
 // ============================================================================
 

--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -108,6 +108,20 @@ public:
     bool reconfigure(float freq_mhz, uint8_t sf, float bw_khz, uint8_t cr, int8_t tx_power,
                      bool wait_for_tx = true);
 
+    // Apply the frame-format parameters that begin() fixes (preamble length,
+    // CRC, RX boosted gain, sync word). These were historically "boot-fixed"
+    // only because this class exposed no setter — the underlying SX126x
+    // commands are runtime-settable. Needed by the UART radio modem (#409):
+    // its SET_CONFIG carries all eight radio fields and must be fully
+    // authoritative, or a host whose preamble differs from the modem's boot
+    // default silently gets the wrong airtime per packet (the FCC dwell
+    // budget in RocketComputerTypes.h is computed from the host's value).
+    // Call only while the radio is idle (canSend() && !isScanActive());
+    // returns false otherwise. Like reconfigure(), exits RX mode — the
+    // caller re-enters RX (startReceive) afterwards.
+    bool applyFrameParams(uint16_t preamble_len, bool crc_on,
+                          bool rx_boosted_gain, bool syncword_private);
+
     // Lightweight frequency-only retune for per-packet hopping (#40 / #41).
     // Unlike reconfigure(), this does not touch BW/SF/CR/power — those
     // remain locked across hops within a session.  Returns false if the

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
@@ -49,10 +49,20 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
     // S3 boot is ~1 s from the ACT edge; wait generously. If we attached to
     // an already-running modem (warm OC reboot), there is no BOOT coming, so
     // also poke GET_IDENTITY and accept either reply.
+    // GET_IDENTITY is re-sent through the wait, not fired once: on hosts
+    // without an ACT pin (the BS — J6 pin 1 is hard ground) an
+    // already-running modem sends no BOOT, so a single lost/garbled request
+    // frame would have been the difference between a radio and a radio-less
+    // session until someone power-cycled the daughterboard.
     const uint32_t deadline = millis() + 4000;
-    (void)link_.sendFrame(MSG_GET_IDENTITY, nullptr, 0);
+    uint32_t next_identity_ms = 0;
     while (millis() < deadline && !modem_alive_)
     {
+        if ((int32_t)(millis() - next_identity_ms) >= 0)
+        {
+            (void)link_.sendFrame(MSG_GET_IDENTITY, nullptr, 0);
+            next_identity_ms = millis() + 300;
+        }
         link_.poll(&UartModemBackend::onFrameTrampoline, this);
         vTaskDelay(pdMS_TO_TICKS(10));
     }
@@ -151,6 +161,9 @@ bool UartModemBackend::pushConfig(float freq_mhz, uint8_t sf, float bw_khz,
             cfg_bw_khz_ = bw_khz;
             cfg_cr_ = cr;
             cfg_tx_power_ = d.tx_power_dbm;
+            // Any successful push satisfies a pending post-BOOT re-push —
+            // e.g. a host-driven reconfigure() racing the BOOT handler.
+            config_repush_pending_ = false;
             return true;
         }
         vTaskDelay(1);
@@ -282,6 +295,19 @@ void UartModemBackend::onFrame(uint8_t type, const uint8_t* payload, size_t len)
                 break;
             }
             memcpy(&identity_, payload, sizeof(identity_));
+            // Version-check EVERY identity, not just the one begin() sees:
+            // a BOOT can arrive because the daughterboard was reflashed or
+            // physically swapped under a running host, and re-arming
+            // modem_alive_ without the check would reintroduce the exact
+            // mis-parsing begin() refuses (#569 class).
+            if (identity_.protocol_version != PROTOCOL_VERSION)
+            {
+                ESP_LOGE(TAG, "modem protocol v%u != host v%u — radio stays "
+                              "disabled (mismatched daughterboard pair?)",
+                         identity_.protocol_version, PROTOCOL_VERSION);
+                modem_alive_ = false;
+                break;
+            }
             const bool was_alive = modem_alive_;
             modem_alive_ = true;
             if (type == MSG_BOOT)
@@ -335,19 +361,79 @@ void UartModemBackend::service()
     link_.poll(&UartModemBackend::onFrameTrampoline, this);
 
     // Deferred BOOT config re-push (see onFrame) — outside the poll handler.
-    if (config_repush_pending_ && modem_alive_)
+    // DURABLE: the pending flag stays set until a push actually succeeds,
+    // retrying on a timer. The modem announces BOOT exactly once, so this
+    // re-push is the only mechanism keeping the pair on one modulation
+    // after a daughterboard reboot/reflash — a single-shot push whose ack
+    // frame is lost would leave the modem on boot defaults while it keeps
+    // radiating and returning TX_RESULT ok=1: healthy-looking stats on a
+    // dead link. send() holds TX while this is pending for the same reason.
+    if (config_repush_pending_ && modem_alive_ &&
+        (int32_t)(millis() - repush_retry_at_ms_) >= 0)
     {
-        config_repush_pending_ = false;
-        (void)pushConfig(cfg_freq_mhz_, cfg_sf_, cfg_bw_khz_, cfg_cr_,
-                         cfg_tx_power_, /*start_rx=*/true,
-                         /*ack_timeout_ms=*/300);
+        // 500 ms matches begin(): the modem may be doing a full radio
+        // begin() (>=100 ms of fixed resets) before it can ack.
+        if (pushConfig(cfg_freq_mhz_, cfg_sf_, cfg_bw_khz_, cfg_cr_,
+                       cfg_tx_power_, /*start_rx=*/true,
+                       /*ack_timeout_ms=*/500))
+        {
+            config_repush_pending_ = false;
+            ESP_LOGI(TAG, "post-BOOT config re-push applied");
+        }
+        else
+        {
+            // Also the RF-dead recovery path: the modem retries a full
+            // radio begin() on every SET_CONFIG, so keep knocking (slowly).
+            repush_retry_at_ms_ = millis() + 2000;
+            ESP_LOGW(TAG, "post-BOOT config re-push failed — retrying in 2 s");
+        }
+    }
+
+    // Periodic link-health poll. STATUS carries the counters neither side
+    // logs otherwise (modem-side uart_rx_crc_fails/resync_bytes, air-side
+    // rx_crc_fail), and polling keeps the getStats() mirror fresh instead
+    // of frozen at the last SET_CONFIG ack. ~8 B up / 60 B down every 2 s
+    // is noise next to telemetry.
+    if (modem_alive_ && (int32_t)(millis() - status_poll_at_ms_) >= 0)
+    {
+        status_poll_at_ms_ = millis() + STATUS_POLL_MS;
+        (void)link_.sendFrame(MSG_GET_STATUS, nullptr, 0);
+    }
+
+    // Surface link degradation as it happens rather than on autopsy: log
+    // when either side's UART error counters moved. Host side = frames the
+    // modem sent us that arrived damaged; modem side = our frames damaged
+    // in the other direction.
+    if ((int32_t)(millis() - health_log_at_ms_) >= 0)
+    {
+        health_log_at_ms_ = millis() + HEALTH_LOG_MS;
+        TR_UART_Link::Stats ls = {};
+        link_.getStats(ls);
+        const uint32_t modem_crc = last_status_.uart_rx_crc_fails;
+        const uint32_t modem_rsn = last_status_.uart_rx_resync_bytes;
+        if (ls.rx_crc_fails != health_host_crc_snap_ ||
+            ls.rx_resync_bytes != health_host_resync_snap_ ||
+            modem_crc != health_modem_crc_snap_ ||
+            modem_rsn != health_modem_resync_snap_)
+        {
+            ESP_LOGW(TAG, "UART link health: host rx_crc=%u resync=%uB | "
+                          "modem rx_crc=%u resync=%uB",
+                     ls.rx_crc_fails, ls.rx_resync_bytes, modem_crc, modem_rsn);
+            health_host_crc_snap_ = ls.rx_crc_fails;
+            health_host_resync_snap_ = ls.rx_resync_bytes;
+            health_modem_crc_snap_ = modem_crc;
+            health_modem_resync_snap_ = modem_rsn;
+        }
     }
 }
 
 bool UartModemBackend::send(const uint8_t* payload, size_t len)
 {
-    if (!modem_alive_ || payload == nullptr || len == 0 ||
-        len > MAX_AIR_FRAME || tx_in_flight_)
+    // config_repush_pending_: the modem just rebooted and is still on its
+    // boot-default modulation — transmitting now would radiate on the wrong
+    // channel/SF. Refuse (caller retries next loop) until the re-push lands.
+    if (!modem_alive_ || config_repush_pending_ || payload == nullptr ||
+        len == 0 || len > MAX_AIR_FRAME || tx_in_flight_)
     {
         return false;
     }

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.cpp
@@ -38,10 +38,29 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
         gpio_set_level((gpio_num_t)cfg.act_pin, 1);  // power the daughterboard
     }
 
+    // Every failure path below leaves the daughterboard UNPOWERED and the
+    // backend not-began. Previously they all returned false with act_pin still
+    // high and began_ already true, which cost two things: an unused 22 dBm
+    // radio module sat powered for the rest of the flight, and service() kept
+    // polling a link that begin() had just declared dead. LORA_ACT is also the
+    // recovery hammer for a wedged modem (#412) — dropping it means a later
+    // retry gets a genuine power cycle instead of re-poking a stuck part.
+    auto failClosed = [&]() -> bool
+    {
+        modem_alive_   = false;
+        began_         = false;
+        stats_.enabled = false;
+        if (cfg.act_pin >= 0)
+        {
+            gpio_set_level((gpio_num_t)cfg.act_pin, 0);
+        }
+        return false;
+    };
+
     if (link_.begin(cfg.uart) != ESP_OK)
     {
         ESP_LOGE(TAG, "UART link init failed");
-        return false;
+        return failClosed();
     }
     began_ = true;
 
@@ -54,7 +73,14 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
     // already-running modem sends no BOOT, so a single lost/garbled request
     // frame would have been the difference between a radio and a radio-less
     // session until someone power-cycled the daughterboard.
-    const uint32_t deadline = millis() + 4000;
+    // 4 s is sized for the ACT-less host (the BS): there we are attaching to a
+    // modem that may already have been running for hours, so the only way in is
+    // to keep asking and hope one GET_IDENTITY lands. A host WITH an ACT pin
+    // just powered the module itself and knows the S3 boots in ~1 s from that
+    // edge, so 2.5 s is already 2.5x margin — and every extra second here is
+    // paid inside an initPeripherals() that can already block 30-90 s, on the
+    // exact path a user hits when the daughterboard is simply not plugged in.
+    const uint32_t deadline = millis() + (cfg.act_pin >= 0 ? 2500 : 4000);
     uint32_t next_identity_ms = 0;
     while (millis() < deadline && !modem_alive_)
     {
@@ -69,7 +95,7 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
     if (!modem_alive_)
     {
         ESP_LOGE(TAG, "no modem answer on the UART link — radio disabled");
-        return false;
+        return failClosed();
     }
     if (identity_.protocol_version != PROTOCOL_VERSION)
     {
@@ -78,8 +104,7 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
         ESP_LOGE(TAG, "modem protocol v%u != host v%u — radio disabled "
                       "(mismatched daughterboard pair?)",
                  identity_.protocol_version, PROTOCOL_VERSION);
-        modem_alive_ = false;
-        return false;
+        return failClosed();
     }
     ESP_LOGI(TAG, "modem up: chip=%u fw=%.32s max_tx=%ddBm band=%.0f-%.0fMHz",
              identity_.chip, identity_.fw_version,
@@ -95,8 +120,7 @@ bool UartModemBackend::begin(const Config& cfg, float freq_mhz, uint8_t sf,
         // #569: covers both "no STATUS ack" and "ack with radio_enabled=0"
         // (RF dead on the daughterboard — pushConfig logs the specific cause).
         ESP_LOGE(TAG, "initial SET_CONFIG rejected — radio disabled");
-        modem_alive_ = false;
-        return false;
+        return failClosed();
     }
 
     stats_.enabled = true;

--- a/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
+++ b/tinkerrocket-idf/components/TR_RadioLink/UartModemBackend.h
@@ -137,8 +137,21 @@ private:
     // STATUS ack tracking for reconfigure()
     uint32_t status_rx_count_ = 0;
 
-    // BOOT config re-push deferred out of the frame handler (see onFrame)
+    // BOOT config re-push deferred out of the frame handler (see onFrame).
+    // Durable: stays set until a pushConfig() succeeds; send() refuses while
+    // pending (the modem is on boot defaults until the push lands).
     bool config_repush_pending_ = false;
+    uint32_t repush_retry_at_ms_ = 0;
+
+    // Periodic link-health poll + change-triggered logging (see service())
+    static constexpr uint32_t STATUS_POLL_MS = 2000;
+    static constexpr uint32_t HEALTH_LOG_MS = 5000;
+    uint32_t status_poll_at_ms_ = 0;
+    uint32_t health_log_at_ms_ = 0;
+    uint32_t health_host_crc_snap_ = 0;
+    uint32_t health_host_resync_snap_ = 0;
+    uint32_t health_modem_crc_snap_ = 0;
+    uint32_t health_modem_resync_snap_ = 0;
 
     // Scan state (cached SCAN_RESULT; see startScan comment)
     bool scan_active_ = false;

--- a/tinkerrocket-idf/components/TR_UART_Link/RadioModemProtocol.h
+++ b/tinkerrocket-idf/components/TR_UART_Link/RadioModemProtocol.h
@@ -87,11 +87,12 @@ struct __attribute__((packed)) TxFrameHeader
 };
 static_assert(sizeof(TxFrameHeader) == 1, "TxFrameHeader must be 1 byte");
 
-// Mirrors the radio-parameter fields of TR_LoRa_Comms::Config. The five
-// reconfigure() parameters (freq/sf/bw/cr/power) apply at any time; the
-// boot-fixed fields (preamble/flags) only take effect if the radio has not
-// begun yet (e.g. first SET_CONFIG after a failed-at-boot radio) — matching
-// the direct-SPI driver, which also fixes them at begin().
+// Mirrors the radio-parameter fields of TR_LoRa_Comms::Config. Every field
+// is authoritative on every SET_CONFIG: the modem applies freq/sf/bw/cr/power
+// via reconfigure() and preamble/flags via applyFrameParams() (all are
+// runtime-settable SX126x commands). Hosts may assume the STATUS ack means
+// the full config — including preamble — is what is on the air; the airtime
+// accounting in RocketComputerTypes.h depends on that.
 struct __attribute__((packed)) RadioConfigData
 {
     float freq_mhz;

--- a/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
+++ b/tinkerrocket-idf/components/TR_UART_Link/TR_UART_Link.cpp
@@ -20,7 +20,17 @@ esp_err_t TR_UART_Link::begin(const Config& cfg)
         // connector.
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
         .rx_flow_ctrl_thresh = 0,
-        .source_clk = UART_SCLK_DEFAULT,
+        // XTAL, not the default APB, because APB is DFS-sensitive and the
+        // base station runs DFS (CONFIG_PM_DFS_INIT_AUTO, #518-era power
+        // work). The IDF UART driver holds its APB pm-lock only around TX,
+        // so with the divider programmed against APB=80 MHz a DFS drop to
+        // 40 MHz halves the effective RX baud — every frame the modem sends
+        // up fails CRC while our own TX keeps working, which presents as
+        // "downlink dead, uplink fine" with nothing pointing at the UART.
+        // esp_pm re-clocks only the CONSOLE uart for DFS; application UARTs
+        // are on their own. XTAL is a fixed 40 MHz on every board this link
+        // touches and carries 921600 with ~0.06% divider error.
+        .source_clk = UART_SCLK_XTAL,
         // Zero the sleep-power flags (allow_pd / backup_before_sleep) added in
         // IDF v6 — we don't power-gate this UART across light sleep.
         .flags = {},

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
@@ -33,13 +33,16 @@ struct board_pins
     static constexpr int LORA_DIO3_PIN = -1;
 
     // --- Radio daughterboard host link ---
-    // Schematic labels LoRa_TX (GPIO35) / LoRa_RX (GPIO36): wired as-labeled
-    // (TX net = BS transmit), matching the OC V8 convention. CAUTION: TX/RX
-    // label perspective has been wrong on this schematic family before
-    // (RunCam, #234) — if the daughterboard's BOOT message never arrives on
-    // bring-up, swap these two first.
-    static constexpr int LORA_UART_TX_PIN = 35;  // LoRa_TX (label-perspective)
-    static constexpr int LORA_UART_RX_PIN = 36;  // LoRa_RX (label-perspective)
+    // CONFIRMED against both PCBs' pad->net maps, not the labels alone: our
+    // J6.4 (net LoRa_TX, GPIO35) lands on the daughterboard's J6.4 (its net
+    // LoRa_RX, its GPIO5), and our J6.3 (net LoRa_RX, GPIO36) lands on its
+    // J6.3 (its net LoRa_TX, its GPIO6). The two boards name the nets from
+    // their own perspective, so the same pair of names appears on both ends
+    // of a crossed link — the cable pin number is the only unambiguous
+    // reference. (This is the trap that #234/RunCam hit; it is resolved here,
+    // so do NOT "fix" it by swapping these two on bring-up.)
+    static constexpr int LORA_UART_TX_PIN = 35;  // LoRa_TX -> J6.4 (CONFIRMED)
+    static constexpr int LORA_UART_RX_PIN = 36;  // LoRa_RX <- J6.3 (CONFIRMED)
     // No daughterboard power-gate net identified on the V3 schematic (the OC
     // V8 has LoRa_ACT); set if one exists — it's also the recovery hammer for
     // a wedged daughterboard (#412).

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
@@ -16,11 +16,20 @@ struct board_pins
     static constexpr uint8_t SPI_SDI = 52;  // SENS_SDI
 
     // ### GNSS serial ###
-    // Schematic: GNSS_TX=3, GNSS_RX=4 (label perspective unverified — the
-    // driver's 9600-baud boot probe auto-detects a swap, as it did on V7).
+    // Label perspective RESOLVED 2026-08-03 against the as-built KiCad, both
+    // ends, pad->net->component-pin. The nets are named from the MODULE's
+    // point of view, not ours:
+    //   net GNSS_TX = P4 GPIO3 -> J3.2 -> SAM-M10Q U1 pad 13 = TXD (it drives)
+    //   net GNSS_RX = P4 GPIO4 -> J3.1 -> SAM-M10Q U1 pad 14 = RXD (it listens)
+    // So OUR receive pin is GPIO3 and OUR transmit pin is GPIO4 — the reverse
+    // of what the net names suggest if you read them from the FC's side. These
+    // constants are the FC's own rx/tx (they are passed straight to
+    // uartBegin(baud, rx, tx)), so they must be 3 and 4 in that order. V7 had
+    // it right; the V8 header had it backwards and the driver's swap probe was
+    // silently papering over it at ~1.5 s of boot cost.
     // GNSS_RXD2 net on GPIO2 (receiver's second UART) is unused by firmware.
-    static constexpr uint8_t GNSS_RX = 4;   // GNSS_RX
-    static constexpr uint8_t GNSS_TX = 3;   // GNSS_TX
+    static constexpr uint8_t GNSS_RX = 3;   // FC receives; module TXD drives this
+    static constexpr uint8_t GNSS_TX = 4;   // FC drives;   module RXD listens here
     static constexpr int8_t GNSS_RESET_N = -1;
     static constexpr int8_t GNSS_SAFEBOOT_N = -1;
 

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
@@ -58,12 +58,16 @@ struct board_pins
 
     // --- Radio daughterboard host link (consumed by the UART-modem backend,
     //     #410; constants staged here so the pin map is complete) ---
-    // Schematic labels LoRa_TX/LoRa_RX: wired as-labeled (TX net = OC
-    // transmit). CAUTION: TX/RX label perspective has been wrong on this
-    // schematic family before (RunCam, #234) — if the daughterboard's BOOT
-    // message never arrives on bring-up, swap these two first.
-    static constexpr int LORA_UART_TX_PIN = 11;  // LoRa_TX (label-perspective)
-    static constexpr int LORA_UART_RX_PIN = 10;  // LoRa_RX (label-perspective)
+    // CONFIRMED against both PCBs' pad->net maps, not the labels alone: our
+    // J5.4 (net LoRa_TX, GPIO11) lands on the daughterboard's J6.4 (its net
+    // LoRa_RX, its GPIO5), and our J5.3 (net LoRa_RX, GPIO10) lands on its
+    // J6.3 (its net LoRa_TX, its GPIO6). The two boards name the nets from
+    // their own perspective, so the same pair of names appears on both ends
+    // of a crossed link — the cable pin number is the only unambiguous
+    // reference. (This is the trap that #234/RunCam hit; it is resolved here,
+    // so do NOT "fix" it by swapping these two on bring-up.)
+    static constexpr int LORA_UART_TX_PIN = 11;  // LoRa_TX -> J5.4 (CONFIRMED)
+    static constexpr int LORA_UART_RX_PIN = 10;  // LoRa_RX <- J5.3 (CONFIRMED)
     // Daughterboard power gate (high = powered), like CAM_ACT for the RunCam.
     // Also the recovery hammer for a wedged/bricked daughterboard (#412).
     static constexpr int LORA_ACT_PIN = 12;      // LoRa_ACT (CONFIRMED)

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -4159,6 +4159,17 @@ static void serviceLoRaUplink()
 
     lora_comms.service();  // Complete any pending TX (auto-enters RX after TX)
 
+    // Watchdog BEFORE the canSend() gate. Below it, the watchdog only ran in
+    // the state where it has nothing to do: a stuck TX means canSend() is
+    // false, which returned out of this function right here — so the one
+    // path meant to clear a wedge was unreachable from the wedge. Latent on
+    // V7 (DIO1 + the driver's own polling cleared tx_ongoing_ locally); on
+    // V8 the only nominal clear is the modem's TX_RESULT, so one lost UART
+    // frame would have pinned canSend() false forever: no telemetry, no
+    // beacons, and no uplink RX either (readPacket sits below the same
+    // gate). The BS has always ordered these correctly.
+    lora_comms.serviceTxWatchdog();  // Force-clear stuck TX (#105)
+
     // Only enter RX when radio is idle (not transmitting)
     if (!lora_comms.canSend()) return;
 
@@ -4182,7 +4193,6 @@ static void serviceLoRaUplink()
     // boards the interrupt may not trigger for RX-done.  pollDio1()
     // checks the pin level and sets rx_done_ if DIO1 is asserted.
     lora_comms.pollDio1();
-    lora_comms.serviceTxWatchdog();  // Force-clear stuck tx_ongoing_ (#105)
 
     // Non-blocking poll for uplink packet
     uint8_t rx_buf[32];

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -169,7 +169,38 @@ rocket or a base station wired up to get started.
 python3 tools/bench_radio_modem.py --selftest
 ```
 
-**Step 1 — the link is alive.** Expect `BOOT` within ~1 s of power-up and an
+**Step 1 — is the radio alive at all?** USB-C only; no UART adapter, no host,
+no J6. The board in hand was subjected to a **backwards power connector**, so
+this comes before anything about the link — there is no point debugging a
+protocol against a dead module.
+
+```bash
+idf.py -p <usb-port> flash monitor
+```
+
+The firmware probes the E220 at the pin level before the driver touches the
+SPI bus, because a failed `begin()` cannot tell a dead module from a rejected
+config. BUSY and DIO1 are push-pull module outputs with no board pull
+resistors, so the probe fights them with the S3's internal pulls: a level that
+follows the pull means nothing is driving the pin.
+
+| Boot line | Reading |
+|-----------|---------|
+| `radio probe: module ALIVE — BUSY released N us after reset and is driven` | The module has power, booted, and drives its pins. If `begin()` still fails after this, the fault is on SPI or in config — not the module. |
+| `radio probe: BUSY is FLOATING` | Nothing drives U14 pad 11. Module unpowered, dead, or open joints. **Measure +3V3 at U14 pad 1 first.** This is the expected signature of reverse-polarity damage. |
+| `radio probe: BUSY driven but STUCK HIGH past 50 ms` | Powered and driving, but never finished its internal boot — damaged die, or a bad NRST/SPI joint. |
+| `radio init FAILED (RadioLib <code>)` | The RadioLib code narrows it further: `-2` is chip-not-found (SPI silent), the `-70x` family are SPI command failures. |
+| `radio up, listening at 915.0 MHz SF10` | Radio is good; move on. |
+
+Two LED blinks at boot say the S3 itself is running — the only such sign if
+the board is powered from J6 with no USB attached. (D6 is a hardwired power
+LED and proves only that the rail is up. Note R59/R60 are 10 kΩ, so the blue
+LED may be very dim or dark; see the config.h bench note.)
+
+If the S3 does not enumerate over USB at all, the reverse-polarity damage
+reached past the radio and the rest of this plan is moot.
+
+**Step 2 — the link is alive.** Expect `BOOT` within ~1 s of power-up and an
 `IDENTITY` on demand. `protocol=v1`, `chip=LLCC68`, `band=850.000-930.000`,
 and an `fw=` git sha that matches what you flashed:
 
@@ -182,7 +213,7 @@ mismatch. `STATUS` also reports `uart_crc_fail` / `uart_resync` — nonzero
 there means the link is up but noisy, which is a different problem from
 silent.
 
-**Step 2 — the radio came up.** `SET_CONFIG` is acked with a `STATUS`, and
+**Step 3 — the radio came up.** `SET_CONFIG` is acked with a `STATUS`, and
 that ack is the only proof the LLCC68 actually initialised — `radio=DOWN`
 means the modem is alive with dead RF:
 
@@ -190,7 +221,7 @@ means the modem is alive with dead RF:
 python3 tools/bench_radio_modem.py -p PORT --config 915 125 10 7 20
 ```
 
-**Step 3 — flow control.** Push more frames than the 8-deep credit window and
+**Step 4 — flow control.** Push more frames than the 8-deep credit window and
 confirm `0 unanswered`. That is the "a TX frame must never be silently
 dropped" clause of #409 as a number:
 
@@ -198,7 +229,7 @@ dropped" clause of #409 as a number:
 python3 tools/bench_radio_modem.py -p PORT --tx DEADBEEF --repeat 50
 ```
 
-**Step 4 — over the air (the #409 acceptance criterion).** With a second
+**Step 5 — over the air (the #409 acceptance criterion).** With a second
 radio on the same parameters, `--listen` on one end and `--tx` on the other;
 `RX_FRAME` carries the air bytes back verbatim with RSSI/SNR. Then repeat
 against an **unmodified deployed base station**, transmitting bytes its
@@ -209,7 +240,7 @@ tunnel and the credit return, not application interop.
 quickest way to confirm the RF switch and antenna path are doing something.
 
 **Not yet run on hardware.** Everything above is bench-ready but unexecuted:
-the daughterboard has not been brought up. Steps 1–4 need a board on the bench
+the daughterboard has not been brought up. Steps 1–5 need a board on the bench
 and a go-ahead.
 
 ## Tests

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -200,7 +200,43 @@ LED may be very dim or dark; see the config.h bench note.)
 If the S3 does not enumerate over USB at all, the reverse-polarity damage
 reached past the radio and the rest of this plan is moot.
 
-**Step 2 — the link is alive.** Expect `BOOT` within ~1 s of power-up and an
+**Step 2 — link + receive path, still USB only.** A separate bench image runs
+an on-chip self-test at boot. It needs no adapter, no host and no antenna:
+
+```bash
+idf.py -B build_bench -DTR_BENCH_SELFTEST=1 build
+idf.py -B build_bench -p <usb-port> flash monitor
+```
+
+The UART half puts the peripheral in **internal loopback**, so the whole
+framing path — codec, driver ring buffers, deframer — runs at the real 921600
+baud with the pins unconnected. The radio half sweeps 902–928 MHz in RX and
+reads RSSI back, which exercises the SPI command path, 53 synthesiser retunes,
+RX-mode entry, the RXEN half of the RF switch, and the RSSI readback. Nothing
+transmits, so it is safe with no antenna fitted.
+
+Result on the as-built board (2026-08-01), all 9 checks:
+
+```
+ok  round trip, 7 payload sizes 0..255 B, bytes identical
+    24 frames (6120 B on the wire) in 67557 us -> 91 kB/s
+ok  24-frame back-to-back burst, none dropped
+    discarded 5 B hunting for SOF (6 B of garbage in)
+ok  resyncs past garbage incl. a false SOF, counts 5 of 6 B
+ok  CRC-corrupted frame dropped + counted, next frame survives
+ok  truncated frame swallows exactly one follower, then recovers
+ok  on-chip codec matches the host golden frame
+    53 samples 902-928 MHz: min -117, mean -115, max -109 dBm
+ok  RSSI is a noise floor, not a stuck rail
+```
+
+91 kB/s is ~99 % of the 92.16 kB/s line rate at 921600 8N1, so the baud is
+real and the ring buffers keep up.
+
+**Reflash the production image before plugging into a host** — the bench build
+runs loopback traffic out of the TX pin at boot.
+
+**Step 3 — the link is alive.** Expect `BOOT` within ~1 s of power-up and an
 `IDENTITY` on demand. `protocol=v1`, `chip=LLCC68`, `band=850.000-930.000`,
 and an `fw=` git sha that matches what you flashed:
 
@@ -213,7 +249,7 @@ mismatch. `STATUS` also reports `uart_crc_fail` / `uart_resync` — nonzero
 there means the link is up but noisy, which is a different problem from
 silent.
 
-**Step 3 — the radio came up.** `SET_CONFIG` is acked with a `STATUS`, and
+**Step 4 — the radio came up.** `SET_CONFIG` is acked with a `STATUS`, and
 that ack is the only proof the LLCC68 actually initialised — `radio=DOWN`
 means the modem is alive with dead RF:
 
@@ -221,7 +257,7 @@ means the modem is alive with dead RF:
 python3 tools/bench_radio_modem.py -p PORT --config 915 125 10 7 20
 ```
 
-**Step 4 — flow control.** Push more frames than the 8-deep credit window and
+**Step 5 — flow control.** Push more frames than the 8-deep credit window and
 confirm `0 unanswered`. That is the "a TX frame must never be silently
 dropped" clause of #409 as a number:
 
@@ -229,7 +265,7 @@ dropped" clause of #409 as a number:
 python3 tools/bench_radio_modem.py -p PORT --tx DEADBEEF --repeat 50
 ```
 
-**Step 5 — over the air (the #409 acceptance criterion).** With a second
+**Step 6 — over the air (the #409 acceptance criterion).** With a second
 radio on the same parameters, `--listen` on one end and `--tx` on the other;
 `RX_FRAME` carries the air bytes back verbatim with RSSI/SNR. Then repeat
 against an **unmodified deployed base station**, transmitting bytes its
@@ -240,8 +276,8 @@ tunnel and the credit return, not application interop.
 quickest way to confirm the RF switch and antenna path are doing something.
 
 **Not yet run on hardware.** Everything above is bench-ready but unexecuted:
-the daughterboard has not been brought up. Steps 1–5 need a board on the bench
-and a go-ahead.
+steps 3-6 need a UART adapter on J6 and, for step 6, a second radio or a
+deployed base station. Steps 1 and 2 are DONE on the as-built board.
 
 ## Tests
 

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -12,6 +12,55 @@ The modem never parses them. The on-air format (`LORA_PROTO_VERSION`,
 network ids, hop schedules) is owned entirely by the hosts, so deployed
 direct-radio base stations interoperate with a V8 rocket unchanged.
 
+## The board
+
+Target is the as-built **LoRa Board V3** daughterboard: an ESP32-S3 (U28), an
+EBYTE **E220-900MM22S** radio module (U14 — an LLCC68 with a fixed 900 MHz
+matching network, its own 32 MHz crystal, and an RF switch), a W25Q64 boot
+flash, USB-C for console+programming, and a 4-pin JST-SH host link. A later
+board revision exists in `hardware/lora-daughterboard` (S3RH2, W25Q128); its
+GPIO net map is pad-by-pad identical, so only the flash size in
+`sdkconfig.defaults` is revision-specific.
+
+Every pin in [main/config.h](main/config.h) is a schematic net verified
+against the board's `.kicad_pcb` pad→net map:
+
+| Signal | GPIO | Net | Goes to |
+|--------|------|-----|---------|
+| Host UART TX | 6 | `LoRa_TX` | J6.3 → host's RX |
+| Host UART RX | 5 | `LoRa_RX` | J6.4 ← host's TX |
+| SPI SCK / MISO / MOSI | 17 / 33 / 21 | `L_SCK` / `L_MISO` / `L_MOSI` | U14 15 / 12 / 13 |
+| Radio CS / DIO1 / RST / BUSY | 18 / 2 / 38 / 34 | `L_CS` / `L_DI01` / `L_RST` / `L_BUSY` | U14 14 / 20 / 3 / 11 |
+| RF switch RXEN | 35 | `L_RXEN` | U14 10 |
+| RX LED (red D5) | 7 | `IND_2` | R60 → D5 |
+| TX LED (blue D4) | 8 | `IND_1` | R59 → D4 |
+
+Two things the schematic decides that the firmware must respect:
+
+- **The TX half of the RF switch is not ours.** U14's DIO2 (19) is shorted to
+  TXEN (9) on the board, which is the split EBYTE prescribes; only RXEN
+  reaches a GPIO. `TR_LoRa_Comms` handles this with `setDio2AsRfSwitch(true)`
+  plus `setRfSwitchPins(rxen, NC)`.
+- **DIO3 is floating on purpose.** The E220 carries its own passive crystal,
+  so this radio must never be set up for a DIO3-powered TCXO.
+
+### Host connector (J6)
+
+J6 mates 1:1 with rocket-computer J5 and base-station J6.
+
+| Pin | Daughterboard net | Direction | Rocket host | Base-station host |
+|-----|-------------------|-----------|-------------|-------------------|
+| 1 | `VSS` | — | Q10-switched ground (`LoRa_ACT`) | hard GND |
+| 2 | `+BATT` | in | 6.4–8.4 V pack | ~4.6 V `V_LORA` |
+| 3 | `LoRa_TX` (GPIO6) | **out** | OC GPIO10 (its RX) | BS GPIO36 (its RX) |
+| 4 | `LoRa_RX` (GPIO5) | **in** | OC GPIO11 (its TX) | BS GPIO35 (its TX) |
+
+Every board names these nets from *its own* perspective, so the same two names
+appear on both ends of a crossed pair — **the cable pin number is the only
+unambiguous reference.** Deriving the direction from the net name is what put
+`HOST_UART_TX = 5` in this file originally, which would have driven two
+push-pull CMOS outputs onto one wire.
+
 ## Build & flash
 
 ```sh
@@ -20,10 +69,20 @@ idf.py build
 idf.py -p <port> flash monitor
 ```
 
-LoRa, RXEN, and indicator-LED pins in [main/config.h](main/config.h) are the
-V8 daughterboard schematic values; the **host-link UART pins are still
-placeholders** (TODO in config.h). The TX LED lights for the duration of each
-transmission; the RX LED pulses per received air packet.
+Console and programming are over USB-C (`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG`);
+UART0 is unconnected on this board, and the host UART owns its own pins.
+
+### Hardware constraints (enforced, not just documented)
+
+- **No Wi-Fi, no BLE, ever.** The S3's `LNA_IN` is left floating with no
+  matching network. `CONFIG_BT_ENABLED` fails the build. Wi-Fi has no
+  equivalent switch — `CONFIG_ESP_WIFI_ENABLED` is a non-prompt SoC-capability
+  symbol that is always `y` on an S3 — so that half is a rule stated in
+  [main/main.cpp](main/main.cpp): nothing here may call `esp_wifi_init()`.
+- **No PSRAM.** `CONFIG_SPIRAM` fails the build. On the as-built board there is
+  none to enable; on the S3RH2 revision the in-package PSRAM shares VDD_SPI's
+  internal ~14 Ω with the boot flash, and both active sags that rail under
+  either part's 2.7 V minimum.
 
 ## UART link
 
@@ -70,6 +129,13 @@ Hosts clamp their radio config to the reported capabilities and must refuse
 loudly on a protocol-version mismatch. The modem additionally clamps TX power
 itself — a mismatched pair degrades, it never transmits out of spec.
 
+The band edges reported are the **module's** (850–930 MHz for the
+E220-900MM22S), not the bare LLCC68 die's 150–960 MHz. The die's range is not
+reachable through a fixed 900 MHz matching network and RF switch, and
+reporting capability a host could act on but the hardware cannot deliver
+defeats the handshake. A higher-power or different-band module variant changes
+these constants and nothing else.
+
 ### Modem behavior
 
 - Boots listening on defaults (915 MHz / SF10 / BW125) so a bench modem is
@@ -83,14 +149,74 @@ itself — a mismatched pair degrades, it never transmits out of spec.
 
 ## Bench validation
 
-1. **UART loopback** (no radio): drive with a USB-UART, check `BOOT`,
-   `IDENTITY`, `STATUS`, and TX_RESULT fail-fasts.
-2. **Over-the-air**: devkit + LLCC68 breakout driven over UART, exchanging
-   frames with an **unmodified existing base station** — proves the
-   transparent tunnel end-to-end (acceptance criterion of #409).
+The test host is [`tools/bench_radio_modem.py`](../../../tools/bench_radio_modem.py)
+— a laptop-side speaker of this protocol, so none of the steps below need a
+rocket or a base station wired up to get started.
+
+**Wiring.** 3.3 V TTL adapter only — the S3 is not 5 V tolerant.
+
+| J6 | Adapter |
+|----|---------|
+| 1 `VSS` | GND |
+| 2 `+BATT` | 6.4–8.4 V bench supply, or leave it and power over USB-C |
+| 3 | adapter **RX** |
+| 4 | adapter **TX** |
+
+**Step 0 — codec, no hardware.** Also runs in CI
+(`tests/integration/test_radio_modem_codec.py`):
+
+```bash
+python3 tools/bench_radio_modem.py --selftest
+```
+
+**Step 1 — the link is alive.** Expect `BOOT` within ~1 s of power-up and an
+`IDENTITY` on demand. `protocol=v1`, `chip=LLCC68`, `band=850.000-930.000`,
+and an `fw=` git sha that matches what you flashed:
+
+```bash
+python3 tools/bench_radio_modem.py -p /dev/tty.usbserial-XXXX --identity --status
+```
+
+No reply is almost always wiring: TX/RX swapped at the adapter, or a baud
+mismatch. `STATUS` also reports `uart_crc_fail` / `uart_resync` — nonzero
+there means the link is up but noisy, which is a different problem from
+silent.
+
+**Step 2 — the radio came up.** `SET_CONFIG` is acked with a `STATUS`, and
+that ack is the only proof the LLCC68 actually initialised — `radio=DOWN`
+means the modem is alive with dead RF:
+
+```bash
+python3 tools/bench_radio_modem.py -p PORT --config 915 125 10 7 20
+```
+
+**Step 3 — flow control.** Push more frames than the 8-deep credit window and
+confirm `0 unanswered`. That is the "a TX frame must never be silently
+dropped" clause of #409 as a number:
+
+```bash
+python3 tools/bench_radio_modem.py -p PORT --tx DEADBEEF --repeat 50
+```
+
+**Step 4 — over the air (the #409 acceptance criterion).** With a second
+radio on the same parameters, `--listen` on one end and `--tx` on the other;
+`RX_FRAME` carries the air bytes back verbatim with RSSI/SNR. Then repeat
+against an **unmodified deployed base station**, transmitting bytes its
+`LORA_PROTO_VERSION` parser accepts — `--tx` of arbitrary hex proves the
+tunnel and the credit return, not application interop.
+
+`--scan 902 928 500 30` sweeps the band and prints the peak, which is the
+quickest way to confirm the RF switch and antenna path are doing something.
+
+**Not yet run on hardware.** Everything above is bench-ready but unexecuted:
+the daughterboard has not been brought up. Steps 1–4 need a board on the bench
+and a go-ahead.
 
 ## Tests
 
-Host-side codec/protocol tests: `tests_cpp/test_uart_link_codec.cpp`
-(golden wire-format bytes, deframer resync/corruption behavior, wire-stable
-struct layouts).
+- `tests_cpp/test_uart_link_codec.cpp` — golden wire-format bytes (literal, so
+  a CRC-parameter change is caught), deframer resync/corruption behaviour,
+  wire-stable struct layouts.
+- `tests/integration/test_radio_modem_codec.py` — pins the bench host's
+  independent Python codec to the same golden frames, so the two
+  implementations of this wire format cannot drift apart.

--- a/tinkerrocket-idf/projects/radio_board/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/radio_board/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.cpp"
+    SRCS "main.cpp" "bench_selftest.cpp"
     INCLUDE_DIRS "."
     REQUIRES
         TR_Compat
@@ -10,3 +10,12 @@ idf_component_register(
         TR_LoRa_Comms
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format)
+
+# Bench self-test (#409): `idf.py -B build_bench -DTR_BENCH_SELFTEST=1 build`.
+# Kept out of production images on purpose — the UART tests run the peripheral
+# in internal loopback, and the TX pin keeps driving while they do, so a host
+# on J6 would see the test traffic.
+if(TR_BENCH_SELFTEST)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BENCH_SELFTEST=1)
+    message(STATUS "radio_board: BENCH SELF-TEST build — not a production image")
+endif()

--- a/tinkerrocket-idf/projects/radio_board/main/bench_selftest.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/bench_selftest.cpp
@@ -1,0 +1,415 @@
+#include "bench_selftest.h"
+
+#ifdef TR_BENCH_SELFTEST
+
+#include <cstring>
+
+#include <driver/uart.h>
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <RadioModemProtocol.h>
+#include <TR_MsgCodec.h>
+
+namespace bench
+{
+
+static const char* TAG = "bench";
+
+using namespace radio_modem;
+
+// ---------------------------------------------------------------------------
+// Capture harness: collect frames the deframer hands back
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+struct Capture
+{
+    static constexpr size_t MAX_FRAMES = 64;
+    struct Frame
+    {
+        uint8_t type;
+        size_t len;
+        uint8_t payload[tr_msg::MAX_PAYLOAD];
+    };
+    Frame frames[MAX_FRAMES];
+    size_t count = 0;
+    size_t overflow = 0;
+
+    void reset()
+    {
+        count = 0;
+        overflow = 0;
+    }
+};
+
+Capture g_cap;
+
+void onFrame(void* /*ctx*/, uint8_t type, const uint8_t* payload, size_t len)
+{
+    if (g_cap.count >= Capture::MAX_FRAMES)
+    {
+        g_cap.overflow++;
+        return;
+    }
+    Capture::Frame& f = g_cap.frames[g_cap.count++];
+    f.type = type;
+    f.len = len;
+    if (len > 0)
+    {
+        memcpy(f.payload, payload, len);
+    }
+}
+
+// Pump the link for up to timeout_ms, stopping early once `want` frames are in.
+void pumpUntil(TR_UART_Link& link, size_t want, uint32_t timeout_ms)
+{
+    const int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000;
+    while (esp_timer_get_time() < deadline)
+    {
+        link.poll(onFrame, nullptr);
+        if (g_cap.count >= want)
+        {
+            // One more poll: a trailing frame may already be in the FIFO, and
+            // "we got what we asked for" must not hide an extra arrival.
+            link.poll(onFrame, nullptr);
+            return;
+        }
+        vTaskDelay(1);
+    }
+}
+
+struct Results
+{
+    int checks = 0;
+    int failures = 0;
+
+    void check(bool ok, const char* what)
+    {
+        checks++;
+        if (ok)
+        {
+            ESP_LOGI(TAG, "  ok   %s", what);
+        }
+        else
+        {
+            failures++;
+            ESP_LOGE(TAG, "  FAIL %s", what);
+        }
+    }
+};
+
+// Write raw bytes straight at the UART, bypassing the codec — needed to feed
+// the deframer garbage and deliberately corrupted frames.
+void writeRaw(uart_port_t port, const uint8_t* data, size_t len)
+{
+    uart_write_bytes(port, reinterpret_cast<const char*>(data), len);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// UART link tests (internal loopback — no adapter, no host)
+// ---------------------------------------------------------------------------
+
+static void testUartLink(TR_UART_Link& link, uart_port_t port, Results& r)
+{
+    ESP_LOGI(TAG, "UART link (internal loopback @ real baud):");
+
+    ESP_ERROR_CHECK(uart_set_loop_back(port, true));
+    // Anything already in flight would land in the middle of test 1.
+    uart_flush_input(port);
+
+    TR_UART_Link::Stats before = {};
+    link.getStats(before);
+
+    // --- 1. Round trip across the payload-size range, including the edges ---
+    // 0 is the common case on this link (GET_STATUS et al) and 255 is the
+    // codec's ceiling; both are where a length bug shows up first.
+    {
+        const size_t sizes[] = {0, 1, 16, 64, sizeof(ModemStatusData),
+                                MAX_AIR_FRAME, tr_msg::MAX_PAYLOAD};
+        const size_t n = sizeof(sizes) / sizeof(sizes[0]);
+        static uint8_t payload[tr_msg::MAX_PAYLOAD];
+        for (size_t i = 0; i < sizeof(payload); i++)
+        {
+            payload[i] = static_cast<uint8_t>(i * 7 + 3);  // non-trivial pattern
+        }
+
+        g_cap.reset();
+        for (size_t i = 0; i < n; i++)
+        {
+            link.sendFrame(static_cast<uint8_t>(0x40 + i), payload, sizes[i]);
+        }
+        pumpUntil(link, n, 500);
+
+        bool ok = (g_cap.count == n);
+        for (size_t i = 0; ok && i < n; i++)
+        {
+            ok = g_cap.frames[i].type == static_cast<uint8_t>(0x40 + i) &&
+                 g_cap.frames[i].len == sizes[i] &&
+                 memcmp(g_cap.frames[i].payload, payload, sizes[i]) == 0;
+        }
+        if (!ok)
+        {
+            ESP_LOGE(TAG, "   got %u/%u frames back", (unsigned)g_cap.count,
+                     (unsigned)n);
+        }
+        r.check(ok, "round trip, 7 payload sizes 0..255 B, bytes identical");
+    }
+
+    // --- 2. Back-to-back burst: does the ring buffer hold at 921600? --------
+    // TR_UART_Link sizes rx_ring at 4096; 24 full frames is ~6.3 kB, so this
+    // only passes if poll() is draining as fast as the wire fills.
+    {
+        static uint8_t payload[MAX_AIR_FRAME];
+        memset(payload, 0xA5, sizeof(payload));
+        const size_t burst = 24;
+
+        g_cap.reset();
+        const int64_t t0 = esp_timer_get_time();
+        for (size_t i = 0; i < burst; i++)
+        {
+            // Interleave polling: this mirrors the real loop, which is the
+            // only configuration whose ring-buffer behaviour we care about.
+            link.sendFrame(0x51, payload, sizeof(payload));
+            link.poll(onFrame, nullptr);
+        }
+        pumpUntil(link, burst, 1000);
+        const int64_t dt = esp_timer_get_time() - t0;
+
+        const size_t wire_bytes = burst * (tr_msg::FRAME_OVERHEAD + sizeof(payload));
+        ESP_LOGI(TAG, "   %u frames (%u B on the wire) in %lld us -> %.0f kB/s",
+                 (unsigned)burst, (unsigned)wire_bytes, dt,
+                 (double)wire_bytes / ((double)dt / 1000.0));
+        r.check(g_cap.count == burst && g_cap.overflow == 0,
+                "24-frame back-to-back burst, none dropped");
+    }
+
+    // --- 3. Resynchronize through garbage ----------------------------------
+    // Includes a false SOF prefix (AA AA 13 55), which is the case a naive
+    // "restart at byte 0" hunt gets wrong.
+    {
+        TR_UART_Link::Stats s0 = {};
+        link.getStats(s0);
+        const uint8_t garbage[] = {0x00, 0xFF, 0xAA, 0xAA, 0x13, 0x55};
+
+        g_cap.reset();
+        writeRaw(port, garbage, sizeof(garbage));
+        const uint8_t payload[] = {0x01, 0x02};
+        link.sendFrame(0x33, payload, sizeof(payload));
+        pumpUntil(link, 1, 500);
+
+        TR_UART_Link::Stats s1 = {};
+        link.getStats(s1);
+        const uint32_t resynced = s1.rx_resync_bytes - s0.rx_resync_bytes;
+        ESP_LOGI(TAG, "   discarded %u B hunting for SOF (6 B of garbage in)",
+                 resynced);
+        // 5, not 6: the counter tracks what the state machine DISCARDS, and
+        // one of the two 0xAAs is consumed as a SOF candidate rather than
+        // dropped. Pinned at 5 because this number goes to hosts in
+        // STATUS.uart_rx_resync_bytes and anything that recomputes it (the
+        // bench host did) must agree.
+        r.check(g_cap.count == 1 && g_cap.frames[0].type == 0x33 &&
+                    g_cap.frames[0].len == 2 && resynced == 5,
+                "resyncs past garbage incl. a false SOF, counts 5 of 6 B");
+    }
+
+    // --- 4. A corrupted frame is dropped, counted, and recovered from -------
+    {
+        TR_UART_Link::Stats s0 = {};
+        link.getStats(s0);
+
+        uint8_t frame[tr_msg::MAX_FRAME];
+        size_t frame_len = 0;
+        const uint8_t bad_payload[] = {0x0A, 0x14, 0x1E};
+        tr_msg::pack(0x44, bad_payload, sizeof(bad_payload), frame,
+                     sizeof(frame), frame_len);
+        frame[7] ^= 0xFF;  // flip a payload byte -> CRC mismatch
+
+        g_cap.reset();
+        writeRaw(port, frame, frame_len);
+        const uint8_t good[] = {0x2A};
+        link.sendFrame(0x55, good, sizeof(good));
+        pumpUntil(link, 1, 500);
+
+        TR_UART_Link::Stats s1 = {};
+        link.getStats(s1);
+        r.check(g_cap.count == 1 && g_cap.frames[0].type == 0x55 &&
+                    (s1.rx_crc_fails - s0.rx_crc_fails) == 1,
+                "CRC-corrupted frame dropped + counted, next frame survives");
+    }
+
+    // --- 5. A truncated frame costs exactly two frames, then recovers ------
+    // The deframer is length-driven: a frame cut short keeps consuming, so it
+    // eats the NEXT frame's SOF as its own payload/CRC, fails the CRC, and
+    // only recovers on the frame after that. That is the documented contract
+    // ("a rare drop is recovered by the next frame", TR_MsgCodec.h), not a
+    // defect — but it is worth pinning, because the obvious host-side
+    // implementation (scan forward to the next SOF) loses only one frame and
+    // would therefore report better link quality than the modem really has.
+    {
+        TR_UART_Link::Stats s0 = {};
+        link.getStats(s0);
+
+        uint8_t frame[tr_msg::MAX_FRAME];
+        size_t frame_len = 0;
+        const uint8_t payload[] = {1, 2, 3, 4, 5, 6, 7, 8};
+        tr_msg::pack(0x66, payload, sizeof(payload), frame, sizeof(frame),
+                     frame_len);
+
+        g_cap.reset();
+        writeRaw(port, frame, frame_len - 4);  // cut it short
+        const uint8_t eaten[] = {0xEE};
+        link.sendFrame(0x77, eaten, sizeof(eaten));   // expected casualty
+        const uint8_t good[] = {0xEF};
+        link.sendFrame(0x78, good, sizeof(good));     // must get through
+        pumpUntil(link, 1, 500);
+
+        TR_UART_Link::Stats s1 = {};
+        link.getStats(s1);
+        r.check(g_cap.count == 1 && g_cap.frames[0].type == 0x78 &&
+                    g_cap.frames[0].payload[0] == 0xEF &&
+                    (s1.rx_crc_fails - s0.rx_crc_fails) == 1,
+                "truncated frame swallows exactly one follower, then recovers");
+    }
+
+    // --- 6. Codec agrees with the host-side golden bytes --------------------
+    // Same literal frame asserted in tests_cpp and tools/bench_radio_modem.py.
+    // Cheap to check here too, and it proves the ON-CHIP build produces it —
+    // the host tests compile the same source with a different toolchain.
+    {
+        uint8_t frame[tr_msg::MAX_FRAME];
+        size_t frame_len = 0;
+        const uint8_t payload[] = {0x01, 0x02, 0x03};
+        tr_msg::pack(0x42, payload, sizeof(payload), frame, sizeof(frame),
+                     frame_len);
+        const uint8_t golden[] = {0xAA, 0x55, 0xAA, 0x55, 0x42, 0x03,
+                                  0x01, 0x02, 0x03, 0x00, 0x66};
+        r.check(frame_len == sizeof(golden) &&
+                    memcmp(frame, golden, sizeof(golden)) == 0,
+                "on-chip codec matches the host golden frame");
+    }
+
+    ESP_ERROR_CHECK(uart_set_loop_back(port, false));
+    uart_flush_input(port);
+}
+
+// ---------------------------------------------------------------------------
+// Radio receive-path test (no transmission — safe with no antenna)
+// ---------------------------------------------------------------------------
+
+static void testRadioRxPath(TR_LoRa_Comms& radio, Results& r)
+{
+    ESP_LOGI(TAG, "Radio RX path (spectrum scan, receive-only):");
+
+    // 902-928 MHz at 500 kHz = 53 samples, inside SCAN_MAX_SAMPLES (128).
+    // The sweep drives the SPI command path, retunes the synthesiser 53
+    // times, enters RX at each step (toggling RXEN, i.e. the half of the RF
+    // switch this MCU actually owns) and reads RSSI back out of the chip.
+    if (!radio.startScan(902.0f, 928.0f, 500, 30))
+    {
+        r.check(false, "startScan accepted");
+        return;
+    }
+
+    const int64_t deadline = esp_timer_get_time() + 15'000'000;
+    while (!radio.isScanDone() && esp_timer_get_time() < deadline)
+    {
+        radio.serviceScan();
+        vTaskDelay(1);
+    }
+    if (!radio.isScanDone())
+    {
+        r.check(false, "scan completed within 15 s");
+        return;
+    }
+
+    const size_t n = radio.getScanSampleCount();
+    const TR_LoRa_Comms::ScanSample* s = radio.getScanSamples();
+    r.check(n > 0, "scan returned samples");
+    if (n == 0)
+    {
+        radio.consumeScanDone();
+        return;
+    }
+
+    int lo = 127, hi = -128;
+    long sum = 0;
+    size_t pegged = 0;
+    for (size_t i = 0; i < n; i++)
+    {
+        const int v = s[i].rssi_dbm;
+        lo = v < lo ? v : lo;
+        hi = v > hi ? v : hi;
+        sum += v;
+        // A dead receive path reads as a rail, not as noise.
+        if (v == 0 || v <= -127)
+        {
+            pegged++;
+        }
+    }
+    const int mean = static_cast<int>(sum / (long)n);
+    ESP_LOGI(TAG, "   %u samples 902-928 MHz: min %d, mean %d, max %d dBm",
+             (unsigned)n, lo, mean, hi);
+
+    // Coarse profile so a real signal or a stuck reading is visible by eye.
+    char bar[80];
+    const size_t width = n < sizeof(bar) - 1 ? n : sizeof(bar) - 1;
+    for (size_t i = 0; i < width; i++)
+    {
+        const int v = s[i * n / width].rssi_dbm;
+        bar[i] = v > -60 ? '#' : v > -80 ? '+' : v > -100 ? '.' : ' ';
+    }
+    bar[width] = '\0';
+    ESP_LOGI(TAG, "   902 MHz [%s] 928 MHz   (' '<-100  '.'<-80  '+'<-60  '#')",
+             bar);
+
+    r.check(pegged < n,
+            "RSSI is a noise floor, not a stuck rail (0 or -127 dBm)");
+    // A healthy 900 MHz front end sits well below -80 dBm on a quiet bench;
+    // anything above -50 across the whole sweep means the reading is not noise.
+    r.check(mean < -50, "mean noise floor is plausible for a quiet bench");
+
+    radio.consumeScanDone();
+    radio.startReceive();  // leave the radio as we found it
+}
+
+// ---------------------------------------------------------------------------
+
+int runSelfTest(TR_UART_Link& link, TR_LoRa_Comms& radio, uart_port_t port,
+                bool radio_up)
+{
+    Results r;
+    ESP_LOGW(TAG, "==== bench self-test (TR_BENCH_SELFTEST build) ====");
+
+    testUartLink(link, port, r);
+
+    if (radio_up)
+    {
+        testRadioRxPath(radio, r);
+    }
+    else
+    {
+        ESP_LOGW(TAG, "Radio RX path: SKIPPED — radio never initialised");
+    }
+
+    if (r.failures == 0)
+    {
+        ESP_LOGW(TAG, "==== self-test PASSED (%d checks) ====", r.checks);
+    }
+    else
+    {
+        ESP_LOGE(TAG, "==== self-test FAILED: %d of %d checks ====", r.failures,
+                 r.checks);
+    }
+    return r.failures;
+}
+
+}  // namespace bench
+
+#endif  // TR_BENCH_SELFTEST

--- a/tinkerrocket-idf/projects/radio_board/main/bench_selftest.h
+++ b/tinkerrocket-idf/projects/radio_board/main/bench_selftest.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <TR_LoRa_Comms.h>
+#include <TR_UART_Link.h>
+
+// On-hardware bench self-test for the radio daughterboard (#409).
+//
+// Built only with `idf.py -B build_bench -DTR_BENCH_SELFTEST=1 build`, never
+// in a production image: the UART tests put the peripheral in internal
+// loopback, and while loopback routes TX back to RX inside the chip, the TX
+// pin keeps driving — a host on J6 would see the test frames.
+//
+// It exists because the two halves of this firmware were verifiable in
+// completely different places. The framing codec has host tests
+// (tests_cpp/test_uart_link_codec.cpp) but had never run on a real UART at a
+// real baud rate, and the radio had never been asked to do anything beyond
+// initialise. Neither gap needs a second board or even a UART adapter to
+// close, so neither should have waited for one.
+//
+// Everything here is receive-only on the RF side. Nothing transmits, so it is
+// safe to run with no antenna fitted.
+
+namespace bench
+{
+
+// Runs the whole suite, logging results to the console. Returns the number of
+// failed checks (0 = all good). Safe to call once, after uart_link.begin()
+// and the radio's begin() attempt; leaves both in their normal state.
+int runSelfTest(TR_UART_Link& link, TR_LoRa_Comms& radio, uart_port_t port,
+                bool radio_up);
+
+}  // namespace bench

--- a/tinkerrocket-idf/projects/radio_board/main/config.h
+++ b/tinkerrocket-idf/projects/radio_board/main/config.h
@@ -4,22 +4,38 @@
 
 // Radio daughterboard (ESP32-S3) pin/board configuration (#409).
 //
-// LoRa + LED pins are from the V8 daughterboard schematic (L_* / LED nets).
-// TODO: host-link UART pins are still placeholders — set from the schematic's
-// host-connector nets before flashing real hardware.
+// Board: "LoRa Board V3", the as-built daughterboard — ESP32-S3 (U28) + EBYTE
+// E220-900MM22S (U14, LLCC68 + its own 32 MHz crystal) + W25Q64 boot flash,
+// USB-C console/programming, 4-pin JST-SH host link (J6). Every pin below is
+// the schematic net, verified against that board's .kicad_pcb pad->net map.
+//
+// A later revision exists (hardware/lora-daughterboard: S3RH2, W25Q128,
+// different passives). Its GPIO net map is IDENTICAL — pad-by-pad diffed —
+// so everything in this file serves both boards; only the flash size in
+// sdkconfig.defaults is revision-specific.
 struct config
 {
     // ---- UART link to the host (OC on the rocket, BS on the ground) --------
     // The modem must never care which host it is plugged into (#409:
     // host-agnostic, swappable matched pairs).
+    //
+    // J6 mates 1:1 with rocket-computer J5 and base-station J6:
+    //   J6.1 VSS  <- switched ground return (rocket: Q10 / LoRa_ACT)
+    //   J6.2 +BATT<- 6.4-8.4 V pack (rocket) or ~4.6 V V_LORA (base station)
+    //   J6.3 net LoRa_TX = GPIO6 -> host's RX   (we drive it)
+    //   J6.4 net LoRa_RX = GPIO5 <- host's TX   (host drives it)
+    // The net *names* are self-perspective on each board, so the same two
+    // names appear on both ends of a crossed pair — the cable pin number is
+    // the only unambiguous reference. Host ends: OC GPIO11 TX / GPIO10 RX
+    // (board_v8.h), BS GPIO35 TX / GPIO36 RX (board_v3.h).
     static constexpr uart_port_t HOST_UART_PORT = UART_NUM_1;
-    static constexpr int HOST_UART_TX = 5;   // TODO: TBD from V8 schematic
-    static constexpr int HOST_UART_RX = 6;   // TODO: TBD from V8 schematic
+    static constexpr int HOST_UART_TX = 6;   // LoRa_TX -> J6.3 (CONFIRMED)
+    static constexpr int HOST_UART_RX = 5;   // LoRa_RX <- J6.4 (CONFIRMED)
     // Sized for tunnel traffic (LoRa airtime dominates), not raw UART
     // capability; must match the host side (#410).
     static constexpr int HOST_UART_BAUD = 921'600;
 
-    // ---- LoRa radio (LLCC68 over SPI) — V8 daughterboard nets ---------------
+    // ---- LoRa radio (LLCC68 over SPI) — daughterboard L_* nets -------------
     static constexpr int LORA_SPI_SCK = 17;   // L_SCK
     static constexpr int LORA_SPI_MISO = 33;  // L_MISO
     static constexpr int LORA_SPI_MOSI = 21;  // L_MOSI
@@ -27,21 +43,41 @@ struct config
     static constexpr int LORA_DIO1_PIN = 2;   // L_DIO1
     static constexpr int LORA_RST_PIN = 38;   // L_RST
     static constexpr int LORA_BUSY_PIN = 34;  // L_BUSY
-    static constexpr int LORA_RXEN_PIN = 35;  // L_RXEN (RF switch RX enable;
-                                              // TX side is DIO2-driven)
+    static constexpr int LORA_RXEN_PIN = 35;  // L_RXEN -> U14 pad 10.
+                                              // TX side is DIO2-driven: the
+                                              // board shorts U14 DIO2 (19) to
+                                              // TXEN (9), which is the split
+                                              // EBYTE prescribes. Only the RX
+                                              // half reaches an MCU pin.
+    // U14 DIO3 is left floating on purpose — the E220 carries its own 32 MHz
+    // passive crystal, so this radio must NOT be configured for a DIO3-powered
+    // TCXO (TR_LoRa_Comms does not, which is why it is correct here).
 
     // ---- Indicator LEDs ------------------------------------------------------
     // TX LED is lit for the duration of a transmission (airtime-length flash);
-    // RX LED pulses per received air packet.
+    // RX LED pulses per received air packet. Both are anode-to-GPIO through a
+    // series resistor with the cathode on GND, so active level is HIGH.
+    //   GPIO7 = net IND_2 -> R60 -> D5 (red)
+    //   GPIO8 = net IND_1 -> R59 -> D4 (blue)
+    // D6 is a hardwired power LED — no GPIO, nothing to drive.
+    // Bench note: R59/R60 are 10 k on LoRa V3, i.e. ~140 uA into the red and
+    // 0-70 uA into the blue (hardware pre-fab review finding 9). If the blue
+    // TX LED never visibly lights on the first article, that is the resistor
+    // value, not this firmware.
     static constexpr int LED_RX_PIN = 7;
     static constexpr int LED_TX_PIN = 8;
     static constexpr uint32_t LED_ACTIVE_LEVEL = 1;  // flip if wired to VCC
     static constexpr uint32_t LED_RX_PULSE_MS = 40;
 
     // ---- Radio capability (reported in IDENTITY; hosts clamp to these) -----
-    static constexpr int8_t RADIO_MAX_TX_POWER_DBM = 22;   // LLCC68 ceiling
-    static constexpr float RADIO_FREQ_MIN_MHZ = 150.0f;    // LLCC68 band edges
-    static constexpr float RADIO_FREQ_MAX_MHZ = 960.0f;
+    // These are the MODULE's limits, not the bare LLCC68 die's (150-960 MHz):
+    // the E220-900MM22S has a fixed 900 MHz matching network and RF switch, so
+    // the die's band edges are not reachable capability. Reporting the module
+    // limits is the whole point of IDENTITY — it is what lets a different
+    // module variant drop in later without a host firmware change.
+    static constexpr int8_t RADIO_MAX_TX_POWER_DBM = 22;   // E220-900MM22S
+    static constexpr float RADIO_FREQ_MIN_MHZ = 850.0f;    // E220-900MM22S
+    static constexpr float RADIO_FREQ_MAX_MHZ = 930.0f;    //   850-930 MHz
 
     // ---- Boot radio defaults ------------------------------------------------
     // The modem comes up listening on these until the host pushes SET_CONFIG,

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -17,6 +17,7 @@
 #include <driver/gpio.h>
 #include <esp_app_desc.h>
 #include <esp_log.h>
+#include <esp_rom_sys.h>
 #include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -107,6 +108,23 @@ static void initLeds()
     ledWrite(config::LED_TX_PIN, false);
 }
 
+// One visible blink at boot. On a board powered from J6 with no USB attached
+// this is the only sign the S3 is running at all, which matters when the
+// question is "is anything on this board alive". Blocking is fine here —
+// nothing is listening yet.
+static void blinkBoot()
+{
+    for (int i = 0; i < 2; i++)
+    {
+        ledWrite(config::LED_RX_PIN, true);
+        ledWrite(config::LED_TX_PIN, true);
+        vTaskDelay(pdMS_TO_TICKS(120));
+        ledWrite(config::LED_RX_PIN, false);
+        ledWrite(config::LED_TX_PIN, false);
+        vTaskDelay(pdMS_TO_TICKS(120));
+    }
+}
+
 static void pulseRxLed()
 {
     ledWrite(config::LED_RX_PIN, true);
@@ -121,6 +139,109 @@ static void serviceLeds()
         ledWrite(config::LED_RX_PIN, false);
         rx_led_off_at_ms = 0;
     }
+}
+
+// ---- Radio hardware probe ----------------------------------------------------
+// Runs BEFORE TR_LoRa_Comms claims the pins, and answers a question begin()
+// cannot: is the E220 module electrically there at all? A failed begin() is
+// ambiguous -- dead module, dead SPI, or a config the chip rejected all look
+// the same from the return code. This separates "the module is not answering
+// at the pin level" from "the module answers but the link setup failed", which
+// is the first thing worth knowing on a board that has seen reverse polarity.
+//
+// The test is a pull fight. U14's BUSY (pad 11) and DIO1 (pad 20) are
+// push-pull outputs of the LLCC68 with no board pull resistors, so:
+//   * level follows our internal pull  -> nothing is driving it (module
+//     unpowered, dead, or the joint is open)
+//   * level holds against our pull     -> the module is driving it, alive
+// After a reset the LLCC68 holds BUSY high through its internal boot and
+// releases it in standby (~1 ms typical), so a BUSY stuck high past the
+// timeout is the same verdict as a floating one, reported separately because
+// the fix differs (dead die vs. no VCC / open joint).
+
+struct RadioProbe
+{
+    bool busy_driven = false;    // something is holding BUSY against our pull
+    bool busy_released = false;  // BUSY went low after reset, i.e. booted
+    bool dio1_driven = false;
+    uint32_t busy_release_us = 0;
+};
+
+static bool pinHoldsAgainstPull(gpio_num_t pin)
+{
+    // Read with an internal pull-up, then a pull-down. A floating pin follows
+    // both; a driven pin reads the same level twice.
+    gpio_set_pull_mode(pin, GPIO_PULLUP_ONLY);
+    esp_rom_delay_us(200);
+    const int with_pu = gpio_get_level(pin);
+    gpio_set_pull_mode(pin, GPIO_PULLDOWN_ONLY);
+    esp_rom_delay_us(200);
+    const int with_pd = gpio_get_level(pin);
+    gpio_set_pull_mode(pin, GPIO_FLOATING);
+    return with_pu == with_pd;
+}
+
+static RadioProbe probeRadioHardware()
+{
+    RadioProbe p = {};
+    const gpio_num_t rst = static_cast<gpio_num_t>(config::LORA_RST_PIN);
+    const gpio_num_t busy = static_cast<gpio_num_t>(config::LORA_BUSY_PIN);
+    const gpio_num_t dio1 = static_cast<gpio_num_t>(config::LORA_DIO1_PIN);
+
+    gpio_config_t out = {};
+    out.pin_bit_mask = 1ULL << config::LORA_RST_PIN;
+    out.mode = GPIO_MODE_OUTPUT;
+    gpio_config(&out);
+
+    gpio_config_t in = {};
+    in.pin_bit_mask = (1ULL << config::LORA_BUSY_PIN) |
+                      (1ULL << config::LORA_DIO1_PIN);
+    in.mode = GPIO_MODE_INPUT;
+    gpio_config(&in);
+
+    // Same reset shape TR_LoRa_Comms::begin() uses, so a module that survives
+    // this one will see nothing new from the driver.
+    gpio_set_level(rst, 0);
+    vTaskDelay(pdMS_TO_TICKS(50));
+    gpio_set_level(rst, 1);
+
+    const int64_t t0 = esp_timer_get_time();
+    while (esp_timer_get_time() - t0 < 50'000)
+    {
+        if (gpio_get_level(busy) == 0)
+        {
+            p.busy_released = true;
+            p.busy_release_us = static_cast<uint32_t>(esp_timer_get_time() - t0);
+            break;
+        }
+        esp_rom_delay_us(100);
+    }
+
+    p.busy_driven = pinHoldsAgainstPull(busy);
+    p.dio1_driven = pinHoldsAgainstPull(dio1);
+    return p;
+}
+
+static void logRadioProbe(const RadioProbe& p)
+{
+    if (p.busy_released && p.busy_driven)
+    {
+        ESP_LOGI(TAG, "radio probe: module ALIVE — BUSY released %u us after "
+                      "reset and is driven (DIO1 %s)",
+                 p.busy_release_us, p.dio1_driven ? "driven" : "floating");
+        return;
+    }
+    if (!p.busy_driven)
+    {
+        ESP_LOGE(TAG, "radio probe: BUSY is FLOATING — nothing is driving U14 "
+                      "pad 11. The module is unpowered, dead, or its joints are "
+                      "open. Check +3V3 at U14 pad 1 before suspecting "
+                      "firmware.");
+        return;
+    }
+    ESP_LOGE(TAG, "radio probe: BUSY driven but STUCK HIGH past 50 ms — the "
+                  "module has power and is driving the pin, but never finished "
+                  "its boot. Suspect a damaged die or a bad NRST/SPI joint.");
 }
 
 static void sendTxResult(uint8_t seq, bool ok)
@@ -418,6 +539,7 @@ extern "C" void app_main(void)
              PROTOCOL_VERSION);
 
     initLeds();
+    blinkBoot();
 
     TR_UART_Link::Config ucfg = {};
     ucfg.port = config::HOST_UART_PORT;
@@ -438,6 +560,10 @@ extern "C" void app_main(void)
     boot.preamble_len = 16;
     boot.flags = CFG_FLAG_CRC_ON | CFG_FLAG_RX_BOOSTED_GAIN |
                  CFG_FLAG_SYNCWORD_PRIVATE;
+    // Probe first: if the module is not answering at the pin level, the
+    // begin() failure below is a symptom, not the finding.
+    logRadioProbe(probeRadioHardware());
+
     radio_up = radio.begin(radioConfigFromMsg(boot), config::DEBUG);
     if (radio_up)
     {
@@ -447,8 +573,10 @@ extern "C" void app_main(void)
     }
     else
     {
-        ESP_LOGE(TAG, "radio init FAILED — modem alive, RF dead (host sees "
-                      "radio_enabled=0)");
+        TR_LoRa_Comms::Stats rs = {};
+        radio.getStats(rs);
+        ESP_LOGE(TAG, "radio init FAILED (RadioLib %d) — modem alive, RF dead "
+                      "(host sees radio_enabled=0)", rs.last_error);
     }
 
     // Announce boot: identity payload doubles as the host's signal to reset

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -28,6 +28,10 @@
 
 #include "config.h"
 
+#ifdef TR_BENCH_SELFTEST
+#include "bench_selftest.h"
+#endif
+
 // ---- Board constraints -------------------------------------------------------
 // LoRa V3 hardware facts that a future sdkconfig edit could violate silently.
 // The two that map to a settable Kconfig symbol fail the build rather than the
@@ -578,6 +582,14 @@ extern "C" void app_main(void)
         ESP_LOGE(TAG, "radio init FAILED (RadioLib %d) — modem alive, RF dead "
                       "(host sees radio_enabled=0)", rs.last_error);
     }
+
+#ifdef TR_BENCH_SELFTEST
+    // Bench build only (see main/CMakeLists.txt). Runs before BOOT is
+    // announced so a host can never see the loopback traffic ahead of the
+    // handshake — though a bench image should not be plugged into a host at
+    // all.
+    bench::runSelfTest(uart_link, radio, config::HOST_UART_PORT, radio_up);
+#endif
 
     // Announce boot: identity payload doubles as the host's signal to reset
     // its credit window (our TX queue is empty now).

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -374,14 +374,26 @@ static void handleSetConfig(const uint8_t* payload, size_t len)
 
     if (!radio_up)
     {
-        // Radio never came up (or wasn't wired at boot) — full begin() so the
-        // boot-fixed fields (preamble/flags) from the host apply too.
+        // Radio never came up (or wasn't wired at boot) — full begin(), which
+        // applies every field including preamble/flags.
         radio_up = radio.begin(radioConfigFromMsg(d), config::DEBUG);
     }
     else
     {
-        radio.reconfigure(d.freq_mhz, d.spreading_factor, d.bandwidth_khz,
-                          d.coding_rate, d.tx_power_dbm);
+        // SET_CONFIG is fully authoritative: modulation via reconfigure(),
+        // then the frame-format fields (preamble/CRC/gain/syncword) via
+        // applyFrameParams(). Without the second half, a host whose preamble
+        // differs from our boot default would silently keep ours — its
+        // airtime model (FCC dwell accounting, RocketComputerTypes.h) counts
+        // preamble symbols it never actually got.
+        if (radio.reconfigure(d.freq_mhz, d.spreading_factor, d.bandwidth_khz,
+                              d.coding_rate, d.tx_power_dbm))
+        {
+            (void)radio.applyFrameParams(
+                d.preamble_len, (d.flags & CFG_FLAG_CRC_ON) != 0,
+                (d.flags & CFG_FLAG_RX_BOOSTED_GAIN) != 0,
+                (d.flags & CFG_FLAG_SYNCWORD_PRIVATE) != 0);
+        }
     }
     if (radio_up && d.start_rx)
     {
@@ -561,7 +573,13 @@ extern "C" void app_main(void)
     boot.spreading_factor = config::BOOT_SF;
     boot.coding_rate = config::BOOT_CR;
     boot.tx_power_dbm = config::BOOT_TX_POWER_DBM;
-    boot.preamble_len = 16;
+    // 12, matching both hosts' LORA_PREAMBLE_LEN. This mattered more than it
+    // looks: the hosts' airtime model (LORA_TELEM_PREAMBLE_SYMS,
+    // RocketComputerTypes.h) assumes their preamble is what's on the air,
+    // and the FCC dwell budget on the tightest hop rung has ~2 ms of margin
+    // — a 16-symbol boot default that survived (pre-applyFrameParams) blew
+    // that budget silently.
+    boot.preamble_len = 12;
     boot.flags = CFG_FLAG_CRC_ON | CFG_FLAG_RX_BOOSTED_GAIN |
                  CFG_FLAG_SYNCWORD_PRIVATE;
     // Probe first: if the module is not answering at the pin level, the

--- a/tinkerrocket-idf/projects/radio_board/main/main.cpp
+++ b/tinkerrocket-idf/projects/radio_board/main/main.cpp
@@ -27,6 +27,29 @@
 
 #include "config.h"
 
+// ---- Board constraints -------------------------------------------------------
+// LoRa V3 hardware facts that a future sdkconfig edit could violate silently.
+// The two that map to a settable Kconfig symbol fail the build rather than the
+// bench; the third has no such symbol and is stated here so it is at least on
+// the page next to the code it constrains.
+//
+// NO 2.4 GHz, EVER. The S3's LNA_IN (pin 1) is left floating on this board
+// with no matching network, and the RF supply is a 2 nH 0402 + 100 nF. Nothing
+// in this firmware may call esp_wifi_init() or esp_bt_controller_init().
+// (CONFIG_ESP_WIFI_ENABLED cannot be asserted on: it is a non-prompt SoC
+// capability symbol, always y on an S3 — the BT half below is the settable one.)
+
+#ifdef CONFIG_BT_ENABLED
+#error "radio_board: the daughterboard leaves the S3's LNA_IN floating with no \
+matching network — no 2.4 GHz radio may be brought up on this board."
+#endif
+#ifdef CONFIG_SPIRAM
+#error "radio_board: the as-built board's S3 has no in-package PSRAM at all, \
+and on the S3RH2 revision the PSRAM shares VDD_SPI (fed through ~14 ohm) with \
+the boot flash — both active sags that rail under the 2.7 V minimum of each. \
+See sdkconfig.defaults."
+#endif
+
 static const char* TAG = "radio_board";
 
 using namespace radio_modem;

--- a/tinkerrocket-idf/projects/radio_board/partitions.csv
+++ b/tinkerrocket-idf/projects/radio_board/partitions.csv
@@ -1,6 +1,9 @@
 # Name,   Type, SubType, Offset,  Size,    Flags
-# Compact enough for a 4 MB flash part (daughterboard module TBD); OTA pair
-# kept so #412 (UART-tunneled update) needs no repartition later.
+# Deliberately compact — 3.2 MB of the as-built board's 8 MB W25Q64. The modem
+# app builds to ~280 KB, so a 1.5 MB OTA slot is already 5x headroom, and
+# keeping the table inside 4 MB means the same binary+table flashes onto any
+# bench devkit (and onto the 16 MB board revision). The OTA pair exists so
+# #412 (UART-tunneled update) needs no repartition later.
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
 ota_0,    app,  ota_0,   0x10000, 0x180000,

--- a/tinkerrocket-idf/projects/radio_board/sdkconfig.defaults
+++ b/tinkerrocket-idf/projects/radio_board/sdkconfig.defaults
@@ -1,9 +1,25 @@
 CONFIG_IDF_TARGET="esp32s3"
 
-# Flash — devkit modules are >=8MB; partition table stays within 4MB in case
-# the final daughterboard uses a smaller part.
+# Flash — 8 MB, settled from the as-built board: U22 = W25Q64JVXGIQ (64 Mbit).
+# This was previously 8 MB for a guess ("devkits are >=8MB, final part TBD");
+# it is now 8 MB for a reason. A later board revision fits a W25Q128 (16 MB) —
+# 8 MB is the safe value for both, since an 8 MB image runs on a 16 MB part
+# while the reverse bricks the boot. Do not raise this to match a schematic
+# without checking which board is in your hand. (Reading the flash part off a
+# stale field is the OC's 128-of-512 MB mistake, #492.)
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+
+# PSRAM stays OFF — hardware constraint, not a preference, and it holds for
+# both board revisions for different reasons. The as-built board fits a plain
+# ESP32-S3 (no in-package PSRAM, so there is nothing to enable). The revision
+# that fits an S3RH2 has 2 MB of quad PSRAM hanging on VDD_SPI, which in 3.3 V
+# mode is fed internally from VDD3P3_RTC through ~14 ohm — and the external
+# boot flash shares that node. Flash alone (~25 mA) holds ~2.95 V; flash +
+# PSRAM active (~50 mA) sags to ~2.60 V, below both parts' 2.7 V minimum, i.e.
+# enabling PSRAM browns out the chip's own boot flash. Do not turn this on
+# unless VDD_SPI is re-fed (hardware pre-fab review finding 4).
+CONFIG_SPIRAM=n
 
 # FreeRTOS
 CONFIG_FREERTOS_HZ=1000

--- a/tools/bench_radio_modem.py
+++ b/tools/bench_radio_modem.py
@@ -111,51 +111,98 @@ def pack(msg_type: int, payload: bytes = b"") -> bytes:
 
 
 class Deframer:
-    """Byte-at-a-time deframer mirroring tr_msg::MsgDeframer.
+    """Byte-at-a-time port of tr_msg::MsgDeframer (TR_MsgCodec.cpp).
 
-    Same recovery contract: garbage is discarded while hunting for SOF, a
-    CRC-failed frame is dropped and counted, and the next good frame parses.
+    This is a state machine and not a `buf.find(SOF)` scan on purpose, because
+    the two are NOT equivalent and the difference is observable on a real
+    link:
+
+      * `resync_bytes` differs. The firmware counts bytes its state machine
+        discards, and a stray 0xAA that becomes a SOF candidate is accounted
+        for differently than a byte simply skipped over. On the canonical
+        `00 FF AA AA 13 55` garbage prefix the firmware counts 5, a find-based
+        scan counts 6. That number is reported to hosts in
+        STATUS.uart_rx_resync_bytes, so a bench tool that computes it
+        differently mis-reports link health.
+
+      * Recovery after a TRUNCATED frame differs, which is the one that
+        matters. This framer is length-driven: a frame cut short leaves it
+        consuming the *next* frame's bytes as payload/CRC, so a truncation
+        costs two frames, not one. A find-based scan would re-anchor on the
+        next SOF and lose only one -- i.e. it would quietly report better
+        behaviour than the modem actually has.
+
+    Both divergences were found by running the on-chip bench self-test
+    (TR_BENCH_SELFTEST) against this file's expectations.
     """
 
+    SOF_BYTES = (0xAA, 0x55, 0xAA, 0x55)
+
+    # States, mirroring St:: in TR_MsgCodec.h
+    _HUNT0, _HUNT1, _HUNT2, _HUNT3, _TYPE, _LEN, _PAYLOAD, _CRC0, _CRC1 = range(9)
+
     def __init__(self):
-        self.buf = bytearray()
+        self.state = self._HUNT0
+        self.body = bytearray()   # type + len + payload, what the CRC covers
+        self.payload_len = 0
+        self.crc_hi = 0
         self.frames = 0
         self.crc_fails = 0
         self.resync_bytes = 0
 
+    def _rehunt(self, b: int):
+        """tr_msg::MsgDeframer::rehunt — a stray 0xAA restarts one byte in."""
+        self.resync_bytes += 1
+        self.state = self._HUNT1 if b == 0xAA else self._HUNT0
+
     def feed(self, data: bytes):
         """Yield (type, payload) for each complete CRC-valid frame."""
-        self.buf.extend(data)
-        while True:
-            start = self.buf.find(SOF)
-            if start < 0:
-                # Keep the last 3 bytes: a SOF may straddle this chunk.
-                drop = max(0, len(self.buf) - 3)
-                self.resync_bytes += drop
-                del self.buf[:drop]
-                return
-            if start > 0:
-                self.resync_bytes += start
-                del self.buf[:start]
-            if len(self.buf) < 6:
-                return
-            msg_type, length = self.buf[4], self.buf[5]
-            total = 4 + 2 + length + 2
-            if len(self.buf) < total:
-                return
-            body = bytes(self.buf[4:6 + length])
-            got = struct.unpack(">H", bytes(self.buf[6 + length:total]))[0]
-            if got == crc16(body):
-                self.frames += 1
-                payload = bytes(self.buf[6:6 + length])
-                del self.buf[:total]
-                yield msg_type, payload
-            else:
-                self.crc_fails += 1
-                # Drop only the SOF so a real frame starting inside this one's
-                # bytes is still found -- same as rehunt() in the firmware.
-                self.resync_bytes += 1
-                del self.buf[:1]
+        for b in data:
+            if self.state == self._HUNT0:
+                if b == 0xAA:
+                    self.state = self._HUNT1
+                else:
+                    self.resync_bytes += 1
+            elif self.state == self._HUNT1:
+                if b == 0x55:
+                    self.state = self._HUNT2
+                elif b == 0xAA:
+                    # AA AA 55 ... — the second AA may start the real SOF.
+                    self.resync_bytes += 1
+                else:
+                    self._rehunt(b)
+            elif self.state == self._HUNT2:
+                if b == 0xAA:
+                    self.state = self._HUNT3
+                else:
+                    self._rehunt(b)
+            elif self.state == self._HUNT3:
+                if b == 0x55:
+                    self.state = self._TYPE
+                else:
+                    self._rehunt(b)
+            elif self.state == self._TYPE:
+                self.body = bytearray([b])
+                self.state = self._LEN
+            elif self.state == self._LEN:
+                self.body.append(b)
+                self.payload_len = b
+                self.state = self._PAYLOAD if b > 0 else self._CRC0
+            elif self.state == self._PAYLOAD:
+                self.body.append(b)
+                if len(self.body) - 2 >= self.payload_len:
+                    self.state = self._CRC0
+            elif self.state == self._CRC0:
+                self.crc_hi = b
+                self.state = self._CRC1
+            elif self.state == self._CRC1:
+                expected = (self.crc_hi << 8) | b
+                self.state = self._HUNT0
+                if crc16(bytes(self.body)) == expected:
+                    self.frames += 1
+                    yield self.body[0], bytes(self.body[2:])
+                else:
+                    self.crc_fails += 1
 
 
 # ---------------------------------------------------------------------------
@@ -387,14 +434,33 @@ def selftest() -> int:
         print("ok  frame reassembles across arbitrary chunk boundaries")
 
     # Leading garbage (including a false SOF prefix) then a good frame.
+    # resync_bytes == 5, not 6: the firmware counts what its state machine
+    # discards, and one 0xAA is consumed as a SOF candidate rather than
+    # dropped. Verified against the on-chip self-test — do not "fix" to 6.
     d = Deframer()
     good = pack(0x33, b"\x01\x02")
     got = list(d.feed(b"\x00\xFF\xAA\xAA\x13\x55" + good))
-    if got != [(0x33, b"\x01\x02")] or d.resync_bytes != 6:
-        print(f"FAIL resync: {got!r} resync={d.resync_bytes}")
+    if got != [(0x33, b"\x01\x02")] or d.resync_bytes != 5:
+        print(f"FAIL resync: {got!r} resync={d.resync_bytes} (want 5)")
         failures += 1
     else:
         print(f"ok  resynchronizes past garbage ({d.resync_bytes} B discarded)")
+
+    # A truncated frame costs TWO frames, not one. This framer is
+    # length-driven, so a frame cut short keeps consuming: it eats the next
+    # frame's SOF as its own payload/CRC, fails the CRC, and only recovers on
+    # the frame after that. Documented in TR_MsgCodec.h as "a rare drop is
+    # recovered by the next frame"; pinned here because a find-based deframer
+    # would lose only one and thereby overstate link quality.
+    d = Deframer()
+    truncated = pack(0x66, bytes(range(1, 9)))[:-4]
+    got = list(d.feed(truncated + pack(0x77, b"\xEE") + pack(0x78, b"\xEF")))
+    if got != [(0x78, b"\xEF")] or d.crc_fails != 1:
+        print(f"FAIL truncation: {got!r} crc_fails={d.crc_fails} "
+              f"(want only 0x78 through, 1 CRC fail)")
+        failures += 1
+    else:
+        print("ok  truncated frame swallows exactly one follower, then recovers")
 
     # A corrupted frame is dropped and counted; the next one still parses.
     d = Deframer()

--- a/tools/bench_radio_modem.py
+++ b/tools/bench_radio_modem.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Bench host for the LoRa daughterboard's UART modem link (#409).
+
+The daughterboard is a transparent modem: it never parses the air frames it
+radiates, so the thing that has to be proven on the bench is the *link* --
+framing, the credit window, capability reporting -- and then that an air frame
+pushed through it comes out of an unmodified base station unchanged.  The OC
+(#410) and the BS (#414) are the production hosts; this is the bench one, so
+that acceptance step does not need a rocket wired up to run.
+
+Wire facts, all extracted from the firmware rather than transcribed:
+  framing   AA 55 AA 55 | type | len | payload | CRC16-BE   (TR_MsgCodec.h)
+  CRC       poly 0x8001, init 0x0000, no reflection, no xorout, over
+            type+len+payload  (components/CRC defaults, as TR_I2C_Interface)
+  protocol  components/TR_UART_Link/RadioModemProtocol.h, PROTOCOL_VERSION 1
+  baud      921600 8N1, no RTS/CTS -- flow control is the in-band credit
+            window (<= TX_QUEUE_CAPACITY unacknowledged TX_FRAME seqs)
+
+Bench wiring to J6 on the daughterboard (3.3 V TTL adapter only -- the S3 is
+not 5 V tolerant):
+  J6.1 VSS   -> adapter GND
+  J6.2 +BATT -> 6.4-8.4 V bench supply (or leave it and power over USB-C)
+  J6.3       -> adapter RX     (board GPIO6, the modem's TX)
+  J6.4       -> adapter TX     (board GPIO5, the modem's RX)
+
+Examples:
+  python3 tools/bench_radio_modem.py --selftest          # codec, no hardware
+  python3 tools/bench_radio_modem.py -p /dev/tty.usbserial-X --identity
+  python3 tools/bench_radio_modem.py -p PORT --status
+  python3 tools/bench_radio_modem.py -p PORT --config 915 125 10 7 20
+  python3 tools/bench_radio_modem.py -p PORT --tx DEADBEEF --repeat 20
+  python3 tools/bench_radio_modem.py -p PORT --listen 60
+  python3 tools/bench_radio_modem.py -p PORT --scan 902 928 500 30
+
+Notes:
+  * The modem emits BOOT (an identity payload) once at startup and it may
+    arrive at any time -- every mode below decodes unsolicited frames, so a
+    board that resets mid-run is visible rather than confusing.
+  * --tx payloads are opaque to the modem by design.  To exercise a *real*
+    base station you have to hand it bytes the deployed LORA_PROTO_VERSION
+    parser accepts; --tx of arbitrary hex proves the tunnel and the credit
+    return, not application interop.
+  * The modem has no NVS: every setting is pushed by the host and is gone on
+    reset.  --config is not persistent, and that is deliberate.
+"""
+
+import argparse
+import struct
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# Codec -- must stay byte-identical to TR_MsgCodec.cpp
+# ---------------------------------------------------------------------------
+
+SOF = bytes([0xAA, 0x55, 0xAA, 0x55])
+MAX_PAYLOAD = 255
+
+PROTOCOL_VERSION = 1
+TX_QUEUE_CAPACITY = 8
+MAX_AIR_FRAME = 247
+
+# host -> modem
+MSG_TX_FRAME     = 0x01
+MSG_SET_CONFIG   = 0x02
+MSG_HOP_FREQ     = 0x03
+MSG_START_RX     = 0x04
+MSG_GET_STATUS   = 0x05
+MSG_GET_IDENTITY = 0x06
+MSG_START_SCAN   = 0x07
+# modem -> host
+MSG_RX_FRAME     = 0x81
+MSG_TX_RESULT    = 0x82
+MSG_STATUS       = 0x83
+MSG_IDENTITY     = 0x84
+MSG_SCAN_RESULT  = 0x85
+MSG_BOOT         = 0x86
+
+TYPE_NAMES = {
+    MSG_TX_FRAME: "TX_FRAME", MSG_SET_CONFIG: "SET_CONFIG",
+    MSG_HOP_FREQ: "HOP_FREQ", MSG_START_RX: "START_RX",
+    MSG_GET_STATUS: "GET_STATUS", MSG_GET_IDENTITY: "GET_IDENTITY",
+    MSG_START_SCAN: "START_SCAN", MSG_RX_FRAME: "RX_FRAME",
+    MSG_TX_RESULT: "TX_RESULT", MSG_STATUS: "STATUS",
+    MSG_IDENTITY: "IDENTITY", MSG_SCAN_RESULT: "SCAN_RESULT",
+    MSG_BOOT: "BOOT",
+}
+
+CFG_FLAG_CRC_ON           = 1 << 0
+CFG_FLAG_RX_BOOSTED_GAIN  = 1 << 1
+CFG_FLAG_SYNCWORD_PRIVATE = 1 << 2
+
+CHIP_NAMES = {0: "UNKNOWN", 1: "LLCC68"}
+
+
+def crc16(data: bytes) -> int:
+    """CRC16 with the components/CRC library defaults (poly 0x8001, init 0)."""
+    crc = 0
+    for b in data:
+        crc ^= b << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x8001) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+    return crc
+
+
+def pack(msg_type: int, payload: bytes = b"") -> bytes:
+    if len(payload) > MAX_PAYLOAD:
+        raise ValueError(f"payload {len(payload)} > {MAX_PAYLOAD}")
+    body = bytes([msg_type, len(payload)]) + payload
+    return SOF + body + struct.pack(">H", crc16(body))
+
+
+class Deframer:
+    """Byte-at-a-time deframer mirroring tr_msg::MsgDeframer.
+
+    Same recovery contract: garbage is discarded while hunting for SOF, a
+    CRC-failed frame is dropped and counted, and the next good frame parses.
+    """
+
+    def __init__(self):
+        self.buf = bytearray()
+        self.frames = 0
+        self.crc_fails = 0
+        self.resync_bytes = 0
+
+    def feed(self, data: bytes):
+        """Yield (type, payload) for each complete CRC-valid frame."""
+        self.buf.extend(data)
+        while True:
+            start = self.buf.find(SOF)
+            if start < 0:
+                # Keep the last 3 bytes: a SOF may straddle this chunk.
+                drop = max(0, len(self.buf) - 3)
+                self.resync_bytes += drop
+                del self.buf[:drop]
+                return
+            if start > 0:
+                self.resync_bytes += start
+                del self.buf[:start]
+            if len(self.buf) < 6:
+                return
+            msg_type, length = self.buf[4], self.buf[5]
+            total = 4 + 2 + length + 2
+            if len(self.buf) < total:
+                return
+            body = bytes(self.buf[4:6 + length])
+            got = struct.unpack(">H", bytes(self.buf[6 + length:total]))[0]
+            if got == crc16(body):
+                self.frames += 1
+                payload = bytes(self.buf[6:6 + length])
+                del self.buf[:total]
+                yield msg_type, payload
+            else:
+                self.crc_fails += 1
+                # Drop only the SOF so a real frame starting inside this one's
+                # bytes is still found -- same as rehunt() in the firmware.
+                self.resync_bytes += 1
+                del self.buf[:1]
+
+
+# ---------------------------------------------------------------------------
+# Payload structs -- layouts asserted in RadioModemProtocol.h
+# ---------------------------------------------------------------------------
+
+FMT_CONFIG      = "<ffBBbBHBB"        # 16 B
+FMT_HOP         = "<f"                # 4 B
+FMT_RX_HEADER   = "<ff"               # 8 B
+FMT_TX_RESULT   = "<BB"               # 2 B
+FMT_IDENTITY    = "<BBbBff32s"        # 44 B
+FMT_STATUS      = "<IBBBBIIIIIIIfffB3s"  # 52 B
+FMT_SCAN_REQ    = "<ffHH"             # 12 B
+FMT_SCAN_HEADER = "<B3sff"            # 12 B
+
+for _fmt, _size in ((FMT_CONFIG, 16), (FMT_HOP, 4), (FMT_RX_HEADER, 8),
+                    (FMT_TX_RESULT, 2), (FMT_IDENTITY, 44), (FMT_STATUS, 52),
+                    (FMT_SCAN_REQ, 12), (FMT_SCAN_HEADER, 12)):
+    assert struct.calcsize(_fmt) == _size, f"{_fmt} != {_size} B"
+
+
+def describe(msg_type: int, payload: bytes) -> str:
+    name = TYPE_NAMES.get(msg_type, f"0x{msg_type:02X}")
+    if msg_type in (MSG_IDENTITY, MSG_BOOT) and len(payload) == 44:
+        ver, chip, pwr, _, fmin, fmax, fw = struct.unpack(FMT_IDENTITY, payload)
+        fw = fw.split(b"\0", 1)[0].decode("ascii", "replace")
+        warn = "" if ver == PROTOCOL_VERSION else f"  ** expected v{PROTOCOL_VERSION} **"
+        return (f"{name} protocol=v{ver} chip={CHIP_NAMES.get(chip, chip)} "
+                f"max_tx={pwr} dBm band={fmin:.3f}-{fmax:.3f} MHz fw={fw}{warn}")
+    if msg_type == MSG_STATUS and len(payload) == 52:
+        (up, en, rxm, qu, qc, tx_ok, tx_fail, rx_n, rx_crc, wd, u_crc, u_res,
+         rssi, snr, freq, sf, _) = struct.unpack(FMT_STATUS, payload)
+        return (f"{name} up={up / 1000:.1f}s radio={'up' if en else 'DOWN'} "
+                f"rx_mode={rxm} txq={qu}/{qc} tx={tx_ok}/{tx_fail}f rx={rx_n} "
+                f"rx_crc_fail={rx_crc} tx_wdog={wd} uart_crc_fail={u_crc} "
+                f"uart_resync={u_res}B last={rssi:.0f}dBm/{snr:.1f}dB "
+                f"@{freq:.3f}MHz SF{sf}")
+    if msg_type == MSG_TX_RESULT and len(payload) == 2:
+        seq, ok = struct.unpack(FMT_TX_RESULT, payload)
+        return f"{name} seq={seq} {'ok' if ok else 'FAILED'}"
+    if msg_type == MSG_RX_FRAME and len(payload) >= 8:
+        rssi, snr = struct.unpack(FMT_RX_HEADER, payload[:8])
+        air = payload[8:]
+        return (f"{name} rssi={rssi:.0f} dBm snr={snr:.1f} dB "
+                f"{len(air)} B air={air.hex().upper()}")
+    if msg_type == MSG_SCAN_RESULT and len(payload) >= 12:
+        count, _, start, step = struct.unpack(FMT_SCAN_HEADER, payload[:12])
+        if len(payload) < 12 + count:
+            return f"{name} TRUNCATED: header claims {count} samples, got {len(payload) - 12}"
+        rssi = struct.unpack(f"<{count}b", payload[12:12 + count])
+        peak = max(range(count), key=lambda i: rssi[i]) if count else 0
+        return (f"{name} {count} samples from {start:.3f} MHz step {step:.0f} kHz; "
+                f"peak {rssi[peak] if count else 0} dBm at "
+                f"{start + peak * step / 1000:.3f} MHz")
+    return f"{name} {len(payload)} B {payload.hex().upper()}"
+
+
+# ---------------------------------------------------------------------------
+# Link
+# ---------------------------------------------------------------------------
+
+class ModemLink:
+    def __init__(self, port: str, baud: int, verbose: bool = True):
+        import serial  # imported here so --selftest needs no pyserial
+        self.ser = serial.Serial(port, baud, timeout=0)
+        self.deframer = Deframer()
+        self.verbose = verbose
+
+    def send(self, msg_type: int, payload: bytes = b""):
+        self.ser.write(pack(msg_type, payload))
+
+    def pump(self, timeout_s: float):
+        """Yield (type, payload) for `timeout_s`, printing each as it lands."""
+        deadline = time.monotonic() + timeout_s
+        while True:
+            data = self.ser.read(4096)
+            if data:
+                for msg_type, payload in self.deframer.feed(data):
+                    if self.verbose:
+                        print(f"  [{time.strftime('%H:%M:%S')}] "
+                              f"{describe(msg_type, payload)}")
+                    yield msg_type, payload
+            if time.monotonic() >= deadline:
+                return
+            if not data:
+                time.sleep(0.002)
+
+    def request(self, msg_type: int, want: int, timeout_s: float = 2.0,
+                payload: bytes = b""):
+        """Send a request and return the first matching reply payload."""
+        self.send(msg_type, payload)
+        for got_type, got_payload in self.pump(timeout_s):
+            if got_type == want:
+                return got_payload
+        return None
+
+
+def cmd_identity(link: ModemLink) -> int:
+    if link.request(MSG_GET_IDENTITY, MSG_IDENTITY) is None:
+        print("no IDENTITY reply -- check wiring/baud, and that TX/RX are not swapped",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_status(link: ModemLink) -> int:
+    if link.request(MSG_GET_STATUS, MSG_STATUS) is None:
+        print("no STATUS reply", file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_config(link: ModemLink, freq, bw, sf, cr, pwr, start_rx: bool) -> int:
+    flags = CFG_FLAG_CRC_ON | CFG_FLAG_RX_BOOSTED_GAIN | CFG_FLAG_SYNCWORD_PRIVATE
+    payload = struct.pack(FMT_CONFIG, freq, bw, sf, cr, pwr, flags, 16,
+                          1 if start_rx else 0, 0)
+    # The modem acks every SET_CONFIG with a STATUS -- that ack is the only
+    # proof the radio actually came up (radio_enabled in the status line).
+    if link.request(MSG_SET_CONFIG, MSG_STATUS, payload=payload) is None:
+        print("no STATUS ack for SET_CONFIG", file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_tx(link: ModemLink, air: bytes, repeat: int, gap_s: float,
+           stall_s: float = 10.0) -> int:
+    """Push `repeat` copies of `air`, respecting the in-band credit window.
+
+    The contract being exercised: every accepted seq comes back in a
+    TX_RESULT, so `unanswered` at the end should always be 0.  A nonzero
+    count means the modem dropped a frame silently, which #409 says must not
+    happen -- that is the failure this loop is here to catch.
+    """
+    if len(air) > MAX_AIR_FRAME:
+        print(f"air frame {len(air)} B > MAX_AIR_FRAME {MAX_AIR_FRAME}", file=sys.stderr)
+        return 1
+
+    outstanding = set()
+    sent = ok = failed = 0
+    seq = 0
+    last_progress = time.monotonic()
+
+    while sent < repeat or outstanding:
+        if sent < repeat and len(outstanding) < TX_QUEUE_CAPACITY:
+            link.send(MSG_TX_FRAME, bytes([seq]) + air)
+            outstanding.add(seq)
+            seq = (seq + 1) & 0xFF
+            sent += 1
+            last_progress = time.monotonic()
+            if gap_s:
+                time.sleep(gap_s)
+            continue
+
+        # Either the window is full or everything is submitted: wait for
+        # credits.  LoRa airtime dominates, so poll in short slices.
+        for msg_type, payload in link.pump(0.1):
+            if msg_type == MSG_TX_RESULT and len(payload) == 2:
+                got_seq, good = struct.unpack(FMT_TX_RESULT, payload)
+                if got_seq in outstanding:
+                    outstanding.discard(got_seq)
+                    last_progress = time.monotonic()
+                    ok, failed = ok + bool(good), failed + (not good)
+
+        if time.monotonic() - last_progress > stall_s:
+            print(f"stalled {stall_s:.0f}s with {len(outstanding)} credit(s) "
+                  f"unreturned: seq {sorted(outstanding)}", file=sys.stderr)
+            break
+
+    print(f"tx: {sent} submitted, {ok} radiated, {failed} rejected, "
+          f"{len(outstanding)} unanswered")
+    return 0 if failed == 0 and not outstanding else 1
+
+
+def cmd_scan(link: ModemLink, start, stop, step_khz, dwell_ms) -> int:
+    payload = struct.pack(FMT_SCAN_REQ, start, stop, step_khz, dwell_ms)
+    # Sweep time is samples * dwell; give it that plus slack.
+    budget = ((stop - start) * 1000 / max(step_khz, 1)) * dwell_ms / 1000.0 + 5.0
+    if link.request(MSG_START_SCAN, MSG_SCAN_RESULT, timeout_s=budget,
+                    payload=payload) is None:
+        print("no SCAN_RESULT", file=sys.stderr)
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Self-test: codec only, no hardware
+# ---------------------------------------------------------------------------
+
+# Generated by the firmware codec itself (tr_msg::pack via the host build), so
+# a divergence here means this file drifted from TR_MsgCodec.cpp.
+GOLDEN = [
+    (0x42, "010203", "AA55AA5542030102030066"),
+    (MSG_GET_IDENTITY, "", "AA55AA5506000400"),
+    (MSG_GET_STATUS, "", "AA55AA5505000600"),
+    (MSG_TX_FRAME, "07DEADBEEF", "AA55AA55010507DEADBEEF2DA7"),
+]
+
+
+def selftest() -> int:
+    failures = 0
+
+    for msg_type, payload_hex, expect in GOLDEN:
+        got = pack(msg_type, bytes.fromhex(payload_hex)).hex().upper()
+        if got != expect:
+            print(f"FAIL pack(0x{msg_type:02X}, {payload_hex or '-'}): "
+                  f"{got} != {expect}")
+            failures += 1
+    print(f"ok  {len(GOLDEN)} golden frames match the firmware codec")
+
+    # Round trip, including a max-length payload.
+    d = Deframer()
+    cases = [(MSG_BOOT, bytes(range(44))), (MSG_START_RX, b""),
+             (0x77, bytes(MAX_PAYLOAD))]
+    stream = b"".join(pack(t, p) for t, p in cases)
+    got = list(d.feed(stream))
+    if got != cases:
+        print(f"FAIL round trip: {got!r}")
+        failures += 1
+    else:
+        print(f"ok  {len(cases)} frames round-trip (incl. {MAX_PAYLOAD} B payload)")
+
+    # Split across chunk boundaries, one byte at a time.
+    d = Deframer()
+    got = [f for b in pack(MSG_STATUS, bytes(52)) for f in d.feed(bytes([b]))]
+    if got != [(MSG_STATUS, bytes(52))]:
+        print(f"FAIL byte-at-a-time reassembly: {got!r}")
+        failures += 1
+    else:
+        print("ok  frame reassembles across arbitrary chunk boundaries")
+
+    # Leading garbage (including a false SOF prefix) then a good frame.
+    d = Deframer()
+    good = pack(0x33, b"\x01\x02")
+    got = list(d.feed(b"\x00\xFF\xAA\xAA\x13\x55" + good))
+    if got != [(0x33, b"\x01\x02")] or d.resync_bytes != 6:
+        print(f"FAIL resync: {got!r} resync={d.resync_bytes}")
+        failures += 1
+    else:
+        print(f"ok  resynchronizes past garbage ({d.resync_bytes} B discarded)")
+
+    # A corrupted frame is dropped and counted; the next one still parses.
+    d = Deframer()
+    bad = bytearray(pack(0x44, b"\x0A\x14\x1E"))
+    bad[7] ^= 0xFF
+    got = list(d.feed(bytes(bad) + pack(0x55, b"\x2A")))
+    if got != [(0x55, b"\x2A")] or d.crc_fails != 1:
+        print(f"FAIL corruption: {got!r} crc_fails={d.crc_fails}")
+        failures += 1
+    else:
+        print("ok  CRC-corrupted frame dropped and counted; next frame parses")
+
+    # Struct sizes are asserted at import; say so explicitly.
+    print("ok  8 payload struct layouts match RadioModemProtocol.h")
+
+    # Every decoder runs on a synthetic payload of the right size: a field
+    # order that drifts from RadioModemProtocol.h shows up as a wrong value
+    # here rather than as nonsense on the bench.
+    decoders = [
+        (MSG_IDENTITY,
+         struct.pack(FMT_IDENTITY, PROTOCOL_VERSION, 1, 22, 0, 850.0, 930.0,
+                     b"abc123+20260731-1200"),
+         ["protocol=v1", "chip=LLCC68", "max_tx=22", "850.000-930.000",
+          "fw=abc123+20260731-1200"]),
+        (MSG_STATUS,
+         struct.pack(FMT_STATUS, 12345, 1, 1, 2, 8, 100, 3, 55, 1, 0, 0, 0,
+                     -91.0, 7.5, 915.0, 10, b""),
+         ["up=12.3s", "radio=up", "txq=2/8", "tx=100/3f", "rx=55",
+          "-91dBm/7.5dB", "@915.000MHz", "SF10"]),
+        (MSG_TX_RESULT, struct.pack(FMT_TX_RESULT, 7, 0), ["seq=7", "FAILED"]),
+        (MSG_RX_FRAME, struct.pack(FMT_RX_HEADER, -104.0, -3.25) + b"\xDE\xAD",
+         ["-104 dBm", "-3.2 dB", "2 B", "DEAD"]),
+        (MSG_SCAN_RESULT,
+         struct.pack(FMT_SCAN_HEADER, 3, b"", 902.0, 500.0) +
+         struct.pack("<3b", -120, -60, -110),
+         ["3 samples", "902.000 MHz", "step 500 kHz", "peak -60 dBm",
+          "at 902.500 MHz"]),
+    ]
+    for msg_type, payload, expect in decoders:
+        line = describe(msg_type, payload)
+        missing = [e for e in expect if e not in line]
+        if missing:
+            print(f"FAIL decode {TYPE_NAMES[msg_type]}: missing {missing}\n     {line}")
+            failures += 1
+    print(f"ok  {len(decoders)} payload decoders read back the fields they packed")
+
+    # A short SCAN_RESULT must be reported, not crash on the sample unpack.
+    truncated = describe(MSG_SCAN_RESULT,
+                         struct.pack(FMT_SCAN_HEADER, 64, b"", 902.0, 500.0))
+    if "TRUNCATED" not in truncated:
+        print(f"FAIL truncated SCAN_RESULT not flagged: {truncated}")
+        failures += 1
+    else:
+        print("ok  truncated SCAN_RESULT is reported rather than crashing")
+
+    print("FAILED" if failures else "\nAll codec self-tests passed.")
+    return 1 if failures else 0
+
+
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Bench host for the LoRa daughterboard UART modem link (#409)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Examples:", 1)[1] if "Examples:" in __doc__ else None)
+    ap.add_argument("-p", "--port", help="serial device of the USB-UART adapter")
+    ap.add_argument("-b", "--baud", type=int, default=921600,
+                    help="must match config::HOST_UART_BAUD (default 921600)")
+    ap.add_argument("--selftest", action="store_true",
+                    help="verify the codec against golden firmware frames; no hardware")
+    ap.add_argument("--identity", action="store_true", help="GET_IDENTITY")
+    ap.add_argument("--status", action="store_true", help="GET_STATUS")
+    ap.add_argument("--config", nargs=5, metavar=("FREQ_MHZ", "BW_KHZ", "SF", "CR", "DBM"),
+                    help="SET_CONFIG, e.g. --config 915 125 10 7 20")
+    ap.add_argument("--no-rx", action="store_true",
+                    help="with --config: do not enter RX after applying")
+    ap.add_argument("--hop", type=float, metavar="MHZ", help="HOP_FREQ (no reply)")
+    ap.add_argument("--start-rx", action="store_true", help="START_RX")
+    ap.add_argument("--tx", metavar="HEX", help="tunnel these air bytes (hex)")
+    ap.add_argument("--repeat", type=int, default=1, help="with --tx (default 1)")
+    ap.add_argument("--gap", type=float, default=0.0,
+                    help="with --tx: seconds between submissions (default 0)")
+    ap.add_argument("--scan", nargs=4, type=float,
+                    metavar=("START_MHZ", "STOP_MHZ", "STEP_KHZ", "DWELL_MS"),
+                    help="START_SCAN, e.g. --scan 902 928 500 30")
+    ap.add_argument("--listen", type=float, metavar="SECONDS",
+                    help="decode everything the modem sends for N seconds")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+    if not args.port:
+        ap.error("--port is required (or use --selftest)")
+
+    try:
+        link = ModemLink(args.port, args.baud)
+    except ImportError:
+        print("pyserial not installed:  python3 -m pip install pyserial", file=sys.stderr)
+        return 2
+
+    rc = 0
+    did_something = False
+    if args.identity:
+        rc |= cmd_identity(link); did_something = True
+    if args.config:
+        freq, bw, sf, cr, pwr = args.config
+        rc |= cmd_config(link, float(freq), float(bw), int(sf), int(cr), int(pwr),
+                         not args.no_rx)
+        did_something = True
+    if args.hop is not None:
+        link.send(MSG_HOP_FREQ, struct.pack(FMT_HOP, args.hop))
+        print(f"  HOP_FREQ {args.hop:.3f} MHz sent (fire-and-forget, no reply)")
+        did_something = True
+    if args.start_rx:
+        link.send(MSG_START_RX); did_something = True
+    if args.tx:
+        rc |= cmd_tx(link, bytes.fromhex(args.tx), args.repeat, args.gap)
+        did_something = True
+    if args.scan:
+        rc |= cmd_scan(link, args.scan[0], args.scan[1], int(args.scan[2]),
+                       int(args.scan[3]))
+        did_something = True
+    if args.status:
+        rc |= cmd_status(link); did_something = True
+    if args.listen:
+        print(f"listening {args.listen:.0f}s (Ctrl-C to stop)")
+        try:
+            for _ in link.pump(args.listen):
+                pass
+        except KeyboardInterrupt:
+            pass
+        did_something = True
+
+    if not did_something:
+        ap.error("nothing to do: pick an action (--identity/--status/--config/...)")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Bench session 2026-08-03/04: brought the LoRa daughterboard, rocket computer and flight computer up together for the first time and fixed what that exposed.

## The reason this branch exists at all

The V8 radio-path audit fixes were sitting on a **never-pushed local branch**. Building "latest" from `main` produced a modem booting **preamble 16** while both hosts assume 12 — undercounting airtime ~4 sym/packet and eating the FCC dwell margin on SF10/BW250 — with no `applyFrameParams()`, so `SET_CONFIG` could not correct it. Merged here as `3fbd32c3`.

## Bench results

- **LoRa RF proven end to end.** RSSI −64 dBm / SNR 11.8 dB rocket → base station. First time the PA, RXEN/DIO2 antenna switch, SMA and antenna have been exercised.
- **Daughterboard unit B self-test 9/9** — 91 kB/s of a 92.16 kB/s line rate, resync 5 of 6 B, noise floor −117/−115/−111 dBm across 902–928 MHz.
- **FC ↔ OC link healthy** — zero I2S drops, zero I2C query failures, EKF 488 µs, loop 976/s.

## Fixes

**`fix(ble)` — the 2M PHY mask forbade any fallback.** `ble_gap_set_prefered_le_phy()` was called with `BLE_GAP_LE_PHY_2M_MASK` for both tx and rx. That mask is "which PHYs am I willing to use at all", not a preference, so 1M was forbidden and the controller had nowhere to retreat when 2M stopped closing. 2M costs ~3 dB; on a board with a marginal BLE antenna that is the whole margin. Every connection ran connect → 2M → `reason=520` (supervision timeout) within 0.6–1.6 s, forever. In the app it looked like the rocket appearing and disappearing. Fixed to `1M|2M`: **zero** `reason=520` across a full session, telemetry back to full 350–352 B.

**`fix(gnss)` — the M10's default baud was buried past the deadline.** `probe_bauds` led with 9600 (the M8-era default) and put **38400 — the SAM-M10Q's actual factory default** — fifth, where the 35 s bring-up deadline expired first. The module was alive and transmitting the whole time. The deadline was also sized against a timing model ~6× optimistic: it assumed ~1.5 s/baud, true only when `hasSerialActivity()` sees nothing, but that check is a bare `uartAvailable() > 0` with no framing validation, so a real stream at the wrong baud still trips it and burns ~9.5 s (measured). 38400 first, budget 60 s.

**`fix(radio)` — daughterboard rail left powered on failure.** Every failure path in `UartModemBackend::begin()` returned false with `act_pin` still high, three of four with `began_ = true`. An unused 22 dBm module sat powered and `service()` kept polling a dead link. Also makes `LORA_ACT` work as the documented recovery hammer (#412).

**`fix(telemetry)` — Tier 3 backfilled space Tier 1 could not use.** The JSON packer is best-fit, not priority-ordered, and `keyBytes()` charges one byte less while `first` is true — so a field reached after everything above it was dropped is *cheaper* than the fields it outranks. At MTU 23 that emitted `{"af":"","tr":1}`: the empty filename as sole survivor while state, position, altitude and battery were all dropped. Priority floor added at the Tier 1 / Tier 2 boundary.

**`fix(app)` — a dangling BS focus pin could not heal.** The pin latches once, is re-seeded from the fleet cache each reconnect, and re-pushed as cmd 45 — which sets `focus_rid_pinned` and **disables the BS's own 30 s auto-fallback**. A pin naming a rocket no longer on the air wedged the app onto the relay branch with no Signal card, arrow, GNSS bar or LoRa bars, and nothing able to recover it.

**`ble` follow-ups** — DLE asked for `17040 us`, the *Coded-PHY* ceiling, for a link that never uses Coded (the 1M ceiling is 2120 us); disconnect reasons now decode instead of printing a bare number.

Also corrects `board_v8.h` GNSS_RX/TX, which were backwards versus the as-built hardware (V7 had them right).

## Verification status

- Firmware: all targets build (OC V8, FC V8, BS V3, radio_board). iOS builds via `xcodebuild`.
- **Bench-confirmed:** the BLE fix (0× `reason=520`), the RF path, the FC↔OC link, the daughterboard self-test.
- **Compile-verified only:** the focus-pin heal (needs two rockets on one BS to reproduce) and the telemetry trim floor (the JSON builder sits behind NimBLE, so a host test needs it extracted first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
