### PR TITLE
firmware(fc): add the V9/V10 pin map and make the board flag mandatory

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -23,12 +23,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project:
-          - out_computer
-          - base_station
-          - flight_computer
-          - radio_board
-          - rocket_computer_mini
+        include:
+          - project: out_computer
+          - project: base_station
+          - project: radio_board
+          - project: rocket_computer_mini
+          # flight_computer has no default board revision: the flag is
+          # mandatory (projects/flight_computer/main/CMakeLists.txt) because a
+          # wrong pyro pin map is silent at runtime. Build every map so none of
+          # them rots — V8 and V9 differ on ARM and swap FIRE 2/3.
+          - project: flight_computer
+            board: V7
+            flags: -B build_v7 -DTR_BOARD_V7=1
+          - project: flight_computer
+            board: V8
+            flags: -B build_v8 -DTR_BOARD_V8=1
+          - project: flight_computer
+            board: V9
+            flags: -B build_v9 -DTR_BOARD_V9=1
 
     steps:
       - uses: actions/checkout@v5
@@ -55,9 +67,9 @@ jobs:
           git -c submodule."tinkerrocket-idf/components/TR_GuidancePN".update=checkout \
             submodule update --init --recursive tinkerrocket-idf/components/TR_GuidancePN
 
-      - name: Build ${{ matrix.project }}
+      - name: Build ${{ matrix.project }} ${{ matrix.board }}
         working-directory: tinkerrocket-idf/projects/${{ matrix.project }}
         shell: bash
         run: |
           . $IDF_PATH/export.sh
-          idf.py build
+          idf.py ${{ matrix.flags }} build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,29 @@ git will merge them happily and produce a corrupt or subtly wrong board. See
 [`hardware/README.md`](hardware/README.md), which covers this and three other
 hardware-specific rules in detail.
 
+### Building the flight computer
+
+There is no default board revision, and the build fails without one:
+
+```bash
+idf.py -B build_v9 -DTR_BOARD_V9=1 build
+```
+
+`TR_BOARD_V9=1` is the board in `hardware/rocket-computer/` (its title block reads V9, V10
+at HEAD). `TR_BOARD_V8=1` is the older bench boards, whose PCB was never committed;
+`TR_BOARD_V7=1` is the legacy board.
+
+The flag is mandatory here — and only here — because the failure mode is pyrotechnic and
+silent. V8 and V9 disagree on the ARM pin (5 vs 16) and swap the FIRE pins of channels 2
+and 3, while keeping all four continuity pins identical. A V9 board flashed with the V8
+map boots clean, reports the correct channel armed and continuous, then fires the *other*
+channel's connector — or, since ARM is never driven, fires nothing at all through a 1 kΩ
+bleed that still lights a test LED. The boot log prints the map it was built with
+(`[BOARD] pin map:` / `[BOARD] pyro:`); check it against the board before arming anything.
+
+The out computer takes `-DTR_BOARD_V9=1` too, though on that MCU it selects the same pins
+as V8 — pass it anyway so both halves of a pair are built with one flag.
+
 ### Building the base station
 
 The build flag does not match the board number. Current hardware is **V5**, built as

--- a/docs/architecture/generated/flight-computer-map.md
+++ b/docs/architecture/generated/flight-computer-map.md
@@ -3,7 +3,7 @@
 
 # Flight Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,624 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/flight_computer/main/main.cpp` is 7,635 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -33,22 +33,22 @@ and leading comments.
 | [**Camera control (GoPro pulse, RunCam serial)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2101-L2510) | 410 | 2101-2510 |
 | [**Boot chirp and heartbeat beep**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2511-L2586) | 76 | 2511-2586 |
 | [**OTA boot validation**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2587-L2604) | 18 | 2587-2604 |
-| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2605-L3528) | 924 | 2605-3528 |
-| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3529-L3605) | 77 | 3529-3605 |
-| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3606-L3747) | 142 | 3606-3747 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3748-L7609) | 3,862 | 3748-7609 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3785-L3925) | 141 | 3785-3925 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3926-L4029) | 104 | 3926-4029 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4030-L4147) | 118 | 4030-4147 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4148-L4566) | 419 | 4148-4566 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4567-L4731) | 165 | 4567-4731 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4732-L6339) | 1,608 | 4732-6339 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6340-L6457) | 118 | 6340-6457 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6458-L6587) | 130 | 6458-6587 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6588-L7109) | 522 | 6588-7109 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7110-L7153) | 44 | 7110-7153 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7154-L7409) | 256 | 7154-7409 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7410-L7609) | 200 | 7410-7609 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7610-L7624) | 15 | 7610-7624 |
+| [**Boot setup**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L2605-L3539) | 935 | 2605-3539 |
+| [**Simulator re-arm**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3540-L3616) | 77 | 3540-3616 |
+| [**INFLIGHT entry**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3617-L3758) | 142 | 3617-3758 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3759-L7620) | 3,862 | 3759-7620 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Sensor drain and conversion](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3796-L3936) | 141 | 3796-3936 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Magnetometer calibration status](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L3937-L4040) | 104 | 3937-4040 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight logic: pressure altitude and orientation](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4041-L4158) | 118 | 4041-4158 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [EKF input, initialization, and update](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4159-L4577) | 419 | 4159-4577 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [I2C status poll to the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4578-L4742) | 165 | 4578-4742 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Command dispatch from the Out Computer](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L4743-L6350) | 1,608 | 4743-6350 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Kinematic checks and sensor health](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6351-L6468) | 118 | 6351-6468 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Test modes (ground, servo, replay)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6469-L6598) | 130 | 6469-6598 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Flight state machine](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L6599-L7120) | 522 | 6599-7120 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Simulator re-arm and diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7121-L7164) | 44 | 7121-7164 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Telemetry packing (NonSensorData)](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7165-L7420) | 256 | 7165-7420 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [Periodic diagnostics](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7421-L7620) | 200 | 7421-7620 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/flight_computer/main/main.cpp#L7621-L7635) | 15 | 7621-7635 |
 
