### PR TITLE
firmware(radio_board): boot on SF8/BW250 — SF10/BW125 is illegal on LLCC68

### DIFF
--- a/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
+++ b/tinkerrocket-idf/components/TR_LoRa_Comms/TR_LoRa_Comms.h
@@ -32,8 +32,10 @@ public:
         int spi_mosi = -1;
         spi_host_device_t spi_host = SPI2_HOST;
         float freq_mhz = 915.0f;
-        uint8_t spreading_factor = 10;
-        float bandwidth_khz = 125.0f;
+        // Defaults are the fleet operating point, and a legal LLCC68 pair
+        // (SF10/BW125 is not: LLCC68 caps SF at 9 for BW125).
+        uint8_t spreading_factor = 8;
+        float bandwidth_khz = 250.0f;
         uint8_t coding_rate = 7;
         uint16_t preamble_len = 16;
         int8_t tx_power_dbm = 20;
@@ -190,8 +192,8 @@ private:
 
     // Last-known-good radio config (for rollback on reconfigure failure)
     float   cfg_freq_mhz_ = 915.0f;
-    uint8_t cfg_sf_ = 10;
-    float   cfg_bw_khz_ = 125.0f;
+    uint8_t cfg_sf_ = 8;
+    float   cfg_bw_khz_ = 250.0f;
     uint8_t cfg_cr_ = 7;
     int8_t  cfg_tx_power_ = 20;
 

--- a/tinkerrocket-idf/projects/radio_board/README.md
+++ b/tinkerrocket-idf/projects/radio_board/README.md
@@ -138,7 +138,8 @@ these constants and nothing else.
 
 ### Modem behavior
 
-- Boots listening on defaults (915 MHz / SF10 / BW125) so a bench modem is
+- Boots listening on defaults (915 MHz / SF8 / BW250, the fleet operating
+  point and a legal LLCC68 pair) so a bench modem is
   immediately visible; the host's `SET_CONFIG` replaces this. The host owns
   config — the modem has **no NVS**.
 - Half-duplex policy matches `TR_LoRa_Comms`: auto-return to RX after every
@@ -190,7 +191,7 @@ follows the pull means nothing is driving the pin.
 | `radio probe: BUSY is FLOATING` | Nothing drives U14 pad 11. Module unpowered, dead, or open joints. **Measure +3V3 at U14 pad 1 first.** This is the expected signature of reverse-polarity damage. |
 | `radio probe: BUSY driven but STUCK HIGH past 50 ms` | Powered and driving, but never finished its internal boot — damaged die, or a bad NRST/SPI joint. |
 | `radio init FAILED (RadioLib <code>)` | The RadioLib code narrows it further: `-2` is chip-not-found (SPI silent), the `-70x` family are SPI command failures. |
-| `radio up, listening at 915.0 MHz SF10` | Radio is good; move on. |
+| `radio up, listening at 915.0 MHz SF8` | Radio is good; move on. |
 
 Two LED blinks at boot say the S3 itself is running — the only such sign if
 the board is powered from J6 with no USB attached. (D6 is a hardwired power

--- a/tinkerrocket-idf/projects/radio_board/main/config.h
+++ b/tinkerrocket-idf/projects/radio_board/main/config.h
@@ -86,9 +86,13 @@ struct config
     // The modem comes up listening on these until the host pushes SET_CONFIG,
     // mirroring TR_LoRa_Comms defaults. The host owns the real config
     // (transparent-modem principle: no NVS on the modem).
+    // SF/BW must be a legal LLCC68 pair: the die supports SF5-9 at BW125,
+    // SF5-10 at BW250, SF5-11 at BW500. SF8/BW250 is the fleet operating
+    // point; the previous SF10/BW125 boot value was out of range for the
+    // E220-900MM22S's LLCC68 die (undefined behavior until SET_CONFIG).
     static constexpr float BOOT_FREQ_MHZ = 915.0f;
-    static constexpr uint8_t BOOT_SF = 10;
-    static constexpr float BOOT_BW_KHZ = 125.0f;
+    static constexpr uint8_t BOOT_SF = 8;
+    static constexpr float BOOT_BW_KHZ = 250.0f;
     static constexpr uint8_t BOOT_CR = 7;
     static constexpr int8_t BOOT_TX_POWER_DBM = 20;
 


### PR DESCRIPTION
## Summary

The [base-station-mini pre-fab review](hardware/base-station-mini/prefab-review-2026-08-12.md) confirmed a firmware residue: the radio modem's pre-`SET_CONFIG` boot defaults were **SF10/BW125**, which is not a legal pair on the E220-900MM22S's LLCC68 die — the LLCC68 caps SF at 9 for BW125 (legal pairs: SF5–9 @ BW125, SF5–10 @ BW250, SF5–11 @ BW500), so the boot state was undefined behavior until the host pushed `SET_CONFIG`.

- `projects/radio_board/main/config.h`: `BOOT_SF` 10 → 8, `BOOT_BW_KHZ` 125 → 250 (the fleet operating point), with a comment recording the legal LLCC68 pairs.
- `components/TR_LoRa_Comms/TR_LoRa_Comms.h`: the `Config` struct's SF10/BW125 defaults retired to SF8/BW250; the pre-`begin()` placeholder members `cfg_sf_`/`cfg_bw_khz_` updated to match (`begin()` overwrites them, so this is consistency only).
- `projects/radio_board/README.md`: the two lines documenting the old boot point updated — the bench-log table row again literally matches what `main.cpp` logs (`radio up, listening at 915.0 MHz SF8`).

## Scope

Every `TR_LoRa_Comms` consumer sets SF/BW explicitly and host configs were already SF8/BW250, so only the modem's pre-`SET_CONFIG` listening state changes. No module substitution — the E220-900MM22S stays (an E22 needs a DIO3-fed TCXO and would come up dead against the current `begin()`).

## Verification

All four firmware projects build clean with ESP-IDF v6.0: `radio_board`, `base_station`, `out_computer`, `flight_computer` (`rocket_computer_mini` does not exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)