### PR TITLE
firmware: snapshot v4 — sim flag blocks INFLIGHT restore of simulated flights

### DIFF
--- a/tests_cpp/test_rocket_computer_types.cpp
+++ b/tests_cpp/test_rocket_computer_types.cpp
@@ -983,6 +983,48 @@ TEST(RocketComputerTypes, FlightSettingsData_Layout) {
     EXPECT_EQ(offsetof(FlightSettingsData, guid_tgt_src),      218u);
 }
 
+// --- Flight snapshot (crash recovery) ---
+// The snapshot is built and re-parsed at byte-exact offsets by the FC
+// (I2S→OC MRAM→I2C round trip) and the mini (NAND log stream tail-scan).
+// Lock the layout so a struct edit can't silently desync the two ends —
+// especially sim_flight (v4), the byte that keeps a mid-sim reboot from
+// restoring to LIVE INFLIGHT with bench igniters connected.
+TEST(RocketComputerTypes, FlightSnapshotData_Layout) {
+    // 224 = one I2S frame, one I2C TX response, and the OC MRAM slot bound.
+    EXPECT_EQ(sizeof(FlightSnapshotData), 224u);
+    EXPECT_EQ(sizeof(FlightSnapshotData), (size_t)MAX_PAYLOAD);
+    // v4: sim_flight reclaimed from the header pad.  Restore paths refuse
+    // any other version — a v3 frame can't prove it wasn't a sim flight.
+    EXPECT_EQ(FlightSnapshotData::VERSION, 4u);
+
+    EXPECT_EQ(offsetof(FlightSnapshotData, magic),               0u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, version),             4u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, rocket_state),        5u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, sim_flight),          6u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, flight_elapsed_ms),   8u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, apogee_elapsed_ms),  12u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, burnout_elapsed_ms), 16u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, pyro_apogee_detected), 20u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, pyro1_fired),        21u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, pyro4_fired),        24u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, b2r_code),           25u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, b2r_mode),           26u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ground_pressure_pa), 28u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ref_lat_rad),        32u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ref_alt_m),          48u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_initialized),    56u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_pos_rrm),        60u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_vel_ned_mps),    84u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_quat),           96u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_P_diag),        136u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_t_prev_us),     196u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, ekf_euler),         200u);
+    EXPECT_EQ(offsetof(FlightSnapshotData, b2r_q),             212u);
+    // CRC32 covers everything before it — both computeSnapshotCRC()
+    // implementations hash [0, offsetof(crc32)).
+    EXPECT_EQ(offsetof(FlightSnapshotData, crc32),             220u);
+}
+
 TEST(RocketComputerTypes, FlightSettings_FlagBits_NoOverlap) {
     uint8_t all = (uint8_t)((1u << FlightSettingsData::F_USE_ANGLE_CONTROL) |
                             (1u << FlightSettingsData::F_GAIN_SCHEDULE) |

--- a/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
+++ b/tinkerrocket-idf/components/TR_RocketComputerTypes/RocketComputerTypes.h
@@ -2587,14 +2587,22 @@ static_assert(sizeof(GuidanceTelemData) == 19, "GuidanceTelemData must be 19 byt
 struct __attribute__((packed)) FlightSnapshotData
 {
     static constexpr uint32_t MAGIC   = 0xF1A75A7E;  // distinct from old NVS magic (0xF1A7C0DE)
-    static constexpr uint8_t  VERSION = 3;           // v2: 4-channel pyro layout, no per-channel ARM
+    static constexpr uint8_t  VERSION = 4;           // v2: 4-channel pyro layout, no per-channel ARM
                                                      // v3: board→rocket orientation (b2r_*)
+                                                     // v4: sim_flight flag (reclaimed from pad)
 
     // --- Header ---
     uint32_t magic;
     uint8_t  version;
     uint8_t  rocket_state;
-    uint8_t  pad[2];
+    // 1 = snapshot was built during a SIMULATED flight (v4).  isSimActive()
+    // does not survive a reboot, so restore paths MUST refuse sim snapshots:
+    // restoring one would resume LIVE INFLIGHT with the pyro dry-fire gate
+    // off and bench igniters connected.  Restore paths also refuse v3
+    // snapshots outright (version check) — a v3 frame can't prove it wasn't
+    // a sim flight.
+    uint8_t  sim_flight;
+    uint8_t  pad[1];
 
     // --- Flight timestamps (relative to launch) ---
     uint32_t flight_elapsed_ms;
@@ -2795,7 +2803,7 @@ static constexpr size_t P5 = SIZE_OF_POWER_DATA;
 static constexpr size_t P6 = SIZE_OF_NON_SENSOR_DATA;
 static constexpr size_t P7 = SIZE_OF_LORA_DATA;
 static constexpr size_t P8 = sizeof(RollProfileData);
-static constexpr size_t P9 = sizeof(FlightSnapshotData);  // largest payload (224 B as of snapshot v3)
+static constexpr size_t P9 = sizeof(FlightSnapshotData);  // largest payload (224 B as of snapshot v4)
 
 static constexpr size_t M12   = (P1 > P2 ? P1 : P2);
 static constexpr size_t M34   = (P3 > P4 ? P3 : P4);

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -594,6 +594,10 @@ static void buildFlightSnapshot(FlightSnapshotData& snap, uint32_t now_ms, uint8
     snap.magic        = FlightSnapshotData::MAGIC;
     snap.version      = FlightSnapshotData::VERSION;
     snap.rocket_state = (override_state != 0xFF) ? override_state : (uint8_t)rocket_state;
+    // v4: latch sim mode into the snapshot — isSimActive() is false after a
+    // reboot, so the restore path can only learn this from the snapshot
+    // itself (and refuses to restore when set).
+    snap.sim_flight   = sensor_collector.isSimActive() ? 1 : 0;
 
     snap.flight_elapsed_ms  = now_ms - launch_time_millis;
     snap.apogee_elapsed_ms  = pyro_apogee_detected
@@ -3266,7 +3270,15 @@ static void setup_fc()
                                     snap.version == FlightSnapshotData::VERSION &&
                                     snap.rocket_state == (uint8_t)INFLIGHT &&
                                     snap.crc32 == computeSnapshotCRC(snap)) {
-                                    valid = true;
+                                    if (snap.sim_flight) {
+                                        // The dry-fire gate lives in isSimActive(),
+                                        // which a reboot resets — restoring here
+                                        // would fire real pyro outputs on bench
+                                        // igniters mid-sim.
+                                        ESP_LOGW(TAG, "[RECOVERY] Snapshot is from a SIMULATED flight — refusing restore");
+                                    } else {
+                                        valid = true;
+                                    }
                                 } else {
                                     ESP_LOGW(TAG, "[RECOVERY] Snapshot invalid (magic=0x%08lX state=%u crc=%s)",
                                              (unsigned long)snap.magic, snap.rocket_state,

--- a/tinkerrocket-idf/projects/rocket_computer_mini/main/flight.cpp
+++ b/tinkerrocket-idf/projects/rocket_computer_mini/main/flight.cpp
@@ -739,6 +739,10 @@ static void buildFlightSnapshot(FlightSnapshotData& snap, uint32_t now_ms, uint8
     snap.magic        = FlightSnapshotData::MAGIC;
     snap.version      = FlightSnapshotData::VERSION;
     snap.rocket_state = (override_state != 0xFF) ? override_state : (uint8_t)rocket_state;
+    // v4: latch sim mode into the snapshot — isSimActive() is false after a
+    // reboot, so the restore path can only learn this from the snapshot
+    // itself (and refuses to restore when set).
+    snap.sim_flight   = sensor_collector.isSimActive() ? 1 : 0;
 
     snap.flight_elapsed_ms  = now_ms - launch_time_millis;
     snap.apogee_elapsed_ms  = pyro_apogee_detected
@@ -1927,7 +1931,9 @@ static void handleCommandFrame(const mini_link::CmdFrame& cmd, uint32_t now_ms)
 //   3. that entry is the NEWEST flight on the chip (highest flight_id) — an
 //      old never-deleted recovered file must not resurrect a stale flight,
 //   4. the last snapshot frame validates: magic, version, INFLIGHT, CRC32
-//      (the same four the FC required).
+//      (the same four the FC required),
+//   5. the snapshot is not from a SIMULATED flight (sim_flight, v4) — the
+//      dry-fire gate does not survive a reboot.
 extern tr_flightlog::TR_FlightLog flightlog;   // defined in main.cpp
 
 // One packed snapshot frame in the log stream: SOF(4) | type | len | 224 | CRC16.
@@ -2373,7 +2379,15 @@ void flight_setup()
                        snap.version == FlightSnapshotData::VERSION &&
                        snap.rocket_state == (uint8_t)INFLIGHT &&
                        snap.crc32 == computeSnapshotCRC(snap)) {
-                valid = true;
+                if (snap.sim_flight) {
+                    // The dry-fire gate lives in isSimActive(), which a reboot
+                    // resets — restoring here would fire real pyro outputs on
+                    // bench igniters mid-sim.  Falls through to the
+                    // evaluated-marker write below like any other decline.
+                    ESP_LOGW(TAG, "[RECOVERY] snapshot is from a SIMULATED flight — refusing restore");
+                } else {
+                    valid = true;
+                }
             } else {
                 ESP_LOGW(TAG, "[RECOVERY] Snapshot invalid (magic=0x%08lX state=%u crc=%s)",
                          (unsigned long)snap.magic, snap.rocket_state,


### PR DESCRIPTION
**Stacked on #799** — base is `claude/mini-rocket-computer-firmware-b136b3`; merge that first and this reduces to the single sim-flag commit.

## Problem

`FlightSnapshotData` had no record that a flight was a SIMULATION. Both the FC (10 Hz snapshot → OC MRAM → I2C round-trip, #261) and the mini (NAND log-stream tail-scan) restore to LIVE INFLIGHT after an unexpected reboot — and `isSimActive()` is false after reboot. So a crash mid-sim restored flight state with the pyro dry-fire gate off and bench igniters connected: any enabled channel whose trigger condition was still satisfied would really fire. Pre-existing fleet property, found during the mini firmware adversarial review (filed as a residual in #799).

## Fix

- **`FlightSnapshotData` v3 → v4**: `sim_flight` reclaimed from the header pad at offset 6 — size stays exactly 224 (one I2S frame / I2C TX response / OC MRAM slot; the out_computer treats the payload as an opaque blob and is untouched).
- Both `buildFlightSnapshot()`s latch `sensor_collector.isSimActive()` into the flag on every save.
- Both restore paths refuse an otherwise-valid INFLIGHT snapshot whose sim flag is set, logging why. On the mini the refusal flows into the evaluated-marker write like any other decline, so the same sim snapshot is never re-evaluated.
- **v3 snapshots are refused everywhere** by the existing `version == VERSION` equality check — deliberate, since a v3 frame can't prove it wasn't a sim flight. The only cross-upgrade effect is one declined recovery, which is the safe direction.
- New `FlightSnapshotData_Layout` offset-pin test (the snapshot had no layout pins; follows the `FlightSettingsData_Layout` convention). No other fixtures or host tooling decode the snapshot — `catalog.py` only counts 0xD2 frames.

## Verification

- Host suite: 703/703
- `flight_computer`, `out_computer`, `rocket_computer_mini` all build with ESP-IDF v6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
