### PR TITLE
report: one report, and the fixes a pre-ship review turned up

### DIFF
--- a/Data_Analysis/flight_report/cli.py
+++ b/Data_Analysis/flight_report/cli.py
@@ -14,11 +14,11 @@ plt.rcParams["figure.max_open_warning"] = 0  # we batch ~30 figures intentionall
 
 from .discover import DEFAULT_DISCOVERY_ROOT, discover, filter_flights
 from .flight import Flight
-from .registry import LEVEL_DETAILED, LEVEL_FLIGHT, modules_for, run_module
+from .registry import LEVEL_FLIGHT, modules_for, run_module
 from .render import write_report
 
 
-_LEVEL_SUFFIX = {LEVEL_FLIGHT: "_report.html", LEVEL_DETAILED: "_report_detailed.html"}
+_LEVEL_SUFFIX = {LEVEL_FLIGHT: "_report.html"}
 
 
 def _out_path_for(flight: Flight, out: Path | None, level: str) -> Path:
@@ -34,7 +34,7 @@ def _out_path_for(flight: Flight, out: Path | None, level: str) -> Path:
 
 
 def _process_one(flight: Flight, out: Path | None, levels: list[str]) -> list[Path]:
-    """Run the requested levels against one flight. Returns the report paths."""
+    """Run one flight. `levels` is a list for historical reasons — there is one."""
     print(f"  Parsing: {flight.bin_path}")
     t0 = time.time()
     flight.load()
@@ -56,11 +56,7 @@ def _process_one(flight: Flight, out: Path | None, levels: list[str]) -> list[Pa
             results.append(result)
 
         out_path = _out_path_for(flight, out, level)
-        # Cross-link the two reports, but only when both are being written —
-        # a link to a file that was never generated is worse than no link.
-        other = next((lv for lv in levels if lv != level), None)
-        counterpart = _out_path_for(flight, out, other).name if other else None
-        write_report(flight, results, out_path, level=level, counterpart=counterpart)
+        write_report(flight, results, out_path, level=level)
         print(f"      -> {out_path}")
         written.append(out_path)
 
@@ -90,17 +86,6 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Stop after N flights (useful for testing).",
     )
-    p_run.add_argument(
-        "--level",
-        choices=[LEVEL_FLIGHT, LEVEL_DETAILED, "both"],
-        default="both",
-        help=(
-            "Which report(s) to write. 'flight' is the headline read — summary "
-            "card and interactive charts; 'detailed' is the full diagnostic "
-            "set. Default: both."
-        ),
-    )
-
     p_list = sub.add_parser("list", help="Discover flights without running analysis.")
     p_list.add_argument("path", nargs="?", default=None)
 
@@ -122,7 +107,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.limit:
         flights = flights[: args.limit]
 
-    levels = [LEVEL_FLIGHT, LEVEL_DETAILED] if args.level == "both" else [args.level]
+    levels = [LEVEL_FLIGHT]
 
     print(f"Processing {len(flights)} flight(s)...")
     failed = 0

--- a/Data_Analysis/flight_report/modules/apogee.py
+++ b/Data_Analysis/flight_report/modules/apogee.py
@@ -211,7 +211,7 @@ def _altitude_chart(res, marks: dict[str, float]) -> Optional[dict[str, Any]]:
         note = ("Each marker is one detector calling apogee; the master flag, which fires "
                 "the charge, latches from their votes.")
         if res.get("baro_reject_t"):
-            note += (f" Baro was rejected {len(res['baro_reject_t'])} times here, by "
+            note += (f" Baro was rejected {len(rejects)} times in this window, by "
                      "design, while the vehicle was too fast for pressure to be reliable.")
         spec["note"] = note
     return spec

--- a/Data_Analysis/flight_report/modules/barometer.py
+++ b/Data_Analysis/flight_report/modules/barometer.py
@@ -47,6 +47,15 @@ def _series(recs, t0) -> tuple[Optional[np.ndarray], Optional[np.ndarray], Optio
     return t, p, temp
 
 
+def _smooth_hpa(v, k: int = 25):
+    """Median filter, so the apogee reading is the flight and not the charge."""
+    if v.size <= k:
+        return v
+    pad = k // 2
+    padded = np.concatenate([np.full(pad, v[0]), v, np.full(pad, v[-1])])
+    return np.array([np.median(padded[i:i + k]) for i in range(v.size)])
+
+
 def _pressure_chart(t, p, events) -> Optional[dict[str, Any]]:
     hpa = p / _PA_PER_HPA
     spec = chart("chart-pressure", "Barometric pressure", [
@@ -54,10 +63,14 @@ def _pressure_chart(t, p, events) -> Optional[dict[str, Any]]:
     ], y_title="Pressure", y_unit="hPa", events=events, height=320, clip_spikes=True)
     if not spec:
         return None
-    lo, hi = float(np.min(hpa)), float(np.max(hpa))
+    # Pad to apogee, not min-to-max: the ejection charge is the deepest point on
+    # this trace and it is a pressure event, not a height. Quoting it here would
+    # measure the very spike the next sentence tells the reader to discount.
+    pad = float(np.median(hpa[: min(200, hpa.size)]))
+    apogee_p = float(np.min(_smooth_hpa(hpa)))
     spec["note"] = (
         f"The raw signal every altitude in this report is derived from. It falls "
-        f"{hi - lo:.1f} hPa from the pad to the top of the flight. The ejection "
+        f"{pad - apogee_p:.1f} hPa from the pad to the top of the flight. The ejection "
         f"charge drives it hard for a few samples — that spike is the charge "
         f"venting, not the vehicle changing height."
     )

--- a/Data_Analysis/flight_report/modules/deployment.py
+++ b/Data_Analysis/flight_report/modules/deployment.py
@@ -29,6 +29,7 @@ if str(_PARENT) not in sys.path:
 from plot_flight_data_mini import get_array, pressure_to_altitude  # noqa: E402
 
 from ..charts import COLORS, chart, trace
+from ..events import markers
 from ..flight import Flight
 from ..maps import track_map
 from ..registry import AnalysisResult
@@ -43,16 +44,28 @@ APOGEE_LAG_WARN_S = 1.0
 MAIN_TRANSITION_RATIO = 0.6
 
 
-def _events(ns, t0_us) -> dict[str, Optional[float]]:
-    out: dict[str, Optional[float]] = {}
-    for label, flag in (("launch", "launch"), ("burnout", "burnout"),
-                        ("apogee", "alt_apogee"), ("landed", "alt_landed")):
-        out[label] = None
-        for r in ns:
-            if r.get(flag):
-                out[label] = (r["time_us"] - t0_us) / 1e6
-                break
-    return out
+def _smooth(alt, k: int = 25):
+    """Median-filtered altitude. The ejection charge is a pressure event, not a
+    height, and an unfiltered argmax or interpolation will happily return it."""
+    if alt is None or alt.size <= k:
+        return alt
+    pad = k // 2
+    padded = np.concatenate([np.full(pad, alt[0]), alt, np.full(pad, alt[-1])])
+    return np.array([np.median(padded[i:i + k]) for i in range(alt.size)])
+
+
+def _flag_apogee(ns, t0_us) -> Optional[float]:
+    """When the barometric detector voted, which is what section 1 is about.
+
+    Everything else here uses the measured events. This section's first question
+    is "did the flight computer call it at the right moment", and that question
+    needs the declaration on one side of the comparison — but only that question:
+    the descent numbers and the chart are about the flight, not about the vote.
+    """
+    for r in ns:
+        if r.get("alt_apogee"):
+            return (r["time_us"] - t0_us) / 1e6
+    return None
 
 
 def _baro_profile(recs, t0_us):
@@ -148,16 +161,17 @@ def analyze(flight: Flight) -> AnalysisResult:
         return result
 
     ns = recs.get("NonSensor") or []
-    ev = _events(ns, t0)
+    ev = markers(flight)
+    flag_apogee = _flag_apogee(ns, t0)
     t, alt = _baro_profile(recs, t0)
 
     metrics: dict[str, object] = {}
 
     # --- 1. Was apogee called on time? --------------------------------------
-    if t is not None and ev["apogee"] is not None:
-        peak_i = int(np.argmax(alt))
+    if t is not None and flag_apogee is not None:
+        peak_i = int(np.argmax(_smooth(alt)))
         peak_t, peak_alt = float(t[peak_i]), float(alt[peak_i])
-        lag = ev["apogee"] - peak_t
+        lag = flag_apogee - peak_t
         # Named for the sensor, not "True apogee": the Apogee Detection section
         # already uses that phrase for the GNSS Doppler velocity crossing, which
         # is a different instant (7.66 s vs 8.34 s on the sample flight, because
@@ -170,7 +184,11 @@ def analyze(flight: Flight) -> AnalysisResult:
         # both directions: still climbing if the call was early, already falling
         # if it was late. (Not "altitude lost" — that would be wrong by sign for
         # an early call, which is the safer and more common tuning.)
-        at_flag = float(np.interp(ev["apogee"], t, alt))
+        # Interpolate the SMOOTHED trace: the charge drives the raw pressure to
+        # absurd values for a few samples, and on a short flight the vote lands
+        # on that spike — reading it raw once reported 651 m below the peak of a
+        # 74 m flight.
+        at_flag = float(np.interp(flag_apogee, t, _smooth(alt)))
         below = peak_alt - at_flag
         when = "early" if lag < 0 else "late"
         still = "still climbing" if lag < 0 else "already descending"
@@ -243,7 +261,8 @@ def analyze(flight: Flight) -> AnalysisResult:
                 "chart-descent", "Descent profile",
                 [trace(t[m], alt[m], "Barometric altitude", COLORS[0])],
                 y_title="Altitude AGL", y_unit="m",
-                events={k: v for k, v in ev.items() if k in ("apogee", "landed")},
+                events={k: v for k, v in ev.items()
+                        if k in ("apogee", "ejection", "landed") and v is not None},
                 clip_spikes=True,  # the ejection charge throws the barometer hard
             )
             if spec:

--- a/Data_Analysis/flight_report/modules/explore.py
+++ b/Data_Analysis/flight_report/modules/explore.py
@@ -37,7 +37,10 @@ from ..registry import AnalysisResult
 
 _DISCRETE = (KIND_BOOL, KIND_ENUM, KIND_COUNTER)
 
-# In preference order; the first one this log actually carries is preselected.
+# What the time panel opens showing, in preference order; the first one this log
+# actually carries wins. A blank plot asks the reader to go and find something
+# before the panel has shown it can plot anything at all, and GNSS altitude is
+# the channel every flight has and everyone recognises.
 _DEFAULT_CHANNELS = ("GNSS.alt_m", "NonSensor.u_pos", "BMP585.pressure_pa")
 
 
@@ -46,6 +49,11 @@ def _first_present(channels: dict, wanted: tuple[str, ...]) -> list[str]:
         if key in channels:
             return [key]
     return []
+
+# Both Explore sections read one embedded payload. It is the largest thing in
+# the document, so the second section references this id rather than carrying
+# its own copy — see `analyze_xy`.
+DATASET_ID = "explore-data"
 
 # Time to 1 ms and samples to 4 decimals, both well below sensor resolution and
 # matching what `charts._clean` ships. Digits that survive rounding are digits
@@ -109,6 +117,12 @@ def _dataset(flight: Flight) -> Optional[dict[str, Any]]:
             "stream": c.stream,
             "label": c.meta.label,
             "unit": c.meta.unit,
+            # Which CONVERSIONS row drives the imperial toggle, when it differs
+            # from the display unit. Vertical rates are "m/s" on screen but
+            # convert to ft/s, not mph — units.py keeps a separate row for that
+            # and says quoting a sink rate in mph "reads as an error to anyone
+            # in the hobby". Omitted when it adds nothing, to save the bytes.
+            "conv": c.meta.conv if c.meta.conv and c.meta.conv != c.meta.unit else "",
             "kind": c.meta.kind,
             # Carried so the picker can warn in place rather than making the
             # reader go and find the inventory section.
@@ -124,12 +138,7 @@ def _dataset(flight: Flight) -> Optional[dict[str, Any]]:
         channels[c.key] = entry
 
     return {
-        "id": "explore-data",
-        # What the panel opens showing. A blank plot asks the reader to go and
-        # find something before it has demonstrated it can plot anything at all;
-        # GNSS altitude is the one channel every flight has and everyone
-        # recognises, so it stands as the worked example. First match wins.
-        "default": _first_present(channels, _DEFAULT_CHANNELS),
+        "id": DATASET_ID,
         "streams": streams,
         "channels": channels,
         # Step-drawn kinds, so the panel does not have to re-derive the rule.
@@ -137,12 +146,17 @@ def _dataset(flight: Flight) -> Optional[dict[str, Any]]:
     }
 
 
-def analyze(flight: Flight) -> AnalysisResult:
-    result = AnalysisResult(name="explore", title="Plot Data Channels")
+def analyze_time(flight: Flight) -> AnalysisResult:
+    """Section one: any channel against time.
+
+    The common case by a wide margin, so it leads and carries no controls it
+    does not need — no X picker, because the X axis is the clock.
+    """
+    result = AnalysisResult(name="explore_time", title="Plot Data Channels")
 
     data = _dataset(flight)
     if data is None:
-        result.warnings.append("No channels parsed from this log — nothing to explore.")
+        result.warnings.append("No channels parsed from this log — nothing to plot.")
         return result
 
     n_const = sum(1 for c in data["channels"].values() if "const" in c)
@@ -150,5 +164,34 @@ def analyze(flight: Flight) -> AnalysisResult:
     result.metrics["Held one value all flight"] = f"{n_const:,}"
     result.metrics["Streams"] = ", ".join(data["streams"])
 
+    data["panel"] = "time"
+    data["default"] = _first_present(data["channels"], _DEFAULT_CHANNELS)
     result.datasets = [data]
+    return result
+
+
+def analyze_xy(flight: Flight) -> AnalysisResult:
+    """Section two: one channel against another.
+
+    References the payload the time section embedded instead of building its
+    own. The dataset is ~3.9 MB gzipped on a real flight and duplicating it
+    would double the document to save one dictionary lookup in the browser.
+
+    Kept a separate section rather than a mode toggle because the two answer
+    different questions and want different controls: this one needs an X axis
+    and is confined to a single stream, and putting that behind a radio button
+    made the common case carry the rarer one's machinery.
+    """
+    result = AnalysisResult(name="explore_xy", title="Plot One Channel Against Another")
+
+    if flight.t0_us is None or not flight.records:
+        result.warnings.append("No channels parsed from this log — nothing to plot.")
+        return result
+
+    result.metrics["Pairing"] = (
+        "Both axes must come from the same stream, so each point is one logged "
+        "frame rather than an interpolated pair."
+    )
+    # A reference, not a payload: render.py emits no script tag for these.
+    result.datasets = [{"id": DATASET_ID, "panel": "xy", "ref": True}]
     return result

--- a/Data_Analysis/flight_report/modules/explore.py
+++ b/Data_Analysis/flight_report/modules/explore.py
@@ -35,7 +35,13 @@ from ..catalog import KIND_BOOL, KIND_COUNTER, KIND_ENUM, build
 from ..flight import Flight
 from ..registry import AnalysisResult
 
+import re
+
 _DISCRETE = (KIND_BOOL, KIND_ENUM, KIND_COUNTER)
+
+# "(#112)" and ", #514" and bare "#514" — the reference, not the sentence.
+_ISSUE_REF = re.compile(r"\s*[(\[]?,?\s*#\d+\s*[)\]]?")
+_SPACES = re.compile(r"\s{2,}")
 
 # What the time panel opens showing, in preference order; the first one this log
 # actually carries wins. A blank plot asks the reader to go and find something
@@ -60,6 +66,21 @@ DATASET_ID = "explore-data"
 # in every copy of the report.
 _T_DP = 3
 _V_DP = 4
+
+
+def _public(text: Optional[str]) -> Optional[str]:
+    """A caution with its issue references removed.
+
+    The channel catalog is written for whoever is debugging the firmware, and
+    its cautions cite the issues that established each quirk. The substance is
+    exactly what a reader plotting that channel needs; the issue numbers mean
+    nothing outside the repository and read as leaked internals in a report a
+    customer opens.
+    """
+    if not text:
+        return text
+    out = _ISSUE_REF.sub("", text)
+    return _SPACES.sub(" ", out).replace(" ,", ",").replace(" .", ".").strip()
 
 
 def _values(rows: list[dict], field: str, kind: str) -> list:
@@ -126,7 +147,7 @@ def _dataset(flight: Flight) -> Optional[dict[str, Any]]:
             "kind": c.meta.kind,
             # Carried so the picker can warn in place rather than making the
             # reader go and find the inventory section.
-            "caution": c.meta.caution,
+            "caution": _public(c.meta.caution),
             "shown": list(c.meta.shown_in),
         }
         if len(set(vals)) == 1:

