### PR TITLE
report: un-quantize GNSS position, fix flight duration, read the right magnetometer

### DIFF
--- a/Data_Analysis/flight_report/flight.py
+++ b/Data_Analysis/flight_report/flight.py
@@ -25,6 +25,12 @@ from plot_flight_data_mini import parse_binary_file  # noqa: E402
 _FLIGHT_STEM_RE = re.compile(r"^flight_(?:(\d{8})_(\d{6})|recovered_(\d+))$")
 
 
+# Streams timestamped against something other than the flight clock. They are
+# still parsed and still charted on their own axis; they just cannot take part
+# in "how long was the flight".
+_FOREIGN_CLOCKS = frozenset({"LogBufferStats"})
+
+
 @dataclass
 class Flight:
     """One flight's on-disk artifacts + parsed records (lazy)."""
@@ -144,8 +150,22 @@ class Flight:
 
     @property
     def duration_s(self) -> Optional[float]:
+        """How long the recording ran, from the sensor streams alone.
+
+        LogBufferStats is excluded because it is not on the same clock: the out
+        computer emits it against its own uptime, which on the sample flight
+        runs 809-886 s while every sensor sits inside 0-78 s. Taking max-minus-min
+        across all streams therefore reported 886 s for a 78-second flight — an
+        eleven-fold overstatement of the headline duration.
+        """
         recs = self.records
-        ts = [r["time_us"] for sensor in recs.values() for r in sensor if "time_us" in r]
+        ts = [
+            r["time_us"]
+            for name, sensor in recs.items()
+            if name not in _FOREIGN_CLOCKS
+            for r in sensor
+            if "time_us" in r
+        ]
         if not ts:
             return None
         return (max(ts) - min(ts)) / 1e6

--- a/Data_Analysis/flight_report/modules/explore.py
+++ b/Data_Analysis/flight_report/modules/explore.py
@@ -67,6 +67,13 @@ DATASET_ID = "explore-data"
 _T_DP = 3
 _V_DP = 4
 
+# Except where a unit is enormous. A degree of latitude is 111 km, so the default
+# four decimals quantises a position to 11 m: on the sample flight that collapsed
+# 1,397 GNSS fixes into 21 distinct points, and plotting lat against lon drew a
+# staircase rather than a track. Seven decimals is 1.1 cm, comfortably finer than
+# any receiver, and costs about 40 kB on that flight.
+_V_DP_BY_KEY = {"GNSS.lat": 7, "GNSS.lon": 7}
+
 
 def _public(text: Optional[str]) -> Optional[str]:
     """A caution with its issue references removed.
@@ -83,7 +90,7 @@ def _public(text: Optional[str]) -> Optional[str]:
     return _SPACES.sub(" ", out).replace(" ,", ",").replace(" .", ".").strip()
 
 
-def _values(rows: list[dict], field: str, kind: str) -> list:
+def _values(rows: list[dict], field: str, kind: str, decimals: int = _V_DP) -> list:
     """One channel as int / float / None, ready to serialize.
 
     Kept as Python objects rather than a numpy array on purpose: run detection
@@ -102,7 +109,7 @@ def _values(rows: list[dict], field: str, kind: str) -> list:
             # Non-finite is not valid JSON and render.py serializes with
             # allow_nan=False, outside any error containment — one of these
             # would take down the whole document rather than one channel.
-            out.append(round(f, _V_DP) if f == f and abs(f) != float("inf") else None)
+            out.append(round(f, decimals) if f == f and abs(f) != float("inf") else None)
     return out
 
 
@@ -133,7 +140,8 @@ def _dataset(flight: Flight) -> Optional[dict[str, Any]]:
 
     channels: dict[str, Any] = {}
     for c in cat.channels:
-        vals = _values(recs[c.stream], c.field, c.meta.kind)
+        vals = _values(recs[c.stream], c.field, c.meta.kind,
+                       _V_DP_BY_KEY.get(c.key, _V_DP))
         entry: dict[str, Any] = {
             "stream": c.stream,
             "label": c.meta.label,

--- a/Data_Analysis/flight_report/modules/sensor_noise.py
+++ b/Data_Analysis/flight_report/modules/sensor_noise.py
@@ -88,7 +88,14 @@ def _baro_stats(records, pad_start_us, pad_end_us):
 
 
 def _mag_stats(records, pad_start_us, pad_end_us):
-    mag = records.get("MMC5983MA") or []
+    """Pad-phase magnetometer noise.
+
+    Read the magnetometer this board actually has. This looked only for the
+    MMC5983MA, which is the previous PCB revision's part and is absent from every
+    current log — so these statistics were silently missing from every real
+    flight rather than reported as zero or unavailable.
+    """
+    mag = records.get("IIS2MDC") or []
     if not mag:
         return {}
     mt = get_array(mag, "time_us")


### PR DESCRIPTION
Three defects, none of which surfaced as an error.

## GNSS position was quantized to 11 m

The Explore payload rounded every value to four decimals. For an accelerometer that's far finer than the sensor; for a **coordinate it's 11.1 m**, and it collapsed 1,397 GNSS fixes into **21 distinct positions**. Plotting `GNSS.lat` against `GNSS.lon` in the X-Y panel drew a staircase instead of a track.

Latitude and longitude now carry seven decimals (1.1 cm). It costs nothing measurable — **2.90 MB gzipped before and after** — because a coordinate's extra digits compress against the identical digits above them.

## Flight duration was 11× too long

`Flight.duration_s` took max−min of `time_us` across every stream, including `LogBufferStats`, which the out computer emits against its own uptime: 809–886 s while every sensor sits inside 0–78 s. A 78-second flight reported **885.94 s**. Sensor streams only now → 77.89 s.

Nothing displays it since the log-duration line went with the detailed report, but `render.py` still passes it to the template and `kinematics` still publishes it as a metric.

## The magnetometer noise stats read the wrong part

`sensor_noise._mag_stats` looked for `MMC5983MA`, the previous PCB revision's magnetometer. Every current board logs `IIS2MDC`, so pad-phase noise statistics were **absent from every real flight** rather than reported as missing — `{}` looks the same as "no magnetometer" to the caller.

## On trimming the payload: there is nothing worth trimming

I measured before proposing, and my earlier suggestion was wrong. The 24 constant channels cost **10 kB of 9.58 MB between them** — the encoder already ships one value rather than one per frame — and the run-encoded channels round to zero. All the weight is 50 genuine series.

Dropping to three decimals everywhere would save 12% (2.90 → 2.55 MB gzipped, ~2.5% of the report), at the cost of headroom on channels whose quantum is finer than that: the low-G accelerometer resolves 0.0048 m/s², so even two decimals would quantize it below its own noise floor. Not worth it.

## Verification

27 Python tests, 32 JS tests. Report builds at 18.82 MB, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
