### PR TITLE
dashboard: two base-station fixes found with a real BS on the bench

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -216,7 +216,7 @@ fun DashboardScreen(
         if (session.isBaseStation) FlightSummaryCard(telemetry)
 
         SignalCard(telemetry, rssi, session.isBaseStation)
-        BatteryCard(telemetry)
+        BatteryCard(telemetry, session.isBaseStation)
         // Orientation source is picked strictly by link type (iOS
         // RocketTelemetryCards): BS = relayed flags2 "imo", direct = the
         // imu_orient config readback.  No cross-fallback on either platform.
@@ -1237,11 +1237,36 @@ private fun SignalBar(fraction: Float, value: String, label: String) {
     }
 }
 
-/** iOS BatteryView twin: Charge / Voltage / Current row for the rocket. */
+/**
+ * iOS BatteryView twin: Charge / Voltage / Current, one row per pack.
+ *
+ * The base-station row is not decoration.  On a BS link the operator is
+ * holding the base station, and its own pack is the one that ends the session
+ * when it dies — the rocket's is relayed from something on the pad.  The BS
+ * sends bsoc/bvol/bcur in every telemetry frame and the decoder has always
+ * parsed them; only the row was missing, so the numbers arrived and were
+ * dropped on the floor (bench 2026-08-11: the console read
+ * "[BATT] 4.18 V | 98% SoC | 456 mA" while the card showed one Rocket row).
+ */
 @Composable
