### PR TITLE
firmware(base-station): log the phone's GPS fix, so range is in the record

### DIFF
--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/BleCommandId.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/BleCommandId.kt
@@ -66,6 +66,10 @@ public object BleCommandId {
     public const val SET_ROCKET_ID: Int = 42       // [rid u8] 1..254
     public const val SET_FOCUS_ROCKET_BS: Int = 45 // [rid u8], 0 = auto (#390)
     public const val BS_LOGGING: Int = 46          // [bool] (#390)
+    // Phone GPS fix -> BS CSV as an EVENT row. The BS has no GNSS, so this is
+    // the only record of where the base station was, i.e. of the range.
+    // [lat_e7 i32][lon_e7 i32][alt_m i16][h_acc_m u8] = 11 B, little-endian.
+    public const val SET_PHONE_FIX_BS: Int = 47
 
     // cmd 50 is the canonical dual-namespace number (the checker's docstring
     // example): mag-cal start on a rocket link, relay envelope on a BS link.

--- a/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift
@@ -14,10 +14,25 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
 
     @Published var userLocation: CLLocationCoordinate2D?
     @Published var userAltitude: Double?  // Phone GPS altitude in meters (MSL)
+    @Published var userAccuracy: Double?  // Horizontal accuracy in meters; nil when invalid
     @Published var heading: Double = 0    // True north compass heading in degrees
 
     private let manager = CLLocationManager()
     private var isRunning = false
+
+    // Throttle state for reportFix(to:).  Lives here rather than in a global
+    // because the fix and its cadence are this object's business, and it keeps
+    // the sender free of shared mutable state.
+    private var lastFixSentAt: Date?
+    private var lastFixSentFrom: CLLocationCoordinate2D?
+
+    /// Minimum wall time between phone-fix pushes while the operator stands
+    /// still.  distanceFilter is 5 m, so an unthrottled push would put a BLE
+    /// write and a log row on every few steps, competing with telemetry RX.
+    private let fixMinInterval: TimeInterval = 30
+    /// Movement that forces a push regardless of the interval — actually
+    /// repositioning the base station should reach the log promptly.
+    private let fixForceDistance: CLLocationDistance = 25
 
     override init() {
         super.init()
@@ -51,6 +66,45 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         manager.stopUpdatingHeading()
     }
 
+    // MARK: - Phone fix -> base station
+
+    /// Push the current fix to `device` as BLE_BS_CMD_SET_PHONE_FIX, throttled.
+    ///
+    /// The base station is wherever the phone is, and the BS has no GNSS of
+    /// its own, so this is the only way the range between the two ends ever
+    /// reaches a log file. The BS writes the row only while a logging session
+    /// is open, so calling this off-session costs one BLE write and nothing
+    /// else. Safe to call on every location update.
+    func reportFix(to device: BLEDevice) {
+        guard let coord = userLocation, CLLocationCoordinate2DIsValid(coord) else { return }
+
+        let now = Date()
+        if let sentAt = lastFixSentAt, let from = lastFixSentFrom {
+            let moved = CLLocation(latitude: from.latitude, longitude: from.longitude)
+                .distance(from: CLLocation(latitude: coord.latitude, longitude: coord.longitude))
+            if now.timeIntervalSince(sentAt) < fixMinInterval && moved < fixForceDistance {
+                return
+            }
+        }
+        lastFixSentAt = now
+        lastFixSentFrom = coord
+
+        // 47 == BLE_BS_CMD_SET_PHONE_FIX. Literal on purpose — see the note
+        // in PhoneFixCodec about the CI parity sweep.
+        device.sendRawCommand(47,
+                              payload: PhoneFixCodec.encode(coord,
+                                                            altitude: userAltitude,
+                                                            accuracy: userAccuracy))
+    }
+
+    /// Drop the throttle so the next fix is pushed immediately.  Called on
+    /// (re)connect: the fix at the START of a log is the one that matters, and
+    /// a timestamp left over from the previous session could suppress it.
+    func resetFixThrottle() {
+        lastFixSentAt = nil
+        lastFixSentFrom = nil
+    }
+
     // MARK: - CLLocationManagerDelegate
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
@@ -59,6 +113,9 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             if loc.verticalAccuracy >= 0 {
                 userAltitude = loc.altitude
             }
+            // Negative means the fix is invalid, per CLLocation — publish nil
+            // rather than a negative "accuracy" that would log as garbage.
+            userAccuracy = loc.horizontalAccuracy >= 0 ? loc.horizontalAccuracy : nil
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/PhoneFixCodec.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/PhoneFixCodec.swift
@@ -1,0 +1,62 @@
+//
+//  PhoneFixCodec.swift
+//  TinkerRocketApp
+//
+//  Wire encoding for BLE_BS_CMD_SET_PHONE_FIX (47) — the phone's GPS fix,
+//  pushed to the base station so its CSV records where the base station was.
+//
+//  The base station has no GNSS: every lat/lon column in its log is the
+//  ROCKET's relayed position. The app computes and shows the range between
+//  the two ends from this fix and then discards it, so the one number a range
+//  test is about was never written down. The 2026-08-08 Kaua'i test could
+//  only be analysed because the operator remembered the site afterwards.
+//
+//  Kept as a free function with no BLE or CoreLocation-manager dependency so
+//  the byte layout is unit-testable without a radio or a device.
+//
+
+import Foundation
+import CoreLocation
+
+nonisolated enum PhoneFixCodec {
+
+    // The command number itself is deliberately NOT held here. Senders pass
+    // the literal 47, because tools/check_ble_command_ids.py sweeps Swift for
+    // literal send(Raw)Command numbers to prove every one has a firmware
+    // handler and matches the Kotlin table — a named constant is invisible to
+    // that sweep, and silently opting out of the parity gate is worse than
+    // repeating one number. Firmware side: BLE_BS_CMD_SET_PHONE_FIX.
+
+    /// Payload length the firmware requires before it will parse.
+    static let payloadLength = 11
+
+    /// Horizontal accuracy sentinel. A phone fix worse than 255 m is useless
+    /// for range, and clamping to the sentinel keeps it distinguishable from
+    /// a real reading instead of wrapping into a plausible one.
+    static let accuracyUnknown: UInt8 = 255
+
+    /// `[lat_e7 i32][lon_e7 i32][alt_m i16][h_acc_m u8]`, little-endian.
+    ///
+    /// 1e-7 degrees matches GNSSData's convention and resolves ~1 cm — far
+    /// finer than any phone fix, so the encoding never limits accuracy.
+    /// Every field clamps rather than wraps: a wrapped coordinate would read
+    /// as a valid position somewhere else on Earth.
+    static func encode(_ coord: CLLocationCoordinate2D,
+                       altitude: Double?,
+                       accuracy: Double?) -> Data {
+        let latE7 = Int32(clamping: Int64((coord.latitude  * 1e7).rounded()))
+        let lonE7 = Int32(clamping: Int64((coord.longitude * 1e7).rounded()))
+        let altM  = Int16(clamping: Int64((altitude ?? 0).rounded()))
+        let accM: UInt8 = {
+            guard let a = accuracy, a >= 0 else { return accuracyUnknown }
+            return UInt8(clamping: Int64(a.rounded()))
+        }()
+
+        var data = Data(capacity: payloadLength)
+        withUnsafeBytes(of: latE7.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: lonE7.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: altM.littleEndian)  { data.append(contentsOf: $0) }
+        data.append(accM)
+        return data
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -411,8 +411,22 @@ struct ConnectedFleetView: View {
             BaseStationStripView(bs: bs)
                 // Phone GPS drives the direction-to-rocket arrow — only
                 // useful while a base station is relaying positions.
-                .onAppear { locationManager.startUpdates() }
+                .onAppear {
+                    locationManager.startUpdates()
+                    // Re-report promptly on (re)appear: the fix at the start
+                    // of a logging session is the one worth having.
+                    locationManager.resetFixThrottle()
+                }
                 .onDisappear { locationManager.stopUpdates() }
+                // …and, since the phone IS the base station's position, push
+                // it down so the CSV records it. The BS has no GNSS, so
+                // without this the range between the two ends is displayed
+                // and then discarded, and a range test cannot be
+                // reconstructed from its own logs. Throttled inside
+                // reportFix; the BS ignores it unless a session is open.
+                .onReceive(locationManager.$userLocation) { _ in
+                    locationManager.reportFix(to: bs)
+                }
         }
 
         ForEach(displayed) { subject in

--- a/TinkerRocketApp/TinkerRocketAppTests/PhoneFixCodecTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/PhoneFixCodecTests.swift
@@ -1,0 +1,80 @@
+//
+//  PhoneFixCodecTests.swift
+//  TinkerRocketAppTests
+//
+//  The phone fix is the ONLY record of where the base station was — the BS has
+//  no GNSS — so a silent encoding bug loses the range for a whole test day and
+//  is not recoverable afterwards. These pin the byte layout the firmware
+//  parses in BLE_BS_CMD_SET_PHONE_FIX.
+//
+
+import XCTest
+import CoreLocation
+@testable import TinkerRocketApp
+
+final class PhoneFixCodecTests: XCTestCase {
+
+    private func i32(_ d: Data, _ o: Int) -> Int32 {
+        d.subdata(in: o..<(o + 4)).withUnsafeBytes {
+            Int32(littleEndian: $0.loadUnaligned(as: Int32.self))
+        }
+    }
+    private func i16(_ d: Data, _ o: Int) -> Int16 {
+        d.subdata(in: o..<(o + 2)).withUnsafeBytes {
+            Int16(littleEndian: $0.loadUnaligned(as: Int16.self))
+        }
+    }
+
+    /// The real 2026-08-08 Kaua'i base-station site, round-tripped.
+    func testEncodesRealSiteToFirmwareLayout() {
+        let coord = CLLocationCoordinate2D(latitude: 22.062009925676062,
+                                           longitude: -159.35412251709172)
+        let d = PhoneFixCodec.encode(coord, altitude: 12.4, accuracy: 4.6)
+
+        XCTAssertEqual(d.count, PhoneFixCodec.payloadLength)
+        XCTAssertEqual(i32(d, 0), 220620099)
+        XCTAssertEqual(i32(d, 4), -1593541225)
+        XCTAssertEqual(i16(d, 8), 12)
+        XCTAssertEqual(d[10], 5)
+
+        // Decoding the way the firmware does must land back on the site to
+        // well under a metre.
+        XCTAssertEqual(Double(i32(d, 0)) * 1e-7, coord.latitude,  accuracy: 1e-6)
+        XCTAssertEqual(Double(i32(d, 4)) * 1e-7, coord.longitude, accuracy: 1e-6)
+    }
+
+    func testMissingAltitudeAndAccuracyUseSentinels() {
+        let d = PhoneFixCodec.encode(CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                                     altitude: nil, accuracy: nil)
+        XCTAssertEqual(i16(d, 8), 0)
+        XCTAssertEqual(d[10], PhoneFixCodec.accuracyUnknown)
+    }
+
+    /// CLLocation reports a negative horizontalAccuracy for an invalid fix.
+    /// That must become the sentinel, not wrap to a small plausible number.
+    func testNegativeAccuracyBecomesSentinel() {
+        let d = PhoneFixCodec.encode(CLLocationCoordinate2D(latitude: 1, longitude: 1),
+                                     altitude: 0, accuracy: -1)
+        XCTAssertEqual(d[10], PhoneFixCodec.accuracyUnknown)
+    }
+
+    /// Clamping, not wrapping. A wrapped coordinate reads as a valid position
+    /// somewhere else on Earth and would be undetectable in the log.
+    func testExtremeValuesClamp() {
+        let d = PhoneFixCodec.encode(CLLocationCoordinate2D(latitude: 90, longitude: -180),
+                                     altitude: 1e9, accuracy: 1e9)
+        XCTAssertEqual(i32(d, 0), 900000000)
+        XCTAssertEqual(i32(d, 4), -1800000000)
+        XCTAssertEqual(i16(d, 8), Int16.max)
+        XCTAssertEqual(d[10], 255)
+    }
+
+    /// Southern/eastern hemispheres must stay signed through the round trip.
+    func testSignedHemispheres() {
+        let coord = CLLocationCoordinate2D(latitude: -33.8688, longitude: 151.2093)
+        let d = PhoneFixCodec.encode(coord, altitude: -5, accuracy: 3)
+        XCTAssertEqual(Double(i32(d, 0)) * 1e-7, coord.latitude,  accuracy: 1e-6)
+        XCTAssertEqual(Double(i32(d, 4)) * 1e-7, coord.longitude, accuracy: 1e-6)
+        XCTAssertEqual(i16(d, 8), -5)
+    }
+}

--- a/docs/architecture/generated/base-station-map.md
+++ b/docs/architecture/generated/base-station-map.md
@@ -3,7 +3,7 @@
 
 # Base Station -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/base_station/main/main.cpp` is 5,212 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/base_station/main/main.cpp` is 5,261 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -19,24 +19,24 @@ and leading comments.
 | [**Auto-acquire state**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L428-L506) | 79 | 428-506 |
 | [**Multi-rocket tracker**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L507-L695) | 189 | 507-695 |
 | [**Battery monitoring and charger FETs**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L696-L819) | 124 | 696-819 |
-| [**CSV logging: clock, file lifecycle, and writers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L820-L1286) | 467 | 820-1286 |
-| [**BLE file operations (list, delete, download)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1287-L1522) | 236 | 1287-1522 |
-| [**BLE telemetry frame and console output**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1523-L1823) | 301 | 1523-1823 |
-| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1824-L1888) | 65 | 1824-1888 |
-| [**LoRa uplink to the rocket**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1889-L2081) | 193 | 1889-2081 |
-| [**Transactional LoRa reconfigure**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2082-L2300) | 219 | 2082-2300 |
-| [**Silence recovery**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2301-L2557) | 257 | 2301-2557 |
-| [**Heartbeat to the rocket**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2558-L2651) | 94 | 2558-2651 |
-| [**Coordinated noise scan and channel set**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2652-L3275) | 624 | 2652-3275 |
-| [**Auto-acquire**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3276-L3382) | 107 | 3276-3382 |
-| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3383-L3952) | 570 | 3383-3952 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3953-L5202) | 1,250 | 3953-5202 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [LoRa service and hop management](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3964-L4027) | 64 | 3964-4027 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Packet receive: beacon, telemetry, tracker](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4028-L4510) | 483 | 4028-4510 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Log lifecycle timeouts and flush](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4511-L4578) | 68 | 4511-4578 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Battery read and standalone BLE update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4579-L4668) | 90 | 4579-4668 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4669-L5115) | 447 | 4669-5115 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Scan completion and periodic service chain](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5116-L5202) | 87 | 5116-5202 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5203-L5212) | 10 | 5203-5212 |
+| [**CSV logging: clock, file lifecycle, and writers**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L820-L1313) | 494 | 820-1313 |
+| [**BLE file operations (list, delete, download)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1314-L1549) | 236 | 1314-1549 |
+| [**BLE telemetry frame and console output**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1550-L1850) | 301 | 1550-1850 |
+| [**Config readback to the app**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1851-L1915) | 65 | 1851-1915 |
+| [**LoRa uplink to the rocket**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L1916-L2108) | 193 | 1916-2108 |
+| [**Transactional LoRa reconfigure**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2109-L2327) | 219 | 2109-2327 |
+| [**Silence recovery**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2328-L2584) | 257 | 2328-2584 |
+| [**Heartbeat to the rocket**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2585-L2678) | 94 | 2585-2678 |
+| [**Coordinated noise scan and channel set**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L2679-L3302) | 624 | 2679-3302 |
+| [**Auto-acquire**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3303-L3409) | 107 | 3303-3409 |
+| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3410-L3979) | 570 | 3410-3979 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3980-L5251) | 1,272 | 3980-5251 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [LoRa service and hop management](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L3991-L4054) | 64 | 3991-4054 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Packet receive: beacon, telemetry, tracker](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4055-L4537) | 483 | 4055-4537 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Log lifecycle timeouts and flush](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4538-L4605) | 68 | 4538-4605 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Battery read and standalone BLE update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4606-L4695) | 90 | 4606-4695 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L4696-L5164) | 469 | 4696-5164 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Scan completion and periodic service chain](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5165-L5251) | 87 | 5165-5251 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/base_station/main/main.cpp#L5252-L5261) | 10 | 5252-5261 |
 
