### PR TITLE
storage: stop the two remaining silent failures from being silent

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -984,18 +984,31 @@ internal fun StorageCard(
     // reported from the field.  A reboot usually clears it, which is worth
     // saying out loud because the alternative is deciding not to fly.
     val bsOnFallbackFlash = isBaseStation && bs != null && bs.totalBytes > 0 && bs.backend == 0
+    // The BS sets flags bit 0 when its filesystem query succeeded.  It has been
+    // decoded since the frame was added and never once read, so an unmounted
+    // volume drew a normal-looking bar out of whatever total/used happened to be
+    // in the frame -- numbers that mean nothing.  Nothing will be logged in this
+    // state, which is worth more than a silent zero.
+    val bsUnmounted = isBaseStation && bs != null && !bs.mounted
     Card(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 Text(title, style = MaterialTheme.typography.titleMedium)
                 Text(
-                    subtitle,
+                    if (bsUnmounted) "Not mounted" else subtitle,
                     style = MaterialTheme.typography.bodySmall,
-                    color = if (bsOnFallbackFlash) tr.orientWarn
+                    color = if (bsOnFallbackFlash || bsUnmounted) tr.orientWarn
                     else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (bsOnFallbackFlash) {
+            if (bsUnmounted) {
+                Text(
+                    "Base station storage is not mounted — nothing will be logged. " +
+                        "Power-cycle the base station.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = tr.orientWarn,
+                )
+            } else if (bsOnFallbackFlash) {
                 Text(
                     "External NAND not mounted — logging to internal flash. " +
                         "Capacity is ~2 MB instead of 512 MB. Power-cycle the base " +

--- a/tinkerrocket-idf/components/spi_nand_flash/src/dhara_glue.c
+++ b/tinkerrocket-idf/components/spi_nand_flash/src/dhara_glue.c
@@ -24,6 +24,8 @@
 #include "esp_nand_blockdev.h"
 #endif
 
+static const char *TAG = "nand_dhara";
+
 typedef struct {
     struct dhara_nand dhara_nand;
     struct dhara_map dhara_map;
@@ -52,8 +54,26 @@ static esp_err_t dhara_init(spi_nand_flash_device_t *handle, void *bdl_handle)
     dhara_priv_data->dhara_nand.num_blocks = handle->chip.num_blocks;
 
     dhara_map_init(&dhara_priv_data->dhara_map, &dhara_priv_data->dhara_nand, handle->work_buffer, handle->config.gc_factor);
-    dhara_error_t ignored;
-    dhara_map_resume(&dhara_priv_data->dhara_map, &ignored);
+    // Upstream discards this into a variable named `ignored`, which makes the
+    // worst outcome on this device completely silent.  dhara_map_resume rebuilds
+    // the translation map from metadata already on the NAND; when it fails the
+    // map comes up EMPTY, the chip then looks blank to FATFS, f_mount fails, and
+    // the caller's format_if_mount_failed reformats -- taking every flight log
+    // with it.  Nothing above here ever learns: the mount "succeeds", the
+    // backend still reports external NAND, and the app shows a healthy volume
+    // with plenty of free space.
+    //
+    // Deliberately still not fatal.  A blank or freshly-erased NAND fails resume
+    // for a perfectly good reason and MUST go on to be formatted; telling that
+    // apart from "there was a map and we could not read it" needs more than this
+    // return value.  So this reports rather than decides -- enough that a field
+    // log distinguishes the two instead of leaving it to guesswork.
+    dhara_error_t resume_err = DHARA_E_NONE;
+    if (dhara_map_resume(&dhara_priv_data->dhara_map, &resume_err) < 0) {
+        ESP_LOGW(TAG, "dhara_map_resume failed (dhara err %d) -- treating the NAND as "
+                 "blank; if it was not, FATFS is about to reformat it and existing "
+                 "logs are gone", (int)resume_err);
+    }
 
     return ESP_OK;
 }


### PR DESCRIPTION
Two paths could lose or misreport base-station logging with nothing said. Both found while diagnosing the internal-flash fallback; neither *is* that fallback.

## 1. A failed map resume silently reformats the NAND

`dhara_map_resume` rebuilds the NAND's translation map from metadata already on the chip. Upstream throws its error away — into a variable literally named `ignored` — and returns `ESP_OK` regardless ([dhara_glue.c:55](tinkerrocket-idf/components/spi_nand_flash/src/dhara_glue.c:55)).

When resume fails the map comes up **empty**, so the chip looks blank to FATFS, `f_mount` fails, and the caller's `format_if_mount_failed` reformats it — taking every flight log with it. Nothing above ever learns: the mount "succeeds", the backend still reports **External NAND**, and the app draws a healthy volume with plenty of free space.

That is worse than the SPIFFS fallback #760 addresses. The fallback at least shows a suspiciously small number; this shows nothing wrong at all.

**Still not fatal, on purpose.** A blank or freshly-erased NAND fails resume for a perfectly good reason and must go on to be formatted. Telling that apart from "there was a map and we could not read it" needs more than this return value, so this reports rather than decides. **This is not the cure** — it is the difference between a field report that identifies the failure and one that cannot.

## 2. The app never read the `mounted` flag

Bit 0 of the storage frame's `flags` has been decoded since the frame was added, and is even unit-tested ([FileOpsGoldenTest.kt:130](TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/FileOpsGoldenTest.kt:130)) — but no UI reads it. An unmounted volume therefore drew a normal-looking bar out of whatever `total`/`used` happened to be in the frame. Numbers that mean nothing. It now says so, and says that nothing will be logged.

## Scope

Deliberately **not** touched: `mountExternalFlashFat` and its retry/leak behaviour, which is being fixed in a separate session, and the hardcoded FAT drive `"0:"` in `bsQueryStorage` that lives in the same file. Staying out of that file so the two changes don't collide.

## Verification

Both build (base_station via IDF v6.0.1; Android suite green). **Neither is bench-verified** — the resume failure has never been reproduced here, and provoking it means deliberately corrupting a NAND. The `mounted` path likewise needs a BS that fails to mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
