### PR TITLE
android: derive the FileProvider authority from applicationId

### DIFF
--- a/TinkerRocketAndroid/app/src/main/AndroidManifest.xml
+++ b/TinkerRocketAndroid/app/src/main/AndroidManifest.xml
@@ -27,9 +27,17 @@
             </intent-filter>
         </activity>
 
+        <!-- Authority is DERIVED, not literal, so it tracks applicationId:
+             FlightCache asks for "${context.packageName}.files" at runtime,
+             which carries any applicationIdSuffix, so a literal here would
+             disagree with the only caller.  A suffixed variant (side-by-side
+             bench install) then can't install at all
+             (INSTALL_FAILED_CONFLICTING_PROVIDER — two packages may not claim
+             one authority), and would throw from getUriForFile if it could.
+             Expands to the identical string for the shipped build. -->
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.tinkerbug.tinkerrocket.files"
+            android:authorities="${applicationId}.files"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
One-line manifest change: the FileProvider authority is now derived from `applicationId` instead of hardcoded.

## Why it's a real bug, not just bench friction

The manifest declared `com.tinkerbug.tinkerrocket.files`, but the **only** caller derives it at runtime:

```kotlin
// FlightCache.kt:90
val uri = FileProvider.getUriForFile(context, "${context.packageName}.files", csv)
```

`context.packageName` is the *installed* applicationId, so it carries any `applicationIdSuffix`. The declaration and its only caller therefore disagree in any suffixed variant — the manifest asks for one authority and the code looks up another. Two consequences:

1. A suffixed build can't install alongside the normal one at all — `INSTALL_FAILED_CONFLICTING_PROVIDER`, because two packages may not claim the same provider authority.
2. If it could install, `getUriForFile` would throw `IllegalArgumentException` ("couldn't find meta-data for provider with authority …") the moment someone tapped share.

This surfaced on 2026-08-10 trying to bench-verify a UI change on the Pixel 8 side-by-side: the installed app is signed with a different debug keystore, so `adb install -r` fails, and uninstalling to make room would have dropped that install's saved flights and offline tiles. A suffixed variant is the non-destructive way out, and this was what blocked it.

## Safety

Zero behavior change for shipped builds — confirmed from the merged manifest rather than assumed:

| Build | applicationId (per `aapt2 dump packagename`) | Resolved authority |
|---|---|---|
| normal | `com.tinkerbug.tinkerrocket` | `com.tinkerbug.tinkerrocket.files` — byte-identical to the old literal |
| `applicationIdSuffix=".designpass"` | `com.tinkerbug.tinkerrocket.designpass` | `com.tinkerbug.tinkerrocket.designpass.files` — matches what the caller asks for |

## Checks requested

- `grep -rn "com.tinkerbug.tinkerrocket.files" TinkerRocketAndroid/` → the manifest line only, nothing else referenced it.
- Every `FileProvider` / `getUriForFile` call site reviewed: exactly one (`FlightCache.shareCsv`), and it already builds the authority from `context.packageName`, so no caller needed updating.
- `:app:assembleDebug` clean both with and without the suffix.

## Not verified

**The on-device half did not run** — the Pixel was unplugged before I could do the install-alongside and exercise the FilesScreen share verb. The fix is proven at the manifest/APK level (the table above), not by a share sheet actually opening. Worth one manual share after merge to close that out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