-Total: 22 sections (6 nested) across 5,212 lines.
+Total: 22 sections (6 nested) across 5,261 lines.

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,351 lines across 69 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,484 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,7 +30,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 32 files, 11,899 lines
+## `Models/` — 33 files, 12,018 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
@@ -64,11 +64,12 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [UnitFormatter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/UnitFormatter.swift) | 204 | `UnitSystem`, `UnitFormatter` |
 | [RocketRoster.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RocketRoster.swift) | 197 | `RocketKey`, `RocketFreshness`, `RelayPath`, `RocketCommandLink`, `RocketSubject`, `RocketRoster` |
 | [VirtualRocket.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/VirtualRocket.swift) | 186 | `VirtualRocketDriver` |
+| [LocationManager.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift) | 166 | `LocationManager` |
 | [MagCalCells.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MagCalCells.swift) | 161 | `MagCalCells` |
 | [MessageParser.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/MessageParser.swift) | 151 | — |
-| [LocationManager.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LocationManager.swift) | 109 | `LocationManager` |
 | [StorageStats.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/StorageStats.swift) | 89 | `RocketStorageStats`, `BaseStationStorageStats` |
 | [OTATimeouts.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/OTATimeouts.swift) | 82 | `OTAStage`, `OTATimeouts` |