-Total: 28 sections (12 nested) across 7,624 lines.
+Total: 28 sections (12 nested) across 7,635 lines.

--- a/docs/architecture/generated/out-computer-map.md
+++ b/docs/architecture/generated/out-computer-map.md
@@ -3,7 +3,7 @@
 
 # Out Computer -- `main.cpp` navigation map
 
-`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,815 lines in one translation unit. These are the
+`tinkerrocket-idf/projects/out_computer/main/main.cpp` is 7,818 lines in one translation unit. These are the
 `// SECTION:` banners in it, in file order. Indented rows (↳) are regions
 inside a single large function. Line counts include each section's banner
 and leading comments.
@@ -35,9 +35,9 @@ and leading comments.
 | [**LoRa rendezvous and hop fallback**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4441-L4773) | 333 | 4441-4773 |
 | [**Diagnostics and periodic statistics**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L4774-L5512) | 739 | 4774-5512 |
 | [**Peripheral initialization (runs on power-on)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L5513-L6019) | 507 | 5513-6019 |
-| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6020-L6297) | 278 | 6020-6297 |
-| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6298-L7806) | 1,509 | 6298-7806 |
-| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6671-L7806) | 1,136 | 6671-7806 |
-| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7807-L7815) | 9 | 7807-7815 |
+| [**Boot setup (rail off, BLE only)**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6020-L6300) | 281 | 6020-6300 |
+| [**Main loop**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6301-L7809) | 1,509 | 6301-7809 |
+| &nbsp;&nbsp;&nbsp;&nbsp;↳ [BLE command dispatch](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L6674-L7809) | 1,136 | 6674-7809 |
+| [**FreeRTOS entry point**](https://github.com/Tinkerbug-Robotics/TinkerRocket/blob/main/tinkerrocket-idf/projects/out_computer/main/main.cpp#L7810-L7818) | 9 | 7810-7818 |
 
-Total: 28 sections (1 nested) across 7,815 lines.
+Total: 28 sections (1 nested) across 7,818 lines.

--- a/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/CMakeLists.txt
@@ -47,10 +47,16 @@ if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
     set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
 endif()
 string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
-# Board revision marker (#411): V8 builds are identifiable from the app
-# version string (BLE config_identity "fw" field, boot log, OTA metadata).
-if(TR_BOARD_V8)
+# Board revision marker (#411): every build is identifiable from the app
+# version string (BLE config_identity "fw" field, boot log, OTA metadata), so
+# an image flashed onto the wrong revision can be spotted after the fact.
+# main/CMakeLists.txt is what validates the flag; this only labels the image.
+if(TR_BOARD_V9)
+    set(TR_BOARD_SUFFIX "-v9")
+elseif(TR_BOARD_V8)
     set(TR_BOARD_SUFFIX "-v8")
+elseif(TR_BOARD_V7)
+    set(TR_BOARD_SUFFIX "-v7")
 else()
     set(TR_BOARD_SUFFIX "")
 endif()

--- a/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/flight_computer/main/CMakeLists.txt
@@ -62,9 +62,46 @@ target_compile_definitions(${COMPONENT_LIB} PRIVATE
     FW_GIT_SHA="${FW_GIT_SHA}"
     FW_GIT_DIRTY=${FW_GIT_DIRTY})
 
-# Board revision selection (#411): `idf.py -B build_v8 -DTR_BOARD_V8=1 build`
-# compiles the V8 pin map (main/board/board_v8.h); default is V7. Use a
-# separate build dir per variant — the flag is cached by CMake.
-if(TR_BOARD_V8)
-    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V8=1)
+# Board revision selection (#411). Exactly one flag, and it is MANDATORY:
+#
+#   idf.py -B build_v7 -DTR_BOARD_V7=1 build   # legacy V7 board
+#   idf.py -B build_v8 -DTR_BOARD_V8=1 build   # V8 bench boards
+#   idf.py -B build_v9 -DTR_BOARD_V9=1 build   # V9/V10 (hardware/rocket-computer)
+#
+# Unlike the other projects there is no default here, because the failure is
+# silent and pyrotechnic: V8 and V9 disagree on PYRO_ARM (5 vs 16) and swap
+# PYRO2/PYRO3 FIRE, while all four continuity pins stay put. A mis-flashed
+# board therefore boots clean, reports the right channel armed and continuous,
+# and then fires the wrong connector (or, with ARM undriven, none at all).
+# Better to fail here than to find out on the pad.
+#
+# The build-dir name is cosmetic — the board comes ONLY from the flag. Use a
+# separate -B dir per variant anyway, since CMake caches it.
+set(_tr_board_flags_set "")
+foreach(_tr_flag TR_BOARD_V7 TR_BOARD_V8 TR_BOARD_V9)
+    if(${_tr_flag})
+        list(APPEND _tr_board_flags_set ${_tr_flag})
+    endif()
+endforeach()
+list(LENGTH _tr_board_flags_set _tr_board_flag_count)
+if(_tr_board_flag_count EQUAL 0)
+    message(FATAL_ERROR
+        "flight_computer: no board revision selected. Pass exactly one of "
+        "-DTR_BOARD_V7=1 / -DTR_BOARD_V8=1 / -DTR_BOARD_V9=1 (V9 is the "
+        "hardware/rocket-computer V9/V10 board). There is no default: the V8 "
+        "and V9 pyro maps differ and a wrong map fires the wrong channel with "
+        "no runtime symptom.")
+elseif(NOT _tr_board_flag_count EQUAL 1)
+    message(FATAL_ERROR
+        "flight_computer: more than one board revision selected "
+        "(${_tr_board_flags_set}). Pass exactly one, and use a separate build "
+        "dir per variant — a stale CMake cache is the usual cause.")
+endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE ${_tr_board_flags_set}=1)
+if(TR_BOARD_V9)
+    message(STATUS "flight_computer: board pin map V9/V10 (main/board/board_v9.h)")
+elseif(TR_BOARD_V8)
+    message(STATUS "flight_computer: board pin map V8 (main/board/board_v8.h)")
+else()
+    message(STATUS "flight_computer: board pin map V7 (main/board/board_v7.h)")
 endif()

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v7.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v7.h
@@ -95,7 +95,10 @@ struct board_pins
     static constexpr int I2S_DOUT_PIN  = 23;
     static constexpr int I2S_FSYNC_PIN = 17;
 
