### PR TITLE
report: consolidate the detailed sections into the main report

### DIFF
--- a/Data_Analysis/flight_report/modules/barometer.py
+++ b/Data_Analysis/flight_report/modules/barometer.py
@@ -1,0 +1,96 @@
+"""What the barometer actually measured, before it became an altitude.
+
+Every altitude in this report is derived from this one pressure trace, so it is
+worth being able to look at the raw signal: a sensor that saturated, drifted or
+took a hit from the ejection charge shows up here as a shape, and nowhere else as
+anything but a number that looks slightly wrong.
+
+The temperature is the sensor die, not the air. It sits 15-20 °C above ambient
+because the board heats itself, and it falls through the flight as airflow cools
+it. That is normal and the chart says so — a flyer who reads 45 °C as an outside
+air temperature would reasonably conclude the sensor is broken.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+_PARENT = Path(__file__).resolve().parent.parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from plot_flight_data_mini import get_array  # noqa: E402
+
+from ..charts import COLORS, chart, trace
+from ..events import markers
+from ..flight import Flight
+from ..registry import AnalysisResult
+
+# hPa is what altimeters, weather stations and field boxes all quote, and it puts
+# the numbers in a range a flyer recognises. The stored value is Pa.
+_PA_PER_HPA = 100.0
+
+
+def _series(recs, t0) -> tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]:
+    baro = recs.get("BMP585") or []
+    if not baro or t0 is None:
+        return None, None, None
+    t = (get_array(baro, "time_us") - t0) / 1e6
+    p = get_array(baro, "pressure_pa")
+    temp = get_array(baro, "temperature") if "temperature" in baro[0] else None
+    if not t.size or not p.size:
+        return None, None, None
+    return t, p, temp
+
+
+def _pressure_chart(t, p, events) -> Optional[dict[str, Any]]:
+    hpa = p / _PA_PER_HPA
+    spec = chart("chart-pressure", "Barometric pressure", [
+        trace(t, hpa, "Pressure", COLORS[0]),
+    ], y_title="Pressure", y_unit="hPa", events=events, height=320, clip_spikes=True)
+    if not spec:
+        return None
+    lo, hi = float(np.min(hpa)), float(np.max(hpa))
+    spec["note"] = (
+        f"The raw signal every altitude in this report is derived from. It falls "
+        f"{hi - lo:.1f} hPa from the pad to the top of the flight. The ejection "
+        f"charge drives it hard for a few samples — that spike is the charge "
+        f"venting, not the vehicle changing height."
+    )
+    return spec
+
+
+def _temperature_chart(t, temp, events) -> Optional[dict[str, Any]]:
+    if temp is None or not temp.size:
+        return None
+    spec = chart("chart-baro-temp", "Barometer die temperature", [
+        trace(t, temp, "Die Temperature", COLORS[1]),
+    ], y_title="Temperature", y_unit="°C", events=events, height=300)
+    if not spec:
+        return None
+    spec["note"] = (
+        "The sensor's own die, not the outside air — the board warms it well above "
+        "ambient, and it cools through the flight as air moves over the airframe. "
+        "It is here because pressure sensors drift with temperature, so a reading "
+        "that swings hard is a reason to distrust the altitude at that moment."
+    )
+    return spec
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="barometer", title="Barometer")
+    t, p, temp = _series(flight.records, flight.t0_us)
+    if t is None:
+        result.warnings.append("No barometer records, so there is no pressure to show.")
+        return result
+
+    events = {k: round(v, 3) for k, v in markers(flight).items() if v is not None}
+    result.charts = [c for c in (_pressure_chart(t, p, events),
+                                 _temperature_chart(t, temp, events)) if c]
+    if not result.charts:
+        result.warnings.append("Barometer records carry no usable pressure series.")
+    return result

--- a/Data_Analysis/flight_report/modules/lora_link.py
+++ b/Data_Analysis/flight_report/modules/lora_link.py
@@ -1,0 +1,291 @@
+"""What came down the radio, and how well the link held up.
+
+Three questions a flyer asks about telemetry, in order:
+
+1. Did the numbers arrive? The altitude the ground station saw, against the
+   altitude the flight computer recorded. They are the same measurement taking
+   two different routes, so where they diverge, packets were lost.
+2. Where did it go? The track as the ground station knew it — which is the track
+   you would have used to walk it down, gaps and all.
+3. Why did the link fade? Received strength against how far away the rocket was,
+   with the low passes marked.
+
+That last one is the point of the section. Free-space loss alone predicts a
+smooth curve against range, and the measured points do not lie on one: the ones
+that fall short are the ones taken at a low look-angle, where the path grazes the
+ground and the direct ray arrives with a reflection on top of it. So the chart
+colours by elevation angle rather than by time, and the answer to "why was my
+link bad at 400 m" turns out to be "because the rocket was low, not because it
+was far".
+
+The ground station does not record its own position. The pad is used instead —
+the receiver is normally within a few metres of it, which is nothing against the
+ranges here. Ranges are honest to about that few metres; the elevation angle is
+only meaningful once the rocket is well clear of the pad, which is why the
+geometry is computed over the flight and not over the whole session (most packets
+are the rocket sitting a couple of metres away, where a metre of GNSS noise
+swings the angle through tens of degrees).
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+_PARENT = Path(__file__).resolve().parent.parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from ..charts import COLORS, chart, trace
+from ..flight import Flight
+from ..registry import AnalysisResult
+
+# Below this the path grazes terrain and the ground reflection starts to matter.
+# A round number, not a derived one: the transition is gradual.
+_LOW_ELEVATION_DEG = 10.0
+
+_M_PER_DEG_LAT = 111_132.0
+_M_PER_DEG_LON_EQ = 111_320.0
+
+# States the flight computer reports before it is off the pad. Used to pick the
+# packets that establish where the pad is.
+_ON_PAD = ("INIT", "READY", "PRELAUNCH")
+_IN_FLIGHT = "INFLIGHT"
+
+_LOW_COLOR = "#d62728"
+_HIGH_COLOR = "#1f77b4"
+
+
+def _read(flight: Flight):
+    """The ground-station packet log as a DataFrame, or None if there isn't one."""
+    try:
+        import pandas as pd
+    except ImportError:                                    # pragma: no cover
+        return None
+    paths = sorted(p for p in flight.bin_path.parent.glob("lora_*.csv") if p.is_file())
+    if not paths:
+        return None
+    frames = []
+    for p in paths:
+        try:
+            frames.append(pd.read_csv(p))
+        except Exception:
+            continue
+    if not frames:
+        return None
+    df = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+    return df if len(df) else None
+
+
+def _fixes(df):
+    """Rows carrying a usable position. Null island is a receiver with no fix."""
+    if not {"lat", "lon", "alt_m"} <= set(df.columns):
+        return None
+    d = df.dropna(subset=["lat", "lon", "alt_m"])
+    d = d[(d["lat"].abs() > 0.001) & (d["lon"].abs() > 0.001)]
+    return d if len(d) else None
+
+
+def _pad(d):
+    """Ground-station position, taken as the pad. See the module docstring."""
+    on_pad = d[d["state"].isin(_ON_PAD)] if "state" in d.columns else d.iloc[:0]
+    src = on_pad if len(on_pad) >= 5 else d
+    return float(src["lat"].median()), float(src["lon"].median()), float(src["alt_m"].median())
+
+
+def _enu(d, lat0, lon0, alt0):
+    m_lon = _M_PER_DEG_LON_EQ * math.cos(math.radians(lat0))
+    east = (d["lon"].to_numpy() - lon0) * m_lon
+    north = (d["lat"].to_numpy() - lat0) * _M_PER_DEG_LAT
+    up = d["alt_m"].to_numpy() - alt0
+    return east, north, up
+
+
+def _altitude_chart(df) -> Optional[dict[str, Any]]:
+    """Altitude as the ground station received it."""
+    if "time_ms" not in df.columns:
+        return None
+    t = df["time_ms"].to_numpy() / 1000.0
+    traces = []
+    if "pressure_alt" in df.columns:
+        traces.append(trace(t, df["pressure_alt"].to_numpy(),
+                            "Telemetered Baro Altitude", COLORS[0]))
+    if "alt_m" in df.columns:
+        alt = df["alt_m"].to_numpy(dtype=float)
+        base = np.nanmin(alt) if np.isfinite(alt).any() else 0.0
+        traces.append(trace(t, alt - base, "Telemetered GNSS Altitude", COLORS[1]))
+    spec = chart("chart-lora-alt", "Altitude received over the radio", traces,
+                 x_title="Ground station time (s)", y_title="Altitude", y_unit="m",
+                 height=330, clip_spikes=True)
+    if not spec:
+        return None
+    spec["note"] = (
+        "The flight as the ground station saw it, on the receiver's own clock. "
+        "Each point is one packet that arrived; a flat stretch across the boost "
+        "is packets that did not. Compare the peak against the apogee on the "
+        "summary card — telemetry is downsampled and lossy, so it reads low."
+    )
+    return spec
+
+
+def _track_chart(d, lat0, lon0, alt0) -> Optional[dict[str, Any]]:
+    """Ground track from telemetry, coloured by height, pad and landing called out.
+
+    Restricted to the flight. Before launch the rocket sits on the pad for
+    minutes and the receiver logs every wander of the fix, which draws a scribble
+    around the origin and a tail wherever the GNSS lost and regained lock — none
+    of it flight, all of it louder than the track itself.
+    """
+    fl = d[d["state"] == _IN_FLIGHT] if "state" in d.columns else d
+    if len(fl) < 2:
+        fl = d
+    east, north, up = _enu(fl, lat0, lon0, alt0)
+    if east.size < 2:
+        return None
+
+    # Height as colour: on a flat track it is the only way to tell the climb from
+    # the descent, and it shows at a glance how much of the ground distance was
+    # covered under the canopy.
+    t = trace(east, north, "Telemetered Track", COLORS[0], mode="lines+markers", size=6)
+    if not t:
+        return None
+    t["marker"] = {
+        "size": 6, "color": [round(float(v), 1) for v in up],
+        "colorscale": "Viridis", "showscale": True,
+        "colorbar": {"title": {"text": "Height (m)", "side": "right"},
+                     "thickness": 12, "len": 0.7},
+    }
+    t["line"] = {"width": 1, "color": "#bbbbbb"}
+    t["hovertemplate"] = "%{x:.0f} m E, %{y:.0f} m N<br>%{marker.color:.0f} m up<extra></extra>"
+    spec = chart("chart-lora-track", "Ground track, as received", [t],
+                 x_title="East of the pad (m)", y_title="Distance north", y_unit="m",
+                 height=460, equal_aspect=True)
+    if not spec:
+        return None
+
+    # The pad is the origin by construction; the landing is the last fix that
+    # arrived, which is the point a flyer actually walks to.
+    spec["layout"].setdefault("annotations", []).extend([
+        {"x": 0.0, "y": 0.0, "text": "Pad", "showarrow": True, "arrowhead": 0,
+         "ax": 0, "ay": -28, "font": {"size": 11, "color": "#2ca02c"}},
+        {"x": float(east[-1]), "y": float(north[-1]), "text": "Last fix received",
+         "showarrow": True, "arrowhead": 0, "ax": 0, "ay": -28,
+         "font": {"size": 11, "color": "#d62728"}},
+    ])
+    spec["layout"].setdefault("shapes", []).extend([
+        {"type": "circle", "x0": -4, "x1": 4, "y0": -4, "y1": 4,
+         "line": {"color": "#2ca02c", "width": 2}, "layer": "above"},
+        {"type": "circle", "x0": float(east[-1]) - 4, "x1": float(east[-1]) + 4,
+         "y0": float(north[-1]) - 4, "y1": float(north[-1]) + 4,
+         "line": {"color": "#d62728", "width": 2}, "layer": "above"},
+    ])
+    spec["layout"]["showlegend"] = False
+    dist = float(math.hypot(east[-1], north[-1]))
+    spec["note"] = (
+        f"The flight only, coloured by height above the pad. Built from packets "
+        f"that arrived, so a long straight run between two points is a stretch "
+        f"where the link dropped rather than a straight piece of flying. The last "
+        f"fix received is {dist:,.0f} m from the pad — that is where the search "
+        f"starts if the rocket is not in sight."
+    )
+    return spec
+
+
+def _rssi_chart(d, lat0, lon0, alt0) -> tuple[Optional[dict[str, Any]], dict[str, Any]]:
+    """Received strength against slant range, low look-angles picked out."""
+    facts: dict[str, Any] = {}
+    if "rssi" not in d.columns:
+        return None, facts
+
+    # Flight only. On the pad the rocket is a couple of metres from the receiver,
+    # where a metre of GNSS noise swings the elevation angle through tens of
+    # degrees and the geometry means nothing.
+    fl = d[d["state"] == _IN_FLIGHT] if "state" in d.columns else d
+    if len(fl) < 5:
+        return None, facts
+
+    east, north, up = _enu(fl, lat0, lon0, alt0)
+    horizontal = np.hypot(east, north)
+    slant = np.hypot(horizontal, up)
+    elevation = np.degrees(np.arctan2(up, np.maximum(horizontal, 1e-6)))
+    rssi = fl["rssi"].to_numpy(dtype=float)
+
+    low = elevation < _LOW_ELEVATION_DEG
+    facts = {
+        "n": int(len(fl)), "low": int(low.sum()),
+        "max_range": float(np.max(slant)),
+        "rssi_low": float(np.median(rssi[low])) if low.any() else None,
+        "rssi_high": float(np.median(rssi[~low])) if (~low).any() else None,
+    }
+
+    traces = []
+    for mask, name, color in ((~low, f"Above {_LOW_ELEVATION_DEG:.0f}° elevation", _HIGH_COLOR),
+                              (low, f"Below {_LOW_ELEVATION_DEG:.0f}° elevation", _LOW_COLOR)):
+        if not mask.any():
+            continue
+        t = trace(slant[mask], rssi[mask], name, color, mode="markers", size=7)
+        if t:
+            t["hovertemplate"] = f"{name}<br>%{{x:.0f}} m · %{{y:.0f}} dBm<extra></extra>"
+            traces.append(t)
+
+    spec = chart("chart-lora-rssi", "Signal strength against distance", traces,
+                 x_title="Slant range from the pad (m)",
+                 y_title="Received strength", y_unit="dBm", height=380)
+    if not spec:
+        return None, facts
+    spec["layout"]["hovermode"] = "closest"
+
+    note = (
+        f"Every packet of the flight, placed by how far away the rocket was rather "
+        f"than by when it arrived. Red marks the passes taken below "
+        f"{_LOW_ELEVATION_DEG:.0f}° above the horizon, where the path grazes the "
+        f"ground and the direct ray arrives with a reflection on top of it."
+    )
+    if facts["rssi_low"] is not None and facts["rssi_high"] is not None:
+        note += (
+            f" Here the low passes ran {facts['rssi_high'] - facts['rssi_low']:.0f} dB "
+            f"weaker than the rest ({facts['rssi_low']:.0f} against "
+            f"{facts['rssi_high']:.0f} dBm), at no greater range — which is the "
+            f"case for getting the antenna up rather than for more power."
+        )
+    spec["note"] = note
+    return spec, facts
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="lora_link", title="Radio Link")
+
+    df = _read(flight)
+    if df is None:
+        # Not a warning. Most flights are flown without a ground station, and a
+        # missing telemetry log is not a fault in the flight.
+        return result
+
+    result.charts.append(_altitude_chart(df))
+    d = _fixes(df)
+    if d is not None:
+        lat0, lon0, alt0 = _pad(d)
+        result.charts.append(_track_chart(d, lat0, lon0, alt0))
+        rssi_spec, facts = _rssi_chart(d, lat0, lon0, alt0)
+        result.charts.append(rssi_spec)
+        if facts.get("n"):
+            result.metrics["Packets in flight"] = f"{facts['n']:,}"
+            result.metrics["Longest range"] = f"{facts['max_range']:,.0f} m"
+            if facts["low"]:
+                result.metrics["Below 10° elevation"] = (
+                    f"{facts['low']} packets ({100.0 * facts['low'] / facts['n']:.0f}%)"
+                )
+    elif "rssi" in df.columns:
+        result.warnings.append(
+            "Telemetry arrived but never carried a position, so range and look-angle "
+            "cannot be worked out — only the altitude chart above is available."
+        )
+
+    result.charts = [c for c in result.charts if c]
+    if not result.charts:
+        result.warnings.append("The ground-station log carried no plottable telemetry.")
+    return result