-private fun BatteryCard(telemetry: TelemetryData) {
+private fun BatteryCard(telemetry: TelemetryData, isBaseStation: Boolean) {
     val caption = MaterialTheme.typography.bodySmall
     val mono = androidx.compose.ui.text.font.FontFamily.Monospace
+
+    @Composable
+    fun row(label: String, charge: String, voltage: String, current: String) {
+        Row(Modifier.fillMaxWidth()) {
+            Text(label, style = caption, modifier = Modifier.width(70.dp))
+            listOf(charge, voltage, current).forEach {
+                Text(
+                    it, style = caption.copy(fontFamily = mono),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+
     Card(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Text("Battery", style = MaterialTheme.typography.titleMedium)
@@ -1256,19 +1281,20 @@ private fun BatteryCard(telemetry: TelemetryData) {
                     )
                 }
             }
-            Row(Modifier.fillMaxWidth()) {
-                Text("Rocket", style = caption, modifier = Modifier.width(70.dp))
-                listOf(
-                    telemetry.socDisplay,
-                    telemetry.voltage?.let { String.format(Locale.ROOT, "%.2f V", it) } ?: "—",
-                    telemetry.current?.let { String.format(Locale.ROOT, "%.0f mA", it) } ?: "—",
-                ).forEach {
-                    Text(
-                        it, style = caption.copy(fontFamily = mono),
-                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+            row(
+                "Rocket",
+                telemetry.socDisplay,
+                telemetry.voltage?.let { String.format(Locale.ROOT, "%.2f V", it) } ?: "—",
+                telemetry.current?.let { String.format(Locale.ROOT, "%.0f mA", it) } ?: "—",
+            )
+            // iOS DashboardView.swift:1294 gates the same row the same way.
+            if (isBaseStation) {
+                row(
+                    "Base Stn",
+                    telemetry.bsSocDisplay,
+                    telemetry.bsVoltage?.let { String.format(Locale.ROOT, "%.2f V", it) } ?: "—",
+                    telemetry.bsCurrent?.let { String.format(Locale.ROOT, "%.0f mA", it) } ?: "—",
+                )
             }
         }
     }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -186,6 +186,17 @@ fun DashboardScreen(
 
         // Power section — #377: never offer the blind cmd-8 toggle until the
         // first telemetry frame of this session confirmed the power state.
+        //
+        // Direct links only, as on iOS ("rocket only, confirmed by telemetry",
+        // DashboardView.swift:574, which gates the same branch on
+        // deviceType == .rocket).  The power pin is an OC-local signal that the
+        // LoRa relay does not carry: on a base-station link fs bit 0x10 is
+        // always clear, so this card read a confident "OFF" with a Power on
+        // button directly above a live banner from a rocket that was plainly
+        // powered and reporting READY (bench 2026-08-11, fs=128 = bsLogging
+        // only). Offering to power on a running rocket is worse than showing
+        // nothing.
+        if (!session.isBaseStation) {
         Card(Modifier.fillMaxWidth()) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text("Rocket power", style = MaterialTheme.typography.titleMedium)
@@ -208,6 +219,7 @@ fun DashboardScreen(
                     }
                 }
             }
+        }
         }
 
         // iOS section order (screenshots 2026-07-31): the summary sits right

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryData.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryData.kt
@@ -162,6 +162,12 @@ public data class TelemetryData(
      * running off USB shows on every line.  Em dash for absent, as elsewhere
      * on this dashboard (iOS says "N/A" here).
      */
+    /** The base station's own pack, same formatting rules as [socDisplay]. */
+    public val bsSocDisplay: String
+        get() = bsSoc?.let {
+            String.format(java.util.Locale.ROOT, "%.1f%%", it.coerceIn(0f, 100f) + 0f)
+        } ?: "—"
+
     public val socDisplay: String
         get() = soc?.let {
             // The `+ 0f` is what actually kills "-0.0%", and it is not

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryDataTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/TelemetryDataTest.kt
@@ -493,4 +493,14 @@ class TelemetryDataTest {
         assertEquals("42.5%", TelemetryData(soc = 42.5f).socDisplay)
         assertEquals("\u2014", TelemetryData(soc = null).socDisplay)
     }
+
+    @Test
+    fun `base station soc display follows the same rules as the rocket's`() {
+        // The BS pack empties the same way and would print the same "-0.0%".
+        assertEquals("0.0%", TelemetryData(bsSoc = -0.0f).bsSocDisplay)
+        assertEquals("100.0%", TelemetryData(bsSoc = 125f).bsSocDisplay)
+        assertEquals("98.2%", TelemetryData(bsSoc = 98.2f).bsSocDisplay)
+        // Absent on a direct rocket link, where the row is not rendered at all.
+        assertEquals("\u2014", TelemetryData(bsSoc = null).bsSocDisplay)
+    }
 }

--- a/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift
@@ -518,9 +518,12 @@ struct TelemetryData: Codable {
     }
 
     // Base station battery display helpers
+    /// Same clamp and negative-zero guard as `socDisplay` — the base station's
+    /// pack reaches 0 the same way the rocket's does, and would print the same
+    /// "-0.0%".
     var bsSocDisplay: String {
         if let soc = bs_soc {
-            return String(format: "%.1f%%", soc)
+            return String(format: "%.1f%%", min(100, max(0, soc)) + 0)
         }
         return "N/A"
     }

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,737 lines across 70 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,740 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,7 +30,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 33 files, 12,027 lines
+## `Models/` — 33 files, 12,030 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
@@ -40,7 +40,7 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
 | [CSVGenerator.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/CSVGenerator.swift) | 947 | `DeviceType`, `CSVError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Device Auto-Detection · Main CSV Generation · Rotation Configuration · Helper Functions · Flight Summary · Flight Settings (#165) · CSV Errors |
-| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 607 | `TelemetryData` |
+| [TelemetryData.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/TelemetryData.swift) | 610 | `TelemetryData` |
 | [BLEFleet.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEFleet.swift) | 600 | `BLEFleet` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published state · Rocket roster (#390) · Private state · Init · Scanning · Connection · Virtual Rocket (iOS twin of Android demo mode, 2026-07-30) · Device lookup · Last-valid rocket fix cache (#140) · CBCentralManagerDelegate |
 | [FlightAnnouncer.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FlightAnnouncer.swift) | 558 | `TelemetryAnnouncer`, `AnnouncerSpeech`, `FlightAnnouncer`, `SystemSpeech` |
@@ -122,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 70 files, 26,737 lines.
+Total: 70 files, 26,740 lines.


### PR DESCRIPTION
Two defects found by driving the Android app against **BaseStation V4** with a rocket relaying through it, both confirmed against the BS serial console rather than inferred.

## 1. The base station's own battery was never shown

The BS sends `bsoc`/`bvol`/`bcur` in every telemetry frame and the decoder has always parsed them into `bsSoc`/`bsVoltage`/`bsCurrent`. Only the row was missing, so the numbers arrived and were dropped on the floor. iOS has rendered a "Base Stn" row since it had a battery card at all ([DashboardView.swift:1294](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift:1294)).

It matters more than a second row of numbers suggests: on a BS link the operator is holding the base station, and **its** pack is the one that ends the session when it dies. The rocket's is relayed from something on the pad and already has its own card.

The defect looked like a one-row Battery card while the console read:

```
I (382333) BS: [BATT] 4.18 V | 98% SoC (est from voltage) | 456 mA | 25.6 C
```

with `"bsoc":98.2,"bvol":4.18,"bcur":456` in the telemetry JSON on the same console. After the fix the card reads **Base Stn 98.2% / 4.18 V / 456 mA** — matching the wire on all three fields.

`bsSocDisplay` gets the same clamp and negative-zero guard as `socDisplay`. **iOS's `bsSocDisplay` had the identical unguarded format** and is fixed here too — it was missed when the rocket-side one was fixed in #735.

## 2. It offered to power on a rocket that was already flying-ready

The power card read a confident **OFF** with a **Power on** button, directly above a live banner from a rocket that was plainly powered and reporting READY.

The power pin is an OC-local signal the LoRa relay does not carry, so `fs` bit `0x10` is always clear on a BS link — observed as `fs=128`, which is `bsLoggingActive` alone. The app was faithfully rendering the wire; the mistake was rendering that field at all on a link that cannot report it.

iOS never had this: [DashboardView.swift:574](TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift:574) gates the same branch on `device.deviceType == .rocket && !device.telemetry.pwr_pin_on`, commented "(rocket only, confirmed by telemetry)". The port kept the telemetry term and dropped the device-type one. Offering to power on a running rocket is worse than showing nothing.

Verified: the dashboard now goes straight from the state banner to the flight summary, which is the iOS section order for BS links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)