-    // ### Power gates (V8-only topology; -1 = rail not FC-switched) ###
+    // ### Power gates (V8+ topology; -1 = rail not FC-switched) ###
     static constexpr int GPS_ACT_PIN = -1;
     static constexpr int SERVO_ACT_PIN = -1;
+
+    // ### Power latch (V9+ only; -1 = the FC cannot hold its own rail) ###
+    static constexpr int PWR_HOLD_PIN = -1;
 };

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v8.h
@@ -8,6 +8,14 @@
 //
 // Net names in comments are the V8 schematic nets (2026-07-05 capture).
 // Values marked TODO are unconfirmed — replace as bring-up proceeds.
+//
+// THIS MAP IS V8-ONLY. It is bench-proven on the physical V8 boards
+// (2026-08-17: commanding channel 3 fires connector 3, channel 1 fires
+// connector 1), and the V8 PCB was never committed, so this header is its
+// only record — do not "correct" it against hardware/rocket-computer/, which
+// holds V9/V10. Those boards moved PYRO_ARM to 16, PYRO2_FIRE to 11 and
+// PYRO3_FIRE to 9, and gave GPIO5 to the power latch; build them with
+// -DTR_BOARD_V9=1 (board_v9.h), which explains what this map does to them.
 struct board_pins
 {
     // ### Sensor SPI bus (SENS_* nets) ###
@@ -133,4 +141,7 @@ struct board_pins
                                               // driven high at boot for now,
                                               // pad-relax integration is a
                                               // follow-up)
+
+    // ### Power latch (V9+ only; -1 = the FC cannot hold its own rail) ###
+    static constexpr int PWR_HOLD_PIN = -1;
 };