--- a/Data_Analysis/flight_report/modules/overview.py
+++ b/Data_Analysis/flight_report/modules/overview.py
@@ -228,8 +228,49 @@ def _gyro_chart(recs, t0, events):
         for i, ax in enumerate(("x", "y", "z"))
         if f"gyro_{ax}" in imu[0]
     ]
-    return chart("chart-gyro", "Angular rate", traces,
-                 y_title="Rate (deg/s)", events=events)
+    spec = chart("chart-gyro", "Angular rate", traces,
+                 y_title="Angular rate", y_unit="°/s", events=events,
+                 clip_spikes=True)
+    if spec:
+        # Clipped, like altitude and velocity: the ejection charge spins the
+        # airframe far harder than the flight does, and autoranging to that
+        # squashes the part worth reading into a band a few pixels tall.
+        spec["note"] = (
+            "Rotation about each body axis. X is roll, the axis the fins control; "
+            "Y and Z are pitch and yaw, which say how much the airframe was "
+            "coning. Rates past the ejection are the airframe swinging under the "
+            "canopy, not flight."
+        )
+    return spec
+
+
+# Two magnetometers appear across board revisions and never both on one board.
+# They parse to identical field names and units, so the chart takes whichever is
+# populated rather than naming a part.
+_MAG_SOURCES = ("IIS2MDC", "MMC5983MA")
+
+
+def _mag_chart(recs, t0, events):
+    """Magnetometer, three axes. Uncalibrated, so shape only — see the note."""
+    name, mag = next(((n, recs[n]) for n in _MAG_SOURCES if recs.get(n)), (None, None))
+    if not mag:
+        return None
+    t = _t(mag, t0)
+    traces = [
+        trace(t, get_array(mag, f"mag_{ax}"), f"Mag {ax.upper()}", COLORS[i])
+        for i, ax in enumerate(("x", "y", "z"))
+        if f"mag_{ax}" in mag[0]
+    ]
+    spec = chart("chart-mag", "Magnetometer", traces,
+                 y_title="Field", y_unit="µT", events=events, height=320)
+    if spec:
+        spec["note"] = (
+            "The field in the rocket's own frame, so the traces swing as the "
+            "airframe turns — it reads rotation, not heading. The sensor is not "
+            "calibrated in flight and the motor casing pulls it off true, so read "
+            "the shape and not the absolute values."
+        )
+    return spec
 
 
 def _ground_track_chart(recs):
