### PR TITLE
firmware+apps: power-rail BLE command carries desired state

### DIFF
--- a/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
+++ b/TinkerRocketAndroid/app/src/main/kotlin/com/tinkerbug/tinkerrocket/app/DashboardScreen.kt
@@ -215,7 +215,7 @@ fun DashboardScreen(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text("ON")
-                        Button(onClick = { session.sendPowerToggle() }) { Text("Power off") }
+                        Button(onClick = { session.sendPowerState(railOn = false) }) { Text("Power off") }
                     }
                     else -> Row(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/Commands.kt
+++ b/TinkerRocketAndroid/core/protocol/src/main/kotlin/com/tinkerbug/tinkerrocket/protocol/Commands.kt
@@ -288,19 +288,29 @@ public object Commands {
         frame(BleCommandId.CAMERA_CONFIG) { u8(cameraType) }
 
     /**
-     * cmd 1 with an explicit desired-state byte — ONLY used as the inner
-     * frame of a BS relay (#390): the direct link sends bare cmd 1
-     * ([bare]).  desired 1 = start recording, 0 = stop.
+     * cmd 1 with an explicit desired-state byte — used both as the inner
+     * frame of a BS relay (#390) and on the direct link: a blind toggle
+     * inverts whenever the app and the OC disagree about the current state.
+     * desired 1 = start recording, 0 = stop.  Firmware treats a bare cmd 1
+     * as a legacy toggle.
      */
     public fun cameraToggleWithState(recordOn: Boolean): ByteArray =
         frame(BleCommandId.CAMERA_TOGGLE) { bool(recordOn) }
 
-    /**
-     * cmd 23 with an explicit desired-state byte — ONLY used as the inner
-     * frame of a BS relay (#390); the direct link sends bare cmd 23.
-     */
+    /** cmd 23 with an explicit desired-state byte — same rationale and
+     *  legacy fallback as [cameraToggleWithState]. */
     public fun toggleLoggingWithState(loggingOn: Boolean): ByteArray =
         frame(BleCommandId.TOGGLE_LOGGING) { bool(loggingOn) }
+
+    /**
+     * cmd 8 with an explicit desired-state byte — 1 = rail on, 0 = rail off.
+     * Same rationale as [cameraToggleWithState], and the stakes are higher:
+     * a blind toggle that inverts cuts the flight computer's rail when the
+     * operator asked to power it up.  Firmware treats a bare cmd 8 as a
+     * legacy toggle.
+     */
+    public fun powerState(railOn: Boolean): ByteArray =
+        frame(BleCommandId.POWER_TOGGLE) { bool(railOn) }
 
     /** cmd 64 — IMU mounting orientation: 0xFF = auto (pad-gravity detect),
      *  0..23 = manual board→rocket code. `[setting u8]`. */

--- a/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/CommandsGoldenTest.kt
+++ b/TinkerRocketAndroid/core/protocol/src/test/kotlin/com/tinkerbug/tinkerrocket/protocol/CommandsGoldenTest.kt
@@ -406,6 +406,10 @@ class CommandsGoldenTest {
         assertEquals(listOf(1, 1), Commands.cameraToggleWithState(true).map { it.toInt() })
         assertEquals(listOf(23, 0), Commands.toggleLoggingWithState(false).map { it.toInt() })
         assertEquals(listOf(2, 3), Commands.fileList(3).map { it.toInt() })
+        // cmd 8 both ways: state-based is what the app sends now, bare is the
+        // legacy toggle old apps send and firmware still accepts.
+        assertEquals(listOf(8, 1), Commands.powerState(railOn = true).map { it.toInt() })
+        assertEquals(listOf(8, 0), Commands.powerState(railOn = false).map { it.toInt() })
         assertEquals(listOf(8), Commands.bare(BleCommandId.POWER_TOGGLE).map { it.toInt() })
         assertEquals(listOf(64, 7), Commands.imuOrient(7).map { it.toInt() })
     }

--- a/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/DeviceSession.kt
+++ b/TinkerRocketAndroid/core/session/src/main/kotlin/com/tinkerbug/tinkerrocket/session/DeviceSession.kt
@@ -881,15 +881,23 @@ public class DeviceSession(
         scope.launch { writeCommand(frame) }
     }
 
-    /** Blind cmd-8 toggle — UI must gate on [hasReceivedTelemetry] (#377). */
-    public fun sendPowerToggle(): Unit = sendBareCommand(BleCommandId.POWER_TOGGLE)
+    /**
+     * cmd 8 with the desired rail state.  Explicit rather than a blind
+     * toggle: a desync would otherwise cut the FC's rail when the operator
+     * asked to power it up.  The UI still gates on [hasReceivedTelemetry]
+     * (#377) so [railOn] is derived from a state we have actually seen.
+     */
+    public fun sendPowerState(railOn: Boolean): Unit =
+        sendCommandFrame(Commands.powerState(railOn))
 
     /**
      * #159 power-on press: lights the busy state and arms a 3 min watchdog
-     * before sending the toggle.  Cleared by the first pwr_pin_on telemetry
-     * frame, by the watchdog (a genuinely-dropped command), or by disconnect.
-     * 3 min because the OC can block its loop up to ~90 s flushing the
-     * flight log before acting on cmd 8 — the watchdog must outlast that.
+     * before commanding the rail ON.  Cleared by the first pwr_pin_on
+     * telemetry frame, by the watchdog (a genuinely-dropped command), or by
+     * disconnect.  3 min because the OC can block its loop up to ~90 s
+     * flushing the flight log before acting on cmd 8 — the watchdog must
+     * outlast that.  The command carries the desired state, so a repeat
+     * while busy is now idempotent rather than powering the rocket back off.
      */
     public fun beginPowerOn() {
         scope.launch {
@@ -899,7 +907,7 @@ public class DeviceSession(
                 delay(POWER_ON_WATCHDOG_MS)
                 clearPoweringOnNow()
             }
-            writeCommand(Commands.bare(BleCommandId.POWER_TOGGLE))
+            writeCommand(Commands.powerState(railOn = true))
         }
     }
 

--- a/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift
@@ -409,17 +409,22 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         print("Sent command: \(command)")
     }
 
-    func sendPowerToggle() {
-        sendCommand(8)
+    /// cmd 8 with the desired rail state.  Explicit rather than a blind
+    /// toggle: a desync would otherwise cut the FC's rail when the operator
+    /// asked to power it up.  The UI gates the button on having received
+    /// telemetry (#377), so the state passed here is one we have seen.
+    /// Firmware treats a bare cmd 8 as a legacy toggle.
+    func sendPowerState(railOn: Bool) {
+        sendRawCommand(8, payload: Data([railOn ? 1 : 0]))
     }
 
     /// Power-on press handler (#159).  Lights the button's busy state and
-    /// arms a watchdog before sending the toggle.  `poweringOn` clears on the
-    /// first `pwr_pin_on` telemetry frame (see telemetry decode) or on
+    /// arms a watchdog before commanding the rail ON.  `poweringOn` clears on
+    /// the first `pwr_pin_on` telemetry frame (see telemetry decode) or on
     /// disconnect; the watchdog is a backstop so a silently-dropped command
-    /// can't leave the button spinning forever.  Cmd 8 is a toggle, so the
-    /// button stays disabled while busy to prevent a double-press from
-    /// powering the rocket back off.
+    /// can't leave the button spinning forever.  The command now carries the
+    /// desired state, so a double-press is idempotent rather than powering
+    /// the rocket back off; the button still disables while busy.
     func beginPowerOn() {
         poweringOn = true
         poweringOnTimer?.invalidate()
@@ -431,7 +436,7 @@ class BLEDevice: NSObject, ObservableObject, CBPeripheralDelegate {
         poweringOnTimer = Timer.scheduledTimer(withTimeInterval: 180.0, repeats: false) { [weak self] _ in
             DispatchQueue.main.async { self?.clearPoweringOn() }
         }
-        sendPowerToggle()
+        sendPowerState(railOn: true)
     }
 
     func clearPoweringOn() {

--- a/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
+++ b/TinkerRocketApp/TinkerRocketApp/Views/DashboardView.swift
@@ -698,7 +698,7 @@ struct ConnectedDashboardView: View {
 
             if !device.isBaseStation {
                 Button {
-                    device.sendPowerToggle()
+                    device.sendPowerState(railOn: false)
                 } label: {
                     HStack {
                         Image(systemName: "bolt.slash.fill")

--- a/docs/architecture/generated/ios-app-map.md
+++ b/docs/architecture/generated/ios-app-map.md
@@ -3,7 +3,7 @@
 
 # iOS App -- module map
 
-`TinkerRocketApp/TinkerRocketApp` is 27,254 lines across 70 Swift files, grouped by directory.
+`TinkerRocketApp/TinkerRocketApp` is 27,259 lines across 70 Swift files, grouped by directory.
 "Declares" lists the top-level types in each file. Files of 400+ lines also
 list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 
@@ -30,11 +30,11 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [BasemapOverlayController.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Maps/Offline/BasemapOverlayController.swift) | 36 | `BasemapOverlayController` |
 
 
-## `Models/` — 33 files, 12,224 lines
+## `Models/` — 33 files, 12,229 lines
 
 | File | Lines | Declares |
 |------|-------|----------|
-| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 2,141 | `BLEDeviceType`, `BLEDevice` |
+| [BLEDevice.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/BLEDevice.swift) | 2,146 | `BLEDeviceType`, `BLEDevice` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Published per-device state · Device identity (populated from config_identity readback) · Internal state · Init · Connection lifecycle (called by BLEFleet) · BLE RSSI Polling · Sim state · Commands · OTA helpers (#8 phase 2) · Magnetometer hard-iron calibration (issue #96) · Identity commands · File operations · File chunk handling (private) · CSV Generation · Download State Management · CBPeripheralDelegate · Telemetry parsing |
 | [SensorTypes.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Models/SensorTypes.swift) | 1,014 | `MessageType`, `RocketState`, `ParseError` |
 | &nbsp;&nbsp;&nbsp;&nbsp;↳ *sections* | | Message Types · Rocket State · Status Query Data (10 bytes) — sensor config from FlightComputer · Flight Settings Snapshot (176 bytes) — runtime config at launch (#165) · Raw Packed Data Structures · Legacy Raw Data Structures · SI Unit Structures · Parsing Errors · Data Extension for Binary Parsing |
@@ -122,4 +122,4 @@ list their `// MARK: -` sections, which is what Xcode's jump bar shows.
 | [ColumnPickerView.swift](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/TinkerRocketApp/TinkerRocketApp/Views/ColumnPickerView.swift) | 72 | `ColumnPickerView` |
 
 
-Total: 70 files, 27,254 lines.
+Total: 70 files, 27,259 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,848 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,871 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -36,8 +36,8 @@ and leading comments.
 | [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4774-L5512) | 739 | 4774-5512 |
 | [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5513-L6019) | 507 | 5513-6019 |
 | [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6020-L6297) | 278 | 6020-6297 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6298-L7839) | 1,542 | 6298-7839 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6671-L7839) | 1,169 | 6671-7839 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7840-L7848) | 9 | 7840-7848 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6298-L7862) | 1,565 | 6298-7862 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6671-L7862) | 1,192 | 6671-7862 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7863-L7871) | 9 | 7863-7871 |
 
-Total: 28 sections (1 nested) across 7,848 lines.
+Total: 28 sections (1 nested) across 7,871 lines.

--- a/docs/architecture/generated/protocol-reference.md
+++ b/docs/architecture/generated/protocol-reference.md
@@ -199,7 +199,7 @@ for internal uniqueness by [`tools/check_ble_command_ids.py`](https://github.com
 | 5 |  | Configure simulation: [mass_g:4][thrust_n:4][burn_s:4][descent_rate_mps:4] |
 | 6 |  |  |
 | 7 |  |  |
-| 8 |  | Toggle power rail |
+| 8 |  | Power rail: payload[0] = desired state (1 = on, 0 = off), same semantics as cmds 1/23. A blind toggle inverts… |
 | 9 |  | Phone time sync: [year_lo][year_hi][month][day][hour][minute][second] |
 | 10 |  | Direct LoRa reconfig over BLE is no longer accepted on the rocket side (#106). LoRa link parameters are owned… |
 | 11 |  | Rocket computer sound enable/disable: [enabled:1] |

--- a/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
+++ b/tinkerrocket-idf/components/TR_BLE_To_APP/TR_BLE_To_APP.cpp
@@ -750,8 +750,26 @@ void TR_BLE_To_APP::onCommandWrite(const uint8_t* data, size_t length)
     }
     else if (cmd == 8)
     {
-        // Command 8: Toggle power rail (PWR_PIN)
-        ESP_LOGI(BLE_TAG, "Power toggle");
+        // Command 8: power rail (PWR_PIN).  [desired u8] (1 = on, 0 = off);
+        // bare = legacy toggle.  This branch matches ANY length, so it has to
+        // capture the payload itself — it shadows the generic handler below,
+        // and without this the state byte was silently dropped and the rail
+        // stayed a blind toggle no matter what the app sent.
+        if (length > 1)
+        {
+            payload_len_local = length - 1;
+            if (payload_len_local > sizeof(payload_local))
+            {
+                payload_len_local = sizeof(payload_local);
+            }
+            memcpy(payload_local, data + 1, payload_len_local);
+            have_payload = true;
+            ESP_LOGI(BLE_TAG, "Power %s", data[1] ? "ON" : "OFF");
+        }
+        else
+        {
+            ESP_LOGI(BLE_TAG, "Power toggle (legacy, no state byte)");
+        }
     }
     else if (cmd == 9 && length >= 8)
     {

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -7153,11 +7153,27 @@ static void loop_oc()
         }
         else if (ble_cmd == 8)
         {
-            // Toggle power rail
-            pwr_pin_on = !pwr_pin_on;
+            // Power rail: payload[0] = desired state (1 = on, 0 = off), same
+            // semantics as cmds 1/23.  A blind toggle inverts whenever the
+            // app's view and ours disagree — and here that means cutting the
+            // FC's rail when the operator asked to power it up (or a repeated
+            // command double-toggling).  The app knows the true state: the OC
+            // stays alive with the rail down and keeps reporting pwr_pin_on,
+            // and the UI gates the button on having received telemetry
+            // (#377).  No payload still means toggle (legacy app compat).
+            const uint8_t* payload = ble_app.getCommandPayload();
+            const size_t   plen    = ble_app.getCommandPayloadLength();
+            const bool was_on  = pwr_pin_on;
+            const bool want_on = (plen >= 1) ? (payload[0] != 0) : !pwr_pin_on;
 
-            if (pwr_pin_on)
+            if (want_on == was_on)
             {
+                ESP_LOGI("BLE", "Power rail already %s, ignoring",
+                         was_on ? "ON" : "OFF");
+            }
+            else if (want_on)
+            {
+                pwr_pin_on = true;
                 // Exit low-power mode BEFORE powering peripherals — need
                 // full CPU speed and no auto light-sleep during init.
                 exitLowPowerMode();
@@ -7193,6 +7209,7 @@ static void loop_oc()
             }
             else
             {
+                pwr_pin_on = false;
                 // Power off: drop the FC rail and reset the OC.
                 //
                 // Surgically tearing down each peripheral on power-off
@@ -7264,13 +7281,19 @@ static void loop_oc()
                 // not reached
             }
 
-            ESP_LOGI("BLE", "Power rail toggled: %s", pwr_pin_on ? "ON" : "OFF");
+            // Only on an actual state change — an ignored duplicate must not
+            // claim the rail was switched, nor re-push config.
+            if (want_on != was_on)
+            {
+                ESP_LOGI("BLE", "Power rail: %s%s", pwr_pin_on ? "ON" : "OFF",
+                         (plen >= 1) ? "" : " (legacy toggle)");
 
-            // After power-on, NVS config is freshly loaded — resend config
-            // readback so the app gets the actual persisted values.
-            if (pwr_pin_on && ble_app.isConnected()) {
-                delay(100);  // let peripherals finish init
-                sendCurrentConfig();
+                // After power-on, NVS config is freshly loaded — resend config
+                // readback so the app gets the actual persisted values.
+                if (pwr_pin_on && ble_app.isConnected()) {
+                    delay(100);  // let peripherals finish init
+                    sendCurrentConfig();
+                }
             }
         }
         else if (ble_cmd == 9)


### PR DESCRIPTION
**Stacked on [#805](https://github.com/Tinkerbug-Robotics/TinkerRocket/pull/805)** — based on that branch, so review/merge #805 first; this PR's own diff is the last three commits. GitHub will retarget it to `main` automatically once #805 merges.

## Why

cmd 8 (power rail) was the last blind toggle, and the worst one to invert: a desync turns "power on" into cutting the flight computer's rail, and a repeated or retried command double-toggles.

## The part that made this more than a one-liner

Unlike camera/logging, **the payload never reached the dispatcher**. `TR_BLE_To_APP.cpp` captures payloads in a per-command if-chain, and its `else if (cmd == 8)` branch matches *any* length and never sets `payload_len` — so a state byte was silently dropped at the transport before the dispatcher could see it. Camera and logging worked without a transport change only because they have no explicit branch and fall through to the generic `else if (length > 1)` handler. Both layers are fixed here. (cmds 6/7 have the same swallowing shape, but they're distinct sim start/stop commands, not toggles, so there's nothing to desync.)

## What changed

- **Transport** — the cmd 8 branch captures `[desired u8]` when present, and logs which form arrived.
- **OC dispatcher** — reads the desired state, ignores a command matching the current rail state, falls back to toggling when there's no payload. The long power-on and power-off bodies are **untouched and keep their exact indentation** (state check in front, `else if (want_on)` / `else`), so the diff stays reviewable.
- **Both apps** — power-off buttons send 0; the #159 power-on path sends 1, which also makes a double-press idempotent instead of powering the rocket back off. Android gains `Commands.powerState()` / `DeviceSession.sendPowerState()`; iOS gains `sendPowerState(railOn:)`.
- Refreshes two `Commands.kt` doc comments that #805 had made stale.

## Compatibility

| | old firmware | new firmware |
|---|---|---|
| **old app** (bare) | toggle | toggle — legacy path preserved |
| **new app** (payload) | payload ignored → toggle | desired state, idempotent |

## Preserved deliberately

- **#159** power-on busy state + 3-minute watchdog (which must outlast the OC's ~90 s log-flush).
- **#377** UI gate on received telemetry — so the state the app sends is one it has actually seen. Worth noting the power-on case is safe for exactly this reason: with the rail down the FC is silent, but the OC is alive and still reports `pwr_pin_on`.
- **#9** power-off back-feed pin parking and OC reset.
- The "rail switched" log and post-power-on config re-push now sit behind an actual-change guard, so an ignored duplicate can't claim a switch or re-push config.

## Verification

- `out_computer` builds (IDF 6.0.1, the CI version).
- `check_ble_command_ids.py`, `check_docs.py`, and all three doc generators clean.
- Android `:core:protocol` + `:core:session` tests and `:app:compileDebugKotlin` pass; new golden assertions pin `[8,1]` / `[8,0]` alongside the legacy bare `[8]`.
- **Not yet done: bench verification** of the real power-on and power-off paths. The power-off path ends in `esp_restart()` and can't be unit tested, so it deserves a hardware pass before this is trusted in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)