### PR TITLE
ci: upload-pages-artifact v5, for the last Node 20 warning

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,7 +81,10 @@ jobs:
 
       # The site root is the webtool directory: index.html, app.js, worker.js
       # and the payload built above. Nothing else in the repository ships.
-      - uses: actions/upload-pages-artifact@v4
+      # v5 rather than v4: v4 still pins a Node 20 copy of upload-artifact
+      # internally, which is the one deprecation warning the rest of the
+      # bump did not silence. Nothing here uses upload-artifact directly.
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: Data_Analysis/webtool
 


### PR DESCRIPTION
Follow-up to #765, which cleared the Node 20 deprecation everywhere except one line of the Pages run:

```
actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
```

Nothing here calls `upload-artifact` directly — `upload-pages-artifact@v4` pins that SHA internally, and it is a Node 20 build. v5 is the release that updates it to v7.

Verified after this lands by re-reading the Pages run for the warning string.