@@ -318,11 +359,11 @@ def _build(result: AnalysisResult, builders) -> AnalysisResult:
 def analyze(flight: Flight) -> AnalysisResult:
     """Flight-level charts: the trajectory, as a flyer thinks about it.
 
-    Deliberately excludes the raw IMU series. Accelerometer and gyro log at ~1 kHz
-    for the whole session — several hundred thousand samples, most of them the
-    rocket sitting on the pad — and carrying them at full resolution would make
-    the flight report several times heavier than the detailed one. They live
-    in `analyze_sensors` instead, where detail costs nothing.
+    Carries the gyro and the magnetometer but not the raw accelerometer. The
+    accelerometer's own charts above are already built from it, windowed and
+    clipped; the raw series adds ~200k more points and says nothing the derived
+    views do not. The gyro earns its place because no other flight-level chart
+    shows pitch and yaw rate — only roll, in the roll section.
     """
     result = AnalysisResult(name="overview", title="Flight Overview")
     result.metrics = dict(DATA_SOURCES)
@@ -347,6 +388,12 @@ def analyze(flight: Flight) -> AnalysisResult:
         lambda: _velocity_chart(recs, t0, events),
         lambda: _accel_chart_flight(recs, t0, events),
         lambda: _accel_chart_boost(recs, t0, events),
