### PR TITLE
firmware+apps: camera and logging BLE commands carry desired state

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -899,8 +899,13 @@ private fun ControlsCard(session: DeviceSession, telemetry: TelemetryData) {
                                 ),
                             )
                         } else {
-                            session.sendBareCommand(
-                                com.tinkerbug.tinkerrocket.protocol.BleCommandId.CAMERA_TOGGLE,
+                            // Explicit desired state on the direct link too:
+                            // a bare toggle inverts whenever the app and the
+                            // OC disagree about the current state (a "start"
+                            // tap stopping the camera — bench 2026-08-16).
+                            session.sendCommandFrame(
+                                com.tinkerbug.tinkerrocket.protocol.Commands
+                                    .cameraToggleWithState(!cam),
                             )
                         }
                     },
@@ -921,8 +926,11 @@ private fun ControlsCard(session: DeviceSession, telemetry: TelemetryData) {
                                 ),
                             )
                         } else {
-                            session.sendBareCommand(
-                                com.tinkerbug.tinkerrocket.protocol.BleCommandId.TOGGLE_LOGGING,
+                            // Explicit desired state — same reason as the
+                            // camera button above.
+                            session.sendCommandFrame(
+                                com.tinkerbug.tinkerrocket.protocol.Commands
+                                    .toggleLoggingWithState(!log),
                             )
                         }
                     },

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/BleCommandId.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/BleCommandId.kt
@@ -19,10 +19,11 @@ package com.tinkerbug.tinkerrocket.protocol
  * Payload layouts are pinned byte-exactly by tests_cpp/fixtures/wire/commands/.
  */
 public object BleCommandId {
-    // Camera toggle. Direct link: bare cmd 1. BS link: relayed with an
-    // explicit desired-state byte computed from the FOCUSED rocket's
-    // telemetry (#390 — the legacy broadcast keyed off whichever rocket was
-    // heard last).
+    // Camera on/off. `[desired u8]` (1 = record, 0 = stop) on BOTH links —
+    // BS relayed to the FOCUSED rocket (#390 — the legacy broadcast keyed off
+    // whichever rocket was heard last), direct link state-based too since a
+    // blind toggle inverts on any app/OC desync. Firmware still accepts the
+    // bare form as a legacy toggle.
     public const val CAMERA_TOGGLE: Int = 1
 
     // File operations (sent as raw writes in iOS — Data([N, ...]), not
@@ -49,7 +50,7 @@ public object BleCommandId {
     public const val REQUEST_CONFIG: Int = 20
     public const val SENSOR_CAL_RUN: Int = 21      // on-pad gyro+high-g cal, ~12 s
     public const val GAIN_SCHED_ENABLE: Int = 22   // [bool]
-    public const val TOGGLE_LOGGING: Int = 23
+    public const val TOGGLE_LOGGING: Int = 23      // [desired u8]; bare = legacy toggle
     public const val SERVO_TEST: Int = 24          // ServoTestAnglesData 8 B
     public const val SERVO_TEST_STOP: Int = 25
     public const val ROLL_PROFILE: Int = 26        // RollProfileData 76 B

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -2376,7 +2376,12 @@ struct ControlsView: View {
                                             innerCommand: 1,
                                             innerPayload: Data([desired]))
                 } else {
-                    device.sendCommand(1)
+                    // Direct link: send the desired state too.  A bare toggle
+                    // inverts whenever the app and the OC disagree about the
+                    // current state (a "start" tap stopping the camera —
+                    // bench 2026-08-16); firmware still accepts the bare form.
+                    let desired: UInt8 = device.telemetry.camera_recording ? 0 : 1
+                    device.sendRawCommand(1, payload: Data([desired]))
                 }
             }) {
                 HStack {
@@ -2402,7 +2407,10 @@ struct ControlsView: View {
                                             innerCommand: 23,
                                             innerPayload: Data([desired]))
                 } else {
-                    device.sendCommand(23)   // direct link: OC toggle
+                    // Direct link: desired state, same reason as the camera
+                    // button above.
+                    let desired: UInt8 = device.telemetry.rocketLoggingActive ? 0 : 1
+                    device.sendRawCommand(23, payload: Data([desired]))
                 }
             }) {
                 let active = device.telemetry.rocketLoggingActive

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 27,246 lines across 70 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 27,254 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -78,11 +78,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [FrequencyScanSample.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/FrequencyScanSample.swift) | 15 | `FrequencyScanSample` |
 
 
-## `Views/` — 27 files, 14,112 lines
+## `Views/` — 27 files, 14,120 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 3,033 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +40 more |
+| [DashboardView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift) | 3,041 | `IdentifiableInt`, `DashboardSheet`, `DashboardView`, `ConnectedFleetView`, `DirectRocketSection`, `FocusedRelaySection`, +40 more |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Connected fleet dashboard (#390) · Connected device dashboard (observes the BLEDevice for live updates) · Shared rocket telemetry cards · Component Views · Pyro Channels · Controls · Branded Toolbar · Signal Strength Tile · LoRa RSSI mapping (-130 to -30 dBm) · GNSS Satellites (0 to 30) · BLE RSSI mapping (-100 to -30 dBm) · Preview |
 | [SettingsView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/SettingsView.swift) | 1,748 | `SettingsView`, `PyroChannelTestControls` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Focus-driven self-apply (#144) · Base station (read-only display) · No active profile · Rocket settings (profile-backed) · Per-channel profile accessors (centralise the 4-channel switch) · Profile bindings · String ↔ profile sync · Helpers · Apply actions (write profile + push when connected) · LoRa TX power (base station only) · Pyro live controls |
@@ -122,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 70 files, 27,246 lines.
+Total: 70 files, 27,254 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,815 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,848 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -36,8 +36,8 @@ and leading comments.
 | [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4774-L5512) | 739 | 4774-5512 |
 | [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5513-L6019) | 507 | 5513-6019 |
 | [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6020-L6297) | 278 | 6020-6297 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6298-L7806) | 1,509 | 6298-7806 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6671-L7806) | 1,136 | 6671-7806 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7807-L7815) | 9 | 7807-7815 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6298-L7839) | 1,542 | 6298-7839 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6671-L7839) | 1,169 | 6671-7839 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7840-L7848) | 9 | 7840-7848 |
 