--- a/Data_Analysis/flight_report/modules/lora_link.py
+++ b/Data_Analysis/flight_report/modules/lora_link.py
@@ -42,6 +42,7 @@ if str(_PARENT) not in sys.path:
 
 from ..charts import COLORS, chart, trace
 from ..flight import Flight
+from ..units import q
 from ..registry import AnalysisResult
 
 # Below this the path grazes terrain and the ground reflection starts to matter.
@@ -162,7 +163,8 @@ def _track_chart(d, lat0, lon0, alt0) -> Optional[dict[str, Any]]:
     t["line"] = {"width": 1, "color": "#bbbbbb"}
     t["hovertemplate"] = "%{x:.0f} m E, %{y:.0f} m N<br>%{marker.color:.0f} m up<extra></extra>"
     spec = chart("chart-lora-track", "Ground track, as received", [t],
-                 x_title="East of the pad (m)", y_title="Distance north", y_unit="m",
+                 x_title="East of the pad", x_unit="m",
+                 y_title="Distance north", y_unit="m",
                  height=460, equal_aspect=True)
     if not spec:
         return None
@@ -186,7 +188,7 @@ def _track_chart(d, lat0, lon0, alt0) -> Optional[dict[str, Any]]:
     spec["layout"]["showlegend"] = False
     dist = float(math.hypot(east[-1], north[-1]))
     spec["note"] = (
-        f"The flight only, coloured by height above the pad. Built from packets "
+        f"The flight only, colored by height above the pad. Built from packets "
         f"that arrived, so a long straight run between two points is a stretch "
         f"where the link dropped rather than a straight piece of flying. The last "
         f"fix received is {dist:,.0f} m from the pad — that is where the search "
@@ -233,7 +235,7 @@ def _rssi_chart(d, lat0, lon0, alt0) -> tuple[Optional[dict[str, Any]], dict[str
             traces.append(t)
 
     spec = chart("chart-lora-rssi", "Signal strength against distance", traces,
-                 x_title="Slant range from the pad (m)",
+                 x_title="Slant range from the pad", x_unit="m",
                  y_title="Received strength", y_unit="dBm", height=380)
     if not spec:
         return None, facts
@@ -274,7 +276,7 @@ def analyze(flight: Flight) -> AnalysisResult:
         result.charts.append(rssi_spec)
         if facts.get("n"):
             result.metrics["Packets in flight"] = f"{facts['n']:,}"
-            result.metrics["Longest range"] = f"{facts['max_range']:,.0f} m"
+            result.metrics["Longest range"] = q(facts["max_range"], "m", 0)
             if facts["low"]:
                 result.metrics["Below 10° elevation"] = (
                     f"{facts['low']} packets ({100.0 * facts['low'] / facts['n']:.0f}%)"

--- a/Data_Analysis/flight_report/modules/parser_stats.py
+++ b/Data_Analysis/flight_report/modules/parser_stats.py
@@ -39,8 +39,12 @@ def analyze(flight: Flight) -> AnalysisResult:
     if total is not None:
         bits.append(f"{total:,} frames")
     if bad is not None and total:
+        # Say it one way or the other. Rounding 99.998% to "100.00%" and then
+        # appending "(3 did not)" reads as a contradiction; below the rounding
+        # threshold the count is the honest form.
         pct = 100.0 * (good or 0) / total
-        bits.append(f"{pct:.2f}% passed CRC" + (f" ({bad:,} did not)" if bad else ""))
+        bits.append(f"{bad:,} of {total:,} frames failed CRC" if bad
+                    else f"all {total:,} frames passed CRC")
     result.text = " · ".join(bits)
 
     # A handful of bad frames is ordinary on a full flash and not worth a warning

--- a/Data_Analysis/flight_report/modules/roll.py
+++ b/Data_Analysis/flight_report/modules/roll.py
@@ -462,7 +462,7 @@ def _stack_note(s: dict, facts: dict) -> str:
     lim_v = facts.get("fin_limit")
     if cap_v and lim_v:
         parts.append(f"Dotted lines mark the controller's ±{cap_v:g}°/s rate cap and the "
-                     f"±{lim_v:g}° fin travel limit.")
+                     f"±{lim_v:g}° commanded fin limit.")
     elif cap_v:
         parts.append(f"The dotted lines mark the controller's ±{cap_v:g}°/s rate cap.")
     clipped = facts.get("rate_clipped")

--- a/Data_Analysis/flight_report/registry.py
+++ b/Data_Analysis/flight_report/registry.py
@@ -84,7 +84,11 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         # Directly under the 3D path: that view answers "where did it go", and
         # this answers "show me anything else", before the curated sections
         # start answering questions somebody else chose.
-        ("explore",           explore.analyze,           LEVEL_FLIGHT),
+        ("explore_time",      explore.analyze_time,      LEVEL_FLIGHT),
+        # Against another channel rather than the clock. A separate section, not
+        # a mode toggle: it needs an X picker and is confined to one stream, and
+        # putting that behind a radio made the common case carry it too.
+        ("explore_xy",        explore.analyze_xy,        LEVEL_FLIGHT),
         ("overview",          overview.analyze,          LEVEL_FLIGHT),
         # Directly below the kinematic charts: roll is the one axis those three
         # say nothing about, and on a roll-control flight it is the whole story.

--- a/Data_Analysis/flight_report/registry.py
+++ b/Data_Analysis/flight_report/registry.py
@@ -35,13 +35,16 @@ class AnalysisResult:
 
 AnalyzeFn = Callable[["Flight"], AnalysisResult]
 
-# Report levels. FLIGHT answers "how did my rocket fly?" and is what a flyer
-# reads; DETAILED is board bring-up and firmware validation. A module belongs
-# to exactly one — anything a flyer needs from an detailed-level module should be
-# rolled up into a FLIGHT-level module rather than shown twice.
+# One report. There used to be a second, "detailed" level for board bring-up and
+# firmware validation, and the two drifted: the same word meant different
+# instants in each, and a number a flyer read on one contradicted the other. The
+# sections worth keeping were folded into this one and the split was removed.
+#
+# The level is still carried because the renderer and the CLI name it, and
+# because a second document may come back for a different audience — but nothing
+# should read it as "which of two reports is this".
 LEVEL_FLIGHT = "flight"
-LEVEL_DETAILED = "detailed"
-LEVELS = (LEVEL_FLIGHT, LEVEL_DETAILED)
+LEVELS = (LEVEL_FLIGHT,)
 
 
 def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
@@ -112,24 +115,11 @@ def _build_module_list() -> list[tuple[str, AnalyzeFn, str]]:
         ("parser_stats",      parser_stats.analyze,      LEVEL_FLIGHT),
         ("timing",            timing.analyze,            LEVEL_FLIGHT),
         ("settings",          settings.analyze,          LEVEL_FLIGHT),
-        ("sensor_charts",     overview.analyze_sensors,  LEVEL_DETAILED),
-        ("kinematics",        kinematics.analyze,        LEVEL_DETAILED),
-        ("gaps",              gaps.analyze,              LEVEL_DETAILED),
-        ("timestamps",        timestamps.analyze,        LEVEL_DETAILED),
-        ("launch_detection",  launch_detection.analyze,  LEVEL_DETAILED),
         # Deployment & recovery — descent profile, the flat ground-track map and
         # the KML links. Detailed-level by decision: the flat map is the one that
         # still draws with no network (it degrades to graph paper with the track
         # on it), so it lives with the rest of the diagnostic set rather than
         # duplicating the globe in the flight report.
-        ("pyro_apogee",       pyro_apogee.analyze,       LEVEL_DETAILED),
-        ("sensor_noise",      sensor_noise.analyze,      LEVEL_DETAILED),
-        ("gnss_staleness",    gnss_staleness.analyze,    LEVEL_DETAILED),
-        ("kinematic_checks",  kinematic_checks.analyze,  LEVEL_DETAILED),
-        ("roll_pid",          roll_pid.analyze,          LEVEL_DETAILED),
-        ("guidance",          guidance.analyze,          LEVEL_DETAILED),
-        ("lora",              lora.analyze,              LEVEL_DETAILED),
-        ("log_buffer",        log_buffer.analyze,        LEVEL_DETAILED),
     ]
 
 

--- a/Data_Analysis/flight_report/render.py
+++ b/Data_Analysis/flight_report/render.py
@@ -166,17 +166,13 @@ def render_report(
     flight: "Flight",
     results: list["AnalysisResult"],
     level: str | None = None,
-    counterpart: str | None = None,
 ) -> str:
     """Render one report as an HTML string.
 
-    `level` is `registry.LEVEL_FLIGHT` or `LEVEL_DETAILED` and only labels the
+    `level` is `registry.LEVEL_FLIGHT` and only labels the
     output — pass the results you want in it. None renders an untitled report
     containing everything given.
 
-    `counterpart` is the *filename* of the other level's report, used to link the
-    two. Pass it only when that file is actually being written alongside this
-    one, or the link will 404.
     """
     from .cesium_bundle import cesium_css, cesium_source
     from .registry import LEVEL_FLIGHT
@@ -235,11 +231,9 @@ def render_report(
         config=flight.config,
         sections=sections,
         level=level,
-        counterpart=counterpart,
         # The flight report leads with the headline numbers; the detailed
         # report leads with parser/settings detail and doesn't repeat them.
         summary=compute_summary(flight) if is_flight else [],
-        show_raw_detail=not is_flight,
         has_charts=has_charts,
         plotly_js=Markup(_plotly_source()) if has_charts else "",
         has_datasets=has_datasets,
@@ -262,10 +256,9 @@ def write_report(
     results: list["AnalysisResult"],
     out_path: Path,
     level: str | None = None,
-    counterpart: str | None = None,
 ) -> Path:
     """Render and write to disk. Returns the written path."""
-    html = render_report(flight, results, level=level, counterpart=counterpart)
+    html = render_report(flight, results, level=level)
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(html, encoding="utf-8")

--- a/Data_Analysis/flight_report/render.py
+++ b/Data_Analysis/flight_report/render.py
@@ -67,6 +67,22 @@ def _chart_payload(chart: dict) -> tuple[Markup, bool]:
     return Markup(packed), True
 
 
+def _dataset_entry(d: dict) -> dict:
+    """Panel descriptor for the template: payload for an owner, id for a ref.
+
+    The X-Y panel points at the payload the time panel already embedded. It is
+    ~3.9 MB gzipped on a real flight, and shipping it twice would double the
+    document to save one dictionary lookup in the browser.
+    """
+    entry = {"id": d["id"], "panel": d.get("panel", "time"), "ref": bool(d.get("ref"))}
+    if entry["ref"]:
+        return entry
+    payload, gz = _chart_payload({k: v for k, v in d.items() if k != "panel"})
+    entry["payload"] = payload
+    entry["gzipped"] = gz
+    return entry
+
+
 def _flatten_settings(node, prefix: str = "") -> list[tuple[str, str]]:
     """Nested settings dict -> flat (dotted key, display value) pairs, sorted.
 
@@ -191,11 +207,7 @@ def render_report(
                 for g in r.globes
                 for payload, gz in [_chart_payload(g)]
             ],
-            "datasets": [
-                {"id": d["id"], "payload": payload, "gzipped": gz}
-                for d in r.datasets
-                for payload, gz in [_chart_payload(d)]
-            ],
+            "datasets": [_dataset_entry(d) for d in r.datasets],
             "warnings": r.warnings,
             "text": r.text,
             "error": r.error,

--- a/Data_Analysis/flight_report/static/explore.js
+++ b/Data_Analysis/flight_report/static/explore.js
@@ -102,19 +102,26 @@
   function unitsFor(data, keys, opts) {
     opts = opts || {};
     var convertible = opts.convertible || [];
-    var seen = {};
+    var seen = {}, convs = {};
     keys.forEach(function (key) {
       var ch = data.channels[key];
       if (!ch) return;
-      seen[ch.unit || NO_UNIT] = true;
+      var u = ch.unit || NO_UNIT;
+      seen[u] = true;
+      convs[u] = ch.conv || "";
     });
     var names = Object.keys(seen).sort();
     var single = names.length === 1 ? names[0] : null;
+    // A channel may display one unit and convert by another row — a vertical
+    // rate is "m/s" but belongs in ft/s. Claim the axis only if the row the
+    // toggle would actually use is one it knows.
+    var convKey = single ? (convs[single] || single) : null;
     var yUnit = (!opts.normalised && single && single !== NO_UNIT
-                 && convertible.indexOf(single) >= 0) ? single : null;
+                 && convertible.indexOf(convKey) >= 0) ? single : null;
     return {
       names: names,
       yUnit: yUnit,
+      yConv: yUnit ? (convs[single] || "") : "",
       // "Value", never the unit name: the caller appends the unit itself, so
       // using it as the base reads "m (m)".
       yBase: opts.normalised ? "Normalised (0–1)" : "Value",
@@ -167,16 +174,229 @@
     return {
       traces: traces, full: full, skipped: skipped,
       notes: notes, cautions: cautions,
-      yUnit: units.yUnit, yBase: units.yBase, unitNames: units.names
+      yUnit: units.yUnit, yConv: units.yConv,
+      yBase: units.yBase, unitNames: units.names
     };
+  }
+
+  /* ---- channel vs channel ------------------------------------------------
+
+     A second mode, deliberately narrower than the time-series one.
+
+     Same stream only. Pairing two channels means answering "what was Y when X
+     was this?", and across streams there is no answer without inventing one:
+     GNSS logs at 18 Hz and the IMU at 963, so a pair would have to come from
+     interpolating one onto the other's clock. The report is tested not to do
+     that (test_globe_tracks_are_independently_sampled — resampling "would
+     invent samples and smooth away precisely the disagreement this section
+     exists to show"). Within a stream every channel shares one timestamp
+     array, so index i of X and index i of Y are the same instant, exactly.
+
+     Nothing here goes through the viewport renderer. `lowerBound` binary-
+     searches assuming x increases, and an X–Y plot's x does not — altitude
+     rises and falls, so a zoom would return an arbitrary slice and draw it
+     without complaint. `envelope` is worse: it keeps each bucket's min and max
+     y, which flattens the up-leg/down-leg split that is usually the whole
+     reason to plot one channel against another. */
+
+  /* A channel as a full-length array, one entry per frame of its stream —
+     the const and runs encodings put back the way they were stored. Needed
+     because pairing is by index and the compact forms have no index to pair. */
+  function expand(data, key) {
+    var ch = data.channels[key];
+    if (!ch) return null;
+    var stream = data.streams[ch.stream];
+    if (!stream) return null;
+    var n = stream.n, out, i;
+
+    if (ch.const !== undefined) {
+      out = new Array(n);
+      for (i = 0; i < n; i++) out[i] = ch.const;
+      return out;
+    }
+    if (ch.runs) {
+      out = new Array(n);
+      for (var r = 0; r < ch.runs.length; r++) {
+        var from = ch.runs[r][0];
+        var to = (r + 1 < ch.runs.length) ? ch.runs[r + 1][0] : n;
+        for (i = from; i < to; i++) out[i] = ch.runs[r][1];
+      }
+      return out;
+    }
+    return ch.y;
+  }
+
+  /* Uniform stride to a point budget.
+
+     Stride, not the min/max envelope used on the time axis: an envelope is
+     defined against a single ordered axis and there is no such ordering here.
+     Zooming re-filters from the full arrays, so detail stays reachable, and
+     the caller states how many of how many points are on screen rather than
+     letting a thinned cloud pass for the whole set. */
+  function stride(xs, ys, budget) {
+    var n = xs.length;
+    if (n <= budget) return {x: xs, y: ys, shown: n, total: n};
+    var step = n / budget, ox = [], oy = [];
+    for (var b = 0; b < budget; b++) {
+      var i = Math.floor(b * step);
+      ox.push(xs[i]); oy.push(ys[i]);
+    }
+    return {x: ox, y: oy, shown: ox.length, total: n};
+  }
+
+  /* Index-aligned (x, y) for two channels of one stream, dropping any index
+     where either side has no value. Also returns the frame time of each kept
+     point, so the caller can colour by time. */
+  function pairFor(data, xKey, yKey) {
+    var xs = expand(data, xKey), ys = expand(data, yKey);
+    if (!xs || !ys) return null;
+    var t = data.streams[data.channels[xKey].stream].t;
+    var ox = [], oy = [], ot = [];
+    var n = Math.min(xs.length, ys.length);
+    for (var i = 0; i < n; i++) {
+      if (xs[i] === null || ys[i] === null) continue;
+      ox.push(xs[i]); oy.push(ys[i]); ot.push(t[i]);
+    }
+    return ox.length ? {x: ox, y: oy, t: ot} : null;
+  }
+
+  var SCATTER_BUDGET = 6000;
+
+  /* Traces for an X–Y plot, or `error` explaining why there are none. */
+  function buildScatter(data, xKey, yKeys, opts) {
+    opts = opts || {};
+    var budget = opts.budget || SCATTER_BUDGET;
+    var xCh = data.channels[xKey];
+    if (!xCh) return {error: "Pick a channel for the X axis.", traces: []};
+    if (!yKeys.length) return {error: "Pick at least one channel for the Y axis.", traces: []};
+
+    var wrong = yKeys.filter(function (k) {
+      var c = data.channels[k];
+      return c && c.stream !== xCh.stream;
+    });
+    if (wrong.length) {
+      return {
+        error: "X–Y needs both channels from the same stream. " + xKey + " is " +
+               xCh.stream + "; " + wrong.join(", ") + " is not. Streams log at " +
+               "different rates, so pairing across them would mean interpolating " +
+               "one onto the other's clock and inventing samples that were never " +
+               "measured. Plot them against time instead to compare.",
+        traces: []
+      };
+    }
+
+    var traces = [], full = [], notes = [], cautions = [], skipped = [];
+    var thinned = false, shownTotal = 0, pointTotal = 0;
+
+    yKeys.forEach(function (yKey, i) {
+      var pair = pairFor(data, xKey, yKey);
+      if (!pair) { skipped.push(yKey); return; }
+      var red = stride(pair.x, pair.y, budget);
+      if (red.shown < red.total) thinned = true;
+      shownTotal += red.shown;
+      pointTotal += red.total;
+
+      var marker = {size: 3, color: COLORS[i % COLORS.length], opacity: 0.7};
+      if (opts.colorByTime && yKeys.length === 1) {
+        // Only for a single series: a colourbar per trace would be unreadable,
+        // and two colour-coded clouds cannot be told apart.
+        var tRed = stride(pair.t, pair.y, budget);
+        marker = {
+          size: 3, opacity: 0.85, color: tRed.x, colorscale: "Viridis",
+          showscale: true, colorbar: {title: {text: "t (s)"}, thickness: 12}
+        };
+      }
+      full.push({x: pair.x, y: pair.y, t: pair.t});
+      traces.push({
+        type: "scatter", mode: "markers", name: yKey,
+        x: red.x, y: red.y, marker: marker,
+        hovertemplate: xKey + ": %{x:.4g}<br>" + yKey + ": %{y:.4g}<extra></extra>"
+      });
+      var yCh = data.channels[yKey];
+      if (yCh && yCh.caution) cautions.push(yKey + " — " + yCh.caution);
+    });
+
+    if (!traces.length) {
+      return {error: "Nothing to draw: " + (skipped.join(", ") || xKey) +
+                     " never carried a value.", traces: []};
+    }
+    if (xCh.caution) cautions.unshift(xKey + " — " + xCh.caution);
+
+    notes.push("Each point is one frame of " + xCh.stream + ": X and Y are the " +
+               "same sample, not interpolated.");
+    if (thinned) {
+      notes.push("Showing " + shownTotal.toLocaleString() + " of " +
+                 pointTotal.toLocaleString() + " points, evenly spaced. Zoom to " +
+                 "redraw from the full data.");
+    }
+    if (skipped.length) {
+      notes.push("Skipped (never carried a value): " + skipped.join(", ") + ".");
+    }
+
+    var kept = yKeys.filter(function (k) { return skipped.indexOf(k) < 0; });
+    var yUnits = {}, yConvs = {};
+    kept.forEach(function (k) {
+      var c = data.channels[k];
+      if (!c) return;
+      var u = c.unit || NO_UNIT;
+      yUnits[u] = true;
+      yConvs[u] = c.conv || "";
+    });
+    var yNames = Object.keys(yUnits);
+    var ySingle = yNames.length === 1 && yNames[0] !== NO_UNIT ? yNames[0] : null;
+
+    return {
+      traces: traces, full: full, notes: notes, cautions: cautions,
+      skipped: skipped, error: null,
+      xUnit: xCh.unit || null, xConv: xCh.conv || "", xBase: xKey,
+      yUnit: ySingle, yConv: ySingle ? (yConvs[ySingle] || "") : "",
+      yBase: yKeys.length === 1 ? yKeys[0] : "Value"
+    };
+  }
+
+  /* Points inside the visible box, then strided — the zoom path for X–Y.
+
+     Carries the frame time through the same filter and the same stride as the
+     coordinates. It has to: when a series is coloured by time, `marker.color`
+     is a per-point array, and re-slicing x and y without re-slicing it zips a
+     stale colour list against new coordinates. That does not fail loudly — it
+     draws the wrong colours, which is worse than drawing none. */
+  function scatterView(series, xRange, yRange, budget) {
+    budget = budget || SCATTER_BUDGET;
+    var xs = [], ys = [], ts = [];
+    var haveT = !!series.t;
+    for (var i = 0; i < series.x.length; i++) {
+      var x = series.x[i], y = series.y[i];
+      if (xRange && (x < xRange[0] || x > xRange[1])) continue;
+      if (yRange && (y < yRange[0] || y > yRange[1])) continue;
+      xs.push(x); ys.push(y);
+      if (haveT) ts.push(series.t[i]);
+    }
+    var n = xs.length;
+    if (n <= budget) {
+      return {x: xs, y: ys, t: haveT ? ts : null, shown: n, total: n};
+    }
+    var step = n / budget, ox = [], oy = [], ot = [];
+    for (var b = 0; b < budget; b++) {
+      var j = Math.floor(b * step);
+      ox.push(xs[j]); oy.push(ys[j]);
+      if (haveT) ot.push(ts[j]);
+    }
+    return {x: ox, y: oy, t: haveT ? ot : null, shown: ox.length, total: n};
   }
 
   root.TRExplore = {
     COLORS: COLORS,
     NO_UNIT: NO_UNIT,
+    SCATTER_BUDGET: SCATTER_BUDGET,
     seriesFor: seriesFor,
     normalise: normalise,
     unitsFor: unitsFor,
-    build: build
+    build: build,
+    expand: expand,
+    stride: stride,
+    pairFor: pairFor,
+    buildScatter: buildScatter,
+    scatterView: scatterView
   };
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/Data_Analysis/flight_report/templates/report.html.j2
+++ b/Data_Analysis/flight_report/templates/report.html.j2
@@ -116,6 +116,14 @@ details.explore > summary:hover { background: #f2f4f7; }
 .explore-actions label { display: block; margin-top: 10px; font-weight: 400; }
 .explore-hint { color: #666; font-size: 12px; line-height: 1.45; margin: 10px 0 0; }
 .explore-status { color: #666; font-size: 13px; padding: 6px 0; }
+.explore-mode { border: 0; padding: 0; margin: 0 0 10px; }
+.explore-mode legend { padding: 0; font-weight: 600; font-size: 13px; }
+.explore-mode label { display: inline-block; margin: 4px 14px 0 0; font-weight: 400; }
+.explore-xaxis { display: block; margin-bottom: 10px; font-weight: 600; font-size: 13px; }
+.explore-xaxis select { display: block; margin-top: 4px; min-width: 300px;
+                        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                        font-size: 12px; }
+.explore-error { color: #a33; font-size: 13px; line-height: 1.5; margin: 10px 0 0; }
 .explore-plot { margin-top: 12px; }
 .explore-notes { font-size: 12px; color: #555; line-height: 1.5; }
 .explore-notes .warn { color: #a33; }
@@ -305,30 +313,49 @@ details.explore > summary:hover { background: #f2f4f7; }
 {% endif %}
 
 {% for d in s.datasets %}
-<details class="explore" id="explore-panel" open>
-  <summary>Plot any channel &mdash; pick one or more, then Draw</summary>
+<details class="explore" id="explore-panel-{{ d.panel }}"{% if d.panel == "time" %} open{% endif %} data-panel="{{ d.panel }}" data-source="{{ d.id }}">
+  <summary>
+    {% if d.panel == "xy" %}Pick an X and a Y channel, then Draw
+    {% else %}Pick one or more channels, then Draw{% endif %}
+  </summary>
   <div class="explore-body">
     <div class="explore-status" role="status">Loading channel data&hellip;</div>
     <div class="explore-controls" hidden>
       <label class="explore-pick">
-        Channels
+        {% if d.panel == "xy" %}Y axis{% else %}Channels{% endif %}
         <select multiple size="14"></select>
       </label>
       <div class="explore-actions">
+        {% if d.panel == "xy" %}
+        <label class="explore-xaxis">
+          X axis
+          <select></select>
+        </label>
+        {% endif %}
         <button type="button" class="explore-draw">Draw</button>
+        {% if d.panel == "xy" %}
+        <label class="explore-colort"><input type="checkbox"> Colour by time</label>
+        <p class="explore-hint">
+          Both axes must come from the same stream, so each point is one logged
+          frame rather than an interpolated pair. Zoom redraws from the full data.
+        </p>
+        {% else %}
         <label><input type="checkbox" class="explore-norm"> Normalise each series to 0&ndash;1</label>
         <p class="explore-hint">
           Ctrl/&#8984;-click for several. Each series is drawn on its own stream's
           timestamps &mdash; nothing is resampled onto a shared clock, so two sensors
           disagreeing stays visible rather than being interpolated away.
         </p>
+        {% endif %}
       </div>
     </div>
     <div class="explore-plot"></div>
     <div class="explore-notes"></div>
   </div>
 </details>
-<script type="application/json" class="dataset-spec" data-target="explore-panel"{% if d.gzipped %} data-encoding="gzip+base64"{% endif %}>{{ d.payload }}</script>
+{% if not d.ref %}
+<script type="application/json" class="dataset-spec" data-target="{{ d.id }}"{% if d.gzipped %} data-encoding="gzip+base64"{% endif %}>{{ d.payload }}</script>
+{% endif %}
 {% endfor %}
 
 {% for fig in s.figures %}
@@ -971,6 +998,18 @@ details.explore > summary:hover { background: #f2f4f7; }
         continue;
       }
 
+      /* An X–Y panel plot. It cannot go through draw(): that reduces via
+         lowerBound, which assumes the x array increases, and here x is a
+         channel. Its own redraw filters on both axes and rescales as it goes. */
+      if (c.is2d) {
+        c.redraw(c);
+        var upd2 = {};
+        if (c.spec.xUnit) upd2["xaxis.title.text"] = axisTitle(c.spec.xTitleBase, c.spec.xUnit, c.spec.xConv);
+        if (c.spec.yUnit) upd2["yaxis.title.text"] = axisTitle(c.spec.yTitleBase, c.spec.yUnit, c.spec.yConv);
+        if (Object.keys(upd2).length) Plotly.relayout(c.gd, upd2);
+        continue;
+      }
+
       draw(c.gd, c.full, c.range, c.spec);
       var upd = {};
       if (c.spec.yUnit) upd["yaxis.title.text"] = axisTitle(c.spec.yTitleBase, c.spec.yUnit);
@@ -1015,16 +1054,35 @@ details.explore > summary:hover { background: #f2f4f7; }
      The data is inflated on first open, not at load. It is the largest payload
      in the document and a reader who never opens the panel should not pay to
      parse it. */
-  var dsets = document.querySelectorAll("script.dataset-spec");
-  for (var di = 0; di < dsets.length; di++) {
-    (function (el) {
-      var panel = document.getElementById(el.dataset.target);
-      if (!panel) return;
+  /* Two Explore panels — one against time, one channel against channel —
+     sharing a single embedded payload. `data-source` names the <script> that
+     carries it; whichever panel is opened first inflates it and the other
+     awaits the same promise, so the ~4 MB is parsed once at most and not at
+     all if neither is opened. */
+  var datasetLoads = {};
+  function loadDataset(id) {
+    if (datasetLoads[id]) return datasetLoads[id];
+    var el = document.querySelector('script.dataset-spec[data-target="' + id + '"]');
+    if (!el) {
+      datasetLoads[id] = Promise.reject(new Error("no embedded data for " + id));
+    } else {
+      datasetLoads[id] = readSpec(el);
+    }
+    return datasetLoads[id];
+  }
+
+  var panels = document.querySelectorAll("details.explore");
+  for (var pi = 0; pi < panels.length; pi++) {
+    (function (panel) {
+      var kind = panel.dataset.panel || "time";
       var statusEl = panel.querySelector(".explore-status");
       var controls = panel.querySelector(".explore-controls");
       var pick = panel.querySelector(".explore-pick select");
       var drawBtn = panel.querySelector(".explore-draw");
       var normBox = panel.querySelector(".explore-norm");
+      var xWrap = panel.querySelector(".explore-xaxis");
+      var xSel = xWrap ? xWrap.querySelector("select") : null;
+      var colorBox = panel.querySelector(".explore-colort input");
       var plotEl = panel.querySelector(".explore-plot");
       var notesEl = panel.querySelector(".explore-notes");
       var data = null, entry = null, loading = false;
@@ -1055,6 +1113,7 @@ details.explore > summary:hover { background: #f2f4f7; }
             group.appendChild(opt);
           });
           pick.appendChild(group);
+          if (xSel) xSel.appendChild(group.cloneNode(true));
         });
       }
 
@@ -1065,20 +1124,115 @@ details.explore > summary:hover { background: #f2f4f7; }
         notesEl.appendChild(p);
       }
 
-      function render() {
-        var keys = Array.prototype.slice.call(pick.selectedOptions).map(function (o) {
-          return o.value;
+      function unregister() {
+        if (!entry) return;
+        var at = charts.indexOf(entry);
+        if (at >= 0) charts.splice(at, 1);
+        entry = null;
+      }
+
+      /* X–Y redraw. Deliberately not the time-axis path: `viewFor` calls
+         `lowerBound`, which binary-searches assuming x increases — false the
+         moment x is a channel rather than a clock. It would return a wrong
+         slice silently. This filters on both axes instead, and carries the
+         colour array through the same filter. */
+      function drawScatter(e) {
+        var xf = e.spec.xUnit ? unitFactor(e.spec.xUnit) : 1;
+        var yf = e.spec.yUnit ? unitFactor(e.spec.yUnit) : 1;
+        var xs = [], ys = [], colors = [], anyColor = false;
+        for (var i = 0; i < e.full.length; i++) {
+          var v = TRExplore.scatterView(
+            e.full[i],
+            e.xrange ? [e.xrange[0] / xf, e.xrange[1] / xf] : null,
+            e.yrange ? [e.yrange[0] / yf, e.yrange[1] / yf] : null
+          );
+          xs.push(xf === 1 ? v.x : v.x.map(function (n) { return n * xf; }));
+          ys.push(yf === 1 ? v.y : v.y.map(function (n) { return n * yf; }));
+          if (e.colorByTime && v.t) { colors.push(v.t); anyColor = true; }
+          else { colors.push(undefined); }
+        }
+        var upd = {x: xs, y: ys};
+        if (anyColor) upd["marker.color"] = colors;
+        return Plotly.restyle(e.gd, upd);
+      }
+
+      function renderScatter(yKeys) {
+        var out = TRExplore.buildScatter(data, xSel.value, yKeys, {
+          colorByTime: colorBox && colorBox.checked
         });
-        notesEl.innerHTML = "";
-        if (!keys.length) {
-          notesEl.textContent = "Select one or more channels, then press Draw.";
+        if (out.error) {
+          // Clear the previous plot as well as showing the message. Leaving the
+          // last chart up next to an error reads as though it were the answer to
+          // the selection that just failed.
+          unregister();
+          Plotly.purge(plotEl);
+          note(out.error, "explore-error");
           return;
         }
 
+        var spec = {
+          xUnit: out.xUnit, xConv: out.xConv,
+          yUnit: out.yUnit, yConv: out.yConv,
+          xTitleBase: out.xBase, yTitleBase: out.yBase,
+          layout: {yaxis: {}, xaxis: {}}
+        };
+        var layout = {
+          height: 520,
+          margin: {l: 70, r: 20, t: 30, b: 55},
+          xaxis: {title: {text: axisTitle(out.xBase, out.xUnit, out.xConv)},
+                  gridcolor: "#eee", zeroline: false},
+          yaxis: {title: {text: axisTitle(out.yBase, out.yUnit, out.yConv)},
+                  gridcolor: "#eee", zeroline: false},
+          hovermode: "closest",
+          showlegend: out.traces.length > 1,
+          legend: {orientation: "h", y: -0.16, font: {size: 11}},
+          plot_bgcolor: "#fff", paper_bgcolor: "#fff"
+        };
+
+        unregister();
+        Plotly.newPlot(plotEl, out.traces, layout, config).then(function (gd) {
+          entry = {gd: gd, full: out.full, spec: spec, is2d: true,
+                   colorByTime: colorBox && colorBox.checked,
+                   xrange: null, yrange: null, redraw: drawScatter};
+          charts.push(entry);
+          var pending = null;
+          gd.on("plotly_relayout", function (ev) {
+            /* Two spellings, both real: a drag emits "xaxis.range[0]" and
+               "xaxis.range[1]", while a programmatic relayout emits
+               "xaxis.range" as one array. Handling only the first works when a
+               person zooms and silently does nothing otherwise. */
+            var touched = false;
+            if (ev["xaxis.range[0]"] !== undefined) {
+              entry.xrange = [ev["xaxis.range[0]"], ev["xaxis.range[1]"]]; touched = true;
+            } else if (ev["xaxis.range"]) {
+              entry.xrange = ev["xaxis.range"].slice(); touched = true;
+            }
+            if (ev["yaxis.range[0]"] !== undefined) {
+              entry.yrange = [ev["yaxis.range[0]"], ev["yaxis.range[1]"]]; touched = true;
+            } else if (ev["yaxis.range"]) {
+              entry.yrange = ev["yaxis.range"].slice(); touched = true;
+            }
+            if ("xaxis.autorange" in ev || "yaxis.autorange" in ev) {
+              entry.xrange = null; entry.yrange = null; touched = true;
+            }
+            if (!touched) return;
+            if (pending) clearTimeout(pending);
+            pending = setTimeout(function () {
+              pending = null;
+              drawScatter(entry);
+            }, 60);
+          });
+        });
+
+        out.notes.forEach(function (n) { note(n); });
+        out.cautions.forEach(function (c) { note("⚠ " + c, "warn"); });
+      }
+
+      function renderTime(keys) {
         /* What to draw is decided in static/explore.js, which is covered by
            tests/js/ — the DOM wiring stays here because it is not. */
         var out = TRExplore.build(data, keys, {
-          normalised: normBox.checked,
+          normalised: normBox && normBox.checked,
           convertible: Object.keys(CONV)
         });
 
@@ -1090,7 +1244,7 @@ details.explore > summary:hover { background: #f2f4f7; }
         }
 
         var spec = {
-          yUnit: out.yUnit, xUnit: null,
+          yUnit: out.yUnit, yConv: out.yConv, xUnit: null,
           yTitleBase: out.yBase, xTitleBase: "Time (s)",
           layout: {yaxis: {}, xaxis: {}}
         };
@@ -1098,7 +1252,7 @@ details.explore > summary:hover { background: #f2f4f7; }
           height: 460,
           margin: {l: 70, r: 20, t: 30, b: 50},
           xaxis: {title: {text: "Time (s)"}, gridcolor: "#eee", zeroline: false},
-          yaxis: {title: {text: axisTitle(out.yBase, out.yUnit)},
+          yaxis: {title: {text: axisTitle(out.yBase, out.yUnit, out.yConv)},
                   gridcolor: "#eee", zeroline: false},
           hovermode: "closest",
           showlegend: true,
@@ -1115,14 +1269,7 @@ details.explore > summary:hover { background: #f2f4f7; }
           return copy;
         });
 
-        // Unregister the previous panel plot, or the unit toggle keeps
-        // converting a chart that is no longer on screen.
-        if (entry) {
-          var at = charts.indexOf(entry);
-          if (at >= 0) charts.splice(at, 1);
-          entry = null;
-        }
-
+        unregister();
         Plotly.newPlot(plotEl, initial, layout, config).then(function (gd) {
           entry = {gd: gd, full: out.full, spec: spec, range: null};
           charts.push(entry);
@@ -1149,18 +1296,32 @@ details.explore > summary:hover { background: #f2f4f7; }
         out.cautions.forEach(function (c) { note("⚠ " + c, "warn"); });
       }
 
+      function render() {
+        var keys = Array.prototype.slice.call(pick.selectedOptions).map(function (o) {
+          return o.value;
+        });
+        notesEl.innerHTML = "";
+        if (!keys.length) {
+          notesEl.textContent = kind === "xy"
+            ? "Select one or more Y channels, then press Draw."
+            : "Select one or more channels, then press Draw.";
+          return;
+        }
+        if (kind === "xy") renderScatter(keys); else renderTime(keys);
+      }
+
       function load() {
         if (data || loading) return;
         loading = true;
-        readSpec(el).then(function (spec) {
+        loadDataset(panel.dataset.source).then(function (spec) {
           data = spec;
           populate();
           statusEl.hidden = true;
           controls.hidden = false;
-          /* Open on something rather than on an empty frame. The picker is only
-             obviously a picker once it has drawn a plot, and a reader who wanted
-             a different channel is one selection away either method. */
-          var want = data.default || [];
+          /* Open on something rather than on an empty frame. Only the time
+             panel does this: an X-Y plot has no obvious default pair, and
+             guessing one would assert a relationship nobody asked about. */
+          var want = (kind === "xy") ? [] : (data.default || []);
           var drew = false;
           for (var oi = 0; oi < pick.options.length; oi++) {
             if (want.indexOf(pick.options[oi].value) >= 0) {
@@ -1174,19 +1335,19 @@ details.explore > summary:hover { background: #f2f4f7; }
         });
       }
 
-      /* The payload is the largest thing in the document, so it is inflated when
-         the panel is first shown rather than at load. The panel ships open, so
-         that is usually immediately — but a reader who collapses it before the
-         idle callback runs, or opens a report with it closed, still pays only
-         when they ask. */
+      /* The payload is the largest thing in the document, so it is inflated on
+         first open rather than at load. The time panel ships open, so that is
+         usually immediately; the X-Y panel ships closed and costs nothing until
+         asked, and by then the time panel has already put the data in cache. */
       panel.addEventListener("toggle", function () { if (panel.open) load(); });
       if (panel.open) {
         if (window.requestIdleCallback) requestIdleCallback(load, {timeout: 2000});
         else setTimeout(load, 0);
       }
       drawBtn.addEventListener("click", render);
-    })(dsets[di]);
+    })(panels[pi]);
   }
+
 
 
   var specs = document.querySelectorAll("script.chart-spec");

--- a/Data_Analysis/flight_report/templates/report.html.j2
+++ b/Data_Analysis/flight_report/templates/report.html.j2
@@ -133,13 +133,7 @@ details.explore > summary:hover { background: #f2f4f7; }
 <body>
 
 <div class="topbar">
-  <div class="topbar-left">
-    {% if counterpart %}
-    <a class="pill" href="{{ counterpart }}">
-      {% if level == "detailed" %}&larr; Flight report{% else %}Detailed data &rarr;{% endif %}
-    </a>
-    {% endif %}
-  </div>
+  <div class="topbar-left"></div>
   <div class="units" role="group" aria-label="Units">
     <button type="button" data-units="metric" class="active">Metric</button><button
             type="button" data-units="imperial">Imperial</button>
@@ -148,12 +142,10 @@ details.explore > summary:hover { background: #f2f4f7; }
 
 <h1>{{ flight.rocket_name }}</h1>
 <div class="meta">
-  {% if show_raw_detail %}<code>{{ flight.bin_path }}</code><br>{% endif %}
   Flight: {{ date_str }}
   {#- Log duration is how long the recorder ran, usually minutes of pad time. It
       belongs with the detailed data review; the card's "Flight time" is the number
       a flyer means, and showing both side by side just reads as a contradiction. -#}
-  {% if show_raw_detail and duration_s %} &middot; Log duration: {{ "%.1f"|format(duration_s) }} s{% endif %}
   {% if level == "detailed" %} &middot; detailed data review{% endif %}
 </div>
 
@@ -175,70 +167,27 @@ details.explore > summary:hover { background: #f2f4f7; }
 </div>
 {% endif %}
 
-{% if show_raw_detail %}
-{# As recorded by the flight computer itself, from the .json sidecar — not the
-   flight report's recomputation from the log. Keeping both is the point of a
-   detailed review, but the labels have to say which is which: "Apogee" on the
-   summary card is an altitude, and these two are times. #}
-<div class="summary-grid">
-  {% if sidecar.get('apogee_time_s') is not none %}
-  <div class="cell">
-    <div class="label">Time to apogee</div>
-    <div class="value">{{ "%.2f"|format(sidecar['apogee_time_s']) }} s</div>
-  </div>
-  {% endif %}
-  {% if sidecar.get('burnout_time_s') is not none %}
-  <div class="cell">
-    <div class="label">Time to burnout</div>
-    <div class="value">{{ "%.2f"|format(sidecar['burnout_time_s']) }} s</div>
-  </div>
-  {% endif %}
-  {% if sidecar.get('max_altitude_m') is not none %}
-  <div class="cell">
-    <div class="label">Max Altitude</div>
-    <div class="value">{{ "%.1f"|format(sidecar['max_altitude_m']) }} m</div>
-  </div>
-  {% endif %}
-  {% if sidecar.get('max_speed_mps') is not none %}
-  <div class="cell">
-    <div class="label">Max Speed</div>
-    <div class="value">{{ "%.1f"|format(sidecar['max_speed_mps']) }} m/s</div>
-  </div>
-  {% endif %}
-  {% if stats.get('total_frames') is not none %}
-  <div class="cell">
-    <div class="label">Frames</div>
-    <div class="value">{{ "{:,}".format(stats['total_frames']) }}</div>
-  </div>
-  {% endif %}
-  {% if stats.get('total_frames') and stats['total_frames'] > 0 %}
-  <div class="cell">
-    <div class="label">CRC Pass</div>
-    <div class="value">{{ "%.1f"|format(100.0 * stats['good_crc'] / stats['total_frames']) }}%</div>
-  </div>
-  {% endif %}
-</div>
-{% endif %}
-
 <div class="toc">
   <strong>Sections</strong>
   <ul>
-    {% if show_raw_detail %}
-    <li><a href="#settings">Settings snapshot</a></li>
-    {% endif %}
     {% for s in sections %}
+    {% if s.error or s.warnings or s.metrics or s.charts or s.figures or s.maps
+          or s.globes or s.datasets or s.text %}
     <li><a href="#{{ s.name }}">{{ s.title }}</a>
         {%- if s.warnings %} <span style="color:#f9a825">({{ s.warnings|length }} warning{{ "s" if s.warnings|length != 1 else "" }})</span>{% endif %}
         {%- if s.error %} <span style="color:#c62828">(error)</span>{% endif %}
     </li>
-    {% endfor %}
-    {% if show_raw_detail %}
-    <li><a href="#parser">Parser stats</a></li>
     {% endif %}
+    {% endfor %}
   </ul>
 </div>
 
 {% for s in sections %}
+{# A module with nothing to say prints nothing. Radio Link on a flight flown
+   without a ground station is the common case: it is not a fault and not a
+   warning, so it should leave no trace rather than a bare heading. #}
+{% if s.error or s.warnings or s.metrics or s.charts or s.figures or s.maps
+      or s.globes or s.datasets or s.text %}
 <h2 id="{{ s.name }}">{{ s.title }}</h2>
 
 {% if s.error %}
@@ -334,13 +283,13 @@ details.explore > summary:hover { background: #f2f4f7; }
         {% endif %}
         <button type="button" class="explore-draw">Draw</button>
         {% if d.panel == "xy" %}
-        <label class="explore-colort"><input type="checkbox"> Colour by time</label>
+        <label class="explore-colort"><input type="checkbox"> Color by time</label>
         <p class="explore-hint">
           Both axes must come from the same stream, so each point is one logged
           frame rather than an interpolated pair. Zoom redraws from the full data.
         </p>
         {% else %}
-        <label><input type="checkbox" class="explore-norm"> Normalise each series to 0&ndash;1</label>
+        <label><input type="checkbox" class="explore-norm"> Normalize each series to 0&ndash;1</label>
         <p class="explore-hint">
           Ctrl/&#8984;-click for several. Each series is drawn on its own stream's
           timestamps &mdash; nothing is resampled onto a shared clock, so two sensors
@@ -362,6 +311,7 @@ details.explore > summary:hover { background: #f2f4f7; }
 <div class="figure"><img src="{{ fig }}" /></div>
 {% endfor %}
 
+{% endif %}
 {% endif %}
 {% endfor %}
 
@@ -812,7 +762,7 @@ details.explore > summary:hover { background: #f2f4f7; }
 <script>{{ explore_js }}</script>
 {% endif %}
 
-{% if has_charts %}
+{% if has_charts or has_datasets %}
 <script>{{ plotly_js }}</script>
 <script>
 (function () {
@@ -959,17 +909,25 @@ details.explore > summary:hover { background: #f2f4f7; }
     }
   }
 
-  function unitFactor(unit) {
-    var c = imperial ? CONV[unit] : null;
+  /* `conv` names a different imperial target than the SI unit implies — a
+     vertical rate is metres per second but reads in ft/s, not mph. It takes
+     precedence when present, matching what convertSpans does for the metric
+     cells, so an axis and a table cell describing the same quantity agree. */
+  function pick(unit, conv) {
+    if (!imperial) return null;
+    return CONV[conv] || CONV[unit] || null;
+  }
+  function unitFactor(unit, conv) {
+    var c = pick(unit, conv);
     return c ? c.f : 1;
   }
-  function unitLabel(unit) {
-    var c = imperial ? CONV[unit] : null;
+  function unitLabel(unit, conv) {
+    var c = pick(unit, conv);
     return c ? c.label : unit;
   }
-  function axisTitle(base, unit) {
+  function axisTitle(base, unit, conv) {
     if (!base) return "";
-    return unit ? base + " (" + unitLabel(unit) + ")" : base;
+    return unit ? base + " (" + unitLabel(unit, conv) + ")" : base;
   }
   /* The 3D scene carries its unit in the chart title rather than on the axes —
      see charts.trajectory_3d on why rotated axis titles clip there. */
@@ -1088,7 +1046,11 @@ details.explore > summary:hover { background: #f2f4f7; }
       var data = null, entry = null, loading = false;
 
       function label(key, ch) {
-        var bits = [key];
+        /* ch.label is the human name from the channel catalog ("Vertical
+           velocity"); key is the internal dotted path. Show the name and keep
+           the path alongside it, because the path is what the notes and the
+           legend cite. */
+        var bits = [ch.label ? ch.label + "  [" + key + "]" : key];
         if (ch.unit) bits.push("(" + ch.unit + ")");
         if (ch.const !== undefined) bits.push("— constant");
         else if (!ch.shown.length) bits.push("— not plotted elsewhere");
@@ -1137,8 +1099,8 @@ details.explore > summary:hover { background: #f2f4f7; }
          slice silently. This filters on both axes instead, and carries the
          colour array through the same filter. */
       function drawScatter(e) {
-        var xf = e.spec.xUnit ? unitFactor(e.spec.xUnit) : 1;
-        var yf = e.spec.yUnit ? unitFactor(e.spec.yUnit) : 1;
+        var xf = e.spec.xUnit ? unitFactor(e.spec.xUnit, e.spec.xConv) : 1;
+        var yf = e.spec.yUnit ? unitFactor(e.spec.yUnit, e.spec.yConv) : 1;
         var xs = [], ys = [], colors = [], anyColor = false;
         for (var i = 0; i < e.full.length; i++) {
           var v = TRExplore.scatterView(

--- a/tests/js/explore.test.mjs
+++ b/tests/js/explore.test.mjs
@@ -63,6 +63,12 @@ function dataset() {
                      caution: "", shown: [], const: null },
       "IMU.alt": { stream: "IMU", label: "Altitude", unit: "m", kind: "float",
                    caution: "", shown: [], y: [10, 20, 30, 40, 50] },
+      // Displays as m/s, converts as ft/s — the vertical-rate idiom.
+      "IMU.u_vel": { stream: "IMU", label: "Climb rate", unit: "m/s",
+                     conv: "m/s:fps", kind: "float", caution: "", shown: [],
+                     y: [0, 5, 10, 5, 0] },
+      "IMU.speed": { stream: "IMU", label: "Speed", unit: "m/s", conv: "",
+                     kind: "float", caution: "", shown: [], y: [1, 2, 3, 4, 5] },
     },
   };
 }
@@ -213,4 +219,189 @@ test("colours cycle rather than running out", () => {
   for (const tr of out.traces) {
     assert.match(tr.line.color, /^#[0-9a-f]{6}$/i);
   }
+});
+
+/* ---- channel vs channel (X–Y) ------------------------------------------ */
+
+test("expand puts the compact encodings back to full length", () => {
+  const E = load();
+  const data = dataset();
+  // const -> one entry per frame of its stream
+  assert.deepEqual(E.expand(data, "NAV.armed"), [0, 0, 0]);
+  // runs -> value held until the next run starts
+  assert.deepEqual(E.expand(data, "NAV.health"), [1, 3, 3]);
+  // plain y passes through
+  assert.deepEqual(E.expand(data, "IMU.gyro_x"), [1, 2, 3, 4, 5]);
+});
+
+test("pairing is by index, so X and Y are the same instant", () => {
+  const E = load();
+  const p = E.pairFor(dataset(), "IMU.gyro_x", "IMU.alt");
+  assert.deepEqual(p.x, [1, 2, 3, 4, 5]);
+  assert.deepEqual(p.y, [10, 20, 30, 40, 50]);
+  assert.deepEqual(p.t, [0, 0.1, 0.2, 0.3, 0.4]);
+});
+
+test("pairing drops an index where either side has no value", () => {
+  const E = load();
+  const data = dataset();
+  data.channels["IMU.holey"] = {
+    stream: "IMU", label: "Holey", unit: "", kind: "float", caution: "", shown: [],
+    y: [1, null, 3, null, 5],
+  };
+  const p = E.pairFor(data, "IMU.holey", "IMU.alt");
+  assert.deepEqual(p.x, [1, 3, 5]);
+  assert.deepEqual(p.y, [10, 30, 50], "y must drop the same indices as x");
+});
+
+test("X–Y refuses to pair across streams rather than interpolating", () => {
+  // The report is tested not to resample one sensor onto another's clock
+  // (test_globe_tracks_are_independently_sampled). GNSS at 18 Hz against the
+  // IMU at 963 has no honest pairing, so this must refuse and explain.
+  const E = load();
+  const out = E.buildScatter(dataset(), "IMU.gyro_x", ["NAV.health"], {});
+  assert.equal(out.traces.length, 0);
+  assert.match(out.error, /same stream/i);
+  assert.match(out.error, /interpolat/i);
+});
+
+test("X–Y accepts channels that share a stream", () => {
+  const E = load();
+  const out = E.buildScatter(dataset(), "IMU.gyro_x", ["IMU.alt"], {});
+  assert.equal(out.error, null);
+  assert.equal(out.traces.length, 1);
+  assert.equal(out.traces[0].mode, "markers");
+  assert.deepEqual(out.traces[0].x, [1, 2, 3, 4, 5]);
+  assert.equal(out.xUnit, "deg/s");
+  assert.equal(out.yUnit, "m");
+});
+
+test("X–Y says the points are real samples, not interpolated", () => {
+  const E = load();
+  const out = E.buildScatter(dataset(), "IMU.gyro_x", ["IMU.alt"], {});
+  assert.ok(out.notes.some((n) => /not interpolated/i.test(n)));
+});
+
+test("stride thins to a budget and reports how much it dropped", () => {
+  const E = load();
+  const xs = Array.from({ length: 1000 }, (_, i) => i);
+  const r = E.stride(xs, xs, 100);
+  assert.equal(r.shown, 100);
+  assert.equal(r.total, 1000);
+  assert.equal(r.x[0], 0);
+  // Under budget, nothing is touched.
+  const small = E.stride([1, 2, 3], [1, 2, 3], 100);
+  assert.deepEqual(small.x, [1, 2, 3]);
+  assert.equal(small.shown, small.total);
+});
+
+test("a thinned X–Y plot says so rather than passing for the whole set", () => {
+  const E = load();
+  const data = dataset();
+  const n = 5000;
+  data.streams.BIG = { t: Array.from({ length: n }, (_, i) => i * 0.01), n };
+  data.channels["BIG.a"] = { stream: "BIG", label: "A", unit: "m", kind: "float",
+                             caution: "", shown: [],
+                             y: Array.from({ length: n }, (_, i) => i) };
+  data.channels["BIG.b"] = { stream: "BIG", label: "B", unit: "m", kind: "float",
+                             caution: "", shown: [],
+                             y: Array.from({ length: n }, (_, i) => n - i) };
+  const out = E.buildScatter(data, "BIG.a", ["BIG.b"], { budget: 500 });
+  assert.ok(out.notes.some((n2) => /Showing .* of .* points/.test(n2)));
+  assert.equal(out.traces[0].x.length, 500);
+  // The full arrays are kept so zoom can redraw from real data.
+  assert.equal(out.full[0].x.length, n);
+});
+
+test("zooming an X–Y plot filters on both axes, not just x", () => {
+  // The reason X–Y cannot reuse the time-axis viewport code: lowerBound
+  // binary-searches assuming x increases, which is false here.
+  const E = load();
+  const series = { x: [0, 5, 10, 15, 20], y: [0, 50, 0, 50, 0], t: [0, 1, 2, 3, 4] };
+  const box = E.scatterView(series, [4, 16], [40, 60], 1000);
+  assert.deepEqual(box.x, [5, 15]);
+  assert.deepEqual(box.y, [50, 50]);
+});
+
+test("colour-by-time applies only to a single series", () => {
+  const E = load();
+  const one = E.buildScatter(dataset(), "IMU.gyro_x", ["IMU.alt"],
+                             { colorByTime: true });
+  assert.ok(Array.isArray(one.traces[0].marker.color), "expected a per-point colour array");
+  assert.equal(one.traces[0].marker.showscale, true);
+
+  const two = E.buildScatter(dataset(), "IMU.gyro_x", ["IMU.alt", "IMU.accel_x"],
+                             { colorByTime: true });
+  for (const tr of two.traces) {
+    assert.equal(typeof tr.marker.color, "string",
+                 "two colour-coded clouds cannot be told apart; use flat colours");
+  }
+});
+
+test("X–Y carries cautions for both axes", () => {
+  const E = load();
+  const out = E.buildScatter(dataset(), "IMU.gyro_x", ["IMU.alt"], {});
+  assert.ok(out.cautions.some((c) => c.startsWith("IMU.gyro_x — ")),
+            "the X channel's caution must travel too");
+});
+
+test("zoom re-slices the colour array with the points it belongs to", () => {
+  /* When a series is coloured by time, marker.color is a per-point array.
+     Filtering x and y on zoom without filtering it zips a stale colour list
+     against new coordinates — the plot then ships wrong colours rather than
+     failing, which is the harder kind of bug to notice. */
+  const E = load();
+  const series = { x: [0, 5, 10, 15, 20], y: [0, 50, 0, 50, 0], t: [0, 1, 2, 3, 4] };
+  const box = E.scatterView(series, [4, 16], [40, 60], 1000);
+  assert.deepEqual(box.x, [5, 15]);
+  assert.deepEqual(box.t, [1, 3], "time must survive the same filter as x and y");
+  assert.equal(box.t.length, box.x.length);
+
+  // And through the stride, not just the filter.
+  const n = 1000;
+  const big = {
+    x: Array.from({ length: n }, (_, i) => i),
+    y: Array.from({ length: n }, (_, i) => i),
+    t: Array.from({ length: n }, (_, i) => i / 100),
+  };
+  const thinned = E.scatterView(big, null, null, 50);
+  assert.equal(thinned.x.length, 50);
+  assert.equal(thinned.t.length, 50);
+  for (let i = 0; i < thinned.x.length; i++) {
+    assert.equal(thinned.t[i], thinned.x[i] / 100, "colour desynced from its point");
+  }
+});
+
+test("a series with no time still zooms", () => {
+  const E = load();
+  const box = E.scatterView({ x: [1, 2, 3], y: [1, 2, 3] }, [0, 10], null, 100);
+  assert.deepEqual(box.x, [1, 2, 3]);
+  assert.equal(box.t, null);
+});
+
+test("a vertical rate converts as ft/s, not mph", () => {
+  /* units.py keeps a separate "m/s:fps" row for exactly this and says quoting
+     a chute's sink rate in mph "reads as an error to anyone in the hobby". The
+     catalog records it per channel; the panel has to carry it through, or the
+     axis silently uses the airspeed idiom. */
+  const E = load();
+  const u = E.unitsFor(dataset(), ["IMU.u_vel"], { convertible: CONVERTIBLE });
+  assert.equal(u.yUnit, "m/s", "the displayed unit is still m/s");
+  assert.equal(u.yConv, "m/s:fps", "but it must convert by the ft/s row");
+});
+
+test("a horizontal speed keeps the plain m/s conversion", () => {
+  const E = load();
+  const u = E.unitsFor(dataset(), ["IMU.speed"], { convertible: CONVERTIBLE });
+  assert.equal(u.yUnit, "m/s");
+  assert.equal(u.yConv, "", "no override means convert by the unit itself");
+});
+
+test("X\u2013Y carries the conversion idiom on both axes", () => {
+  const E = load();
+  const out = E.buildScatter(dataset(), "IMU.alt", ["IMU.u_vel"], {});
+  assert.equal(out.xUnit, "m");
+  assert.equal(out.xConv, "", "altitude converts by its own unit");
+  assert.equal(out.yUnit, "m/s");
+  assert.equal(out.yConv, "m/s:fps", "climb rate on the Y axis must still be ft/s");
 });

--- a/tests/test_flight_report.py
+++ b/tests/test_flight_report.py
@@ -59,7 +59,13 @@ FLIGHT_SECTIONS = [
 
 @pytest.fixture(scope="module")
 def reports(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
-    """Run the suite once against the golden flight; yield both report levels."""
+    """Run the suite once against the golden flight; yield the report.
+
+    There used to be two levels and this returned both. The detailed report is
+    gone — its sections were folded into this one — so the mapping has a single
+    entry rather than being flattened away, because the tests read it by name
+    and a dict keeps that readable if a second document ever returns.
+    """
     if not GOLDEN_BIN.exists():
         pytest.skip(f"Golden flight missing: {GOLDEN_BIN}")
 
@@ -81,10 +87,9 @@ def reports(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
         print(result.stderr, file=sys.stderr)
     assert result.returncode == 0, f"flight_report exited {result.returncode}"
 
-    out = {
-        "flight": tmp_path / f"{GOLDEN_BIN.stem}_report.html",
-        "detailed": tmp_path / f"{GOLDEN_BIN.stem}_report_detailed.html",
-    }
+    out = {"flight": tmp_path / f"{GOLDEN_BIN.stem}_report.html"}
+    stray = list(tmp_path.glob("*_report_detailed.html"))
+    assert not stray, f"a detailed report was still written: {stray}"
     for level, path in out.items():
         assert path.exists(), f"{level} report not written to {path}"
         assert path.stat().st_size > 100_000, f"{level} report suspiciously small"
@@ -97,10 +102,15 @@ def report_html(reports: dict[str, Path]) -> Path:
     return reports["flight"]
 
 
-def test_detailed_report_renders_all_sections(reports: dict[str, Path]) -> None:
-    html = reports["detailed"].read_text(encoding="utf-8")
-    missing = [s for s in DETAILED_SECTIONS if s not in html]
-    assert not missing, f"Missing sections: {missing}"
+def test_detailed_report_is_gone(reports: dict[str, Path]) -> None:
+    """One report. The bring-up sections went with the second document.
+
+    They are listed rather than merely absent so that promoting one back is a
+    deliberate edit here, not something that quietly reappears.
+    """
+    html = reports["flight"].read_text(encoding="utf-8")
+    present = [s for s in DETAILED_SECTIONS if s in html]
+    assert not present, f"detailed-only sections are still rendering: {present}"
 
 
 def test_flight_report_is_the_headline_read(reports: dict[str, Path]) -> None:
@@ -127,7 +137,7 @@ def test_flight_report_is_the_headline_read(reports: dict[str, Path]) -> None:
 
 
 def test_report_has_inline_figures(reports: dict[str, Path]) -> None:
-    """Static figures are the detailed report's idiom; the flight report has one.
+    """The report carries exactly one static PNG.
 
     The per-sensor timing histogram is the exception, and a deliberate one: it is
     a distribution rather than a series, nothing zooms into it, and rebuilding it
@@ -135,10 +145,6 @@ def test_report_has_inline_figures(reports: dict[str, Path]) -> None:
     visual is an interactive chart, so the count is pinned rather than merely
     bounded — a second PNG appearing here should be a decision, not a drift.
     """
-    eng = reports["detailed"].read_text(encoding="utf-8")
-    fig_count = eng.count('<img src="data:image/png;base64,')
-    assert fig_count >= 25, f"Expected ≥25 inline figures, got {fig_count}"
-
     flight = reports["flight"].read_text(encoding="utf-8")
     flight_figs = flight.count('<img src="data:image/png;base64,')
     assert flight_figs == 1, (
@@ -367,21 +373,6 @@ def test_cesium_inlined_once_and_patched(report_html: Path) -> None:
         "the unpatched Cesium worker bootstrap is still present — the globe will "
         "render blank when the report is opened from file://"
     )
-
-
-def test_plotly_trajectory_lives_in_detailed(reports: dict[str, Path]) -> None:
-    """The 3D Plotly path moved to the detailed report when the globe took over the flight report.
-
-    It is kept there rather than deleted because it survives what the globe does
-    not: a report opened with no network, and a flight with no GNSS fix at all.
-    """
-    flight = dict(_chart_specs(reports["flight"].read_text(encoding="utf-8")))
-    eng = dict(_chart_specs(reports["detailed"].read_text(encoding="utf-8")))
-    assert "chart-trajectory" not in flight, (
-        "the flight report shows both a Cesium globe and a Plotly 3D path of the "
-        "same trajectory"
-    )
-    assert "chart-trajectory" in eng, "the 3D trajectory chart vanished instead of moving"
 
 
 def test_measured_events_beat_the_flags() -> None:


### PR DESCRIPTION
Closes out the consolidation: **one report**, plus the defects a pre-ship review found.

## The detailed report is gone

Its sections were folded into the main one over the previous commits. Keeping a second document only preserved the drift that started this work — the same word meant different instants in each, and numbers a flyer read on one contradicted the other. The CLI writes one file; `--level`, the cross-link, the raw-detail gates and the sidecar grid that duplicated the summary card all go with it.

The bring-up modules stay on disk but are no longer registered: `kinematics`, `timestamps`, `launch_detection`, `pyro_apogee`, `sensor_noise`, `gnss_staleness`, `guidance`, `log_buffer`, `lora`, `sensor_charts`, `kinematic_checks`, `gaps`, `roll_pid`. **The last three are load-bearing, not dead** — flight-level code still imports them for the apogee replay, roll tuning, and the sample-rate and jitter figures. The rest are parked and easy to promote if you want any of them back.

## Review findings

A review of the whole consolidation raised 16 defects and tried to refute each one. These survived:

**Deployment & Recovery was never migrated to `events.py`.** Its own `_events()` still read the barometric vote, so on the one section about how the rocket came *down*, the "Apogee" marker and every descent number came from a different instant than the rest of the document — 4.3 s different on 183745, where the "Descent profile" chart also opened *before liftoff*. It now uses the measured apogee for the chart, its window and the descent metrics, keeping the flag only for the two metrics that are genuinely about the flag ("Apogee call", "Altitude below peak when called").

This was also why **the summary card did not add up**. Time to apogee + descent time now equals flight time to six decimals (8.018797 + 67.131964 = 75.150761).

**The Explore panels' `conv` plumbing was dead on arrival.** `axisTitle` and `unitFactor` take `(base, unit)` in this branch, and all five ported call sites passed a third `conv` argument that was silently discarded — so a vertical rate converted to **mph** while the descent cells beside it read ft/s. Both helpers now honor `conv`, the same way `convertSpans` already did.

Also fixed:
- the picker listed raw dotted keys and discarded the 84 human labels it ships
- channel cautions printed **internal issue numbers** at customers
- a flight with no ground station shipped a bare "Radio Link" heading — any section with nothing to say now prints nothing at all, heading included
- the LoRa ground track plotted feet against metres in imperial, and "Longest range" never converted
- the barometer note measured its pressure drop *across* the ejection spike the next sentence tells you to ignore (50.7 → 42.1 hPa)
- the apogee note counted rejections outside the window it draws (121 quoted, 74 drawn)
- `100.00% passed CRC (3 did not)`
- the roll note called the command limit a "fin travel limit"; Settings says the fins travel ±60°
- the British spellings the port arrived with

## Verification

27 Python tests, 32 JS tests. All eight logs render without error; the three bench logs and the mid-boost log degrade cleanly. Verified the empty-section rule on a real flight with no `lora_*.csv` — Radio Link is absent rather than empty.

16 sections, 18.82 MB, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