+        # Rotation follows translation: having seen where it went and how hard it
+        # was pushed, angular rate says which way it was pointing while that
+        # happened, and the magnetometer corroborates the turning independently
+        # of the gyro's drift.
+        lambda: _gyro_chart(recs, t0, events),
+        lambda: _mag_chart(recs, t0, events),
     ])
 
 

--- a/Data_Analysis/flight_report/modules/parser_stats.py
+++ b/Data_Analysis/flight_report/modules/parser_stats.py
@@ -1,0 +1,54 @@
+"""What the parser found in the file, and how much of it survived the trip.
+
+The counts are a completeness check on everything above them. A stream whose
+count is far below what its configured rate implies did not record what it was
+asked to, and every number derived from it is thinner than it looks. A bad-CRC
+count above a handful means frames were corrupted in flash or over the wire, and
+the affected samples are simply missing.
+"""
+
+from __future__ import annotations
+
+from ..flight import Flight
+from ..registry import AnalysisResult
+
+# Under this it is background noise from flash wear, not a data problem.
+_BAD_CRC_WARN_FRACTION = 0.001
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="parser_stats", title="Log Contents")
+    result.metric_headers = ("Message", "Frames")
+
+    stats = flight.stats or {}
+    total = stats.get("total_frames")
+    good = stats.get("good_crc")
+    bad = stats.get("bad_crc")
+
+    counts = stats.get("type_counts") or {}
+    if counts:
+        result.metrics = {name: f"{count:,}" for name, count
+                          in sorted(counts.items(), key=lambda kv: -kv[1])}
+    if not result.metrics:
+        result.warnings.append("The parser reported no message counts for this log.")
+        return result
+
+    bits = []
+    if stats.get("file_size") is not None:
+        bits.append(f"{stats['file_size'] / 1024 / 1024:.1f} MB on disk")
+    if total is not None:
+        bits.append(f"{total:,} frames")
+    if bad is not None and total:
+        pct = 100.0 * (good or 0) / total
+        bits.append(f"{pct:.2f}% passed CRC" + (f" ({bad:,} did not)" if bad else ""))
+    result.text = " · ".join(bits)
+
+    # A handful of bad frames is ordinary on a full flash and not worth a warning
+    # banner; a rate that starts costing real samples is.
+    if bad and total and bad / total > _BAD_CRC_WARN_FRACTION:
+        result.warnings.append(
+            f"{bad:,} of {total:,} frames failed their checksum and were dropped "
+            f"({100.0 * bad / total:.2f}%). Those samples are missing from the "
+            "record the rest of this report is built on."
+        )
+    return result

