### PR TITLE
android: release CI checks the version inside the APK, and can be dry-run before the tag exists

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,6 +21,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history + tags: the version check below reads the previous
+          # android-v* tag's build.gradle.kts.  The default depth-1 checkout
+          # fetches only the tagged commit and `git show <prev-tag>:...` fails.
+          fetch-depth: 0
 
       - uses: actions/setup-java@v4
         with:
@@ -55,9 +60,10 @@ jobs:
         run: ./gradlew --no-daemon :app:assembleRelease
         working-directory: TinkerRocketAndroid
 
-      - name: Verify the APK is signed with the release key (not debug)
+      - name: Verify the APK — release-signed, version matches the tag, versionCode advanced
         run: |
           APK=TinkerRocketAndroid/app/build/outputs/apk/release/app-release.apk
+          GRADLE=TinkerRocketAndroid/app/build.gradle.kts
           ls -la "$APK"
           # Runners ship several build-tools versions — a bare glob expands to
           # multiple paths and the first binary eats the second as an argument.
@@ -70,6 +76,57 @@ jobs:
               echo "::error::APK is debug-signed — the release signing env did not take"
               exit 1 ;;
           esac
+
+          # The signer check says the APK is ours; it says nothing about which
+          # version is inside it.  android-v0.9.0 shipped an APK reporting
+          # versionName 0.1.0-phase3 and this workflow published it clean.  Read
+          # the version out of the built APK itself — not out of the gradle file
+          # — so a bump left uncommitted in a working tree cannot pass.
+          AAPT2=$(ls -d "$ANDROID_HOME"/build-tools/*/aapt2 | sort -V | tail -1)
+          # `|| true`: steps run under bash -e, and a no-match grep here would
+          # abort with no explanation — let the emptiness check below report it.
+          BADGING=$("$AAPT2" dump badging "$APK" | grep -m1 '^package:' || true)
+          echo "$BADGING"
+          APK_NAME=$(printf '%s\n' "$BADGING" | sed -n "s/.*versionName='\([^']*\)'.*/\1/p")
+          APK_CODE=$(printf '%s\n' "$BADGING" | sed -n "s/.*versionCode='\([0-9]*\)'.*/\1/p")
+          if [ -z "$APK_NAME" ] || [ -z "$APK_CODE" ]; then
+            echo "::error::could not read versionName/versionCode from $APK — aapt2 badging line was: $BADGING"
+            exit 1
+          fi
+
+          # 1. The APK must call itself what the tag calls it.  A mismatch here
+          #    is what pins a phantom "update available" banner on every install
+          #    forever: UpdateChecker reads the *installed* versionName, and any
+          #    release strictly ahead of it stays offered, persisted across
+          #    restarts.  A 1.0.3 release against a 1.0.2-reporting install
+          #    never clears — no later release can fix an APK already out.
+          EXPECTED_NAME="${GITHUB_REF_NAME#android-v}"
+          if [ "$APK_NAME" != "$EXPECTED_NAME" ]; then
+            echo "::error::version mismatch: tag $GITHUB_REF_NAME expects versionName '$EXPECTED_NAME' but the APK reports '$APK_NAME' (versionCode $APK_CODE). Set versionName = \"$EXPECTED_NAME\" in $GRADLE, commit it, then move the tag onto that commit — the bump was probably never committed."
+            exit 1
+          fi
+          echo "versionName '$APK_NAME' matches tag $GITHUB_REF_NAME"
+
+          # 2. versionCode must strictly increase, or sideload/Play refuse the
+          #    install as a downgrade.  Compare against the previous android-v*
+          #    tag in version order (needs the fetch-depth: 0 checkout above).
+          PREV_TAG=$(git tag -l 'android-v*' | sort -V | awk -v cur="$GITHUB_REF_NAME" '$0 == cur { exit } { prev = $0 } END { print prev }')
+          if [ -z "$PREV_TAG" ]; then
+            echo "::notice::$GITHUB_REF_NAME is the earliest android-v* tag — no previous versionCode to compare against"
+          else
+            # `grep versionCode` alone matches the explanatory comment above the
+            # field first and parses to nothing; anchor on the assignment.
+            PREV_CODE=$(git show "$PREV_TAG:$GRADLE" | sed -n 's/.*versionCode *= *\([0-9][0-9]*\).*/\1/p' | head -1)
+            if [ -z "$PREV_CODE" ]; then
+              echo "::error::could not read versionCode from $GRADLE at $PREV_TAG — the file may have moved or the field been renamed since that tag. Fix this check's path/pattern before releasing."
+              exit 1
+            fi
+            if [ "$APK_CODE" -le "$PREV_CODE" ]; then
+              echo "::error::versionCode did not advance: $GITHUB_REF_NAME builds versionCode $APK_CODE but $PREV_TAG already shipped $PREV_CODE. Set versionCode = $((PREV_CODE + 1)) (or higher) in $GRADLE, commit it, then move the tag onto that commit. Installs of $PREV_TAG will reject this APK as a downgrade."
+              exit 1
+            fi
+            echo "versionCode $APK_CODE advances on $PREV_TAG's $PREV_CODE"
+          fi
 
       - name: Attach APK to the GitHub release
         env:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -7,11 +7,26 @@ name: Android Release
 # see docs/android-release-signing.md for minting, custody, and secret setup.
 #
 # Runs the full JVM suite first — a release must never outrun the tests.
+#
+# Also runnable by hand as a dry run: same tests, same signed build, same
+# verification, but it stops before creating the release.  Use it to prove a
+# commit is releasable before the tag exists — a tag push is otherwise the
+# only way this workflow ever runs, which would make every change to it
+# untested until the one moment it must not fail.
 
 on:
   push:
     tags:
       - 'android-v*'
+  workflow_dispatch:
+    inputs:
+      simulated_tag:
+        description: >-
+          Tag to verify against, e.g. android-v1.0.4.  Blank derives
+          android-v<versionName> from build.gradle.kts, which makes the
+          name check self-consistent — name a tag to test a mismatch.
+        required: false
+        default: ''
 
 jobs:
   release:
@@ -61,10 +76,39 @@ jobs:
         working-directory: TinkerRocketAndroid
 
       - name: Verify the APK — release-signed, version matches the tag, versionCode advanced
+        env:
+          # Via env, not ${{ }} inlined into the script: a dispatch input is
+          # free text and would otherwise be pasted straight into bash.
+          SIMULATED_TAG: ${{ inputs.simulated_tag }}
         run: |
           APK=TinkerRocketAndroid/app/build/outputs/apk/release/app-release.apk
           GRADLE=TinkerRocketAndroid/app/build.gradle.kts
           ls -la "$APK"
+
+          # On a tag push the tag is the ref; on a manual dry run there is no
+          # tag yet, so check against the one this commit is heading for.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # How the failures below tell you to finish the job.  On a dry run
+            # there is no tag to move yet — telling you to move one is noise.
+            THEN="re-run this dry run"
+            TAG="$SIMULATED_TAG"
+            if [ -z "$TAG" ]; then
+              TAG="android-v$(sed -n 's/.*versionName *= *"\([^"]*\)".*/\1/p' "$GRADLE" | head -1)"
+              echo "::notice::dry run against $TAG, derived from $GRADLE — the versionName check below can only agree with itself. Re-run with an explicit tag to test a mismatch."
+            else
+              echo "::notice::dry run against $TAG — no release will be created"
+            fi
+          else
+            THEN="move the tag onto that commit"
+            TAG="$GITHUB_REF_NAME"
+          fi
+          case "$TAG" in
+            android-v?*) ;;
+            *)
+              echo "::error::'$TAG' is not a release tag — expected android-v<versionName>, e.g. android-v1.0.4"
+              exit 1 ;;
+          esac
+
           # Runners ship several build-tools versions — a bare glob expands to
           # multiple paths and the first binary eats the second as an argument.
           APKSIGNER=$(ls -d "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
@@ -100,19 +144,19 @@ jobs:
           #    release strictly ahead of it stays offered, persisted across
           #    restarts.  A 1.0.3 release against a 1.0.2-reporting install
           #    never clears — no later release can fix an APK already out.
-          EXPECTED_NAME="${GITHUB_REF_NAME#android-v}"
+          EXPECTED_NAME="${TAG#android-v}"
           if [ "$APK_NAME" != "$EXPECTED_NAME" ]; then
-            echo "::error::version mismatch: tag $GITHUB_REF_NAME expects versionName '$EXPECTED_NAME' but the APK reports '$APK_NAME' (versionCode $APK_CODE). Set versionName = \"$EXPECTED_NAME\" in $GRADLE, commit it, then move the tag onto that commit — the bump was probably never committed."
+            echo "::error::version mismatch: tag $TAG expects versionName '$EXPECTED_NAME' but the APK reports '$APK_NAME' (versionCode $APK_CODE). Set versionName = \"$EXPECTED_NAME\" in $GRADLE, commit it, then $THEN — the bump was probably never committed."
             exit 1
           fi
-          echo "versionName '$APK_NAME' matches tag $GITHUB_REF_NAME"
+          echo "versionName '$APK_NAME' matches tag $TAG"
 
           # 2. versionCode must strictly increase, or sideload/Play refuse the
           #    install as a downgrade.  Compare against the previous android-v*
           #    tag in version order (needs the fetch-depth: 0 checkout above).
-          PREV_TAG=$(git tag -l 'android-v*' | sort -V | awk -v cur="$GITHUB_REF_NAME" '$0 == cur { exit } { prev = $0 } END { print prev }')
+          PREV_TAG=$(git tag -l 'android-v*' | sort -V | awk -v cur="$TAG" '$0 == cur { exit } { prev = $0 } END { print prev }')
           if [ -z "$PREV_TAG" ]; then
-            echo "::notice::$GITHUB_REF_NAME is the earliest android-v* tag — no previous versionCode to compare against"
+            echo "::notice::$TAG is the earliest android-v* tag — no previous versionCode to compare against"
           else
             # `grep versionCode` alone matches the explanatory comment above the
             # field first and parses to nothing; anchor on the assignment.
@@ -122,13 +166,16 @@ jobs:
               exit 1
             fi
             if [ "$APK_CODE" -le "$PREV_CODE" ]; then
-              echo "::error::versionCode did not advance: $GITHUB_REF_NAME builds versionCode $APK_CODE but $PREV_TAG already shipped $PREV_CODE. Set versionCode = $((PREV_CODE + 1)) (or higher) in $GRADLE, commit it, then move the tag onto that commit. Installs of $PREV_TAG will reject this APK as a downgrade."
+              echo "::error::versionCode did not advance: $TAG builds versionCode $APK_CODE but $PREV_TAG already shipped $PREV_CODE. Set versionCode = $((PREV_CODE + 1)) (or higher) in $GRADLE, commit it, then $THEN. Installs of $PREV_TAG will reject this APK as a downgrade."
               exit 1
             fi
             echo "versionCode $APK_CODE advances on $PREV_TAG's $PREV_CODE"
           fi
 
+      # Everything above is the dry run.  This is the one step a manual run
+      # must never reach — a dispatch verifies, it does not publish.
       - name: Attach APK to the GitHub release
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## The gap

`android-release.yml` verified that the APK was signed with the release key and stopped there. Nothing tied the artifact's version to the tag being published.

This is not hypothetical: **`android-v0.9.0` shipped an APK reporting `versionName` `0.1.0-phase3`**, and the workflow published it clean.

The failure mode is worse than a mislabelled download. `UpdateChecker` reads the *installed* `versionName` and keeps any release strictly ahead of it, persisted across restarts — so an APK that under-reports its own version pins a phantom "update available" banner on every install of it, permanently. No later release can clear it. The 1.0.3 release on 2026-08-10 came close to exactly this: the version bump was briefly only in a working tree, and tagging at that moment would have published an APK self-reporting 1.0.2 with versionCode 6.

## The checks (50fe886)

Two assertions appended to the existing verify step, after the signer check. Both read the **built APK** via `aapt2 dump badging` rather than the gradle file, so a bump left uncommitted in a working tree cannot pass:

1. `versionName` must equal the tag minus its `android-v` prefix
2. `versionCode` must strictly exceed the previous `android-v*` tag's

`aapt2` is located with the same `ls -d … | sort -V | tail -1` pattern already used for `apksigner`.

`actions/checkout@v4` gains `fetch-depth: 0` — resolving the previous tag needs history, and the default depth-1 checkout fetches only the tagged commit, so `git show <prev-tag>:…` fails.

Two shell details worth a reviewer's eye:

- The versionCode pattern anchors on `versionCode *=`. A bare `grep versionCode` matches the explanatory comment above the field first and parses to an empty string — confirmed against the real file. An unreadable version is a hard failure at both ends, so if the field is ever renamed this breaks loudly instead of passing silently.
- No `set -o pipefail`. Combined with the existing `grep -m1` it would SIGPIPE `apksigner`/`aapt2` and fail the step spuriously. Steps already run under `bash -e`, which is why the badging capture carries `|| true` — a no-match grep produces the explanatory error rather than an unexplained abort.

## The dry run (850f167)

As first written, those checks could not be exercised before the moment they matter: a tag push was the only trigger, and the workflow's first real action is creating a release. A bad pattern would have surfaced *during* a release.

`workflow_dispatch` now runs the same tests, the same signed build and the same verification, then stops — the attach step is gated on `github.event_name == 'push'`.

A dry run has no tag in the ref, so the checks take their tag from a `simulated_tag` input:

- **Blank** → derives `android-v<versionName>` from `build.gradle.kts`. This makes check 1 agree with itself by construction, which the run states in a `::notice::`. Still worth running: it proves `aapt2` is present, the badging line parses, and the versionCode comparison works on a real runner.
- **Named** (e.g. `android-v1.0.4`) → the useful mode. Answers "is this commit releasable as 1.0.4?" before the tag is cut.

The input reaches bash through `env:` rather than `${{ }}` interpolation, and a tag not shaped like `android-v*` is rejected up front. Failure advice is event-aware — telling you to move a tag is noise on a dry run, where the fix is to commit and re-run.

## Verification

The verify step's `run:` block was extracted and executed against the real tag history with a stub `aapt2`, for both event types:

| case | event | result |
|---|---|---|
| real 1.0.3 (code 7, name 1.0.3) | push | passes |
| the 2026-08-10 near-miss — tag `android-v1.0.3`, APK reports 1.0.2 / code 6 | push | fails, names expected vs. actual |
| `android-v0.9.0` as it actually shipped (`0.1.0-phase3`) | push | fails |
| name correct, versionCode stuck at 6 under tag 1.0.4 | push | fails, prints `Set versionCode = 8 (or higher)` |
| earliest tag, no predecessor | push | passes with a `::notice::` |
| `aapt2` output unparseable | push | fails with the badging line echoed |
| no input, tree at 1.0.3/7 | dispatch | passes, notes the check is self-consistent |
| `android-v1.0.4`, bump already made | dispatch | passes |
| **`android-v1.0.4`, bump not made** — the near-miss, caught pre-tag | dispatch | fails, advises commit + re-run |
| `android-v1.0.4`, versionCode regressed | dispatch | fails |
| malformed input `1.0.4` | dispatch | fails on the tag shape |

Both checks were also replayed across all seven existing `android-v*` tags: every release from 0.9.1 onward passes on its own terms, so this doesn't retroactively block anything legitimate.

## Verified on a real runner

Both modes dispatched off this branch before merge — the untested-plumbing caveat is now closed:

**[Run 31465518868](https://github.com/Tinkerbug-Robotics/TinkerRocket/actions/runs/31465518868)** — `simulated_tag: android-v1.0.4`, tree at 1.0.3. Failed as intended, reproducing the 2026-08-10 near-miss before any tag existed:

> version mismatch: tag android-v1.0.4 expects versionName '1.0.4' but the APK reports '1.0.3' (versionCode 7). Set versionName = "1.0.4" ... commit it, then re-run this dry run

**[Run 31465811715](https://github.com/Tinkerbug-Robotics/TinkerRocket/actions/runs/31465811715)** — blank input, passed. Real `aapt2` output off the 89 MB signed APK:

```
package: name='com.tinkerbug.***' versionCode='7' versionName='1.0.3' platformBuildVersionName='16' compileSdkVersion='36' ...
versionName '1.0.3' matches tag android-v1.0.3
versionCode 7 advances on android-v1.0.2's 6
```

That confirms `aapt2` sits alongside `apksigner` in the runner's build-tools dir, the badging line parses (note it carries more fields than expected — `platformBuildVersionName` does not collide, its `V` is capitalised), the signer DN reads `CN=TinkerRocket, O=Tinkerbug Robotics`, and `git show android-v1.0.2:…` resolves under `fetch-depth: 0`. **Attach step: `skipped` in both runs** — no release was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

