### PR TITLE
android: bump to 1.0.2 so a release can carry the Google Satellite basemap

### DIFF
--- a/TinkerRocketAndroid/app/build.gradle.kts
+++ b/TinkerRocketAndroid/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         targetSdk = 36
         // versionCode must only ever increase (Play + sideload "update"
         // installs both key on it); bump BOTH before tagging android-v<name>.
-        versionCode = 5
-        versionName = "1.0.1"
+        versionCode = 6
+        versionName = "1.0.2"
 
         // Google Map Tiles API key (online-only satellite basemap).  Same
         // env-var discipline as release signing below: never in the repo;


### PR DESCRIPTION
The Google Map Tiles work merged on 2026-08-01 ([#709](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/709), `676ae416`) and has never been in an installable build. `git tag --contains 676ae416` returns only hardware tags — the newest Android tag is `android-v1.0.1` from 2026-07-30, two days before the merge.

`main` still sits at exactly the `versionCode`/`versionName` that tag shipped, so tagging as-is would publish an APK that sideload and Play both refuse as an "update". Bumping both is the precondition for `android-v1.0.2`.

Nothing else is needed on the code side — I checked each piece rather than taking it on faith:

- `TileSource.GOOGLE_SATELLITE`, `GoogleTileUpstream`, the proxy branch and the attribution route are all on main.
- The picker entry is build-time gated on `BuildConfig.TR_MAPS_API_KEY` ([AppContainer.kt:135](TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/AppContainer.kt:135)), which [build.gradle.kts:32](TinkerRocketAndroid/app/build.gradle.kts:32) fills from `TR_ANDROID_MAPS_API_KEY`.
- `.github/workflows/android-release.yml` already injects that secret, so a tagged build gets the source; a local build without the env var silently omits it.

Merging this does not publish anything. The release happens when `android-v1.0.2` is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)