### PR TITLE
dashboard: say so when the base station is logging to its fallback flash

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -961,6 +961,17 @@ internal fun StorageCard(
     val usedColor = tr.logging
     val reservedColor = tr.statusIdle
     val freeColor = tr.scan
+    // backend 0 = the internal SPIFFS partition.  On a base station that is a
+    // FALLBACK, not a configuration: the board carries a 512 MB NAND, and the
+    // firmware demotes to internal flash for the whole boot if any step of the
+    // NAND bring-up fails -- then keeps logging, into ~2 MB instead of 512.
+    //
+    // Rendered as a plain backend name it read as a statement of fact, and the
+    // only other clue was a small number ("Free 0.4 MB") that looks like a
+    // full disk rather than the wrong disk.  Seen on the bench 2026-08-11 and
+    // reported from the field.  A reboot usually clears it, which is worth
+    // saying out loud because the alternative is deciding not to fly.
+    val bsOnFallbackFlash = isBaseStation && bs != null && bs.totalBytes > 0 && bs.backend == 0
     Card(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -968,7 +979,17 @@ internal fun StorageCard(
                 Text(
                     subtitle,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (bsOnFallbackFlash) tr.orientWarn
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (bsOnFallbackFlash) {
+                Text(
+                    "External NAND not mounted — logging to internal flash. " +
+                        "Capacity is ~2 MB instead of 512 MB. Power-cycle the base " +
+                        "station before flying.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = tr.orientWarn,
                 )
             }
             // Segment bar: used | reserved | free, weighted by bytes — the


### PR DESCRIPTION
The BS carries a 512 MB NAND, and the firmware demotes to a **~2 MB internal SPIFFS partition for the whole boot** if any step of the NAND bring-up fails — `mountExternalFlashFat` is single-shot, and bus init / add-device / NAND init / FAT mount each return straight out to the caller's fallback. It then keeps logging, into 2 MB instead of 512.

The app rendered that as a plain backend name — "Internal flash" — next to "Free 0.4 MB". Read together those look like a **full** disk rather than the **wrong** disk, and the difference matters: one means delete some logs, the other means this flight will truncate.

## Observed on the bench, in both states

| | |
|---|---|
| `Internal flash — Used 1.3 MB, Free 0.4 MB` | fallback, after a flash |
| `External NAND — Used 0.1 MB, Free 459.1 MB` | healthy, after a reset |

Same unit, same firmware (`6025f58+20260811-1716`), an hour apart. The operator reports seeing it in the field too.

The boot log distinguishes them unambiguously — a healthy boot says:

```
SPI NAND up: 2048 blocks x 262144 B (page 4096 B) = 512 MB
External-flash FAT mounted at /extflash
Storage write test: OK (external NAND)
[LOG] Started logging: /extflash/lora_001.csv
```

I scripted **ten consecutive warm resets** over USB and all ten came up on the NAND, so a warm boot is not the trigger — it is cold start, or the reset that follows a flash.

## Scope

Display only. Nothing about which volume gets written changes here.

**Not fixed here, and worth a firmware issue:** the bring-up has no retry, so one transient failure costs the whole boot. Retrying the NAND probe a couple of times before demoting would likely make this disappear at the source. I did not touch firmware for this because the trigger is not reproducible on the bench yet and a blind retry would ship untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)