### PR TITLE
Rename "engineering" to "detailed data review"; sensor sample rates and recovery marks in the flight report

### DIFF
--- a/Data_Analysis/flight_report/cli.py
+++ b/Data_Analysis/flight_report/cli.py
@@ -14,11 +14,11 @@ plt.rcParams["figure.max_open_warning"] = 0  # we batch ~30 figures intentionall
 
 from .discover import DEFAULT_DISCOVERY_ROOT, discover, filter_flights
 from .flight import Flight
-from .registry import LEVEL_ENGINEERING, LEVEL_FLIGHT, modules_for, run_module
+from .registry import LEVEL_DETAILED, LEVEL_FLIGHT, modules_for, run_module
 from .render import write_report
 
 
-_LEVEL_SUFFIX = {LEVEL_FLIGHT: "_report.html", LEVEL_ENGINEERING: "_report_engineering.html"}
+_LEVEL_SUFFIX = {LEVEL_FLIGHT: "_report.html", LEVEL_DETAILED: "_report_detailed.html"}
 
 
 def _out_path_for(flight: Flight, out: Path | None, level: str) -> Path:
@@ -30,7 +30,7 @@ def _out_path_for(flight: Flight, out: Path | None, level: str) -> Path:
     # An explicit filename names the first report; the other gets a sibling.
     if level == LEVEL_FLIGHT:
         return out
-    return out.with_name(f"{out.stem}_engineering{out.suffix or '.html'}")
+    return out.with_name(f"{out.stem}_detailed{out.suffix or '.html'}")
 
 
 def _process_one(flight: Flight, out: Path | None, levels: list[str]) -> list[Path]:
@@ -92,11 +92,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_run.add_argument(
         "--level",
-        choices=[LEVEL_FLIGHT, LEVEL_ENGINEERING, "both"],
+        choices=[LEVEL_FLIGHT, LEVEL_DETAILED, "both"],
         default="both",
         help=(
             "Which report(s) to write. 'flight' is the headline read — summary "
-            "card and interactive charts; 'engineering' is the full diagnostic "
+            "card and interactive charts; 'detailed' is the full diagnostic "
             "set. Default: both."
         ),
     )
@@ -122,7 +122,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.limit:
         flights = flights[: args.limit]
 
-    levels = [LEVEL_FLIGHT, LEVEL_ENGINEERING] if args.level == "both" else [args.level]
+    levels = [LEVEL_FLIGHT, LEVEL_DETAILED] if args.level == "both" else [args.level]
 
     print(f"Processing {len(flights)} flight(s)...")
     failed = 0

--- a/Data_Analysis/flight_report/modules/apogee.py
+++ b/Data_Analysis/flight_report/modules/apogee.py
@@ -36,7 +36,7 @@ from .kinematic_checks import (
 )
 
 # The detector labels this report uses. kinematic_checks calls them "Vel" and
-# "GPS"; renamed locally rather than in the shared constant, so the engineering
+# "GPS"; renamed locally rather than in the shared constant, so the detailed
 # figures keep their wording while this report stays consistent with the Data
 # Sources table ("GNSS", never "GPS").
 _DET_LABEL = {"vel": "Velocity", "baro": "Baro", "gps": "GNSS", "pitch": "Pitch"}
