### PR TITLE
dashboard: stop the battery reading "-0.0%" on a rocket running off USB

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -1235,7 +1235,7 @@ private fun BatteryCard(telemetry: TelemetryData) {
             Row(Modifier.fillMaxWidth()) {
                 Text("Rocket", style = caption, modifier = Modifier.width(70.dp))
                 listOf(
-                    telemetry.soc?.let { String.format(Locale.ROOT, "%.1f%%", it) } ?: "—",
+                    telemetry.socDisplay,
                     telemetry.voltage?.let { String.format(Locale.ROOT, "%.2f V", it) } ?: "—",
                     telemetry.current?.let { String.format(Locale.ROOT, "%.0f mA", it) } ?: "—",
                 ).forEach {

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryData.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryData.kt
@@ -154,6 +154,26 @@ public data class TelemetryData(
     // valid, low-priority tail fields absent by design.
     val fieldsTrimmed: Boolean = false,
 ) {
+    /**
+     * iOS `socDisplay` twin.  Clamped to 0..100 for display only — the stored
+     * value and the CSV keep whatever came off the wire.  SOC is packed as an
+     * i16 spanning -25..125% for headroom, so an exact 0% round-trips to
+     * -0.00077 and "%.1f%%" prints it as "-0.0%", which is what a rocket
+     * running off USB shows on every line.  Em dash for absent, as elsewhere
+     * on this dashboard (iOS says "N/A" here).
+     */
+    public val socDisplay: String
+        get() = soc?.let {
+            // The `+ 0f` is what actually kills "-0.0%", and it is not
+            // redundant with coerceIn: the OC prints SOC to one decimal, so an
+            // exact 0% arrives as the literal -0.0, and -0.0 == 0.0 means
+            // coerceIn considers it already in range and hands it back
+            // untouched.  Adding positive zero is the IEEE way to drop the
+            // sign.  coerceIn still earns its place for a genuinely
+            // out-of-range value.
+            String.format(java.util.Locale.ROOT, "%.1f%%", it.coerceIn(0f, 100f) + 0f)
+        } ?: "—"
+
     // ── Telemetry freshness (#95) ─────────────────────────────────────────
     public enum class DataStatus(public val raw: Int) {
         LIVE(0), STALE(1), SYNCING(2);

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryDataTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryDataTest.kt
@@ -476,4 +476,21 @@ class TelemetryDataTest {
         assertEquals(IMUOrientationMode.UNKNOWN, zero.relayedOrientationMode)
         assertEquals("", zero.relayedOrientationName)
     }
+
+    @Test
+    fun `soc display never shows a negative percent`() {
+        // A rocket on USB sits below the 2S curve, so the OC clamps SOC to 0
+        // before packing.  The i16 spans -25..125% for headroom, so an exact
+        // 0% comes back as -0.00077 and printed as "-0.0%" on the dashboard.
+        // The one that actually shipped: the OC prints SOC to one decimal,
+        // so an exact 0% arrives as the literal -0.0, which is == 0.0 and so
+        // survives any clamp untouched.
+        assertEquals("0.0%", TelemetryData(soc = -0.0f).socDisplay)
+        assertEquals("0.0%", TelemetryData(soc = -0.00077f).socDisplay)
+        assertEquals("0.0%", TelemetryData(soc = -25f).socDisplay)
+        assertEquals("100.0%", TelemetryData(soc = 125f).socDisplay)
+        // In-range values are untouched, and absent stays absent.
+        assertEquals("42.5%", TelemetryData(soc = 42.5f).socDisplay)
+        assertEquals("\u2014", TelemetryData(soc = null).socDisplay)
+    }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -385,9 +385,18 @@ struct TelemetryData: Codable {
     init() {}
 
     // Computed properties for display
+    /// Clamped to 0...100 for display only — the stored value and the CSV keep
+    /// whatever came off the wire. SOC is packed as an i16 spanning -25...125%
+    /// for headroom, so an exact 0% round-trips to -0.00077 and "%.1f%%" prints
+    /// it as "-0.0%", which is what a rocket on USB shows on every line.
     var socDisplay: String {
         if let soc = soc {
-            return String(format: "%.1f%%", soc)
+            // The `+ 0` is what actually kills "-0.0%", and it is not
+            // redundant with the clamp: the OC prints SOC to one decimal, so
+            // an exact 0% arrives as the literal -0.0, and -0.0 == 0 means
+            // max(0, soc) hands it straight back. Adding positive zero is the
+            // IEEE way to drop the sign.
+            return String(format: "%.1f%%", min(100, max(0, soc)) + 0)
         }
         return "N/A"
     }

--- a/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
+++ b/TinkerRocketApp/TinkerRocketAppTests/TelemetryDataTests.swift
@@ -344,4 +344,26 @@ final class TelemetryDataTests: XCTestCase {
         XCTAssertEqual(zero.relayedOrientationMode, .unknown)
         XCTAssertEqual(zero.relayedOrientationName, "")
     }
+
+    func testSocDisplayNeverShowsANegativePercent() {
+        // A rocket on USB sits below the 2S curve, so the OC clamps SOC to 0
+        // before packing. The i16 spans -25...125% for headroom, so an exact
+        // 0% comes back as -0.00077 and printed as "-0.0%" on the dashboard.
+        func display(_ soc: Float?) -> String {
+            var t = TelemetryData()
+            t.soc = soc
+            return t.socDisplay
+        }
+
+        // The one that actually shipped: the OC prints SOC to one decimal,
+        // so an exact 0% arrives as the literal -0.0, which is == 0 and so
+        // survives any clamp untouched.
+        XCTAssertEqual(display(-0.0), "0.0%")
+        XCTAssertEqual(display(-0.00077), "0.0%")
+        XCTAssertEqual(display(-25), "0.0%")
+        XCTAssertEqual(display(125), "100.0%")
+        // In-range values are untouched, and absent stays absent.
+        XCTAssertEqual(display(42.5), "42.5%")
+        XCTAssertEqual(display(nil), "N/A")
+    }
 }

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,711 lines across 70 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,720 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,7 +30,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 33 files, 12,018 lines
+## `Models/` — 33 files, 12,027 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
@@ -40,9 +40,9 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
 | [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 947 | `DeviceType`, `CSVError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Device Auto-Detection · Main CSV Generation · Rotation Configuration · Helper Functions · Flight Summary · Flight Settings (#165) · CSV Errors |
+| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 607 | `TelemetryData` |
 | [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 600 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Virtual Rocket (iOS twin of Android demo mode, 2026-07-30) · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
-| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 598 | `TelemetryData` |
 | [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 558 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Seams · Private State · Constants · Init · Main Entry Point · Event Detectors · Horizontal Distance · Speak policy · State Reset · Production speech engine |
 | [SensorConverter.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorConverter.swift) | 529 | — |
@@ -122,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 70 files, 26,711 lines.
+Total: 70 files, 26,720 lines.


### PR DESCRIPTION
Every bench session with the rocket on USB shows **Charge = −0.0%**. A negative state of charge isn't a thing, and "−0.0%" sitting next to 5.20 V reads like a measurement rather than the formatting artifact it is.

## The chain

The OC clamps SOC to 0 below the 2S curve, then prints it into the telemetry JSON at one decimal. An exact 0 that has been through the i16 wire form — which spans −25…125% for headroom — comes back a hair under zero, so the OC prints the literal `-0.0` and the app parses it to **negative zero**.

Which is why a clamp alone does not fix it, and I found that out on the bench rather than by reading code: I shipped `coerceIn(0f, 100f)` to the phone, restarted, and the dashboard still said −0.0%. `-0.0 == 0.0`, so `coerceIn` / `max(0, ·)` consider it already in range and hand it straight back. `+ 0` is the IEEE way to drop the sign; the clamp stays for a genuinely out-of-range value.

## Display only, on purpose

My first attempt clamped in `SensorConverter`, which broke `CsvGeneratorTest` — that fixture deliberately uses 125.0, the wire maximum, and is a hand-computed **cross-platform** parity string. The converter is shared with `CSVGenerator`, so clamping there would have quietly rewritten logged flight data to fix a label. Reverted; the stored value and the CSV keep exactly what came off the wire.

Android gains a `socDisplay` on `TelemetryData` to match iOS's, so both apps format this in one tested place instead of inline in a Composable. Android keeps its em dash for absent and iOS keeps `N/A` — an existing divergence, not one this PR introduces.

## Tests

Both suites gain the same case, including `-0.0` explicitly, which is the one that actually shipped and the one a clamp-only fix passes right over.

## Verified on hardware

TR-R-e424 over a direct link: **0.0%** at 5.20 V, where the same build one commit earlier read −0.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