--- a/Data_Analysis/flight_report/modules/rocket_state.py
+++ b/Data_Analysis/flight_report/modules/rocket_state.py
@@ -1,0 +1,48 @@
+"""The flight computer's own state machine, as it stepped through the flight.
+
+Read directly under the apogee section, because this is where the detectors'
+votes end up: the transition out of coast is the master apogee flag latching, and
+the step to LANDED is the touchdown declaration the flight time is measured to.
+When a detector fires late, this is the trace that shows what the vehicle
+believed it was doing at the time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARENT = Path(__file__).resolve().parent.parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from ..events import markers
+from ..flight import Flight
+from ..registry import AnalysisResult
+from .overview import _state_chart
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="rocket_state", title="Rocket State")
+    recs, t0 = flight.records, flight.t0_us
+    if t0 is None:
+        result.warnings.append("No timestamped records, so there is no state to plot.")
+        return result
+
+    events = {k: round(v, 3) for k, v in markers(flight).items() if v is not None}
+    spec = _state_chart(recs, t0, events)
+    if spec is None:
+        result.warnings.append("The log carries no rocket-state channel.")
+        return result
+
+    # Two of the five lanes are always empty: INIT and READY are passed through
+    # before logging starts, so they exist in the state enum and never in a log.
+    spec["note"] = (
+        "The state the flight computer believed it was in. The step out of "
+        "PRELAUNCH is the launch declaration and the step to LANDED is the "
+        "touchdown one; the markers show where those instants actually were. "
+        "INIT and READY are passed through before logging begins, so those lanes "
+        "stay empty."
+    )
+    result.charts = [spec]
+    return result

--- a/Data_Analysis/flight_report/modules/settings.py
+++ b/Data_Analysis/flight_report/modules/settings.py
@@ -1,0 +1,88 @@
+"""How the flight computer was configured for this flight.
+
+Last, because it is reference rather than reading: nobody opens a flight report
+to look at settings, but the moment a number above looks wrong the first question
+is what the vehicle was told to do. Keeping it here means that question is always
+one scroll away and never in the way.
+
+Two sources are merged. The sidecar's `settings` object is what the ground tools
+wrote — pyro channels, roll-control profile, servo travel. The log's own config
+block is what the firmware reported at boot: full-scale ranges and the sensor
+mounting rotations. They overlap on the ranges, and where they do the log wins,
+because it is what the sensors were actually running.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_PARENT = Path(__file__).resolve().parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from ..flight import Flight
+from ..registry import AnalysisResult
+from ..render import _flatten_settings
+
+# Results, not settings. The summary card owns these; repeating them here invites
+# the two to disagree, which is exactly the confusion this report has been
+# working to remove.
+_RESULT_KEYS = {"apogee_time_s", "max_altitude_m", "max_speed_mps", "burnout_time_s"}
+
+# Config keys whose meaning is not obvious from the key alone.
+_CONFIG_LABELS = {
+    "low_g_fs_g": "Low-G accelerometer range (g)",
+    "high_g_fs_g": "High-G accelerometer range (g)",
+    "gyro_fs_dps": "Gyroscope range (°/s)",
+    "ism6_rot_z_deg": "IMU mounting rotation (°)",
+    "iis2mdc_rot_z_deg": "Magnetometer mounting rotation (°)",
+    "mmc_rot_z_deg": "Magnetometer mounting rotation, old board (°)",
+    "hg_bias": "High-G zero offset (m/s²)",
+    "b2r_code": "Board-to-rocket frame code",
+    "b2r_mode": "Board-to-rocket frame mode",
+    "b2r_quat": "Board-to-rocket rotation (quaternion)",
+}
+
+
+def _config_rows(config: dict[str, Any]) -> list[tuple[str, str]]:
+    """The sensor configuration the firmware reported, as readable rows.
+
+    Rendered as a table rather than the JSON dump this used to be: it is a flat
+    list of scalars and a wall of braces is not easier to read for being literal.
+    """
+    rows: list[tuple[str, str]] = []
+    for key, value in config.items():
+        label = _CONFIG_LABELS.get(key, key)
+        for _k, text in _flatten_settings(value, label):
+            rows.append((_k, text))
+    return rows
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="settings", title="Settings Snapshot")
+    result.metric_headers = ("Setting", "Value")
+
+    rows: list[tuple[str, str]] = []
+
+    settings = (flight.sidecar or {}).get("settings")
+    if isinstance(settings, dict):
+        rows.extend(_flatten_settings(
+            {k: v for k, v in settings.items() if k not in _RESULT_KEYS}))
+
+    config = flight.config or {}
+    if config:
+        rows.extend(_config_rows(config))
+
+    if not rows:
+        result.warnings.append(
+            "No settings were recorded with this flight, so there is nothing to show. "
+            "The sidecar .json carries them; a log opened on its own has none."
+        )
+        return result
+
+    # Later wins, so the log's own config overrides a sidecar value of the same
+    # name — it is what the sensors were actually running.
+    result.metrics = dict(rows)
+    return result

