### PR TITLE
android(dashboard): grade signal bars like iOS instead of one flat amber

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.tinkerbug.tinkerrocket.protocol.IMUOrientationMode
+import com.tinkerbug.tinkerrocket.protocol.SignalQuality
 import com.tinkerbug.tinkerrocket.protocol.TelemetryData
 import com.tinkerbug.tinkerrocket.session.FleetDevice
 import com.tinkerbug.tinkerrocket.session.DeviceSession
@@ -1215,8 +1216,12 @@ private fun FlightSummaryCard(telemetry: TelemetryData) {
 
 /**
  * iOS SignalStrengthView twin: vertical bars for LoRa (BS links), GNSS
- * satellites, and BLE RSSI, value labels underneath.  Fill fraction uses the
- * same rough scaling ideas as iOS (RSSI −100..−30 dBm, sats 0..12).
+ * satellites, and BLE RSSI, value labels underneath.
+ *
+ * Fill fraction AND colour both come from [SignalQuality], which holds iOS's
+ * exact bands.  Both were wrong here: the bars used invented scales ("rough
+ * scaling ideas", per the comment this replaces) and a single hardcoded amber,
+ * so the green/yellow/orange/red grading iOS shows was missing entirely.
  */
 @Composable
 private fun SignalCard(telemetry: TelemetryData, bleRssi: Int?, isBaseStation: Boolean) {
@@ -1231,18 +1236,21 @@ private fun SignalCard(telemetry: TelemetryData, bleRssi: Int?, isBaseStation: B
                 if (isBaseStation) {
                     val lora = telemetry.rssi
                     SignalBar(
-                        fraction = lora?.let { ((it + 100f) / 70f).coerceIn(0f, 1f) } ?: 0f,
+                        fraction = SignalQuality.loraFill(lora),
+                        quality = SignalQuality.forLoraRssi(lora),
                         value = lora?.let { String.format(Locale.ROOT, "%.0f", it) } ?: "——",
                         label = "LoRa",
                     )
                 }
                 SignalBar(
-                    fraction = (telemetry.numSats / 12f).coerceIn(0f, 1f),
+                    fraction = SignalQuality.satFill(telemetry.numSats),
+                    quality = SignalQuality.forSatCount(telemetry.numSats),
                     value = "${telemetry.numSats}",
                     label = "GNSS",
                 )
                 SignalBar(
-                    fraction = bleRssi?.let { ((it + 100f) / 70f).coerceIn(0f, 1f) } ?: 0f,
+                    fraction = SignalQuality.bleFill(bleRssi),
+                    quality = SignalQuality.forBleRssi(bleRssi),
                     value = bleRssi?.let { "$it" } ?: "——",
                     label = "BLE",
                 )
@@ -1252,8 +1260,22 @@ private fun SignalCard(telemetry: TelemetryData, bleRssi: Int?, isBaseStation: B
 }
 
 @Composable
-private fun SignalBar(fraction: Float, value: String, label: String) {
+private fun SignalBar(
+    fraction: Float,
+    quality: SignalQuality,
+    value: String,
+    label: String,
+) {
     val tr = com.tinkerbug.tinkerrocket.app.theme.TrTheme.colors
+    val fill = when (quality) {
+        SignalQuality.BEST -> tr.signalBest
+        SignalQuality.GOOD -> tr.signalGood
+        SignalQuality.FAIR -> tr.signalFair
+        SignalQuality.WEAK -> tr.signalWeak
+        SignalQuality.BAD -> tr.signalBad
+        // iOS returns .gray for a missing reading; statusIdle is that same gray.
+        SignalQuality.UNKNOWN -> tr.statusIdle
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -1271,7 +1293,7 @@ private fun SignalBar(fraction: Float, value: String, label: String) {
                         .padding(bottom = 6.dp)
                         .width(24.dp)
                         .height((10 + 100 * fraction).dp)
-                        .background(tr.logging, RoundedCornerShape(12.dp)),
+                        .background(fill, RoundedCornerShape(12.dp)),
                 )
             }
         }

--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/theme/DesignTokens.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/theme/DesignTokens.kt
@@ -33,6 +33,11 @@ class TrColors(
     val voiceWarn: Color,
     val voiceError: Color,
     val orientWarn: Color,
+    val signalBest: Color,
+    val signalGood: Color,
+    val signalFair: Color,
+    val signalWeak: Color,
+    val signalBad: Color,
     val background: Color,
     val card: Color,
     val cardSecondary: Color,
@@ -57,6 +62,11 @@ val TrColorsLight = TrColors(
     voiceWarn = Color(0xFFFF9500),  // orange
     voiceError = Color(0xFFFF3B30),  // red
     orientWarn = Color(0xFFFF9500),  // orange
+    signalBest = Color(0xFF007AFF),  // blue
+    signalGood = Color(0xFF34C759),  // green
+    signalFair = Color(0xFFFFCC00),  // yellow
+    signalWeak = Color(0xFFFF9500),  // orange
+    signalBad = Color(0xFFFF3B30),  // red
     background = Color(0xFFFFFFFF),
     card = Color(0xFFF2F2F7),
     cardSecondary = Color(0xFFE5E5EA),
@@ -81,6 +91,11 @@ val TrColorsDark = TrColors(
     voiceWarn = Color(0xFFFF9F0A),  // orange
     voiceError = Color(0xFFFF453A),  // red
     orientWarn = Color(0xFFFF9F0A),  // orange
+    signalBest = Color(0xFF0A84FF),  // blue
+    signalGood = Color(0xFF30D158),  // green
+    signalFair = Color(0xFFFFD60A),  // yellow
+    signalWeak = Color(0xFFFF9F0A),  // orange
+    signalBad = Color(0xFFFF453A),  // red
     background = Color(0xFF000000),
     card = Color(0xFF1C1C1E),
     cardSecondary = Color(0xFF2C2C2E),

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/SignalQuality.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/SignalQuality.kt
@@ -1,0 +1,84 @@
+package com.tinkerbug.tinkerrocket.protocol
+
+/**
+ * Quality band for the dashboard's LoRa / GNSS / BLE indicators — a direct port
+ * of the iOS `loraColor` / `gnssColor` / `bleColor` computed properties
+ * (DashboardView.swift:2899, :2918, :2938).
+ *
+ * Android rendered all three bars in one hardcoded amber and varied only the
+ * bar HEIGHT, so a dying link and a perfect one were the same colour and the
+ * grading iOS has always shown was simply absent.
+ *
+ * The bands live here rather than in the Composable because they are the whole
+ * substance of the feature: a boundary off by one reads as a healthy link on a
+ * marginal one, which is the failure that matters at a launch site.
+ */
+public enum class SignalQuality {
+    /** Better than "good" — GNSS only, where more satellites keeps helping. */
+    BEST,
+    GOOD,
+    FAIR,
+    WEAK,
+    BAD,
+
+    /** No value at all: link down, or the metric is not reported on this path. */
+    UNKNOWN,
+    ;
+
+    public companion object {
+        /**
+         * LoRa RSSI in dBm; null when the base station has heard nothing.
+         *
+         * iOS bands, ported verbatim including the strict `>` at every edge:
+         * `> -70` green, `> -90` yellow, `> -110` orange, else red.
+         */
+        public fun forLoraRssi(rssi: Float?): SignalQuality = when {
+            rssi == null -> UNKNOWN
+            rssi > -70f -> GOOD
+            rssi > -90f -> FAIR
+            rssi > -110f -> WEAK
+            else -> BAD
+        }
+
+        /**
+         * GNSS satellite count.
+         *
+         * The odd one out, and ported as-is: it has a fourth, BETTER band above
+         * 15 satellites, and its lower edges are `>=` where the RSSI bands are
+         * `>`.  iOS: `> 15` blue, `>= 11` green, `>= 6` yellow, else red — with
+         * no unknown state, because zero satellites is a real reading rather
+         * than a missing one.
+         */
+        public fun forSatCount(sats: Int): SignalQuality = when {
+            sats > 15 -> BEST
+            sats >= 11 -> GOOD
+            sats >= 6 -> FAIR
+            else -> BAD
+        }
+
+        /**
+         * BLE RSSI in dBm; null before the first read of the connected link.
+         *
+         * iOS: `> -50` green, `> -65` yellow, `> -80` orange, else red.  Tighter
+         * than LoRa because it is a metres-range radio, not a kilometres one.
+         */
+        public fun forBleRssi(rssi: Int?): SignalQuality = when {
+            rssi == null -> UNKNOWN
+            rssi > -50 -> GOOD
+            rssi > -65 -> FAIR
+            rssi > -80 -> WEAK
+            else -> BAD
+        }
+
+        /** iOS loraFill: (rssi + 130) / 100, clamped. */
+        public fun loraFill(rssi: Float?): Float =
+            rssi?.let { ((it + 130f) / 100f).coerceIn(0f, 1f) } ?: 0f
+
+        /** iOS gnssFill: sats / 30, clamped. */
+        public fun satFill(sats: Int): Float = (sats / 30f).coerceIn(0f, 1f)
+
+        /** iOS bleFill: (rssi + 100) / 70, clamped. */
+        public fun bleFill(rssi: Int?): Float =
+            rssi?.let { ((it + 100f) / 70f).coerceIn(0f, 1f) } ?: 0f
+    }
+}

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/SignalQualityTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/SignalQualityTest.kt
@@ -1,0 +1,115 @@
+package com.tinkerbug.tinkerrocket.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Band edges checked against the iOS source (DashboardView.swift `loraColor`,
+ * `gnssColor`, `bleColor`) one value either side of every boundary.
+ *
+ * The edges are the point of these tests.  A boundary off by one renders a
+ * marginal link in the colour of a healthy one, which is exactly the reading an
+ * operator trusts when deciding whether to launch.
+ */
+class SignalQualityTest {
+
+    // ---- LoRa: > -70 good, > -90 fair, > -110 weak, else bad ----
+
+    @Test
+    fun `lora bands match iOS at every edge`() {
+        assertEquals(SignalQuality.GOOD, SignalQuality.forLoraRssi(-30f))
+        assertEquals(SignalQuality.GOOD, SignalQuality.forLoraRssi(-69.9f))
+        // -70 exactly is NOT good: iOS uses a strict `>`.
+        assertEquals(SignalQuality.FAIR, SignalQuality.forLoraRssi(-70f))
+        assertEquals(SignalQuality.FAIR, SignalQuality.forLoraRssi(-89.9f))
+        assertEquals(SignalQuality.WEAK, SignalQuality.forLoraRssi(-90f))
+        assertEquals(SignalQuality.WEAK, SignalQuality.forLoraRssi(-109.9f))
+        assertEquals(SignalQuality.BAD, SignalQuality.forLoraRssi(-110f))
+        assertEquals(SignalQuality.BAD, SignalQuality.forLoraRssi(-140f))
+    }
+
+    @Test
+    fun `lora with no reading is unknown, not bad`() {
+        // A silent link and a terrible one are different facts; iOS greys the
+        // first and reds the second.
+        assertEquals(SignalQuality.UNKNOWN, SignalQuality.forLoraRssi(null))
+        assertEquals(0f, SignalQuality.loraFill(null), 0f)
+    }
+
+    // ---- GNSS: > 15 best, >= 11 good, >= 6 fair, else bad ----
+
+    @Test
+    fun `gnss bands match iOS at every edge`() {
+        assertEquals(SignalQuality.BEST, SignalQuality.forSatCount(16))
+        // 15 is good, not best — `>` at the top edge, unlike the two below it.
+        assertEquals(SignalQuality.GOOD, SignalQuality.forSatCount(15))
+        assertEquals(SignalQuality.GOOD, SignalQuality.forSatCount(11))
+        assertEquals(SignalQuality.FAIR, SignalQuality.forSatCount(10))
+        assertEquals(SignalQuality.FAIR, SignalQuality.forSatCount(6))
+        assertEquals(SignalQuality.BAD, SignalQuality.forSatCount(5))
+        assertEquals(SignalQuality.BAD, SignalQuality.forSatCount(0))
+    }
+
+    @Test
+    fun `zero satellites is a real reading, never unknown`() {
+        // No null overload exists on purpose: the frame always carries a count.
+        assertEquals(SignalQuality.BAD, SignalQuality.forSatCount(0))
+    }
+
+    // ---- BLE: > -50 good, > -65 fair, > -80 weak, else bad ----
+
+    @Test
+    fun `ble bands match iOS at every edge`() {
+        assertEquals(SignalQuality.GOOD, SignalQuality.forBleRssi(-49))
+        assertEquals(SignalQuality.FAIR, SignalQuality.forBleRssi(-50))
+        assertEquals(SignalQuality.FAIR, SignalQuality.forBleRssi(-64))
+        assertEquals(SignalQuality.WEAK, SignalQuality.forBleRssi(-65))
+        assertEquals(SignalQuality.WEAK, SignalQuality.forBleRssi(-79))
+        assertEquals(SignalQuality.BAD, SignalQuality.forBleRssi(-80))
+        assertEquals(SignalQuality.UNKNOWN, SignalQuality.forBleRssi(null))
+    }
+
+    // ---- Fills: iOS scales, clamped ----
+
+    @Test
+    fun `fills use the iOS scales and clamp at both ends`() {
+        // LoRa spans -130..-30, not the -100..-30 this code used to assume.
+        assertEquals(0f, SignalQuality.loraFill(-130f), 1e-6f)
+        assertEquals(0.5f, SignalQuality.loraFill(-80f), 1e-6f)
+        assertEquals(1f, SignalQuality.loraFill(-30f), 1e-6f)
+        assertEquals(0f, SignalQuality.loraFill(-200f), 0f)
+        assertEquals(1f, SignalQuality.loraFill(0f), 0f)
+
+        // Sats span 0..30, not 0..12 — 12 sats used to peg the bar full.
+        assertEquals(0.4f, SignalQuality.satFill(12), 1e-6f)
+        assertEquals(1f, SignalQuality.satFill(30), 1e-6f)
+        assertEquals(1f, SignalQuality.satFill(40), 0f)
+        assertEquals(0f, SignalQuality.satFill(0), 0f)
+
+        assertEquals(0f, SignalQuality.bleFill(-100), 1e-6f)
+        assertEquals(1f, SignalQuality.bleFill(-30), 1e-6f)
+        assertEquals(0f, SignalQuality.bleFill(null), 0f)
+    }
+
+    @Test
+    fun `a full bar always means a good link, on every metric`() {
+        // Guards the pairing rather than either half: fill and colour are
+        // computed separately, so nothing else stops them drifting apart into
+        // a full bar rendered red.
+        for (rssi in -130..-30) {
+            if (SignalQuality.loraFill(rssi.toFloat()) >= 1f) {
+                assertEquals(SignalQuality.GOOD, SignalQuality.forLoraRssi(rssi.toFloat()))
+            }
+        }
+        for (rssi in -100..-30) {
+            if (SignalQuality.bleFill(rssi) >= 1f) {
+                assertEquals(SignalQuality.GOOD, SignalQuality.forBleRssi(rssi))
+            }
+        }
+        for (sats in 0..40) {
+            if (SignalQuality.satFill(sats) >= 1f) {
+                assertEquals(SignalQuality.BEST, SignalQuality.forSatCount(sats))
+            }
+        }
+    }
+}

--- a/TinkerRocketApp/TinkerRocketApp/DesignTokens.swift
+++ b/TinkerRocketApp/TinkerRocketApp/DesignTokens.swift
@@ -27,6 +27,11 @@ enum TRColor {
     static let voiceWarn = dynamic(0xFF9500, 0xFF9F0A)  // orange
     static let voiceError = dynamic(0xFF3B30, 0xFF453A)  // red
     static let orientWarn = dynamic(0xFF9500, 0xFF9F0A)  // orange
+    static let signalBest = dynamic(0x007AFF, 0x0A84FF)  // blue
+    static let signalGood = dynamic(0x34C759, 0x30D158)  // green
+    static let signalFair = dynamic(0xFFCC00, 0xFFD60A)  // yellow
+    static let signalWeak = dynamic(0xFF9500, 0xFF9F0A)  // orange
+    static let signalBad = dynamic(0xFF3B30, 0xFF453A)  // red
 
     static let background = dynamic(0xFFFFFF, 0x000000)
     static let card = dynamic(0xF2F2F7, 0x1C1C1E)

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -6,6 +6,7 @@
     "red":    { "light": "#FF3B30", "dark": "#FF453A" },
     "green":  { "light": "#34C759", "dark": "#30D158" },
     "orange": { "light": "#FF9500", "dark": "#FF9F0A" },
+    "yellow": { "light": "#FFCC00", "dark": "#FFD60A" },
     "teal":   { "light": "#30B0C7", "dark": "#40C8E0" },
     "purple": { "light": "#AF52DE", "dark": "#BF5AF2" },
     "gray":   { "light": "#8E8E93", "dark": "#8E8E93" }
@@ -29,7 +30,12 @@
     "voiceReady": "green",
     "voiceWarn": "orange",
     "voiceError": "red",
-    "orientWarn": "orange"
+    "orientWarn": "orange",
+    "signalBest": "blue",
+    "signalGood": "green",
+    "signalFair": "yellow",
+    "signalWeak": "orange",
+    "signalBad": "red"
   },
   "surfaces": {
     "_comment": "iOS system surfaces the app actually uses: cards are systemGray6, row chips inside cards are systemGray5, screens are systemBackground.",

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,16 +3,16 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 26,740 lines across 70 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 26,745 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
 
-## `(root)/` — 2 files, 92 lines
+## `(root)/` — 2 files, 97 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DesignTokens.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/DesignTokens.swift) | 62 | `TRColor`, `TRShape`, `TRSpacing` |
+| [DesignTokens.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/DesignTokens.swift) | 67 | `TRColor`, `TRShape`, `TRSpacing` |
 | [TinkerRocketAppApp.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/TinkerRocketAppApp.swift) | 30 | `TinkerRocketAppApp` |
 
 
@@ -122,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 70 files, 26,740 lines.
+Total: 70 files, 26,745 lines.


### PR DESCRIPTION
Every bar in the Signal card rendered the same amber — `tr.logging`, hardcoded — with only the bar height varying. iOS has graded these green/yellow/orange/red since the card existed, so on Android a base station hearing its rocket at −33 dBm and one about to lose it at −82 looked identical, both painted the colour [design-language.md:49](docs/design-language.md:49) defines as *degraded*. The grading was not subtly wrong; it was absent.

## Why the palette, not just the screen

`design/tokens.json` had **no yellow** — blue/indigo/red/green/orange/teal/purple/gray. Two live iOS bands (LoRa −90..−70, GNSS 6..10) had nothing to point at, so the port collapsed them onto the nearest thing, orange, and from there onto everything else. Adds Apple systemYellow and five `signalXxx` roles, per the roles block's own one-role-per-meaning rule.

## The edges are the feature

Bands live in [SignalQuality.kt](TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/SignalQuality.kt) in `core:protocol` — testable, unlike a Composable. Two asymmetries in the iOS source are load-bearing and easy to "clean up" into bugs:

- **Every RSSI edge is a strict `>`**, so the boundary value falls to the *lower* band. −50 dBm BLE is yellow, not green.
- **GNSS mixes operators** — `>` on its top edge, `>=` on the two below. 15 sats is green, 16 is blue; 6 is yellow, 5 is red.

A boundary off by one renders a marginal link in a healthy link's colour, which is the reading someone trusts when deciding whether to launch. Tests check one value either side of all ten edges.

## Two things beyond what was asked

**GNSS has a fourth band.** Above 15 satellites iOS renders **blue**, outside the green/yellow/red vocabulary this was described in. Kept it, on parity grounds — 16+ sats is ordinary outdoors, so it will show up. Easy to drop to green if it reads as noise.

**The fill fractions were independently wrong**, unrelated to colour: LoRa used BLE's scale (`(rssi+100)/70` vs iOS `(rssi+130)/100`) and GNSS pegged full at 12 sats instead of 30. 8 sats drew two-thirds full on Android and a quarter full on iOS. Fixed here rather than split out, because colour alone leaves the bars the right hue and still the wrong height — the same comparison, run twice. **GNSS bars are now visibly shorter.**

## Verification

Bench, BaseStation V4 over BLE: LoRa −33 / GNSS 14 / BLE −43 all **green**, heights matching the iOS formulas (0.97 / 0.47 / 0.81). Synthetic flight: GNSS 9 and BLE −50 both **yellow** — −50 being exactly the strict-`>` edge, the most error-prone boundary in the port, confirmed on pixels. LoRa with no reading draws nothing, as on iOS.

**WEAK and BAD are covered by tests only.** The bench cannot produce a dying link on demand, so orange and red have not been seen on a real screen — the next range test is the first time they will be.

Android suite green; both `gen_design_tokens.py --check` and `gen_section_index.py --check` regenerated and clean (the new roles grow `DesignTokens.swift`, which the iOS section index counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
