### PR TITLE
report: mark measured events on every chart, add Ejection, tilt at ejection

### DIFF
--- a/Data_Analysis/flight_report/charts.py
+++ b/Data_Analysis/flight_report/charts.py
@@ -30,9 +30,14 @@ COLORS = [
     "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
 ]
 
+# Chronological, which is the order they are drawn and listed in. Ejection sits
+# between burnout and apogee because that is where it usually falls — but not
+# always: a rocket can deploy before it stops climbing, and the sample flight
+# does, which is exactly why the event is worth marking.
 _EVENT_STYLE = {
     "launch": ("#2ca02c", "Launch"),
     "burnout": ("#ff7f0e", "Burnout"),
+    "ejection": ("#9467bd", "Ejection"),
     "apogee": ("#d62728", "Apogee"),
     "landed": ("#7f7f7f", "Landed"),
 }

--- a/Data_Analysis/flight_report/events.py
+++ b/Data_Analysis/flight_report/events.py
@@ -305,6 +305,25 @@ def measured(flight) -> dict[str, Optional[float]]:
     return out
 
 
+def markers(flight) -> dict[str, Optional[float]]:
+    """Measured events, but with the launch flag standing in when first motion
+    cannot be measured.
+
+    For anchoring, not for quoting. Chart windows and the globe's pad reference
+    are all pinned to launch, and a log that opens mid-boost has no measurable
+    one — which would silently widen every window to the whole record and take
+    the pad datum from a second of powered flight. At chart scale the flag's
+    fifth of a second does not show, so it is the right answer there.
+
+    The summary card must NOT use this: a burn time started from a flag 0.2 s
+    late is wrong by 13 per cent, which is the whole reason events.py exists.
+    """
+    out = dict(measured(flight))
+    if out["launch"] is None:
+        out["launch"] = _flag_time(flight.records, flight.t0_us, "launch")
+    return out
+
+
 def span(events: dict[str, Optional[float]], a: str, b: str) -> Optional[float]:
     """Seconds from event `a` to event `b`, or None if either is missing.
 

--- a/Data_Analysis/flight_report/modules/globe.py
+++ b/Data_Analysis/flight_report/modules/globe.py
@@ -59,6 +59,7 @@ from plot_flight_data_mini import get_array  # noqa: E402
 
 from ..cesium_bundle import CesiumPatchError, CesiumUnavailable, cesium_source
 from ..charts import chart, trace
+from ..events import markers
 from ..flight import Flight
 from ..registry import AnalysisResult
 from ..units import q
@@ -89,17 +90,14 @@ def _t(records, t0_us) -> np.ndarray:
     return (get_array(records, "time_us") - t0_us) / 1e6
 
 
-def _events(recs, t0_us) -> dict[str, Optional[float]]:
-    ns = recs.get("NonSensor") or []
-    out: dict[str, Optional[float]] = {}
-    for label, flag in (("launch", "launch"), ("apogee", "alt_apogee"),
-                        ("landed", "alt_landed")):
-        out[label] = None
-        for r in ns:
-            if r.get(flag):
-                out[label] = (r["time_us"] - t0_us) / 1e6
-                break
-    return out
+def _events(flight) -> dict[str, Optional[float]]:
+    """Measured flight events; see events.py.
+
+    Also the fallback bound for the plotted window, which is why it matters that
+    these are not detector votes: a boost-phase false vote used to clip the whole
+    3D track to the first second of flight.
+    """
+    return markers(flight)
 
 
 def _pad_reference(gnss, t, launch_s) -> Optional[tuple[float, float, float]]:
@@ -308,7 +306,7 @@ def _apogee_m(track: dict) -> float:
     return max(track["positions"][2::3])
 
 
-def _accel_sats_chart(recs, t0) -> Optional[dict[str, Any]]:
+def _accel_sats_chart(flight, recs, t0) -> Optional[dict[str, Any]]:
     """Acceleration against satellite count, on one time axis.
 
     The two tracks above diverge because the receiver loses lock under boost.
@@ -320,7 +318,7 @@ def _accel_sats_chart(recs, t0) -> Optional[dict[str, Any]]:
     if not imu or not gnss or "num_sats" not in gnss[0]:
         return None
 
-    events = _events(recs, t0)
+    events = _events(flight)
     t_imu = _t(imu, t0)
     start = events.get("launch")
     end = events.get("landed") or events.get("apogee")
@@ -366,7 +364,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         result.warnings.append("No timestamped records — nothing to place on the map.")
         return result
 