--- a/tinkerrocket-idf/projects/flight_computer/main/board/board_v9.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/board/board_v9.h
@@ -1,0 +1,192 @@
+#pragma once
+
+#include <stdint.h>
+
+// V9/V10 PCB pin map + board topology for the flight computer (ESP32-P4).
+// Selected with TR_BOARD_V9=1:
+//   idf.py -B build_v9 -DTR_BOARD_V9=1 build
+//
+// This is the map of the board files in hardware/rocket-computer/ — the
+// .kicad_pcb title block reads V9 up to 25fb08d and V10 at HEAD. It is NOT
+// board_v8.h: no V8 PCB was ever committed (the physical V8 bench boards
+// predate the import), and three pyro pins moved between them.
+//
+// Verified 2026-08-17 two independent ways: `kicad-cli sch export netlist` on
+// rocket-computer.kicad_sch, and a pad -> pinfunction -> net walk of U17 in
+// rocket-computer.kicad_pcb at every commit that has ever touched that file
+// (199ecec, bdcc507, 8f87aa0, 25fb08d, HEAD). Every GPIO below is identical
+// across all of them; the one thing that ever changed is GPIO5, unconnected
+// in the first two and wired to P4_EN_HOLD from the V9 pre-fab close-out
+// (8f87aa0) onward. So this single header covers V9 and V10.
+//
+//   signal        board_v8.h    here (V9/V10)
+//   PYRO_ARM           5             16
+//   PYRO2_FIRE         9             11
+//   PYRO3_FIRE        11              9
+//
+// Everything else — all four CONT pins, PYRO1/PYRO4 FIRE, and every sensor,
+// servo, I2S, I2C, indicator and power-gate pin — is the same on both maps.
+//
+// ### Why flashing V9/V10 hardware with TR_BOARD_V8=1 is a silent hazard ###
+//   * ARM never fires. On this board the arming FET is U9 (CSD16323Q3),
+//     gate driven from PYRO_ARM through R21 (100 R), drain on PYRO_GND (the
+//     squib return at J2). With GPIO16 undriven the return never reaches
+//     ground and the only path left is R73, a 1 k bleed — roughly 8 mA off
+//     the pack. That is enough to light a bench LED and nowhere near enough
+//     to fire a real igniter.
+//   * Channels 2 and 3 fire each other's connector, while PYRO2_CONT and
+//     PYRO3_CONT still read their own channel correctly — so the app shows
+//     the right channel armed and continuous, and the wrong squib goes.
+//   * GPIO5 is this board's power latch (P4_EN_HOLD, below), not ARM, so an
+//     arm request holds the FC's own rail up and a disarm releases it.
+//
+// ### SAFETY: first power-up of this revision ###
+// Carried forward from board_v8.h and NOT yet done on V9/V10 hardware: with
+// NO squibs connected, scope all four FIRE pads and the ARM pad across reset
+// and the whole boot sequence and confirm they stay quiet. All output init
+// goes through safePyroOutputInit() (main.cpp); check each pin's P4 IO-MUX
+// default function before trusting it — the V7 hazard was pins 14-19
+// defaulting to SPI2/SPI3, see commit 421dd63. Note that the pins this
+// revision uses for ARM (16) and PYRO2/PYRO3 FIRE (11, 9) were NOT part of
+// the V8 bring-up scope check, so none of them has been cleared yet.
+struct board_pins
+{
+    // ### Sensor SPI bus (SENS_* nets) ###
+    static constexpr uint8_t SPI_SCK = 53;  // SENS_SCLK
+    static constexpr uint8_t SPI_SDO = 51;  // SENS_SDO
+    static constexpr uint8_t SPI_SDI = 52;  // SENS_SDI
+
+    // ### GNSS serial ###
+    // Same nets and same label-perspective trap as V8: the nets are named
+    // from the MODULE's point of view, not ours —
+    //   net GNSS_TX = P4 GPIO3 -> J1 -> receiver TXD (it drives)
+    //   net GNSS_RX = P4 GPIO4 -> J1 -> receiver RXD (it listens)
+    // so OUR receive pin is 3 and OUR transmit pin is 4. These constants are
+    // the FC's own rx/tx (passed straight to uartBegin(baud, rx, tx)) and
+    // must stay in that order; do not "fix" them to match the net names.
+    // GNSS_RXD2 on GPIO2 (the receiver's second UART) is unused by firmware.
+    static constexpr uint8_t GNSS_RX = 3;   // FC receives; module TXD drives this
+    static constexpr uint8_t GNSS_TX = 4;   // FC drives;   module RXD listens here
+    static constexpr int8_t GNSS_RESET_N = -1;
+    static constexpr int8_t GNSS_SAFEBOOT_N = -1;
+
+    // ### Sensor CS / bus pins ###
+    static constexpr int MMC5983MA_CS = -1;    // no MMC5983MA on V9/V10
+    static constexpr uint8_t BMP585_CS = 41;   // BMP585_CS
+    static constexpr uint8_t ISM6HG256_CS = 49;// ISM6HG256_CS
+    static constexpr uint8_t IIS2MDC_SDA = 47; // IIS2MDCTR_SDA
+    static constexpr uint8_t IIS2MDC_SCL = 48; // IIS2MDCTR_SCL
+
+    // ### Part presence ###
+    static constexpr bool USE_BMP585 = true;
+    static constexpr bool USE_MMC5983MA = false;  // no MMC5983MA net on this board
+    static constexpr bool USE_GNSS = true;
+    static constexpr bool USE_ISM6HG256 = true;
+    static constexpr bool USE_IIS2MDC = true;
+
+    // ### Sensor interrupt pins ###
+    static constexpr uint8_t ISM6HG256_INT = 50;  // ISM6HG256_INT1
+    static constexpr uint8_t BMP585_INT = 42;     // BMP585_INT
+    static constexpr int MMC5983MA_INT = -1;      // no MMC5983MA on V9/V10
+    static constexpr uint8_t IIS2MDC_INT = 46;    // IIS2MDCTR_INT
+
+    // ### Camera ###
+    // Unchanged from V8 (Camera_TX=30, Camera_RX=31, CAM_ACT=32). These nets
+    // are named from the FC's perspective — Camera_TX is the line the FC
+    // transmits on, into the camera's RX pad — the OPPOSITE of the
+    // GNSS_TX/GNSS_RX convention above. Bench-proven on V8 hardware with two
+    // RunCam units; don't "fix" them to a module-perspective reading.
+    //
+    // What DID change: CAM_ACT now enables U26, a TPS22811 HIGH-side switch
+    // whose output is the camera V+ on J4.1 (V8 switched the camera's ground
+    // through a low-side MOSFET). Still active-high, so firmware is unchanged,
+    // but the connector's polarity is not what a V8 harness expects. The
+    // switch's IMON is read by the OutComputer, not by us.
+    static constexpr int8_t CAM_PWR_PIN = 30;      // GoPro path, unused
+    static constexpr int8_t CAM_SHUTTER_PIN = 31;  // GoPro path, unused
+    static constexpr int8_t RUNCAM_RX_PIN = 31;    // FC receives (net Camera_RX, camera's TX pad)
+    static constexpr int8_t RUNCAM_TX_PIN = 30;    // FC transmits (net Camera_TX, camera's RX pad)
+    static constexpr int8_t RUNCAM_PWR_PIN = 32;   // camera power gate (CAM_ACT)
+
+    // ### Pyro channels — ARM and FIRE 2/3 differ from V8 (see header note) ###
+    // One shared arming FET (U9) feeds all four squib drivers; each FIRE pin
+    // drives a DTC123J (Q2-Q5). ALL output-pad init MUST go through
+    // safePyroOutputInit() — never gpio_reset_pin() a FIRE or ARM pad.
+    static constexpr uint8_t PYRO_ARM_PIN   = 16;  // PYRO_ARM   (V8: 5)
+    static constexpr uint8_t PYRO1_FIRE_PIN = 6;   // PYRO1_FIRE
+    static constexpr uint8_t PYRO1_CONT_PIN = 7;   // PYRO1_CONT
+    static constexpr uint8_t PYRO2_FIRE_PIN = 11;  // PYRO2_FIRE (V8: 9)
+    static constexpr uint8_t PYRO2_CONT_PIN = 10;  // PYRO2_CONT
+    static constexpr uint8_t PYRO3_FIRE_PIN = 9;   // PYRO3_FIRE (V8: 11)
+    static constexpr uint8_t PYRO3_CONT_PIN = 12;  // PYRO3_CONT
+    static constexpr uint8_t PYRO4_FIRE_PIN = 13;  // PYRO4_FIRE
+    static constexpr uint8_t PYRO4_CONT_PIN = 14;  // PYRO4_CONT
+
+    // ### Fin servos ###
+    // Same four EXP nets as V8, same P4 pins. Full expansion map (net, GPIO,
+    // package pin), read out of the V10 .kicad_pcb:
+    //
+    //   net       GPIO   pkg pin      net       GPIO   pkg pin
+    //   EXP_01     45      87         EXP_07     29      58
+    //   EXP_02     44      86         EXP_08     28      57
+    //   EXP_03     43      84         EXP_09     38      70
+    //   EXP_04     54      98         EXP_10     37      69
+    //   EXP_05     39      80         EXP_11     34      65
+    //   EXP_06     40      81         EXP_12     33      64
+    //
+    // All twelve come out on the 16-pin Molex J3: pins 3..8 carry EXP_01..06
+    // ascending, then pins 9..14 carry EXP_12..07 DESCENDING — pin 9 is
+    // EXP_12, not EXP_07.
+    //
+    // CONNECTOR POLARITY CHANGED vs V8: J3 pins 1-2 are now the SWITCHED
+    // POSITIVE servo rail (output of U28, a TPS22811 high-side switch gated
+    // by SERVO_ACT) and pins 15-16 are GND. On V8 that was the other way
+    // around — pins 1-2 a MOSFET-switched return, pins 15-16 VBATT. A V8
+    // servo harness plugged into a V9/V10 board is reverse-polarity.
+    static constexpr uint8_t SERVO_PIN_1 = 45;  // EXP_01, connector pin 3
+    static constexpr uint8_t SERVO_PIN_2 = 44;  // EXP_02, connector pin 4
+    static constexpr uint8_t SERVO_PIN_3 = 43;  // EXP_03, connector pin 5
+    static constexpr uint8_t SERVO_PIN_4 = 54;  // EXP_04, connector pin 6
+
+    // ### Indicators ###
+    static constexpr uint8_t PIEZO_PIN = 17;      // PIEZZO
+    // TODO: confirm which IND_* is which color (guess: IND_1=red, IND_2=blue).
+    static constexpr uint8_t RED_LED_PIN = 27;    // IND_1
+    static constexpr uint8_t BLUE_LED_PIN = 26;   // IND_2
+
+    // ### I2C command/config channel to the OutComputer ###
+    static constexpr uint8_t ESP_SDA_PIN = 23;  // ESP_SDA (OC GPIO5)
+    static constexpr uint8_t ESP_SCL_PIN = 22;  // ESP_SCL (OC GPIO6)
+
+    // ### I2S high-frequency telemetry to the OutComputer ###
+    // ESP_* net convention (must match the OC's board header per-net):
+    //   ESP_SCLK = bit clock, ESP_SDO = FC data out, ESP_CS = word select,
+    //   ESP_SDI = frame sync.
+    static constexpr int I2S_BCLK_PIN  = 21;  // ESP_SCLK (OC GPIO2)
+    static constexpr int I2S_WS_PIN    = 18;  // ESP_CS   (OC GPIO1)
+    static constexpr int I2S_DOUT_PIN  = 19;  // ESP_SDO  (OC GPIO3)
+    static constexpr int I2S_FSYNC_PIN = 20;  // ESP_SDI  (OC GPIO4)
+
+    // ### Power gates ###
+    // Same pins as V8, but both now enable TPS22811 high-side switches
+    // (GPS_ACT -> U27, SERVO_ACT -> U28) instead of low-side MOSFETs. Both
+    // are still active-high enables, so the firmware sequence is unchanged.
+    static constexpr int GPS_ACT_PIN = 15;    // GPS_ACT — GNSS rail enable
+    static constexpr int SERVO_ACT_PIN = 8;   // SERVO_ACT — servo rail enable
+
+    // ### Power latch — new on V9, no equivalent on V7/V8 ###
+    // GPIO5 = net P4_EN_HOLD, one anode of D9 (BAV170M dual diode). The other
+    // anode is P4_EN_S3, which is the OutComputer's PWR_PIN (its GPIO7). The
+    // common cathode is POWER_SWITCH = EN/UVLO of U30 (TPS22810), and U30's
+    // output V_MCU_SWTCH feeds every P4 supply pin. So the OC switches this
+    // board on, and either MCU can hold it on.
+    //
+    // Firmware deliberately does NOT drive this pin. The OC holds P4_EN_S3
+    // high for the whole powered session (out_computer main.cpp, PWR_PIN), so
+    // the FC boots and runs without it. Asserting it would make the FC
+    // un-power-off-able until something releases it, so the release policy has
+    // to be designed before it is wired up. For reference, R84 (100 k) and
+    // C105 (10 uF) on POWER_SWITCH hold the rail roughly 0.8 s after the last
+    // driver lets go.
+    static constexpr int PWR_HOLD_PIN = 5;    // P4_EN_HOLD (not driven yet)
+};