@@ -48,10 +48,41 @@ _DET_LABEL = {"vel": "Velocity", "baro": "Baro", "gps": "GNSS", "pitch": "Pitch"
 # below: near-black for the truth, red for the flag that fired the charge.
 _TRUE_APOGEE = "True Apogee"
 _MASTER_APOGEE = "Master Apogee"
+_LANDED = "Landed"
 _EVENT_EMPHASIS = {
     _TRUE_APOGEE: "#1a1a1a",
     _MASTER_APOGEE: "#c62828",
+    _LANDED: "#6b4c3b",
+    "Pyro 1": "#000000", "Pyro 2": "#444444",
+    "Pyro 3": "#666666", "Pyro 4": "#888888",
 }
+
+
+def _log_events(recs) -> dict[str, float]:
+    """Pyro fires and the landing declaration, on the replay's time base.
+
+    The replay measures from the first IMU sample rather than `Flight.t0_us`, so
+    these are read against the same origin — a few milliseconds either way would
+    put the ejection charge on the wrong side of the apogee call.
+
+    Pyro channels are almost always disabled on a motor-ejection flight, in which
+    case nothing is drawn. The lines exist for the flights that do fire one.
+    """
+    ns = recs.get("NonSensor") or []
+    imu = recs.get("ISM6HG256") or []
+    if not ns or not imu:
+        return {}
+    t0_us = imu[0]["time_us"]
+
+    out: dict[str, float] = {}
+    for label, key in (("Landed", "alt_landed"),
+                       ("Pyro 1", "pyro1_fired"), ("Pyro 2", "pyro2_fired"),
+                       ("Pyro 3", "pyro3_fired"), ("Pyro 4", "pyro4_fired")):
+        for r in ns:
+            if r.get(key):
+                out[label] = round((r["time_us"] - t0_us) / 1e6, 3)
+                break
+    return out
 
 
 # Matplotlib's tab: names mean nothing to Plotly.
@@ -63,8 +94,8 @@ _TAB = {"tab:blue": "#1f77b4", "tab:green": "#2ca02c",
 _BEFORE, _AFTER = 8.0, 5.0
 
 
-def _emphasize_events(spec: dict) -> None:
-    """Darken and enlarge the two apogee reference lines and their labels."""
+def _emphasize_events(spec: dict, lo=None, hi=None) -> None:
+    """Darken and enlarge the reference lines and their labels."""
     if not spec:
         return
     layout = spec["layout"]
@@ -81,8 +112,13 @@ def _emphasize_events(spec: dict) -> None:
         ann["font"] = {"size": 12, "color": color}
         ann["y"] = 0.97 - 0.09 * row
         ann["yanchor"] = "top"
-        ann["xanchor"] = "left"
-        ann["xshift"] = 4
+        # Labels sit to the right of their line, except near the right edge,
+        # where that runs them off the plot — the landing declaration is at the
+        # far end of this window by construction.
+        near_right = (lo is not None and hi is not None
+                      and float(ann["x"]) > lo + 0.82 * (hi - lo))
+        ann["xanchor"] = "right" if near_right else "left"
+        ann["xshift"] = -4 if near_right else 4
         ann["bgcolor"] = "rgba(255,255,255,0.82)"
         ann["borderpad"] = 2
     for shape in layout.get("shapes", []):
@@ -91,12 +127,23 @@ def _emphasize_events(spec: dict) -> None:
             shape["line"] = {"color": color, "width": 1.6, "dash": "dash"}
 
 
-def _window(res) -> tuple[Optional[float], Optional[float]]:
+def _window(res, marks: Optional[dict[str, float]] = None) -> tuple[Optional[float], Optional[float]]:
+    """The plotted span: around the apogee call, extended to reach any mark.
+
+    Landing is tens of seconds after apogee, so including it stretches the
+    chart well beyond the turnover it was cropped to. That is the trade the
+    marks are worth: the section then covers the whole recovery sequence, and
+    the apogee detail is a zoom away rather than a separate chart.
+    """
     t_master = res["sim_fires"].get("apogee_flag")
     t_raw, _ = res["raw_palt"]
     if t_master is None or not t_raw:
         return None, None
-    return max(0.0, t_master - _BEFORE), min(t_master + _AFTER, t_raw[-1])
+    lo = max(0.0, t_master - _BEFORE)
+    hi = t_master + _AFTER
+    if marks:
+        hi = max(hi, max(marks.values()) + 2.0)
+    return lo, min(hi, t_raw[-1])
 
 
 def _crop(ts, vs, lo, hi):
@@ -106,11 +153,11 @@ def _crop(ts, vs, lo, hi):
     return [p[0] for p in pairs], [p[1] for p in pairs]
 
 
-def _altitude_chart(res) -> Optional[dict[str, Any]]:
+def _altitude_chart(res, marks: dict[str, float]) -> Optional[dict[str, Any]]:
     t_sim, v_sim = res["sim_alt"]
     if not t_sim:
         return None
-    lo, hi = _window(res)
+    lo, hi = _window(res, marks)
     t_raw, v_raw = res["raw_palt"]
 
     traces = []
@@ -155,15 +202,18 @@ def _altitude_chart(res) -> Optional[dict[str, Any]]:
     t_master = res["sim_fires"].get("apogee_flag")
     if t_master is not None:
         events[_MASTER_APOGEE] = round(float(t_master), 3)
+    events.update(marks)
 
     spec = chart("chart-apogee-vote", "Apogee detection — which detector fired when",
                  traces, y_title="Altitude", y_unit="m", events=events, height=400)
     if spec and lo is not None:
         spec["layout"]["xaxis"]["range"] = [lo, hi]
-    _emphasize_events(spec)
+    _emphasize_events(spec, lo, hi)
     if spec:
         note = ("Each marker is one detector calling apogee; the master flag, which fires "
-                "the charge, latches from their votes.")
+                "the charge, latches from their votes. The window runs to the landing "
+                "declaration, so the detectors sit close together — zoom into the "
+                "turnover to separate them.")
         if res.get("baro_reject_t"):
             note += (f" Baro was rejected {len(res['baro_reject_t'])} times here, by "
                      "design, while the vehicle was too fast for pressure to be reliable.")
@@ -171,9 +221,9 @@ def _altitude_chart(res) -> Optional[dict[str, Any]]:
     return spec
 
 
-def _lane_chart(res) -> Optional[dict[str, Any]]:
+def _lane_chart(res, marks: dict[str, float]) -> Optional[dict[str, Any]]:
     """One row per detector, showing every span where its condition held."""
-    lo, hi = _window(res)
+    lo, hi = _window(res, marks)
     rows = [("vel", res["vel_periods"]), ("baro", res["baro_periods"]),
             ("gps", res["gps_periods"]), ("pitch", res["pitch_periods"])]
 
@@ -247,12 +297,13 @@ def analyze(flight: Flight) -> AnalysisResult:
         result.warnings.append("The apogee-detector replay produced no data.")
         return result
 
-    charts = [c for c in (_altitude_chart(res), _lane_chart(res)) if c]
+    marks = _log_events(recs)
+    charts = [c for c in (_altitude_chart(res, marks), _lane_chart(res, marks)) if c]
     if not charts:
         result.warnings.append("The replay ran but produced no altitude series to plot.")
         return result
 
-    # Stack them as one figure, as the engineering version does with a shared-x
+    # Stack them as one figure, as the detailed report's version does with a shared-x
     # GridSpec: the lanes only mean anything read against the altitude above
     # them, and a gap plus a caption between the two breaks that reading.
     if len(charts) == 2:
@@ -263,10 +314,10 @@ def analyze(flight: Flight) -> AnalysisResult:
         top["layout"]["margin"] = {"l": 70, "r": 20, "t": 40, "b": 6}
         bottom["layout"]["margin"] = {"l": 70, "r": 20, "t": 8, "b": 42}
         bottom["layout"]["title"] = {"text": "", "font": {"size": 14}}
-        # Top-left: the altitude curve climbs from the bottom-left corner and
-        # the rejection marks run along the floor, so those are the two places
-        # a legend cannot go.
-        top["layout"]["legend"] = {"x": 0.008, "xanchor": "left", "y": 0.98,
+        # Top-right. The detector marks cluster at the apogee turnover on the
+        # left of this window and the rejection marks run along the floor, so
+        # the upper right is the only corner that is reliably empty.
+        top["layout"]["legend"] = {"x": 0.992, "xanchor": "right", "y": 0.98,
                                    "yanchor": "top", "font": {"size": 10},
                                    "bgcolor": "rgba(255,255,255,0.72)"}
         # One caption, under the pair.

--- a/Data_Analysis/flight_report/modules/globe.py
+++ b/Data_Analysis/flight_report/modules/globe.py
@@ -3,7 +3,7 @@
 Two tracks are drawn, deliberately:
 
 * the **navigation filter** — the onboard fusion solution, the same series the
-  engineering report plots as a 3D chart, and
+  detailed report plots as a 3D chart, and
 * the **raw GNSS fixes** — what the receiver reported, unfiltered.
 
 Showing one alone would be a claim. Showing both is a measurement. On the sample
@@ -373,7 +373,7 @@ def analyze(flight: Flight) -> AnalysisResult:
     if pad is None:
         result.warnings.append(
             "No usable GNSS fix on the pad, so there is no way to say where on "
-            "Earth this flight happened. The 3D path is still in the engineering "
+            "Earth this flight happened. The 3D path is still in the detailed "
             "report, plotted in meters from the pad."
         )
         return result
@@ -394,13 +394,13 @@ def analyze(flight: Flight) -> AnalysisResult:
     except CesiumUnavailable as e:
         result.warnings.append(
             f"The 3D view was left out: the CesiumJS bundle could not be read ({e}). "
-            "The flight path is still plotted in the engineering report."
+            "The flight path is still plotted in the detailed report."
         )
         return result
     except CesiumPatchError as e:
         result.warnings.append(
             f"The 3D view was left out: {e} The flight path is still plotted in "
-            "the engineering report."
+            "the detailed report."
         )
         return result
 

--- a/Data_Analysis/flight_report/modules/health.py
+++ b/Data_Analysis/flight_report/modules/health.py
@@ -1,6 +1,6 @@
 """Vehicle health — one verdict per subsystem, so the detail stays optional.
 
-The engineering report already dissects battery, GNSS, logging and radio at
+The detailed report already dissects battery, GNSS, logging and radio at
 length. A flyer needs only to know whether anything needs attention before the
 next flight, so each subsystem reduces to OK / CHECK / PROBLEM with the number
 that decided it. Anything worse than OK also raises a warning, which surfaces in

--- a/Data_Analysis/flight_report/modules/overview.py
+++ b/Data_Analysis/flight_report/modules/overview.py
@@ -132,7 +132,7 @@ _ACCEL_SERIES = [
 
 
 def _accel_chart_axes(recs, t0, events, chart_id, title, end_key, note):
-    """Per-axis acceleration from both accelerometers, as the engineering plots show it.
+    """Per-axis acceleration from both accelerometers, as the detailed report's plots show it.
 
     Three axes times two sensors. In G rather than m/s² because that is what the
     hobby quotes and what the summary card reports, and because at rest the
@@ -260,7 +260,7 @@ def _trajectory_chart(recs, t0, events):
     draw and not part of the trajectory. Everything between launch and landing
     is kept at full resolution.
 
-    Engineering-level, since the globe module draws the same path over real
+    Detailed-level, since the globe module draws the same path over real
     imagery in the flight report. Kept rather than deleted because it survives
     two things the globe does not: no network when the report is opened (Cesium
     fetches imagery and terrain at view time, and model rocketry happens in
@@ -324,7 +324,7 @@ def analyze(flight: Flight) -> AnalysisResult:
     Deliberately excludes the raw IMU series. Accelerometer and gyro log at ~1 kHz
     for the whole session — several hundred thousand samples, most of them the
     rocket sitting on the pad — and carrying them at full resolution would make
-    the flight report several times heavier than the engineering one. They live
+    the flight report several times heavier than the detailed one. They live
     in `analyze_sensors` instead, where detail costs nothing.
     """
     result = AnalysisResult(name="overview", title="Flight Overview")
@@ -339,7 +339,7 @@ def analyze(flight: Flight) -> AnalysisResult:
 
     events = _events(recs, t0)
     # No ground-track chart here: the flight report's geography is the 3D globe.
-    # The ENU chart and the flat recovery map both live in engineering, along
+    # The ENU chart and the flat recovery map both live in the detailed report, along
     # with the 3D Plotly trajectory — see _trajectory_chart for why that one is
     # kept rather than deleted.
     # Position, then velocity, then acceleration — each the derivative of the one
@@ -354,7 +354,7 @@ def analyze(flight: Flight) -> AnalysisResult:
 
 
 def analyze_sensors(flight: Flight) -> AnalysisResult:
-    """Engineering-level charts: raw inertial sensors at full logged rate."""
+    """Detailed-level charts: raw inertial sensors at full logged rate."""
     result = AnalysisResult(name="sensor_charts", title="Inertial Sensors (interactive)")
     recs = flight.records
     t0 = flight.t0_us

--- a/Data_Analysis/flight_report/modules/roll.py
+++ b/Data_Analysis/flight_report/modules/roll.py
@@ -16,10 +16,10 @@ Which of the two is not read off the sidecar. A sidecar can claim
 2026-07-05 labeled any flight with a *stored* profile that way, even with
 `use_angle_control` off — so `roll_series` cross-checks the claim against the
 servo command with an R² fit and can overrule it. This module asks that shared
-function rather than deciding for itself, so the flight and engineering reports
+function rather than deciding for itself, so the flight and detailed reports
 can never disagree about what the flight was.
 
-The engineering report keeps the same four panels as static figures, plus the
+The detailed report keeps the same four panels as static figures, plus the
 plant-gain estimate, the FFT and the tuning recommendation. This is the readable
 subset, made interactive.
 """
@@ -43,7 +43,7 @@ from ..flight import Flight
 from ..registry import AnalysisResult
 from .roll_pid import roll_series
 
-# Matching the engineering figures, so the two reports read as the same picture.
+# Matching the detailed report's figures, so the two reports read as the same picture.
 C_TARGET = "#ff7f0e"    # commanded
 C_ACTUAL = "#2ca02c"    # achieved
 C_ERROR = "#d62728"
@@ -54,7 +54,7 @@ def _null_rate_segments(tw: np.ndarray, is_ang: np.ndarray) -> list[tuple[float,
     """Contiguous spans where NO angle was being commanded.
 
     The inverse of the angle segments, matching `roll_pid._shade_segments`: the
-    engineering figures tint the *rate-null* stretches, leaving the angle-tracking
+    detailed report's figures tint the *rate-null* stretches, leaving the angle-tracking
     ones on white, because those are the parts a reader is being asked to judge.
     Shading the other way round reads as "this is the interesting bit" pointed at
     exactly the wrong half.
@@ -75,7 +75,7 @@ def _null_rate_segments(tw: np.ndarray, is_ang: np.ndarray) -> list[tuple[float,
 
 
 def _shade(spec: dict, spans: list[tuple[float, float]]) -> None:
-    """Tint the rate-null spans, the way the engineering figures do.
+    """Tint the rate-null spans, the way the detailed report's figures do.
 
     `yref: "paper"` rather than data coordinates on purpose: the metric/imperial
     toggle rescales trace data and the y-axis range but leaves shape coordinates
@@ -205,7 +205,7 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
     `chart()` cannot make subplots, so this is as close to a shared x axis as the
     spec allows — the ranges match because every panel covers the same window.
 
-    Lines *and* markers. The engineering figure draws these with `ax.plot`, and
+    Lines *and* markers. The detailed report's figure draws these with `ax.plot`, and
     the shape between samples is what a control signal is read for — but the
     individual samples matter too, so both are drawn. The template scales marker
     size and opacity to how many are on screen, so they stay out of the way at
@@ -236,7 +236,7 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
         + _segmented(tw, s["track_act"], "EKF Roll", C_ACTUAL, 1.6),
         x_title=NO_X, y_title="Roll angle", y_unit="°",
         events=events, height=H,
-        # Fixed to a full turn with ticks on the quarters, as the engineering
+        # Fixed to a full turn with ticks on the quarters, as the detailed
         # figure has it: autoscaling a wrapped angle hides how close a trace is
         # to the ±180 seam, which is exactly where tracking looks worst.
         y_ticks=([-180, -90, 0, 90, 180], ["−180", "−90", "0", "90", "180"]),
@@ -286,12 +286,12 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
     )
     cap = s.get("rate_cap_cfg")
     if rate_spec:
-        # Scale the axis the way the engineering figure does, rather than with the
+        # Scale the axis the way the detailed report's figure does, rather than with the
         # generic spike clipper: anchor on the rate cap, which is the natural size
         # of controlled roll, and exclude the last second before ejection so a
         # tumble starting early cannot inflate it. Without this the ~620°/s
         # off-the-rail spike flattens the entire controlled portion into a line.
-        # win_end, not eject_t — the engineering helper is passed the end of the
+        # win_end, not eject_t — the detailed report's helper is passed the end of the
         # plotting window, and using apogee instead would admit a second of
         # tumble into the percentile and quietly widen the axis.
         lim, peak = _rate_limit(t_imu[win], g[win], win_end, cap)
@@ -322,7 +322,7 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
             limit = float(limit) if limit is not None else None
         except (TypeError, ValueError):
             limit = None
-        # Zoomed to the command's own range plus 5°, as the engineering panel is.
+        # Zoomed to the command's own range plus 5°, as the detailed report's panel is.
         # The fin command lives in a few degrees while its limit is ±20; scaling
         # to the limit would flatten every detail of what the controller did.
         cw = cmd[win_c]
@@ -353,11 +353,11 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
     # Shared window and a 1 s tick grid with 0.5 s minors, so a transition time
     # can be read off the bottom panel and traced straight up. Only that bottom
     # panel draws tick labels and a title for the axis — the same thing the
-    # engineering figure does with `sharex` plus
+    # detailed report's figure does with `sharex` plus
     # `setp(ax.get_xticklabels(), visible=False)`.
     #
     # Only the first panel carries event *labels*; the rest keep the marker lines
-    # but drop the annotations, which is both what the engineering figure does
+    # but drop the annotations, which is both what the detailed report's figure does
     # (`_mark_events(ax)` without `annotate`) and what lets the top margin
     # collapse. Between them, the label suppression and the margin trim are what
     # actually close the gaps — CSS alone would leave four boxes of white space.
@@ -379,7 +379,7 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
         }
         if not first:
             sp["layout"]["title"] = {"text": "", "font": {"size": 14}}
-        # Legend inside the axes, as the engineering figure has it. The report's
+        # Legend inside the axes, as the detailed report's figure has it. The report's
         # default is a horizontal strip below the plot, which in a stack is a band
         # of text sitting between two panels — the exact thing the stack is meant
         # not to have. Top-left on the first panel, top-right on the rest, so it
@@ -489,7 +489,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         # One note, under the whole group, so nothing lands between the panels.
         # No metrics table: the flight report's roll section is a picture, and
         # the numbers behind it (plant gain, phase margin, suggested gains, the
-        # steady-state spectrum) are tuning work that belongs in the engineering
+        # steady-state spectrum) are tuning work that belongs in the detailed
         # report, where they already are.
         result.charts[-1]["note"] = _stack_note(s, facts)
         return result

--- a/Data_Analysis/flight_report/modules/roll_pid.py
+++ b/Data_Analysis/flight_report/modules/roll_pid.py
@@ -355,7 +355,7 @@ def _baro_eject_time(flight, t0, launch_t, burnout_t, apogee_t):
 def tuning(K_plant: float, kp_flight: float | None) -> dict:
     """Loop stability with the gains that flew, and the gains to fly next time.
 
-    Shared by the engineering roll-PID section and the flight-level roll section
+    Shared by the detailed report's roll-PID section and the flight-level roll section
     so the two cannot recommend different numbers for the same flight. Phase
     margin is the first-order servo lag plus the loop delay subtracted from the
     90° a pure integrator would give; the recommendation places the crossover at
@@ -391,7 +391,7 @@ def tuning(K_plant: float, kp_flight: float | None) -> dict:
 def roll_series(flight: Flight) -> dict:
     """Every series and flag the roll analysis needs, computed once.
 
-    Shared by the engineering `roll_pid` section and the flight-level `roll`
+    Shared by the detailed report's `roll_pid` section and the flight-level `roll`
     section so both agree on what the flight was. In particular
     `has_angle_profile` — "did roll *angle* control actually fly?" — is not the
     sidecar's word for it: a mislabelled export is cross-checked against the

--- a/Data_Analysis/flight_report/modules/sample_rates.py
+++ b/Data_Analysis/flight_report/modules/sample_rates.py
@@ -1,0 +1,95 @@
+"""How fast each sensor actually logged.
+
+A rate well below what a sensor is configured for means samples were dropped,
+and everything downstream — apogee timing, the filter, the peak acceleration
+figure — is reading a thinner record than it appears to. Worth a glance on any
+flight, which is why it is here and not only in the detailed report.
+
+The rates come from `gaps._per_sensor_summary`, the same function the detailed
+report's table and figure use, so the two cannot disagree about what a sensor
+managed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+_PARENT = Path(__file__).resolve().parent.parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from analyze_gaps import extract_per_sensor_timestamps  # noqa: E402
+
+from ..flight import Flight
+from ..registry import AnalysisResult
+from .gaps import _per_sensor_summary
+
+# Bars, so the comparison between sensors is a length rather than a number to be
+# read off. charts.trace() only builds scatter traces, so this one is assembled
+# directly — chart() itself is trace-type agnostic.
+_BAR_COLOR = "#1f77b4"
+_BAR_GAPPY = "#d62728"
+
+
+def _chart(summary: dict[str, dict[str, float]]) -> Optional[dict[str, Any]]:
+    from ..charts import chart
+
+    if not summary:
+        return None
+    names = sorted(summary, key=lambda n: summary[n]["rate_hz"])
+    rates = [summary[n]["rate_hz"] for n in names]
+    gaps = [int(summary[n]["gap_count"]) for n in names]
+
+    # A sensor that dropped samples is colored rather than annotated: the point
+    # of the chart is that one bar is not like the others.
+    colors = [_BAR_GAPPY if g else _BAR_COLOR for g in gaps]
+    bar = {
+        "type": "bar",
+        "orientation": "h",
+        "name": "Median rate",
+        "x": rates,
+        "y": names,
+        "marker": {"color": colors},
+        "text": [f"{r:,.0f} Hz" for r in rates],
+        "textposition": "outside",
+        "cliponaxis": False,
+        "hovertemplate": "%{y}: %{x:,.0f} Hz<extra></extra>",
+    }
+
+    spec = chart("chart-sample-rates", "Per-sensor sample rate", [bar],
+                 x_title="Median rate (Hz)", y_title="",
+                 height=60 + 34 * len(names))
+    if not spec:
+        return None
+    layout = spec["layout"]
+    layout["showlegend"] = False
+    layout["margin"] = {"l": 130, "r": 70, "t": 40, "b": 45}
+    layout["xaxis"]["range"] = [0, max(rates) * 1.18]
+    layout["yaxis"]["gridcolor"] = "#fff"
+
+    dropped = [n for n, g in zip(names, gaps) if g]
+    note = "Median logged rate for each sensor, measured from the timestamps themselves."
+    if dropped:
+        note += (" Red marks a sensor with a gap in its record: "
+                 + ", ".join(f"{n} ({summary[n]['gap_count']})" for n in dropped) + ".")
+    spec["note"] = note
+    return spec
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="sample_rates", title="Sensor Sample Rates")
+
+    per_sensor = extract_per_sensor_timestamps(flight.records)
+    if not per_sensor:
+        result.warnings.append("No per-sensor timestamps, so sample rates cannot be measured.")
+        return result
+
+    summary, _ = _per_sensor_summary(per_sensor)
+    spec = _chart(summary)
+    if spec is None:
+        result.warnings.append("Not enough samples to measure a rate for any sensor.")
+        return result
+    result.charts = [spec]
+    return result

--- a/Data_Analysis/flight_report/registry.py
+++ b/Data_Analysis/flight_report/registry.py
@@ -32,12 +32,12 @@ class AnalysisResult:
 AnalyzeFn = Callable[["Flight"], AnalysisResult]
 
 # Report levels. FLIGHT answers "how did my rocket fly?" and is what a flyer
-# reads; ENGINEERING is board bring-up and firmware validation. A module belongs
-# to exactly one — anything a flyer needs from an engineering module should be
+# reads; DETAILED is board bring-up and firmware validation. A module belongs
+# to exactly one — anything a flyer needs from an detailed-level module should be
 # rolled up into a FLIGHT-level module rather than shown twice.
 LEVEL_FLIGHT = "flight"
-LEVEL_ENGINEERING = "engineering"
-LEVELS = (LEVEL_FLIGHT, LEVEL_ENGINEERING)
+LEVEL_DETAILED = "detailed"
+LEVELS = (LEVEL_FLIGHT, LEVEL_DETAILED)
 
 
 def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
@@ -48,6 +48,7 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         globe,
         roll,
         apogee,
+        sample_rates,
         stability,
         motor,
         health,
@@ -76,26 +77,31 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         ("roll",              roll.analyze,              LEVEL_FLIGHT),
         ("apogee",            apogee.analyze,            LEVEL_FLIGHT),
         ("stability",         stability.analyze,         LEVEL_FLIGHT),
+        # Above Motor Performance: a sensor that logged short makes every
+        # number below it thinner than it looks. Still in the detailed report
+        # too, alongside the gap analysis it comes from.
+        ("sample_rates",      sample_rates.analyze,      LEVEL_FLIGHT),
         ("motor",             motor.analyze,             LEVEL_FLIGHT),
         ("health",            health.analyze,            LEVEL_FLIGHT),
-        ("sensor_charts",     overview.analyze_sensors,  LEVEL_ENGINEERING),
-        ("kinematics",        kinematics.analyze,        LEVEL_ENGINEERING),
-        ("gaps",              gaps.analyze,              LEVEL_ENGINEERING),
-        ("timestamps",        timestamps.analyze,        LEVEL_ENGINEERING),
-        ("launch_detection",  launch_detection.analyze,  LEVEL_ENGINEERING),
+        ("sensor_charts",     overview.analyze_sensors,  LEVEL_DETAILED),
+        ("kinematics",        kinematics.analyze,        LEVEL_DETAILED),
+        ("gaps",              gaps.analyze,              LEVEL_DETAILED),
+        ("timestamps",        timestamps.analyze,        LEVEL_DETAILED),
+        ("launch_detection",  launch_detection.analyze,  LEVEL_DETAILED),
         # Deployment & recovery — descent profile, the flat ground-track map and
-        # the KML links. Engineering-level for now; note this leaves the flight
-        # report with no map that works without a network, since the 3D globe
-        # fetches its imagery when the report is opened.
-        ("deployment",        deployment.analyze,        LEVEL_ENGINEERING),
-        ("pyro_apogee",       pyro_apogee.analyze,       LEVEL_ENGINEERING),
-        ("sensor_noise",      sensor_noise.analyze,      LEVEL_ENGINEERING),
-        ("gnss_staleness",    gnss_staleness.analyze,    LEVEL_ENGINEERING),
-        ("kinematic_checks",  kinematic_checks.analyze,  LEVEL_ENGINEERING),
-        ("roll_pid",          roll_pid.analyze,          LEVEL_ENGINEERING),
-        ("guidance",          guidance.analyze,          LEVEL_ENGINEERING),
-        ("lora",              lora.analyze,              LEVEL_ENGINEERING),
-        ("log_buffer",        log_buffer.analyze,        LEVEL_ENGINEERING),
+        # the KML links. Detailed-level by decision: the flat map is the one that
+        # still draws with no network (it degrades to graph paper with the track
+        # on it), so it lives with the rest of the diagnostic set rather than
+        # duplicating the globe in the flight report.
+        ("deployment",        deployment.analyze,        LEVEL_DETAILED),
+        ("pyro_apogee",       pyro_apogee.analyze,       LEVEL_DETAILED),
+        ("sensor_noise",      sensor_noise.analyze,      LEVEL_DETAILED),
+        ("gnss_staleness",    gnss_staleness.analyze,    LEVEL_DETAILED),
+        ("kinematic_checks",  kinematic_checks.analyze,  LEVEL_DETAILED),
+        ("roll_pid",          roll_pid.analyze,          LEVEL_DETAILED),
+        ("guidance",          guidance.analyze,          LEVEL_DETAILED),
+        ("lora",              lora.analyze,              LEVEL_DETAILED),
+        ("log_buffer",        log_buffer.analyze,        LEVEL_DETAILED),
     ]
 
 

--- a/Data_Analysis/flight_report/render.py
+++ b/Data_Analysis/flight_report/render.py
@@ -143,7 +143,7 @@ def render_report(
 ) -> str:
     """Render one report as an HTML string.
 
-    `level` is `registry.LEVEL_FLIGHT` or `LEVEL_ENGINEERING` and only labels the
+    `level` is `registry.LEVEL_FLIGHT` or `LEVEL_DETAILED` and only labels the
     output — pass the results you want in it. None renders an untitled report
     containing everything given.
 
@@ -207,7 +207,7 @@ def render_report(
         sections=sections,
         level=level,
         counterpart=counterpart,
-        # The flight report leads with the headline numbers; the engineering
+        # The flight report leads with the headline numbers; the detailed
         # report leads with parser/settings detail and doesn't repeat them.
         summary=compute_summary(flight) if is_flight else [],
         show_raw_detail=not is_flight,

--- a/Data_Analysis/flight_report/summary.py
+++ b/Data_Analysis/flight_report/summary.py
@@ -25,6 +25,8 @@ if str(_PARENT) not in sys.path:
 
 from plot_flight_data_mini import get_array, gnss_to_enu, pressure_to_altitude  # noqa: E402
 
+from markupsafe import Markup
+
 from .imu import accel_magnitude
 from .units import q
 
@@ -89,7 +91,11 @@ def compute_summary(flight) -> list[dict[str, Any]]:
         baro_apogee = float(np.max(alt))
         hint = "barometric, above the pad"
         if gnss_apogee is not None:
-            hint += f" · GNSS says {gnss_apogee:,.0f} m"
+            # A Quantity, not a formatted string: the hint is the one place a
+            # number was baked into prose, so it stayed in metres while the value
+            # above it switched to feet. Markup + Quantity works because Jinja's
+            # escape() honours __html__, so the span survives autoescaping.
+            hint = Markup(hint + " · GNSS says ") + q(gnss_apogee, "m", 0)
         cells.append(_cell("Apogee", baro_apogee, "m", 1, hint))
     elif gnss_apogee is not None:
         cells.append(_cell("Apogee", gnss_apogee, "m", 1, "GNSS (no barometer data)"))
@@ -103,7 +109,7 @@ def compute_summary(flight) -> list[dict[str, Any]]:
                     + get_array(ns, "n_vel") ** 2
                     + get_array(ns, "u_vel") ** 2)
         if v.size:
-            speed, hint = float(np.max(v)), "navigation filter"
+            speed, hint = float(np.max(v)), "EKF"
     if speed is None and gnss and all(k in gnss[0] for k in ("vel_e", "vel_n", "vel_u")):
         v = np.sqrt(get_array(gnss, "vel_e") ** 2
                     + get_array(gnss, "vel_n") ** 2

--- a/Data_Analysis/flight_report/templates/report.html.j2
+++ b/Data_Analysis/flight_report/templates/report.html.j2
@@ -105,7 +105,7 @@
   <div class="topbar-left">
     {% if counterpart %}
     <a class="pill" href="{{ counterpart }}">
-      {% if level == "engineering" %}&larr; Flight report{% else %}Engineering detail &rarr;{% endif %}
+      {% if level == "detailed" %}&larr; Flight report{% else %}Detailed data &rarr;{% endif %}
     </a>
     {% endif %}
   </div>
@@ -120,10 +120,10 @@
   {% if show_raw_detail %}<code>{{ flight.bin_path }}</code><br>{% endif %}
   Flight: {{ date_str }}
   {#- Log duration is how long the recorder ran, usually minutes of pad time. It
-      belongs with the engineering detail; the card's "Flight time" is the number
+      belongs with the detailed data review; the card's "Flight time" is the number
       a flyer means, and showing both side by side just reads as a contradiction. -#}
   {% if show_raw_detail and duration_s %} &middot; Log duration: {{ "%.1f"|format(duration_s) }} s{% endif %}
-  {% if level == "engineering" %} &middot; engineering detail{% endif %}
+  {% if level == "detailed" %} &middot; detailed data review{% endif %}
 </div>
 
 {% if summary %}
@@ -569,7 +569,7 @@
             fullscreenButton: true
           });
         } catch (e) {
-          say("The 3D view could not start: " + e.message + ". The flight path is also plotted in the engineering report.", true);
+          say("The 3D view could not start: " + e.message + ". The flight path is also plotted in the detailed report.", true);
           return;
         }
 

--- a/Data_Analysis/webtool/README.md
+++ b/Data_Analysis/webtool/README.md
@@ -46,7 +46,7 @@ browser afterwards).
 | Engine start, warm cache | ~12 s |
 | Flight report, in browser | ~21 s |
 | Flight report size | ~9.0 MB (5.7 MB of it CesiumJS, for the 3D globe) |
