### PR TITLE
firmware(out-computer): log uplink RSSI/SNR -- the rocket's only RF measurement

### DIFF
--- a/Data_Analysis/analyze_launch_detection.py
+++ b/Data_Analysis/analyze_launch_detection.py
@@ -37,6 +37,7 @@ MSG_POWER            = 0xA6
 MSG_START_LOGGING    = 0xA7
 MSG_END_FLIGHT       = 0xA8
 MSG_LORA             = 0xF1
+MSG_LORA_UPLINK      = 0xF9  # OC-self-emitted uplink RSSI/SNR record
 
 MSG_NAMES = {
     MSG_OUT_STATUS_QUERY: "OUT_STATUS_QUERY",
@@ -49,6 +50,7 @@ MSG_NAMES = {
     MSG_START_LOGGING:    "StartLogging",
     MSG_END_FLIGHT:       "EndFlight",
     MSG_LORA:             "LoRa",
+    MSG_LORA_UPLINK:      "LoRaUplink",
 }
 
 MSG_EXPECTED_LEN = {
@@ -61,6 +63,7 @@ MSG_EXPECTED_LEN = {
     MSG_POWER:            10,
     MSG_START_LOGGING:    None,
     MSG_END_FLIGHT:       None,
+    MSG_LORA_UPLINK:      13,   # sizeof(LoRaUplinkData)
     MSG_LORA:             65,   # sizeof(LoRaData) — #572: was a stale 49; sweep on struct-size changes (#227)
 }
 

--- a/Data_Analysis/analyze_lora_link.py
+++ b/Data_Analysis/analyze_lora_link.py
@@ -38,8 +38,16 @@ from collections import Counter
 
 PREAMBLE = b'\xAA\x55\xAA\x55'
 MSG_LORA = 0xF1
+MSG_LORA_UPLINK = 0xF9        # OC-self-emitted uplink RX record
 MSG_ISM6HG256 = 0xA2          # carries FC time_us; dates neighbouring records
 SIZE_OF_LORA_DATA = 65
+SIZE_OF_LORA_UPLINK = 13
+
+# LoRaUplinkData: time_us, rssi*10, snr*10, (MHz-900)*1000, sf, cmd, flags
+FMT_LORA_UPLINK = '<IhhHBBB'
+UL_FLAGS = [(1 << 0, 'accepted'), (1 << 1, 'snr_drop'), (1 << 2, 'nid_drop'),
+            (1 << 3, 'not_for_us'), (1 << 4, 'malformed')]
+LORA_CMD_HEARTBEAT = 0xFE
 
 # LoRaData prefix — the routing header plus the two fields worth reporting.
 # Offsets are pinned by static_asserts in RocketComputerTypes.h.
@@ -76,10 +84,19 @@ def read_rocket_bin(path):
     interval (~256 us), which beats a second clock domain.
     """
     rows, imu_frames, t_last = [], 0, None
+    uplinks = []
     for mtype, payload in iter_frames(path):
         if mtype == MSG_ISM6HG256 and len(payload) >= 4:
             t_last = struct.unpack_from('<I', payload, 0)[0] / 1e6
             imu_frames += 1
+        elif mtype == MSG_LORA_UPLINK:
+            if len(payload) != SIZE_OF_LORA_UPLINK:
+                continue
+            tus, rssi, snr, fkhz, sf, cmd, fl = struct.unpack(FMT_LORA_UPLINK, payload)
+            uplinks.append(dict(t_s=t_last, oc_t_s=tus / 1e6, rssi=rssi / 10.0,
+                                snr=snr / 10.0, freq_mhz=900.0 + fkhz / 1000.0,
+                                sf=sf, cmd=cmd, flags=fl,
+                                disp=next((n for b, n in UL_FLAGS if fl & b), 'unknown')))
         elif mtype == MSG_LORA:
             if len(payload) != SIZE_OF_LORA_DATA:
                 print(f"  ! 0xF1 record with {len(payload)} B payload, expected "
@@ -91,7 +108,7 @@ def read_rocket_bin(path):
                              next_ch=nch, num_sats=sats & ~LORA_LOGGING_BIT,
                              logging=bool(sats & LORA_LOGGING_BIT),
                              pdop=pdop / 10.0))
-    return rows, imu_frames
+    return rows, imu_frames, uplinks
 
 
 def read_bs_csv(path):
@@ -137,7 +154,7 @@ def main():
     tx, rx = [], []
 
     if args.binpath:
-        tx, imu = read_rocket_bin(args.binpath)
+        tx, imu, ul = read_rocket_bin(args.binpath)
         print(f"rocket log  {args.binpath}")
         if not tx:
             print(f"  no 0xF1 LORA_MSG records ({imu} IMU frames present).")
@@ -156,6 +173,26 @@ def main():
                   + ("   (0xFF=255 => not hopping, fixed channel)" if 255 in hop else ""))
             if tx[0]['t_s'] is not None and tx[-1]['t_s'] is not None:
                 print(f"  spans FC t = {tx[0]['t_s']:.3f}..{tx[-1]['t_s']:.3f} s")
+
+        # Uplink RX (0xF9) — the rocket's own measurement of the RF path.
+        if ul:
+            acc = [u for u in ul if u['disp'] == 'accepted']
+            print(f"\n  uplink decodes heard by the rocket: {len(ul)}")
+            by = {}
+            for u in ul:
+                by[u['disp']] = by.get(u['disp'], 0) + 1
+            print(f"    disposition: {by}")
+            print(describe('    rssi (dBm)', [u['rssi'] for u in ul]))
+            print(describe('    snr  (dB) ', [u['snr'] for u in ul]))
+            if acc and len(acc) != len(ul):
+                print(describe('    rssi, accepted only', [u['rssi'] for u in acc]))
+            hb = sum(1 for u in ul if u['cmd'] == LORA_CMD_HEARTBEAT)
+            print(f"    {hb} were base-station heartbeats (cmd 0xFE)")
+            sfs = sorted({u['sf'] for u in ul}); fs = sorted({round(u['freq_mhz'], 3) for u in ul})
+            print(f"    SF {sfs}   freq {fs} MHz")
+        else:
+            print("  no 0xF9 uplink records — the rocket heard nothing from the "
+                  "base station, or predates uplink RX logging")
 
     if args.bspath:
         rx = read_bs_csv(args.bspath)

--- a/Data_Analysis/plot_flight_data_mini.py
+++ b/Data_Analysis/plot_flight_data_mini.py
@@ -78,6 +78,7 @@ MSG_END_FLIGHT        = 0xA8
 MSG_IIS2MDC           = 0xD1  # new-PCB IIS2MDC magnetometer raw frame
 MSG_LOG_BUFFER_STATS  = 0xE2  # OC self-emitted ring-buffer snapshot (~1 Hz)
 MSG_LORA              = 0xF1
+MSG_LORA_UPLINK       = 0xF9  # OC-self-emitted uplink RSSI/SNR record
 MSG_GUIDANCE_TELEM    = 0xCA  # GuidanceTelemData, ~10 Hz during guided coast
 
 MSG_NAMES = {
@@ -93,6 +94,7 @@ MSG_NAMES = {
     MSG_END_FLIGHT:       "EndFlight",
     MSG_LOG_BUFFER_STATS: "LogBufferStats",
     MSG_LORA:             "LoRa",
+    MSG_LORA_UPLINK:      "LoRaUplink",
     MSG_GUIDANCE_TELEM:   "Guidance",
 }
 
@@ -110,6 +112,7 @@ MSG_EXPECTED_LEN = {
     MSG_START_LOGGING:     None,  # variable / no payload
     MSG_END_FLIGHT:        None,
     MSG_LOG_BUFFER_STATS:  28,    # LogBufferStatsData
+    MSG_LORA_UPLINK:       13,   # sizeof(LoRaUplinkData)
     MSG_LORA:              65,  # sizeof(LoRaData) — #572: was a stale 49; sweep on struct-size changes (#227)
     MSG_GUIDANCE_TELEM:    (15, 19),  # legacy (mislabeled) / current (+fin cmds)
 }

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ The main sensor frames, with the rate each is produced at:
 | 0xA6 | Power | 10 B | 10 Hz |
 | 0xD1 | IIS2MDC (Mag) | 10 B | 100 Hz |
 | 0xF1 | LoRa Telemetry | 65 B | 2 Hz |
+| 0xF9 | LoRa Uplink RX | 13 B | per uplink decode |
 
 `0xA4` (MMC5983MA, 16 B) is the magnetometer frame from an earlier sensor, still on the
 wire so older logs decode.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,657 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,727 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -16,28 +16,28 @@ and leading comments.
 | [**LoRa radio backend and shared device state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L411-L437) | 27 | 411-437 |
 | [**FC command queue (OC -> FC over I2C)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L438-L583) | 146 | 438-583 |
 | [**LoRa frequency lock and channel hopping**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L584-L789) | 206 | 584-789 |
-| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L975) | 186 | 790-975 |
-| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L976-L1109) | 134 | 976-1109 |
-| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1110-L1350) | 241 | 1110-1350 |
-| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1351-L1463) | 113 | 1351-1463 |
-| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1464-L1535) | 72 | 1464-1535 |
-| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1536-L1575) | 40 | 1536-1575 |
-| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1576-L1715) | 140 | 1576-1715 |
-| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1716-L1823) | 108 | 1716-1823 |
-| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1824-L1998) | 175 | 1824-1998 |
-| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1999-L2260) | 262 | 1999-2260 |
-| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2261-L2983) | 723 | 2261-2983 |
-| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2984-L3106) | 123 | 2984-3106 |
-| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3107-L3124) | 18 | 3107-3124 |
-| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3125-L3494) | 370 | 3125-3494 |
-| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3495-L3773) | 279 | 3495-3773 |
-| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3774-L4298) | 525 | 3774-4298 |
-| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4299-L4631) | 333 | 4299-4631 |
-| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4632-L5369) | 738 | 4632-5369 |
-| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5370-L5876) | 507 | 5370-5876 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5877-L6154) | 278 | 5877-6154 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6155-L7648) | 1,494 | 6155-7648 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6528-L7648) | 1,121 | 6528-7648 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7649-L7657) | 9 | 7649-7657 |
+| [**Cached configuration (NVS <-> FC <-> app)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L790-L981) | 192 | 790-981 |
+| [**Battery sampling and state of charge**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L982-L1115) | 134 | 982-1115 |
+| [**Clock sources, low-power mode, and boot USB-serial grace**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1116-L1356) | 241 | 1116-1356 |
+| [**BLE connection-parameter policy**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1357-L1469) | 113 | 1357-1469 |
+| [**Derived telemetry (altitude and speed)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1470-L1541) | 72 | 1470-1541 |
+| [**IMU full-scale decode helpers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1542-L1581) | 40 | 1542-1581 |
+| [**Ingest ring buffers and frame counters**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1582-L1721) | 140 | 1582-1721 |
+| [**Phone-I/O power management**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1722-L1829) | 108 | 1722-1829 |
+| [**I2C status-query response to the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L1830-L2004) | 175 | 1830-2004 |
+| [**FC OTA relay: I2S direction flip and image feeder**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2005-L2266) | 262 | 2005-2266 |
+| [**Frame processing: FC -> OC telemetry ingest**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2267-L2989) | 723 | 2267-2989 |
+| [**I2S DMA callback and parser task**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L2990-L3112) | 123 | 2990-3112 |
+| [**I2C ingress from the FC**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3113-L3130) | 18 | 3113-3130 |
+| [**LoRa downlink: telemetry payload and beacon**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3131-L3500) | 370 | 3131-3500 |
+| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3501-L3779) | 279 | 3501-3779 |
+| [**LoRa uplink command handling**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L3780-L4367) | 588 | 3780-4367 |
+| [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4368-L4700) | 333 | 4368-4700 |
+| [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4701-L5439) | 739 | 4701-5439 |
+| [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5440-L5946) | 507 | 5440-5946 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5947-L6224) | 278 | 5947-6224 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6225-L7718) | 1,494 | 6225-7718 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6598-L7718) | 1,121 | 6598-7718 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7719-L7727) | 9 | 7719-7727 |
 
-Total: 28 sections (1 nested) across 7,657 lines.
+Total: 28 sections (1 nested) across 7,727 lines.

--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -29,6 +29,7 @@ TEST(RocketComputerTypes, KnownSizes) {
     EXPECT_EQ(sizeof(POWERData),      10u);
     EXPECT_EQ(sizeof(NonSensorData),  50u);  // #529: +uint16 ekf_ticks (2 B)
     EXPECT_EQ(sizeof(LoRaData),       65u);  // #191: +ENU vel +flags2, -derived Euler/speed
+    EXPECT_EQ(sizeof(LoRaUplinkData), 13u);  // uplink RSSI/SNR log record (0xF9)
     EXPECT_EQ(sizeof(i24le_t),         3u);
     EXPECT_EQ(sizeof(Vec3i16),         6u);
 }
@@ -1436,6 +1437,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
         MT(GUIDANCE_POINT_PENDING),   MT(GUIDANCE_POINT_MSG),
         // #402: FC->OC slave TX-ring desync recovery trigger.
         MT(I2C_TX_RESYNC),
+        // OC-self-emitted uplink RX record — the rocket's only RF measurement.
+        MT(LORA_UPLINK_MSG),
     };
 #undef MT
 
@@ -1458,7 +1461,8 @@ TEST(RocketComputerTypes, MessageTypeCodes_AllUnique) {
     // 87 = 80 prior + guidance/fin config pair codes (were missing, #386 gap)
     //    + I2C_TX_RESYNC (#402) + IMU rate config pair (BLE cmd 67).
     // 89 = 87 + Drift-Cast guidance point pair (#435, BLE cmd 28).
-    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 89u)
+    // 90 = 89 + LORA_UPLINK_MSG (OC-self-emitted uplink RSSI/SNR record).
+    EXPECT_EQ(sizeof(codes) / sizeof(codes[0]), 90u)
         << "Message-type count changed: update the registry in this test to "
            "match the '### Message Types from In ESP32 ###' header block.";
 }

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -1973,6 +1973,61 @@ struct __attribute__((packed)) OtaRelayStatusData {
 
 static constexpr uint8_t LORA_MSG            = 0xF1;
 
+// --- LoRa uplink RX log record (LORA_UPLINK_MSG payload) --------------------
+// OC self-emitted, one per uplink packet the radio hands up, logged straight
+// into the flight log.
+//
+// This is the only rocket-side measurement of link quality that exists.  A
+// transmitter cannot measure its own downlink, so LoRaData (0xF1) carries no
+// RSSI — it gives per-packet LOSS via `seq`, not signal strength.  What the
+// rocket CAN measure is the packets coming the other way: the base station's
+// ~30 s heartbeat plus any operator command.  Channel reciprocity makes the
+// uplink RSSI a good proxy for the downlink path, so a flight whose base
+// station log is lost still yields a path-loss history.
+//
+// Every decode is logged, INCLUDING the ones thrown away.  The low-SNR drops
+// are the marginal-link samples — the packets that arrived too weak to trust
+// are exactly the evidence you want when asking how close to the floor the
+// link was running, and counting them without recording their RSSI throws
+// away the interesting half of the distribution.
+typedef struct __attribute__((packed))
+{
+    uint32_t time_us;       // OC esp_timer at RX.  Note this is the OC clock,
+                            // NOT the FC time_us the sensor records carry;
+                            // the record's position in the log stream is what
+                            // ties it to flight time.  Kept anyway because it
+                            // shares a clock with LOG_BUFFER_STATS_MSG and is
+                            // what lines these up against the base station.
+    int16_t  rssi_dbm_x10;  // dBm * 10
+    int16_t  snr_db_x10;    // dB * 10
+    uint16_t freq_khz_o900; // (MHz - 900) * 1000; covers the whole 902-928 band
+    uint8_t  sf;            // spreading factor in use at RX (rendezvous differs)
+    uint8_t  cmd;           // uplink command byte, 0 when not parsed that far
+    uint8_t  flags;         // LORA_UL_* below
+} LoRaUplinkData;
+static_assert(sizeof(LoRaUplinkData) == 13, "LoRaUplinkData must be 13 bytes");
+
+static constexpr uint8_t LORA_UPLINK_MSG     = 0xF9;
+
+// LoRaUplinkData.flags — the disposition of the decode.  Exactly one of these
+// is set; they are separate bits rather than an enum so a reader can mask for
+// "anything that reached us" (all of them) vs "acted on" (ACCEPTED).
+static constexpr uint8_t LORA_UL_ACCEPTED   = (1u << 0);  // passed every filter, command dispatched
+static constexpr uint8_t LORA_UL_SNR_DROP   = (1u << 1);  // under loraMinValidSnrDb for the current SF
+static constexpr uint8_t LORA_UL_NID_DROP   = (1u << 2);  // wrong network_id
+static constexpr uint8_t LORA_UL_NOT_FOR_US = (1u << 3);  // our network, another rocket_id
+static constexpr uint8_t LORA_UL_MALFORMED  = (1u << 4);  // bad sync byte or short frame
+
+// 0.1-unit fixed point, saturating.  NAN and out-of-range readings clamp
+// rather than wrap: a garbage RSSI that wraps to a plausible value would be
+// indistinguishable from a real one in the log.
+static inline int16_t loraPackTenths(float v)
+{
+    if (!(v > -3276.7f)) return -32767;   // also catches NAN
+    if (v > 3276.7f)     return 32767;
+    return (int16_t)(v * 10.0f + (v >= 0.0f ? 0.5f : -0.5f));
+}
+
 // Camera types
 static constexpr uint8_t CAM_TYPE_NONE   = 0;
 static constexpr uint8_t CAM_TYPE_GOPRO  = 1;

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -893,6 +893,12 @@ static uint32_t lora_tx_fail = 0;
 // ring is overrunning and the seq record the post-flight loss analysis
 // depends on is being dropped.
 static uint32_t lora_tx_logged = 0;
+// LORA_UPLINK_MSG (0xF9) records accepted by the ring — every decode the radio
+// handed up, not just the ones that passed the filters, so this climbs faster
+// than lora_uplink_rx_count whenever the link is noisy.  That difference is
+// itself the signal: uplink_rx flat while logged climbs means packets are
+// arriving but landing under the SNR floor.
+static uint32_t lora_uplink_logged = 0;
 // #150: uplinks dropped by the network-id filter.  Counted (and logged in
 // the periodic LoRa stats line) because the #133-era nid-drift regression
 // was invisible precisely because this drop path said nothing.
@@ -4200,6 +4206,44 @@ static void processUplinkCommand(uint8_t cmd, const uint8_t* payload, size_t pay
     }
 }
 
+// Write one LORA_UPLINK_MSG (0xF9) record for a decode the radio handed up.
+//
+// The rocket's only measurement of the RF path.  A transmitter cannot read its
+// own downlink RSSI, so 0xF1 gives loss but not signal strength; these records
+// give signal strength, on the reciprocal path, whether or not the base
+// station's own log survives.  Every disposition is recorded — accepted,
+// low-SNR, wrong network, not addressed to us, malformed — because a decode
+// that was discarded still measures the channel just as well as one that was
+// acted on.
+//
+// Rate is bounded by how often the base station actually transmits (a ~30 s
+// heartbeat plus operator commands), so this is a handful of 13 B records per
+// minute, not a stream.  enqueueFrame() drops it when no session is open.
+static void logUplinkRx(const TR_LoRa_Comms::Stats& ls, uint8_t cmd, uint8_t flags)
+{
+    LoRaUplinkData ul = {};
+    ul.time_us       = (uint32_t)esp_timer_get_time();
+    ul.rssi_dbm_x10  = loraPackTenths(ls.last_rssi);
+    ul.snr_db_x10    = loraPackTenths(ls.last_snr);
+    const float mhz  = lora_comms.currentFrequencyMHz();
+    const float khz  = (mhz - 900.0f) * 1000.0f;
+    ul.freq_khz_o900 = (khz < 0.0f) ? 0u
+                     : (khz > 65535.0f) ? 65535u
+                     : (uint16_t)(khz + 0.5f);
+    ul.sf            = lora_comms.currentSpreadingFactor();
+    ul.cmd           = cmd;
+    ul.flags         = flags;
+
+    uint8_t frame[MAX_FRAME];
+    size_t  frame_len = 0;
+    if (TR_I2C_Interface::packMessage(LORA_UPLINK_MSG,
+                                      (const uint8_t*)&ul, sizeof(ul),
+                                      frame, sizeof(frame), frame_len))
+    {
+        if (logger.enqueueFrame(frame, frame_len)) lora_uplink_logged++;
+    }
+}
+
 /// Enter RX mode between TX cycles and check for uplink commands
 static void serviceLoRaUplink()
 {
@@ -4259,6 +4303,11 @@ static void serviceLoRaUplink()
         if (ls.last_snr < min_snr)
         {
             lora_low_snr_drops++;
+            // Logged before the return.  These are the samples nearest the
+            // floor — dropping them from the record would bias the logged
+            // RSSI distribution upward exactly where the link is marginal,
+            // which is the regime the log exists to characterise.
+            logUplinkRx(ls, 0, LORA_UL_SNR_DROP);
             ESP_LOGW("LORA", "RX drop: SNR %.1f dB < %.1f dB floor (SF%u) "
                               "— likely noise-floor false positive",
                      (double)ls.last_snr, (double)min_snr,
@@ -4281,16 +4330,36 @@ static void serviceLoRaUplink()
                 uint8_t payload_len = rx_buf[5];
                 if (rx_len >= (size_t)(6 + payload_len))
                 {
+                    logUplinkRx(ls, cmd, LORA_UL_ACCEPTED);
                     processUplinkCommand(cmd, &rx_buf[6], payload_len);
                     lora_uplink_rx_count++;
                     last_uplink_rx_ms = millis();
                     if (hop_active_) hop_session_uplink_count++;
                 }
+                else
+                {
+                    // Header said payload_len but the frame is short — a
+                    // truncated decode, which is a real signal-quality data
+                    // point, not a nothing.
+                    logUplinkRx(ls, cmd, LORA_UL_MALFORMED);
+                }
             }
             else if (pkt_nid != network_id)
             {
                 lora_uplink_nid_drops++;   // #150: no more silent nid drops
+                logUplinkRx(ls, 0, LORA_UL_NID_DROP);
             }
+            else
+            {
+                // Our network, addressed to a different rocket.  Still a clean
+                // decode off the air, so its RSSI is as valid a path-loss
+                // sample as one addressed to us.
+                logUplinkRx(ls, 0, LORA_UL_NOT_FOR_US);
+            }
+        }
+        else
+        {
+            logUplinkRx(ls, 0, LORA_UL_MALFORMED);
         }
         // readPacket() internally re-enters RX mode after reading
     }
@@ -5146,7 +5215,7 @@ static void printStats()
             // logged= counts LORA_MSG records the flight-log ring accepted.
             // Expect it to track tx= once a session is open, and to stay at 0
             // on the pad with no session — see lora_tx_logged.
-            ESP_LOGI("LORA", "LoRa tx=%lu/%lu logged=%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu nid_drop=%lu rxmode=%c",
+            ESP_LOGI("LORA", "LoRa tx=%lu/%lu logged=%lu rx=%lu crc_fail=%lu low_snr=%lu isr=%lu uplink_rx=%lu ul_logged=%lu nid_drop=%lu rxmode=%c",
                           (unsigned long)ls.tx_ok,
                           (unsigned long)ls.tx_fail,
                           (unsigned long)lora_tx_logged,
@@ -5155,6 +5224,7 @@ static void printStats()
                           (unsigned long)lora_low_snr_drops,
                           (unsigned long)ls.isr_count,
                           (unsigned long)lora_uplink_rx_count,
+                          (unsigned long)lora_uplink_logged,
                           (unsigned long)lora_uplink_nid_drops,
                           ls.rx_mode ? 'Y' : 'N');
         }

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -55,6 +55,7 @@ CODE_TO_STRUCT = {
     0xA6: "POWERData",
     0xD1: "IIS2MDCData",
     0xF1: "LoRaData",
+    0xF9: "LoRaUplinkData",
 }
 
 HTML_COMMENT = re.compile(r"<!--.*?-->", re.S)


### PR DESCRIPTION
## What

New `LORA_UPLINK_MSG` (0xF9) / `LoRaUplinkData`, 13 B — one record per uplink packet the radio hands up, written straight into the flight log.

## Why

#719 gives per-packet **loss** via `seq`. It cannot give **signal strength**: a transmitter cannot measure its own downlink, so `LoRaData` has no RSSI field. With the base-station log lost there was still no rocket-side answer to "how strong was the link".

What the rocket *can* measure is the traffic coming the other way — the base station's ~30 s heartbeat plus any operator command. Channel reciprocity makes uplink RSSI a good proxy for the downlink path, so this yields a path-loss history that survives on its own.

## Record

`time_us` (OC clock), RSSI and SNR in 0.1 units, frequency, spreading factor, the uplink command byte, and a disposition flag.

Frequency and SF are *in* the record rather than assumed, because a rendezvous visit runs a different preset and a fixed assumption would silently mislabel those samples.

## Every decode is logged, including the discarded ones

The low-SNR drops were previously counted and thrown away. They are the samples nearest the floor — recording only the accepted ones would bias the logged RSSI distribution upward exactly in the marginal regime the log exists to characterise. Wrong-network and not-addressed-to-us decodes are logged for the same reason: a clean decode off the air measures the channel whether or not we act on it.

`lora_uplink_logged` climbing while `lora_uplink_rx_count` stays flat is now a readable symptom — packets arriving, landing under the floor.

## Cost

Bounded by how often the base station transmits: a handful of 13 B records per minute, and zero off-session since `enqueueFrame()` drops the frame when no session is open.

## Detail

`loraPackTenths()` saturates rather than wraps and maps NAN to the negative rail — a garbage RSSI that wrapped to a plausible value would be indistinguishable from a real one in the log.

`analyze_lora_link.py` reports the uplink distribution alongside the downlink loss, split by disposition so the accepted-only figure can be compared against the full one.

## Verification

- Builds under IDF v6.0.
- 665/665 host tests pass. Message-type registry count bumped 89 -> 90; 0xF9 confirmed unique by the existing guard.
- Python decoder checked **byte-for-byte** against bytes emitted by the real C struct (compiled against the actual header), including the NAN and saturation paths.
- Framed round-trip through `read_rocket_bin()` confirms the record is dated by the preceding IMU frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