+| [PhoneFixCodec.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/PhoneFixCodec.swift) | 62 | — |
 | [LastValidRocketFix.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/LastValidRocketFix.swift) | 56 | `LastValidRocketFix` |
 | [SensorCalStatus.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorCalStatus.swift) | 50 | `SensorCalStatus` |
 | [RemoteRocket.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/RemoteRocket.swift) | 48 | `RemoteRocket` |
@@ -77,11 +78,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 13,735 lines
+## `Views/` — 27 files, 13,749 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,981 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +40 more |
+| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 2,995 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +40 more |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Shared rocket telemetry cards · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
 | [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,668 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
@@ -121,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 69 files, 26,351 lines.
+Total: 70 files, 26,484 lines.

--- a/docs/architecture/generated/protocol-reference.md
+++ b/docs/architecture/generated/protocol-reference.md
@@ -251,7 +251,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 
 ### app to Base Station
 
-20 commands.
+21 commands.
 
 | Cmd | Constant | Description |
 |-----|----------|-------------|
@@ -273,6 +273,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 | 41 | `BLE_BS_CMD_SET_NETWORK_ID` | Set network_id — payload: [nid:1] |
 | 45 | `BLE_BS_CMD_SET_FOCUS_ROCKET` | #390: pin the radio focus to one rocket. Payload: [rid], 0 = back to auto (sticky first-heard). RAM-only on… |
 | 46 | `BLE_BS_CMD_SET_BS_LOGGING` | #390: BS-only CSV logging control for the app's base-station screen. Payload: [on]. Unlike legacy cmd 23 this… |
+| 47 | `BLE_BS_CMD_SET_PHONE_FIX` | Where the base station actually is. Logged, never acted on -- nothing in the BS behaviour depends on this, it… |
 | 50 | `BLE_BS_CMD_RELAY_TO_ROCKET` | Relay command to a specific rocket via LoRa uplink Payload: [target_rid:1][inner_cmd:1][inner_payload:0..33… |
 | 60 | `BLE_BS_CMD_FREQ_SCAN` | Frequency scan (base-station radio, pre-launch collision avoidance). Payload: [start_mhz f32][stop_mhz… |
 

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -284,6 +284,16 @@ static constexpr uint8_t BLE_BS_CMD_SET_FOCUS_ROCKET  = 45;
 // #390: BS-only CSV logging toggle ([on]) — decoupled from the legacy
 // cmd 23, which also broadcasts a rocket-logging uplink.
 static constexpr uint8_t BLE_BS_CMD_SET_BS_LOGGING    = 46;
+// Phone GPS fix, pushed by the app so the CSV records where the base station
+// actually was.  The BS has no GNSS of its own -- the lat/lon columns in the
+// log are the ROCKET's relayed position -- so until now nothing anywhere
+// recorded the one number a range test is about: the distance between the two
+// ends.  The app computes and displays that distance live from the phone fix,
+// then throws it away; the 2026-08-08 Kaua'i test was reconstructed only
+// because the operator remembered the site.
+// Payload: [lat_e7 i32][lon_e7 i32][alt_m i16][h_acc_m u8] = 11 B.
+// 1e-7 deg matches GNSSData and is ~1 cm -- far finer than any phone fix.
+static constexpr uint8_t BLE_BS_CMD_SET_PHONE_FIX     = 47;
 static constexpr uint8_t BLE_BS_CMD_RELAY_TO_ROCKET   = 50;
 static constexpr uint8_t BLE_BS_CMD_FREQ_SCAN         = 60;
 

--- a/tinkerrocket-idf/projects/base_station/main/main.cpp
+++ b/tinkerrocket-idf/projects/base_station/main/main.cpp
@@ -1284,6 +1284,33 @@ static inline float currentRxFreqMHz()
     return lora_freq_mhz;
 }
 
+// Record the operator's phone fix as an EVENT row (BLE_BS_CMD_SET_PHONE_FIX).
+//
+// This is the base station's position, which nothing else in the system
+// captures: the BS has no GNSS, so every lat/lon in this CSV is the ROCKET's
+// relayed position. Range -- the whole point of a range test -- was therefore
+// unreconstructable from the logs alone.
+//
+// Emitted as an EVENT row rather than a new column because the schema already
+// has the mechanism (state == "EVENT", free-text `event`), every existing
+// parser already skips those rows, and the fix arrives on its own cadence
+// rather than per packet. Range is then a one-line offline computation
+// against the rocket lat/lon on the surrounding telemetry rows.
+//
+// The event text is space-separated: `event` is a CSV field and a comma here
+// would silently shift every column to its right.
+static void logPhoneFixEvent(int32_t lat_e7, int32_t lon_e7,
+                             int16_t alt_m, uint8_t h_acc_m)
+{
+    if (!logging_active || log_file == nullptr) return;
+    char ev[96];
+    snprintf(ev, sizeof(ev),
+             "phone_fix lat=%.7f lon=%.7f alt=%d hacc=%u",
+             (double)lat_e7 * 1e-7, (double)lon_e7 * 1e-7,
+             (int)alt_m, (unsigned)h_acc_m);
+    logHopEvent(ev, currentRxFreqMHz());
+}
+
 // ==========================================================================
 // SECTION: BLE file operations (list, delete, download)
 // ==========================================================================
@@ -4831,6 +4858,28 @@ static void loop_bs()
             // If a sequential-named log was opened before sync arrived,
             // promote it to its proper timestamped name now (#168).
             renameOpenLogIfSequential();
+        }
+    }
+    else if (ble_cmd == BLE_BS_CMD_SET_PHONE_FIX)
+    {
+        // Where the base station actually is.  Logged, never acted on --
+        // nothing in the BS behaviour depends on this, it exists purely so
+        // the CSV records the range.
+        const uint8_t* payload = ble_app.getCommandPayload();
+        size_t payload_len = ble_app.getCommandPayloadLength();
+        if (payload_len >= 11)
+        {
+            int32_t lat_e7, lon_e7;
+            int16_t alt_m;
+            memcpy(&lat_e7, payload + 0, 4);
+            memcpy(&lon_e7, payload + 4, 4);
+            memcpy(&alt_m,  payload + 8, 2);
+            const uint8_t h_acc_m = payload[10];
+            logPhoneFixEvent(lat_e7, lon_e7, alt_m, h_acc_m);
+            ESP_LOGI(TAG, "[LOG] phone fix %.7f, %.7f alt=%d hacc=%u%s",
+                     (double)lat_e7 * 1e-7, (double)lon_e7 * 1e-7,
+                     (int)alt_m, (unsigned)h_acc_m,
+                     logging_active ? "" : " (no session open -- not logged)");
         }
     }
     else if (ble_cmd == BLE_BS_CMD_LORA_RECONFIG)


