### PR TITLE
report: measure launch, burnout, apogee and ejection instead of reading flags

### DIFF
--- a/Data_Analysis/flight_report/events.py
+++ b/Data_Analysis/flight_report/events.py
@@ -1,0 +1,317 @@
+"""Measured flight events — what the vehicle did, not what it declared.
+
+The flight computer's flags are *declarations*. Each one latches only after its
+detector is confident, so it lands a little after the thing it names: on the
+sample flight the launch flag is 0.20 s after the motor lit and the burnout flag
+is 0.07 s after thrust ended. That lag is correct for firing a charge and wrong
+for a report that quotes a burn time — a fifth of a second on a 1.5 s burn is 13
+per cent.
+
+Apogee is worse than late, because there is no single apogee flag to be late.
+The log carries five: one vote each from the barometric, velocity, pitch and
+GNSS detectors, plus the master that latches from them and fires the charge. The
+report used to read the barometric vote — the earliest of the four — and call it
+"apogee", which is how the summary card came to disagree with the flight
+computer's own record by 1.15 s.
+
+So every event here is measured from the sensor record, and every module that
+needs one calls the same function. Two sections cannot then disagree about when
+the rocket left the pad.
+
+Where a flag is genuinely the best available answer it is still used, and said
+so: touchdown has no distinctive signature in the accelerometer once the vehicle
+is down, so `landed` is the declaration.
+
+Everything returned is seconds since `flight.t0_us`, or None when the flight
+does not contain the event. None is normal — a bench log has no launch — and
+callers must render a blank rather than a guess.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+_PARENT = Path(__file__).resolve().parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from plot_flight_data_mini import get_array, pressure_to_altitude  # noqa: E402
+
+from .imu import accel_magnitude
+
+G = 9.80665
+
+# Sitting on the pad the accelerometer reads 1 g plus noise. Above this it is
+# being pushed by something.
+_PAD_G = 1.2
+# Unambiguously under thrust — used only to find the burn, never as the launch
+# instant itself, which is walked back to from here.
+_IGNITION_G = 2.0
+# Thrust has ended when specific force falls back through 1 g: the motor is no
+# longer holding the vehicle up against its own weight.
+_COAST_G = 1.0
+# ...and stays there. A momentary dip mid-burn (chuffing, a stager) is not
+# burnout.
+_COAST_HOLD_S = 0.05
+# Search the launch flag's neighbourhood rather than the whole log, so handling
+# the rocket on the pad cannot be mistaken for ignition.
+_LAUNCH_SEARCH_BEFORE_S = 3.0
+_LAUNCH_SEARCH_AFTER_S = 1.0
+
+# An ejection charge is impulsive and violent: 38 g against a 0.2 g coast on the
+# sample flight. Both bars must be cleared — an absolute floor so ordinary
+# tumbling under a canopy cannot qualify, and a ratio so a quiet log cannot have
+# its own noise promoted to an event.
+_EJECT_MIN_G = 4.0
+_EJECT_MIN_RATIO = 8.0
+# The charge cannot fire into the burn, and the touchdown impact is not an
+# ejection.
+_EJECT_AFTER_BURNOUT_S = 0.2
+_EJECT_BEFORE_LANDING_S = 1.0
+
+# Below this the barometer is looking at weather, not a flight. Guards the
+# fallback peak: a log recorded on a bench has an argmax like any other, and
+# without this it is reported as an apogee.
+_MIN_FLIGHT_ALT_M = 20.0
+
+_CACHE_KEY = "_measured_events"
+
+
+def _flags(recs) -> list:
+    return recs.get("NonSensor") or []
+
+
+def _flag_time(recs, t0_us, name: str) -> Optional[float]:
+    """Seconds since t0 for the first record with `name` set."""
+    for r in _flags(recs):
+        if r.get(name):
+            return (r["time_us"] - t0_us) / 1e6
+    return None
+
+
+def _accel_series(flight) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """(seconds since t0, |a| in g) from the IMU, low-G unless it saturated."""
+    recs = flight.records
+    imu = recs.get("ISM6HG256") or []
+    if not imu or flight.t0_us is None:
+        return None, None
+    t = (get_array(imu, "time_us") - flight.t0_us) / 1e6
+    mag, _which = accel_magnitude(recs, flight.sidecar, None)
+    if mag is None or not mag.size or mag.size != t.size:
+        return None, None
+    return t, mag / G
+
+
+def _cross(t, y, i, level) -> float:
+    """Time at which y crosses `level` between samples i-1 and i."""
+    y0, y1 = float(y[i - 1]), float(y[i])
+    if y1 == y0:
+        return float(t[i])
+    f = (level - y0) / (y1 - y0)
+    return float(t[i - 1] + f * (float(t[i]) - float(t[i - 1])))
+
+
+def true_launch(flight, t, g) -> Optional[float]:
+    """First motion: the moment the accelerometer leaves the pad band.
+
+    Found by locating an unambiguous thrust sample and walking *back* to where
+    the trace left 1 g, which is the instant the motor started pushing rather
+    than the instant it became obvious.
+    """
+    if t is None:
+        return None
+    flag = _flag_time(flight.records, flight.t0_us, "launch")
+    if flag is not None:
+        window = (t >= flag - _LAUNCH_SEARCH_BEFORE_S) & (t <= flag + _LAUNCH_SEARCH_AFTER_S)
+    else:
+        window = np.ones(t.size, dtype=bool)
+    idx = np.flatnonzero(window & (g > _IGNITION_G))
+    if not idx.size:
+        return None
+
+    i = int(idx[0])
+    while i > 0 and g[i] > _PAD_G:
+        i -= 1
+    # Walked all the way to the start of the record and never found the pad: the
+    # log begins with the vehicle already under thrust, so first motion happened
+    # before anything was written down and cannot be measured. One of the bench
+    # logs is like this, opening at 8.1 g.
+    if i == 0 and g[0] > _PAD_G:
+        return None
+    if i + 1 >= t.size:
+        return None
+    return _cross(t, g, i + 1, _PAD_G)
+
+
+def true_burnout(flight, t, g, launch: Optional[float]) -> Optional[float]:
+    """Thrust ends: specific force falls back through 1 g and stays there.
+
+    Walking forward from launch rather than back from the burn's peak, because
+    the largest acceleration in the flight is usually the ejection charge, not
+    the motor — 38 g against 9 g on the sample flight.
+    """
+    if t is None or launch is None:
+        return None
+    idx = np.flatnonzero((t > launch) & (g < _COAST_G))
+    for i in idx:
+        i = int(i)
+        if i == 0:
+            continue
+        held = (t >= t[i]) & (t <= t[i] + _COAST_HOLD_S)
+        if held.any() and float(np.max(g[held])) < _COAST_G:
+            return _cross(t, g, i, _COAST_G)
+    return None
+
+
+def ejection(flight, t, g, burnout: Optional[float], landed: Optional[float]) -> Optional[float]:
+    """When the recovery system was deployed.
+
+    A fired pyro channel records its own time, so that is used when there is
+    one. Otherwise the vehicle recovers on motor ejection, which logs nothing —
+    but the charge is the most violent thing that happens between burnout and
+    touchdown, so it is found as the dominant transient in that span.
+    """
+    recs = flight.records
+    ns = _flags(recs)
+    fired = [_flag_time(recs, flight.t0_us, f"pyro{ch}_fired") for ch in (1, 2, 3, 4)
+             if ns and f"pyro{ch}_fired" in ns[0]]
+    fired = [f for f in fired if f is not None]
+    if fired:
+        return min(fired)
+
+    if t is None or burnout is None:
+        return None
+    hi = (landed - _EJECT_BEFORE_LANDING_S) if landed is not None else float(t[-1])
+    window = (t > burnout + _EJECT_AFTER_BURNOUT_S) & (t < hi)
+    if not window.any():
+        return None
+
+    tw, gw = t[window], g[window]
+    i = int(np.argmax(gw))
+    peak = float(gw[i])
+    if peak < _EJECT_MIN_G:
+        return None
+    # Background is the coast before the peak, which is the quiet part; taking it
+    # after would include the canopy ringing the charge itself caused.
+    before = gw[:i]
+    background = float(np.median(before)) if before.size else float(np.median(gw))
+    if peak < _EJECT_MIN_RATIO * max(background, 0.05):
+        return None
+    return float(tw[i])
+
+
+def gnss_vertical_zero(t, vu) -> Optional[float]:
+    """Apogee from the GNSS Doppler vertical velocity crossing zero downwards.
+
+    Gated to after the vehicle clearly ascended (vu > 10 m/s) so on-pad noise is
+    skipped, with a 5-sample median to de-spike vu first.
+
+    Preferred over the barometric peak, which lags and is spike-prone (#112) —
+    and on a flight that ejects at or before apogee the pressure transient lands
+    directly on the peak the barometer is being asked to find.
+    """
+    if t is None or len(t) < 6:
+        return None
+    half = 2
+    sm = [sorted(vu[max(0, i - half):min(len(vu), i + half + 1)])[
+              (min(len(vu), i + half + 1) - max(0, i - half)) // 2]
+          for i in range(len(vu))]
+    ascended = False
+    for i in range(1, len(sm)):
+        if sm[i - 1] > 10.0:
+            ascended = True
+        if ascended and sm[i - 1] >= 0.0 and sm[i] < 0.0:
+            denom = sm[i - 1] - sm[i]
+            f = (sm[i - 1] / denom) if denom else 0.0
+            return float(t[i - 1] + f * (t[i] - t[i - 1]))
+    return None
+
+
+def _baro_peak(flight, launch: Optional[float]) -> Optional[float]:
+    """Time of maximum barometric altitude, median-filtered.
+
+    The fallback when there is no usable GNSS. Filtered because an ejection
+    charge drives the pressure sensor hard for a few samples, and an unfiltered
+    argmax will happily return the top of that spike.
+    """
+    recs = flight.records
+    baro = recs.get("BMP585") or []
+    if not baro or flight.t0_us is None:
+        return None
+    p = get_array(baro, "pressure_pa")
+    tb = (get_array(baro, "time_us") - flight.t0_us) / 1e6
+    if p.size < 20:
+        return None
+    ground = float(np.mean(p[: min(200, p.size)]))
+    alt = np.array([pressure_to_altitude(float(v), ground) for v in p])
+    if float(np.max(alt)) < _MIN_FLIGHT_ALT_M:
+        return None
+
+    k = 25
+    if alt.size > k:
+        pad = k // 2
+        padded = np.concatenate([np.full(pad, alt[0]), alt, np.full(pad, alt[-1])])
+        alt = np.array([np.median(padded[i:i + k]) for i in range(alt.size)])
+
+    mask = tb > launch if launch is not None else np.ones(tb.size, dtype=bool)
+    if not mask.any():
+        return None
+    return float(tb[mask][int(np.argmax(alt[mask]))])
+
+
+def true_apogee(flight, launch: Optional[float]) -> Optional[float]:
+    """The top of the trajectory, measured rather than declared."""
+    recs = flight.records
+    gnss = recs.get("GNSS") or []
+    if gnss and flight.t0_us is not None and "vel_u" in gnss[0]:
+        tg = list((get_array(gnss, "time_us") - flight.t0_us) / 1e6)
+        vu = list(get_array(gnss, "vel_u"))
+        found = gnss_vertical_zero(tg, vu)
+        if found is not None:
+            return found
+    return _baro_peak(flight, launch)
+
+
+def measured(flight) -> dict[str, Optional[float]]:
+    """Every event this module can find, in seconds since t0. Cached per flight.
+
+    Keys: launch, burnout, apogee, ejection, landed. A value of None means the
+    flight does not contain that event — render nothing rather than a guess.
+    """
+    cached = flight.__dict__.get(_CACHE_KEY)
+    if cached is not None:
+        return cached
+
+    out: dict[str, Optional[float]] = {
+        "launch": None, "burnout": None, "apogee": None,
+        "ejection": None, "landed": None,
+    }
+    if flight.t0_us is None:
+        flight.__dict__[_CACHE_KEY] = out
+        return out
+
+    t, g = _accel_series(flight)
+    out["landed"] = _flag_time(flight.records, flight.t0_us, "alt_landed")
+    out["launch"] = true_launch(flight, t, g)
+    out["burnout"] = true_burnout(flight, t, g, out["launch"])
+    out["ejection"] = ejection(flight, t, g, out["burnout"], out["landed"])
+    out["apogee"] = true_apogee(flight, out["launch"])
+
+    flight.__dict__[_CACHE_KEY] = out
+    return out
+
+
+def span(events: dict[str, Optional[float]], a: str, b: str) -> Optional[float]:
+    """Seconds from event `a` to event `b`, or None if either is missing.
+
+    Negative spans are returned as-is: a rocket really can eject before apogee,
+    and hiding that would be the opposite of useful.
+    """
+    ta, tb = events.get(a), events.get(b)
+    if ta is None or tb is None:
+        return None
+    return tb - ta

--- a/Data_Analysis/flight_report/modules/deployment.py
+++ b/Data_Analysis/flight_report/modules/deployment.py
@@ -158,7 +158,13 @@ def analyze(flight: Flight) -> AnalysisResult:
         peak_i = int(np.argmax(alt))
         peak_t, peak_alt = float(t[peak_i]), float(alt[peak_i])
         lag = ev["apogee"] - peak_t
-        metrics["True apogee"] = q(peak_alt, "m", 1, suffix=f" at {peak_t:.2f} s")
+        # Named for the sensor, not "True apogee": the Apogee Detection section
+        # already uses that phrase for the GNSS Doppler velocity crossing, which
+        # is a different instant (7.66 s vs 8.34 s on the sample flight, because
+        # the ejection charge lands on the pressure peak the barometer is being
+        # asked to find).
+        metrics["Peak barometric altitude"] = q(peak_alt, "m", 1,
+                                                suffix=f" at {peak_t:.2f} s")
 
         # How far below the peak the vehicle was when the flag went up. Stated in
         # both directions: still climbing if the call was early, already falling

--- a/Data_Analysis/flight_report/summary.py
+++ b/Data_Analysis/flight_report/summary.py
@@ -27,6 +27,7 @@ from plot_flight_data_mini import get_array, gnss_to_enu, pressure_to_altitude  
 
 from markupsafe import Markup
 
+from .events import measured, span as _span
 from .imu import accel_magnitude
 from .units import q
 
@@ -42,18 +43,29 @@ def _cell(label: str, value: Optional[float], unit: str, places: int = 1,
     return {"label": label, "q": q(value, unit, places, suffix), "hint": hint}
 
 
-def _event_times(records, t0_us) -> dict[str, Optional[float]]:
-    """Seconds since t0 for the first occurrence of each flight event."""
+def _event_times(flight) -> dict[str, Optional[float]]:
+    """Seconds since t0 for each flight event, measured rather than declared.
+
+    See events.py. The card used to read the flags, which meant "time to apogee"
+    was the barometric detector's vote minus the launch declaration — two
+    different kinds of lateness, one of them 1.15 s.
+    """
+    return measured(flight)
+
+
+def _eject_hint(records) -> str:
+    """Where the ejection time came from: a channel that logged it, or the trace.
+
+    Worth saying on the card. A pyro time is recorded by the thing that fired;
+    a motor ejection is inferred from the transient it leaves in the
+    accelerometer, and a reader is entitled to know which they are looking at.
+    """
     ns = records.get("NonSensor") or []
-    out: dict[str, Optional[float]] = {}
-    for label, flag in (("launch", "launch"), ("burnout", "burnout"),
-                        ("apogee", "alt_apogee"), ("landed", "alt_landed")):
-        out[label] = None
-        for r in ns:
-            if r.get(flag):
-                out[label] = (r["time_us"] - t0_us) / 1e6
-                break
-    return out
+    for ch in (1, 2, 3, 4):
+        key = f"pyro{ch}_fired"
+        if ns and key in ns[0] and any(r.get(key) for r in ns):
+            return f"pyro {ch} firing"
+    return "ejection, found in the accelerometer"
 
 
 def _baro_agl(records) -> Optional[np.ndarray]:
@@ -76,7 +88,7 @@ def compute_summary(flight) -> list[dict[str, Any]]:
         return []
 
     cells: list[dict[str, Any]] = []
-    events = _event_times(recs, t0)
+    events = _event_times(flight)
 
     # --- Apogee altitude -----------------------------------------------------
     alt = _baro_agl(recs)
@@ -122,9 +134,12 @@ def compute_summary(flight) -> list[dict[str, Any]]:
     # --- Peak acceleration (boost only) --------------------------------------
     # Measured over launch->burnout on purpose. Touchdown and the ejection
     # charge both slam the accelerometer far harder than the motor does — on the
-    # sample flight the whole-flight peak is 146 G at the moment of landing,
-    # against 5.1 G under thrust — so a whole-flight max would headline an impact
-    # as though it were the rocket's acceleration.
+    # sample flight the whole-flight peak is 77 G, and the ejection charge alone
+    # is 38 G, against 9.5 G under thrust — so a whole-flight max would headline
+    # a bang as though it were the rocket's acceleration.
+    #
+    # The bounds are the measured burn, not the flags, so the window no longer
+    # opens 0.2 s after the motor lit.
     imu = recs.get("ISM6HG256") or []
     if imu:
         if events["launch"] is not None and events["burnout"] is not None:
@@ -144,12 +159,24 @@ def compute_summary(flight) -> list[dict[str, Any]]:
                                f"{hint_window} · {which}"))
 
     # --- Timing --------------------------------------------------------------
-    if events["launch"] is not None and events["apogee"] is not None:
-        cells.append(_cell("Time to apogee", events["apogee"] - events["launch"], "s", 2,
-                           "launch to apogee detection"))
+    # Chronological: the burn, then the coast, then the top, then the whole
+    # thing. Every one of them is measured off the sensor record and starts from
+    # the same instant of first motion, so they add up.
+    burn = _span(events, "launch", "burnout")
+    if burn is not None:
+        cells.append(_cell("Burn time", burn, "s", 2, "first motion to thrust ending"))
+
+    coast = _span(events, "burnout", "ejection")
+    if coast is not None:
+        cells.append(_cell("Coast time", coast, "s", 2, f"burnout to {_eject_hint(recs)}"))
+
+    to_apogee = _span(events, "launch", "apogee")
+    if to_apogee is not None:
+        cells.append(_cell("Time to apogee", to_apogee, "s", 2, "first motion to peak altitude"))
+
     if events["launch"] is not None and events["landed"] is not None:
         cells.append(_cell("Flight time", events["landed"] - events["launch"], "s", 1,
-                           "launch to touchdown"))
+                           "first motion to touchdown"))
 
     # --- Where it came down --------------------------------------------------
     if gnss:

--- a/Data_Analysis/flight_report/templates/report.html.j2
+++ b/Data_Analysis/flight_report/templates/report.html.j2
@@ -145,16 +145,20 @@
 {% endif %}
 
 {% if show_raw_detail %}
+{# As recorded by the flight computer itself, from the .json sidecar — not the
+   flight report's recomputation from the log. Keeping both is the point of a
+   detailed review, but the labels have to say which is which: "Apogee" on the
+   summary card is an altitude, and these two are times. #}
 <div class="summary-grid">
   {% if sidecar.get('apogee_time_s') is not none %}
   <div class="cell">
-    <div class="label">Apogee</div>
+    <div class="label">Time to apogee</div>
     <div class="value">{{ "%.2f"|format(sidecar['apogee_time_s']) }} s</div>
   </div>
   {% endif %}
   {% if sidecar.get('burnout_time_s') is not none %}
   <div class="cell">
-    <div class="label">Burnout</div>
+    <div class="label">Time to burnout</div>
     <div class="value">{{ "%.2f"|format(sidecar['burnout_time_s']) }} s</div>
   </div>
   {% endif %}

--- a/tests/test_flight_report.py
+++ b/tests/test_flight_report.py
@@ -16,6 +16,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GOLDEN_BIN = REPO_ROOT / "tests" / "test_data" / "flight_20260615_170318.bin"
+# A complete flight, pad to touchdown. GOLDEN_BIN deliberately is not one: its
+# record opens at 8.1 g, already under thrust, so it has no measurable liftoff.
+SAMPLE_BIN = REPO_ROOT / "examples" / "flights" / "flight_20260705_174532.bin"
 
 # A few tests reach into the report package directly rather than through the
 # rendered HTML. Data_Analysis has no __init__.py, so it is put on the path the
@@ -348,6 +351,49 @@ def test_plotly_trajectory_lives_in_detailed(reports: dict[str, Path]) -> None:
         "same trajectory"
     )
     assert "chart-trajectory" in eng, "the 3D trajectory chart vanished instead of moving"
+
+
+def test_measured_events_beat_the_flags() -> None:
+    """The card's timings come from the sensor record, not the declarations.
+
+    Each flag latches only once its detector is confident, so it lands after the
+    thing it names. Apogee has no single flag at all — five detectors vote — and
+    reading the barometric vote as "apogee" is what made the summary card
+    disagree with the flight computer's own record by 1.15 s.
+    """
+    from flight_report.events import measured
+    from flight_report.flight import Flight
+
+    flight = Flight.from_bin(SAMPLE_BIN)
+    flight.load()
+    ev = measured(flight)
+    ns = flight.records["NonSensor"]
+    t0 = flight.t0_us
+
+    def flag(name: str) -> float:
+        return next((r["time_us"] - t0) / 1e6 for r in ns if r.get(name))
+
+    for key in ("launch", "burnout", "apogee", "ejection", "landed"):
+        assert ev[key] is not None, f"{key} was not measured on the sample flight"
+
+    # Measured events precede the declarations that chase them.
+    assert ev["launch"] < flag("launch"), "measured launch is not before the launch flag"
+    assert ev["burnout"] < flag("burnout"), "measured burnout is not before the burnout flag"
+    assert flag("launch") - ev["launch"] < 1.0, "measured launch is implausibly early"
+
+    # Apogee must not be any single detector's vote.
+    for vote in ("alt_apogee", "vel_apogee", "gps_apogee", "pitch_apogee"):
+        assert abs(ev["apogee"] - flag(vote)) > 1e-6, (
+            f"apogee collapsed onto the {vote} detector's vote"
+        )
+
+    # Ordering, and the fact this flight deployed before it stopped climbing —
+    # which is exactly why the barometric vote is not an apogee.
+    assert ev["launch"] < ev["burnout"] < ev["ejection"] < ev["landed"]
+    assert ev["ejection"] < ev["apogee"], (
+        "the sample flight ejects ~1 s before apogee; if this flips, the ejection "
+        "detector has latched onto something else"
+    )
 
 
 def test_apogee_turnover_stays_zoomed_in(report_html: Path) -> None:


### PR DESCRIPTION
The summary card read **Time to apogee 6.87 s** while the detailed report's card read **8.02 s** for the same flight.

Not a timebase bug — the sidecar's burnout matches the log's flag to 1 ms. They were different *events*. The log carries five apogee booleans:

| field | first true (since t0) |
|---|---|
| `alt_apogee` — barometric vote | 7.383 s |
| `vel_apogee` | 8.094 s |
| `pitch_apogee` | 8.537 s |
| `gps_apogee` | 8.627 s |
| **`apogee_flag`** — master, fires the charge | **8.537 s** |

The card read `alt_apogee` — one detector's vote, the earliest of four — and called it apogee. Eight modules make the same mapping.

## Measured, not declared

Repointing the card at the master would swap one declaration for another, and declarations are late by construction: each latches only once its detector is confident. So the events are now measured off the sensor record, in one place — [events.py](Data_Analysis/flight_report/events.py):

- **launch** — first motion, by walking back from an unambiguous thrust sample to where the trace left the 1 g pad band. `0.316 s`; the flag is 0.197 s later.
- **burnout** — specific force falls back through 1 g and stays there. `1.844 s`; the flag is 0.074 s later. Walked *forward* from launch rather than back from the burn's peak, because the largest acceleration in a flight is usually the ejection charge (38 g against 9 g here).
- **apogee** — GNSS Doppler vertical velocity crossing zero (the existing #112 rationale), falling back to a median-filtered barometric peak. `8.335 s`.
- **ejection** — a fired pyro channel's own time when there is one; otherwise the dominant transient between burnout and touchdown. `7.325 s` at 38 g against a 0.20 g coast — a 192× excursion.

Worth noting what this surfaced: **the sample flight ejects ~1 s before apogee**, and `alt_apogee` fires 58 ms after the charge. The barometric "apogee" vote was very likely triggered by the ejection pressure spike, not by the altitude turning over.

## Card

`Time to apogee` is now first motion → peak altitude (**8.02 s**, agreeing with the detailed card), joined by **Burn time 1.53 s** and **Coast time 5.48 s**. Burn + coast lands exactly on the ejection. The peak-acceleration window moves onto the measured burn as well, so it no longer opens 0.2 s after the motor lit.

## Verification

Validated across all eight logs in the repo. The four complete flights measure every event and the spans stay self-consistent; the three bench logs measure none. `flight_20260615_170318`, whose record opens at 8.1 g already under thrust, correctly reports no liftoff rather than returning its first sample — and a bench log no longer gets an apogee out of barometer noise.

`test_measured_events_beat_the_flags` pins it: every event present, measured launch and burnout strictly before their flags, apogee not equal to any single detector's vote, and the ejection-before-apogee ordering that makes this flight interesting.

28 tests pass.

## Two label collisions fixed in passing

- `deployment.py` published **"True apogee"** for the barometric peak, while the Apogee Detection section uses those exact words for the GNSS crossing 0.67 s later. Renamed to "Peak barometric altitude" — no number changed.
- The detailed grid labelled a *time* "Apogee" while the summary card labels an *altitude* "Apogee". Now "Time to apogee" / "Time to burnout".

## Left for tomorrow

- The eight chart markers still read `alt_apogee`. `stability.py`'s "Tilt at apogee" **cannot** simply follow them: because this flight ejected before apogee, that number is measured mid-deployment (36.6° at the baro vote, 100.8° at the master, 30.1° at the baro peak). It needs a decision, not a repoint.
- The detailed grid's Max Altitude disagrees with the card's Apogee by up to 6 m on one flight — an unrelated ground-pressure-reference difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)