--- a/tinkerrocket-idf/projects/flight_computer/main/config.h
+++ b/tinkerrocket-idf/projects/flight_computer/main/config.h
@@ -6,15 +6,40 @@
 // --- Board revision (#411, tracking #408) ---
 // Pins + part-presence flags live in the per-board headers; everything in
 // this file is board-independent policy and must not fork per revision.
-// Select the V8 map with: idf.py -B build_v8 -DTR_BOARD_V8=1 build
-// (default stays V7 until V8 bring-up completes).
+//
+// EXACTLY ONE of these must be set — there is no default. A wrong pyro pin
+// map is completely silent at runtime (the board boots, continuity reads
+// correctly, and the wrong channel fires or no channel fires at all), so the
+// flight computer refuses to build rather than guess:
+//
+//   V7 legacy board:  idf.py -B build_v7 -DTR_BOARD_V7=1 build
+//   V8 bench boards:  idf.py -B build_v8 -DTR_BOARD_V8=1 build
+//   V9/V10 boards:    idf.py -B build_v9 -DTR_BOARD_V9=1 build
+//
+// main/CMakeLists.txt enforces the same rule at configure time with a clearer
+// message; this check is the backstop for anything that includes config.h
+// without going through it.
+#ifndef TR_BOARD_V7
+#define TR_BOARD_V7 0
+#endif
 #ifndef TR_BOARD_V8
 #define TR_BOARD_V8 0
 #endif
-#if TR_BOARD_V8
+#ifndef TR_BOARD_V9
+#define TR_BOARD_V9 0
+#endif
+#if (TR_BOARD_V7 + TR_BOARD_V8 + TR_BOARD_V9) != 1
+#error "Set exactly one board revision: -DTR_BOARD_V7=1, -DTR_BOARD_V8=1 or -DTR_BOARD_V9=1. There is no default — the V8 and V9 pyro maps differ (ARM 5 vs 16, FIRE 2/3 swapped) and a wrong map fires the wrong channel silently."
+#endif
+#if TR_BOARD_V9
+#include "board/board_v9.h"
+#define TR_BOARD_REV_STR "V9/V10"
+#elif TR_BOARD_V8
 #include "board/board_v8.h"
