### PR TITLE
firmware: stage post-#728 ADC scale constants in the board maps

### DIFF
--- a/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v1.h
@@ -57,4 +57,8 @@ struct board_pins
 
     // --- Flight-pack charger (MP2672): V3-only feature ---
     static constexpr bool HAS_PACK_CHARGER = false;
+    // --- Flight-pack voltage sense: not present on this board (see V3) ---
+    static constexpr int   PACK_VSENSE_GPIO     = -1;
+    static constexpr float PACK_VSENSE_DIVIDER  = 0.0f;
+    static constexpr int   PACK_VSENSE_ATTEN_DB = -1;
 };

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v2.h
@@ -55,4 +55,8 @@ struct board_pins
 
     // --- Flight-pack charger (MP2672): V3-only feature ---
     static constexpr bool HAS_PACK_CHARGER = false;
+    // --- Flight-pack voltage sense: not present on this board (see V3) ---
+    static constexpr int   PACK_VSENSE_GPIO     = -1;
+    static constexpr float PACK_VSENSE_DIVIDER  = 0.0f;
+    static constexpr int   PACK_VSENSE_ATTEN_DB = -1;
 };

--- a/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
+++ b/tinkerrocket-idf/projects/base_station/main/board/board_v3.h
@@ -73,4 +73,21 @@ struct board_pins
 
     // --- Flight-pack charger (MP2672GD-0000-Z, external 2S packs) ---
     static constexpr bool HAS_PACK_CHARGER = true;
+
+    // --- Flight-pack voltage sense (net PosADC, external_charger sheet) ---
+    // BatteryPos -> R40 -> PosADC -> R42 -> GND, with C55 100 nF at the pin
+    // as the sampling reservoir; read on GPIO8 (ADC1_CH7). Hardware PR #728
+    // (2026-08-09) re-ratioed the divider onto fleet resistor values:
+    // R40 300 k -> 1 M, R42 100 k -> 180 k. A full 2S pack (8.4 V) now puts
+    // 1.281 V at the pin (was 2.1 V); divider drain drops 21 uA -> 7 uA.
+    // Nothing reads this yet — constants staged so the first implementation
+    // cannot inherit the pre-#728 scale of 4.000.
+    static constexpr int   PACK_VSENSE_GPIO       = 8;    // PosADC, ADC1_CH7
+    static constexpr float PACK_VSENSE_DIVIDER    = 1180.0f / 180.0f;  // 6.5556 (pre-#728: 4.000)
+    // Attenuation chosen deliberately with the new scale: 6 dB. Its ~1.75 V
+    // calibrated range covers the 1.281 V full-pack reading with 27% headroom
+    // and roughly halves the LSB size vs 12 dB. The esp-idf cal curve is
+    // per-attenuation — create the adc_cali handle FOR THIS setting; changing
+    // one without the other silently mis-scales every read.
+    static constexpr int   PACK_VSENSE_ATTEN_DB   = 6;    // ADC_ATTEN_DB_6
 };

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v7.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v7.h
@@ -56,4 +56,10 @@ struct board_pins
     static constexpr int LORA_UART_TX_PIN = -1;
     static constexpr int LORA_UART_RX_PIN = -1;
     static constexpr int LORA_ACT_PIN = -1;
+    // --- High-side-switch current monitors: not present on V7 (see V8) ---
+    static constexpr int   CAM_IMON_GPIO      = -1;
+    static constexpr int   SERVO_IMON_GPIO    = -1;
+    static constexpr float IMON_GAIN_A_PER_A  = 0.0f;
+    static constexpr float CAM_IMON_R_OHM     = 0.0f;
+    static constexpr float SERVO_IMON_R_OHM   = 0.0f;
 };

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
@@ -71,4 +71,20 @@ struct board_pins
     // Daughterboard power gate (high = powered), like CAM_ACT for the RunCam.
     // Also the recovery hammer for a wedged/bricked daughterboard (#412).
     static constexpr int LORA_ACT_PIN = 12;      // LoRa_ACT (CONFIRMED)
+
+    // --- High-side-switch current monitors (V9 close-out: TPS22811 U26/U28) ---
+    // IMON sources GIMON x ILOAD into a ground-referenced gain resistor:
+    //   ILOAD = V(pin) / (IMON_GAIN_A_PER_A * R).
+    // GIMON is 95.3 uA/A typical but 82.9-107.6 over temp (datasheet, at
+    // 1.5 A) — calibrate against a known load before trusting absolute amps.
+    // Gain resistors per hardware PR #728: CAM R85 = 2.0 k (2.2 k in the
+    // original V9 close-out) and SERVO R88 = 1.0 k — deliberately landing
+    // BOTH channels near 0.286 V at their design currents (camera 1.5 A,
+    // servo 3 A per high-side-switch-design.md). Nothing reads these yet;
+    // staged so the first implementation cannot inherit the 2.2 k scale.
+    static constexpr int   CAM_IMON_GPIO      = 8;         // CAM_IMON, ADC1_CH7
+    static constexpr int   SERVO_IMON_GPIO    = 9;         // SERVO_IMON, ADC1_CH8
+    static constexpr float IMON_GAIN_A_PER_A  = 95.3e-6f;  // TPS22811 GIMON typ
+    static constexpr float CAM_IMON_R_OHM     = 2000.0f;   // R85 (PR #728)
+    static constexpr float SERVO_IMON_R_OHM   = 1000.0f;   // R88
 };


### PR DESCRIPTION
Follow-up to hardware #728 (two scale-setting resistors changed). **Finding: nothing in firmware reads either signal yet** — the base station takes battery voltage from the I²C fuel gauge, and no IMON scaling exists — so rather than dead plumbing, the correct constants are staged in the newest board headers (placeholders on older revs per the existing convention):

**base-station `board_v3.h` — flight-pack voltage sense** (net PosADC, GPIO8/ADC1_CH7)
- `PACK_VSENSE_DIVIDER = 1180/180 = 6.5556` (pre-#728 was 4.000); full 2S pack → 1.281 V at pin
- Attenuation picked deliberately: **6 dB** (1.75 V cal range = 27 % headroom, ~2× finer LSB than 12 dB), with a comment warning that the `adc_cali` handle must be created for the same setting

**out-computer `board_v8.h` — TPS22811 IMON channels** (CAM GPIO8, SERVO GPIO9)
- `ILOAD = V / (GIMON × R)`, GIMON 95.3 µA/A typ (82.9–107.6 over temp — calibrate before trusting absolute amps)
- CAM R85 = 2.0 k (per #728), SERVO R88 = 1.0 k — both channels land ≈0.286 V at their design currents (1.5 A / 3 A per `high-side-switch-design.md`)

All five board headers syntax-checked standalone with the new members reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