-Total: 28 sections (1 nested) across 7,815 lines.
+Total: 28 sections (1 nested) across 7,848 lines.

--- a/docs/architecture/generated/protocol-reference.md
+++ b/docs/architecture/generated/protocol-reference.md
@@ -193,7 +193,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 
 | Cmd | Constant | Description |
 |-----|----------|-------------|
-| 1 |  | Toggle camera recording |
+| 1 |  | Camera: payload[0] = desired state (1 = on, 0 = off), same semantics as the LoRa uplink (processUplinkCommand… |
 | 2 |  | Send file list with pagination (5 files per page). Encoder lives in wire_format:: and is byte-tested against… |
 | 3 |  | Delete file, then return the refreshed page-0 listing |
 | 5 |  | Configure simulation: [mass_g:4][thrust_n:4][burn_s:4][descent_rate_mps:4] |
@@ -211,7 +211,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 | 20 |  | Config readback request |
 | 21 |  |  |
 | 22 |  | Gain schedule enable/disable: [enabled:1] |
-| 23 |  | Toggle logging (manual start/stop from app) |
+| 23 |  | Logging: payload[0] = desired state (1 = start, 0 = stop), matching the LoRa uplink and BS relay. Same desync… |
 | 24 |  | Servo test: set angles |
 | 25 |  | Servo test: stop |
 | 26 |  | Roll profile set: [num_wp:1][pad:3][wp0_time:4f][wp0_angle:4f]...[wp7_time:4f][wp7_angle:4f] |

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6677,10 +6677,30 @@ static void loop_oc()
         ESP_LOGI("OC_CMD", "BLE cmd=%u", (unsigned)ble_cmd);
         if (ble_cmd == 1)
         {
-            // Toggle camera recording
-            camera_recording_requested = !camera_recording_requested;
-            setPendingCommand(camera_recording_requested ? CAMERA_START : CAMERA_STOP);
-            ESP_LOGI("BLE", "Camera toggle requested: %s", camera_recording_requested ? "START" : "STOP");
+            // Camera: payload[0] = desired state (1 = on, 0 = off), same
+            // semantics as the LoRa uplink (processUplinkCommand cmd 1) and
+            // the BS relay.  A blind toggle inverts whenever the app's idea
+            // of the state and ours disagree — bench-observed 2026-08-16: the
+            // OC held recording_requested=true across an FC reboot, so the
+            // next "start" tap stopped the camera 11 ms after the FC had sent
+            // START_RECORDING.  Falls back to toggle with no payload (legacy
+            // app compat).
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t   plen    = ble_app.getCommandPayloadLength();
+            const bool want_on = (plen >= 1) ? (payload[0] != 0)
+                                             : !camera_recording_requested;
+            if (want_on != camera_recording_requested)
+            {
+                camera_recording_requested = want_on;
+                setPendingCommand(want_on ? CAMERA_START : CAMERA_STOP);
+                ESP_LOGI("BLE", "Camera %s%s", want_on ? "START" : "STOP",
+                         (plen >= 1) ? "" : " (legacy toggle)");
+            }
+            else
+            {
+                ESP_LOGI("BLE", "Camera already %s, ignoring",
+                         want_on ? "ON" : "OFF");
+            }
         }
         else if (ble_cmd == 2)
         {
@@ -6696,8 +6716,21 @@ static void loop_oc()
         }
         else if (ble_cmd == 23)
         {
-            // Toggle logging (manual start/stop from app)
-            if (logger.isLoggingActive())
+            // Logging: payload[0] = desired state (1 = start, 0 = stop),
+            // matching the LoRa uplink and BS relay.  Same desync hazard as
+            // cmd 1 above — a blind toggle turns "start" into "stop" whenever
+            // the app's view disagrees with ours.  Falls back to toggle with
+            // no payload (legacy app compat).
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t   plen    = ble_app.getCommandPayloadLength();
+            const bool logging_now = logger.isLoggingActive();
+            const bool want_on = (plen >= 1) ? (payload[0] != 0) : !logging_now;
+            if (want_on == logging_now)
+            {
+                ESP_LOGI("OC_CMD", "Logging already %s, ignoring",
+                         logging_now ? "ACTIVE" : "STOPPED");
+            }
+            else if (!want_on)
             {
                 logger.endLogging();
                 flightlogEndFlight();


### PR DESCRIPTION
## Why

The BLE camera command (cmd 1) was a **blind toggle** — the OC flipped `camera_recording_requested` and derived START/STOP from the result — so any disagreement between the app's view and the OC's inverts the user's intent.

Observed live on the bench 2026-08-16: the OC held `recording_requested = true` across a flight-computer reboot, so the operator's "start" tap arrived as `CAMERA_STOP` and killed the camera 11 ms after the FC had sent `START_RECORDING`. From the outside this looked like "the RunCam won't record" and cost a chunk of a debugging session.

The LoRa uplink path already solved exactly this (`payload[0]` = desired state, bare = legacy toggle), and so did the BS relay path in both apps. Only the **direct BLE link** was still blind.

## What changed

- **OC firmware** — cmd 1 (camera) and cmd 23 (logging, same shape and same hazard) now read `payload[0]` as the desired state, ignore a command that matches the current state, and fall back to toggling when there is no payload.
- **Both apps** — the direct-link camera and logging buttons send the explicit state (`cameraToggleWithState` / `toggleLoggingWithState` on Android, `sendRawCommand(n, payload:)` on iOS), matching what they already did on the BS relay path.
- **BleCommandId docs** updated to describe the payload.

## Compatibility (both directions)

| | old firmware | new firmware |
|---|---|---|
| **old app** (bare) | toggle | toggle — legacy path preserved |
| **new app** (payload) | payload ignored → toggle | desired state, idempotent |

Repeats and retries are now idempotent rather than state-flipping. The BLE transport already forwards a cmd 1/23 payload via its generic handler, so no `TR_BLE_To_APP.cpp` change was needed.

## Verification

- `out_computer` firmware builds (IDF 6.0.1, the CI version).
- `tools/check_ble_command_ids.py` passes — Swift/Kotlin/firmware command sets still agree.
- `tools/check_docs.py` passes.
- Android `:core:protocol` and `:core:session` tests pass; `CommandsGoldenTest` already pins the frames as `[1, 1]` and `[23, 0]`.

## Deliberately not in this PR

**cmd 8 (power rail)** is the same blind-toggle shape and the consequence of an inversion is worse (cutting the FC rail). It needs more than a one-line change: `TR_BLE_To_APP.cpp` has an explicit `else if (cmd == 8)` branch that matches any length and **discards the payload**, so the transport must change too — and the power-off path resets the OC, with the `#159` power-on watchdog and `#377` telemetry gate layered on top. The UI gate already mitigates the desync. Worth doing as its own reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)