+#define TR_BOARD_REV_STR "V8"
 #else
 #include "board/board_v7.h"
+#define TR_BOARD_REV_STR "V7"
 #endif
 
 struct config : board_pins

--- a/tinkerrocket-idf/projects/flight_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/flight_computer/main/main.cpp
@@ -2673,8 +2673,19 @@ static void setup_fc()
     }
 
     ESP_LOGI(TAG, "Starting ....");
-    ESP_LOGW(TAG, "[BOARD] pin map: %s  (flash the other variant with/without -B build_v8 -DTR_BOARD_V8=1)",
-             TR_BOARD_V8 ? "V8" : "V7");
+    // Board revision + the pyro pins it implies. The pyro map is the one part
+    // of the pin map whose mismatch has no runtime symptom (V8 and V9 swap
+    // FIRE 2/3 and move ARM, but keep all four CONT pins), so print the
+    // numbers rather than just the revision — they can be checked against the
+    // connector with a meter before anything is armed.
+    ESP_LOGW(TAG, "[BOARD] pin map: %s  (select with -DTR_BOARD_V7/V8/V9=1; no default)",
+             TR_BOARD_REV_STR);
+    ESP_LOGW(TAG, "[BOARD] pyro: ARM=%d FIRE=%d/%d/%d/%d CONT=%d/%d/%d/%d",
+             (int)config::PYRO_ARM_PIN,
+             (int)config::PYRO1_FIRE_PIN, (int)config::PYRO2_FIRE_PIN,
+             (int)config::PYRO3_FIRE_PIN, (int)config::PYRO4_FIRE_PIN,
+             (int)config::PYRO1_CONT_PIN, (int)config::PYRO2_CONT_PIN,
+             (int)config::PYRO3_CONT_PIN, (int)config::PYRO4_CONT_PIN);
     gpio_set_direction((gpio_num_t)(config::RED_LED_PIN), GPIO_MODE_OUTPUT);
     gpio_set_level((gpio_num_t)(config::RED_LED_PIN), 1);
     gpio_set_direction((gpio_num_t)(config::BLUE_LED_PIN), GPIO_MODE_OUTPUT);

--- a/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/CMakeLists.txt
@@ -28,9 +28,13 @@ if(NOT TR_GIT_DIRTY_CODE EQUAL 0)
     set(TR_GIT_SHA "${TR_GIT_SHA}-dirty")
 endif()
 string(TIMESTAMP TR_BUILD_DATE "%Y%m%d-%H%M" UTC)
-# Board revision marker (#411): V8 builds are identifiable from the app
+# Board revision marker (#411): V8/V9 builds are identifiable from the app
 # version string (BLE config_identity "fw" field, boot log, OTA metadata).
-if(TR_BOARD_V8)
+# The two select the same pin map on this MCU (see main/config.h) but are
+# stamped apart so an image can be traced back to the board it was built for.
+if(TR_BOARD_V9)
+    set(TR_BOARD_SUFFIX "-v9")
+elseif(TR_BOARD_V8)
     set(TR_BOARD_SUFFIX "-v8")
 else()
     set(TR_BOARD_SUFFIX "")

--- a/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/out_computer/main/CMakeLists.txt
@@ -28,8 +28,20 @@ target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error -Wno-format -Wno-narr
 # Board revision selection (#411): `idf.py -DTR_BOARD_V8=1 build` compiles the
 # V8 pin map (main/board/board_v8.h); default is V7. Use a separate build dir
 # per variant (e.g. -B build_v8) — the flag is cached by CMake.
+#
+# -DTR_BOARD_V9=1 is accepted and selects the same map: the S3 pin map did not
+# change between V8 and V9/V10 (see board_v8.h and main/config.h). It exists so
+# both MCUs of a V9 pair take the same flag — the FC's V9 map is a genuinely
+# different header, and mixing -DTR_BOARD_V8=1 here with -DTR_BOARD_V9=1 there
+# reads like a mistake even when it isn't.
 if(TR_BOARD_V8)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V8=1)
+    message(STATUS "out_computer: board pin map V8")
+elseif(TR_BOARD_V9)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V9=1)
+    message(STATUS "out_computer: board pin map V9/V10 (identical to V8 on this MCU)")
+else()
+    message(STATUS "out_computer: board pin map V7 (default; pass -DTR_BOARD_V8=1 or -DTR_BOARD_V9=1 for newer hardware)")
 endif()
 
 # Bench-debug image: `idf.py -B build_bench -DTR_OC_BENCH_DEBUG=1 build`.

--- a/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
+++ b/tinkerrocket-idf/projects/out_computer/main/board/board_v8.h
@@ -7,6 +7,26 @@
 //
 // Net names in comments are the V8 schematic nets. Values marked TODO are
 // still unconfirmed — replace as bring-up proceeds.