-| Engineering report size | ~9.4 MB |
+| Detailed report size | ~9.4 MB |
 | Source payload zip | 2.5 MB (was 715 KB before Cesium was vendored) |
 
 The first analysis on a machine pays a one-off WebAssembly/matplotlib warm-up
@@ -55,7 +55,7 @@ CLI exactly.
 
 ## Two report levels
 
-`flight_report` writes two reports, chosen with `--level flight|engineering|both`
+`flight_report` writes two reports, chosen with `--level flight|detailed|both`
 (default `both`); the web tool has a matching **Report** selector.
 
 - **Flight** (`<stem>_report.html`) — the headline read. Summary card (apogee,
@@ -63,7 +63,7 @@ CLI exactly.
   distance and bearing), interactive altitude, velocity, ground-track and state
   charts, and a **Deployment & Recovery** section. No static figures, no raw JSON
   dump, no parser stats.
-- **Engineering** (`<stem>_report_engineering.html`) — everything else: the 26
+- **Detailed data review** (`<stem>_report_detailed.html`) — everything else: the 26
   kinematics figures, full-rate interactive accelerometer and gyro charts, frame
   gaps, timestamps, sensor noise, GNSS health, kinematic-checks replay, roll PID,
   guidance, LoRa, MRAM log buffer, settings snapshot and parser stats.
