### PR TITLE
firmware(out-computer): log the LoRa frames we transmit (0xF1)

### DIFF
--- a/Data_Analysis/analyze_lora_link.py
+++ b/Data_Analysis/analyze_lora_link.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+analyze_lora_link.py
+
+Measures the real downlink packet loss of a flight by joining the two halves
+of the record:
+
+  * the rocket's flight log (.bin) — LORA_MSG (0xF1) records, one per frame the
+    OC actually radiated, each carrying the `seq` that went on the air;
+  * the base station's lora_*.csv — one row per frame it decoded, with `seq`,
+    `rssi` and `snr`.
+
+Loss = the seq values the rocket logged that never show up on the ground.  That
+is the only honest number: the base station alone cannot distinguish "the
+rocket skipped a slot" from "the packet did not make it", and the rocket alone
+cannot tell you whether anything was heard.
+
+Either side may be given on its own.  With only the base station, gaps in the
+received seq run are *assumed* to be losses (the rocket is presumed to have
+transmitted continuously) and the report says so — that assumption is exactly
+what the 0xF1 records exist to remove.
+
+Usage:
+    analyze_lora_link.py --bin flight_YYYYmmdd_HHMMSS.bin \\
+                         --bs  lora_YYYYmmdd_HHMMSS.csv
+    analyze_lora_link.py --bs lora_*.csv          # ground side only
+    analyze_lora_link.py --bin flight_*.bin       # rocket side only
+"""
+
+import argparse
+import csv
+import struct
+import sys
+from collections import Counter
+
+# ── Wire format (see RocketComputerTypes.h) ─────────────────────────────────
+
+PREAMBLE = b'\xAA\x55\xAA\x55'
+MSG_LORA = 0xF1
+MSG_ISM6HG256 = 0xA2          # carries FC time_us; dates neighbouring records
+SIZE_OF_LORA_DATA = 65
+
+# LoRaData prefix — the routing header plus the two fields worth reporting.
+# Offsets are pinned by static_asserts in RocketComputerTypes.h.
+FMT_LORA_HEAD = '<BBBHBB'     # network_id, rocket_id, next_channel_idx, seq,
+                              # num_sats, pdop_u8
+LORA_LOGGING_BIT = 0x80       # packed into the MSB of num_sats
+
+
+def iter_frames(path):
+    """Yield (type, payload) for every CRC-length-plausible frame in a .bin."""
+    blob = open(path, 'rb').read()
+    i = 0
+    while True:
+        p = blob.find(PREAMBLE, i)
+        if p < 0:
+            return
+        j = p + len(PREAMBLE)
+        if j + 3 >= len(blob):
+            return
+        mtype, length = blob[j], blob[j + 1]
+        j += 2
+        if j + length + 2 > len(blob):
+            return
+        yield mtype, blob[j:j + length]
+        i = j + length + 2
+
+
+def read_rocket_bin(path):
+    """Extract the transmitted-seq record from a rocket flight log.
+
+    Returns (rows, imu_frames) where rows is a list of dicts in log order.
+    `t_s` is the FC timestamp of the most recent IMU frame — LoRaData has no
+    time field of its own, and its position in the stream dates it to the IMU
+    interval (~256 us), which beats a second clock domain.
+    """
+    rows, imu_frames, t_last = [], 0, None
+    for mtype, payload in iter_frames(path):
+        if mtype == MSG_ISM6HG256 and len(payload) >= 4:
+            t_last = struct.unpack_from('<I', payload, 0)[0] / 1e6
+            imu_frames += 1
+        elif mtype == MSG_LORA:
+            if len(payload) != SIZE_OF_LORA_DATA:
+                print(f"  ! 0xF1 record with {len(payload)} B payload, expected "
+                      f"{SIZE_OF_LORA_DATA} — LoRaData changed size and this "
+                      f"parser was not swept (#227)", file=sys.stderr)
+                continue
+            nid, rid, nch, seq, sats, pdop = struct.unpack_from(FMT_LORA_HEAD, payload, 0)
+            rows.append(dict(seq=seq, t_s=t_last, network_id=nid, rocket_id=rid,
+                             next_ch=nch, num_sats=sats & ~LORA_LOGGING_BIT,
+                             logging=bool(sats & LORA_LOGGING_BIT),
+                             pdop=pdop / 10.0))
+    return rows, imu_frames
+
+
+def read_bs_csv(path):
+    """Read a base-station lora_*.csv. Tolerates a truncated final row."""
+    rows = []
+    with open(path, newline='') as fh:
+        for rec in csv.DictReader(fh):
+            try:
+                rows.append(dict(seq=int(rec['seq']),
+                                 t_s=float(rec['time_ms']) / 1000.0,
+                                 rssi=float(rec['rssi']),
+                                 snr=float(rec['snr']),
+                                 rocket_id=rec.get('rocket_id'),
+                                 next_ch=rec.get('next_ch')))
+            except (TypeError, ValueError, KeyError):
+                continue          # truncated tail row, or a partial flush
+    return rows
+
+
+def pct(n, d):
+    return f"{100.0 * n / d:.1f}%" if d else "n/a"
+
+
+def describe(name, vals):
+    if not vals:
+        return f"  {name}: none"
+    vals = sorted(vals)
+    n = len(vals)
+    q = lambda f: vals[min(n - 1, int(f * n))]
+    return (f"  {name}: median {q(.5):.1f}  p10 {q(.1):.1f}  p90 {q(.9):.1f}  "
+            f"min {vals[0]:.1f}  max {vals[-1]:.1f}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--bin', dest='binpath', help='rocket flight log (.bin)')
+    ap.add_argument('--bs', dest='bspath', help='base-station lora_*.csv')
+    args = ap.parse_args()
+    if not args.binpath and not args.bspath:
+        ap.error('give --bin, --bs, or both')
+
+    tx, rx = [], []
+
+    if args.binpath:
+        tx, imu = read_rocket_bin(args.binpath)
+        print(f"rocket log  {args.binpath}")
+        if not tx:
+            print(f"  no 0xF1 LORA_MSG records ({imu} IMU frames present).")
+            print("  Firmware predating the 0xF1 restore does not log what it "
+                  "transmitted — loss below is ground-side inference only.")
+        else:
+            spread = tx[-1]['seq'] - tx[0]['seq'] + 1
+            print(f"  {len(tx)} transmitted frames, seq {tx[0]['seq']}..{tx[-1]['seq']}")
+            if spread != len(tx):
+                print(f"  ! {spread - len(tx)} seq values missing from the rocket's "
+                      f"own log — ring overrun, not RF loss")
+            ids = Counter((r['network_id'], r['rocket_id']) for r in tx)
+            print(f"  network/rocket id: {dict(ids)}")
+            hop = Counter(r['next_ch'] for r in tx)
+            print(f"  next_channel_idx: {dict(hop)}"
+                  + ("   (0xFF=255 => not hopping, fixed channel)" if 255 in hop else ""))
+            if tx[0]['t_s'] is not None and tx[-1]['t_s'] is not None:
+                print(f"  spans FC t = {tx[0]['t_s']:.3f}..{tx[-1]['t_s']:.3f} s")
+
+    if args.bspath:
+        rx = read_bs_csv(args.bspath)
+        print(f"\nbase station  {args.bspath}")
+        if not rx:
+            print("  no decodable rows")
+        else:
+            print(f"  {len(rx)} received frames, seq {rx[0]['seq']}..{rx[-1]['seq']}, "
+                  f"{(rx[-1]['t_s'] - rx[0]['t_s']) / 60:.1f} min")
+            print(describe('rssi (dBm)', [r['rssi'] for r in rx]))
+            print(describe('snr  (dB) ', [r['snr'] for r in rx]))
+
+    print("\n" + "=" * 62)
+    if tx and rx:
+        sent = {r['seq'] for r in tx}
+        heard = {r['seq'] for r in rx}
+        lost = sent - heard
+        extra = heard - sent          # BS heard a seq the rocket never logged
+        print(f"TRUE downlink loss (rocket-logged seq vs base-station seq)")
+        print(f"  transmitted {len(sent)}   received {len(sent & heard)}   "
+              f"lost {len(lost)}  ({pct(len(lost), len(sent))})")
+        if extra:
+            print(f"  ! {len(extra)} received seq never logged as transmitted — "
+                  f"overlapping sessions, a second rocket, or a dropped log record")
+        if lost:
+            runs, cur = [], None
+            for s in sorted(lost):
+                if cur and s == cur[1] + 1:
+                    cur[1] = s
+                else:
+                    cur = [s, s]
+                    runs.append(cur)
+            worst = max(runs, key=lambda r: r[1] - r[0])
+            print(f"  {len(runs)} loss bursts, longest {worst[1] - worst[0] + 1} "
+                  f"consecutive frames (seq {worst[0]}..{worst[1]})")
+    elif rx:
+        heard = sorted(r['seq'] for r in rx)
+        span = heard[-1] - heard[0] + 1
+        print("Ground-side inference only (no 0xF1 records to compare against)")
+        print(f"  seq run {heard[0]}..{heard[-1]} = {span} slots, "
+              f"{len(heard)} decoded, {span - len(heard)} missing "
+              f"({pct(span - len(heard), span)})")
+        print("  Assumes the rocket transmitted every slot. Fly firmware that "
+              "logs 0xF1 to replace this with a measurement.")
+    elif tx:
+        print("Rocket side only — what was transmitted is known, what was heard "
+              "is not. Pair with the base station's lora_*.csv.")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,605 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,657 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -16,28 +16,28 @@ and leading comments.
 | [**LoRa radio backend and shared device state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L411-L437) | 27 | 411-437 |
 | [**FC command queue (OC -> FC over I2C)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L438-L583) | 146 | 438-583 |
 | [**LoRa frequency lock and channel hopping**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L584-L789) | 206 | 584-789 |
-| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L967) | 178 | 790-967 |
-| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L968-L1101) | 134 | 968-1101 |
-| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1102-L1342) | 241 | 1102-1342 |
-| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1343-L1455) | 113 | 1343-1455 |
-| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1456-L1527) | 72 | 1456-1527 |
-| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1528-L1567) | 40 | 1528-1567 |
-| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1568-L1707) | 140 | 1568-1707 |
-| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1708-L1815) | 108 | 1708-1815 |
-| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1816-L1990) | 175 | 1816-1990 |
-| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1991-L2252) | 262 | 1991-2252 |
-| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2253-L2975) | 723 | 2253-2975 |
-| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2976-L3098) | 123 | 2976-3098 |
-| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3099-L3116) | 18 | 3099-3116 |
-| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3117-L3446) | 330 | 3117-3446 |
-| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3447-L3725) | 279 | 3447-3725 |
-| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3726-L4250) | 525 | 3726-4250 |
-| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4251-L4583) | 333 | 4251-4583 |
-| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4584-L5317) | 734 | 4584-5317 |
-| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5318-L5824) | 507 | 5318-5824 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5825-L6102) | 278 | 5825-6102 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6103-L7596) | 1,494 | 6103-7596 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6476-L7596) | 1,121 | 6476-7596 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7597-L7605) | 9 | 7597-7605 |
+| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L975) | 186 | 790-975 |
+| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L976-L1109) | 134 | 976-1109 |
+| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1110-L1350) | 241 | 1110-1350 |
+| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1351-L1463) | 113 | 1351-1463 |
+| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1464-L1535) | 72 | 1464-1535 |
+| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1536-L1575) | 40 | 1536-1575 |
+| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1576-L1715) | 140 | 1576-1715 |
+| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1716-L1823) | 108 | 1716-1823 |
+| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1824-L1998) | 175 | 1824-1998 |
+| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1999-L2260) | 262 | 1999-2260 |
+| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2261-L2983) | 723 | 2261-2983 |
+| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2984-L3106) | 123 | 2984-3106 |
+| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3107-L3124) | 18 | 3107-3124 |
+| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3125-L3494) | 370 | 3125-3494 |
+| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3495-L3773) | 279 | 3495-3773 |
+| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3774-L4298) | 525 | 3774-4298 |
+| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4299-L4631) | 333 | 4299-4631 |
+| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4632-L5369) | 738 | 4632-5369 |
+| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5370-L5876) | 507 | 5370-5876 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5877-L6154) | 278 | 5877-6154 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6155-L7648) | 1,494 | 6155-7648 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6528-L7648) | 1,121 | 6528-7648 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7649-L7657) | 9 | 7649-7657 |
 
-Total: 28 sections (1 nested) across 7,605 lines.
+Total: 28 sections (1 nested) across 7,657 lines.

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -885,6 +885,14 @@ static float max_speed_mps = 0.0f;
 
 static uint32_t lora_tx_ok = 0;
 static uint32_t lora_tx_fail = 0;
+// LORA_MSG (0xF1) records accepted by the flight-log ring.  Tracked separately
+// from lora_tx_ok because the two diverge for a real reason: enqueueFrame()
+// drops the record whenever no logging session is open, so tx_ok climbing
+// while logged stays flat is the normal pad state, not a fault.  Once a
+// session IS open the two must climb together — a gap between them means the
+// ring is overrunning and the seq record the post-flight loss analysis
+// depends on is being dropped.
+static uint32_t lora_tx_logged = 0;
 // #150: uplinks dropped by the network-id filter.  Counted (and logged in
 // the periodic LoRa stats line) because the #133-era nid-drift regression
 // was invisible precisely because this drop path said nothing.
@@ -3359,6 +3367,46 @@ static void serviceLoRa()
     if (lora_comms.send(payload, sizeof(payload)))
     {
         lora_tx_ok++;
+
+        // Persist the exact 65 B that just went on the air as a LORA_MSG
+        // (0xF1) record.  The type has always been in the wire format and
+        // every decoder already knows it, but nothing had emitted it — so
+        // the rocket log carried no evidence the radio had even keyed up,
+        // and a lost base-station log meant the whole downlink measurement
+        // was gone (2026-08-08 Kaua'i range test).  The frame carries `seq`,
+        // so diffing the seq set logged here against the seq column in the
+        // base station's lora_*.csv yields true per-packet loss without
+        // needing both logs to survive.
+        //
+        // Logged AFTER send() returns true and BEFORE lora_tx_seq++, so the
+        // record holds the seq actually transmitted, and a failed
+        // startTransmit() leaves no record — the log is exactly what was
+        // radiated, which is what makes the seq diff meaningful.
+        //
+        // Deliberately no timestamp field: the payload stays byte-identical
+        // to LoRaData (65 B, what MSG_EXPECTED_LEN and every parser already
+        // expect), and the record's position between IMU frames dates it to
+        // ~256 us — better than an OC timestamp could, since esp_timer here
+        // is a different clock domain from the FC time_us that every other
+        // log record carries.
+        //
+        // enqueueFrame() drops the frame when no session is open, so this
+        // costs nothing off-session; on-session it is 65 B + 8 B of framing
+        // at LORA_TX_RATE_HZ (146 B/s at 2 Hz).  Name beacons are NOT logged
+        // — they are a different, variable-length payload and would break
+        // the fixed 65 B expectation for this type.
+        {
+            uint8_t lora_frame[MAX_FRAME];
+            size_t  lora_frame_len = 0;
+            if (TR_I2C_Interface::packMessage(LORA_MSG,
+                                              payload, sizeof(payload),
+                                              lora_frame, sizeof(lora_frame),
+                                              lora_frame_len))
+            {
+                if (logger.enqueueFrame(lora_frame, lora_frame_len)) lora_tx_logged++;
+            }
+        }
+
         // Advance the seq AFTER a successful send — failed startTransmit()
         // means nothing went over the air, so the BS shouldn't see a gap.
         lora_tx_seq++;
@@ -5095,9 +5143,13 @@ static void printStats()
         {
             TR_LoRa_Comms::Stats ls = {};
             lora_comms.getStats(ls);
-            ESP_LOGI("LORA", "LoRa tx=%lu/%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu nid_drop=%lu rxmode=%c",
+            // logged= counts LORA_MSG records the flight-log ring accepted.
+            // Expect it to track tx= once a session is open, and to stay at 0
+            // on the pad with no session — see lora_tx_logged.
+            ESP_LOGI("LORA", "LoRa tx=%lu/%lu logged=%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu nid_drop=%lu rxmode=%c",
                           (unsigned long)ls.tx_ok,
                           (unsigned long)ls.tx_fail,
+                          (unsigned long)lora_tx_logged,
                           (unsigned long)ls.rx_count,
                           (unsigned long)ls.rx_crc_fail,
                           (unsigned long)lora_low_snr_drops,


### PR DESCRIPTION
## What

`serviceLoRa()` now writes the exact 65 B it just put on the air into the flight log as a `LORA_MSG` (0xF1) record.

The type has been in the wire format all along — `isKnownMessageType` accepts it, the length tables pin it at 65 B, every decoder knows it — but **nothing had ever emitted it**. So the rocket log carried no evidence the radio had even keyed up, and link quality lived exclusively on the base station.

## Why now

The 2026-08-08 Kauai range test is what that costs. The base-station logs were believed lost, and the rocket-side `.bin` could say nothing at all about the radio — the only way to show the rocket had been transmitting was to pick the 2 Hz TX bursts out of the battery-current trace.

## Design notes

- Logged **after** `send()` returns true and **before** `lora_tx_seq++`, so the record holds the seq actually radiated and a failed `startTransmit()` leaves no record. The log is exactly what was transmitted — which is what makes the seq set diffable against the base station's `seq` column for true per-packet loss when only one log survives.
- **No timestamp field, deliberately.** The payload stays byte-identical to `LoRaData`, so `MSG_EXPECTED_LEN` and every existing decoder need no change, and the record's position between IMU frames dates it to ~256 us — better than an OC `esp_timer` value, which is a different clock domain from the FC `time_us` every other record carries.
- Name beacons are **not** logged: variable-length payload would break the fixed 65 B expectation for the type.
- Cost is 65 B + 8 B framing at `LORA_TX_RATE_HZ` = 146 B/s at 2 Hz, and zero off-session — `enqueueFrame()` drops the frame when no session is open.
- New `lora_tx_logged` counter in the periodic LoRa stats line, so a gap between `tx=` and `logged=` flags a ring overrun eating the records.

## Scope caveat

This gives per-packet **loss**, not rocket-side **RSSI**. `LoRaData` has no RSSI field because a transmitter cannot measure its own downlink. Logging the RSSI/SNR of received *uplinks* is a follow-up.

## Tooling

`Data_Analysis/analyze_lora_link.py` joins the two halves. Without it the new records are inert — the Swift and Kotlin CSV generators both hit their `default` arm and skip unknown types. Given both sides it reports measured loss; given only the base station it falls back to assuming the rocket transmitted every slot, and says so.

## Verification

- Builds under IDF v6.0 (the version CI pins).
- 665/665 host tests pass.
- CRC and framing checked against all 36048 frames of a real flight log.
- The loss join validated against a synthetic log with injected ground truth (reported 6297 lost / 80.6 %, matching exactly, and correctly excluding slots the rocket never transmitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