--- a/Data_Analysis/flight_report/modules/timing.py
+++ b/Data_Analysis/flight_report/modules/timing.py
@@ -1,0 +1,44 @@
+"""How evenly each sensor actually sampled.
+
+The sample-rate chart earlier in the report gives one number per sensor, which
+is a median and hides its own spread. This is the distribution behind it: a
+sensor keeping time cleanly shows a single narrow spike, and one being starved
+by a busy bus or a slow write shows a tail, or a second mode, that no median
+would reveal.
+
+It sits after the message counts because it answers the next question those
+raise — the counts say how many frames arrived, this says whether they arrived
+when they should have.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PARENT = Path(__file__).resolve().parent.parent.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from analyze_gaps import extract_per_sensor_timestamps  # noqa: E402
+
+from ..flight import Flight
+from ..registry import AnalysisResult
+from .gaps import _plot_per_sensor_dt
+
+
+def analyze(flight: Flight) -> AnalysisResult:
+    result = AnalysisResult(name="timing", title="Per-Sensor Sample Timing")
+
+    per_sensor = extract_per_sensor_timestamps(flight.records)
+    if not per_sensor:
+        result.warnings.append("No per-sensor timestamps, so timing cannot be measured.")
+        return result
+
+    fig = _plot_per_sensor_dt(per_sensor)
+    if fig is None:
+        result.warnings.append("Not enough samples to show a timing distribution.")
+        return result
+
+    result.figures = [fig]
+    return result

--- a/Data_Analysis/flight_report/registry.py
+++ b/Data_Analysis/flight_report/registry.py
@@ -51,6 +51,12 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         sample_rates,
         stability,
         health,
+        rocket_state,
+        barometer,
+        lora_link,
+        parser_stats,
+        timing,
+        settings,
         kinematics,
         gaps,
         launch_detection,
@@ -75,12 +81,24 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         # say nothing about, and on a roll-control flight it is the whole story.
         ("roll",              roll.analyze,              LEVEL_FLIGHT),
         ("apogee",            apogee.analyze,            LEVEL_FLIGHT),
+        # Straight after the detectors: this is where their votes land, and the
+        # step out of coast is the master flag latching.
+        ("rocket_state",      rocket_state.analyze,      LEVEL_FLIGHT),
         ("stability",         stability.analyze,         LEVEL_FLIGHT),
         # Late, but on the flight report rather than only in the detailed one:
         # a sensor that logged short makes every number above it thinner than
         # it looks, so it belongs where the numbers are read.
         ("sample_rates",      sample_rates.analyze,      LEVEL_FLIGHT),
         ("health",            health.analyze,            LEVEL_FLIGHT),
+        # The tail of the report: what happened after the charge fired, then the
+        # raw signal behind every altitude, then the radio, then the record of
+        # the record itself. Reference rather than reading, in that order.
+        ("deployment",        deployment.analyze,        LEVEL_FLIGHT),
+        ("barometer",         barometer.analyze,         LEVEL_FLIGHT),
+        ("lora_link",         lora_link.analyze,         LEVEL_FLIGHT),
+        ("parser_stats",      parser_stats.analyze,      LEVEL_FLIGHT),
+        ("timing",            timing.analyze,            LEVEL_FLIGHT),
+        ("settings",          settings.analyze,          LEVEL_FLIGHT),
         ("sensor_charts",     overview.analyze_sensors,  LEVEL_DETAILED),
         ("kinematics",        kinematics.analyze,        LEVEL_DETAILED),
         ("gaps",              gaps.analyze,              LEVEL_DETAILED),
@@ -91,7 +109,6 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         # still draws with no network (it degrades to graph paper with the track
         # on it), so it lives with the rest of the diagnostic set rather than
         # duplicating the globe in the flight report.
-        ("deployment",        deployment.analyze,        LEVEL_DETAILED),
         ("pyro_apogee",       pyro_apogee.analyze,       LEVEL_DETAILED),
         ("sensor_noise",      sensor_noise.analyze,      LEVEL_DETAILED),
         ("gnss_staleness",    gnss_staleness.analyze,    LEVEL_DETAILED),

--- a/Data_Analysis/flight_report/templates/report.html.j2
+++ b/Data_Analysis/flight_report/templates/report.html.j2
@@ -207,34 +207,6 @@
   </ul>
 </div>
 
-{% if show_raw_detail %}
-<h2 id="settings">Settings snapshot</h2>
-{% if settings_groups %}
-<p class="settings-note">
-  How the flight computer was configured for this flight. Measured results are in
-  the flight report, not here.
-</p>
-<div class="settings">
-  {% for g in settings_groups %}
-  <div class="settings-group">
-    <h3>{{ g.name.replace("_", " ") }}</h3>
-    <table class="metrics">
-      <tbody>
-      {% for k, v in g.rows %}
-        <tr><td>{{ k }}</td><td class="num">{{ v }}</td></tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% endfor %}
-</div>
-{% elif sidecar %}
-<p>The .json sidecar has no <code>settings</code> block.</p>
-{% else %}
-<p>No .json sidecar found.</p>
-{% endif %}
-{% endif %}
-
 {% for s in sections %}
 <h2 id="{{ s.name }}">{{ s.title }}</h2>
 
@@ -315,30 +287,6 @@
 {% endif %}
 {% endfor %}
 
-{% if show_raw_detail %}
-<h2 id="parser">Parser stats</h2>
-<table class="metrics">
-  <thead><tr><th>Field</th><th>Value</th></tr></thead>
-  <tbody>
-    <tr><td>File size</td><td class="num">{{ "{:,}".format(stats.get('file_size', 0)) }} bytes</td></tr>
-    <tr><td>Total frames</td><td class="num">{{ "{:,}".format(stats.get('total_frames', 0)) }}</td></tr>
-    <tr><td>Good CRC</td><td class="num">{{ "{:,}".format(stats.get('good_crc', 0)) }}</td></tr>
-    <tr><td>Bad CRC</td><td class="num">{{ "{:,}".format(stats.get('bad_crc', 0)) }}</td></tr>
-  </tbody>
-</table>
-
-<h3>Message counts</h3>
-<table class="metrics">
-  <tbody>
-  {% for name, count in stats.get('type_counts', {}).items() | sort(attribute=1, reverse=True) %}
-    <tr><td>{{ name }}</td><td class="num">{{ "{:,}".format(count) }}</td></tr>
-  {% endfor %}
-  </tbody>
-</table>
-
-<h3>Sensor configuration</h3>
-<pre>{{ config | tojson(indent=2) }}</pre>
-{% endif %}
 
 {% if has_maps %}
 <style>
@@ -893,10 +841,16 @@
      Values render in SI and are converted in place, so one file serves both
      systems and switching costs no regeneration. */
   var CONV = {
-    "m":     {f: 3.280839895, label: "ft",    places: 0},
-    "km":    {f: 0.621371192, label: "mi",    places: 2},
-    "m/s":   {f: 2.236936292, label: "mph",   places: 1},
-    "m/s²": {f: 3.280839895, label: "ft/s²", places: 1}
+    "m":       {f: 3.280839895, label: "ft",    places: 0},
+    "km":      {f: 0.621371192, label: "mi",    places: 2},
+    "m/s":     {f: 2.236936292, label: "mph",   places: 1},
+    /* Vertical rates read in ft/s, not mph — a descent rate is compared against
+       a canopy's rated sink rate, which every chart and table quotes in ft/s.
+       Quantity emits data-conv="m/s:fps" alongside data-unit="m/s" to ask for
+       this; without the entry below the lookup fell through to "m/s" and the
+       report showed a descent rate in mph. */
+    "m/s:fps": {f: 3.280839895, label: "ft/s",  places: 1},
+    "m/s²":   {f: 3.280839895, label: "ft/s²", places: 1}
   };
   var imperial = false;
   var charts = [];   // {gd, spec, range} registered as each one is plotted
@@ -913,7 +867,10 @@
       var unit = el.dataset.unit;
       var places = parseInt(el.dataset.places, 10) || 0;
       var suffix = el.dataset.suffix || "";
-      var c = imperial ? CONV[unit] : null;
+      /* data-conv overrides data-unit when a value wants a different imperial
+         target than its SI unit implies. The metric branch still prints
+         data-unit, so the SI label stays "m/s" rather than the lookup key. */
+      var c = imperial ? (CONV[el.dataset.conv] || CONV[unit]) : null;
       el.textContent = c
         ? fmt(si * c.f, c.places) + " " + c.label + suffix
         : fmt(si, places) + " " + unit + suffix;

--- a/tests/test_flight_report.py
+++ b/tests/test_flight_report.py
@@ -39,11 +39,22 @@ DETAILED_SECTIONS = [
     'id="roll_pid"',
     'id="lora"',
     'id="log_buffer"',
-    'id="settings"',
-    'id="parser"',
 ]
 
-FLIGHT_SECTIONS = ['id="overview"', 'id="globe"']
+# The consolidation is moving the report towards a single page, so sections keep
+# arriving here from the detailed side. Settings, the log contents and the
+# deployment write-up moved first; the detailed report keeps only what has not
+# been rebuilt as interactive charts yet.
+FLIGHT_SECTIONS = [
+    'id="overview"',
+    'id="globe"',
+    'id="rocket_state"',
+    'id="deployment"',
+    'id="barometer"',
+    'id="parser_stats"',
+    'id="timing"',
+    'id="settings"',
+]
 
 
 @pytest.fixture(scope="module")
@@ -100,19 +111,39 @@ def test_flight_report_is_the_headline_read(reports: dict[str, Path]) -> None:
     assert not missing, f"Missing sections: {missing}"
     assert 'class="card"' in html, "Flight report is missing the summary card"
 
-    leaked = [s for s in ('id="parser"', 'id="settings"', 'id="log_buffer"') if s in html]
+    # Still board bring-up rather than flying, so still not here.
+    leaked = [s for s in ('id="log_buffer"', 'id="kinematic_checks"',
+                          'id="sensor_noise"') if s in html]
     assert not leaked, f"Detailed-only sections leaked into the flight report: {leaked}"
+
+    # Settings is reference material and belongs at the very bottom, below every
+    # section that is actually about the flight.
+    assert html.index('id="settings"') > html.index('id="deployment"'), (
+        "Settings snapshot should sit below Deployment & Recovery"
+    )
+    assert html.index('id="timing"') > html.index('id="parser_stats"'), (
+        "Per-sensor timing should follow the message counts it explains"
+    )
 
 
 def test_report_has_inline_figures(reports: dict[str, Path]) -> None:
-    """Static figures live in the detailed report; the flight report has none."""
+    """Static figures are the detailed report's idiom; the flight report has one.
+
+    The per-sensor timing histogram is the exception, and a deliberate one: it is
+    a distribution rather than a series, nothing zooms into it, and rebuilding it
+    as a Plotly figure would cost more than it returns. Every other flight-level
+    visual is an interactive chart, so the count is pinned rather than merely
+    bounded — a second PNG appearing here should be a decision, not a drift.
+    """
     eng = reports["detailed"].read_text(encoding="utf-8")
     fig_count = eng.count('<img src="data:image/png;base64,')
     assert fig_count >= 25, f"Expected ≥25 inline figures, got {fig_count}"
 
     flight = reports["flight"].read_text(encoding="utf-8")
-    assert '<img src="data:image/png;base64,' not in flight, (
-        "Flight report should carry interactive charts only, no static PNGs"
+    flight_figs = flight.count('<img src="data:image/png;base64,')
+    assert flight_figs == 1, (
+        f"Flight report should carry exactly one static PNG (per-sensor timing), "
+        f"got {flight_figs}"
     )
 
 


### PR DESCRIPTION
First step toward a single report. The flight report goes from 7 sections to 14, in the requested order:

`3D path → overview → roll → apogee → rocket state → stability → sample rates → health → deployment → barometer → radio link → log contents → per-sensor timing → settings`

The detailed report stays for now, minus what moved.

## New content

**Angular rate and magnetometer** join Flight Overview, under acceleration. The gyro moves to a toggle-aware unit and gains `clip_spikes`, matching the altitude and velocity charts beside it — the ejection spins the airframe far harder than the flight does, and autoranging to that flattens the flight. The magnetometer takes whichever of the two board revisions' parts is populated rather than naming one, and its note says it is uncalibrated: on-pad |B| reads 73 µT against an earth field of ~51, so the shape is readable and the absolute values are not.

**Barometer** — the raw pressure every altitude in the report is derived from, plus die temperature. Labelled as the *die*, not the air: it sits at 44–46 °C from board self-heating and would otherwise read as a broken sensor.

**Radio link** — three charts:
- telemetered altitude on the receiver's own clock
- ground track coloured by height, pad and last fix annotated, restricted to the flight (pre-launch pad wander otherwise draws a louder scribble than the track)
- **RSSI against slant range, with passes below 10° elevation in red**

That third chart is the point of the section, and it measures the effect you predicted: the low passes run **6 dB weaker than the rest (−88 vs −82 dBm) at no greater range**. 18 of 150 in-flight packets. The ground station does not log its own position, so the pad stands in — documented in the module. Geometry is computed over the flight only, because on the pad the rocket sits ~2 m from the receiver and a metre of GNSS noise swings the elevation angle through tens of degrees.

## Structural

**Settings snapshot and log contents become modules** rather than template blocks pinned above and below the section list, so ordering is now one list in `registry.py`. Settings merges the sidecar's settings with the firmware's own config block — the sensor ranges and mounting rotations that were previously a raw JSON `<pre>` dump — rendered as a table with readable labels (64 rows).

**Per-sensor sample timing** follows the message counts it explains.

## Descent rate now reads ft/s

`deployment.py` has passed `conv="m/s:fps"` since it was written, but the template's JS `CONV` table had no `m/s:fps` entry *and* `convertSpans` read `data-unit` rather than `data-conv` — so the shipped report silently rendered descent rate in **mph**. Verified fixed end to end: 5.41 m/s now toggles to **17.7 ft/s**, not 12.1 mph.

## Deliberately not promoted

`kinematics` — 26 matplotlib figures, +4.2 MB, for content the interactive charts already cover. It stays in the detailed report along with the other board bring-up sections (`log_buffer`, `kinematic_checks`, `sensor_noise`, …).

## Verification

28 tests pass. The section-inventory tests were updated to encode the new split, plus two new ordering assertions (settings below deployment; timing after the message counts). `test_report_has_inline_figures` now pins the flight report at **exactly one** PNG — the timing histogram, which is a distribution rather than a series and gains nothing from being interactive — so a second static figure appearing has to be a decision rather than a drift.

Flight report 12.46 → 14.33 MB, 0 warnings, 16.5 s to build both levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