+//
+// ALSO THE V9/V10 MAP — this MCU did not move (verified 2026-08-17 by walking
+// U15's pad -> pinfunction -> net in hardware/rocket-computer.kicad_pcb at
+// every commit that ever touched it, and against a kicad-cli netlist export
+// of the V10 schematic). -DTR_BOARD_V9=1 selects this same header; see
+// main/config.h. That is the opposite of the FC, whose V9 map moved PYRO_ARM
+// and swapped two FIRE pins and therefore has its own board_v9.h.
+//
+// Two things changed around this map without changing it:
+//   * PWR_PIN's net was renamed Power_Switch -> P4_EN_S3 at the V9 pre-fab
+//     close-out. Same GPIO7, same job: it is the enable that powers the P4's
+//     rail (U30, a TPS22810). On V9+ the P4 also has its own hold line into
+//     the same enable (its GPIO5, net P4_EN_HOLD) which its firmware does not
+//     currently drive — so dropping PWR_PIN still powers the FC down, but
+//     check flight_computer/main/board/board_v9.h before assuming that.
+//   * MRAM_CS (GPIO34) is V8-only. There is no MRAM_CS net anywhere in the
+//     V9/V10 schematic; the pin is unconnected and the part is unfitted.
+//     Left at 34 because it is correct for V8 and harmless on V9/V10 (it
+//     drives a floating pad), but set it to -1 if an MRAM-present code path
+//     ever costs more than a probe.
 struct board_pins
 {
     // --- Power rail switch ---

--- a/tinkerrocket-idf/projects/out_computer/main/config.h
+++ b/tinkerrocket-idf/projects/out_computer/main/config.h
@@ -9,10 +9,21 @@
 // everything else in this file is board-independent policy and must not
 // fork per revision. Select the V8 map with: idf.py -DTR_BOARD_V8=1 build
 // (default stays V7 until V8 bring-up completes).
+//
+// TR_BOARD_V9=1 selects the SAME board_v8.h. Unlike the FC — where V9 moved
+// three pyro pins and needed its own header — the S3's pin map is unchanged
+// from V8 through V10 (verified 2026-08-17 against every committed revision
+// of hardware/rocket-computer; see board_v8.h). The flag exists so a V9/V10
+// pair is built with one consistent revision flag on both MCUs, and so the
+// image is stamped "-v9". If a future revision does move an S3 pin, split
+// board_v9.h out here and switch this branch to it.
 #ifndef TR_BOARD_V8
 #define TR_BOARD_V8 0
 #endif
-#if TR_BOARD_V8
+#ifndef TR_BOARD_V9
+#define TR_BOARD_V9 0
+#endif
+#if TR_BOARD_V8 || TR_BOARD_V9
 #include "board/board_v8.h"
 #else
 #include "board/board_v7.h"

--- a/tinkerrocket-idf/projects/out_computer/main/main.cpp
+++ b/tinkerrocket-idf/projects/out_computer/main/main.cpp
@@ -6042,7 +6042,10 @@ static void setup_oc()
     pwr_pin_on = false;
 
     ESP_LOGI("OC", "Starting OutComputer (low-power mode)...");
-    ESP_LOGW("OC", "[BOARD] pin map: %s", TR_BOARD_V8 ? "V8" : "V7");
+    // V9 selects the same map as V8 on this MCU (see config.h) — reported
+    // separately so the boot log says which board the image was built for.
+    ESP_LOGW("OC", "[BOARD] pin map: %s",
+             TR_BOARD_V9 ? "V9/V10 (same pins as V8)" : (TR_BOARD_V8 ? "V8" : "V7"));
 
     // OTA boot-state check (#8). If this image was just OTA-installed it
     // boots PENDING_VERIFY; we hold off the "valid" mark until we've seen

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/CMakeLists.txt
@@ -3,7 +3,15 @@ idf_component_register(
     INCLUDE_DIRS "."
 )
 
-# Board revision selection (#411): idf.py -B build_v8 -DTR_BOARD_V8=1 build
-if(TR_BOARD_V8)
+# Board revision selection (#411): idf.py -B build_v9 -DTR_BOARD_V9=1 build
+# (or -DTR_BOARD_V8=1; default is V7). This tool fires squib drivers by hand,
+# so the map it was built with is printed at startup — check it before arming.
+if(TR_BOARD_V9)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V9=1)
+    message(STATUS "pyro_channel_test: board pin map V9/V10")
+elseif(TR_BOARD_V8)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE TR_BOARD_V8=1)
+    message(STATUS "pyro_channel_test: board pin map V8")
+else()
+    message(STATUS "pyro_channel_test: board pin map V7 (default; pass -DTR_BOARD_V8=1 or -DTR_BOARD_V9=1)")
 endif()