@@ -111,7 +111,7 @@ any metadata entry:
 
 ### Moving between the two
 
-Each report links to the other from a pill in the top-left — "Engineering detail →"
+Each report links to the other from a pill in the top-left — "Detailed data →"
 and "← Flight report". The link is only emitted when both files are actually
 written (i.e. `--level both`), since a link to a report that was never generated
 is worse than no link. In the web tool, the **Report** selector picks which one
@@ -206,20 +206,20 @@ worldwide satellite becomes a requirement, that is a paid-tile decision to make
 deliberately.
 - Leaflet's default marker uses PNGs from a relative `images/` path that does not
   exist in a standalone file, so the map uses `circleMarker` (pure SVG) instead.
-  The ENU ground-track chart moved to the engineering report, where exact metres
+  The ENU ground-track chart moved to the detailed report, where exact metres
   off the pad matter more than which field to search.
 
 ### Settings snapshot
 
-Engineering-only, and shows **configuration only** — the sidecar's measured
+Detailed-report-only, and shows **configuration only** — the sidecar's measured
 results (`max_altitude_m` and friends) belong to the summary card, and printing
 them in both places invites the two to disagree. Rendered as grouped tables with
 dotted keys (`pyro.ch1.trigger_mode`) rather than a wall of JSON, so it can be
 scanned and diffed against another flight.
 