### PR DESCRIPTION
## What

New `BLE_BS_CMD_SET_PHONE_FIX` (47) — the app pushes the phone's GPS fix to the base station, which writes it into the CSV as an `EVENT` row.

Payload: `[lat_e7 i32][lon_e7 i32][alt_m i16][h_acc_m u8]`, 11 B.

## Why

The base station has **no GNSS**. Every `lat`/`lon` column in its log is the *rocket's* relayed position, and the phone fix the app uses to display range lives only in `LocationManager` — never persisted, never sent to the BS. The one number a range test is about was shown on screen and then discarded.

The 2026-08-08 Kaua'i test was only analysable because the operator remembered the site afterwards. The logs alone could not say how far apart the two ends were.

## Why an EVENT row

The schema already has the mechanism — `state == "EVENT"` plus a free-text `event` column — and every existing parser already skips those rows. The fix also arrives on its own cadence rather than per packet, which a column would model badly.

It is the first thing ever to use that column outside hop diagnostics: **0 non-empty `event` cells across all 5,530 rows** of the seven recovered 2026-08-08 logs. Range then falls out offline against the rocket lat/lon on the surrounding telemetry rows.

The event text is space-separated on purpose — `event` is a CSV field, and a comma would silently shift every column to its right.

## Cadence

Pushed on location updates, throttled to one per 30 s unless the operator has moved 25 m. `distanceFilter` is 5 m, so unthrottled this would put a BLE write and a log row on every few steps, competing with telemetry RX for the connection. The throttle resets when the BS strip appears, so the fix at the *start* of a session — the one that matters — is never suppressed by a stale timestamp from the previous session.

## Encoding

Clamps rather than wraps on every field. A wrapped coordinate reads as a valid position somewhere else on Earth and would be undetectable in the log. A negative `CLLocation.horizontalAccuracy` (its "invalid fix" signal) becomes the 255 sentinel rather than a small plausible number.

The command number is a **literal** at the call site, not a named constant: `tools/check_ble_command_ids.py` sweeps Swift for literal `send(Raw)Command` numbers to prove every one has a firmware handler and matches the Kotlin table, and a named constant is invisible to that sweep.

## Verification

- `base_station` builds under IDF v6.0.
- 665/665 host tests.
- 5/5 new `PhoneFixCodecTests` pass on the iOS 26 simulator, including the real Kaua'i site round-trip, both hemispheres, clamping, and the invalid-accuracy sentinel.
- `check_ble_command_ids` parity green — Swift == Kotlin, every number firmware-handled.
- All three doc gates regenerated and clean (`gen_protocol_reference --check`, `gen_section_index --check`, `check_docs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
