### PR TITLE
firmware(flight_computer): fix swapped camera net-name comments in board headers

### DIFF
--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v7.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v7.h
@@ -50,10 +50,14 @@ struct board_pins
     static constexpr uint8_t IIS2MDC_INT = 12;  // shared with MMC5983MA_INT
 
     // ### Camera (RunCam wiring bench-confirmed, #234/#251) ###
+    // Direction in camera-side terms: GPIO31 listens to the camera's TX pad,
+    // GPIO30 drives its RX pad. (The V7 schematic isn't in-repo; V8+ names
+    // these nets FC-perspective — Camera_RX on 31, Camera_TX on 30, the
+    // reverse of the GNSS convention — see the note in board_v8.h.)
     static constexpr int8_t CAM_PWR_PIN = 30;      // GoPro path, unused
     static constexpr int8_t CAM_SHUTTER_PIN = 31;  // GoPro path, unused
-    static constexpr int8_t RUNCAM_RX_PIN = 31;    // FC receives (Camera_TX)
-    static constexpr int8_t RUNCAM_TX_PIN = 30;    // FC transmits (Camera_RX)
+    static constexpr int8_t RUNCAM_RX_PIN = 31;    // FC receives (camera's TX pad)
+    static constexpr int8_t RUNCAM_TX_PIN = 30;    // FC transmits (camera's RX pad)
     static constexpr int8_t RUNCAM_PWR_PIN = 32;   // camera power gate (CAM_ACT)
 
     // ### Pyro channels ###

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
@@ -54,10 +54,17 @@ struct board_pins
     static constexpr uint8_t IIS2MDC_INT = 46;    // IIS2MDCTR_INT
 
     // ### Camera (same nets as V7: Camera_TX=30, Camera_RX=31, CAM_ACT=32) ###
+    // The camera nets are named from the FC's perspective — Camera_TX is the
+    // line the FC transmits on, into the camera's RX pad — the OPPOSITE of
+    // the GNSS_TX/GNSS_RX convention above (named from the module's side).
+    // Netlist-verified 2026-08-16: GPIO30 = Camera_TX -> R32 (1k) -> J4.4,
+    // GPIO31 = Camera_RX -> R30 (1k) -> J4.3. The constants below are correct
+    // (two RunCam Split 4 units answered GET_DEVICE_INFO and recorded on this
+    // mapping) — don't "fix" them to a module-perspective reading of the nets.
     static constexpr int8_t CAM_PWR_PIN = 30;      // GoPro path, unused
     static constexpr int8_t CAM_SHUTTER_PIN = 31;  // GoPro path, unused
-    static constexpr int8_t RUNCAM_RX_PIN = 31;    // FC receives (Camera_TX)
-    static constexpr int8_t RUNCAM_TX_PIN = 30;    // FC transmits (Camera_RX)
+    static constexpr int8_t RUNCAM_RX_PIN = 31;    // FC receives (net Camera_RX, camera's TX pad)
+    static constexpr int8_t RUNCAM_TX_PIN = 30;    // FC transmits (net Camera_TX, camera's RX pad)
     static constexpr int8_t RUNCAM_PWR_PIN = 32;   // camera power gate (CAM_ACT)
 
     // ### Pyro channels — FULL REMAP vs V7 ###


### PR DESCRIPTION
## What

Comment-only fix in `board_v7.h` and `board_v8.h`: the `RUNCAM_RX_PIN`/`RUNCAM_TX_PIN` annotations named the wrong schematic nets (claiming GPIO31 = `Camera_TX`). No constants changed — verified by diffing both files against HEAD with comments stripped (byte-identical code).

## Why

The camera nets are named from the **FC's perspective** (`Camera_TX` = the line the FC transmits on), the reverse of the GNSS nets' module-perspective convention documented in the same file. The swapped annotations are exactly what sent the 2026-08-16 bench session hunting for reversed UARTs on the V8 board.

Evidence:
- Netlist (kicad-cli export, both ends): U17 pin 60 = GPIO30 = `Camera_TX` → R32 (1 k) → J4.4; U17 pin 61 = GPIO31 = `Camera_RX` → R30 (1 k) → J4.3.
- Bench: two RunCam Split 4 units answer `GET_DEVICE_INFO` (`RunCam ALIVE — protocol v1, features 0x0077`) and record on RX=31/TX=30. The actual "won't record" root cause was a stale GoPro camera-type setting re-pushed from the app, not wiring.

`board_v8.h` now carries the verified net mapping plus a warning not to "fix" the constants to a module-perspective reading; `board_v7.h` states direction in camera-side terms only (its schematic predates the `hardware/` import and isn't in-repo to verify net names) and points to the V8 note. The out_computer board headers don't have the copied pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)