-Raw 1 kHz inertial data lives in the engineering report on purpose: it is several
+Raw 1 kHz inertial data lives in the detailed report on purpose: it is several
 hundred thousand samples, most of them the rocket sitting on the pad. Keeping it
-out is what makes the flight report ~2 MB against the engineering report's ~9 MB
+out is what makes the flight report ~2 MB against the detailed report's ~9 MB
 on a 154k-frame flight — and it makes the browser tool roughly 3x faster for the
 common case, since the flight report renders no matplotlib figures at all.
 

--- a/Data_Analysis/webtool/app.js
+++ b/Data_Analysis/webtool/app.js
@@ -242,7 +242,7 @@ function runFiles(fileEntries, rocketName) {
   // generated locally without colliding or looking like a different artifact.
   currentBinStem =
     binEntry.name.replace(/\.bin$/i, "") +
-    (level === "engineering" ? "_report_engineering" : "_report");
+    (level === "detailed" ? "_report_detailed" : "_report");
   beginRun(binEntry.name);
   const payload = fileEntries.map((f) => ({ name: f.name, buffer: f.buffer }));
   // Blank fields are omitted rather than sent as empty strings, so the Python

--- a/Data_Analysis/webtool/index.html
+++ b/Data_Analysis/webtool/index.html
@@ -158,7 +158,7 @@
       <label for="level">Report</label>
       <select id="level">
         <option value="flight" selected>Flight — summary and charts</option>
-        <option value="engineering">Engineering — full diagnostics</option>
+        <option value="detailed">Detailed data review — full diagnostics</option>
       </select>
       <span style="flex:1"></span>
       <button id="sample-btn" class="secondary" disabled>Try the sample flight</button>

--- a/tests/test_flight_report.py
+++ b/tests/test_flight_report.py
@@ -24,7 +24,7 @@ GOLDEN_BIN = REPO_ROOT / "tests" / "test_data" / "flight_20260615_170318.bin"
 if str(REPO_ROOT / "Data_Analysis") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "Data_Analysis"))
 
