### PR TITLE
3d: stack coincident trajectory labels instead of overprinting them

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/Trajectory3DCanvas.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/Trajectory3DCanvas.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
@@ -171,15 +173,47 @@ internal fun OrbitSceneCanvas(
         }
 
         // ── Markers + labels ─────────────────────────────────────────────
+        // Labels stack instead of overprinting.  Two markers at the same spot
+        // used to stamp their text at the same pixel, and "Launch Pad" over
+        // "Landing" renders as unreadable mush.  That is not an edge case
+        // here: a reverse drift cast lands you where you launched, so the two
+        // coincide on every normal run, and a bench log or a pad abort does
+        // the same to Apogee/Landing on the flight trajectory.
+        val placed = mutableListOf<Rect>()
+        fun place(candidate: Rect): Rect {
+            var r = candidate
+            val step = r.height + 2.dp.toPx()
+            // Walk upward until clear.  Bounded: markers are few, and running
+            // off the top is better than an illegible pile.
+            var guard = 0
+            while (placed.any { it.overlaps(r) } && guard++ < markers.size * 2) {
+                r = r.translate(0f, -step)
+            }
+            placed += r
+            return r
+        }
+
         for (m in markers) {
             val pp = proj(m.pos) ?: continue
             val r = m.radiusDp.dp.toPx()
             drawCircle(m.color, r, pp.o())
             val t = textMeasurer.measure(m.label, TextStyle(fontSize = 11.sp, color = labelColor))
-            drawText(t, topLeft = Offset(pp.x.toFloat() - t.size.width / 2, pp.y.toFloat() - r - t.size.height - 2))
+            val slot = place(
+                Rect(
+                    Offset(pp.x.toFloat() - t.size.width / 2, pp.y.toFloat() - r - t.size.height - 2),
+                    Size(t.size.width.toFloat(), t.size.height.toFloat()),
+                ),
+            )
+            drawText(t, topLeft = slot.topLeft)
             m.sublabel?.let { sub ->
                 val st = textMeasurer.measure(sub, TextStyle(fontSize = 10.sp, color = labelColor))
-                drawText(st, topLeft = Offset(pp.x.toFloat() - st.size.width / 2, pp.y.toFloat() + 8.dp.toPx()))
+                val subSlot = place(
+                    Rect(
+                        Offset(pp.x.toFloat() - st.size.width / 2, pp.y.toFloat() + 8.dp.toPx()),
+                        Size(st.size.width.toFloat(), st.size.height.toFloat()),
+                    ),
+                )
+                drawText(st, topLeft = subSlot.topLeft)
             }
         }
 


### PR DESCRIPTION
Reverse Drift Cast draws **"Launch Pad" and "Landing" at the same pixel** and the result reads as "Laumdi Rgd". The flight trajectory does the same to "Apogee" and "Landing" on any log that never left the ground.

The drift-cast case is not an edge case. A reverse drift cast solves for where to be at apogee so the rocket comes back to **where it launched** — so launch and landing coincide on a normal run. The labels overlap every time, on the screen whose whole job is telling you where to walk.

## Cause

[Trajectory3DCanvas.kt:174](TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/Trajectory3DCanvas.kt:174) drew markers in a loop, each label centred on its own projected point with no awareness of the others. Labels now claim a rect and walk upward until they clear whatever is already placed. The walk is bounded by the marker count — running a label off the top beats an illegible pile, and there are only ever three or four.

## Android only, on purpose

iOS builds these as `SCNText` nodes in the SceneKit scene ([DriftCastView.swift:377](TinkerRocketApp/TinkerRocketApp/Views/DriftCastView.swift:377)), so its labels are depth-sorted 3D geometry rather than text stamped at a computed pixel. The same fix does not translate and the failure does not present the same way.

## Verified on hardware

Found on the Pixel on both screens, then re-checked after the fix: "Guidance" and "Landing" now stack on separate lines, both legible, where they previously overprinted.

Found during a wider sweep of the ten previously-untested screens; the rest of that sweep's findings are reported separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)