-    events = _events(recs, t0)
+    events = _events(flight)
     gnss = recs.get("GNSS") or []
     t_gnss = _t(gnss, t0) if gnss else np.zeros(0)
     pad = _pad_reference(gnss, t_gnss, events.get("launch"))
@@ -445,7 +443,7 @@ def analyze(flight: Flight) -> AnalysisResult:
                     "GNSS fixes. Imagery loads from Esri when the report is opened, so "
                     "this view needs a connection; the rest of the report does not.")
     result.globes = [spec]
-    accel_sats = _accel_sats_chart(recs, t0)
+    accel_sats = _accel_sats_chart(flight, recs, t0)
     result.charts = [accel_sats] if accel_sats else []
     return result
 

--- a/Data_Analysis/flight_report/modules/overview.py
+++ b/Data_Analysis/flight_report/modules/overview.py
@@ -25,6 +25,7 @@ from plot_flight_data_mini import (  # noqa: E402
 )
 
 from ..charts import COLORS, chart, trace, trajectory_3d
+from ..events import markers
 from ..flight import Flight
 from ..imu import G
 from ..registry import AnalysisResult
@@ -51,18 +52,14 @@ def _t(records, t0_us):
     return (get_array(records, "time_us") - t0_us) / 1e6
 
 
-def _events(records, t0_us) -> dict[str, float]:
-    """First occurrence of each flight event, in seconds since t0."""
-    ns = records.get("NonSensor") or []
-    keys = {"launch": "launch", "burnout": "burnout",
-            "apogee": "alt_apogee", "landed": "alt_landed"}
-    out: dict[str, float] = {}
-    for label, flag in keys.items():
-        for r in ns:
-            if r.get(flag):
-                out[label] = round((r["time_us"] - t0_us) / 1e6, 3)
-                break
-    return out
+def _events(flight) -> dict[str, float]:
+    """Every marker these charts draw, measured off the sensor record.
+
+    See events.py. These used to be the flags, which put the "Apogee" line on
+    the still-climbing part of the altitude trace — the barometric detector's
+    vote fires before the peak, not after it.
+    """
+    return {k: round(v, 3) for k, v in markers(flight).items() if v is not None}
 
 
 def _altitude_chart(recs, t0, events):
@@ -337,7 +334,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         result.warnings.append("No timestamped records — nothing to chart.")
         return result
 
-    events = _events(recs, t0)
+    events = _events(flight)
     # No ground-track chart here: the flight report's geography is the 3D globe.
     # The ENU chart and the flat recovery map both live in the detailed report, along
     # with the 3D Plotly trajectory — see _trajectory_chart for why that one is
@@ -363,7 +360,7 @@ def analyze_sensors(flight: Flight) -> AnalysisResult:
         result.warnings.append("No timestamped records — nothing to chart.")
         return result
 