--- a/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
+++ b/tinkerrocket-idf/projects/pyro_channel_test/main/main.cpp
@@ -9,7 +9,14 @@
  * Pins are board-revision dependent (#411):
  *   V7 (default):            ARM=14, CONT/FIRE = 15/16 18/19 38/34 51/50
  *   V8 (-DTR_BOARD_V8=1):    ARM=5,  CONT/FIRE = 7/6 10/9 12/11 14/13
- * Build the V8 map with:  idf.py -B build_v8 -DTR_BOARD_V8=1 build
+ *   V9/V10 (-DTR_BOARD_V9=1):ARM=16, CONT/FIRE = 7/6 10/11 12/9 14/13
+ * Build the V9 map with:  idf.py -B build_v9 -DTR_BOARD_V9=1 build
+ *
+ * V8 vs V9 is not cosmetic: ARM moves (5 -> 16) and channels 2 and 3 swap
+ * their FIRE pins while keeping their CONT pins, so the wrong build fires the
+ * wrong connector with continuity still reading correctly. hardware/
+ * rocket-computer/ is the V9/V10 board; the V8 boards are the older bench
+ * units. The selected map is printed at startup — read it before arming.
  *
  * V8 NOTE: the CONT sense path is powered through the arming FET (test-board
  * circuit) — use 'C' (momentary arm) or arm first; unarmed 'c'/'r' reads are
@@ -54,6 +61,20 @@ static const char* TAG = "PYRO_DBG";
 #ifndef TR_BOARD_V8
 #define TR_BOARD_V8 0
 #endif
+#ifndef TR_BOARD_V9
+#define TR_BOARD_V9 0
+#endif
+#if TR_BOARD_V8 && TR_BOARD_V9
+#error "Pick one board: -DTR_BOARD_V8=1 or -DTR_BOARD_V9=1, not both."
+#endif
+
+#if TR_BOARD_V9
+#define TR_BOARD_REV_STR "V9/V10"
+#elif TR_BOARD_V8
+#define TR_BOARD_REV_STR "V8"
+#else
+#define TR_BOARD_REV_STR "V7"
+#endif
 
 struct PyroChannel {
     const char*  name;
@@ -61,7 +82,16 @@ struct PyroChannel {
     gpio_num_t   cont;
 };
 
-#if TR_BOARD_V8
+#if TR_BOARD_V9
+// V9/V10 rocket computer (P4): mirror of projects/flight_computer/main/board/board_v9.h
+static constexpr gpio_num_t PYRO_ARM_PIN = GPIO_NUM_16;
+static PyroChannel ch[4] = {
+    { "PYRO1", GPIO_NUM_6,  GPIO_NUM_7  },
+    { "PYRO2", GPIO_NUM_11, GPIO_NUM_10 },
+    { "PYRO3", GPIO_NUM_9,  GPIO_NUM_12 },
+    { "PYRO4", GPIO_NUM_13, GPIO_NUM_14 },
+};
+#elif TR_BOARD_V8
 // V8 rocket computer (P4): mirror of projects/flight_computer/main/board/board_v8.h
 static constexpr gpio_num_t PYRO_ARM_PIN = GPIO_NUM_5;
 static PyroChannel ch[4] = {
@@ -89,6 +119,7 @@ static inline bool cont_from_raw(int raw) { return raw == 0; }
 
 #include <esp_private/gpio.h>      // gpio_func_sel
 #include <rom/gpio.h>              // esp_rom_gpio_connect_out_signal
+#include <soc/gpio_sig_map.h>      // SIG_GPIO_OUT_IDX (implicit before IDF v6)
 
 // Safe ARM/FIRE pad init — same recipe as the flight firmware's
 // safePyroOutputInit (see FC main.cpp / commit 421dd63): NEVER
@@ -149,7 +180,7 @@ static void disarm_all()
 static void print_help()
 {
     printf("\n=== Pyro Channel Debug (%s pin map, shared ARM) ===\n",
-           TR_BOARD_V8 ? "V8" : "V7");
+           TR_BOARD_REV_STR);
     printf("  ?   help\n");
     printf("  s   show state\n");
     for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
## The problem

The flight computer had exactly one pyro-capable pin map, `board_v8.h`. It is correct for the V8 bench boards — bench-proven 2026-08-17, commanding channel 3 fires connector 3 — but the KiCad files in `hardware/rocket-computer/` describe V9/V10 boards, and their pyro mapping differs:

| signal | `board_v8.h` | V9/V10 board |
|---|---|---|
| `PYRO_ARM` | 5 | **GPIO16** (GPIO5 is the net `P4_EN_HOLD`) |
| `PYRO2_FIRE` | 9 | **GPIO11** |
| `PYRO3_FIRE` | 11 | **GPIO9** |
| ch1/ch4 FIRE, all four CONT | — | identical |

Flashing a V9/V10 board with `TR_BOARD_V8=1` is silent: the board boots clean, continuity still reads the right channel, and then channels 2 and 3 fire each other's connector. And with ARM undriven, the arm FET U9 never conducts, so fire current is limited by R73's 1 kΩ to about 8 mA — enough to light a bench LED, nowhere near enough to fire a real igniter.

## What's here

**`board_v9.h`** — every pin re-derived rather than copied from V8: a `kicad-cli sch export netlist` of the V10 schematic, plus a pad → pinfunction → net walk of U17 in `rocket-computer.kicad_pcb` at all five commits that have ever touched it. The P4 map is identical across V9 and V10, so one header covers both. The header records the failure mode above, the connector-polarity change on J3 (pins 1-2 are now the switched positive servo rail, 15-16 GND — the reverse of V8), and the scope-verify note carried forward from `board_v8.h`.

**The board flag is now mandatory for the flight computer.** `idf.py build` with no `-DTR_BOARD_V7/V8/V9=1` is a CMake `FATAL_ERROR`, with an `#error` in `config.h` as the backstop for anything bypassing CMake. This is the one project that gets this treatment, because it is the one where a wrong map is both silent and pyrotechnic. Images are stamped `-v7`/`-v8`/`-v9`, and the boot banner prints the revision plus the pyro pin numbers so they can be metered before anything is armed:

    [BOARD] pin map: V9/V10  (select with -DTR_BOARD_V7/V8/V9=1; no default)
    [BOARD] pyro: ARM=16 FIRE=6/11/9/13 CONT=7/10/12/14

**CI** now builds all three FC maps. It was building the flight computer flagless, which would fail under the new rule.

**out_computer needs no new header** — verified, not assumed. The S3 pin map is unchanged from V8 through V10; `PWR_PIN` GPIO7's net was only renamed `Power_Switch` → `P4_EN_S3`, and `MRAM_CS` (GPIO34) went unconnected when the part was dropped (left at 34: correct for V8, harmless on V9, documented). It accepts `-DTR_BOARD_V9=1` as selecting the same map so both MCUs of a pair take one flag.

**`pyro_channel_test`** gets the V9 map too — it fires squib drivers by hand, so the same hazard applies directly. It also didn't compile at all under IDF v6 (`SIG_GPIO_OUT_IDX` needs an explicit `soc/gpio_sig_map.h`); that's fixed, so the V9 addition is actually verifiable.

## Deliberately not done

`PWR_HOLD_PIN` (GPIO5, net `P4_EN_HOLD`) is defined but **not driven**. It is one anode of D9 (BAV170M) into U30's EN/UVLO; the other anode is the OC's `PWR_PIN`. The OC holds its side high for the whole powered session, so the FC boots and runs without it. Asserting it would make the FC un-power-off-able until something releases it — that release policy needs designing first. This is also why running the V8 map on V9 hardware is worse than "ARM does nothing": arm/disarm flaps the FC's own power latch.

## Verification

All builds run against ESP-IDF v6.0: flight_computer V7/V8/V9, out_computer V9, pyro_channel_test V9. Both failure paths checked — no flag and two flags each produce their intended `FATAL_ERROR`. Version string confirmed as `<sha>-dirty-v9+<date>`. `tools/check_docs.py` passes.

**Nothing here is verified on V9 hardware.** The first power-up still has to scope all four FIRE pads and the ARM pad across reset and boot with no squibs connected — and note that the pins V9 newly uses for ARM (16) and FIRE 2/3 (11, 9) were not part of the V8 bring-up scope check, so none of them has been cleared yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
