### PR TITLE
tools: stop Servo Test and Mag Cal stranding the flight computer

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ConnectedTopBar.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ConnectedTopBar.kt
@@ -50,15 +50,31 @@ fun ConnectedTopBar(
     onDisconnect: () -> Unit,
     unitStore: UnitStore,
     container: AppContainer,
+    toolOpen: Boolean = false,
+    onCloseTool: () -> Unit = {},
 ) {
     Row(
         Modifier.fillMaxWidth().padding(horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(onClick = { if (tab != 0) onTab(0) else onDisconnect() }) {
+        // A tool sub-screen leaves `tab` at 0, so this chevron used to take its
+        // disconnect branch while looking and reading like back -- and a
+        // disconnect tears the GATT down before the tool screen's teardown hook
+        // runs, so the servo-test stop or mag-cal abort never reached the
+        // rocket. From a tool it now closes the tool, which is what it looks
+        // like it does and what iOS does from a pushed screen.
+        IconButton(
+            onClick = {
+                when {
+                    toolOpen -> onCloseTool()
+                    tab != 0 -> onTab(0)
+                    else -> onDisconnect()
+                }
+            },
+        ) {
             Icon(
                 Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                contentDescription = if (tab != 0) "Back to dashboard" else "Disconnect",
+                contentDescription = if (toolOpen || tab != 0) "Back to dashboard" else "Disconnect",
                 tint = TrTheme.colors.savedFlights,
             )
         }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -63,23 +63,29 @@ fun DashboardScreen(
     phoneLocation: PhoneLocationManager? = null,
     profileStore: com.tinkerbug.tinkerrocket.session.RocketProfileStore? = null,
     container: AppContainer? = null,
+    tool: String? = null,
+    onTool: (String?) -> Unit = {},
 ) {
     val session = device.session
 
-    // Tools sub-routes (iOS: sheets from the dashboard).
-    var tool by androidx.compose.runtime.remember {
-        androidx.compose.runtime.mutableStateOf<String?>(null)
-    }
+    // Tools sub-routes (iOS: sheets from the dashboard).  The route state is
+    // owned by MainActivity, not here, so the top bar drawn above this screen
+    // can tell that a tool is open -- see ConnectedTopBar's chevron.
     when (tool) {
-        "servo" -> { ServoTestScreen(session, profileStore, onBack = { tool = null }); return }
-        "sim" -> { SimulationScreen(session, onBack = { tool = null }); return }
-        "scan" -> { FreqScanScreen(session, onBack = { tool = null }); return }
-        "magcal" -> { MagCalScreen(session, syncer, onBack = { tool = null }); return }
+        "servo" -> { ServoTestScreen(session, profileStore, onBack = { onTool(null) }); return }
+        "sim" -> { SimulationScreen(session, onBack = { onTool(null) }); return }
+        "scan" -> { FreqScanScreen(session, onBack = { onTool(null) }); return }
+        "magcal" -> { MagCalScreen(session, syncer, onBack = { onTool(null) }); return }
         "ota" -> {
+            // The return sits outside the null check so an unroutable state
+            // renders nothing rather than falling through into the dashboard
+            // body.  One screen per route state is the invariant the teardown
+            // hooks rest on: two screens composed at once would mean a tool's
+            // onDispose never runs while its route is still selected.
             if (container != null) {
-                FirmwareUpdateScreen(container, device.deviceId, session, onBack = { tool = null })
-                return
+                FirmwareUpdateScreen(container, device.deviceId, session, onBack = { onTool(null) })
             }
+            return
         }
     }
 
@@ -118,6 +124,10 @@ fun DashboardScreen(
     val focusRocketId by session.focusRocketId.collectAsState()
     val imuOrientName by session.imuOrientationName.collectAsState()
     val imuOrientMode by session.imuOrientationMode.collectAsState()
+    // iOS isOnPadState (DashboardView.swift:2422) — the two states in which a
+    // ground test is allowed to move control surfaces.
+    val simLaunched by session.simLaunched.collectAsState()
+    val onPad = telemetry.state == "READY" || telemetry.state == "PRELAUNCH"
 
     Column(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
@@ -420,20 +430,34 @@ fun DashboardScreen(
                 val tr = com.tinkerbug.tinkerrocket.app.theme.TrTheme.colors
                 Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     if (!session.isBaseStation) {
+                        // iOS canStartGroundTest (DashboardView.swift:2437) gates this
+                        // button, and Android had no gate at all -- opening the screen
+                        // sends cmd 24 immediately, and the FC only refuses it from
+                        // INFLIGHT or MAG_CALIBRATION, so a rocket in DESCENT or LANDED
+                        // would deflect its fins on a tap.  The FC's only failsafe for a
+                        // stranded servo test is launch detection: there is no idle or
+                        // link-loss timeout, and neither computer clears it on
+                        // disconnect.
+                        //
+                        // iOS's third term, !groundTestActive, has no Android equivalent
+                        // yet -- the Ground Test screen is not ported -- so it is
+                        // vacuously satisfied rather than omitted by oversight.
                         com.tinkerbug.tinkerrocket.app.theme.TrCompactButton(
-                            "Servo test", tr.servoTest, { tool = "servo" })
+                            "Servo test", tr.servoTest, { onTool("servo") },
+                            enabled = onPad && !simLaunched,
+                        )
                         com.tinkerbug.tinkerrocket.app.theme.TrCompactButton(
-                            "Mag cal", tr.myDevices, { tool = "magcal" })
+                            "Mag cal", tr.myDevices, { onTool("magcal") })
                     }
                     com.tinkerbug.tinkerrocket.app.theme.TrCompactButton(
-                        "Simulate", tr.simulate, { tool = "sim" })
+                        "Simulate", tr.simulate, { onTool("sim") })
                     if (session.isBaseStation) {
                         com.tinkerbug.tinkerrocket.app.theme.TrCompactButton(
-                            "Freq scan", tr.freqScan, { tool = "scan" })
+                            "Freq scan", tr.freqScan, { onTool("scan") })
                     }
                     if (container != null) {
                         com.tinkerbug.tinkerrocket.app.theme.TrCompactButton(
-                            "Firmware", tr.camera, { tool = "ota" })
+                            "Firmware", tr.camera, { onTool("ota") })
                     }
                 }
             }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MagCalScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MagCalScreen.kt
@@ -1,5 +1,6 @@
 package com.tinkerbug.tinkerrocket.app
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,11 +18,13 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -97,14 +100,50 @@ fun MagCalScreen(
     }
 
     fun bare(cmd: Int) = session.sendBareCommand(cmd)
-    fun abortAndBack() {
-        bare(BleCommandId.MAG_CAL_ABORT_OC)
-        onBack()
-    }
 
     val subType = status?.subType ?: MagCalSubType.IDLE
-    val midCal = subType == MagCalSubType.SAMPLING || subType == MagCalSubType.REVIEW ||
-        subType == MagCalSubType.VERIFYING
+    val midCal = subType.needsAbortOnLeave
+
+    // The abort is owned by teardown, not by the Cancel button, because Cancel
+    // was never the only way out.  The screen also disappears when the top bar
+    // switches tab, when the chevron disconnects, when the system back gesture
+    // pops it, and when a rotation recreates the Activity -- and every one of
+    // those left the FC sitting in MAG_CALIBRATION with the magnetometer
+    // offsets zeroed, invisible from wherever the operator ended up.
+    //
+    // Gated on midCal so it is inert when nothing is running: the FC rests in
+    // APPLIED whenever a calibration exists, and blanket-aborting that on every
+    // visit to the screen would be its own bug.  `latestMidCal` because the
+    // onDispose closure would otherwise capture the value from the composition
+    // that installed it, which is IDLE on entry -- exactly when it must not be.
+    //
+    // The gate is widened past midCal by ranCalThisSession because midCal comes
+    // from live 5 Hz FC telemetry: a null or stale magCalStatus at teardown
+    // would silently degrade it to "send nothing" at exactly the moment it must
+    // not. `subType != APPLIED` is the part that actually protects anything --
+    // everything else in the FC's abort handler is individually guarded and it
+    // never writes NVS, so APPLIED is the only state a stray abort can damage.
+    val needsAbort = midCal || (ranCalThisSession && subType != MagCalSubType.APPLIED)
+    val latestNeedsAbort by rememberUpdatedState(needsAbort)
+    var abortSent by remember { mutableStateOf(false) }
+    fun abortOnce() {
+        if (!abortSent) {
+            abortSent = true
+            bare(BleCommandId.MAG_CAL_ABORT_OC)
+        }
+    }
+    DisposableEffect(session) {
+        onDispose { if (latestNeedsAbort) abortOnce() }
+    }
+    fun abortAndBack() {
+        abortOnce()
+        onBack()
+    }
+    // System back popped to the launcher instead of here, because the app has
+    // no BackHandler and back fell through to the Activity default.  Routing it
+    // to the same path as Cancel keeps the process alive long enough for the
+    // abort to actually reach the rocket.
+    BackHandler { if (midCal) abortAndBack() else onBack() }
 
     Column(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/MainActivity.kt
@@ -145,12 +145,35 @@ class MainActivity : ComponentActivity() {
                         // next batch of destinations (plan §4).
                         activeDevice != null -> {
                             var tab by remember { mutableStateOf(0) }
+                            // Which tool sub-screen is open, hoisted out of
+                            // DashboardScreen so the top bar can see it. The bar
+                            // is drawn ABOVE this `when`, so it stays on screen
+                            // over a tool -- and its chevron used to read `tab`,
+                            // which is still 0 there, so it took the DISCONNECT
+                            // branch. That is the one exit a teardown hook cannot
+                            // cover: the GATT goes down before the composition
+                            // unwinds, so the cleanup write lands on a dead
+                            // transport and the FC stays in servo-test or
+                            // mag-cal with nothing on screen to say so.
+                            var tool by remember { mutableStateOf<String?>(null) }
+                            // An active-device hop swaps the session underneath a
+                            // tool screen without disposing it (FleetManager falls
+                            // through to a surviving key rather than null), which
+                            // would leave the screen driving a different rocket.
+                            LaunchedEffect(activeDevice.deviceId) { tool = null }
                             androidx.compose.foundation.layout.Column {
                                 // iOS toolbar arrangement (design pass):
                                 // chevron + units | book · map · voice · gear.
                                 ConnectedTopBar(
                                     tab = tab,
-                                    onTab = { tab = it },
+                                    toolOpen = tool != null,
+                                    onCloseTool = { tool = null },
+                                    // Closing the tool on a tab change is load
+                                    // bearing now that `tool` outlives the tab:
+                                    // otherwise returning to tab 0 would re-enter
+                                    // the tool and re-fire its entry command,
+                                    // re-arming servo test after the stop went out.
+                                    onTab = { tool = null; tab = it },
                                     onDisconnect = {
                                         fleet.disconnect(activeDevice.deviceId)
                                         demoFleet = null
@@ -166,6 +189,8 @@ class MainActivity : ComponentActivity() {
                                         phoneLocation = container.phoneLocation,
                                         profileStore = container.profileStore,
                                         container = container,
+                                        tool = tool,
+                                        onTool = { tool = it },
                                         onDisconnect = {
                                             fleet.disconnect(activeDevice.deviceId)
                                             demoFleet = null

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/ToolsScreens.kt
@@ -1,6 +1,7 @@
 package com.tinkerbug.tinkerrocket.app
 
 import android.content.Context
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -77,9 +78,21 @@ fun ServoTestScreen(session: DeviceSession, profiles: RocketProfileStore?, onBac
     fun send() = session.sendCommandFrame(Commands.servoTestAngles(angles))
 
     LaunchedEffect(Unit) { send() } // initial zeros
-    DisposableEffect(Unit) {
+    // Keyed on session, not Unit, so the hook re-arms if the session identity
+    // changes underneath the screen (OfflineMapsScreen keys the same way).
+    // No state gate: SERVO_TEST_STOP has no state or session precondition in
+    // firmware -- it clears the flag, stows, and arms the pad wake -- so
+    // sending it when nothing is running is inert.
+    DisposableEffect(session) {
         onDispose { session.sendBareCommand(BleCommandId.SERVO_TEST_STOP) }
     }
+    // Without this, the system back gesture fell through to the Activity
+    // default and finished the app, racing the teardown above against process
+    // death -- with the FC left in servo_test_active, its state machine and
+    // pyro servicing suspended, and no UI anywhere to stop it.  Routing back
+    // through onBack disposes this screen while the app stays alive, so the
+    // stop is an ordinary write on a live link.
+    BackHandler(onBack = onBack)
 
     Column(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/MagCalStatus.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/MagCalStatus.kt
@@ -17,6 +17,25 @@ public enum class MagCalSubType(public val raw: Int) {
      */
     VERIFYING(5);
 
+    /**
+     * Is a calibration in flight, such that leaving the screen must abort it?
+     *
+     * The set matters in both directions.  Leaving during any of these three
+     * strands the FC in MAG_CALIBRATION with the magnetometer offsets zeroed,
+     * and that state has NO launch-detect failsafe by design — kinematicChecks
+     * is skipped in MAG_CALIBRATION, so nothing ever clears it on its own.
+     * VERIFYING is the sharpest of the three: a 60 s firmware timeout runs
+     * evaluateVerify() whether or not the app is still watching, so walking
+     * away can commit a permanent NVS calibration nobody reviewed.
+     *
+     * APPLIED must NOT be in the set. The FC rests in APPLIED whenever a
+     * calibration exists, and MagCalibrator::abort() forces ABORTED from ANY
+     * state — so aborting on the way out of a successful save would throw the
+     * calibration away.
+     */
+    public val needsAbortOnLeave: Boolean
+        get() = this == SAMPLING || this == REVIEW || this == VERIFYING
+
     public companion object {
         /** Unknown raw values fall back to [IDLE], mirroring the iOS `?? .idle`. */
         public fun fromRaw(raw: Int): MagCalSubType =

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/MagCalStatusTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/MagCalStatusTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.long
 import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -144,5 +145,32 @@ class MagCalStatusTest {
     fun `unknown enum raws fall back like iOS nil-coalescing`() {
         assertEquals(MagCalSubType.IDLE, MagCalSubType.fromRaw(99))
         assertEquals(MagCalRejectCode.OK, MagCalRejectCode.fromRaw(99))
+    }
+
+    @Test
+    fun `needsAbortOnLeave covers the states a calibration can be stranded in`() {
+        // Leaving during any of these strands the FC in MAG_CALIBRATION with the
+        // magnetometer offsets zeroed, and that state has no launch-detect
+        // failsafe -- kinematicChecks is skipped in MAG_CALIBRATION, so nothing
+        // clears it on its own.
+        assertTrue(MagCalSubType.SAMPLING.needsAbortOnLeave)
+        assertTrue(MagCalSubType.REVIEW.needsAbortOnLeave)
+        // The sharpest one: a 60 s firmware timeout runs evaluateVerify()
+        // whether or not the app is watching, so walking away here can commit a
+        // permanent NVS calibration nobody reviewed.
+        assertTrue(MagCalSubType.VERIFYING.needsAbortOnLeave)
+    }
+
+    @Test
+    fun `needsAbortOnLeave excludes APPLIED so a saved calibration survives the exit`() {
+        // The FC RESTS in APPLIED whenever a calibration exists, and
+        // MagCalibrator::abort() forces ABORTED from ANY state including this
+        // one. An abort on the way out of a successful save would throw the
+        // calibration away -- this is the case the state gate exists for.
+        assertFalse(MagCalSubType.APPLIED.needsAbortOnLeave)
+
+        // Nothing running: an abort would be pointless noise on the link.
+        assertFalse(MagCalSubType.IDLE.needsAbortOnLeave)
+        assertFalse(MagCalSubType.ABORTED.needsAbortOnLeave)
     }
 }


### PR DESCRIPTION
Two of the HIGH findings from yesterday's screen sweep. Both screens could be left in ways that never told the rocket, and the rocket has no way to notice on its own.

## Why mag cal is the worse of the two

Its abort lived on the Cancel button — but Cancel was never the only way out. The top bar's Files/Map/Settings icons, the chevron, the system back gesture and a device rotation all removed the screen without sending anything, leaving the FC in `MAG_CALIBRATION` with the magnetometer offsets zeroed.

That state has **no launch-detect failsafe, by design**: `kinematicChecks()` is skipped entirely in `MAG_CALIBRATION` ([flight_computer/main/main.cpp:6233](tinkerrocket-idf/projects/flight_computer/main/main.cpp:6233)), so nothing clears it on its own — unlike a stranded servo test, which launch detection does clear.

And leaving during `VERIFYING` doesn't merely strand it. A 60 s firmware timeout runs `evaluateVerify()` whether or not the app is watching ([main.cpp:3843](tinkerrocket-idf/projects/flight_computer/main/main.cpp:3843)), so walking away can **commit a permanent NVS calibration nobody reviewed**.

## The fixes

**The abort moves from the button to a teardown hook**, so every exit that disposes the screen is covered by construction rather than by remembering to patch each one.

**The gate on that hook is load bearing, not tidy.** `MagCalibrator::abort()` forces `ABORTED` from *any* state including `APPLIED` ([TR_MagCalibrator.cpp:101](tinkerrocket-idf/components/TR_MagCalibrator/TR_MagCalibrator.cpp:101)), and the FC *rests* in `APPLIED` whenever a calibration exists — so a blanket abort on the way out of a successful save would throw the calibration away. It also has to survive a null or stale `magCalStatus` at teardown, hence `ranCalThisSession` alongside the live sub-type. `rememberUpdatedState` because the `onDispose` closure would otherwise capture the entry-time value, which is `IDLE` — exactly when it must not fire.

**`BackHandler` on both screens.** There was none anywhere in the app, so back fell through to the Activity default and finished the task, racing teardown against process death.

**The chevron no longer disconnects out of a tool screen.** This is the one exit a teardown hook *cannot* cover: a disconnect tears the GATT down first and the composition only unwinds on the next recomposition, so the cleanup write lands on a dead transport and is swallowed by `writeCommand`'s `runCatching`. A tool leaves `tab` at 0, so the chevron took its disconnect branch while looking and reading like back. It now closes the tool — both what it looks like it does and what iOS does from a pushed screen.

**Servo test gets iOS's entry gate** (`canStartGroundTest`, [DashboardView.swift:2437](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift:2437)), minus its vacuous `!groundTestActive` term — the Ground Test screen isn't ported. Android had no gate at all, and the FC only refuses cmd 24 from `INFLIGHT`/`MAG_CALIBRATION`, so a tap in `DESCENT` or `LANDED` deflected fins. The gate also lands the stop in `READY`/`PRELAUNCH`, which is where the FC services the second half of its two-phase stow.

To let the chevron see the tool, the route state moves from `DashboardScreen` up to `MainActivity` — one `remember` up one level. No NavHost, no navigation-compose. Closing the tool on a tab change comes with it: once the state outlives the tab, returning to tab 0 would otherwise re-enter the tool and re-fire its entry command, re-arming servo test after the stop went out.

## Tests

The state gate is the part worth pinning, so it moved to `MagCalSubType.needsAbortOnLeave` where it's JVM-testable — the rest lives in Composables. Two cases: the three states that must abort, and `APPLIED` which must not, which is the one that loses data if it regresses.

Android suite green.

## Not bench-verified

The phone came off the cable before I could run this against TR-R-e424. **Every firmware claim above is read from `tinkerrocket-idf` and cited, not observed.** What would settle it, with a serial console on the FC:

1. Start a mag cal, tumble to `SAMPLING`, then leave via each of: the Map icon, the chevron, system back, and a rotation. Expect `[MAGCAL] abort` on the console each time and the dashboard banner to stop reading MAG_CAL.
2. Complete a calibration through to the Saved banner, then leave. Expect **no** abort — this is the regression the `APPLIED` exclusion prevents.
3. Open Servo Test, press system back, and confirm the `SERVO_TEST_STOP` line plus the anti-backlash stow movement. This is the case that was genuinely undetermined from source.
4. With the rocket in `LANDED`, confirm the Servo test button is dimmed and inert.

## Residual risk

A BLE link that drops on its own — range loss, rocket power-off — still strands both modes, on both platforms. iOS has the identical gap: nothing clears its sheet on disconnect and its disconnect path never re-sends a stop. Fixing that means the firmware noticing the link is gone, not the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
