### PR TITLE
android: derive the FileProvider authority from applicationId

### DIFF
--- a/TinkerRocketAndroid/app/src/main/AndroidManifest.xml
+++ b/TinkerRocketAndroid/app/src/main/AndroidManifest.xml
@@ -27,9 +27,17 @@
             </intent-filter>
         </activity>
 
+        <!-- Authority is DERIVED, not literal, so it tracks applicationId:
+             FlightCache asks for "${context.packageName}.files" at runtime,
+             which carries any applicationIdSuffix, so a literal here would
+             disagree with the only caller.  A suffixed variant (side-by-side
+             bench install) then can't install at all
+             (INSTALL_FAILED_CONFLICTING_PROVIDER — two packages may not claim
+             one authority), and would throw from getUriForFile if it could.
+             Expands to the identical string for the shipped build. -->
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.tinkerbug.tinkerrocket.files"
+            android:authorities="${applicationId}.files"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
The manifest hardcoded `com.tinkerbug.tinkerrocket.files` while the only caller — `FlightCache.shareCsv` — asks for `"${context.packageName}.files"`, which carries any `applicationIdSuffix`. The two therefore disagree silently in any suffixed variant: it cannot install alongside the normal app (`INSTALL_FAILED_CONFLICTING_PROVIDER` — two packages may not claim one authority) and `getUriForFile` would throw if it could.

That is not hypothetical. It blocked a side-by-side bench install on the Pixel 8 today, where the alternative — uninstalling the existing app to make room — drops its flights, offline tiles and paired devices. I hit exactly that cost three times in this session before the suffix route was known.

`${applicationId}.files` makes the declaration track the caller. Verified from the merged manifest both ways: the normal build resolves to `com.tinkerbug.tinkerrocket.files`, byte-identical to the old literal, so shipped behaviour is unchanged; a build with `applicationIdSuffix=".designpass"` resolves to `com.tinkerbug.tinkerrocket.designpass.files`, matching what aapt2 reports as that APK's applicationId.

**Not verified on-device** — the phone was unplugged before the install-alongside and share-sheet run, so this is proven at the manifest/APK level only. The share sheet is the thing to exercise when hardware is back, since it is the one runtime path through this authority.

Authored in a separate session; opening the PR so it lands with the rest of the Android port work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)