-    events = _events(recs, t0)
+    events = _events(flight)
     return _build(result, [
         lambda: _accel_chart(recs, t0, events),
         lambda: _gyro_chart(recs, t0, events),

--- a/Data_Analysis/flight_report/modules/roll.py
+++ b/Data_Analysis/flight_report/modules/roll.py
@@ -39,6 +39,7 @@ if str(_PARENT) not in sys.path:
 from plot_flight_data_mini import get_array  # noqa: E402
 
 from ..charts import COLORS, chart, trace
+from ..events import markers
 from ..flight import Flight
 from ..registry import AnalysisResult
 from .roll_pid import roll_series
@@ -179,25 +180,38 @@ def _rate_limit(t, g, eject_t, cap) -> tuple[float, float]:
     return lim, float(np.max(np.abs(g)))
 
 
-def _events_since_launch(s: dict, lo: float, hi: float) -> dict[str, float]:
-    """Burnout and ejection, on the launch-relative axis these charts use.
+def _events_since_launch(flight, lo: float, hi: float) -> dict[str, float]:
+    """The measured events, on the launch-relative axis these charts use.
 
     Filtered to the plotted window, as `roll_pid._event_list` is. Ejection is
     often after the window ends — the window stops just before the charge fires —
     and an event marker outside the range is not merely invisible: `chart()` gives
     it a data-referenced shape, which drags every panel's autorange out to reach
     it and leaves a second of dead space on the right of all four.
+
+    Two things used to be wrong here. The times came from the roll-PID replay's
+    own flag-derived values rather than the measured ones, so this section marked
+    a burnout 71 ms away from the burnout line on every other chart in the report.
+    And the ejection was drawn under the key "apogee" — the charge, labelled as
+    the top of the flight, which on the sample flight is a second later and in
+    the other direction.
     """
+    ev = markers(flight)
+    launch = ev.get("launch")
+    if launch is None:
+        return {}
     out: dict[str, float] = {}
-    for key, value in (("burnout", s.get("burnout_t")), ("apogee", s.get("eject_t"))):
+    for key in ("burnout", "ejection", "apogee"):
+        value = ev.get(key)
         if value is None or not np.isfinite(value):
             continue
-        if lo <= float(value) <= hi:
-            out[key] = round(float(value), 3)
+        rel = float(value) - launch
+        if lo <= rel <= hi:
+            out[key] = round(rel, 3)
     return out
 
 
-def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
+def _control_charts(flight, s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
     """The four-panel roll-control story, launch to ejection.
 
     Drawn as four charts of equal height with the time axis labeled only on the
@@ -221,7 +235,7 @@ def _control_charts(s: dict, facts: dict[str, Any]) -> list[dict[str, Any]]:
     x_pad = 0.05 * (x_hi - x_lo)
     x_range = [x_lo - x_pad, x_hi + x_pad]
 
-    events = _events_since_launch(s, x_lo, x_hi)
+    events = _events_since_launch(flight, x_lo, x_hi)
     spans = _null_rate_segments(tw, s.get("track_is_ang"))
     specs: list[Optional[dict[str, Any]]] = []
     H = 260                      # one panel height, uniform across the stack
@@ -416,14 +430,10 @@ def _rate_only_chart(flight: Flight) -> Optional[dict[str, Any]]:
     t = (get_array(imu, "time_us") - t0) / 1e6
     g = get_array(imu, "gyro_x")
 
-    ns = recs.get("NonSensor") or []
-    events: dict[str, float] = {}
-    for label, flag in (("launch", "launch"), ("burnout", "burnout"),
-                        ("apogee", "alt_apogee"), ("landed", "alt_landed")):
-        for r in ns:
-            if r.get(flag):
-                events[label] = round((r["time_us"] - t0) / 1e6, 3)
-                break
+    # Measured, not the flags. The roll-control branch reads the same source
+    # (see _events_since_launch), so the two branches of this module no longer
+    # mark different instants depending on which one ran.
+    events = {k: round(v, 3) for k, v in markers(flight).items() if v is not None}
 
     start, end = events.get("launch"), events.get("landed") or events.get("apogee")
     window = (t >= start) & (t <= end) if start is not None and end is not None \
@@ -481,7 +491,7 @@ def analyze(flight: Flight) -> AnalysisResult:
     if controlled:
         result.title = "Roll Control"
         facts: dict[str, Any] = {}
-        result.charts = _control_charts(s, facts)
+        result.charts = _control_charts(flight, s, facts)
         if not result.charts:
             result.warnings.append("Roll control ran, but produced no plottable series.")
             return result

--- a/Data_Analysis/flight_report/modules/stability.py
+++ b/Data_Analysis/flight_report/modules/stability.py
@@ -28,6 +28,7 @@ if str(_PARENT) not in sys.path:
 from plot_flight_data_mini import get_array  # noqa: E402
 
 from ..charts import COLORS, chart, trace
+from ..events import measured
 from ..flight import Flight
 from ..registry import AnalysisResult
 from ..units import q
@@ -68,9 +69,9 @@ def analyze(flight: Flight) -> AnalysisResult:
         return result
 
     t = (get_array(ns, "time_us") - t0) / 1e6
-    launch = _event(ns, t0, "launch")
-    burnout = _event(ns, t0, "burnout")
-    apogee = _event(ns, t0, "alt_apogee")
+    ev = measured(flight)
+    launch, burnout = ev["launch"], ev["burnout"]
+    ejection, apogee = ev["ejection"], ev["apogee"]
 
     if launch is None:
         result.warnings.append("No launch detected — no pad attitude to measure tilt against.")
@@ -101,8 +102,13 @@ def analyze(flight: Flight) -> AnalysisResult:
                 float(np.interp(burnout, t, tilt)), "°", 1,
                 suffix=" from the rail",
             )
-    if apogee is not None:
-        metrics["Tilt at apogee"] = q(float(np.interp(apogee, t, tilt)), "°", 1)
+    # At ejection, not at apogee. The airframe swings freely under a deploying
+    # canopy, so an angle taken after the charge describes the recovery system
+    # rather than the rocket — and a rocket can deploy before it stops climbing.
+    # The sample flight ejects a second early: tilt reads 37.8° at the charge,
+    # 49.9° at apogee and 100.3° two tenths later, all of the growth being tumble.
+    if ejection is not None:
+        metrics["Tilt at ejection"] = q(float(np.interp(ejection, t, tilt)), "°", 1)
 
     boost_max = None
     if burnout is not None:
@@ -120,13 +126,16 @@ def analyze(flight: Flight) -> AnalysisResult:
     result.metrics = metrics
 
     # Chart the powered and coasting phases; once the chute is out the airframe
-    # swings freely and the angle stops describing the vehicle's flight.
-    end = apogee if apogee is not None else float(t[-1])
+    # swings freely and the angle stops describing the vehicle's flight. That
+    # cut is the ejection, which this used to approximate with apogee — fine
+    # until a flight deploys early, when it charts a second of tumble.
+    end = ejection if ejection is not None else (apogee if apogee is not None else float(t[-1]))
     window = (t >= launch - 1.0) & (t <= end + 0.5)
     if window.sum() > 10:
         events = {k: val for k, val in
-                  (("launch", launch), ("burnout", burnout), ("apogee", apogee))
-                  if val is not None}
+                  (("launch", launch), ("burnout", burnout),
+                   ("ejection", ejection), ("apogee", apogee))
+                  if val is not None and val <= end + 0.5}
         spec = chart(
             "chart-tilt", "Tilt away from the pad attitude",
             [trace(t[window], tilt[window], "Tilt", COLORS[3])],


### PR DESCRIPTION
Follow-up to #754, which measured the events but left the charts reading flags.

## Apogee markers move onto the measured apogee

The dashed "Apogee" line sat at the barometric detector's vote. Measured against the median-filtered barometric peak:

| flight | old flag marker | new measured marker |
|---|---|---|
| 174532 | 14.8 m below peak | 1.2 m below peak |
| 183745 | **83.2 m below peak** | 0.2 m below peak |
| 191300 | 4.1 m below peak | 2.9 m below peak |
| 195028 | landed on the ejection pressure spike | 2.8 m below peak |

On 183745 the old line was 4.3 s short of the peak, drawn on the boost part of the trace.

## Ejection becomes a marker

**Three of the four example flights deploy before apogee**, by 0.57–1.01 s. Until now that was invisible outside the Apogee Detection section. Markers are now Launch / Burnout / Ejection / Apogee / Landed, all measured.

## "Tilt at apogee" becomes "Tilt at ejection"

Once the charge fires the airframe swings under a deploying canopy and the angle stops describing the rocket. The argument is conditioning rather than the value: on the sample flight tilt moves **1.0° across ±50 ms at ejection against 12.0° at apogee**, and the apogee slope is −120°/s, reaching 146° a third of a second later. 191300 is the same shape (2.0° vs 17.7°). The tilt chart's window now ends at ejection too — which is what its own comment already said it wanted.

No flight loses the metric: ejection is found on all four. Note that on 183745, which ejects 1.54 s *after* apogee, the new number is **higher** (74.6° vs 54.8°) — still the angle at deployment, but the canopy rationale does not apply there.

## Two defects caught by review of the first cut

Both were mine, both fixed here, and both were confirmed by reviewers whose job was to refute them:

1. **Anchoring on a measured launch silently widened every launch-anchored window on a log that opens mid-boost** — there is no first motion to measure, and nothing replaced it. On the golden test log the boost chart went from 10.1 s to the full 61.4 s and dropped its note, the globe's track ran 2 s past touchdown, and its pad datum moved 14.7 m. `events.markers()` now substitutes the launch flag **for anchoring only**; `events.measured()`, which the summary card quotes, stays pure. A burn time started from a flag 0.2 s late is wrong by 13%, which is the whole point of that module.

2. **The roll section was never migrated on the branch the sample flight actually takes.** `_events_since_launch` read the roll-PID replay's flag-derived values, so it marked a burnout 71 ms away from the burnout line on every other chart in the report — and it drew the **ejection** under the key `"apogee"`: the charge, labelled as the top of the flight.

## Verification

28 tests pass. Golden-log chart extents are identical to HEAD except the boost chart, which now crops at the measured apogee (9.583 s) rather than the flag (10.095 s). All eight logs render without module errors; warning counts unchanged.

Still detailed-report-only and deliberately untouched: `deployment.py`, `pyro_apogee.py`, `kinematics.py`, `kinematic_checks.py`, `guidance.py`. `deployment.py` reading `alt_apogee` is correct — comparing the true peak against that flag is its whole purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