-ENGINEERING_SECTIONS = [
+DETAILED_SECTIONS = [
     'id="kinematics"',
     'id="gaps"',
     'id="timestamps"',
@@ -69,7 +69,7 @@ def reports(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
 
     out = {
         "flight": tmp_path / f"{GOLDEN_BIN.stem}_report.html",
-        "engineering": tmp_path / f"{GOLDEN_BIN.stem}_report_engineering.html",
+        "detailed": tmp_path / f"{GOLDEN_BIN.stem}_report_detailed.html",
     }
     for level, path in out.items():
         assert path.exists(), f"{level} report not written to {path}"
@@ -83,9 +83,9 @@ def report_html(reports: dict[str, Path]) -> Path:
     return reports["flight"]
 
 
-def test_engineering_report_renders_all_sections(reports: dict[str, Path]) -> None:
-    html = reports["engineering"].read_text(encoding="utf-8")
-    missing = [s for s in ENGINEERING_SECTIONS if s not in html]
+def test_detailed_report_renders_all_sections(reports: dict[str, Path]) -> None:
+    html = reports["detailed"].read_text(encoding="utf-8")
+    missing = [s for s in DETAILED_SECTIONS if s not in html]
     assert not missing, f"Missing sections: {missing}"
 
 
@@ -98,12 +98,12 @@ def test_flight_report_is_the_headline_read(reports: dict[str, Path]) -> None:
     assert 'class="card"' in html, "Flight report is missing the summary card"
 
     leaked = [s for s in ('id="parser"', 'id="settings"', 'id="log_buffer"') if s in html]
-    assert not leaked, f"Engineering-only sections leaked into the flight report: {leaked}"
+    assert not leaked, f"Detailed-only sections leaked into the flight report: {leaked}"
 
 
 def test_report_has_inline_figures(reports: dict[str, Path]) -> None:
-    """Static figures live in the engineering report; the flight report has none."""
-    eng = reports["engineering"].read_text(encoding="utf-8")
+    """Static figures live in the detailed report; the flight report has none."""
+    eng = reports["detailed"].read_text(encoding="utf-8")
     fig_count = eng.count('<img src="data:image/png;base64,')
     assert fig_count >= 25, f"Expected ≥25 inline figures, got {fig_count}"
 
@@ -335,14 +335,14 @@ def test_cesium_inlined_once_and_patched(report_html: Path) -> None:
     )
 
 
-def test_plotly_trajectory_lives_in_engineering(reports: dict[str, Path]) -> None:
-    """The 3D Plotly path moved to engineering when the globe took over the flight report.
+def test_plotly_trajectory_lives_in_detailed(reports: dict[str, Path]) -> None:
+    """The 3D Plotly path moved to the detailed report when the globe took over the flight report.
 
     It is kept there rather than deleted because it survives what the globe does
     not: a report opened with no network, and a flight with no GNSS fix at all.
     """
     flight = dict(_chart_specs(reports["flight"].read_text(encoding="utf-8")))
-    eng = dict(_chart_specs(reports["engineering"].read_text(encoding="utf-8")))
+    eng = dict(_chart_specs(reports["detailed"].read_text(encoding="utf-8")))
     assert "chart-trajectory" not in flight, (
         "the flight report shows both a Cesium globe and a Plotly 3D path of the "
         "same trajectory"


### PR DESCRIPTION
Follow-up to #742.

## Rename

"Engineering" told a customer the report was not for them. It is the same
document, so the name now says what it is: **Detailed data review**. The rename
goes all the way down rather than stopping at display text — level value,
`_report_detailed.html` filename suffix, `--level flight|detailed|both`, the web
tool's selector, tests and docs — so the old term does not survive in one place
and not another.

## Fixes and additions

**The apogee card hint did not convert.** It read `1,171 ft … GNSS says 368 m`
in imperial: the GNSS altitude was formatted into prose rather than emitted as a
`Quantity`, so the toggle could not see it. It is a span now.

**Per-sensor sample rate** joins the flight report above Motor Performance, built
from the same `gaps._per_sensor_summary` the detailed report uses. A sensor that
logged short makes every figure below it thinner than it looks, which is worth a
glance without opening the diagnostic set. A sensor with a gap in its record is
colored rather than annotated. It stays in the detailed report as well.

**Pyro fires and the landing declaration** are marked on the apogee chart. Read
on the replay's own time base (first IMU sample), not `Flight.t0_us` — a few ms
either way would put the ejection charge on the wrong side of the apogee call.
Pyro lines draw only when a channel actually fired, so nothing appears on a
motor-ejection flight.

One consequence worth naming: landing is ~70 s after apogee, so the window now
spans the whole recovery rather than the turnover, and the four detector marks
cluster into a small group. The caption says to zoom. If the tight apogee window
matters more than the landing mark, it is a one-line revert in `_window()`.

**The flat recovery map stays in the detailed report by decision** — it is the
one map that still draws with no network, degrading to graph paper with the track
on it. The registry comment says so rather than "for now".

## Testing

62 tests pass; docs check clean. Reports regenerated and verified from `file://`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)